### PR TITLE
Ensure agent does not attempt to submit the same run multiple times in a single iteration

### DIFF
--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -188,7 +188,7 @@ class PrefectAgent:
             seconds=self.prefetch_seconds or PREFECT_AGENT_PREFETCH_SECONDS.value()
         )
 
-        submittable_runs: Set[FlowRun] = {}
+        submittable_runs: Set[FlowRun] = set()
 
         if self.work_pool_name:
             responses = await self.client.get_scheduled_flow_runs_for_work_pool(


### PR DESCRIPTION
`submittable_runs` was a list which meant that duplicate runs _could_ end up in it if the API returned multiple copies of a flow run — I'm not sure why the API would do that though.

Prompted by user report at https://prefect-community.slack.com/archives/C04DZJC94DC/p1682011427021729?thread_ts=1682010657.599149&cid=C04DZJC94DC where the agent logs

```
Apr 19 21:44:54.333
prefect-v2-agent
01:44:54.333 | INFO | prefect.agent - Submitting flow run '9d15021f-e169-41c7-b826-3af39c6b9ef0'

Apr 19 21:44:54.315
prefect-v2-agent
01:44:54.314 | INFO | prefect.agent - Submitting flow run '9d15021f-e169-41c7-b826-3af39c6b9ef0'
```