### PR TITLE
Limit `APILogHandler.flush` time to 5s when called from synchronous contexts

### DIFF
--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -205,6 +205,11 @@ class APILogHandler(logging.Handler):
     def _get_payload_size(self, log: Dict[str, Any]) -> int:
         return len(json.dumps(log).encode())
 
+    def close(self):
+        if not get_running_loop():
+            self.flush()
+        super().close()
+
 
 class PrefectConsoleHandler(logging.StreamHandler):
     def __init__(

--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -7,7 +7,6 @@ import warnings
 from contextlib import asynccontextmanager
 from typing import Any, Dict, List, Type, Union
 
-import threading
 import pendulum
 from rich.console import Console
 from rich.highlighter import Highlighter, NullHighlighter
@@ -17,7 +16,7 @@ from typing_extensions import Self
 import prefect.context
 from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect._internal.concurrency.services import BatchedQueueService
-from prefect._internal.concurrency.threads import get_global_loop
+from prefect._internal.concurrency.event_loop import get_running_loop
 from prefect._internal.concurrency.api import from_sync, create_call
 from prefect.client.orchestration import get_client
 from prefect.exceptions import MissingContextError
@@ -95,7 +94,7 @@ class APILogHandler(logging.Handler):
         If called in a synchronous context, will only block up to 5s before returning.
         """
 
-        if get_global_loop().thread.ident == threading.get_ident():
+        if get_running_loop():
             # Return an awaitable
             return APILogWorker.drain_all()
         else:

--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -7,6 +7,7 @@ import warnings
 from contextlib import asynccontextmanager
 from typing import Any, Dict, List, Type, Union
 
+import threading
 import pendulum
 from rich.console import Console
 from rich.highlighter import Highlighter, NullHighlighter
@@ -16,6 +17,8 @@ from typing_extensions import Self
 import prefect.context
 from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect._internal.concurrency.services import BatchedQueueService
+from prefect._internal.concurrency.threads import get_global_loop
+from prefect._internal.concurrency.api import from_sync, create_call
 from prefect.client.orchestration import get_client
 from prefect.exceptions import MissingContextError
 from prefect.logging.highlighters import PrefectConsoleHighlighter
@@ -88,9 +91,21 @@ class APILogHandler(logging.Handler):
         Tell the `APILogWorker` to send any currently enqueued logs and block until
         completion.
 
-        Returns an awaitable if called from an async context.
+        Returns an awaitable if called from the global event loop.
+        If called in a synchronous context, will only block up to 5s before returning.
         """
-        return APILogWorker.drain_all()
+
+        if get_global_loop().thread.ident == threading.get_ident():
+            # Return an awaitable
+            return APILogWorker.drain_all()
+        else:
+            # We set a timeout of 5s because we don't want to block forever if the worker
+            # is stuck. This can occur when the handler is being shutdown and the
+            # `logging._lock` is held but the worker is attempting to emit logs resulting
+            # in a deadlock.
+            return from_sync.call_soon_in_loop_thread(
+                create_call(APILogWorker.drain_all)
+            ).result(timeout=5)
 
     def emit(self, record: logging.LogRecord):
         """
@@ -190,10 +205,6 @@ class APILogHandler(logging.Handler):
 
     def _get_payload_size(self, log: Dict[str, Any]) -> int:
         return len(json.dumps(log).encode())
-
-    def close(self):
-        APILogWorker.drain_all()
-        super().close()
 
 
 class PrefectConsoleHandler(logging.StreamHandler):

--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -90,7 +90,7 @@ class APILogHandler(logging.Handler):
         Tell the `APILogWorker` to send any currently enqueued logs and block until
         completion.
 
-        Returns an awaitable if called from the global event loop.
+        Returns an awaitable if called from an asynchronous context.
         If called in a synchronous context, will only block up to 5s before returning.
         """
 


### PR DESCRIPTION
Alternative to https://github.com/PrefectHQ/prefect/pull/9354 with reduced change scope.

Closes https://github.com/PrefectHQ/prefect/issues/9345

I'd prefer a solution that resolves the deadlock entirely, but let's not wait forever when it occurs as a starting point.