### PR TITLE
Update `critical_service_loop` to throw a runtime error on failure

### DIFF
--- a/src/prefect/utilities/services.py
+++ b/src/prefect/utilities/services.py
@@ -64,8 +64,6 @@ async def critical_service_loop(
                 failures.append((exc, sys.exc_info()[-1]))
             else:
                 raise
-        except KeyboardInterrupt:
-            return
 
         # Decide whether to exit now based on recent history.
         #
@@ -89,7 +87,7 @@ async def critical_service_loop(
             # We've failed enough times to be sure something is wrong, the writing is
             # on the wall.  Let's explain what we've seen and exit.
             printer(
-                f"\nFailed the last {consecutive} attempts.  "
+                f"\nFailed the last {consecutive} attempts. "
                 "Please check your environment and configuration."
             )
 
@@ -102,7 +100,8 @@ async def critical_service_loop(
             for exception, traceback in failures_by_type:
                 printer("".join(format_exception(None, exception, traceback)))
                 printer()
-            return
+
+            raise RuntimeError("Service exceeded error threshold.")
 
         if run_once:
             return


### PR DESCRIPTION
Fixes bug where the agent hangs when only one of its critical service loops fails.

We've been observing this for a while, but it was not clear what the cause was. It turns out we just _returned_ from this function on error because we assumed it was being used in a context where that would result in an exit. Since the agent now checks for cancelled runs in addition to scheduled runs in separate loops, if one loop failed the agent could continue running without reporting the failure. This almost definitely patches the same bug for workers.

Loosely related to some behavior in #7442 e.g. https://github.com/PrefectHQ/prefect/issues/7442#issuecomment-1515306301
cc @jawnsy who first reported this behavior
Closes #9052 