### PR TITLE
Add `on_crashed` flow run state change hook

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1748,6 +1748,8 @@ async def report_flow_run_crashes(
                 f"Reported crashed flow run {flow_run.name!r} successfully!"
             )
 
+            # Only `on_crashed` flow run state change hook is called here
+            # We call the hook after the state is set to `CRASHED`
             if flow is not None:
                 await _run_flow_hooks(
                     flow=flow,

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -575,6 +575,9 @@ def flow(
     on_failure: Optional[
         List[Callable[[schemas.core.Flow, FlowRun, State], None]]
     ] = None,
+    on_crashed: Optional[
+        List[Callable[[schemas.core.Flow, FlowRun, State], None]]
+    ] = None,
 ) -> Callable[[Callable[P, R]], Flow[P, R]]:
     ...
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -43,6 +43,7 @@ from prefect.futures import PrefectFuture
 from prefect.logging import get_logger
 from prefect.results import ResultSerializer, ResultStorage
 import prefect.server.schemas as schemas
+from prefect.client.schemas import FlowRun
 from prefect.states import State
 from prefect.task_runners import BaseTaskRunner, ConcurrentTaskRunner
 from prefect.utilities.annotations import NotSet
@@ -140,13 +141,13 @@ class Flow(Generic[P, R]):
         cache_result_in_memory: bool = True,
         log_prints: Optional[bool] = None,
         on_completion: Optional[
-            List[Callable[[schemas.core.Flow, schemas.core.FlowRun, State], None]]
+            List[Callable[[schemas.core.Flow, FlowRun, State], None]]
         ] = None,
         on_failure: Optional[
-            List[Callable[[schemas.core.Flow, schemas.core.FlowRun, State], None]]
+            List[Callable[[schemas.core.Flow, FlowRun, State], None]]
         ] = None,
         on_crashed: Optional[
-            List[Callable[[schemas.core.Flow, schemas.core.FlowRun, State], None]]
+            List[Callable[[schemas.core.Flow, FlowRun, State], None]]
         ] = None,
     ):
         if not callable(fn):
@@ -256,13 +257,13 @@ class Flow(Generic[P, R]):
         cache_result_in_memory: bool = None,
         log_prints: Optional[bool] = NotSet,
         on_completion: Optional[
-            List[Callable[[schemas.core.Flow, schemas.core.FlowRun, State], None]]
+            List[Callable[[schemas.core.Flow, FlowRun, State], None]]
         ] = None,
         on_failure: Optional[
-            List[Callable[[schemas.core.Flow, schemas.core.FlowRun, State], None]]
+            List[Callable[[schemas.core.Flow, FlowRun, State], None]]
         ] = None,
         on_crashed: Optional[
-            List[Callable[[schemas.core.Flow, schemas.core.FlowRun, State], None]]
+            List[Callable[[schemas.core.Flow, FlowRun, State], None]]
         ] = None,
     ):
         """
@@ -569,10 +570,10 @@ def flow(
     cache_result_in_memory: bool = True,
     log_prints: Optional[bool] = None,
     on_completion: Optional[
-        List[Callable[[schemas.core.Flow, schemas.core.FlowRun, State], None]]
+        List[Callable[[schemas.core.Flow, FlowRun, State], None]]
     ] = None,
     on_failure: Optional[
-        List[Callable[[schemas.core.Flow, schemas.core.FlowRun, State], None]]
+        List[Callable[[schemas.core.Flow, FlowRun, State], None]]
     ] = None,
 ) -> Callable[[Callable[P, R]], Flow[P, R]]:
     ...
@@ -596,13 +597,13 @@ def flow(
     cache_result_in_memory: bool = True,
     log_prints: Optional[bool] = None,
     on_completion: Optional[
-        List[Callable[[schemas.core.Flow, schemas.core.FlowRun, State], None]]
+        List[Callable[[schemas.core.Flow, FlowRun, State], None]]
     ] = None,
     on_failure: Optional[
-        List[Callable[[schemas.core.Flow, schemas.core.FlowRun, State], None]]
+        List[Callable[[schemas.core.Flow, FlowRun, State], None]]
     ] = None,
     on_crashed: Optional[
-        List[Callable[[schemas.core.Flow, schemas.core.FlowRun, State], None]]
+        List[Callable[[schemas.core.Flow, FlowRun, State], None]]
     ] = None,
 ):
     """

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1262,13 +1262,15 @@ class TestFlowRunCrashes:
         assert flow_run.state.type != StateType.CRASHED
 
     async def test_report_flow_run_crashes_handles_sigterm(
-        self, flow_run, orion_client, monkeypatch
+        self, flow_run, orion_client, monkeypatch, parameterized_flow
     ):
         original_handler = Mock()
         signal.signal(signal.SIGTERM, original_handler)
 
         with pytest.raises(TerminationSignal):
