### PR TITLE
Update `BaseJobConfiguration._related_resources` to handle the case where objects are `None`.

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -254,6 +254,8 @@ class BaseJobConfiguration(BaseModel):
         related = []
 
         for kind, obj in self._related_objects.items():
+            if obj is None:
+                continue
             if hasattr(obj, "tags"):
                 tags.update(obj.tags)
             related.append(object_as_related_resource(kind=kind, role=kind, object=obj))

--- a/tests/events/instrumentation/test_events_workers_instrumentation.py
+++ b/tests/events/instrumentation/test_events_workers_instrumentation.py
@@ -326,3 +326,13 @@ async def test_worker_emits_cancelled_event(
             "prefect.resource.name": work_pool.name,
         },
     ]
+
+
+def test_job_configuration_related_resources_no_objects():
+    config = BaseJobConfiguration()
+    config._related_objects = {
+        "deployment": None,
+        "flow": None,
+        "flow-run": None,
+    }
+    assert config._related_resources() == []


### PR DESCRIPTION
When I was building out the events for the library-based workers I ran into an issue, at least in testing, where the deployment/flow could be `None` and that caused `config._related_resources` to raise an exception. This is the fix I applied in the libraries, just pulling it up so we can pull it out of those libraries at some point.
