### PR TITLE
Handle deleted deployments gracefully

### DIFF
--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -378,6 +378,7 @@ class PrefectAgent:
 
     async def get_infrastructure(self, flow_run: FlowRun) -> Infrastructure:
         deployment = await self.client.read_deployment(flow_run.deployment_id)
+
         flow = await self.client.read_flow(deployment.flow_id)
 
         # overrides only apply when configuring known infra blocks

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -1482,7 +1482,13 @@ class PrefectClient:
         Returns:
             a [Deployment model][prefect.server.schemas.core.Deployment] representation of the deployment
         """
-        response = await self._client.get(f"/deployments/{deployment_id}")
+        try:
+            response = await self._client.get(f"/deployments/{deployment_id}")
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == status.HTTP_404_NOT_FOUND:
+                raise prefect.exceptions.ObjectNotFound(http_exc=e) from e
+            else:
+                raise
         return schemas.responses.DeploymentResponse.parse_obj(response.json())
 
     async def read_deployment_by_name(

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -535,8 +535,6 @@ class BaseWorker(abc.ABC):
                 f"Flow run {flow_run.id!r} cannot be cancelled by this worker:"
                 f" associated deployment {flow_run.deployment_id!r} does not exist."
             )
-            await self._propose_failed_state(flow_run, exc)
-            return
 
         try:
             await self.kill_infrastructure(

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -530,7 +530,7 @@ class BaseWorker(abc.ABC):
 
         try:
             configuration = await self._get_configuration(flow_run)
-        except ObjectNotFound as exc:
+        except ObjectNotFound:
             self._logger.warning(
                 f"Flow run {flow_run.id!r} cannot be cancelled by this worker:"
                 f" associated deployment {flow_run.deployment_id!r} does not exist."

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -722,7 +722,7 @@ async def test_create_then_delete_deployment(orion_client):
     )
 
     await orion_client.delete_deployment(deployment_id)
-    with pytest.raises(httpx.HTTPStatusError, match="404"):
+    with pytest.raises(prefect.exceptions.ObjectNotFound):
         await orion_client.read_deployment(deployment_id)
 
 


### PR DESCRIPTION
Right now if a user deletes a deployment associated with a new work pool, workers trying to cancel its runs will error out with a 404.  This PR updates workers to handle this situation gracefully and mark the flow run as failed.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
