### PR TITLE
docs typo - result_storage declared in the wrong place

### DIFF
--- a/docs/concepts/results.md
+++ b/docs/concepts/results.md
@@ -408,8 +408,8 @@ The path of the result file in the result storage can be configured with the `re
 from prefect import flow, task
 from prefect.filesystems import LocalFileSystem, S3
 
-@flow()
-def my_flow(result_storage=S3(bucket_path="my-bucket")):
+@flow(result_storage=S3(bucket_path="my-bucket"))
+def my_flow():
     my_task()
 
 @task(persist_result=True, result_storage_key="my_task.json")


### PR DESCRIPTION
I suspect that this is a minor typo in the docs.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
