### PR TITLE
Resolves issue with initializing a docker recipe within a git repo

### DIFF
--- a/src/prefect/projects/recipes/docker/prefect.yaml
+++ b/src/prefect/projects/recipes/docker/prefect.yaml
@@ -1,6 +1,6 @@
 prefect-version: null
 name: null
-description: "Store project within a docker image alongside its runtime environment"
+description: "Store project within a custom docker image alongside its runtime environment"
 
 build:
   - prefect_docker.projects.steps.build_docker_image:


### PR DESCRIPTION
This PR resolves an issue on `main` where initializing a `docker` recipe from within a git repo produces errors (due to using the full repo name as the project name).

This simplifies things to always rely on the directory name along instead of mixing and matching git-semantics with filesystem semantics.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
