### PR TITLE
Use new sessions and transactions for each query during `CancellationCleanup`

### DIFF
--- a/src/prefect/server/services/cancellation_cleanup.py
+++ b/src/prefect/server/services/cancellation_cleanup.py
@@ -6,7 +6,6 @@ import asyncio
 
 import pendulum
 import sqlalchemy as sa
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.expression import or_
 
 import prefect.server.models as models
@@ -41,16 +40,15 @@ class CancellationCleanup(LoopService):
         - cancels active tasks belonging to recently cancelled flow runs
         - cancels any active subflow that belongs to a cancelled flow
         """
-        async with db.session_context(begin_transaction=True) as session:
-            # cancels active tasks belonging to recently cancelled flow runs
-            await self.clean_up_cancelled_flow_run_task_runs(db, session)
+        # cancels active tasks belonging to recently cancelled flow runs
+        await self.clean_up_cancelled_flow_run_task_runs(db)
 
-            # cancels any active subflow run that belongs to a cancelled flow run
-            await self.clean_up_cancelled_subflow_runs(db, session)
+        # cancels any active subflow run that belongs to a cancelled flow run
+        await self.clean_up_cancelled_subflow_runs(db)
 
         self.logger.info("Finished cleaning up cancelled flow runs.")
 
-    async def clean_up_cancelled_flow_run_task_runs(self, db, session):
+    async def clean_up_cancelled_flow_run_task_runs(self, db):
         while True:
             cancelled_flow_query = (
                 sa.select(db.FlowRun)
@@ -62,17 +60,18 @@ class CancellationCleanup(LoopService):
                 .limit(self.batch_size)
             )
 
-            flow_run_result = await session.execute(cancelled_flow_query)
+            async with db.session_context() as session:
+                flow_run_result = await session.execute(cancelled_flow_query)
             flow_runs = flow_run_result.scalars().all()
 
             for run in flow_runs:
-                await self._cancel_child_runs(session=session, flow_run=run)
+                await self._cancel_child_runs(db=db, flow_run=run)
 
             # if no relevant flows were found, exit the loop
             if len(flow_runs) < self.batch_size:
                 break
 
-    async def clean_up_cancelled_subflow_runs(self, db, session):
+    async def clean_up_cancelled_subflow_runs(self, db):
         while True:
             subflow_query = (
                 sa.select(db.FlowRun)
@@ -89,56 +88,65 @@ class CancellationCleanup(LoopService):
                 .limit(self.batch_size)
             )
 
-            subflow_run_result = await session.execute(subflow_query)
+            async with db.session_context() as session:
+                subflow_run_result = await session.execute(subflow_query)
             subflow_runs = subflow_run_result.scalars().all()
 
             for subflow_run in subflow_runs:
-                await self._cancel_subflows(session=session, flow_run=subflow_run)
+                await self._cancel_subflows(db=db, flow_run=subflow_run)
 
             # if no relevant flows were found, exit the loop
             if len(subflow_runs) < self.batch_size:
                 break
 
     async def _cancel_child_runs(
-        self, session: AsyncSession, flow_run: PrefectDBInterface.FlowRun
+        self, db: PrefectDBInterface, flow_run: PrefectDBInterface.FlowRun
     ) -> None:
-        child_task_runs = await models.task_runs.read_task_runs(
-            session,
-            flow_run_filter=filters.FlowRunFilter(id={"any_": [flow_run.id]}),
-            task_run_filter=filters.TaskRunFilter(
-                state={"type": {"any_": NON_TERMINAL_STATES}}
-            ),
-            limit=100,
-        )
-
-        for task_run in child_task_runs:
-            await models.task_runs.set_task_run_state(
-                session=session,
-                task_run_id=task_run.id,
-                state=states.Cancelled(message="The parent flow run was cancelled."),
-                force=True,
+        async with db.session_context() as session:
+            child_task_runs = await models.task_runs.read_task_runs(
+                session,
+                flow_run_filter=filters.FlowRunFilter(id={"any_": [flow_run.id]}),
+                task_run_filter=filters.TaskRunFilter(
+                    state={"type": {"any_": NON_TERMINAL_STATES}}
+                ),
+                limit=100,
             )
 
+        for task_run in child_task_runs:
+            async with db.session_context(begin_transaction=True) as session:
+                await models.task_runs.set_task_run_state(
+                    session=session,
+                    task_run_id=task_run.id,
+                    state=states.Cancelled(
+                        message="The parent flow run was cancelled."
+                    ),
+                    force=True,
+                )
+
     async def _cancel_subflows(
-        self, session: AsyncSession, flow_run: PrefectDBInterface.FlowRun
+        self, db: PrefectDBInterface, flow_run: PrefectDBInterface.FlowRun
     ) -> None:
         if not flow_run.parent_task_run_id:
             return
 
-        parent_task_run = await models.task_runs.read_task_run(
-            session, task_run_id=flow_run.parent_task_run_id
-        )
-        containing_flow_run = await models.flow_runs.read_flow_run(
-            session, flow_run_id=parent_task_run.flow_run_id
-        )
+        async with db.session_context() as session:
+            parent_task_run = await models.task_runs.read_task_run(
+                session, task_run_id=flow_run.parent_task_run_id
+            )
+            containing_flow_run = await models.flow_runs.read_flow_run(
+                session, flow_run_id=parent_task_run.flow_run_id
+            )
 
         if containing_flow_run.state.type == states.StateType.CANCELLED:
-            await models.flow_runs.set_flow_run_state(
-                session=session,
-                flow_run_id=flow_run.id,
-                state=states.Cancelled(message="The parent flow run was cancelled."),
-                force=True,
-            )
+            async with db.session_context(begin_transaction=True) as session:
+                await models.flow_runs.set_flow_run_state(
+                    session=session,
+                    flow_run_id=flow_run.id,
+                    state=states.Cancelled(
+                        message="The parent flow run was cancelled."
+                    ),
+                    force=True,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Attempts to resolve https://github.com/PrefectHQ/prefect/issues/9120 by zealously opening and closing sessions and avoiding transactions for reads.