### PR TITLE
Update deployment defaults with project init

### DIFF
--- a/src/prefect/cli/project.py
+++ b/src/prefect/cli/project.py
@@ -87,7 +87,7 @@ async def init(name: str = None, recipe: str = None):
     )
     file_msg = (
         f"Created project in [green]{Path('.').resolve()}[/green] with the following"
-        f" new files:\n {files}"
+        f" new files:\n{files}"
     )
     app.console.print(file_msg if files else empty_msg)
 

--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -434,7 +434,7 @@ async def deploy(
             parameters=base_deploy["parameters"],
             description=base_deploy["description"],
             tags=base_deploy["tags"],
-            path=base_deploy["path"],
+            path=base_deploy.get("path"),
             entrypoint=base_deploy["entrypoint"],
             parameter_openapi_schema=base_deploy["parameter_openapi_schema"].dict(),
             pull_steps=project["pull"],

--- a/src/prefect/projects/templates/deployment.yaml
+++ b/src/prefect/projects/templates/deployment.yaml
@@ -8,7 +8,6 @@ schedule: null
 # flow-specific fields
 flow_name: null
 entrypoint: null
-path: null
 parameters: {}
 parameter_openapi_schema: null
 

--- a/tests/projects/test_base.py
+++ b/tests/projects/test_base.py
@@ -143,6 +143,35 @@ class TestInitProject:
         build_step = contents["build"][0]
         assert "prefect_docker.projects.steps.build_docker_image" in build_step
 
+    @pytest.mark.parametrize(
+        "recipe",
+        [
+            d.absolute().name
+            for d in Path(
+                prefect.__development_base_path__
+                / "src"
+                / "prefect"
+                / "projects"
+                / "recipes"
+            ).iterdir()
+            if d.is_dir() and "docker" in d.absolute().name
+        ],
+    )
+    async def test_initialize_project_with_docker_recipe_default_image(self, recipe):
+        files = initialize_project(recipe=recipe)
+        assert len(files) >= 3
+
+        with open("prefect.yaml", "r") as f:
+            contents = yaml.safe_load(f)
+
+        build_step = contents["build"][0]
+        assert "prefect_docker.projects.steps.build_docker_image" in build_step
+
+        with open("deployment.yaml", "r") as f:
+            contents = yaml.safe_load(f)
+
+        assert contents["work_pool"]["job_variables"]["image"] == "{{ image_name }}"
+
 
 class TestRegisterFlow:
     async def test_register_flow_works_in_root(self, project_dir):


### PR DESCRIPTION
Similar to #9145 this PR updates recipe defaults to guide users to healthy deployments as quickly as possible.  In this case, anytime a user uses a docker-based recipe, we default to using a job variable that references the `image_name` output of `build_docker_image`.

### Example
Running `prefect project init --recipe docker` now produces the following work pool section:
```yaml
work_pool:
  job_variables:
    image: '{{ image_name }}'
  name: null
  work_queue_name: null
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
