### PR TITLE
Mock runtime via environment variable

### DIFF
--- a/docs/concepts/runtime-context.md
+++ b/docs/concepts/runtime-context.md
@@ -15,7 +15,7 @@ Prefect tracks information about the current flow or task run with a run context
 The run context itself is full of internal objects used by Prefect to manage execution of your run and is only available in specific situtations. For this reason, we expose a simple interface that only includes the items you care about and dynamically retrieves additional information when necessary. We call this the "runtime context" as it contains information that can only be accessed when a run is happening.
 
 !!! tip "Mock values via environment variable"
-    Oftentimes you may want to mock certain values for testing purposes, for example by manually setting an ID or a scheduled start time to ensure your code is functioning properly.  Starting in version `2.10.3` you can mock values in runtime via environment variable using the schema `PREFECT__RUNTIME__{SUBMODULE}__{KEY_NAME}=value`:
+    Oftentimes, you may want to mock certain values for testing purposes.  For example, by manually setting an ID or a scheduled start time to ensure your code is functioning properly.  Starting in version `2.10.3`, you can mock values in runtime via environment variable using the schema `PREFECT__RUNTIME__{SUBMODULE}__{KEY_NAME}=value`:
     <div class="terminal">
     ```bash
     $ export PREFECT__RUNTIME__TASK_RUN__FAKE_KEY='foo'

--- a/docs/concepts/runtime-context.md
+++ b/docs/concepts/runtime-context.md
@@ -14,6 +14,16 @@ Prefect tracks information about the current flow or task run with a run context
 
 The run context itself is full of internal objects used by Prefect to manage execution of your run and is only available in specific situtations. For this reason, we expose a simple interface that only includes the items you care about and dynamically retrieves additional information when necessary. We call this the "runtime context" as it contains information that can only be accessed when a run is happening.
 
+!!! tip "Mock values via environment variable"
+    Oftentimes you may want to mock certain values for testing purposes, for example by manually setting an ID or a scheduled start time to ensure your code is functioning properly.  Starting in version `2.10.3` you can mock values in runtime via environment variable using the schema `PREFECT__RUNTIME__{SUBMODULE}__{KEY_NAME}=value`:
+    <div class="terminal">
+    ```bash
+    $ export PREFECT__RUNTIME__TASK_RUN__FAKE_KEY='foo'
+    $ python -c 'from prefect.runtime import task_run; print(task_run.fake_key)' # "foo"
+    ```
+    </div>
+
+
 ## Accessing runtime information
 
 The `prefect.runtime` module is the home for all runtime context access. It has a submodule for each major runtime concept:

--- a/src/prefect/runtime/deployment.py
+++ b/src/prefect/runtime/deployment.py
@@ -3,6 +3,9 @@ Access attributes of the current deployment run dynamically.
 
 Note that if a deployment is not currently being run, all attributes will return empty values.
 
+You can mock the runtime attributes for testing purposes by setting environment variables
+prefixed with `PREFECT__RUNTIME__DEPLOYMENT`.
+
 Example usage:
     ```python
     from prefect.runtime import deployment

--- a/src/prefect/runtime/deployment.py
+++ b/src/prefect/runtime/deployment.py
@@ -41,6 +41,9 @@ def __getattr__(name: str) -> Any:
 
         from prefect.runtime.flow_run import id
     """
+    env_key = f"PREFECT__RUNTIME__DEPLOYMENT__{name.upper()}"
+    if env_key in os.environ:
+        return os.environ[env_key]
     func = FIELDS.get(name)
     if func is None:
         raise AttributeError(f"{__name__} has no attribute {name!r}")

--- a/src/prefect/runtime/flow_run.py
+++ b/src/prefect/runtime/flow_run.py
@@ -3,6 +3,9 @@ Access attributes of the current flow run dynamically.
 
 Note that if a flow run cannot be discovered, all attributes will return empty values.
 
+You can mock the runtime attributes for testing purposes by setting environment variables
+prefixed with `PREFECT__RUNTIME__FLOW_RUN`.
+
 Available attributes:
     - `id`: the flow run's unique ID
     - `tags`: the flow run's set of tags

--- a/src/prefect/runtime/flow_run.py
+++ b/src/prefect/runtime/flow_run.py
@@ -26,6 +26,9 @@ def __getattr__(name: str) -> Any:
 
         from prefect.runtime.flow_run import id
     """
