### PR TITLE
add variables fixes

### DIFF
--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -3,7 +3,7 @@ Reduced schemas for accepting API actions.
 """
 import re
 import warnings
-from copy import copy
+from copy import copy, deepcopy
 from typing import Any, Dict, Generator, List, Optional, Union
 from uuid import UUID
 
@@ -172,7 +172,16 @@ class DeploymentCreate(ActionBaseModel):
         and infra_overrides conforms to the specified schema.
         """
         variables_schema = base_job_template.get("variables")
+
         if variables_schema is not None:
+            # jsonschema considers required fields, even if that field has a default,
+            # to still be required. To get around this we remove the fields from
+            # required if there is a default present.
+            required = variables_schema["required"]
+            for k, v in variables_schema["properties"].items():
+                if "default" in v and k in required:
+                    required.remove(k)
+
             jsonschema.validate(self.infra_overrides, variables_schema)
 
 
@@ -243,7 +252,17 @@ class DeploymentUpdate(ActionBaseModel):
         """Check that the combination of base_job_template defaults
         and infra_overrides conforms to the specified schema.
         """
-        variables_schema = base_job_template.get("variables")
+        variables_schema = deepcopy(base_job_template.get("variables"))
+
+        if variables_schema is not None:
+            # jsonschema considers required fields, even if that field has a default,
+            # to still be required. To get around this we remove the fields from
+            # required if there is a default present.
+            required = variables_schema["required"]
+            for k, v in variables_schema["properties"].items():
+                if "default" in v and k in required:
+                    required.remove(k)
+
         if variables_schema is not None:
             jsonschema.validate(self.infra_overrides, variables_schema)
 

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -171,7 +171,7 @@ class DeploymentCreate(ActionBaseModel):
         """Check that the combination of base_job_template defaults
         and infra_overrides conforms to the specified schema.
         """
-        variables_schema = base_job_template.get("variables")
+        variables_schema = deepcopy(base_job_template.get("variables"))
 
         if variables_schema is not None:
             # jsonschema considers required fields, even if that field has a default,

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -177,10 +177,12 @@ class DeploymentCreate(ActionBaseModel):
             # jsonschema considers required fields, even if that field has a default,
             # to still be required. To get around this we remove the fields from
             # required if there is a default present.
-            required = variables_schema["required"]
-            for k, v in variables_schema["properties"].items():
-                if "default" in v and k in required:
-                    required.remove(k)
+            required = variables_schema.get("required")
+            properties = variables_schema.get("properties")
+            if required is not None and properties is not None:
+                for k, v in properties.items():
+                    if "default" in v and k in required:
+                        required.remove(k)
 
             jsonschema.validate(self.infra_overrides, variables_schema)
 
@@ -258,10 +260,12 @@ class DeploymentUpdate(ActionBaseModel):
             # jsonschema considers required fields, even if that field has a default,
             # to still be required. To get around this we remove the fields from
             # required if there is a default present.
-            required = variables_schema["required"]
-            for k, v in variables_schema["properties"].items():
-                if "default" in v and k in required:
-                    required.remove(k)
+            required = variables_schema.get("required")
+            properties = variables_schema.get("properties")
+            if required is not None and properties is not None:
+                for k, v in properties.items():
+                    if "default" in v and k in required:
+                        required.remove(k)
 
         if variables_schema is not None:
             jsonschema.validate(self.infra_overrides, variables_schema)

--- a/tests/server/schemas/test_actions.py
+++ b/tests/server/schemas/test_actions.py
@@ -121,6 +121,25 @@ class TestDeploymentCreate:
         # make sure the required fields are still there
         assert "my-field" in base_job_template["variables"]["required"]
 
+        # This should also pass
+        base_job_template = {
+            "variables": {
+                "type": "object",
+                "required": ["my-field"],
+                "properties": {
+                    "my-field": {
+                        "type": "string",
+                        "title": "My Field",
+                        "default": "my-default-for-my-field",
+                    },
+                },
+            }
+        }
+        deployment_create = DeploymentUpdate(
+            infra_overrides={"my_field": "my_value"},
+        )
+        deployment_create.check_valid_configuration(base_job_template)
+
 
 class TestDeploymentUpdate:
     def test_update_with_worker_pool_queue_id_warns(self):
@@ -162,7 +181,7 @@ class TestDeploymentUpdate:
 
     def test_check_valid_configuration_removes_required_if_defaults_exist(self):
         # This should fail because my-field is required but has no default
