### PR TITLE
Fix pip requirement inference compatibility with Python 3.11+ and pip 23.1+

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Install packages
         run: |
-          python -m pip install pip==23.0.1
+          python -m pip install -U pip
           # If using not using lower bounds, upgrade eagerly to get the latest versions despite caching
           pip install ${{ ! matrix.lower-bound-requirements && '--upgrade --upgrade-strategy eager' || ''}} -e .[dev]
 

--- a/src/prefect/utilities/compat.py
+++ b/src/prefect/utilities/compat.py
@@ -7,8 +7,10 @@ import shutil
 import sys
 
 if sys.version_info < (3, 10):
+    import importlib_metadata
     from importlib_metadata import EntryPoint, EntryPoints, entry_points
 else:
+    import importlib.metadata as importlib_metadata
     from importlib.metadata import EntryPoint, EntryPoints, entry_points
 
 if sys.version_info < (3, 9):

--- a/tests/software/test_pip.py
+++ b/tests/software/test_pip.py
@@ -39,7 +39,7 @@ def test_current_environment_requirements():
 def test_current_environment_requirements_warns_about_editable_prefect():
     with pytest.warns(
         UserWarning,
-        match=r"prefect.*looks like an editable installation",
+        match=r"prefect.*is an editable installation",
     ):
         requirements = current_environment_requirements(
             on_uninstallable_requirement="warn"
@@ -53,7 +53,7 @@ def test_current_environment_requirements_warns_about_editable_prefect():
 def test_current_environment_requirements_raises_on_editable_prefect():
     with pytest.raises(
         ValueError,
-        match=r"prefect.*looks like an editable installation",
+        match=r"prefect.*is an editable installation",
     ):
         current_environment_requirements(on_uninstallable_requirement="raise")
 


### PR DESCRIPTION
Upgrades from the deprecated `pkg_resources` to `importlib_metadata` for Python 3.11+ compatibility.
Resolves issues inferring if modules are editable for pip 23.1+ compatibility.

Closes https://github.com/PrefectHQ/prefect/issues/9242