### PR TITLE
Update badge styling in docs

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -161,6 +161,16 @@ to force column width */
     border-radius: 5px;
 }
 
+/* vertical align badges inlined in h2 elements */
+h2 > .badge::before {
+    vertical-align: middle;
+}
+
+/* Avoid displaying badges in the right sidebar */
+.md-sidebar--secondary .badge {
+    display: none;
+}
+
 .badge-api::before {
     background-color: #1860F2;
     color: white;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -161,9 +161,25 @@ to force column width */
     border-radius: 5px;
 }
 
-/* vertical align badges inlined in h2 elements */
-h2 > .badge::before {
-    vertical-align: middle;
+/* apply extra styling to badges inside h1 and h2 elements */
+:where(h1, h2) > .badge::before {
+    position: relative;
+    top: -0.42rem;
+    font-weight: 600;
+    margin-left: 0.25rem;
+    vertical-align: super;
+    font-size: 0.63rem;
+    border-radius: 15px;
+}
+
+:is(h1) > .badge::before {
+    margin-left: 0.4rem;
+}
+
+/* badges appearing immediately after another badge 
+ *  should not have additional left margin */
+:is(.badge + .badge)::before {
+    margin-left: 0;
 }
 
 /* Avoid displaying badges in the right sidebar */


### PR DESCRIPTION
We use badges in the docs to provide visual cues for things we want readers to notice. For example, we might use an Enterprise badge to incate a feature that is only available for Enterprise accounts, like so: <picture><img height="40" align="middle" src="https://user-images.githubusercontent.com/228762/231633408-4e293837-e919-42a9-b114-2ef3218a747e.png"></img></picture>

This generally works well, but unfortunately, Mkdocs' table of contents generator is picking up heading badges and inserting them in the table of contents, resulting in unintended badge proliferation:
 
<table align="center"><tr><td><div align="center"><img width="219" alt="Screenshot 2023-04-12 at 11 32 35 PM" src="https://user-images.githubusercontent.com/228762/231642147-e5728f86-968b-41a0-9a50-31b163358a8c.png"></div>
<div align="center"><strong><sup>A somewhat confusing TOC</sup></strong></div></td></tr></table>
<br />

This PR adds CSS to hide badges in the table of contents. At some point, we may want to avoid including inline badges in headings. Badges might be better as block elements styled using Flexbox instead of pseudo-elements glued to a `span` as they are now. 

However, this would require docs authors to add extra HTML around every heading needing a badge, and adding complexity to docs authoring doesn't feel like the correct choice at this time.

Badges also don't quite look badge-like right now. We're applying `vertical-align: super` to them, but their positioning relative to their headings is only about halfway toward typical superscript elevation:

<br />
<table align="center"><tr><td>
<img width="494" alt="Screenshot 2023-04-13 at 12 11 28 AM" src="https://user-images.githubusercontent.com/228762/231650933-f2d8c7af-f8dd-4f42-a68f-78b7c09ec944.png"><div align="center"><strong><sup>This badge looks like it's not quite sure where it's supposed to be</sup></strong></div></td></tr></table>
<br />

So, this PR also adds CSS to adjust the vertical alignment and border-radius of heading badges. Making our badges look more badge-like should make our docs easier for readers to understand. 

An example of how badges would look after this PR:

<br />
<table><tr><td>
<img width="968" alt="Screenshot 2023-04-13 at 1 26 10 AM" src="https://user-images.githubusercontent.com/228762/231661751-fc205b1c-7f07-441e-a9c4-27178b2077c2.png"><div align="center"><strong><sup>Headings and badges living in harmony</sup></strong></div></td></tr></table>
<br />

I'd be happy to revert the badge repositioning/styling if it's the wrong choice or move it to a separate PR if it needs further discussion.

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->


<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
