### PR TITLE
Fix `flow-run logs` limit

### DIFF
--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -199,7 +199,9 @@ async def logs(
             num_logs_to_return_from_page = (
                 LOGS_DEFAULT_PAGE_SIZE
                 if user_specified_num_logs is None
-                else min(LOGS_DEFAULT_PAGE_SIZE, user_specified_num_logs)
+                else min(
+                    LOGS_DEFAULT_PAGE_SIZE, user_specified_num_logs - num_logs_returned
+                )
             )
 
             # Get the next page of logs

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -448,6 +448,30 @@ class TestFlowRunLogs:
             expected_line_count=self.LOGS_DEFAULT_PAGE_SIZE + 1,
         )
 
+    async def test_when_num_logs_greater_than_page_size_with_head_outputs_correct_num_logs(
+        self, flow_run_factory
+    ):
+        flow_run = await flow_run_factory(num_logs=self.LOGS_DEFAULT_PAGE_SIZE + 50)
+
+        # When/Then
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=[
+                "flow-run",
+                "logs",
+                str(flow_run.id),
+                "--head",
+                "--num-logs",
+                self.LOGS_DEFAULT_PAGE_SIZE + 50,
+            ],
+            expected_code=0,
+            expected_output_contains=[
+                f"Flow run '{flow_run.name}' - Log {i} from flow_run {flow_run.id}."
+                for i in range(self.LOGS_DEFAULT_PAGE_SIZE + 50)
+            ],
+            expected_line_count=self.LOGS_DEFAULT_PAGE_SIZE + 50,
+        )
+
     async def test_default_head_returns_default_num_logs(self, flow_run_factory):
         # Given
         flow_run = await flow_run_factory(num_logs=self.LOGS_DEFAULT_PAGE_SIZE + 1)


### PR DESCRIPTION
When using the CLI to retrieve flow run logs, if the `num_logs` to return was >= `LOGS_DEFAULT_PAGE_SIZE`, the limit wasn't being recalculated correctly in the loop. Instead, all logs were being returned if the specified `num_logs` was 200+. With this fix, specifying 205 logs, for example, should return 205 logs.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
