### PR TITLE
Add `configuration` to `kill_infrastructure` signature

### DIFF
--- a/src/prefect/workers/process.py
+++ b/src/prefect/workers/process.py
@@ -59,8 +59,8 @@ def _parse_infrastructure_pid(infrastructure_pid: str) -> Tuple[str, int]:
 
 
 class ProcessJobConfiguration(BaseJobConfiguration):
-    stream_output: bool
-    working_dir: Optional[Path]
+    stream_output: bool = Field(default=True)
+    working_dir: Optional[Path] = Field(default=None)
 
     @validator("working_dir")
     def validate_command(cls, v):
@@ -195,7 +195,10 @@ class ProcessWorker(BaseWorker):
         )
 
     async def kill_infrastructure(
-        self, infrastructure_pid: str, grace_seconds: int = 30
+        self,
+        infrastructure_pid: str,
+        configuration: ProcessJobConfiguration,
+        grace_seconds: int = 30,
     ):
         hostname, pid = _parse_infrastructure_pid(infrastructure_pid)
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Updates `BaseWorker` to pass `configuration` to `kill_infrastructure` calls which allow worker implementations to retrieve the credentials needed to tear down created infrastructure for flow runs.

This update doesn't affect the `ProcessWorker` since it doesn't rely on a configuration object, but other worker implementations in Prefect integration packages will need pin their `prefect` dependency to the version where this change is implemented. Note that no other workers have implemented flow run cancellation yet.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
