### PR TITLE
Fix detection of iterables within `quote` annotations while mapping

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -999,7 +999,7 @@ async def begin_task_map(
     static_parameters = {}
     annotated_parameters = {}
     for key, val in parameters.items():
-        if isinstance(val, allow_failure):
+        if isinstance(val, (allow_failure, quote)):
             # Unwrap annotated parameters to determine if they are iterable
             annotated_parameters[key] = val
             val = val.unwrap()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2652,7 +2652,7 @@ class TestTaskMap:
 
         @flow
         def my_flow():
-            futures = TestTaskMap.add.map(generate_numbers())
+            futures = TestTaskMap.add_one.map(generate_numbers())
             assert all(isinstance(f, PrefectFuture) for f in futures)
             return futures
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2652,7 +2652,7 @@ class TestTaskMap:
 
         @flow
         def my_flow():
-            futures = TestTaskMap.add_one.map(generate_numbers())
+            futures = TestTaskMap.add.map(generate_numbers())
             assert all(isinstance(f, PrefectFuture) for f in futures)
             return futures
 
@@ -2668,6 +2668,26 @@ class TestTaskMap:
         def my_flow():
             numbers_state = some_numbers._run()
             return TestTaskMap.add_one.map(numbers_state)
+
+        task_states = my_flow()
+        assert [state.result() for state in task_states] == [2, 3, 4]
+
+    def test_can_take_quoted_iterable_as_input(self):
+        @flow
+        def my_flow():
+            futures = TestTaskMap.add_together.map(quote(1), [1, 2, 3])
+            assert all(isinstance(f, PrefectFuture) for f in futures)
+            return futures
+
+        task_states = my_flow()
+        assert [state.result() for state in task_states] == [2, 3, 4]
+
+    def test_does_not_treat_quote_as_iterable(self):
+        @flow
+        def my_flow():
+            futures = TestTaskMap.add_one.map(quote([1, 2, 3]))
+            assert all(isinstance(f, PrefectFuture) for f in futures)
+            return futures
 
         task_states = my_flow()
         assert [state.result() for state in task_states] == [2, 3, 4]


### PR DESCRIPTION
Resolves issue raised at https://prefect-community.slack.com/archives/CL09KU1K7/p1680714278761869?thread_ts=1680713049.940769&cid=CL09KU1K7

Quoted items are detected as iterables because annotations inherit from tuple but they should only be treated as iterable if the item within the quote is iterable.

```
@task
def add_together(x, y):
    return x + y

@flow
def my_flow():
    return add_together.map(quote(1), [1, 2, 3])
```

Previously this would complain about mismatched iterable lengths: 1 vs 3. Now, it correctly infers that `quote(1)` is not an iterable. Additionally, we solve the case where the quoted item is iterable.