### PR TITLE
Wire up scheduling kwargs to deploy CLI

### DIFF
--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import platform
 import sys
+from datetime import timedelta
 from typing import List, Optional
 
 import pendulum
@@ -24,6 +25,11 @@ from prefect.flows import load_flow_from_entrypoint
 from prefect.logging.configuration import setup_logging
 from prefect.projects import find_prefect_directory, register_flow
 from prefect.projects.steps import run_step
+from prefect.server.schemas.schedules import (
+    CronSchedule,
+    IntervalSchedule,
+    RRuleSchedule,
+)
 from prefect.settings import (
     PREFECT_CLI_COLORS,
     PREFECT_CLI_WRAP_LINES,
@@ -268,9 +274,20 @@ async def deploy(
 
     Should be run from a project root directory.
     """
-    # TODO: add error handling
-    with open("deployment.yaml", "r") as f:
-        base_deploy = yaml.safe_load(f)
+    if len([value for value in (cron, rrule, interval) if value is not None]) > 1:
+        exit_with_error("Only one schedule type can be provided.")
+
+    if interval_anchor and not interval:
+        exit_with_error("An anchor date can only be provided with an interval schedule")
+
+    try:
+        with open("deployment.yaml", "r") as f:
+            base_deploy = yaml.safe_load(f)
+    except FileNotFoundError:
+        app.console.print(
+            "No deployment.yaml file found, defaulting to empty values.", style="orange"
+        )
+        base_deploy = {}
 
     with open("prefect.yaml", "r") as f:
         project = yaml.safe_load(f)
@@ -371,6 +388,31 @@ async def deploy(
 
     base_deploy["parameters"] = parameters
 
+    # update schedule
+    schedule = None
+    if cron:
+        cron_kwargs = {"cron": cron, "timezone": timezone}
+        schedule = CronSchedule(
+            **{k: v for k, v in cron_kwargs.items() if v is not None}
+        )
+    elif interval:
+        interval_kwargs = {
+            "interval": timedelta(seconds=interval),
+            "anchor_date": interval_anchor,
+            "timezone": timezone,
+        }
+        schedule = IntervalSchedule(
+            **{k: v for k, v in interval_kwargs.items() if v is not None}
+        )
+    elif rrule:
+        try:
+            schedule = RRuleSchedule(**json.loads(rrule))
+            if timezone:
+                # override timezone if specified via CLI argument
+                schedule.timezone = timezone
+        except json.JSONDecodeError:
+            schedule = RRuleSchedule(rrule=rrule, timezone=timezone)
+
     ## RUN BUILD AND PUSH STEPS
     step_outputs = {}
     for step in project["build"] + project["push"]:
@@ -396,8 +438,6 @@ async def deploy(
     elif not base_deploy["description"]:
         base_deploy["description"] = flow.description
 
-    # TODO: add schedule
-
     if work_pool_name:
         base_deploy["work_pool"]["name"] = work_pool_name
     if work_queue_name:
@@ -409,6 +449,10 @@ async def deploy(
     _parameter_schema = base_deploy.pop("parameter_openapi_schema")
     base_deploy = apply_values(base_deploy, step_outputs)
     base_deploy["parameter_openapi_schema"] = _parameter_schema
+
+    # set schedule afterwards to avoid templating errors
+    if schedule:
+        base_deploy["schedule"] = schedule
 
     # prepare the pull step
     project["pull"] = apply_values(project["pull"], step_outputs)

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -1,9 +1,11 @@
 import os
 import shutil
 import sys
+from datetime import timedelta
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import pendulum
 import pytest
 import readchar
 import yaml
@@ -367,4 +369,94 @@ class TestProjectDeploy:
             command="deploy",
             expected_code=1,
             expected_output="An entrypoint or flow name must be provided.",
+        )
+
+
+class TestSchedules:
+    async def test_passing_cron_schedules_to_deploy(self, project_dir, orion_client):
+        result = await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=(
+                "deploy ./flows/hello.py:my_flow -n test-name --cron '0 4 * * *'"
+                " --timezone 'Europe/Berlin'"
+            ),
+        )
+        assert result.exit_code == 0
+
+        deployment = await orion_client.read_deployment_by_name(
+            "An important name/test-name"
+        )
+        assert deployment.schedule.cron == "0 4 * * *"
+        assert deployment.schedule.timezone == "Europe/Berlin"
+
+    async def test_passing_interval_schedules_to_deploy(
+        self, project_dir, orion_client
+    ):
+        result = await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=(
+                "deploy ./flows/hello.py:my_flow -n test-name --interval 42"
+                " --anchor-date 2040-02-02 --timezone 'America/New_York'"
+            ),
+        )
+        assert result.exit_code == 0
+
+        deployment = await orion_client.read_deployment_by_name(
+            "An important name/test-name"
+        )
+        assert deployment.schedule.interval == timedelta(seconds=42)
+        assert deployment.schedule.anchor_date == pendulum.parse("2040-02-02")
+        assert deployment.schedule.timezone == "America/New_York"
+
+    async def test_passing_anchor_without_interval_exits(self, project_dir):
+        result = await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=(
+                "deploy ./flows/hello.py:my_flow -n test-name --anchor-date 2040-02-02"
+            ),
+            expected_code=1,
+            expected_output_contains=(
+                "An anchor date can only be provided with an interval schedule"
+            ),
+        )
+
+    async def test_parsing_rrule_schedule_string_literal(
+        self, project_dir, orion_client
+    ):
+        result = await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=(
+                "deploy ./flows/hello.py:my_flow -n test-name "
+                "--rrule"
+                " 'DTSTART:20220910T110000\nRRULE:FREQ=HOURLY;BYDAY=MO,TU,WE,TH,FR,SA;BYHOUR=9,10,11,12,13,14,15,16,17'"
+            ),
+            expected_code=0,
+        )
+
+        deployment = await orion_client.read_deployment_by_name(
+            "An important name/test-name"
+        )
+        assert (
+            deployment.schedule.rrule
+            == "DTSTART:20220910T110000\nRRULE:FREQ=HOURLY;BYDAY=MO,TU,WE,TH,FR,SA;BYHOUR=9,10,11,12,13,14,15,16,17"
+        )
+
+    @pytest.mark.parametrize(
+        "schedules",
+        [
+            ["--cron", "cron-str", "--interval", "42"],
+            ["--rrule", "rrule-str", "--interval", "42"],
+            ["--rrule", "rrule-str", "--cron", "cron-str"],
+            ["--rrule", "rrule-str", "--cron", "cron-str", "--interval", "42"],
+        ],
+    )
+    async def test_providing_multiple_schedules_exits_with_error(
+        self, project_dir, schedules
+    ):
+        result = await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command="deploy ./flows/hello.py:my_flow -n test-name "
+            + " ".join(schedules),
+            expected_code=1,
+            expected_output="Only one schedule type can be provided.",
         )


### PR DESCRIPTION
I was reviewing some of the new projects code paths and found a TODO for wiring up the scheduling kwargs, so I did it!  All kwarg behavior was mirrored directly from `deployment build`.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
