### PR TITLE
Ensure `close()` is called on the base handler during `APILogHandler` shutdown

### DIFF
--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -193,6 +193,7 @@ class APILogHandler(logging.Handler):
 
     def close(self):
         APILogWorker.drain_all()
+        super().close()
 
 
 class PrefectConsoleHandler(logging.StreamHandler):


### PR DESCRIPTION
The docstring for `close` indicates that it is important for subclasses to call the parent method.

Related to https://github.com/PrefectHQ/prefect/issues/9345