-        deployment_create = DeploymentUpdate(
+        deployment_update = DeploymentUpdate(
             infra_overrides={},
         )
 
@@ -179,7 +198,7 @@ class TestDeploymentUpdate:
             }
         }
         with pytest.raises(jsonschema.ValidationError) as excinfo:
-            deployment_create.check_valid_configuration(base_job_template)
+            deployment_update.check_valid_configuration(base_job_template)
         assert excinfo.value.message == "'my-field' is a required property"
 
         # This should pass because the value has a default
@@ -196,10 +215,29 @@ class TestDeploymentUpdate:
                 },
             }
         }
-        deployment_create.check_valid_configuration(base_job_template)
+        deployment_update.check_valid_configuration(base_job_template)
 
         # make sure the required fields are still there
         assert "my-field" in base_job_template["variables"]["required"]
+
+        # This should also pass
+        base_job_template = {
+            "variables": {
+                "type": "object",
+                "required": ["my-field"],
+                "properties": {
+                    "my-field": {
+                        "type": "string",
+                        "title": "My Field",
+                        "default": "my-default-for-my-field",
+                    },
+                },
+            }
+        }
+        deployment_update = DeploymentUpdate(
+            infra_overrides={"my_field": "my_value"},
+        )
+        deployment_update.check_valid_configuration(base_job_template)
 
 
 class TestBlockTypeUpdate:

--- a/tests/server/schemas/test_actions.py
+++ b/tests/server/schemas/test_actions.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+import jsonschema
 import numpy as np
 import pytest
 
@@ -78,6 +79,48 @@ class TestDeploymentCreate:
         for key in kwargs.keys():
             assert getattr(deployment_create, key, 0) == 0
 
+    def test_check_valid_configuration_removes_required_if_defaults_exist(self):
+        # This should fail because my-field is required but has no default
+        deployment_create = DeploymentCreate(
+            name="test-deployment",
+            infra_overrides={},
+        )
+
+        base_job_template = {
+            "variables": {
+                "type": "object",
+                "required": ["my-field"],
+                "properties": {
+                    "my-field": {
+                        "type": "string",
+                        "title": "My Field",
+                    },
+                },
+            }
+        }
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            deployment_create.check_valid_configuration(base_job_template)
+        assert excinfo.value.message == "'my-field' is a required property"
+
+        # This should pass because the value has a default
+        base_job_template = {
+            "variables": {
+                "type": "object",
+                "required": ["my-field"],
+                "properties": {
+                    "my-field": {
+                        "type": "string",
+                        "title": "My Field",
+                        "default": "my-default-for-my-field",
+                    },
+                },
+            }
+        }
+        deployment_create.check_valid_configuration(base_job_template)
+
+        # make sure the required fields are still there
+        assert "my-field" in base_job_template["variables"]["required"]
+
 
 class TestDeploymentUpdate:
     def test_update_with_worker_pool_queue_id_warns(self):
@@ -116,6 +159,47 @@ class TestDeploymentUpdate:
 
         for key in kwargs.keys():
             assert getattr(deployment_update, key, 0) == 0
+
+    def test_check_valid_configuration_removes_required_if_defaults_exist(self):
+        # This should fail because my-field is required but has no default
+        deployment_create = DeploymentUpdate(
+            infra_overrides={},
+        )
+
+        base_job_template = {
+            "variables": {
+                "type": "object",
+                "required": ["my-field"],
+                "properties": {
+                    "my-field": {
+                        "type": "string",
+                        "title": "My Field",
+                    },
+                },
+            }
+        }
+        with pytest.raises(jsonschema.ValidationError) as excinfo:
+            deployment_create.check_valid_configuration(base_job_template)
+        assert excinfo.value.message == "'my-field' is a required property"
+
+        # This should pass because the value has a default
+        base_job_template = {
+            "variables": {
+                "type": "object",
+                "required": ["my-field"],
+                "properties": {
+                    "my-field": {
+                        "type": "string",
+                        "title": "My Field",
+                        "default": "my-default-for-my-field",
+                    },
+                },
+            }
+        }
+        deployment_create.check_valid_configuration(base_job_template)
+
+        # make sure the required fields are still there
+        assert "my-field" in base_job_template["variables"]["required"]
 
 
 class TestBlockTypeUpdate:


### PR DESCRIPTION
Ensure that if under the `variables` schema of `Workpool.base_job_template`, if there is a required field that has a default, the required-ness of the field is ignored because we can expect the field to be populated via the default