### PR TITLE
Include flow run and flow as related resources when emitting events via the events worker

### DIFF
--- a/src/prefect/events/related.py
+++ b/src/prefect/events/related.py
@@ -1,0 +1,94 @@
+from typing import TYPE_CHECKING, List, Optional, Set, Tuple
+from uuid import UUID
+
+from .schemas import RelatedResource
+
+if TYPE_CHECKING:
+    from prefect.client.schemas import FlowRun
+    from prefect.server.schemas.core import Flow
+
+related_resource_cache: dict[UUID, Tuple[Optional["FlowRun"], Optional["Flow"]]] = {}
+
+
+async def related_resources_from_run_context(
+    exclude: Optional[Set[str]] = None,
+) -> List[RelatedResource]:
+    from prefect.context import FlowRunContext, TaskRunContext
+
+    if exclude is None:
+        exclude = set()
+
+    flow_run_id: Optional[UUID] = None
+    flow_run: Optional["FlowRun"] = None
+    flow: Optional["Flow"] = None
+
+    flow_run_context = FlowRunContext.get()
+
+    if flow_run_context is None:
+        task_run_context = TaskRunContext.get()
+        if task_run_context is None:
+            return []
+
+        flow_run_id = task_run_context.task_run.flow_run_id
+
+        if flow_run_id in related_resource_cache:
+            flow_run, flow = related_resource_cache[flow_run_id]
+        else:
+            client = task_run_context.client
+            flow_run = await client.read_flow_run(flow_run_id)
+            flow = await client.read_flow(flow_run.flow_id) if flow_run else None
+            related_resource_cache[flow_run_id] = (flow_run, flow)
+    else:
+        flow_run_id = flow_run_context.flow_run.id
+
+        if flow_run_id in related_resource_cache:
+            flow_run, flow = related_resource_cache[flow_run_id]
+        else:
+            client = flow_run_context.client
+            flow_run = flow_run_context.flow_run
+            # The `flow` attached to the run context is an instance of the
+            # actual flow function itself and not the database representation.
+            # We request the database version here to ensure we have the id and
+            # tags needed to emit in the event.
+            flow = await client.read_flow(flow_run.flow_id)
+            related_resource_cache[flow_run_id] = (flow_run, flow)
+
+    related = []
+    tags = set()
+
+    if flow_run and f"prefect.flow-run.{flow_run.id}" not in exclude:
+        related.append(
+            RelatedResource(
+                __root__={
+                    "prefect.resource.id": f"prefect.flow-run.{flow_run.id}",
+                    "prefect.resource.role": "flow-run",
+                    "prefect.name": flow_run.name,
+                }
+            )
+        )
+        tags |= set(flow_run.tags)
+
+    if flow and f"prefect.flow.{flow.id}" not in exclude:
+        related.append(
+            RelatedResource(
+                __root__={
+                    "prefect.resource.id": f"prefect.flow.{flow.id}",
+                    "prefect.resource.role": "flow",
+                    "prefect.name": flow.name,
+                }
+            )
+        )
+        tags |= set(flow.tags)
+
+    related += [
+        RelatedResource(
+            __root__={
+                "prefect.resource.id": f"prefect.tag.{tag}",
+                "prefect.resource.role": "tag",
+            }
+        )
+        for tag in sorted(tags)
+        if f"prefect.tag.{tag}" not in exclude
+    ]
+
+    return related

--- a/src/prefect/events/related.py
+++ b/src/prefect/events/related.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 from uuid import UUID
 
 from .schemas import RelatedResource
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from prefect.client.schemas import FlowRun
     from prefect.server.schemas.core import Flow
 
-related_resource_cache: dict[UUID, Tuple[Optional["FlowRun"], Optional["Flow"]]] = {}
+related_resource_cache: Dict[UUID, Tuple[Optional["FlowRun"], Optional["Flow"]]] = {}
 
 
 async def related_resources_from_run_context(

--- a/src/prefect/events/schemas.py
+++ b/src/prefect/events/schemas.py
@@ -114,6 +114,10 @@ class Event(PrefectBaseModel):
         description="The client-provided identifier of this event",
     )
 
