### PR TITLE
Duplicate task runner instances before usage in engine

### DIFF
--- a/benches/bench_flows.py
+++ b/benches/bench_flows.py
@@ -1,7 +1,6 @@
 """
 TODO: Add benches for higher number of tasks; blocked by engine deadlocks in CI.
 """
-import copy
 
 import anyio
 import pytest
@@ -127,7 +126,6 @@ def bench_async_flow_with_concurrent_subflows(
     async def benchmark_flow():
         async with anyio.create_task_group() as tg:
             for _ in range(num_flows):
-                # A copy is needed to avoid duplicate task runner starts
-                tg.start_soon(copy.deepcopy(test_flow))
+                tg.start_soon(test_flow)
 
     benchmark(anyio.run, benchmark_flow)

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -376,8 +376,8 @@ async def begin_flow_run(
             task_runner = flow.task_runner
             logger.warning(
                 f"Task runner {type(task_runner).__name__!r} does not implement the"
-                " `duplicate` method and cannot be used in concurrent execution of the"
-                " same flow."
+                " `duplicate` method and will fail if used for concurrent execution of"
+                " the same flow."
             )
 
         logger.debug(
@@ -544,8 +544,8 @@ async def create_and_begin_subflow_run(
                 task_runner = flow.task_runner
                 logger.warning(
                     f"Task runner {type(task_runner).__name__!r} does not implement the"
-                    " `duplicate` method and cannot be used in concurrent execution of"
-                    " the same flow."
+                    " `duplicate` method and will fail if used for concurrent"
+                    " execution of the same flow."
                 )
 
             await stack.enter_async_context(task_runner.start())

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -370,12 +370,23 @@ async def begin_flow_run(
             stack.enter_context(start_blocking_portal()) if flow.isasync else None
         )
 
+        task_runner = flow.task_runner.duplicate()
+        if task_runner is NotImplemented:
+            # Backwards compatibility; will not support concurrent flow runs
+            task_runner = flow.task_runner
+            logger.warning(
+                f"Task runner {type(task_runner).__name__!r} does not implement the"
+                " `duplicate` method and cannot be used in concurrent execution of the"
+                " same flow."
+            )
+
         logger.debug(
             f"Starting {type(flow.task_runner).__name__!r}; submitted tasks "
             f"will be run {CONCURRENCY_MESSAGES[flow.task_runner.concurrency_type]}..."
         )
+
         flow_run_context.task_runner = await stack.enter_async_context(
-            flow.task_runner.duplicate().start()
+            task_runner.start()
         )
 
         flow_run_context.result_factory = await ResultFactory.from_flow(
@@ -526,9 +537,18 @@ async def create_and_begin_subflow_run(
             await stack.enter_async_context(
                 report_flow_run_crashes(flow_run=flow_run, client=client)
             )
-            task_runner = await stack.enter_async_context(
-                flow.task_runner.duplicate().start()
-            )
+
+            task_runner = flow.task_runner.duplicate()
+            if task_runner is NotImplemented:
+                # Backwards compatibility; will not support concurrent flow runs
+                task_runner = flow.task_runner
+                logger.warning(
+                    f"Task runner {type(task_runner).__name__!r} does not implement the"
+                    " `duplicate` method and cannot be used in concurrent execution of"
+                    " the same flow."
+                )
+
+            await stack.enter_async_context(task_runner.start())
 
             if log_prints:
                 stack.enter_context(patch_print())

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -375,7 +375,7 @@ async def begin_flow_run(
             f"will be run {CONCURRENCY_MESSAGES[flow.task_runner.concurrency_type]}..."
         )
         flow_run_context.task_runner = await stack.enter_async_context(
-            flow.task_runner.start()
+            flow.task_runner.duplicate().start()
         )
 
         flow_run_context.result_factory = await ResultFactory.from_flow(
@@ -526,7 +526,9 @@ async def create_and_begin_subflow_run(
             await stack.enter_async_context(
                 report_flow_run_crashes(flow_run=flow_run, client=client)
             )
-            task_runner = await stack.enter_async_context(flow.task_runner.start())
+            task_runner = await stack.enter_async_context(
+                flow.task_runner.duplicate().start()
+            )
 
             if log_prints:
                 stack.enter_context(patch_print())

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -113,7 +113,9 @@ class BaseTaskRunner(metaclass=abc.ABCMeta):
         """
         Return a new task runner instance with the same options.
         """
-        return type(self)()
+        # The base class returns `NotImplemented` to indicate that this is not yet
+        # implemented by a given task runner.
+        return NotImplemented
 
     def __eq__(self, other: object) -> bool:
         """
@@ -216,6 +218,9 @@ class SequentialTaskRunner(BaseTaskRunner):
     def concurrency_type(self) -> TaskConcurrencyType:
         return TaskConcurrencyType.SEQUENTIAL
 
+    def duplicate(self):
+        return type(self)()
+
     async def submit(
         self,
         key: UUID,
@@ -263,6 +268,9 @@ class ConcurrentTaskRunner(BaseTaskRunner):
     @property
     def concurrency_type(self) -> TaskConcurrencyType:
         return TaskConcurrencyType.CONCURRENT
+
+    def duplicate(self):
+        return type(self)()
 
     async def submit(
         self,

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -115,6 +115,15 @@ class BaseTaskRunner(metaclass=abc.ABCMeta):
         """
         return type(self)()
 
+    def __eq__(self, __value: object) -> bool:
+        """
+        Returns true if the task runners use the same options.
+        """
+        if type(__value) == type(self):
+            return True
+        else:
+            return NotImplemented
+
     @abc.abstractmethod
     async def submit(
         self,

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -115,11 +115,16 @@ class BaseTaskRunner(metaclass=abc.ABCMeta):
         """
         return type(self)()
 
-    def __eq__(self, __value: object) -> bool:
+    def __eq__(self, other: object) -> bool:
         """
         Returns true if the task runners use the same options.
         """
-        if type(__value) == type(self):
+        if type(other) == type(self) and (
+            # Compare public attributes for naive equality check
+            # Subclasses should implement this method with a check init option equality
+            {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
+            == {k: v for k, v in other.__dict__.items() if not k.startswith("_")}
+        ):
             return True
         else:
             return NotImplemented

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -109,6 +109,12 @@ class BaseTaskRunner(metaclass=abc.ABCMeta):
     def name(self):
         return type(self).__name__.lower().replace("taskrunner", "")
 
+    def duplicate(self):
+        """
+        Return a new task runner instance with the same options.
+        """
+        return type(self)()
+
     @abc.abstractmethod
     async def submit(
         self,

--- a/src/prefect/testing/standard_test_suites/task_runners.py
+++ b/src/prefect/testing/standard_test_suites/task_runners.py
@@ -55,6 +55,11 @@ class TaskRunnerStandardTestSuite(ABC):
         file_path.touch()
         return file_path
 
+    async def test_duplicate(self, task_runner):
+        new = task_runner.duplicate()
+        assert new == task_runner
+        assert new is not task_runner
+
     async def test_successful_flow_run(self, task_runner):
         @task
         def task_a():

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2044,7 +2044,7 @@ class TestAPIHealthcheck:
             assert len(API_HEALTHCHECKS.keys()) == 0
 
 
-def test_flow_call_with_task_runner_duplicate_not_implemented():
+def test_flow_call_with_task_runner_duplicate_not_implemented(caplog):
     class MyTaskRunner(BaseTaskRunner):
         @property
         def concurrency_type(self):
@@ -2061,3 +2061,10 @@ def test_flow_call_with_task_runner_duplicate_not_implemented():
         return 1
 
     assert my_flow() == 1
+
+    assert (
+        "Task runner 'MyTaskRunner' does not implement the"
+        " `duplicate` method and cannot be used in concurrent execution of"
+        " the same flow."
+        in caplog.text
+    )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -14,6 +14,7 @@ import anyio
 import pendulum
 import pytest
 from pydantic import BaseModel
+from prefect.task_runners import BaseTaskRunner, TaskConcurrencyType
 
 import prefect.flows
 from prefect import engine, flow, task
@@ -2041,3 +2042,22 @@ class TestAPIHealthcheck:
             # Not cached
             assert "http://ephemeral-prefect/api/" not in API_HEALTHCHECKS
             assert len(API_HEALTHCHECKS.keys()) == 0
+
+
+def test_flow_call_with_task_runner_duplicate_not_implemented():
+    class MyTaskRunner(BaseTaskRunner):
+        @property
+        def concurrency_type(self):
+            return TaskConcurrencyType.SEQUENTIAL
+
+        def wait(self, *args, **kwargs):
+            pass
+
+        def submit(self, *args, **kwargs):
+            pass
+
+    @flow(task_runner=MyTaskRunner)
+    def my_flow():
+        return 1
+
+    assert my_flow() == 1

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2064,7 +2064,37 @@ def test_flow_call_with_task_runner_duplicate_not_implemented(caplog):
 
     assert (
         "Task runner 'MyTaskRunner' does not implement the"
-        " `duplicate` method and cannot be used in concurrent execution of"
+        " `duplicate` method and will fail if used for concurrent execution of"
+        " the same flow."
+        in caplog.text
+    )
+
+
+def test_subflow_call_with_task_runner_duplicate_not_implemented(caplog):
+    class MyTaskRunner(BaseTaskRunner):
+        @property
+        def concurrency_type(self):
+            return TaskConcurrencyType.SEQUENTIAL
+
+        def wait(self, *args, **kwargs):
+            pass
+
+        def submit(self, *args, **kwargs):
+            pass
+
+    @flow(task_runner=MyTaskRunner)
+    def child():
+        return 1
+
+    @flow
+    def parent():
+        return child()
+
+    assert parent() == 1
+
+    assert (
+        "Task runner 'MyTaskRunner' does not implement the"
+        " `duplicate` method and will fail if used for concurrent execution of"
         " the same flow."
         in caplog.text
     )


### PR DESCRIPTION
Allows concurrent execution of the same flow, avoiding the "task runner is already started" issue by creating a new instance for each run. Avoids introducing new types or patterns — task runner implementations will need to implement the `duplicate` method if they take options. We use this instead of `copy` to avoid including any runtime state.

Closes https://github.com/PrefectHQ/prefect/issues/7319
Closes https://github.com/PrefectHQ/prefect/issues/8307

On release, Dask/Ray will ignore options passed to the task runner until their implementations are released:

Dask implementation https://github.com/PrefectHQ/prefect-dask/pull/93
Ray implementation https://github.com/PrefectHQ/prefect-ray/pull/83

We could make this an abstract method if we'd rather they just crashed and burned.

## Example

Concurrent instances of the same subflow

```python
from prefect import flow, task
import asyncio


@task
async def test_task():
    return 1


@flow(log_prints=True)
async def my_child(i):
    assert await test_task() == 1
    print(i)


@flow
async def my_parent():
    coros = [my_child(i) for i in range(10)]
    await asyncio.gather(*coros)


asyncio.run(my_parent())
```

Subflows sharing a dynamically created Dask cluster

```python
from prefect import flow, task
import asyncio
from prefect_dask import DaskTaskRunner
from prefect.context import get_run_context


@task
async def test_task():
    return 1


@flow(log_prints=True)
async def my_child(i):
    assert await test_task() == 1
    print(i)


@flow(task_runner=DaskTaskRunner())
async def my_parent():
    child_task_runner = DaskTaskRunner(
        address=get_run_context().task_runner._client.scheduler_info()["address"]
    )
    coros = [my_child.with_options(task_runner=child_task_runner)(i) for i in range(5)]
    await asyncio.gather(*coros)


if __name__ == "__main__":
    asyncio.run(my_parent())
```