### PR TITLE
Remove outdated warning from task run concurrency UI docs

### DIFF
--- a/docs/ui/task-concurrency.md
+++ b/docs/ui/task-concurrency.md
@@ -35,6 +35,3 @@ On the **Task Run Concurrency** page, you can set concurrency limits on as few o
 Select the **+** button to create a new task run concurrency limit. You'll be able to specify the tag and maximum number of concurrent task runs.
 
 ![Adding a new task run concurrency limit in the Prefect UI](../img/ui/add-concurrency-limit.png)
-
-!!! note "Removing concurrency limits"
-    Currently, to remove a task run concurrency limit, you must use the CLI or Python client. See the [Configuring concurrency limits](/concepts/tasks/#configuring-concurrency-limits) documentation for details.


### PR DESCRIPTION
The task run concurrency UI docs include a warning that you must use the CLI or Python client to delete a task run concurrency limit. This is no longer true; deletion via the UI works now, too.

This PR removes the warning from the docs. 

### Example
Current docs:
<img width="530" alt="image" src="https://user-images.githubusercontent.com/228762/232871079-a4715f19-87c3-447e-a80b-b1791ab9b7f8.png">

Current UI:
<img width="512" alt="image" src="https://user-images.githubusercontent.com/228762/232871626-6fd953cd-f136-414b-9e5b-75cf4ca7ff1c.png">

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