+    @property
+    def involved_resources(self) -> Iterable[Resource]:
+        return [self.resource] + list(self.related)
+
     @validator("related")
     def enforce_maximum_related_resources(cls, value: List[RelatedResource]):
         if len(value) > MAXIMUM_RELATED_RESOURCES:

--- a/src/prefect/events/worker.py
+++ b/src/prefect/events/worker.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+from contextvars import Context, copy_context
 from typing import Any, Optional, Tuple, Type
 
 from typing_extensions import Self
@@ -6,6 +7,7 @@ from typing_extensions import Self
 from prefect._internal.compatibility.experimental import experiment_enabled
 from prefect._internal.concurrency.services import QueueService
 from prefect.settings import PREFECT_API_KEY, PREFECT_API_URL, PREFECT_CLOUD_API_URL
+from prefect.utilities.context import temporary_context
 
 from .clients import EventsClient, NullEventsClient, PrefectCloudEventsClient
 from .related import related_resources_from_run_context
@@ -28,8 +30,14 @@ class EventsWorker(QueueService[Event]):
         async with self._client:
             yield
 
-    async def _handle(self, event: Event):
-        await self.attach_related_resources_from_context(event)
+    def _prepare_item(self, event: Event) -> Tuple[Event, Context]:
+        return (event, copy_context())
+
+    async def _handle(self, event_and_context: Tuple[Event, Context]):
+        event, context = event_and_context
+        with temporary_context(context=context):
+            await self.attach_related_resources_from_context(event)
+
         await self._client.emit(event)
 
     async def attach_related_resources_from_context(self, event: Event):

--- a/src/prefect/utilities/context.py
+++ b/src/prefect/utilities/context.py
@@ -1,0 +1,16 @@
+from contextlib import contextmanager
+from contextvars import Context, ContextVar, Token
+from typing import Dict
+
+
+@contextmanager
+def temporary_context(context: Context):
+    tokens: Dict[ContextVar, Token] = {}
+    for key, value in context.items():
+        token = key.set(value)
+        tokens[key] = token
+    try:
+        yield
+    finally:
+        for key, token in tokens.items():
+            key.reset(token)

--- a/tests/_internal/concurrency/test_services.py
+++ b/tests/_internal/concurrency/test_services.py
@@ -15,6 +15,8 @@ from prefect._internal.concurrency.services import (
     drain_on_exit_async,
 )
 
+THE_ANSWER = ContextVar("the-answer")
+
 
 class MockService(QueueService[int]):
     mock = MagicMock()
@@ -321,9 +323,11 @@ def test_context_available_to_handler():
                 if key.name == "the-answer":
                     self.mock(value)
 
+    # Start the service before setting the context variable so that the context
+    # it has does not have the value being set.
     ContextAwareService.instance().send(1)
 
-    ContextVar("the-answer").set(42)
+    THE_ANSWER.set(42)
 
     ContextAwareService.instance().send(1)
     ContextAwareService.instance().drain()

--- a/tests/_internal/concurrency/test_services.py
+++ b/tests/_internal/concurrency/test_services.py
@@ -1,7 +1,6 @@
 import contextlib
 import threading
 from concurrent.futures import ThreadPoolExecutor
-from contextvars import ContextVar, copy_context
 from typing import List, Optional
 from unittest.mock import ANY, MagicMock, call
 
@@ -14,8 +13,6 @@ from prefect._internal.concurrency.services import (
     drain_on_exit,
     drain_on_exit_async,
 )
-
-THE_ANSWER = ContextVar("the-answer")
 
 
 class MockService(QueueService[int]):
@@ -311,24 +308,3 @@ def test_batched_queue_service_min_interval():
     IntervalMockBatchedService.mock.assert_has_calls(
         [call(instance, [1]), call(instance, [2])]
     )
