### PR TITLE
refresh FlowRunTimeline when navigating

### DIFF
--- a/ui/src/pages/FlowRun.vue
+++ b/ui/src/pages/FlowRun.vue
@@ -4,7 +4,7 @@
       <PageHeadingFlowRun v-if="flowRun" :flow-run-id="flowRun.id" @delete="goToFlowRuns" />
     </template>
 
-    <FlowRunTimeline v-if="flowRun" :flow-run="flowRun" />
+    <FlowRunTimeline v-if="flowRun" :key="flowRunTimelineKey" :flow-run="flowRun" />
 
     <p-tabs v-model:selected="selectedTab" :tabs="tabs">
       <template #details>
@@ -90,6 +90,8 @@
     return values
   })
 
+  const flowRunTimelineKey = ref(0)
+
   const api = useWorkspaceApi()
   const flowRunDetailsSubscription = useSubscription(api.flowRuns.getFlowRun, [flowRunId], { interval: 5000 })
   const flowRun = computed(() => flowRunDetailsSubscription.response)
@@ -99,6 +101,7 @@
   watch(flowRunId, (oldFlowRunId, newFlowRunId) => {
     if (oldFlowRunId !== newFlowRunId) {
       selectedTab.value = 'Logs'
+      flowRunTimelineKey.value += 1
     }
   })
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Currently, when viewing a flow run that includes sub-flows, directly navigating to the sub-flow's flow run page doesn't update the graph and you end up viewing stale data. This refreshes the graph so that it's redrawn.

<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
