### PR TITLE
Raise `UnfinishedRun` instead of `MissingResult` when state is not final

### DIFF
--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -91,6 +91,14 @@ class PausedRun(PrefectException):
     """
 
 
+class UnfinishedRun(PrefectException):
+    """
+    Raised when the result from a run that is not finished is retrieved.
+
+    For example, if a run is in a SCHEDULED, PENDING, CANCELLING, or RUNNING state.
+    """
+
+
 class MissingFlowError(PrefectException):
     """
     Raised when a given flow name is not found in the expected script.

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -20,6 +20,7 @@ from prefect.exceptions import (
     CancelledRun,
     CrashedRun,
     FailedRun,
+    UnfinishedRun,
     MissingResult,
     PausedRun,
 )
@@ -78,6 +79,11 @@ async def _get_state_result(state: State[R], raise_on_failure: bool) -> R:
     if state.is_paused():
         # Paused states are not truly terminal and do not have results associated with them
         raise PausedRun("Run paused.")
+
+    if not state.is_final():
+        raise UnfinishedRun(
+            f"Run is in {state.type.name} state, its result is not available."
+        )
 
     if raise_on_failure and (
         state.is_crashed() or state.is_failed() or state.is_cancelled()

--- a/tests/results/test_state_result.py
+++ b/tests/results/test_state_result.py
@@ -28,7 +28,7 @@ async def test_unfinished_states_raise_on_result_retrieval(
     "state_type",
     [StateType.CRASHED, StateType.COMPLETED, StateType.FAILED, StateType.CANCELLED],
 )
-async def test_finished_states_allow_result_retrival(state_type: StateType):
+async def test_finished_states_allow_result_retrieval(state_type: StateType):
     state = State(type=state_type, data=await UnpersistedResult.create("test"))
 
     assert await state.result(raise_on_failure=False) == "test"

--- a/tests/results/test_state_result.py
+++ b/tests/results/test_state_result.py
@@ -1,0 +1,34 @@
+"""
+Generic tests for `State.result`
+"""
+
+from prefect.exceptions import UnfinishedRun
+from prefect.states import State, StateType
+from prefect.results import UnpersistedResult
+import pytest
+
+
+@pytest.mark.parametrize(
+    "state_type",
+    [StateType.PENDING, StateType.RUNNING, StateType.SCHEDULED, StateType.CANCELLING],
+)
+@pytest.mark.parametrize("raise_on_failure", [True, False])
+async def test_unfinished_states_raise_on_result_retrieval(
+    state_type: StateType, raise_on_failure: bool
+):
+    # We'll even attach a result to the state, but it shouldn't matter
+    state = State(type=state_type, data=await UnpersistedResult.create("test"))
+
+    with pytest.raises(UnfinishedRun):
+        # raise_on_failure should have no effect here
+        await state.result(raise_on_failure=raise_on_failure)
+
+
+@pytest.mark.parametrize(
+    "state_type",
+    [StateType.CRASHED, StateType.COMPLETED, StateType.FAILED, StateType.CANCELLED],
+)
+async def test_finished_states_allow_result_retrival(state_type: StateType):
+    state = State(type=state_type, data=await UnpersistedResult.create("test"))
+
+    assert await state.result(raise_on_failure=False) == "test"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2227,7 +2227,7 @@ class TestSubflowWaitForTasks:
 
         flow_state = await test_flow._run()
         assert flow_state.is_failed()
-        assert "MissingResult: State data is missing" in flow_state.message
+        assert "UnfinishedRun" in flow_state.message
 
     def test_using_wait_for_in_task_definition_raises_reserved(self):
         with pytest.raises(


### PR DESCRIPTION
Improves clarity during the broad set of failure modes related to `MissingResult`

## Example

```python
from prefect.states import Pending

Pending().result()
```

```
Traceback (most recent call last):
  File "/Users/mz/dev/prefect/example.py", line 3, in <module>
    Pending().result()
  File "/Users/mz/dev/prefect/src/prefect/client/schemas.py", line 107, in result
    return get_state_result(self, raise_on_failure=raise_on_failure, fetch=fetch)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mz/dev/prefect/src/prefect/states.py", line 71, in get_state_result
    return _get_state_result(state, raise_on_failure=raise_on_failure)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mz/dev/prefect/src/prefect/utilities/asyncutils.py", line 260, in coroutine_wrapper
    return call()
           ^^^^^^
  File "/Users/mz/dev/prefect/src/prefect/_internal/concurrency/calls.py", line 245, in __call__
    return self.result()
           ^^^^^^^^^^^^^
  File "/Users/mz/dev/prefect/src/prefect/_internal/concurrency/calls.py", line 173, in result
    return self.future.result(timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mz/.pyenv/versions/3.11.2/lib/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/mz/.pyenv/versions/3.11.2/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/Users/mz/dev/prefect/src/prefect/_internal/concurrency/calls.py", line 218, in _run_async
    result = await coro
             ^^^^^^^^^^
  File "/Users/mz/dev/prefect/src/prefect/states.py", line 84, in _get_state_result
    raise UnfinishedRun(
prefect.exceptions.UnfinishedRun: Run is in PENDING state, its result is not available.
```