### PR TITLE
Update base and process worker to send flow-run related logs

### DIFF
--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -4,12 +4,13 @@ import sys
 from builtins import print
 from contextlib import contextmanager
 from functools import lru_cache
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 import prefect
 from prefect.exceptions import MissingContextError
 
 if TYPE_CHECKING:
+    from prefect.client.schemas import FlowRun as ClientFlowRun
     from prefect.context import RunContext
     from prefect.flows import Flow
     from prefect.server.schemas.core import FlowRun, TaskRun
@@ -29,6 +30,20 @@ class PrefectLogAdapter(logging.LoggerAdapter):
     def process(self, msg, kwargs):
         kwargs["extra"] = {**self.extra, **(kwargs.get("extra") or {})}
         return (msg, kwargs)
+
+    def getChild(
+        self, suffix: str, extra: Optional[Dict[str, str]] = None
+    ) -> "PrefectLogAdapter":
+        if extra is None:
+            extra = {}
+
+        return PrefectLogAdapter(
+            self.logger.getChild(suffix),
+            extra={
+                **self.extra,
+                **extra,
+            },
+        )
 
 
 @lru_cache()
@@ -117,7 +132,11 @@ def get_run_logger(
     return logger
 
 
-def flow_run_logger(flow_run: "FlowRun", flow: "Flow" = None, **kwargs: str):
+def flow_run_logger(
+    flow_run: Union["FlowRun", "ClientFlowRun"],
+    flow: Optional["Flow"] = None,
+    **kwargs: str,
+):
     """
     Create a flow run logger with the run's metadata attached.
 

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -22,7 +22,7 @@ from prefect.exceptions import (
     InfrastructureNotFound,
     ObjectNotFound,
 )
-from prefect.logging.loggers import get_logger
+from prefect.logging.loggers import PrefectLogAdapter, get_logger, flow_run_logger
 from prefect.server import schemas
 from prefect.server.schemas.actions import WorkPoolUpdate
 from prefect.server.schemas.filters import (
@@ -390,6 +390,18 @@ class BaseWorker(abc.ABC):
     def get_name_slug(self):
         return slugify(self.name)
 
+    def get_flow_run_logger(self, flow_run: "FlowRun") -> PrefectLogAdapter:
+        return flow_run_logger(flow_run=flow_run).getChild(
+            "worker",
+            extra={
+                "worker_name": self.name,
+                "work_pool_name": (
+                    self._work_pool_name if self._work_pool else "<unknown>"
+                ),
+                "work_pool_id": str(getattr(self._work_pool, "id", "unknown")),
+            },
+        )
+
     @abc.abstractmethod
     async def run(
         self,
@@ -512,8 +524,10 @@ class BaseWorker(abc.ABC):
         return cancelling_flow_runs
 
     async def cancel_run(self, flow_run: "FlowRun"):
+        run_logger = self.get_flow_run_logger(flow_run)
+
         if not flow_run.infrastructure_pid:
-            self._logger.error(
+            run_logger.error(
                 f"Flow run '{flow_run.id}' does not have an infrastructure pid"
                 " attached. Cancellation cannot be guaranteed."
             )
@@ -546,7 +560,7 @@ class BaseWorker(abc.ABC):
         except InfrastructureNotAvailable as exc:
             self._logger.warning(f"{exc} Flow run cannot be cancelled by this worker.")
         except Exception:
-            self._logger.exception(
+            run_logger.exception(
                 "Encountered exception while killing infrastructure for flow run "
                 f"'{flow_run.id}'. Flow run may not be cancelled."
             )
@@ -558,7 +572,7 @@ class BaseWorker(abc.ABC):
                 flow_run=flow_run, configuration=configuration
             )
             await self._mark_flow_run_as_cancelled(flow_run)
-            self._logger.info(f"Cancelled flow run '{flow_run.id}'!")
+            run_logger.info(f"Cancelled flow run '{flow_run.id}'!")
 
     async def _update_local_work_pool_info(self):
         try:
@@ -663,7 +677,10 @@ class BaseWorker(abc.ABC):
                 )
                 break
             else:
-                self._logger.info(f"Submitting flow run '{flow_run.id}'")
+                run_logger = self.get_flow_run_logger(flow_run)
+                run_logger.info(
+                    f"Worker '{self.name}' submitting flow run '{flow_run.id}'"
+                )
                 self._submitting_flow_run_ids.add(flow_run.id)
                 self._runs_task_group.start_soon(
                     self._submit_run,
@@ -696,6 +713,8 @@ class BaseWorker(abc.ABC):
         """
         Submits a given flow run for execution by the worker.
         """
+        run_logger = self.get_flow_run_logger(flow_run)
+
         try:
             await self._check_flow_run(flow_run)
         except ValueError:
@@ -723,13 +742,13 @@ class BaseWorker(abc.ABC):
                         infrastructure_pid=str(readiness_result),
                     )
                 except Exception:
-                    self._logger.exception(
+                    run_logger.exception(
                         "An error occurred while setting the `infrastructure_pid` on "
                         f"flow run {flow_run.id!r}. The flow run will "
                         "not be cancellable."
                     )
 
-            self._logger.info(f"Completed submission of flow run '{flow_run.id}'")
+            run_logger.info(f"Completed submission of flow run '{flow_run.id}'")
 
         else:
             # If the run is not ready to submit, release the concurrency slot
@@ -741,6 +760,8 @@ class BaseWorker(abc.ABC):
     async def _submit_run_and_capture_errors(
         self, flow_run: "FlowRun", task_status: anyio.abc.TaskStatus = None
     ) -> Union[BaseWorkerResult, Exception]:
+        run_logger = self.get_flow_run_logger(flow_run)
+
         try:
             configuration = await self._get_configuration(flow_run)
             submitted_event = self._emit_flow_run_submitted_event(configuration)
@@ -759,7 +780,7 @@ class BaseWorker(abc.ABC):
                 task_status.started(exc)
                 await self._propose_failed_state(flow_run, exc)
             else:
-                self._logger.exception(
+                run_logger.exception(
                     f"An error occurred while monitoring flow run '{flow_run.id}'. "
                     "The flow run will not be marked as failed, but an issue may have "
                     "occurred."
@@ -770,7 +791,7 @@ class BaseWorker(abc.ABC):
                 self._limiter.release_on_behalf_of(flow_run.id)
 
         if not task_status._future.done():
-            self._logger.error(
+            run_logger.error(
                 f"Infrastructure returned without reporting flow run '{flow_run.id}' "
                 "as started or raising an error. This behavior is not expected and "
                 "generally indicates improper implementation of infrastructure. The "
@@ -826,13 +847,14 @@ class BaseWorker(abc.ABC):
         return configuration
 
     async def _propose_pending_state(self, flow_run: "FlowRun") -> bool:
+        run_logger = self.get_flow_run_logger(flow_run)
         state = flow_run.state
         try:
             state = await propose_state(
                 self._client, Pending(), flow_run_id=flow_run.id
             )
         except Abort as exc:
-            self._logger.info(
+            run_logger.info(
                 (
                     f"Aborted submission of flow run '{flow_run.id}'. "
                     f"Server sent an abort signal: {exc}"
@@ -840,13 +862,13 @@ class BaseWorker(abc.ABC):
             )
             return False
         except Exception:
-            self._logger.exception(
+            run_logger.exception(
                 f"Failed to update state of flow run '{flow_run.id}'",
             )
             return False
 
         if not state.is_pending():
-            self._logger.info(
+            run_logger.info(
                 (
                     f"Aborted submission of flow run '{flow_run.id}': "
                     f"Server returned a non-pending state {state.type.value!r}"
@@ -857,6 +879,7 @@ class BaseWorker(abc.ABC):
         return True
 
     async def _propose_failed_state(self, flow_run: "FlowRun", exc: Exception) -> None:
+        run_logger = self.get_flow_run_logger(flow_run)
         try:
             await propose_state(
                 self._client,
@@ -868,12 +891,13 @@ class BaseWorker(abc.ABC):
             # raise in the agent process
             pass
         except Exception:
-            self._logger.error(
+            run_logger.error(
                 f"Failed to update state of flow run '{flow_run.id}'",
                 exc_info=True,
             )
 
     async def _propose_crashed_state(self, flow_run: "FlowRun", message: str) -> None:
+        run_logger = self.get_flow_run_logger(flow_run)
         try:
             state = await propose_state(
                 self._client,
@@ -884,12 +908,10 @@ class BaseWorker(abc.ABC):
             # Flow run already marked as failed
             pass
         except Exception:
-            self._logger.exception(
-                f"Failed to update state of flow run '{flow_run.id}'"
-            )
+            run_logger.exception(f"Failed to update state of flow run '{flow_run.id}'")
         else:
             if state.is_crashed():
-                self._logger.info(
+                run_logger.info(
                     f"Reported flow run '{flow_run.id}' as crashed: {message}"
                 )
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -33,6 +33,7 @@ from prefect.logging.formatters import JsonFormatter
 from prefect.logging.handlers import APILogHandler, APILogWorker, PrefectConsoleHandler
 from prefect.logging.highlighters import PrefectConsoleHighlighter
 from prefect.logging.loggers import (
+    PrefectLogAdapter,
     disable_logger,
     disable_run_logger,
     flow_run_logger,
@@ -1361,3 +1362,12 @@ def test_patch_print_writes_to_logger_with_flow_run_context(caplog, capsys, flow
     assert record.name == "prefect.flow_runs"
     assert record.flow_run_id == str(flow_run.id)
     assert record.flow_name == my_flow.name
+
+
+def test_log_adapter_get_child(flow_run):
+    logger = PrefectLogAdapter(get_logger("prefect.parent"), {"hello": "world"})
+    assert logger.extra == {"hello": "world"}
+
+    child_logger = logger.getChild("child", {"goodnight": "moon"})
+    assert child_logger.logger.name == "prefect.parent.child"
+    assert child_logger.extra == {"hello": "world", "goodnight": "moon"}


### PR DESCRIPTION
This updates the base and process worker to send flow-run related logs to Cloud. There's two main parts:

1. `PrefectLogAdapter` now has a `getChild` method that will get a logger, give it an appropriate name and allow passing `extra` data into the logger itself.
2. A `get_flow_run_logger` method on BaseWorker that gets the proper logger and sets the extra data, including worker and work pool information.

Closes #9218 

### Example
![Screenshot 2023-05-09 at 11 20 33 AM](https://github.com/PrefectHQ/prefect/assets/354286/b55e8c9a-f39c-437d-9095-0267801d2e96)


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
