### PR TITLE
Update `prefect deploy` to pull `flow_name` and `entrypoint` from deployment.yaml if specified

### DIFF
--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -283,11 +283,17 @@ async def deploy(
     if project.get("pull") is None:
         project["pull"] = []
 
-    if not flow_name and not base_deploy["flow_name"] and not entrypoint:
+    # Pull from deployment config if not passed
+    if entrypoint is None:
+        entrypoint = base_deploy.get("entrypoint")
+    if flow_name is None:
+        flow_name = base_deploy.get("flow_name")
+
+    if not flow_name and not entrypoint:
         exit_with_error("An entrypoint or flow name must be provided.")
     if not name and not base_deploy["name"]:
         exit_with_error("A deployment name must be provided.")
-    if (flow_name or base_deploy["flow_name"]) and entrypoint:
+    if flow_name and entrypoint:
         exit_with_error("Can only pass an entrypoint or a flow name but not both.")
 
     # flow-name and entrypoint logic

--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -283,12 +283,6 @@ async def deploy(
     if project.get("pull") is None:
         project["pull"] = []
 
-    # Pull from deployment config if not passed
-    if entrypoint is None:
-        entrypoint = base_deploy.get("entrypoint")
-    if flow_name is None:
-        flow_name = base_deploy.get("flow_name")
-
     if (
         not flow_name
         and not base_deploy.get("flow_name")
@@ -296,9 +290,9 @@ async def deploy(
         and not base_deploy.get("entrypoint")
     ):
         exit_with_error("An entrypoint or flow name must be provided.")
-    if not name and not base_deploy["name"]:
+    if not name and not base_deploy.get("name"):
         exit_with_error("A deployment name must be provided.")
-    if (flow_name or base_deploy["flow_name"]) and entrypoint:
+    if (flow_name or base_deploy.get("flow_name")) and entrypoint:
         exit_with_error("Can only pass an entrypoint or a flow name but not both.")
 
     # Pull from deployment config if not passed

--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -292,7 +292,9 @@ async def deploy(
         exit_with_error("An entrypoint or flow name must be provided.")
     if not name and not base_deploy.get("name"):
         exit_with_error("A deployment name must be provided.")
-    if (flow_name or base_deploy.get("flow_name")) and entrypoint:
+    if (flow_name or base_deploy.get("flow_name")) and (
+        entrypoint or base_deploy.get("entrypoint")
+    ):
         exit_with_error("Can only pass an entrypoint or a flow name but not both.")
 
     # Pull from deployment config if not passed

--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -289,12 +289,23 @@ async def deploy(
     if flow_name is None:
         flow_name = base_deploy.get("flow_name")
 
-    if not flow_name and not entrypoint:
+    if (
+        not flow_name
+        and not base_deploy.get("flow_name")
+        and not entrypoint
+        and not base_deploy.get("entrypoint")
+    ):
         exit_with_error("An entrypoint or flow name must be provided.")
     if not name and not base_deploy["name"]:
         exit_with_error("A deployment name must be provided.")
-    if flow_name and entrypoint:
+    if (flow_name or base_deploy["flow_name"]) and entrypoint:
         exit_with_error("Can only pass an entrypoint or a flow name but not both.")
+
+    # Pull from deployment config if not passed
+    if entrypoint is None:
+        entrypoint = base_deploy.get("entrypoint")
+    if flow_name is None:
+        flow_name = base_deploy.get("flow_name")
 
     # flow-name and entrypoint logic
     flow = None

--- a/src/prefect/projects/templates/deployment.yaml
+++ b/src/prefect/projects/templates/deployment.yaml
@@ -9,7 +9,6 @@ schedule: null
 flow_name: null
 entrypoint: null
 parameters: {}
-parameter_openapi_schema: null
 
 # infra-specific fields
 work_pool:

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -210,9 +210,12 @@ class TestProjectDeploy:
         with open("deployment.yaml", "w") as f:
             yaml.safe_dump(deploy_config, f)
 
-        result = await run_sync_in_worker_thread(invoke_and_assert, command="deploy")
-        assert result.exit_code == 0
-        assert "An important name/test-name" in result.output
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command="deploy",
+            expected_code=0,
+            expected_output_contains="An important name/test-name",
+        )
 
     async def test_project_deploy_reads_entrypoint_from_deployment_yaml(
         self, project_dir, orion_client, work_pool
@@ -228,6 +231,49 @@ class TestProjectDeploy:
         with open("deployment.yaml", "w") as f:
             yaml.safe_dump(deploy_config, f)
 
-        result = await run_sync_in_worker_thread(invoke_and_assert, command="deploy")
-        assert result.exit_code == 0
-        assert "An important name/test-name" in result.output
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command="deploy",
+            expected_code=0,
+            expected_output_contains="An important name/test-name",
+        )
+
+    async def test_project_deploy_exits_with_name_and_entrypoint_passed(
+        self, project_dir, orion_client, work_pool
+    ):
+        create_default_deployment_yaml(".")
+        with open("deployment.yaml", "r") as f:
+            deploy_config = yaml.safe_load(f)
+
+        deploy_config["name"] = "test-name"
+        deploy_config["work_pool"]["name"] = work_pool.name
+
+        with open("deployment.yaml", "w") as f:
+            yaml.safe_dump(deploy_config, f)
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command="deploy -f 'An important name' flows/hello.py:my_flow",
+            expected_code=1,
+            expected_output="Can only pass an entrypoint or a flow name but not both.",
+        )
+
+    async def test_project_deploy_exits_with_no_name_or_entrypoint_configured(
+        self, project_dir, orion_client, work_pool
+    ):
+        create_default_deployment_yaml(".")
+        with open("deployment.yaml", "r") as f:
+            deploy_config = yaml.safe_load(f)
+
+        deploy_config["name"] = "test-name"
+        deploy_config["work_pool"]["name"] = work_pool.name
+
+        with open("deployment.yaml", "w") as f:
+            yaml.safe_dump(deploy_config, f)
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command="deploy",
+            expected_code=1,
+            expected_output="An entrypoint or flow name must be provided.",
+        )

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -9,7 +9,8 @@ import yaml
 
 import prefect
 from prefect.blocks.system import Secret
-from prefect.projects.base import initialize_project
+from prefect.projects import register_flow
+from prefect.projects.base import create_default_deployment_yaml, initialize_project
 from prefect.server.schemas.actions import WorkPoolCreate
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
@@ -193,3 +194,40 @@ class TestProjectDeploy:
                 }
             }
         ]
