### PR TITLE
Stream `git` output during `git_clone_project`

### DIFF
--- a/src/prefect/projects/steps/pull.py
+++ b/src/prefect/projects/steps/pull.py
@@ -35,6 +35,8 @@ def git_clone_project(
     # Limit git history
     cmd += ["--depth", "1"]
 
-    subprocess.check_output(cmd, shell=sys.platform == "win32")
+    subprocess.check_call(
+        cmd, shell=sys.platform == "win32", stderr=sys.stderr, stdout=sys.stdout
+    )
     directory = "/".join(repository.strip().split("/")[-1:]).replace(".git", "")
     return {"directory": directory}


### PR DESCRIPTION
Displays git output during clones which is helpful for debugging when this fails or for monitoring progress

e.g.

```
In [1]: from prefect.projects.steps.pull import git_clone_project

In [2]: git_clone_project("prefecthq/prefect")
fatal: repository 'prefecthq/prefect' does not exist
---------------------------------------------------------------------------
CalledProcessError                        Traceback (most recent call last)
Cell In[2], line 1
----> 1 git_clone_project("prefecthq/prefect")

File ~/dev/prefect/src/prefect/projects/steps/pull.py:38, in git_clone_project(repository, branch, access_token)
     35 # Limit git history
     36 cmd += ["--depth", "1"]
---> 38 subprocess.check_call(
     39     cmd, shell=sys.platform == "win32", stderr=sys.stderr, stdout=sys.stdout
     40 )
     41 directory = "/".join(repository.strip().split("/")[-1:]).replace(".git", "")
     42 return {"directory": directory}

File ~/.pyenv/versions/3.11.2/lib/python3.11/subprocess.py:413, in check_call(*popenargs, **kwargs)
    411     if cmd is None:
    412         cmd = popenargs[0]
--> 413     raise CalledProcessError(retcode, cmd)
    414 return 0

CalledProcessError: Command '['git', 'clone', 'prefecthq/prefect', '--depth', '1']' returned non-zero exit status 128.

In [3]: git_clone_project("http://github.com/prefecthq/prefect")
Cloning into 'prefect'...
warning: redirecting to https://github.com/prefecthq/prefect/
remote: Enumerating objects: 1432, done.
remote: Counting objects: 100% (1432/1432), done.
remote: Compressing objects: 100% (1274/1274), done.
remote: Total 1432 (delta 182), reused 699 (delta 93), pack-reused 0
Receiving objects: 100% (1432/1432), 14.65 MiB | 16.43 MiB/s, done.
Resolving deltas: 100% (182/182), done.
Out[3]: {'directory': 'prefect'}
```