### PR TITLE
Only touch the ignorefile if it doesn't exist

### DIFF
--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -786,7 +786,8 @@ class Deployment(BaseModel):
         deployment.parameter_openapi_schema = parameter_schema(flow)
 
         # ensure the ignore file exists
-        Path(ignore_file).touch()
+        if not Path(ignore_file).exists():
+            Path(ignore_file).touch()
 
         if not deployment.version:
             deployment.version = flow.version


### PR DESCRIPTION
Touching the `.prefectignore` file modifies it even if the file already exists which breaks some read-only CI environments. This change simply performs an existence check before touching the file.

Closes #9332