### PR TITLE
Enable events client experimental flag by default

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1117,7 +1117,7 @@ application. If disabled, task runs and subflow runs belonging to cancelled flow
 remain in non-terminal states.
 """
 
-PREFECT_EXPERIMENTAL_ENABLE_EVENTS_CLIENT = Setting(bool, default=False)
+PREFECT_EXPERIMENTAL_ENABLE_EVENTS_CLIENT = Setting(bool, default=True)
 """
 Whether or not to enable experimental Prefect work pools.
 """

--- a/tests/_internal/compatibility/test_experimental.py
+++ b/tests/_internal/compatibility/test_experimental.py
@@ -459,8 +459,19 @@ def test_experimental_marker_cannot_be_used_without_opt_in_setting_if_required()
 
 @pytest.mark.usefixtures("enable_prefect_experimental_test_opt_in_setting")
 def test_enabled_experiments_with_opt_in():
-    assert enabled_experiments() == {"test", "work_pools", "workers", "artifacts"}
+    assert enabled_experiments() == {
+        "test",
+        "work_pools",
+        "workers",
+        "artifacts",
+        "events_client",
+    }
 
 
 def test_enabled_experiments_without_opt_in():
-    assert enabled_experiments() == set(["work_pools", "workers", "artifacts"])
+    assert enabled_experiments() == {
+        "work_pools",
+        "workers",
+        "artifacts",
+        "events_client",
+    }

--- a/tests/events/test_events_worker.py
+++ b/tests/events/test_events_worker.py
@@ -41,12 +41,7 @@ def test_worker_instance_null_client_no_api_url():
 
 
 def test_worker_instance_null_client_non_cloud_api_url():
-    with temporary_settings(
-        updates={
-            PREFECT_API_URL: "http://localhost:8080/api",
-            PREFECT_API_URL: "https://api.prefect.cloud/api/accounts/72483643-e98d-4323-889a-a12905ff21cd/workspaces/cda37001-1181-4f3c-bf03-00da4b532776",
-        }
-    ):
+    with temporary_settings(updates={PREFECT_API_URL: "http://localhost:8080/api"}):
         worker = EventsWorker.instance()
         assert worker._client_type == NullEventsClient
 

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -30,7 +30,7 @@ def test_app_exposes_ui_settings():
     response.raise_for_status()
     json = response.json()
     assert json["api_url"] == PREFECT_UI_API_URL.value()
-    assert set(json["flags"]) == {"artifacts", "workers", "work_pools"}
+    assert set(json["flags"]) == {"artifacts", "workers", "work_pools", "events_client"}
 
 
 @pytest.mark.usefixtures("enable_prefect_experimental_test_opt_in_setting")
@@ -41,4 +41,10 @@ def test_app_exposes_ui_settings_with_experiments_enabled():
     response.raise_for_status()
     json = response.json()
     assert json["api_url"] == PREFECT_UI_API_URL.value()
-    assert set(json["flags"]) == {"test", "work_pools", "workers", "artifacts"}
+    assert set(json["flags"]) == {
+        "test",
+        "work_pools",
+        "workers",
+        "artifacts",
+        "events_client",
+    }


### PR DESCRIPTION
Defaults the `events_client` experiment to being on.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
