### PR TITLE
Rename `__root_path__` to `__development_base_path__`

### DIFF
--- a/scripts/run-integration-flows.py
+++ b/scripts/run-integration-flows.py
@@ -18,9 +18,9 @@ import sys
 from pathlib import Path
 from typing import Union
 
-from prefect import __root_path__, __version__
+from prefect import __development_base_path__, __version__
 
-DEFAULT_PATH = __root_path__ / "flows"
+DEFAULT_PATH = __development_base_path__ / "flows"
 
 
 def run_flows(search_path: Union[str, Path]):

--- a/scripts/run-integration-flows.py
+++ b/scripts/run-integration-flows.py
@@ -18,9 +18,16 @@ import sys
 from pathlib import Path
 from typing import Union
 
-from prefect import __development_base_path__, __version__
+import prefect
+from prefect import __version__
 
-DEFAULT_PATH = __development_base_path__ / "flows"
+# See https://github.com/PrefectHQ/prefect/pull/9136
+DEFAULT_PATH = (
+    getattr(
+        prefect, "__development_base_path__", getattr(prefect, "__root_path__", None)
+    )
+    / "flows"
+)
 
 
 def run_flows(search_path: Union[str, Path]):

--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -14,7 +14,7 @@ __version__ = __version_info__["version"]
 # The absolute path to this module
 __module_path__ = pathlib.Path(__file__).parent
 # The absolute path to the root of the repository, only valid for use during development.
-__root_path__ = __module_path__.parents[1]
+__development_base_path__ = __module_path__.parents[1]
 # The absolute path to the built UI within the Python module
 __ui_static_path__ = __module_path__ / "server" / "ui"
 

