### PR TITLE
Add future warning for Python 3.7 EOL

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ filterwarnings =
     ignore::sqlalchemy.exc.RemovedIn20Warning
     # Required to pass --cov-config to pytest
     ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning
+    ignore:Prefect will drop support for Python 3.7:FutureWarning
 
 
 [mypy]

--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -25,7 +25,8 @@ if sys.version_info < (3, 8):
         (
             "Prefect will drop support for Python 3.7 when it reaches end-of-life on 27"
             " Jun 2023. To use new versions of Prefect after that date, you will need"
-            " to upgrade to Python 3.8+."
+            " to upgrade to Python 3.8+. See https://devguide.python.org/versions/ for "
+            " more details."
         ),
         FutureWarning,
         stacklevel=2,

--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -20,6 +20,16 @@ __ui_static_path__ = __module_path__ / "server" / "ui"
 
 del _version, pathlib
 
+if sys.version_info < (3, 8):
+    warnings.warn(
+        (
+            "Prefect will drop support for Python 3.7 when it reaches end-of-life on 27"
+            " Jun 2023. To use new versions of Prefect after that date, you will need"
+            " to upgrade to Python 3.8+."
+        ),
+        FutureWarning,
+    )
+
 
 # Import user-facing API
 from prefect.states import State

--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -28,6 +28,7 @@ if sys.version_info < (3, 8):
             " to upgrade to Python 3.8+."
         ),
         FutureWarning,
+        stacklevel=2,
     )
 
 


### PR DESCRIPTION
## Example

```python
# example.py
import prefect
```

```
❯ python example.py
example.py:1: FutureWarning: Prefect will drop support for Python 3.7 when it reaches end-of-life on 27 Jun 2023. 
To use new versions of Prefect after that date, you will need to upgrade to Python 3.8+.
  import prefect
```