### PR TITLE
filter flows by work pool

### DIFF
--- a/src/prefect/server/api/flows.py
+++ b/src/prefect/server/api/flows.py
@@ -79,7 +79,7 @@ async def count_flows(
             flow_run_filter=flow_runs,
             task_run_filter=task_runs,
             deployment_filter=deployments,
-            work_pools_filter=work_pools,
+            work_pool_filter=work_pools,
         )
 
 

--- a/src/prefect/server/api/flows.py
+++ b/src/prefect/server/api/flows.py
@@ -66,6 +66,7 @@ async def count_flows(
     flow_runs: schemas.filters.FlowRunFilter = None,
     task_runs: schemas.filters.TaskRunFilter = None,
     deployments: schemas.filters.DeploymentFilter = None,
+    work_pools: schemas.filters.WorkPoolFilter = None,
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> int:
     """
@@ -78,6 +79,7 @@ async def count_flows(
             flow_run_filter=flow_runs,
             task_run_filter=task_runs,
             deployment_filter=deployments,
+            work_pools_filter=work_pools,
         )
 
 
@@ -123,6 +125,7 @@ async def read_flows(
     flow_runs: schemas.filters.FlowRunFilter = None,
     task_runs: schemas.filters.TaskRunFilter = None,
     deployments: schemas.filters.DeploymentFilter = None,
+    work_pools: schemas.filters.WorkPoolFilter = None,
     sort: schemas.sorting.FlowSort = Body(schemas.sorting.FlowSort.NAME_ASC),
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> List[schemas.core.Flow]:
@@ -136,6 +139,7 @@ async def read_flows(
             flow_run_filter=flow_runs,
             task_run_filter=task_runs,
             deployment_filter=deployments,
+            work_pools=work_pools,
             sort=sort,
             offset=offset,
             limit=limit,

--- a/src/prefect/server/api/flows.py
+++ b/src/prefect/server/api/flows.py
@@ -139,7 +139,7 @@ async def read_flows(
             flow_run_filter=flow_runs,
             task_run_filter=task_runs,
             deployment_filter=deployments,
-            work_pools=work_pools,
+            work_pool_filter=work_pools,
             sort=sort,
             offset=offset,
             limit=limit,

--- a/src/prefect/server/models/flows.py
+++ b/src/prefect/server/models/flows.py
@@ -120,6 +120,7 @@ async def _apply_flow_filters(
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
     deployment_filter: schemas.filters.DeploymentFilter = None,
+    work_pool_filter: schemas.filters.WorkPoolFilter = None,
 ):
     """
     Applies filters to a flow query as a combination of EXISTS subqueries.
@@ -128,11 +129,26 @@ async def _apply_flow_filters(
     if flow_filter:
         query = query.where(flow_filter.as_sql_filter(db))
 
-    if deployment_filter:
-        exists_clause = select(db.Deployment).where(
-            db.Deployment.flow_id == db.Flow.id,
-            deployment_filter.as_sql_filter(db),
+    if deployment_filter or work_pool_filter:
+        exists_clause = select(db.orm.Deployment).where(
+            db.orm.Deployment.flow_id == db.orm.Flow.id
         )
+
+        if deployment_filter:
+            exists_clause = select(db.orm.Deployment).where(
+                db.orm.Deployment.flow_id == db.orm.Flow.id,
+                deployment_filter.as_sql_filter(db),
+            )
+
+        if work_pool_filter:
+            exists_clause = exists_clause.join(
+                db.orm.WorkQueue, db.orm.WorkQueue.id == db.orm.Deployment.work_queue_id
+            )
+            exists_clause = exists_clause.join(
+                db.orm.WorkPool,
+                db.orm.WorkPool.id == db.orm.WorkQueue.work_pool_id,
+            ).where(work_pool_filter.as_sql_filter(db))
+
         query = query.where(exists_clause.exists())
 
     if flow_run_filter or task_run_filter:
@@ -160,6 +176,7 @@ async def read_flows(
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
     deployment_filter: schemas.filters.DeploymentFilter = None,
+    work_pool_filter: schemas.filters.WorkPoolFilter = None,
     sort: schemas.sorting.FlowSort = schemas.sorting.FlowSort.NAME_ASC,
     offset: int = None,
     limit: int = None,
@@ -173,6 +190,7 @@ async def read_flows(
         flow_run_filter: only select flows whose flow runs match these filters
         task_run_filter: only select flows whose task runs match these filters
         deployment_filter: only select flows whose deployments match these filters
+        work_pool_filter: only select flows whose work pools match these filters
         offset: Query offset
         limit: Query limit
 
@@ -188,6 +206,7 @@ async def read_flows(
         flow_run_filter=flow_run_filter,
         task_run_filter=task_run_filter,
         deployment_filter=deployment_filter,
+        work_pool_filter=work_pool_filter,
         db=db,
     )
 
@@ -209,6 +228,7 @@ async def count_flows(
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
     deployment_filter: schemas.filters.DeploymentFilter = None,
+    work_pool_filter: schemas.filters.WorkPoolFilter = None,
 ) -> int:
     """
     Count flows.
@@ -219,6 +239,7 @@ async def count_flows(
         flow_run_filter: only count flows whose flow runs match these filters
         task_run_filter: only count flows whose task runs match these filters
         deployment_filter: only count flows whose deployments match these filters
+        work_pool_filter: only count flows whose work pools match these filters
 
     Returns:
         int: count of flows
@@ -232,6 +253,7 @@ async def count_flows(
         flow_run_filter=flow_run_filter,
         task_run_filter=task_run_filter,
         deployment_filter=deployment_filter,
+        work_pool_filter=work_pool_filter,
         db=db,
     )
 

--- a/src/prefect/server/models/flows.py
+++ b/src/prefect/server/models/flows.py
@@ -135,8 +135,7 @@ async def _apply_flow_filters(
         )
 
         if deployment_filter:
-            exists_clause = select(db.orm.Deployment).where(
-                db.orm.Deployment.flow_id == db.orm.Flow.id,
+            exists_clause = exists_clause.where(
                 deployment_filter.as_sql_filter(db),
             )
 

--- a/tests/server/api/test_flows.py
+++ b/tests/server/api/test_flows.py
@@ -273,6 +273,49 @@ class TestReadFlows:
         assert len(response.json()) == 1
         assert UUID(response.json()[0]["id"]) == flow_1.id
 
+    async def test_read_flows_applies_work_pool(self, client, session, work_pool):
+        flow_1 = await models.flows.create_flow(
+            session=session,
+            flow=schemas.core.Flow(name="my-flow-1", tags=["db", "blue"]),
+        )
+        await models.flows.create_flow(
+            session=session, flow=schemas.core.Flow(name="my-flow-2", tags=["db"])
+        )
+        await session.commit()
+
+        response = await client.post("/flows/filter")
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()) == 2
+
+        # work queue
+        work_queue = await models.workers.create_work_queue(
+            session=session,
+            work_pool_id=work_pool.id,
+            work_queue=schemas.actions.WorkQueueCreate(name="test-queue"),  # type: ignore
+        )
+        # deployment
+        await models.deployments.create_deployment(
+            session=session,
+            deployment=schemas.core.Deployment(
+                name="My Deployment X",
+                manifest_path="file.json",
+                flow_id=flow_1.id,
+                is_schedule_active=True,
+                work_queue_id=work_queue.id,
+            ),
+        )
+        await session.commit()
+
+        work_pool_filter = dict(
+            work_pools=schemas.filters.WorkPoolFilter(
+                id=schemas.filters.WorkPoolFilterId(any_=[work_pool.id])
+            ).dict(json_compatible=True)
+        )
+        response = await client.post("/flows/filter", json=work_pool_filter)
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()) == 1
+        assert UUID(response.json()[0]["id"]) == flow_1.id
+
     async def test_read_flows_offset(self, flows, client):
         # right now this works because flows are ordered by name
         # by default, when ordering is actually implemented, this test


### PR DESCRIPTION
OSS implementation of https://github.com/PrefectHQ/nebula/pull/4439

Add work pool filtering to `/flows/filter`. This allows for extra filtering on the work pool on the related deployment of a flow if exists.

Example usage:
```
  res = await client.post(
      "/flows/filter", 
      json={'work_pools': {'id': {'any_': ['4794ea7b-14a0-4ea3-9b1a-22ae07329a3d']},
                'name': None,
                'operator': 'and_',
                'type': None}}
)
```

This is implemented similarly to how flows can be filtered by task runs if they exist for the flow.