+
+    async def test_project_deploy_reads_flow_name_from_deployment_yaml(
+        self, project_dir, orion_client, work_pool
+    ):
+        await register_flow("flows/hello.py:my_flow")
+        create_default_deployment_yaml(".")
+        with open("deployment.yaml", "r") as f:
+            deploy_config = yaml.safe_load(f)
+
+        deploy_config["name"] = "test-name"
+        deploy_config["flow_name"] = "An important name"
+        deploy_config["work_pool"]["name"] = work_pool.name
+
+        with open("deployment.yaml", "w") as f:
+            yaml.safe_dump(deploy_config, f)
+
+        result = await run_sync_in_worker_thread(invoke_and_assert, command="deploy")
+        assert result.exit_code == 0
+        assert "An important name/test-name" in result.output
+
+    async def test_project_deploy_reads_entrypoint_from_deployment_yaml(
+        self, project_dir, orion_client, work_pool
+    ):
+        create_default_deployment_yaml(".")
+        with open("deployment.yaml", "r") as f:
+            deploy_config = yaml.safe_load(f)
+
+        deploy_config["name"] = "test-name"
+        deploy_config["entrypoint"] = "flows/hello.py:my_flow"
+        deploy_config["work_pool"]["name"] = work_pool.name
+
+        with open("deployment.yaml", "w") as f:
+            yaml.safe_dump(deploy_config, f)
+
+        result = await run_sync_in_worker_thread(invoke_and_assert, command="deploy")
+        assert result.exit_code == 0
+        assert "An important name/test-name" in result.output


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Updates `prefect deploy` behavior to pull `flow_name` and `entrypoint` to pull from `deployment.yaml` if not specified via the CLI. Previously, `prefect deploy` would exit with an error if `flow_name` or `entrypoint` were not passed, but one of them was defined in `deployment.yaml`.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
With a `deployment.yaml` with `name`, `entrypoint`, and `work_pool.name` configured:
```yaml
# base metadata
name: test-deployment
version: null
tags: []
description: null
schedule: null

# flow-specific fields
flow_name: null
entrypoint: flows/hello.py:flow
parameters: {}

# infra-specific fields
work_pool:
  name: my-pool
  work_queue_name: null
  job_variables: {}
```

A deployment can be created by running `prefect deploy` with no arguments or options.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
