### PR TITLE
Fix race condition in event loop thread start

### DIFF
--- a/src/prefect/_internal/concurrency/threads.py
+++ b/src/prefect/_internal/concurrency/threads.py
@@ -132,6 +132,7 @@ class EventLoopThread(Portal):
         self._run_once: bool = run_once
         self._submitted_count: int = 0
         self._on_shutdown: List[Call] = []
+        self._lock = threading.Lock()
 
         if not daemon:
             atexit.register(self.shutdown)
@@ -140,31 +141,34 @@ class EventLoopThread(Portal):
         """
         Start the worker thread; raises any exceptions encountered during startup.
         """
-        self.thread.start()
-        # Wait for the worker to be ready
-        self._ready_future.result()
+        with self._lock:
+            if self._loop is None:
+                self.thread.start()
+                self._ready_future.result()
 
     def submit(self, call: Call) -> Call:
-        if self._submitted_count > 0 and self._run_once:
-            raise RuntimeError(
-                "Worker configured to only run once. A call has already been submitted."
-            )
-
         if self._loop is None:
             self.start()
 
-        if self._shutdown_event.is_set():
-            raise RuntimeError("Worker is shutdown.")
+        with self._lock:
+            if self._submitted_count > 0 and self._run_once:
+                raise RuntimeError(
+                    "Worker configured to only run once. A call has already been"
+                    " submitted."
+                )
 
-        # Track the portal running the call
-        call.set_runner(self)
+            if self._shutdown_event.is_set():
+                raise RuntimeError("Worker is shutdown.")
 
-        # Submit the call to the event loop
-        asyncio.run_coroutine_threadsafe(self._run_call(call), self._loop)
+            # Track the portal running the call
+            call.set_runner(self)
 
-        self._submitted_count += 1
-        if self._run_once:
-            call.future.add_done_callback(lambda _: self.shutdown())
+            # Submit the call to the event loop
+            asyncio.run_coroutine_threadsafe(self._run_call(call), self._loop)
+
+            self._submitted_count += 1
+            if self._run_once:
+                call.future.add_done_callback(lambda _: self.shutdown())
 
         return call
 
@@ -172,10 +176,11 @@ class EventLoopThread(Portal):
         """
         Shutdown the worker thread. Does not wait for the thread to stop.
         """
-        if self._shutdown_event is None:
-            return
+        with self._lock:
+            if self._shutdown_event is None:
+                return
 
-        self._shutdown_event.set()
+            self._shutdown_event.set()
 
     @property
     def name(self) -> str:

--- a/tests/_internal/concurrency/test_threads.py
+++ b/tests/_internal/concurrency/test_threads.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, call
 
 import pytest
-
+import concurrent.futures
 from prefect._internal.concurrency.calls import Call
 from prefect._internal.concurrency.threads import EventLoopThread, WorkerThread
 from prefect.testing.utilities import AsyncMock
@@ -26,6 +26,13 @@ def test_event_loop_thread_with_failure_in_start():
     # The error should propagate to the main thread
     with pytest.raises(ValueError, match="test"):
         event_loop_thread.start()
+
+
+def test_event_loop_thread_start_race_condition():
+    event_loop_thread = EventLoopThread()
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        for _ in range(10):
+            executor.submit(event_loop_thread.start)
 
 
 def test_event_loop_thread_with_on_shutdown_hook():


### PR DESCRIPTION
`EventLoopThread.start` was not safe to calls from multiple threads.

Reported in https://github.com/PrefectHQ/prefect/issues/9296