### PR TITLE
Updated Redoc script source from Redoc CDN to Unpkg

### DIFF
--- a/docs/api-ref/rest-api-reference.md
+++ b/docs/api-ref/rest-api-reference.md
@@ -17,7 +17,7 @@ The Prefect REST API documentation for locally run open-source Prefect servers i
 <hr>
 
 <div id="redoc-container"></div>
-<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>
+<script src="https://www.unpkg.com/redoc@2.x/bundles/redoc.standalone.js"> </script>
 <script>
     Redoc.init('../schema.json', {
         scrollYOffset: 50,

--- a/docs/api-ref/rest-api-reference.md
+++ b/docs/api-ref/rest-api-reference.md
@@ -17,7 +17,7 @@ The Prefect REST API documentation for locally run open-source Prefect servers i
 <hr>
 
 <div id="redoc-container"></div>
-<script src="https://www.unpkg.com/redoc@2.x/bundles/redoc.standalone.js"> </script>
+<script src="https://unpkg.com/redoc@2.x/bundles/redoc.standalone.js"> </script>
 <script>
     Redoc.init('../schema.json', {
         scrollYOffset: 50,

--- a/docs/api-ref/rest-api-reference.md
+++ b/docs/api-ref/rest-api-reference.md
@@ -20,6 +20,7 @@ The Prefect REST API documentation for locally run open-source Prefect servers i
 <script src="https://unpkg.com/redoc@2.x/bundles/redoc.standalone.js"> </script>
 <script>
     Redoc.init('../schema.json', {
-        scrollYOffset: 50,
+        scrollYOffset: 50, 
+        disableSearch: true,
     }, document.getElementById('redoc-container'))
 </script>


### PR DESCRIPTION
**Problem** 
- The REST API reference docs currently don't display correctly due to a CSP issue that prevents the docs site from loading `redoc.standalone.js` from `https://cdn.redoc.ly`. A look in the developer console shows us what's wrong:
  <img width="1053" alt="Screenshot 2023-04-10 at 4 51 34 PM" src="https://user-images.githubusercontent.com/228762/230996494-8badda36-855b-4769-a091-060379bd806a.png">
- Note the presence of https://unpkg.com in the current CSP policy. 

**Solution**
- This PR updates the Redoc JS script source in the REST API docs to use Unpkg instead of `https://cdn.redoc.ly`. Since we've already included `https://unpkg.com` in our CSP policy, this change lets us load Redoc without expanding our CSP policy.
- The PR also uses Unpkg's semver support to request version `2.x` instead of `latest`. This lets us automatically stay up to date with security patches in the 2.x series of Redoc releases without leaving us vulnerable to breaking changes that might appear in the latest version of the library if/when Redoc releases version 3.

### Example
At present, the `Prefect Rest API Reference` page in the docs says "The Prefect REST API documentation for locally run open-source Prefect servers is available below." Unfortunately, nothing appears below:
<img width="1114" alt="Screenshot 2023-04-10 at 4 49 47 PM" src="https://user-images.githubusercontent.com/228762/230996298-4dd48665-2c2f-4e8b-9021-6bd652893efb.png">






### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
