### PR TITLE
Fix `future.result()` and `future.wait()` calls from async contexts

### DIFF
--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -22,7 +22,7 @@ from uuid import UUID
 
 import anyio
 
-from prefect._internal.concurrency.api import create_call, from_sync
+from prefect._internal.concurrency.api import create_call, from_async, from_sync
 from prefect._internal.concurrency.event_loop import run_coroutine_in_loop_from_async
 from prefect.client.orchestration import PrefectClient
 from prefect.client.utilities import inject_client
@@ -154,11 +154,12 @@ class PrefectFuture(Generic[R, A]):
         If the timeout is reached before the run reaches a final state,
         `None` is returned.
         """
+        wait = create_call(self._wait, timeout=timeout)
         if self.asynchronous:
-            return self._wait(timeout=timeout)
+            return from_async.call_soon_in_loop_thread(wait).aresult()
         else:
             # type checking cannot handle the overloaded timeout passing
-            return from_sync.call_soon_in_loop_thread(create_call(self._wait, timeout=timeout)).result()  # type: ignore
+            return from_sync.call_soon_in_loop_thread(wait).result()  # type: ignore
 
     @overload
     async def _wait(self, timeout: None = None) -> State[R]:
@@ -222,14 +223,13 @@ class PrefectFuture(Generic[R, A]):
         If `raise_on_failure` is `True` and the task run failed, the task run's
         exception will be raised.
         """
+        result = create_call(
+            self._result, timeout=timeout, raise_on_failure=raise_on_failure
+        )
         if self.asynchronous:
-            return self._result(timeout=timeout, raise_on_failure=raise_on_failure)
+            return from_async.call_soon_in_loop_thread(result).aresult()
         else:
-            return from_sync.call_soon_in_loop_thread(
-                create_call(
-                    self._result, timeout=timeout, raise_on_failure=raise_on_failure
-                )
-            ).result()
+            return from_sync.call_soon_in_loop_thread(result).result()
 
     async def _result(self, timeout: float = None, raise_on_failure: bool = True):
         """


### PR DESCRIPTION
Ensures that futures retrieve results from the same event loop as the task runner is managed in. Otherwise, mixed event loops can cause bugs — i.e. the Dask client does not detect that it is being used in asynchronous context because the event loops do not match.

Closes https://github.com/PrefectHQ/prefect-dask/issues/91
