### PR TITLE
Ensure workers only create one client while running

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, PrivateAttr, validator
 import prefect
 from prefect._internal.compatibility.experimental import experimental
 from prefect.client.orchestration import PrefectClient, get_client
+from prefect.client.utilities import inject_client
 from prefect.engine import propose_state
 from prefect.events import Event, emit_event
 from prefect.events.related import object_as_related_resource, tags_as_related_resources
@@ -100,7 +101,10 @@ class BaseJobConfiguration(BaseModel):
         return defaults
 
     @classmethod
-    async def from_template_and_values(cls, base_job_template: dict, values: dict):
+    @inject_client
+    async def from_template_and_values(
+        cls, base_job_template: dict, values: dict, client: "PrefectClient" = None
+    ):
         """Creates a valid worker configuration object from the provided base
         configuration and overrides.
 
@@ -113,9 +117,11 @@ class BaseJobConfiguration(BaseModel):
             variables_schema.get("properties", {})
         )
         variables.update(values)
-        variables = await resolve_block_document_references(variables)
+        variables = await resolve_block_document_references(
+            template=variables, client=client
+        )
 
-        populated_configuration = apply_values(job_config, variables)
+        populated_configuration = apply_values(template=job_config, values=variables)
         return cls(**populated_configuration)
 
     @classmethod
@@ -798,6 +804,7 @@ class BaseWorker(abc.ABC):
         configuration = await self.job_configuration.from_template_and_values(
             base_job_template=self._work_pool.base_job_template,
             values=deployment.infra_overrides or {},
+            client=self._client,
         )
         configuration.prepare_for_flow_run(
             flow_run=flow_run, deployment=deployment, flow=flow


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Workers create multiple client contexts during normal operation. Each worker creates a client context which should be reused during the lifespan of the worker. 

This PR adds a `inject_client` decorator to `from_template_and_values` on the `BaseConfiguration` class and updates the `BaseWorker` to pass its client into `from_template_and_values` to prevent recreating a client context. A test has also be added to verify that only one client context is created.

Closes #9301 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
