### PR TITLE
Update `QueueService.send` to wait for the item to be placed in the queue before returning

### DIFF
--- a/src/prefect/_internal/concurrency/event_loop.py
+++ b/src/prefect/_internal/concurrency/event_loop.py
@@ -38,8 +38,11 @@ def call_in_loop(
 
     Returns the result of the call.
     """
-    future = call_soon_in_loop(__loop, __fn, *args, **kwargs)
-    return future.result()
+    if __loop is get_running_loop():
+        return __fn(*args, **kwargs)
+    else:
+        future = call_soon_in_loop(__loop, __fn, *args, **kwargs)
+        return future.result()
 
 
 def call_soon_in_loop(

--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -87,7 +87,7 @@ class QueueService(abc.ABC, Generic[T]):
             self._remove_instance()
 
             self._stopped = True
-            call_soon_in_loop(self._loop, self._queue.put_nowait, None)
+            call_soon_in_loop(self._loop, self._queue.put_nowait, None).result()
 
     def send(self, item: T):
         """
@@ -104,7 +104,7 @@ class QueueService(abc.ABC, Generic[T]):
             else:
                 call_soon_in_loop(
                     self._loop, self._queue.put_nowait, self._prepare_item(item)
-                )
+                ).result()
 
     def _prepare_item(self, item: T) -> T:
         """

--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -12,7 +12,7 @@ import anyio
 from typing_extensions import Self
 
 from prefect._internal.concurrency.api import create_call, from_sync
-from prefect._internal.concurrency.event_loop import call_soon_in_loop, get_running_loop
+from prefect._internal.concurrency.event_loop import call_in_loop, get_running_loop
 from prefect._internal.concurrency.threads import get_global_loop
 from prefect.logging import get_logger
 
@@ -87,7 +87,7 @@ class QueueService(abc.ABC, Generic[T]):
             self._remove_instance()
 
             self._stopped = True
-            call_soon_in_loop(self._loop, self._queue.put_nowait, None).result()
+            call_in_loop(self._loop, self._queue.put_nowait, None)
 
     def send(self, item: T):
         """
@@ -102,9 +102,9 @@ class QueueService(abc.ABC, Generic[T]):
             if not self._started:
                 self._early_items.append(item)
             else:
-                call_soon_in_loop(
+                call_in_loop(
                     self._loop, self._queue.put_nowait, self._prepare_item(item)
-                ).result()
+                )
 
     def _prepare_item(self, item: T) -> T:
         """


### PR DESCRIPTION
Fixes race conditions where items may not be fully sent before the service is drained.

Example flake at https://github.com/PrefectHQ/prefect/actions/runs/4789808505/jobs/8518118439?pr=9316