-            async with report_flow_run_crashes(flow_run=flow_run, client=orion_client):
+            async with report_flow_run_crashes(
+                flow_run=flow_run, client=orion_client, flow=parameterized_flow
+            ):
                 assert signal.getsignal(signal.SIGTERM) != original_handler
                 os.kill(os.getpid(), signal.SIGTERM)
 

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -2490,3 +2490,23 @@ class TestFlowHooksOnCrashed:
 
         my_flow._run()
         assert my_mock.mock_calls == [call(), call()]
+
+    def test_on_crashed_hook_on_subflow_succeeds(self):
+        my_mock = MagicMock()
+
+        def crashed1(flow, flow_run, state):
+            my_mock("crashed1")
+
+        def failed1(flow, flow_run, state):
+            my_mock("failed1")
+
+        @flow(on_crashed=[crashed1])
+        def subflow():
+            return State(type=StateType.CRASHED)
+
+        @flow(on_failure=[failed1])
+        def my_flow():
+            subflow()
+
+        my_flow._run()
+        assert my_mock.mock_calls == [call("crashed1"), call("failed1")]

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -223,6 +223,7 @@ class TestFlowWithOptions:
             cache_result_in_memory=False,
             on_completion=[],
             on_failure=[],
+            on_crashed=[],
         )
         def initial_flow():
             pass
@@ -232,6 +233,9 @@ class TestFlowWithOptions:
 
         def success_hook(task, task_run, state):
             return print("Meow!")
+
+        def crash_hook(task, task_run, state):
+            return print("Crash!")
 
         flow_with_options = initial_flow.with_options(
             name="Copied flow",
@@ -248,6 +252,7 @@ class TestFlowWithOptions:
             cache_result_in_memory=True,
             on_completion=[success_hook],
             on_failure=[failure_hook],
+            on_crashed=[crash_hook],
         )
 
         assert flow_with_options.name == "Copied flow"
@@ -264,6 +269,7 @@ class TestFlowWithOptions:
         assert flow_with_options.cache_result_in_memory is True
         assert flow_with_options.on_completion == [success_hook]
         assert flow_with_options.on_failure == [failure_hook]
