### PR TITLE
Improved recipe initialization UX

### DIFF
--- a/docs/concepts/projects.md
+++ b/docs/concepts/projects.md
@@ -132,7 +132,7 @@ For more information on the mechanics of steps, [see below](#deployment-mechanic
 
 ### The Build Section
 
-The build section of `prefect.yaml` is where any necessary side effects for running your deployments are built - the most common type of side effect produced here is a Docker image.  If we initialize with the docker recipe we are met with a series of prompts to provide required information such as image name and tag: 
+The build section of `prefect.yaml` is where any necessary side effects for running your deployments are built - the most common type of side effect produced here is a Docker image.  If you initialize with the docker recipe, you will be prompted to provide required information, such as image name and tag: 
 
 <div class="terminal">
 ```bash
@@ -161,7 +161,7 @@ build:
     dockerfile: auto
 ```
 
-Once we confirm that these fields are set to their desired values, this step will automatically build a Docker image with the provided name and tag and push it to the repository referenced by the image name.  [As the documentation notes](https://prefecthq.github.io/prefect-docker/projects/steps/#prefect_docker.projects.steps.BuildDockerImageResult), this step produces a few fields that can optionally be used in future steps or within `deployment.yaml` as template values.  It is best practice to use `{{ image_name }}` within `deployment.yaml` (specificially the work pool's job variables section) so that you don't risk having your build step and deployment specification get out of sync with hardcoded values.  For a worked example, [check out the project tutorial](/tutorials/projects/#dockerized-deployment).
+Once you've confirmed that these fields are set to their desired values, this step will automatically build a Docker image with the provided name and tag and push it to the repository referenced by the image name.  [As the documentation notes](https://prefecthq.github.io/prefect-docker/projects/steps/#prefect_docker.projects.steps.BuildDockerImageResult), this step produces a few fields that can optionally be used in future steps or within `deployment.yaml` as template values.  It is best practice to use `{{ image_name }}` within `deployment.yaml` (specificially the work pool's job variables section) so that you don't risk having your build step and deployment specification get out of sync with hardcoded values.  For a worked example, [check out the project tutorial](/tutorials/projects/#dockerized-deployment).
 
 
 !!! note Some steps require Prefect integrations
@@ -224,7 +224,7 @@ There are three main types of steps that typically show up in a `pull` section:
 - `pull_project_from_{cloud}`: this step pulls the project directory from a Cloud storage location (e.g., S3)
 
 !!! tip "Use block and variable references"
-    All [block and variable references](#templating-options) within your pull step will remain unresolved until runtime and will be pulled each time your deployment is run. This allows you to avoid storing sensitive information in an insecure way; it also allows you to manage certain types of configuration from the API and UI without having to rebuild your deployment every time.
+    All [block and variable references](#templating-options) within your pull step will remain unresolved until runtime and will be pulled each time your deployment is run. This allows you to avoid storing sensitive information insecurely; it also allows you to manage certain types of configuration from the API and UI without having to rebuild your deployment every time.
 
 ## The `.prefect/` directory
 

--- a/docs/concepts/projects.md
+++ b/docs/concepts/projects.md
@@ -43,7 +43,6 @@ schedule: null
 # flow-specific fields
 flow_name: null
 entrypoint: null
-path: null
 parameters: {}
 parameter_openapi_schema: null
 
@@ -61,7 +60,7 @@ You can create deployments via the CLI command `prefect deploy` without ever nee
 Values that you place within your `deployment.yaml` file can reference dynamic values in two different ways:
 
 - **step outputs**: every step of both `build` and `push` produce named fields such as `image_name`; you can reference these fields within `deployment.yaml` and `prefect deploy` will populate them with each call.  References must be enclosed in double brackets and be of the form `"{{ field_name }}"`
-- **blocks**: [Prefect blocks](/concepts/blocks) can also be referenced with the special syntax `{{ prefect.blocks.block_type.block_slug }}`
+- **blocks**: [Prefect blocks](/concepts/blocks) can also be referenced with the special syntax `{{ prefect.blocks.block_type.block_slug }}`; it is highly recommended that you use block references for any sensitive information (such as a GitHub access token or any credentials) to avoid hardcoding these values in plaintext
 
 As an example, consider the following `deployment.yaml` file:
 
@@ -133,24 +132,36 @@ For more information on the mechanics of steps, [see below](#deployment-mechanic
 
 ### The Build Section
 
-The build section of `prefect.yaml` is where any necessary side effects for running your deployments are built - the most common type of side effect produced here is a Docker image.  If we initialize with the docker recipe we find a template for such a step: 
+The build section of `prefect.yaml` is where any necessary side effects for running your deployments are built - the most common type of side effect produced here is a Docker image.  If we initialize with the docker recipe we are met with a series of prompts to provide required information such as image name and tag: 
 
 <div class="terminal">
 ```bash
 $ prefect project init --recipe docker
+>> image_name: < insert image name here >
+>> tag: < insert image tag here >
 ```
 </div>
 
+!!! tip "Use `--field` to avoid the interactive experience"
+    We recommend that you only initialize a recipe when you begin a project, and afterwards store your configuration files within version control; however, sometimes you may need to initialize programmatically and avoid the interactive prompts.  To do so, provide all required fields for your recipe using the `--field` flag:
+    <div class="terminal">
+    ```bash
+    $ prefect project init --recipe docker \
+        --field image_name=my-repo/my-image \
+        --field tag=my-tag
+    ```
+    </div>
+    
 ```yaml
 build:
 - prefect_docker.projects.steps.build_docker_image:
     requires: prefect-docker>=0.2.0
-    image_name: null
-    tag: null
+    image_name: my-repo/my-image
+    tag: my-tag
     dockerfile: auto
 ```
 
-Once we edit the `null` fields to their desired values, this step will automatically build a Docker image with the provided name and tag and push it to the repository referenced by the image name.  [As the documentation notes](https://prefecthq.github.io/prefect-docker/projects/steps/#prefect_docker.projects.steps.BuildDockerImageResult), this step produces a few fields that can optionally be used in future steps or within `deployment.yaml` as template values.  It is best practice to use `{{ image_name }}` within `deployment.yaml` (specificially the work pool's job variables section) so that you don't risk having your build step and deployment specification get out of sync with hardcoded values.  For a worked example, [check out the project tutorial](/tutorials/projects/#dockerized-deployment).
+Once we confirm that these fields are set to their desired values, this step will automatically build a Docker image with the provided name and tag and push it to the repository referenced by the image name.  [As the documentation notes](https://prefecthq.github.io/prefect-docker/projects/steps/#prefect_docker.projects.steps.BuildDockerImageResult), this step produces a few fields that can optionally be used in future steps or within `deployment.yaml` as template values.  It is best practice to use `{{ image_name }}` within `deployment.yaml` (specificially the work pool's job variables section) so that you don't risk having your build step and deployment specification get out of sync with hardcoded values.  For a worked example, [check out the project tutorial](/tutorials/projects/#dockerized-deployment).
 
 
 !!! note Some steps require Prefect integrations
@@ -165,6 +176,7 @@ For example, a user wishing to store their project in an S3 bucket and rely on d
 <div class="terminal">
 ```bash
 $ prefect project init --recipe s3
+>> bucket: < insert bucket name here >
 ```
 </div>
 
@@ -172,27 +184,29 @@ Inspecting our newly created `prefect.yaml` file we find that the `push` and `pu
 
 ```yaml
 push:
-  - prefect_aws.projects.steps.pull_project_from_s3:
+  - prefect_aws.projects.steps.push_project_to_s3:
       requires: prefect-aws>=0.3.0
-      bucket: null
+      bucket: my-bucket
       folder: project-name
       credentials: null
 
 pull:
-  - prefect_aws.projects.steps.push_project_to_s3:
+  - prefect_aws.projects.steps.pull_project_from_s3:
       requires: prefect-aws>=0.3.0
-      bucket: null
-      folder: project-name
+      bucket: my-bucket
+      folder: "{{ folder }}"
       credentials: null
 ```
 
-Note that for these steps to function properly, at a minimum we must provide a bucket name; as discussed above, if you are using [blocks](/concepts/blocks/), the credentials section can be templated with a block reference for secure and dynamic credentials access:
+The bucket has been populated with our provided value (which also could have been provided with the `--field` flag); note that the `folder` property of the `push` step is a template - the `pull_project_from_s3` step outputs both a `bucket` value as well as a `folder` value that can be used to template downstream steps.  Doing this helps you keep your steps consistent across edits. 
+
+As discussed above, if you are using [blocks](/concepts/blocks/), the credentials section can be templated with a block reference for secure and dynamic credentials access:
 
 ```yaml
 push:
-  - prefect_aws.projects.steps.pull_project_from_s3:
+  - prefect_aws.projects.steps.push_project_to_s3:
       requires: prefect-aws>=0.3.0
-      bucket: null
+      bucket: my-bucket
       folder: project-name
       credentials: "{{ prefect.blocks.aws-credentials.dev-credentials }}"
 ```
@@ -202,6 +216,15 @@ Anytime you run `prefect deploy`, this `push` section will be executed upon succ
 ### The Pull Section
 
 The pull section is the most important section within the `prefect.yaml` file as it contains instructions for preparing this project for a deployment run.  These instructions will be executed each time a deployment created wthin this project is run via a worker.
+
+There are three main types of steps that typically show up in a `pull` section:
+
+- `set_working_directory`: this step simply sets the working directory for the process prior to importing your flow
+- `git_clone_project`: this step clones the provided repository on the provided branch
+- `pull_project_from_{cloud}`: this step pulls the project directory from a Cloud storage location (e.g., S3)
+
+!!! tip "Use block and variable references"
+    All [block and variable references](#templating-options) within your pull step will remain unresolved until runtime and will be pulled each time your deployment is run. This allows you to avoid storing sensitive information in an insecure way; it also allows you to manage certain types of configuration from the API and UI without having to rebuild your deployment every time.
 
 ## The `.prefect/` directory
 

--- a/docs/tutorials/projects.md
+++ b/docs/tutorials/projects.md
@@ -66,6 +66,8 @@ This command will create your `.prefect/` directory along with the two YAML file
     ```
     </div>
 
+    Providing this flag will prompt you for required variables needed to make the recipe work properly.  If you want to run this CLI programmatically, these required fields can be provided via the `--field` flag: `prefect project init --recipe docker --field image_name=my-image/foo --field tag=dev`.
+
     If no recipe is provided, the `init` command makes an intelligent choice of recipe based on local configuration; for example, if you initialize a project within a git repository, Prefect will automatically use the `git` recipe.
 
 
@@ -213,6 +215,7 @@ A few important notes on what we're looking at here:
     - prefect.projects.steps.git_clone_project:
         repository: https://github.com/PrefectHQ/hello-projects.git
         branch: main
+        access_token: null
     ```
     These `pull` steps are the instructions sent to your worker's runtime environment that allow it to clone your project in remote locations. For more information, see [the project concept documentation](/concepts/projects/).
 
@@ -262,6 +265,7 @@ pull:
 - prefect.projects.steps.git_clone_project:
     repository: https://github.com/PrefectHQ/hello-projects.git
     branch: main
+    access_token: null
 ```
 
 A few notes:

--- a/src/prefect/projects/base.py
+++ b/src/prefect/projects/base.py
@@ -172,7 +172,9 @@ def configure_project_by_recipe(recipe: str, **formatting_kwargs) -> dict:
     return config
 
 
-def initialize_project(name: str = None, recipe: str = None) -> List[str]:
+def initialize_project(
+    name: str = None, recipe: str = None, inputs: dict = None
+) -> List[str]:
     """
     Initializes a basic project structure with base files.  If no name is provided, the name
     of the current directory is used.  If no recipe is provided, one is inferred.
@@ -180,6 +182,7 @@ def initialize_project(name: str = None, recipe: str = None) -> List[str]:
     Args:
         name (str, optional): the name of the project; if not provided, the current directory name
         recipe (str, optional): the name of the recipe to use; if not provided, one is inferred
+        inputs (dict, optional): a dictionary of inputs to use when formatting the recipe
 
     Returns:
         List[str]: a list of files / directories that were created
@@ -230,6 +233,7 @@ def initialize_project(name: str = None, recipe: str = None) -> List[str]:
     elif recipe is None:
         recipe = "local"
 
+    formatting_kwargs.update(inputs or {})
     configuration = configure_project_by_recipe(recipe=recipe, **formatting_kwargs)
 
     project_name = name or dir_name

--- a/src/prefect/projects/recipes/docker-gcs/prefect.yaml
+++ b/src/prefect/projects/recipes/docker-gcs/prefect.yaml
@@ -2,6 +2,11 @@ prefect-version: null
 name: null
 description: "Store project within GCS and build a custom docker image for runtime"
 
+required_inputs:
+  image_name: "The image name, including repository, to give the built Docker image"
+  tag: "The tag to give the built Docker image"
+  bucket: "The bucket to store and retrieve this project from"
+
 build:
   - prefect_docker.projects.steps.build_docker_image:
       requires: "prefect-docker>=0.2.0"
@@ -12,7 +17,7 @@ build:
 push: 
   - prefect_gcp.projects.steps.push_project_to_gcs:
       requires: "prefect-gcp>=0.4.0"
-      bucket: null
+      bucket: "{{ bucket }}"
       folder: "{{ name }}"
 
 pull:

--- a/src/prefect/projects/recipes/docker-git/prefect.yaml
+++ b/src/prefect/projects/recipes/docker-git/prefect.yaml
@@ -2,6 +2,10 @@ prefect-version: null
 name: null
 description: "Store project within a git repository and build a custom docker image for runtime"
 
+required_inputs:
+  image_name: "The image name, including repository, to give the built Docker image"
+  tag: "The tag to give the built Docker image"
+
 build:
   - prefect_docker.projects.steps.build_docker_image:
       requires: "prefect-docker>0.1.0"

--- a/src/prefect/projects/recipes/docker-s3/prefect.yaml
+++ b/src/prefect/projects/recipes/docker-s3/prefect.yaml
@@ -2,6 +2,11 @@ prefect-version: null
 name: null
 description: "Store project within S3 and build a custom docker image for runtime"
 
+required_inputs:
+  image_name: "The image name, including repository, to give the built Docker image"
+  tag: "The tag to give the built Docker image"
+  bucket: "The bucket to store and retrieve this project from"
+
 build:
   - prefect_docker.projects.steps.build_docker_image:
       requires: "prefect-docker>=0.2.0"
@@ -12,7 +17,7 @@ build:
 push: 
   - prefect_aws.projects.steps.push_project_to_s3:
       requires: "prefect-aws>=0.3.0"
-      bucket: null
+      bucket: "{{ bucket }}"
       folder: "{{ name }}"
 
 pull:

--- a/src/prefect/projects/recipes/docker/prefect.yaml
+++ b/src/prefect/projects/recipes/docker/prefect.yaml
@@ -1,12 +1,17 @@
 prefect-version: null
 name: null
+
 description: "Store project within a custom docker image alongside its runtime environment"
+
+required_inputs:
+  image_name: "The image name, including repository, to give the built Docker image"
+  tag: "The tag to give the built Docker image"
 
 build:
   - prefect_docker.projects.steps.build_docker_image:
       requires: "prefect-docker>0.1.0"
-      image_name: null
-      tag: null
+      image_name: "{{ image_name }}"
+      tag: "{{ tag }}"
       dockerfile: "{{ dockerfile }}"
 
 push: null

--- a/src/prefect/projects/recipes/gcs/prefect.yaml
+++ b/src/prefect/projects/recipes/gcs/prefect.yaml
@@ -1,13 +1,16 @@
 prefect-version: null
 name: null
-description: "Store project within GCS bucket"
+description: "Store project within a GCS bucket"
+
+required_inputs:
+  bucket: "The bucket to store and retrieve this project from"
 
 build: null
 
 push: 
   - prefect_gcp.projects.steps.push_project_to_gcs:
       requires: "prefect-gcp>=0.4.0"
-      bucket: null 
+      bucket: "{{ bucket }}" 
       folder: "{{ name }}"
 
 pull:

--- a/src/prefect/projects/recipes/s3/prefect.yaml
+++ b/src/prefect/projects/recipes/s3/prefect.yaml
@@ -1,13 +1,16 @@
 prefect-version: null
 name: null
-description: "Store project within S3 bucket"
+description: "Store project within an S3 bucket"
+
+required_inputs:
+  bucket: "The bucket to store and retrieve this project from"
 
 build: null
 
 push: 
   - prefect_aws.projects.steps.push_project_to_s3:
       requires: "prefect-aws>=0.3.0"
-      bucket: null 
+      bucket: "{{ bucket }}"
       folder: "{{ name }}"
 
 pull:

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -7,6 +7,7 @@ from tempfile import TemporaryDirectory
 import pytest
 import readchar
 import yaml
+from test_cloud import interactive_console  # noqa
 
 import prefect
 from prefect.blocks.system import Secret

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -1,4 +1,5 @@
 import os
+import readchar
 import shutil
 import sys
 from pathlib import Path
@@ -13,6 +14,8 @@ from prefect.projects.base import initialize_project
 from prefect.server.schemas.actions import WorkPoolCreate
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
+
+from test_cloud import interactive_console
 
 TEST_PROJECTS_DIR = prefect.__development_base_path__ / "tests" / "test-projects"
 
@@ -64,6 +67,23 @@ class TestProjectInit:
                 "project init --name test_project --recipe local", temp_dir=str(tempdir)
             )
             assert result.exit_code == 0
+
+    @pytest.mark.usefixtures("interactive_console")
+    def test_project_init_with_interactive_recipe(self):
+        with TemporaryDirectory() as tempdir:
+            result = invoke_and_assert(
+                "project init --name test_project --recipe docker",
+                expected_code=0,
+                temp_dir=str(tempdir),
+                user_input="my-image/foo"
+                + readchar.key.ENTER
+                + "testing"
+                + readchar.key.ENTER,
+                expected_output_contains=[
+                    "image_name:",
+                    "tag:",
+                ],
+            )
 
     def test_project_init_with_unknown_recipe(self):
         result = invoke_and_assert(


### PR DESCRIPTION
This PR introduces a new interactive experience for recipes - all recipes now ship with `required_inputs` that, if not provided, are prompted for whenever initializing that recipe.  These interactive prompts can be avoided by passing the required fields with the new `--field` flag on `project init`.  Documentation has also been updated to reflect this.

### Example
<img width="694" alt="image" src="https://user-images.githubusercontent.com/13255838/230694683-ed125afd-63a3-43f5-a9a8-46b871ce2aa9.png">
produces:

```yaml
# File for configuring project / deployment build, push and pull steps

# Generic metadata about this project
name: hello-projects
prefect-version: 2.10.2+20.gd7df0187c

# build section allows you to manage and build docker images
build:
- prefect_docker.projects.steps.build_docker_image:
    requires: prefect-docker>0.1.0
    image_name: my-image
    tag: my-tag
    dockerfile: auto

# push section allows you to manage if and how this project is uploaded to remote locations
push: null

# pull section allows you to provide instructions for cloning this project in remote locations
pull:
- prefect.projects.steps.set_working_directory:
    directory: /opt/prefect/hello-projects
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
