### PR TITLE
Fail on prefect-agent typed work pools

### DIFF
--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -399,6 +399,13 @@ async def deploy(
     async with prefect.get_client() as client:
         flow_id = await client.create_flow_from_name(base_deploy["flow_name"])
 
+        if base_deploy["work_pool"]:
+            work_pool = await client.read_work_pool(base_deploy["work_pool"])
+
+            # dont allow submitting to prefect-agent typed work pools
+            if work_pool.type == "prefect-agent":
+                exit_with_error("Cannot submit to a work pool of type 'prefect-agent'.")
+
         deployment_id = await client.create_deployment(
             flow_id=flow_id,
             name=base_deploy["name"],


### PR DESCRIPTION
Right now if a user submits work to a `prefect-agent` typed work pool, it runs the risk of running in a half-broken state depending on what version of Prefect that agent is running.

To avoid confusion, this PR enforces that deployments built from projects can only be submitted to non-agent typed work pools.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
