### PR TITLE
Update orchestration rules to allow transitions from terminal states

### DIFF
--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -610,17 +610,12 @@ class UpdateFlowRunTrackerOnTasks(BaseOrchestrationRule):
 
 class HandleTaskTerminalStateTransitions(BaseOrchestrationRule):
     """
-    Prevents transitions from terminal states.
+    We do not allow tasks to leave terminal states if:
+    - The task is completed and has a persisted result
+    - The task is going to CANCELLING / PAUSED / CRASHED
 
-    Orchestration logic in Prefect REST API assumes that once runs enter a terminal state, no
-    further action will be taken on them. This rule prevents unintended transitions out
-    of terminal states and sents an instruction to the client to abort any execution.
-
-    While rerunning a flow, the client will attempt to re-orchestrate tasks that may
-    have previously failed. This rule will permit transitions back into a running state
-    if the parent flow run is either currently restarting or retrying. The task run's
-    run count will also be reset so task-level retries can still fire and tracking
-    metadata is updated.
+    We reset the run count when a task leaves a terminal state for a non-terminal state
+    which resets task run retries; this is particularly relevant for flow run retries.
     """
 
     FROM_STATES = TERMINAL_STATES
@@ -652,8 +647,9 @@ class HandleTaskTerminalStateTransitions(BaseOrchestrationRule):
             await self.reject_transition(None, "This run is already completed.")
             return
 
-        # Reset run count to reset retries
-        context.run.run_count = 0
+        if not proposed_state.is_final():
+            # Reset run count to reset retries
+            context.run.run_count = 0
 
         # Change the name of the state to retrying if its a flow run retry
         if proposed_state.is_running():
@@ -674,16 +670,13 @@ class HandleTaskTerminalStateTransitions(BaseOrchestrationRule):
 
 class HandleFlowTerminalStateTransitions(BaseOrchestrationRule):
     """
-    Prevents transitions from terminal states.
+    We do not allow flows to leave terminal states if:
+    - The flow is completed and has a persisted result
+    - The flow is going to CANCELLING / PAUSED / CRASHED
+    - The flow is going to scheduled and has no deployment
 
-    Orchestration logic in Prefect REST API assumes that once runs enter a terminal state, no
-    further action will be taken on them. This rule prevents unintended transitions out
-    of terminal states and sents an instruction to the client to abort any execution.
-
-    If the orchestrated flow run has an associated deployment, this rule will permit a
-    transition back into a scheduled state as well as performing all necessary
-    bookkeeping such as: tracking the number of times a flow run has been restarted and
-    resetting the run count so flow-level retries can still fire.
+    We reset the pause metadata when a flow leaves a terminal state for a non-terminal
+    state. This resets pause behavior during manual flow run retries.
     """
 
     FROM_STATES = TERMINAL_STATES
@@ -726,13 +719,14 @@ class HandleFlowTerminalStateTransitions(BaseOrchestrationRule):
             )
             return
 
-        # Reset pause metadata when leaving a terminal state
-        api_version = context.parameters.get("api-version", None)
-        if api_version is None or api_version >= Version("0.8.4"):
-            updated_policy = context.run.empirical_policy.dict()
-            updated_policy["resuming"] = False
-            updated_policy["pause_keys"] = set()
-            context.run.empirical_policy = core.FlowRunPolicy(**updated_policy)
+        if not proposed_state.is_final():
+            # Reset pause metadata when leaving a terminal state
+            api_version = context.parameters.get("api-version", None)
+            if api_version is None or api_version >= Version("0.8.4"):
+                updated_policy = context.run.empirical_policy.dict()
+                updated_policy["resuming"] = False
+                updated_policy["pause_keys"] = set()
+                context.run.empirical_policy = core.FlowRunPolicy(**updated_policy)
 
     async def cleanup(
         self,

--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -632,6 +632,8 @@ class HandleTaskTerminalStateTransitions(BaseOrchestrationRule):
         proposed_state: Optional[states.State],
         context: TaskOrchestrationContext,
     ) -> None:
+        self.original_run_count = context.run.run_count
+
         # Only allow departure from a happily completed state if the result is not persisted
         if (
             initial_state.is_completed()
@@ -639,9 +641,6 @@ class HandleTaskTerminalStateTransitions(BaseOrchestrationRule):
             and getattr(initial_state.data, "type") != "unpersisted"
         ):
             await self.reject_transition(None, "This run is already completed.")
-
-        self.original_run_count = context.run.run_count
-        self.original_retry_attempt = context.run.flow_run_run_count
 
         # Reset run count to reset retries
         context.run.run_count = 0

--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -641,6 +641,7 @@ class HandleTaskTerminalStateTransitions(BaseOrchestrationRule):
             and initial_state.data.get("type") != "unpersisted"
         ):
             await self.reject_transition(None, "This run is already completed.")
+            return
 
         # Reset run count to reset retries
         context.run.run_count = 0

--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -638,7 +638,7 @@ class HandleTaskTerminalStateTransitions(BaseOrchestrationRule):
         if (
             initial_state.is_completed()
             and initial_state.data
-            and getattr(initial_state.data, "type") != "unpersisted"
+            and initial_state.data.get("type") != "unpersisted"
         ):
             await self.reject_transition(None, "This run is already completed.")
 

--- a/src/prefect/server/orchestration/rules.py
+++ b/src/prefect/server/orchestration/rules.py
@@ -250,7 +250,16 @@ class FlowOrchestrationContext(OrchestrationContext):
     ):
         if self.proposed_state is None:
             validated_orm_state = self.run.state