+        assert flow_with_options.on_crashed == [crash_hook]
 
     def test_with_options_uses_existing_settings_when_no_override(self):
         @flow(
@@ -2392,3 +2398,95 @@ class TestFlowHooksOnFailure:
         state = my_flow._run()
         assert state.type == StateType.FAILED
         assert my_mock.call_args_list == [call(), call()]
+
+
+class TestFlowHooksOnCrashed:
+    def test_on_crashed_hooks_run_on_crashed_state(self):
+        my_mock = MagicMock()
+
+        def crashed_hook1(flow, flow_run, state):
+            my_mock("crashed_hook1")
+
+        def crashed_hook2(flow, flow_run, state):
+            my_mock("crashed_hook2")
+
+        @flow(on_crashed=[crashed_hook1, crashed_hook2])
+        def my_flow():
+            return State(type=StateType.CRASHED)
+
+        my_flow._run()
+        assert my_mock.mock_calls == [call("crashed_hook1"), call("crashed_hook2")]
+
+    def test_on_crashed_hooks_are_ignored_if_terminal_state_completed(self):
+        my_mock = MagicMock()
+
+        def crashed_hook1(flow, flow_run, state):
+            my_mock("crashed_hook1")
+
+        def crashed_hook2(flow, flow_run, state):
+            my_mock("crashed_hook2")
+
+        @flow(on_crashed=[crashed_hook1, crashed_hook2])
+        def my_passing_flow():
+            pass
+
+        state = my_passing_flow._run()
+        assert state.type == StateType.COMPLETED
+        assert my_mock.mock_calls == []
+
+    def test_on_crashed_hooks_are_ignored_if_terminal_state_failed(self):
+        my_mock = MagicMock()
+
+        def crashed_hook1(flow, flow_run, state):
+            my_mock("crashed_hook1")
+
+        def crashed_hook2(flow, flow_run, state):
+            my_mock("crashed_hook2")
+
+        @flow(on_crashed=[crashed_hook1, crashed_hook2])
+        def my_failing_flow():
+            raise Exception("Failing flow")
+
+        state = my_failing_flow._run()
+        assert state.type == StateType.FAILED
+        assert my_mock.mock_calls == []
+
+    def test_other_crashed_hooks_run_if_one_hook_fails(self):
+        my_mock = MagicMock()
+
+        def crashed1(flow, flow_run, state):
+            my_mock("crashed1")
+
+        def crashed2(flow, flow_run, state):
+            raise Exception("Failing flow")
+
+        def crashed3(flow, flow_run, state):
+            my_mock("crashed3")
+
+        @flow(on_crashed=[crashed1, crashed2, crashed3])
+        def my_flow():
+            return State(type=StateType.CRASHED)
+
+        my_flow._run()
+        assert my_mock.mock_calls == [call("crashed1"), call("crashed3")]
+
+    @pytest.mark.parametrize(
+        "hook1, hook2",
+        [
+            (create_hook, create_hook),
+            (create_hook, create_async_hook),
+            (create_async_hook, create_hook),
+            (create_async_hook, create_async_hook),
+        ],
+    )
+    def test_on_crashed_hooks_work_with_sync_and_async(self, hook1, hook2):
+        my_mock = MagicMock()
+        hook1_with_mock = hook1(my_mock)
+        hook2_with_mock = hook2(my_mock)
+
+        @flow(on_crashed=[hook1_with_mock, hook2_with_mock])
+        def my_flow():
+            return State(type=StateType.CRASHED)
+
+        my_flow._run()
+        assert my_mock.mock_calls == [call(), call()]


### PR DESCRIPTION
Closes #9348 
Closes #8688 

Adds the ability to execute arbitrary code when a flow enters a `CRASHED` state.

### Example
#### Flow:
```python
from prefect import flow

def crash_hook(flow, flow_run, state):
    print("Better call Marvin.. \U0001F641")

@flow(on_crashed=[crash_hook])
def my_flow():
    raise SystemExit(1)

if __name__ == '__main__':
    my_flow()
```

#### Output:
```bash
❯ python example.py
13:27:40.114 | INFO    | prefect.engine - Created flow run 'thundering-narwhal' for flow 'my-flow'
13:27:41.303 | ERROR   | Flow run 'thundering-narwhal' - Crash detected! Execution was aborted by Python system exit call.
13:27:41.360 | INFO    | Flow run 'thundering-narwhal' - Running hook 'crash_hook' in response to entering state 'Crashed'
Better call Marvin.. 🙁
13:27:41.361 | INFO    | Flow run 'thundering-narwhal' - Hook 'crash_hook' finished running successfully
```


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
