### PR TITLE
[enhancement]: Add pull_steps to the base Deployment model

### DIFF
--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -466,7 +466,7 @@ class Deployment(BaseModel):
     timestamp: datetime = Field(default_factory=partial(pendulum.now, "UTC"))
 
     pull_steps: Optional[List[dict]] = Field(
-        default_factory=list,
+        default=None,
         description="Pull steps for cloning and running this deployment.",
     )
 

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -271,6 +271,7 @@ class Deployment(BaseModel):
             if stored on a local filesystem, an absolute path
         entrypoint: The path to the entrypoint for the workflow, always relative to the `path`
         parameter_openapi_schema: The parameter schema of the flow, including defaults.
+        pull_steps: Pull steps for cloning and running this deployment.
 
     Examples:
 
@@ -324,6 +325,7 @@ class Deployment(BaseModel):
             "schedule",
             "is_schedule_active",
             "infra_overrides",
+            "pull_steps",
         ]
 
         # if infrastructure is baked as a pre-saved block, then
@@ -462,6 +464,11 @@ class Deployment(BaseModel):
         description="The parameter schema of the flow, including defaults.",
     )
     timestamp: datetime = Field(default_factory=partial(pendulum.now, "UTC"))
+
+    pull_steps: Optional[List[dict]] = Field(
+        default_factory=list,
+        description="Pull steps for cloning and running this deployment.",
+    )
 
     @validator("infrastructure", pre=True)
     def infrastructure_must_have_capabilities(cls, value):
@@ -706,6 +713,7 @@ class Deployment(BaseModel):
                 storage_document_id=storage_document_id,
                 infrastructure_document_id=infrastructure_document_id,
                 parameter_openapi_schema=self.parameter_openapi_schema.dict(),
+                pull_steps=self.pull_steps,
             )
 
             return deployment_id

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -641,6 +641,29 @@ class TestDeploymentApply:
         dep = await orion_client.read_deployment(dep_id)
         assert dep.is_schedule_active == expected
 
+    @pytest.mark.parametrize(
+        "provided, expected",
+        [([], []), ([{"my_function": {}}], [{"my_function": {}}]), (None, None)],
+    )
+    async def test_deployment_pull_steps_is_set(
+        self, flow_function, provided, expected, orion_client
+    ):
+        d = await Deployment.build_from_flow(
+            flow_function,
+            name="foo",
+            tags=["A", "B"],
+            description="foobar",
+            version="12",
+            pull_steps=provided,
+        )
+        assert d.flow_name == flow_function.name
+        assert d.name == "foo"
+        assert d.pull_steps == provided
+
+        dep_id = await d.apply()
+        dep = await orion_client.read_deployment(dep_id)
+        assert dep.pull_steps == expected
+
 
 class TestRunDeployment:
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

Following an issue related to remote storage in Kubernetes @cicdw pointed me to the new concept of ```project```. Looking at the code project introduces a new concept to the deployment model, which is ```pull_steps```. This exists on the ORM model but is not exposed to the ```prefect.Deployment``` model. This change a  the ```pull_steps``` to the base mdel.
Another issue about that topic is open [#9220](https://github.com/PrefectHQ/prefect/issues/9220)

<!-- Include an overview here -->

### Example

This will allow to create deployment using ```build_from_flow```

``` python

from my_project.flows import my_flow
from prefect.deployments import Deployment

deployment = Deployment.build_from_flow(
      flow=my_flow,
      name="example",
      version="1",
      tags=["demo"],
      pull_steps=[{"prefect.project.steps.pull.set_working_directory": {"directory": "/prefect/workdir"}}]
      )

deployment.apply()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