-
-
-def test_context_available_to_handler():
-    class ContextAwareService(QueueService[int]):
-        mock = MagicMock()
-
-        async def _handle(self, item):
-            context = copy_context()
-            for key, value in context.items():
-                if key.name == "the-answer":
-                    self.mock(value)
-
-    # Start the service before setting the context variable so that the context
-    # it has does not have the value being set.
-    ContextAwareService.instance().send(1)
-
-    THE_ANSWER.set(42)
-
-    ContextAwareService.instance().send(1)
-    ContextAwareService.instance().drain()
-    ContextAwareService.instance().mock.assert_called_once_with(42)

--- a/tests/events/test_event_schemas.py
+++ b/tests/events/test_event_schemas.py
@@ -122,3 +122,20 @@ def test_limit_on_related_resources(monkeypatch: pytest.MonkeyPatch):
             ],
             id=uuid4(),
         )
+
+
+def test_client_event_involved_resources():
+    event = Event(
+        occurred=pendulum.now("UTC"),
+        event="hello",
+        resource={"prefect.resource.id": "hello"},
+        related=[
+            {"prefect.resource.id": "related-1", "prefect.resource.role": "role-1"},
+        ],
+        id=uuid4(),
+    )
+
+    assert [resource.id for resource in event.involved_resources] == [
+        "hello",
+        "related-1",
+    ]

--- a/tests/events/test_events_related_from_context.py
+++ b/tests/events/test_events_related_from_context.py
@@ -1,0 +1,153 @@
+from unittest import mock
+
+from prefect import flow, tags, task
+from prefect.context import FlowRunContext, TaskRunContext
+from prefect.events.related import related_resources_from_run_context
+from prefect.events.schemas import RelatedResource
+
+
+async def test_gracefully_handles_missing_context():
+    related = await related_resources_from_run_context()
+    assert related == []
+
+
+async def test_gets_related_from_run_context(orion_client):
+    @flow
+    async def test_flow():
+        return await related_resources_from_run_context()
+
+    with tags("testing"):
+        state = await test_flow._run()
+
+    flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
+    db_flow = await orion_client.read_flow(flow_run.flow_id)
+
+    related = await state.result()
+
+    assert related == [
+        RelatedResource(
+            __root__={
+                "prefect.resource.id": f"prefect.flow-run.{flow_run.id}",
+                "prefect.resource.role": "flow-run",
+                "prefect.name": flow_run.name,
+            }
+        ),
+        RelatedResource(
+            __root__={
+                "prefect.resource.id": f"prefect.flow.{db_flow.id}",
+                "prefect.resource.role": "flow",
+                "prefect.name": db_flow.name,
+            }
+        ),
+        RelatedResource(
+            __root__={
+                "prefect.resource.id": f"prefect.tag.testing",
+                "prefect.resource.role": "tag",
+            }
+        ),
+    ]
+
+
+async def test_can_exclude_by_resource_id(orion_client):
+    @flow
+    async def test_flow():
+        flow_run_context = FlowRunContext.get()
+        assert flow_run_context is not None
+        exclude = {f"prefect.flow-run.{flow_run_context.flow_run.id}"}
+
+        return await related_resources_from_run_context(exclude=exclude)
+
+    state = await test_flow._run()
+
+    flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
+
+    related = await state.result()
+
+    assert f"prefect.flow-run.{flow_run.id}" not in related
+
+
+async def test_gets_flow_run_from_task_run_context(orion_client):
+    @task
+    async def test_task():
+        FlowRunContext.__var__.set(None)
+        return await related_resources_from_run_context()
+
+    @flow
+    async def test_flow():
+        return await test_task()
+
+    state = await test_flow._run()
+
+    flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
+    db_flow = await orion_client.read_flow(flow_run.flow_id)
+
+    related = await state.result()
+
+    assert related == [
+        RelatedResource(
+            __root__={
+                "prefect.resource.id": f"prefect.flow-run.{flow_run.id}",
+                "prefect.resource.role": "flow-run",
+                "prefect.name": flow_run.name,
+            }
+        ),
+        RelatedResource(
+            __root__={
+                "prefect.resource.id": f"prefect.flow.{db_flow.id}",
+                "prefect.resource.role": "flow",
+                "prefect.name": db_flow.name,
+            }
+        ),
+    ]
+
+
+async def test_caches_related_objects():
+    @flow
+    async def test_flow():
+        flow_run_context = FlowRunContext.get()
+        assert flow_run_context is not None
+        with mock.patch.object(
+            flow_run_context.client,
+            "read_flow",
+            wraps=flow_run_context.client.read_flow,
+        ) as read_flow_mock:
+            await related_resources_from_run_context()
+            await related_resources_from_run_context()
+
+        return read_flow_mock
+
+    read_flow_mock = await test_flow()
+
+    read_flow_mock.assert_called_once()
+
+
+async def test_caches_from_task_run_context():
+    @task
+    async def test_task():
+        FlowRunContext.__var__.set(None)
+        task_run_context = TaskRunContext.get()
+        assert task_run_context is not None
+        with mock.patch.object(
+            task_run_context.client,
+            "read_flow_run",
+            wraps=task_run_context.client.read_flow_run,
+        ) as read_flow_run_mock:
+            with mock.patch.object(
+                task_run_context.client,
+                "read_flow",
+                wraps=task_run_context.client.read_flow,
+            ) as read_flow_mock:
+                await related_resources_from_run_context()
+                await related_resources_from_run_context()
+
+        return read_flow_run_mock, read_flow_mock
+
+    @flow
+    async def test_flow():
+        return await test_task()
+
+    state = await test_flow._run()
+    read_flow_run_mock, read_flow_mock = await state.result()
+
+    read_flow_run_mock.assert_called_once()
+    read_flow_mock.assert_called_once()