-            state_data = None
+            # We cannot access `self.run.state.data` directly for unknown reasons
+            state_data = (
+                (
+                    await artifacts.read_artifact(
+                        self.session, self.run.state.result_artifact_id
+                    )
+                ).data
+                if self.run.state.result_artifact_id
+                else None
+            )
         else:
             state_payload = self.proposed_state.dict(shallow=True)
             state_data = state_payload.pop("data", None)
@@ -384,7 +393,16 @@ class TaskOrchestrationContext(OrchestrationContext):
     ):
         if self.proposed_state is None:
             validated_orm_state = self.run.state
-            state_data = self.run.state.data
+            # We cannot access `self.run.state.data` directly for unknown reasons
+            state_data = (
+                (
+                    await artifacts.read_artifact(
+                        self.session, self.run.state.result_artifact_id
+                    )
+                ).data
+                if self.run.state.result_artifact_id
+                else None
+            )
         else:
             state_payload = self.proposed_state.dict(shallow=True)
             state_data = state_payload.pop("data", None)

--- a/src/prefect/server/orchestration/rules.py
+++ b/src/prefect/server/orchestration/rules.py
@@ -384,7 +384,7 @@ class TaskOrchestrationContext(OrchestrationContext):
     ):
         if self.proposed_state is None:
             validated_orm_state = self.run.state
-            state_data = None
+            state_data = self.run.state.data
         else:
             state_payload = self.proposed_state.dict(shallow=True)
             state_data = state_payload.pop("data", None)

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -582,7 +582,11 @@ async def block_document(session, block_schema, block_type_x):
 
 
 async def commit_task_run_state(
-    session, task_run, state_type: states.StateType, state_details=None
+    session,
+    task_run,
+    state_type: states.StateType,
+    state_details=None,
+    state_data=None,
 ):
     if state_type is None:
         return None
@@ -592,6 +596,7 @@ async def commit_task_run_state(
         type=state_type,
         timestamp=pendulum.now("UTC").subtract(seconds=5),
         state_details=state_details,
+        data=state_data,
     )
 
     result = await models.task_runs.set_task_run_state(
@@ -606,7 +611,11 @@ async def commit_task_run_state(
 
 
 async def commit_flow_run_state(
-    session, flow_run, state_type: states.StateType, state_details=None
+    session,
+    flow_run,
+    state_type: states.StateType,
+    state_details=None,
+    state_data=None,
 ):
     if state_type is None:
         return None
@@ -616,6 +625,7 @@ async def commit_flow_run_state(
         type=state_type,
         timestamp=pendulum.now("UTC").subtract(seconds=5),
         state_details=state_details,
+        data=state_data,
     )
 
     result = await models.flow_runs.set_flow_run_state(
@@ -640,6 +650,7 @@ def initialize_orchestration(flow):
         run_override=None,
         run_tags=None,
         initial_details=None,
+        initial_state_data=None,
         proposed_details=None,
         flow_retries: int = None,
         flow_run_count: int = None,
@@ -703,6 +714,7 @@ def initialize_orchestration(flow):
             run,
             initial_state_type,
             initial_details,
+            state_data=initial_state_data,
         )
 
         proposed_details = proposed_details if proposed_details else dict()

--- a/tests/server/api/test_flow_runs.py
+++ b/tests/server/api/test_flow_runs.py
@@ -1031,24 +1031,6 @@ class TestManuallyRetryingFlowRuns:
         )
         assert restarted_run.state.type == StateType.SCHEDULED
 
-    async def test_only_proposing_scheduled_states_manually_retries(
-        self, failed_flow_run_with_deployment, client, session
-    ):
-        assert failed_flow_run_with_deployment.run_count == 1
-        assert failed_flow_run_with_deployment.deployment_id
-        flow_run_id = failed_flow_run_with_deployment.id
-
-        await client.post(
-            f"/flow_runs/{flow_run_id}/set_state",
-            json=dict(state=dict(type="RUNNING", name="AwaitingRetry")),
-        )
-
-        session.expire_all()
-        restarted_run = await models.flow_runs.read_flow_run(
-            session=session, flow_run_id=flow_run_id
-        )
-        assert restarted_run.state.type == "FAILED"
-
     async def test_cannot_restart_flow_run_without_deployment(
         self, failed_flow_run_without_deployment, client, session
     ):

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1539,12 +1539,12 @@ class TestFlowRetries:
             nonlocal flow_run_count
             flow_run_count += 1
 
-            fut = my_task()
+            state = my_task(return_state=True)
 
             if flow_run_count == 1:
                 raise ValueError()
 
-            return fut
+            return state.result()
 
         assert foo() == "hello"
         assert flow_run_count == 2


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/9012
Closes https://github.com/PrefectHQ/prefect/issues/9292

Previously, transitions out of terminal states were allowed in very specific cases:
- A task run could move from a failed/crashed/cancelled state to running if the flow run was retrying
- A flow run could move to a scheduled (awaiting retry) state

Now, we allow transitions out of terminal states unless the run is completed _and_ has a persisted result. 

This enables the following behaviors:
- A task run that fails and is orchestrated again will run instead of aborting
- A task run that completes but does not persist its result will run again on flow run retry
- A flow run may be rescheduled without using the "awaiting retry" name
- A flow run that fails and is orchestrated again will run instead of aborting

Note above when I say "fails" I am referring to FAILED, CRASHED, and CANCELLED state types.

We do allow some terminal state transitions still:
- We do not allow runs to transition from a terminal state to CANCELLING, CRASHED, or PAUSED

Additionally, we do not abort the transition if a run is completed and has a persisted result. Instead, we reject the transition and return the terminal state. This matches our semantics for rejections and means in the future the client does not need to capture aborts to retrieve the result of finished runs.