### PR TITLE
Emit worker lifecycle events.

### DIFF
--- a/src/prefect/cli/worker.py
+++ b/src/prefect/cli/worker.py
@@ -139,4 +139,7 @@ async def start(
                 )
             )
 
+            started_event = await worker._emit_worker_started_event()
+
+    await worker._emit_worker_stopped_event(started_event)
     app.console.print(f"Worker {worker.name!r} stopped!")

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -981,3 +981,34 @@ class BaseWorker(abc.ABC):
             related=related,
             follows=submitted_event,
         )
+
+    async def _emit_worker_started_event(self):
+        related = []
+        if self._work_pool:
+            related.append(
+                object_as_related_resource(
+                    kind="work-pool", role="work-pool", object=self._work_pool
+                )
+            )
+
+        return emit_event(
+            "prefect.worker.started",
+            resource=self._event_resource(),
+            related=related,
+        )
+
+    async def _emit_worker_stopped_event(self, started_event: Event):
+        related = []
+        if self._work_pool:
+            related.append(
+                object_as_related_resource(
+                    kind="work-pool", role="work-pool", object=self._work_pool
+                )
+            )
+
+        emit_event(
+            "prefect.worker.stopped",
+            resource=self._event_resource(),
+            related=related,
+            follows=started_event,
+        )


### PR DESCRIPTION
This adds events to the worker's lifecycle. It emits an event when the worker starts and another when the worker is stopped.

**Started event**
```json
{
  ...
  "event": "prefect.worker.started",
  "related": [
    {
      "prefect.resource.id": "prefect.work-pool.cd90d075-aade-4931-97d4-2af6fcb2fd4d",
      "prefect.resource.name": "process-pool",
      "prefect.resource.role": "work-pool"
    }
  ],
  "resource": {
    "prefect.version": "2.10.4+4.ge73265d55b",
    "prefect.resource.id": "prefect.worker.process.my-worker",
    "prefect.worker-type": "process",
    "prefect.resource.name": "my-worker"
  },
}
```

**Stopped event**

```json
{
  ...
  "event": "prefect.worker.stopped",
  "related": [
    {
      "prefect.resource.id": "prefect.work-pool.cd90d075-aade-4931-97d4-2af6fcb2fd4d",
      "prefect.resource.name": "process-pool",
      "prefect.resource.role": "work-pool"
    }
  ],
  "resource": {
    "prefect.version": "2.10.4+4.ge73265d55b",
    "prefect.resource.id": "prefect.worker.process.my-worker",
    "prefect.worker-type": "process",
    "prefect.resource.name": "my-worker"
  },
}
```