### PR TITLE
Revert change where `QueueService.send` blocked until the item was enqueued

### DIFF
--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -12,7 +12,10 @@ import anyio
 from typing_extensions import Self
 
 from prefect._internal.concurrency.api import create_call, from_sync
-from prefect._internal.concurrency.event_loop import call_in_loop, get_running_loop
+from prefect._internal.concurrency.event_loop import (
+    call_soon_in_loop,
+    get_running_loop,
+)
 from prefect._internal.concurrency.threads import get_global_loop
 from prefect.logging import get_logger
 
@@ -87,7 +90,8 @@ class QueueService(abc.ABC, Generic[T]):
             self._remove_instance()
 
             self._stopped = True
-            call_in_loop(self._loop, self._queue.put_nowait, None)
+
+            call_soon_in_loop(self._loop, self._queue.put_nowait, None)
 
     def send(self, item: T):
         """
@@ -102,7 +106,7 @@ class QueueService(abc.ABC, Generic[T]):
             if not self._started:
                 self._early_items.append(item)
             else:
-                call_in_loop(
+                call_soon_in_loop(
                     self._loop, self._queue.put_nowait, self._prepare_item(item)
                 )
 

--- a/tests/_internal/concurrency/test_services.py
+++ b/tests/_internal/concurrency/test_services.py
@@ -187,6 +187,12 @@ def test_send_many_threads():
         for i in range(10):
             executor.submit(on_thread, i)
 
+    # Wait for a call in the event loop thread to force a yield ensuring all items
+    # have been sent successfully
+    # TODO: This is a bit of a hack. The queue service should ensure that all items are
+    #       sent on drain but it's tricky to do without introducing deadlocks.
+    from_sync.call_soon_in_loop_thread(create_call(asyncio.sleep, 0)).result()
+
     MockService.drain_all()
     MockService.mock.assert_has_calls([call(ANY, i) for i in range(10)], any_order=True)
 


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/9396
Reverts #9318 

This appears to have introduced a deadlock when the event loop is blocked waiting for the logging lock.