--- a/tests/events/test_events_worker.py
+++ b/tests/events/test_events_worker.py
@@ -2,6 +2,7 @@ import uuid
 
 import pytest
 
+from prefect import flow
 from prefect.events import Event
 from prefect.events.clients import (
     AssertingEventsClient,
@@ -68,3 +69,38 @@ def test_worker_instance_null_client_cloud_api_url_experiment_enabled():
     ):
         worker = EventsWorker.instance()
         assert worker._client_type == PrefectCloudEventsClient
+
+
+async def test_includes_related_resources_from_run_context(
+    asserting_events_worker: EventsWorker, reset_worker_events, orion_client
+):
+    @flow
+    def emitting_flow():
+        from prefect.events import emit_event
+
+        emit_event(
+            event="vogon.poetry.read",
+            resource={"prefect.resource.id": "vogon.poem.oh-freddled-gruntbuggly"},
+        )
+
+    state = emitting_flow._run()
+
+    flow_run = await orion_client.read_flow_run(state.state_details.flow_run_id)
+    db_flow = await orion_client.read_flow(flow_run.flow_id)
+
+    asserting_events_worker.drain()
+
+    assert len(asserting_events_worker._client.events) == 1
+    event = asserting_events_worker._client.events[0]
+    assert event.event == "vogon.poetry.read"
+    assert event.resource.id == "vogon.poem.oh-freddled-gruntbuggly"
+
+    assert len(event.related) == 2
+
+    assert event.related[0].id == f"prefect.flow-run.{flow_run.id}"
+    assert event.related[0].role == "flow-run"
+    assert event.related[0]["prefect.name"] == flow_run.name
+
+    assert event.related[1].id == f"prefect.flow.{db_flow.id}"
+    assert event.related[1].role == "flow"
+    assert event.related[1]["prefect.name"] == db_flow.name


### PR DESCRIPTION
This changes the EventWorker to implicitly add flow run and flow objects from the run context as related objects when emitting events. This allows for events, such as block instrumentation events, to automatically get the correct related resources without needing to get this information directly.

Closes #9127 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
