### PR TITLE
Global flow and task retries and retry delay seconds

### DIFF
--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -245,6 +245,15 @@ from prefect.tasks import exponential_backoff
 )
 ```
 
+You can also set retries and retry delays by using the following global settings. These settings will not override the `retries` or `retry_delay_seconds` that are set in the flow or task decorator. 
+
+```
+prefect config set PREFECT_FLOW_DEFAULT_RETRIES=2
+prefect config set PREFECT_TASK_DEFAULT_RETRIES=2
+prefect config set PREFECT_FLOW_DEFAULT_RETRY_DELAY_SECONDS = [1, 10, 100]
+prefect config set PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS = [1, 10, 100]
+```
+
 !!! note "Retries don't create new task runs"
     A new task run is not created when a task is retried. A new state is added to the state history of the original task run.
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -42,8 +42,16 @@ from prefect.exceptions import (
 from prefect.futures import PrefectFuture
 from prefect.logging import get_logger
 from prefect.results import ResultSerializer, ResultStorage
+<<<<<<< HEAD
 import prefect.server.schemas as schemas
 from prefect.client.schemas import FlowRun
+=======
+from prefect.server.schemas.core import Flow, FlowRun, raise_on_invalid_name
+from prefect.settings import (
+    PREFECT_FLOW_DEFAULT_RETRY_DELAY_SECONDS,
+    PREFECT_FLOWS_DEFAULT_RETRIES,
+)
+>>>>>>> 62e865e0d (Merging and testing)
 from prefect.states import State
 from prefect.task_runners import BaseTaskRunner, ConcurrentTaskRunner
 from prefect.utilities.annotations import NotSet
@@ -129,8 +137,8 @@ class Flow(Generic[P, R]):
         name: Optional[str] = None,
         version: Optional[str] = None,
         flow_run_name: Optional[Union[Callable[[], str], str]] = None,
-        retries: int = 0,
-        retry_delay_seconds: Union[int, float] = 0,
+        retries: Optional[int] = None,
+        retry_delay_seconds: Optional[Union[int, float]] = None,
         task_runner: Union[Type[BaseTaskRunner], BaseTaskRunner] = ConcurrentTaskRunner,
         description: str = None,
         timeout_seconds: Union[int, float] = None,
@@ -195,8 +203,14 @@ class Flow(Generic[P, R]):
         # FlowRunPolicy settings
         # TODO: We can instantiate a `FlowRunPolicy` and add Pydantic bound checks to
         #       validate that the user passes positive numbers here
-        self.retries = retries
-        self.retry_delay_seconds = retry_delay_seconds
+        self.retries = (
+            retries if retries is not None else PREFECT_FLOWS_DEFAULT_RETRIES.value()
+        )
+        self.retry_delay_seconds = (
+            retry_delay_seconds
+            if retry_delay_seconds is not None
+            else PREFECT_FLOW_DEFAULT_RETRY_DELAY_SECONDS.value()
+        )
 
         self.parameters = parameter_schema(self.fn)
         self.should_validate_parameters = validate_parameters
@@ -558,8 +572,8 @@ def flow(
     name: Optional[str] = None,
     version: Optional[str] = None,
     flow_run_name: Optional[Union[Callable[[], str], str]] = None,
-    retries: int = 0,
-    retry_delay_seconds: Union[int, float] = 0,
+    retries: Optional[int] = None,
+    retry_delay_seconds: Optional[Union[int, float]] = None,
     task_runner: BaseTaskRunner = ConcurrentTaskRunner,
     description: str = None,
     timeout_seconds: Union[int, float] = None,

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -42,16 +42,12 @@ from prefect.exceptions import (
 from prefect.futures import PrefectFuture
 from prefect.logging import get_logger
 from prefect.results import ResultSerializer, ResultStorage
-<<<<<<< HEAD
 import prefect.server.schemas as schemas
 from prefect.client.schemas import FlowRun
-=======
-from prefect.server.schemas.core import Flow, FlowRun, raise_on_invalid_name
 from prefect.settings import (
     PREFECT_FLOW_DEFAULT_RETRIES,
     PREFECT_FLOW_DEFAULT_RETRY_DELAY_SECONDS,
 )
->>>>>>> 62e865e0d (Merging and testing)
 from prefect.states import State
 from prefect.task_runners import BaseTaskRunner, ConcurrentTaskRunner
 from prefect.utilities.annotations import NotSet
@@ -206,6 +202,7 @@ class Flow(Generic[P, R]):
         self.retries = (
             retries if retries is not None else PREFECT_FLOW_DEFAULT_RETRIES.value()
         )
+
         self.retry_delay_seconds = (
             retry_delay_seconds
             if retry_delay_seconds is not None
@@ -602,8 +599,8 @@ def flow(
     name: Optional[str] = None,
     version: Optional[str] = None,
     flow_run_name: Optional[Union[Callable[[], str], str]] = None,
-    retries: int = 0,
-    retry_delay_seconds: Union[int, float] = 0,
+    retries: int = None,
+    retry_delay_seconds: Union[int, float] = None,
     task_runner: BaseTaskRunner = ConcurrentTaskRunner,
     description: str = None,
     timeout_seconds: Union[int, float] = None,

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -48,8 +48,8 @@ from prefect.client.schemas import FlowRun
 =======
 from prefect.server.schemas.core import Flow, FlowRun, raise_on_invalid_name
 from prefect.settings import (
+    PREFECT_FLOW_DEFAULT_RETRIES,
     PREFECT_FLOW_DEFAULT_RETRY_DELAY_SECONDS,
-    PREFECT_FLOWS_DEFAULT_RETRIES,
 )
 >>>>>>> 62e865e0d (Merging and testing)
 from prefect.states import State
@@ -204,7 +204,7 @@ class Flow(Generic[P, R]):
         # TODO: We can instantiate a `FlowRunPolicy` and add Pydantic bound checks to
         #       validate that the user passes positive numbers here
         self.retries = (
-            retries if retries is not None else PREFECT_FLOWS_DEFAULT_RETRIES.value()
+            retries if retries is not None else PREFECT_FLOW_DEFAULT_RETRIES.value()
         )
         self.retry_delay_seconds = (
             retry_delay_seconds

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -641,6 +641,30 @@ If `True`, enables a refresh of cached results: re-executing the
 task will refresh the cached results. Defaults to `False`.
 """
 
+PREFECT_TASKS_DEFAULT_RETRIES = Setting(int, default=0)
+"""
+This value sets the retries for all tasks associated with a flow. 
+This value does not overwrite individually set retries values on tasks
+"""
+
+PREFECT_FLOWS_DEFAULT_RETRIES = Setting(int, default=0)
+"""
+This value sets the retries for all flows. 
+This value does not overwrite individually set retries values on a flow
+"""
+
+PREFECT_FLOW_DEFAULT_RETRY_DELAY_SECONDS = Setting(Union[int, float], default=0)
+"""
+This value sets the retry delay seconds for all flows when this environment is set
+This value does not overwrite invidually set retry delay seconds
+"""
+
+PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS = Setting(Union[int, float], default=0)
+"""
+This value sets the retry delay seconds for all flows when this environment is set
+This value does not overwrite invidually set retry delay seconds
+"""
+
 PREFECT_LOCAL_STORAGE_PATH = Setting(
     Path,
     default=Path("${PREFECT_HOME}") / "storage",

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -641,13 +641,13 @@ If `True`, enables a refresh of cached results: re-executing the
 task will refresh the cached results. Defaults to `False`.
 """
 
-PREFECT_TASKS_DEFAULT_RETRIES = Setting(int, default=0)
+PREFECT_TASK_DEFAULT_RETRIES = Setting(int, default=0)
 """
 This value sets the retries for all tasks associated with a flow. 
 This value does not overwrite individually set retries values on tasks
 """
 
-PREFECT_FLOWS_DEFAULT_RETRIES = Setting(int, default=0)
+PREFECT_FLOW_DEFAULT_RETRIES = Setting(int, default=0)
 """
 This value sets the retries for all flows. 
 This value does not overwrite individually set retries values on a flow

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -659,7 +659,9 @@ This value sets the retry delay seconds for all flows when this environment is s
 This value does not overwrite invidually set retry delay seconds
 """
 
-PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS = Setting(Union[int, float], default=0)
+PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS = Setting(
+    Union[float, int, List[float], Callable[[int], List[float]]], default=0
+)
 """
 This value sets the retry delay seconds for all flows when this environment is set
 This value does not overwrite invidually set retry delay seconds

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -660,7 +660,7 @@ This value does not overwrite invidually set retry delay seconds
 """
 
 PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS = Setting(
-    Union[float, int, List[float], Callable[[int], List[float]]], default=0
+    Union[float, int, List[float]], default=0
 )
 """
 This value sets the default retry delay seconds for all tasks.

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -643,19 +643,19 @@ task will refresh the cached results. Defaults to `False`.
 
 PREFECT_TASK_DEFAULT_RETRIES = Setting(int, default=0)
 """
-This value sets the retries for all tasks associated with a flow. 
+This value sets the default number of retries for all tasks.
 This value does not overwrite individually set retries values on tasks
 """
 
 PREFECT_FLOW_DEFAULT_RETRIES = Setting(int, default=0)
 """
-This value sets the retries for all flows. 
+This value sets the default number of retries for all flows. 
 This value does not overwrite individually set retries values on a flow
 """
 
 PREFECT_FLOW_DEFAULT_RETRY_DELAY_SECONDS = Setting(Union[int, float], default=0)
 """
-This value sets the retry delay seconds for all flows when this environment is set
+This value sets the retry delay seconds for all flows.
 This value does not overwrite invidually set retry delay seconds
 """
 
@@ -663,7 +663,7 @@ PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS = Setting(
     Union[float, int, List[float], Callable[[int], List[float]]], default=0
 )
 """
-This value sets the retry delay seconds for all flows when this environment is set
+This value sets the default retry delay seconds for all tasks.
 This value does not overwrite invidually set retry delay seconds
 """
 

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -34,8 +34,8 @@ from prefect.context import PrefectObjectRegistry
 from prefect.futures import PrefectFuture
 from prefect.results import ResultSerializer, ResultStorage
 from prefect.settings import (
+    PREFECT_TASK_DEFAULT_RETRIES,
     PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS,
-    PREFECT_TASKS_DEFAULT_RETRIES,
 )
 from prefect.states import State
 from prefect.utilities.annotations import NotSet
@@ -249,10 +249,10 @@ class Task(Generic[P, R]):
         # TODO: We can instantiate a `TaskRunPolicy` and add Pydantic bound checks to
         #       validate that the user passes positive numbers here
         self.retries = (
-            retries if retries is not None else PREFECT_TASKS_DEFAULT_RETRIES.value()
+            retries if retries is not None else PREFECT_TASK_DEFAULT_RETRIES.value()
         )
         if retry_delay_seconds is None:
-            retry_delay_seconds = PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS
+            retry_delay_seconds = PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS.value()
 
         if callable(retry_delay_seconds):
             self.retry_delay_seconds = retry_delay_seconds(retries)

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -248,9 +248,14 @@ class Task(Generic[P, R]):
         # TaskRunPolicy settings
         # TODO: We can instantiate a `TaskRunPolicy` and add Pydantic bound checks to
         #       validate that the user passes positive numbers here
+        print(retries)
         self.retries = (
             retries if retries is not None else PREFECT_TASK_DEFAULT_RETRIES.value()
         )
+        print(
+            "**********************EIRJGNHVPWEIORNG[OWIERTNGV[OWRIAENTGBV[OIWRANTGBH[PIUNWR]]]]"
+        )
+        print(PREFECT_TASK_DEFAULT_RETRIES.value())
         if retry_delay_seconds is None:
             retry_delay_seconds = PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS.value()
 
@@ -926,13 +931,13 @@ def task(
     cache_key_fn: Callable[["TaskRunContext", Dict[str, Any]], Optional[str]] = None,
     cache_expiration: datetime.timedelta = None,
     task_run_name: Optional[Union[Callable[[], str], str]] = None,
-    retries: int = 0,
+    retries: int = None,
     retry_delay_seconds: Union[
         float,
         int,
         List[float],
         Callable[[int], List[float]],
-    ] = 0,
+    ] = None,
     retry_jitter_factor: Optional[float] = None,
     persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -252,10 +252,6 @@ class Task(Generic[P, R]):
         self.retries = (
             retries if retries is not None else PREFECT_TASK_DEFAULT_RETRIES.value()
         )
-        print(
-            "**********************EIRJGNHVPWEIORNG[OWIERTNGV[OWRIAENTGBV[OIWRANTGBH[PIUNWR]]]]"
-        )
-        print(PREFECT_TASK_DEFAULT_RETRIES.value())
         if retry_delay_seconds is None:
             retry_delay_seconds = PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS.value()
 

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -248,7 +248,7 @@ class Task(Generic[P, R]):
         # TaskRunPolicy settings
         # TODO: We can instantiate a `TaskRunPolicy` and add Pydantic bound checks to
         #       validate that the user passes positive numbers here
-        print(retries)
+
         self.retries = (
             retries if retries is not None else PREFECT_TASK_DEFAULT_RETRIES.value()
         )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -977,6 +977,7 @@ class TestTaskRetries:
                     last_context.start_time < context.start_time
                 ), "Timestamps should be increasing"
 
+    @pytest.mark.parametrize("always_fail", [True, False])
     async def test_global_task_retry_config(self, always_fail):
         with temporary_settings(updates={PREFECT_TASK_DEFAULT_RETRIES: "1"}):
             mock = MagicMock()


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
This PR exposes 4 new global settings that can be set: 

PREFECT_FLOW_DEFAULT_RETRIES,
PREFECT_FLOW_DEFAULT_RETRY_DELAY_SECONDS,
PREFECT_TASK_DEFAULT_RETRIES,
PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS

These values do not overwrite retry or retry delay seconds that are set on the flow/task level. These values will be used if the flow/task does not have a retry/retry delay seconds value set. The default for all of these is 0.

This would solve: https://github.com/PrefectHQ/prefect/issues/9520.
### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
```
prefect config set PREFECT_FLOW_DEFAULT_RETRIES=2
prefect config set PREFECT_TASK_DEFAULT_RETRIES=2
prefect config set PREFECT_FLOW_DEFAULT_RETRY_DELAY_SECONDS = [1, 10, 100]
prefect config set PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS = [1, 10, 100]
```
If retries/retry delay seconds are not set, these values would be used
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