+    env_key = f"PREFECT__RUNTIME__FLOW_RUN__{name.upper()}"
+    if env_key in os.environ:
+        return os.environ[env_key]
     func = FIELDS.get(name)
     if func is None:
         raise AttributeError(f"{__name__} has no attribute {name!r}")

--- a/src/prefect/runtime/task_run.py
+++ b/src/prefect/runtime/task_run.py
@@ -12,6 +12,7 @@ Available attributes:
     - `tags`: the task run's set of tags
     - `parameters`: the parameters the task was called with
 """
+import os
 from typing import Any, Dict, List, Optional
 
 from prefect.context import TaskRunContext

--- a/src/prefect/runtime/task_run.py
+++ b/src/prefect/runtime/task_run.py
@@ -22,6 +22,9 @@ def __getattr__(name: str) -> Any:
 
         from prefect.runtime.task_run import id
     """
+    env_key = f"PREFECT__RUNTIME__TASK_RUN__{name.upper()}"
+    if env_key in os.environ:
+        return os.environ[env_key]
     func = FIELDS.get(name)
     if func is None:
         raise AttributeError(f"{__name__} has no attribute {name!r}")

--- a/src/prefect/runtime/task_run.py
+++ b/src/prefect/runtime/task_run.py
@@ -3,6 +3,9 @@ Access attributes of the current task run dynamically.
 
 Note that if a task run cannot be discovered, all attributes will return empty values.
 
+You can mock the runtime attributes for testing purposes by setting environment variables
+prefixed with `PREFECT__RUNTIME__TASK_RUN`.
+
 Available attributes:
     - `id`: the task run's unique ID
     - `name`: the name of the task run

--- a/tests/runtime/test_deployment.py
+++ b/tests/runtime/test_deployment.py
@@ -29,6 +29,10 @@ class TestAttributeAccessPatterns:
         assert "id" in dir(deployment)
         assert "foo" not in dir(deployment)
 
+    async def test_attribute_override_via_env_var(self, monkeypatch):
+        monkeypatch.setenv(name="PREFECT__RUNTIME__DEPLOYMENT__NEW_KEY", value="foobar")
+        assert deployment.new_key == "foobar"
+
 
 class TestID:
     """

--- a/tests/runtime/test_flow_run.py
+++ b/tests/runtime/test_flow_run.py
@@ -24,6 +24,10 @@ class TestAttributeAccessPatterns:
         assert "id" in dir(flow_run)
         assert "foo" not in dir(flow_run)
 
+    async def test_attribute_override_via_env_var(self, monkeypatch):
+        monkeypatch.setenv(name="PREFECT__RUNTIME__FLOW_RUN__NEW_KEY", value="foobar")
+        assert flow_run.new_key == "foobar"
+
 
 class TestID:
     """

--- a/tests/runtime/test_task_run.py
+++ b/tests/runtime/test_task_run.py
@@ -19,6 +19,10 @@ class TestAttributeAccessPatterns:
         assert "id" in dir(task_run)
         assert "foo" not in dir(task_run)
 
+    async def test_attribute_override_via_env_var(self, monkeypatch):
+        monkeypatch.setenv(name="PREFECT__RUNTIME__TASK_RUN__NEW_KEY", value="foobar")
+        assert task_run.new_key == "foobar"
+
 
 class TestID:
     async def test_id_is_attribute(self):


### PR DESCRIPTION
This PR introduces a mechanism for mocking / manually setting runtime attributes via environment variable.  This was requested by a user looking to test their code and provide explicit known values for the attributes.

<!-- Include an overview here -->

### Example
To do this, a user only needs to set an appropriately prefixed environment variable, e.g., `PREFECT__RUNTIME__TASK_RUN__NEW_KEY="foobar"` and now `prefect.runtime.task_run.new_key` evaluates to `"foobar"`.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
