### PR TITLE
Update orchestration rules to allow additional flow run state transitions

### DIFF
--- a/tests/server/orchestration/test_core_policy.py
+++ b/tests/server/orchestration/test_core_policy.py
@@ -1,7 +1,7 @@
 import contextlib
 import math
 import random
-from itertools import combinations_with_replacement, product
+from itertools import product
 from unittest import mock
 from uuid import uuid4
 
@@ -22,7 +22,7 @@ from prefect.server.orchestration.core_policy import (
     HandlePausingFlows,
     HandleResumingPausedFlows,
     HandleTaskTerminalStateTransitions,
-    PreventRedundantTransitions,
+    PreventPendingTransitions,
     PreventRunningTasksFromStoppedFlows,
     ReleaseTaskConcurrencySlots,
     RenameReruns,
@@ -1255,30 +1255,26 @@ class TestTransitionsFromTerminalStatesRule:
 
 
 @pytest.mark.parametrize("run_type", ["task", "flow"])
-class TestPreventingRedundantTransitionsRule:
-    active_states = (
-        states.StateType.CANCELLING,
-        states.StateType.RUNNING,
-        states.StateType.PENDING,
-        states.StateType.SCHEDULED,
-        None,
-    )
-    all_transitions = set(product(ALL_ORCHESTRATION_STATES, ALL_ORCHESTRATION_STATES))
-    redundant_transitions = set(combinations_with_replacement(active_states, 2))
-
-    # Cast to sorted lists for deterministic ordering.
-    # Sort as strings to handle `None`.
-    active_transitions = list(
-        sorted(all_transitions - redundant_transitions, key=lambda item: str(item))
-    )
-    redundant_transitions = list(
-        sorted(redundant_transitions, key=lambda item: str(item))
-    )
+class TestPreventPendingTransitions:
+    banned_states = [
+        StateType.CANCELLING,
+        StateType.CANCELLED,
+        StateType.RUNNING,
+        StateType.PENDING,
+    ]
+    banned_transitions = [(type_, StateType.PENDING) for type_ in banned_states]
+    allowed_transitions = [
+        (type_, StateType.PENDING)
+        # If you think this is silly, read https://github.com/python/cpython/issues/99295
+        for type_ in sorted(
+            set(ALL_ORCHESTRATION_STATES) - set(banned_states).union({None})
+        )
+    ]
 
     @pytest.mark.parametrize(
-        "intended_transition", redundant_transitions, ids=transition_names
+        "intended_transition", banned_transitions, ids=transition_names
     )
-    async def test_redundant_transitions_are_aborted(
+    async def test_banned_transitions_are_aborted(
         self,
         session,
         run_type,
@@ -1291,7 +1287,7 @@ class TestPreventingRedundantTransitionsRule:
             *intended_transition,
         )
 
-        state_protection = PreventRedundantTransitions(ctx, *intended_transition)
+        state_protection = PreventPendingTransitions(ctx, *intended_transition)
 
         async with state_protection as ctx:
             await ctx.validate_proposed_state()
@@ -1299,7 +1295,7 @@ class TestPreventingRedundantTransitionsRule:
         assert ctx.response_status == SetStateStatus.ABORT
 
     @pytest.mark.parametrize(
-        "intended_transition", active_transitions, ids=transition_names
+        "intended_transition", allowed_transitions, ids=transition_names
     )
     async def test_all_other_transitions_are_accepted(
         self,
@@ -1314,7 +1310,7 @@ class TestPreventingRedundantTransitionsRule:
             *intended_transition,
         )
 
-        state_protection = PreventRedundantTransitions(ctx, *intended_transition)
+        state_protection = PreventPendingTransitions(ctx, *intended_transition)
 
         async with state_protection as ctx:
             await ctx.validate_proposed_state()

--- a/tests/server/orchestration/test_core_policy.py
+++ b/tests/server/orchestration/test_core_policy.py
@@ -1254,7 +1254,7 @@ class TestTransitionsFromTerminalStatesRule:
         assert ctx.response_status == SetStateStatus.ACCEPT
 
 
-@pytest.mark.parametrize("run_type", ["task", "flow"])
+@pytest.mark.parametrize("run_type", ["flow"])
 class TestPreventPendingTransitions:
     banned_states = [
         StateType.CANCELLING,

--- a/tests/server/orchestration/test_core_policy.py
+++ b/tests/server/orchestration/test_core_policy.py
@@ -1263,13 +1263,10 @@ class TestPreventPendingTransitions:
         StateType.PENDING,
     ]
     banned_transitions = [(type_, StateType.PENDING) for type_ in banned_states]
-    allowed_transitions = [
-        (type_, StateType.PENDING)
-        # If you think this is silly, read https://github.com/python/cpython/issues/99295
-        for type_ in sorted(
-            set(ALL_ORCHESTRATION_STATES) - set(banned_states).union({None})
-        )
-    ]
+    all_states = set(ALL_ORCHESTRATION_STATES) - {None}
+    allowed_transitions = list(
+        sorted(set(product(all_states, all_states)).difference(banned_transitions))
+    )
 
     @pytest.mark.parametrize(
         "intended_transition", banned_transitions, ids=transition_names


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/7116

The `PreventRedundantTransitions` rule which was previously intended to prevent backwards transitions is now updated to allow most transitions. Now it **only prevents transitions to PENDING states** to prevent race conditions during duplicate submissions of runs and cancellation.

Before a run is submitted to its execution environment, it should be placed in a PENDING state. If two workers attempt to submit the same run, one of them should encounter a PENDING -> PENDING transition and abort orchestration of the run. 

Similarly, if the execution environment starts quickly the run may be in a RUNNING state when the second worker attempts the PENDING transition. We deny these state changes as well to prevent duplicate submission. If a run has transitioned to a RUNNING state a worker should not attempt to submit it again unless it has moved into a terminal state. 

CANCELLING and CANCELLED runs should not be allowed to transition to PENDING. For re-runs of deployed runs, they should transition to SCHEDULED first. For re-runs of ad-hoc runs, they should transition directly to RUNNING.

This should allow flow runs to RUNNING -> RUNNING transitions due to infrastructure restarts as described in #7116. This is similar to the changes made in https://github.com/PrefectHQ/prefect/pull/8802 but there task runs were made exempt from the entire redundant transition rule and here we retain some of the race condition prevention logic since multiple works could process the same flow run whereas only a single flow run should ever be submitting task runs to an execution environment.

The effective changes should include:
- CANCELLED -> PENDING is not allowed
- CANCELLING/RUNNING -> RUNNING is allowed
- CANCELLING/RUNNING/PENDING -> SCHEDULED is allowed

We may want to introduce a separate rule preventing CANCELLING runs from RUNNING.

Also related #9152  