--- a/src/prefect/cli/dev.py
+++ b/src/prefect/cli/dev.py
@@ -48,7 +48,7 @@ app.add_typer(dev_app)
 def exit_with_error_if_not_editable_install():
     if (
         prefect.__module_path__.parent == "site-packages"
-        or not (prefect.__root_path__ / "setup.py").exists()
+        or not (prefect.__development_base_path__ / "setup.py").exists()
     ):
         exit_with_error(
             "Development commands require an editable Prefect installation. "
@@ -124,7 +124,7 @@ def build_docs(
 
     if not schema_path:
         schema_path = (
-            prefect.__root_path__ / "docs" / "api-ref" / "schema.json"
+            prefect.__development_base_path__ / "docs" / "api-ref" / "schema.json"
         ).absolute()
     # overwrite info for display purposes
     schema["info"] = {}
@@ -136,7 +136,7 @@ def build_docs(
 BUILD_UI_HELP = f"""
 Installs dependencies and builds UI locally.
 
-The built UI will be located at {prefect.__root_path__ / "ui"}
+The built UI will be located at {prefect.__development_base_path__ / "ui"}
 
 Requires npm.
 """
@@ -145,8 +145,8 @@ Requires npm.
 @dev_app.command(help=BUILD_UI_HELP)
 def build_ui():
     exit_with_error_if_not_editable_install()
-    with tmpchdir(prefect.__root_path__):
-        with tmpchdir(prefect.__root_path__ / "ui"):
+    with tmpchdir(prefect.__development_base_path__):
+        with tmpchdir(prefect.__development_base_path__ / "ui"):
             app.console.print("Installing npm packages...")
             try:
                 subprocess.check_output(["npm", "ci"], shell=sys.platform == "win32")
@@ -179,8 +179,8 @@ async def ui():
     Starts a hot-reloading development UI.
     """
     exit_with_error_if_not_editable_install()
-    with tmpchdir(prefect.__root_path__):
-        with tmpchdir(prefect.__root_path__ / "ui"):
+    with tmpchdir(prefect.__development_base_path__):
+        with tmpchdir(prefect.__development_base_path__ / "ui"):
             app.console.print("Installing npm packages...")
             await run_process(["npm", "install"], stream_output=True)
 
@@ -365,7 +365,7 @@ def build_image(
     command = [
         "docker",
         "build",
-        str(prefect.__root_path__),
+        str(prefect.__development_base_path__),
         "--tag",
         tag,
         "--platform",
@@ -426,7 +426,7 @@ def container(bg: bool = False, name="prefect-dev", api: bool = True, tag: str =
         name=name,
         auto_remove=True,
         working_dir="/opt/prefect/repo",
-        volumes=[f"{prefect.__root_path__}:/opt/prefect/repo"],
+        volumes=[f"{prefect.__development_base_path__}:/opt/prefect/repo"],
         shm_size="4G",
     )
 
@@ -497,7 +497,7 @@ def kubernetes_manifest():
     )
     manifest = template.substitute(
         {
-            "prefect_root_directory": prefect.__root_path__,
+            "prefect_root_directory": prefect.__development_base_path__,
             "image_name": get_prefect_image_name(),
         }
     )

--- a/src/prefect/cli/project.py
+++ b/src/prefect/cli/project.py
@@ -7,6 +7,7 @@ import typer
 import yaml
 from rich.table import Table
 
+import prefect
 from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error
 from prefect.cli.root import app
@@ -33,7 +34,7 @@ async def ls():
     List available recipes.
     """
 
-    recipe_paths = Path(__file__).parent / ".." / "projects" / "recipes"
+    recipe_paths = prefect.__module_path__ / "projects" / "recipes"
     recipes = {}
 
     for recipe in recipe_paths.iterdir():

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -14,7 +14,7 @@ from prefect.server.schemas.actions import WorkPoolCreate
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
-TEST_PROJECTS_DIR = prefect.__root_path__ / "tests" / "test-projects"
+TEST_PROJECTS_DIR = prefect.__development_base_path__ / "tests" / "test-projects"
 
 
 @pytest.fixture

--- a/tests/projects/test_base.py
+++ b/tests/projects/test_base.py
@@ -15,7 +15,7 @@ from prefect.projects.base import (
     register_flow,
 )
 
-TEST_PROJECTS_DIR = prefect.__root_path__ / "tests" / "test-projects"
+TEST_PROJECTS_DIR = prefect.__development_base_path__ / "tests" / "test-projects"
 
 
 @pytest.fixture(autouse=True)
@@ -60,7 +60,11 @@ class TestRecipes:
         [
             d.absolute().name
             for d in Path(
-                prefect.__root_path__ / "src" / "prefect" / "projects" / "recipes"
+                prefect.__development_base_path__
+                / "src"
+                / "prefect"
+                / "projects"
+                / "recipes"
             ).iterdir()
             if d.is_dir()
         ],
@@ -75,7 +79,11 @@ class TestRecipes:
         [
             d.absolute().name
             for d in Path(
-                prefect.__root_path__ / "src" / "prefect" / "projects" / "recipes"
+                prefect.__development_base_path__
+                / "src"
+                / "prefect"
+                / "projects"
+                / "recipes"
             ).iterdir()
             if d.is_dir() and "git" in d.absolute().name
         ],

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -11,7 +11,7 @@ from prefect.filesystems import Azure, GitHub, LocalFileSystem, RemoteFileSystem
 from prefect.testing.utilities import AsyncMock, MagicMock
 from prefect.utilities.filesystem import tmpchdir
 
-TEST_PROJECTS_DIR = prefect.__root_path__ / "tests" / "test-projects"
+TEST_PROJECTS_DIR = prefect.__development_base_path__ / "tests" / "test-projects"
 
 
 def setup_test_directory(tmp_src: str, sub_dir: str = "puppy") -> Tuple[str, str]:

--- a/tests/utilities/test_importtools.py
+++ b/tests/utilities/test_importtools.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 import pytest
 
 import prefect
-from prefect import __root_path__
+from prefect import __development_base_path__
 from prefect.docker import docker_client
 from prefect.exceptions import ScriptError
 from prefect.utilities.filesystem import tmpchdir
@@ -19,7 +19,7 @@ from prefect.utilities.importtools import (
     to_qualified_name,
 )
 
-TEST_PROJECTS_DIR = __root_path__ / "tests" / "test-projects"
+TEST_PROJECTS_DIR = __development_base_path__ / "tests" / "test-projects"
 
 
 def my_fn():
@@ -146,10 +146,22 @@ def test_lazy_import_includes_help_message_in_deferred_failure():
     "working_directory,script_path",
     [
         # Working directory is not necessary for these imports to work
-        (__root_path__, TEST_PROJECTS_DIR / "flat-project" / "implicit_relative.py"),
-        (__root_path__, TEST_PROJECTS_DIR / "flat-project" / "explicit_relative.py"),
-        (__root_path__, TEST_PROJECTS_DIR / "nested-project" / "implicit_relative.py"),
-        (__root_path__, TEST_PROJECTS_DIR / "nested-project" / "explicit_relative.py"),
+        (
+            __development_base_path__,
+            TEST_PROJECTS_DIR / "flat-project" / "implicit_relative.py",
+        ),
+        (
+            __development_base_path__,
+            TEST_PROJECTS_DIR / "flat-project" / "explicit_relative.py",
+        ),
+        (
+            __development_base_path__,
+            TEST_PROJECTS_DIR / "nested-project" / "implicit_relative.py",
+        ),
+        (
+            __development_base_path__,
+            TEST_PROJECTS_DIR / "nested-project" / "explicit_relative.py",
+        ),
         # They also work with the working directory set to the project
         (TEST_PROJECTS_DIR / "flat-project", "implicit_relative.py"),
         (TEST_PROJECTS_DIR / "flat-project", "explicit_relative.py"),


### PR DESCRIPTION
To clarify that this path is not available in production installs (i.e. non-editable) to avoid future problems like https://github.com/PrefectHQ/prefect/pull/9132 — this has bit me before as well.