### PR TITLE
Ensure trailing slash in remote filesystems

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cryptography >= 36.0.1
 dateparser >= 1.1.1
 docker >= 4.0
 fastapi >= 0.93
-fsspec >= 2022.5.0, != 2023.3.0
+fsspec >= 2022.5.0
 griffe >= 0.20.0
 httpx[http2] >= 0.23, != 0.23.2
 importlib_metadata >= 4.4; python_version < '3.10'

--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -321,6 +321,10 @@ class RemoteFileSystem(WritableFileSystem, WritableDeploymentStorage):
         if local_path is None:
             local_path = Path(".").absolute()
 
+        # validate that from_path has a trailing slash for proper fsspec behavior across versions
+        if not from_path.endswith("/"):
+            from_path += "/"
+
         return self.filesystem.get(from_path, local_path, recursive=True)
 
     @sync_compatible
@@ -675,13 +679,13 @@ class Azure(WritableFileSystem, WritableDeploymentStorage):
     def filesystem(self) -> RemoteFileSystem:
         settings = {}
         if self.azure_storage_connection_string:
-            settings["connection_string"] = (
-                self.azure_storage_connection_string.get_secret_value()
-            )
+            settings[
+                "connection_string"
+            ] = self.azure_storage_connection_string.get_secret_value()
         if self.azure_storage_account_name:
-            settings["account_name"] = (
-                self.azure_storage_account_name.get_secret_value()
-            )
+            settings[
+                "account_name"
+            ] = self.azure_storage_account_name.get_secret_value()
         if self.azure_storage_account_key:
             settings["account_key"] = self.azure_storage_account_key.get_secret_value()
         if self.azure_storage_tenant_id:
@@ -689,9 +693,9 @@ class Azure(WritableFileSystem, WritableDeploymentStorage):
         if self.azure_storage_client_id:
             settings["client_id"] = self.azure_storage_client_id.get_secret_value()
         if self.azure_storage_client_secret:
-            settings["client_secret"] = (
-                self.azure_storage_client_secret.get_secret_value()
-            )
+            settings[
+                "client_secret"
+            ] = self.azure_storage_client_secret.get_secret_value()
         settings["anon"] = self.azure_storage_anon
         self._remote_file_system = RemoteFileSystem(
             basepath=f"az://{self.bucket_path}", settings=settings

--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -679,13 +679,13 @@ class Azure(WritableFileSystem, WritableDeploymentStorage):
     def filesystem(self) -> RemoteFileSystem:
         settings = {}
         if self.azure_storage_connection_string:
-            settings[
-                "connection_string"
-            ] = self.azure_storage_connection_string.get_secret_value()
+            settings["connection_string"] = (
+                self.azure_storage_connection_string.get_secret_value()
+            )
         if self.azure_storage_account_name:
-            settings[
-                "account_name"
-            ] = self.azure_storage_account_name.get_secret_value()
+            settings["account_name"] = (
+                self.azure_storage_account_name.get_secret_value()
+            )
         if self.azure_storage_account_key:
             settings["account_key"] = self.azure_storage_account_key.get_secret_value()
         if self.azure_storage_tenant_id:
@@ -693,9 +693,9 @@ class Azure(WritableFileSystem, WritableDeploymentStorage):
         if self.azure_storage_client_id:
             settings["client_id"] = self.azure_storage_client_id.get_secret_value()
         if self.azure_storage_client_secret:
-            settings[
-                "client_secret"
-            ] = self.azure_storage_client_secret.get_secret_value()
+            settings["client_secret"] = (
+                self.azure_storage_client_secret.get_secret_value()
+            )
         settings["anon"] = self.azure_storage_anon
         self._remote_file_system = RemoteFileSystem(
             basepath=f"az://{self.bucket_path}", settings=settings


### PR DESCRIPTION
Multiple users have had storage issues that all appear to have the same root cause: fsspec behavior changes across versions depending on whether or not the `from_path` has a trailing slash.

This PR ensures the existence of a trailing slash (always a forward slash due to remote systems following POSIX path schemas) and closes:
- https://github.com/PrefectHQ/prefect/issues/9262
- https://github.com/PrefectHQ/prefect/issues/8710

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
