### PR TITLE
Fix work queues showing as unhealthy when a work queue with the same name is unhealthy

### DIFF
--- a/src/prefect/server/models/work_queues.py
+++ b/src/prefect/server/models/work_queues.py
@@ -392,9 +392,9 @@ async def read_work_queue_status(
         session=session,
         flow_run_filter=schemas.filters.FlowRunFilter(
             state=schemas.filters.FlowRunFilterState(name={"any_": ["Late"]}),
-            work_queue_name=schemas.filters.FlowRunFilterWorkQueueName(
-                any_=[work_queue.name]
-            ),
+        ),
+        work_queue_filter=schemas.filters.WorkQueueFilter(
+            id=schemas.filters.WorkQueueFilterId(any_=[work_queue_id])
         ),
     )
 

--- a/tests/server/api/test_work_queues.py
+++ b/tests/server/api/test_work_queues.py
@@ -439,6 +439,29 @@ class TestReadWorkQueueStatus:
         return work_queue
 
     @pytest.fixture
+    async def recently_pool_work_queue_in_different_work_pool(self, session):
+        work_pool = await models.workers.create_work_pool(
+            session=session,
+            work_pool=schemas.actions.WorkPoolCreate(
+                name="another-work-pool",
+                description="All about my work pool",
+                type="test",
+            ),
+        )
+        work_queue = await models.work_queues.create_work_queue(
+            session=session,
+            work_queue=schemas.core.WorkQueue(
+                name="wq-1",
+                description="All about my work queue",
+                last_polled=pendulum.now("UTC"),
+                work_pool_id=work_pool.id,
+                priority=1,
+            ),
+        )
+        await session.commit()
+        return work_queue
+
+    @pytest.fixture
     async def not_recently_polled_work_queue(self, session, work_pool):
         work_queue = await models.work_queues.create_work_queue(
             session=session,
@@ -472,7 +495,7 @@ class TestReadWorkQueueStatus:
                 state=schemas.states.Late(
                     scheduled_time=pendulum.now().subtract(minutes=60)
                 ),
-                work_queue_name=work_queue.name,
+                work_queue_id=work_queue.id,
             ),
         )
         await session.commit()
@@ -523,6 +546,34 @@ class TestReadWorkQueueStatus:
         assert parsed_response.healthy is False
         assert parsed_response.late_runs_count == 1
         assert parsed_response.last_polled == work_queue_with_late_runs.last_polled
+
+    async def test_read_work_queue_returns_correct_status_when_work_queues_share_name(
+        self,
+        client,
+        work_queue_with_late_runs,
+        recently_pool_work_queue_in_different_work_pool,
+    ):
+        healthy_response = await client.get(
+            f"/work_queues/{recently_pool_work_queue_in_different_work_pool.id}/status"
+        )
+
+        assert healthy_response.status_code == status.HTTP_200_OK
+
+        parsed_healthy_response = pydantic.parse_obj_as(
+            schemas.core.WorkQueueStatusDetail, healthy_response.json()
+        )
+        assert parsed_healthy_response.healthy is True
+
+        unhealthy_response = await client.get(
+            f"/work_queues/{work_queue_with_late_runs.id}/status"
+        )
+
+        assert unhealthy_response.status_code == status.HTTP_200_OK
+
+        parsed_unhealthy_response = pydantic.parse_obj_as(
+            schemas.core.WorkQueueStatusDetail, unhealthy_response.json()
+        )
+        assert parsed_unhealthy_response.healthy is False
 
     async def test_read_work_queue_status_returns_404_if_does_not_exist(self, client):
         response = await client.get(f"/work_queues/{uuid4()}/status")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Updates work queue status to use work queue ID for gathering late flow runs instead of work queue name. Queues that shared the same name but were in different work pools would both show as unhealthy if one of them was unhealthy.

Closes #9433 
Closes #9324 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
