### PR TITLE
Fix bug where SIGTERM was not properly captured as a flow run crash

### DIFF
--- a/src/prefect/_internal/concurrency/api.py
+++ b/src/prefect/_internal/concurrency/api.py
@@ -170,7 +170,7 @@ class from_async(_base):
             for context in contexts or []:
                 stack.enter_context(context)
             await waiter.wait()
-        return call.result()
+            return call.result()
 
     @staticmethod
     async def wait_for_call_in_new_thread(
@@ -229,7 +229,7 @@ class from_sync(_base):
             for context in contexts or []:
                 stack.enter_context(context)
             waiter.wait()
-        return call.result()
+            return call.result()
 
     @staticmethod
     def wait_for_call_in_new_thread(

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -19,6 +19,7 @@ import asyncio
 import logging
 import os
 import signal
+import contextlib
 import sys
 import time
 from contextlib import AsyncExitStack, asynccontextmanager, nullcontext
@@ -171,18 +172,25 @@ def enter_flow_run_engine_from_flow_call(
         [create_call(wait_for_global_loop_exit)] if not is_subflow_run else None
     )
 
+    #
+    contexts = [capture_sigterm()]
+
     if flow.isasync and (
         not is_subflow_run or (is_subflow_run and parent_flow_run_context.flow.isasync)
     ):
         # return a coro for the user to await if the flow is async
         # unless it is an async subflow called in a sync flow
         retval = from_async.wait_for_call_in_loop_thread(
-            begin_run, done_callbacks=done_callbacks
+            begin_run,
+            done_callbacks=done_callbacks,
+            contexts=contexts,
         )
 
     else:
         retval = from_sync.wait_for_call_in_loop_thread(
-            begin_run, done_callbacks=done_callbacks
+            begin_run,
+            done_callbacks=done_callbacks,
+            contexts=contexts,
         )
 
     return retval
@@ -1708,15 +1716,8 @@ async def wait_for_task_runs_and_report_crashes(
     return True
 
 
-@asynccontextmanager
-async def report_flow_run_crashes(flow_run: FlowRun, client: PrefectClient, flow: Flow):
-    """
-    Detect flow run crashes during this context and update the run to a proper final
-    state.
-
-    This context _must_ reraise the exception to properly exit the run.
-    """
-
+@contextlib.contextmanager
+def capture_sigterm():
     def cancel_flow_run(*args):
         raise TerminationSignal(signal=signal.SIGTERM)
 
@@ -1726,6 +1727,33 @@ async def report_flow_run_crashes(flow_run: FlowRun, client: PrefectClient, flow
     except ValueError:
         # Signals only work in the main thread
         pass
+
+    try:
+        yield
+    except BaseException as exc:
+        if isinstance(exc, TerminationSignal):
+            # Termination signals are swapped out during a flow run to perform
+            # a graceful shutdown and raise this exception. This `os.kill` call
+            # ensures that the previous handler, likely the Python default,
+            # gets called as well.
+            signal.signal(exc.signal, original_term_handler)
+            os.kill(os.getpid(), exc.signal)
+
+        raise
+
+    finally:
+        if original_term_handler is not None:
+            signal.signal(signal.SIGTERM, original_term_handler)
+
+
+@asynccontextmanager
+async def report_flow_run_crashes(flow_run: FlowRun, client: PrefectClient, flow: Flow):
+    """
+    Detect flow run crashes during this context and update the run to a proper final
+    state.
+
+    This context _must_ reraise the exception to properly exit the run.
+    """
 
     try:
         yield
@@ -1754,19 +1782,8 @@ async def report_flow_run_crashes(flow_run: FlowRun, client: PrefectClient, flow
                 state=state,
             )
 
-        if isinstance(exc, TerminationSignal):
-            # Termination signals are swapped out during a flow run to perform
-            # a graceful shutdown and raise this exception. This `os.kill` call
-            # ensures that the previous handler, likely the Python default,
-            # gets called as well.
-            signal.signal(exc.signal, original_term_handler)
-            os.kill(os.getpid(), exc.signal)
-
         # Reraise the exception
-        raise exc from None
-    finally:
-        if original_term_handler is not None:
-            signal.signal(signal.SIGTERM, original_term_handler)
+        raise
 
 
 @asynccontextmanager

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -172,7 +172,6 @@ def enter_flow_run_engine_from_flow_call(
         [create_call(wait_for_global_loop_exit)] if not is_subflow_run else None
     )
 
-    #
     contexts = [capture_sigterm()]
 
     if flow.isasync and (

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1730,12 +1730,12 @@ def capture_sigterm():
 
     try:
         yield
-    except BaseException as exc:
-        if isinstance(exc, TerminationSignal):
-            # Termination signals are swapped out during a flow run to perform
-            # a graceful shutdown and raise this exception. This `os.kill` call
-            # ensures that the previous handler, likely the Python default,
-            # gets called as well.
+    except TerminationSignal as exc:
+        # Termination signals are swapped out during a flow run to perform
+        # a graceful shutdown and raise this exception. This `os.kill` call
+        # ensures that the previous handler, likely the Python default,
+        # gets called as well.
+        if original_term_handler is not None:
             signal.signal(exc.signal, original_term_handler)
             os.kill(os.getpid(), exc.signal)
 

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -22,6 +22,7 @@ from prefect.exceptions import (
     FailedRun,
     UnfinishedRun,
     MissingResult,
+    TerminationSignal,
     PausedRun,
 )
 from prefect.results import BaseResult, R, ResultFactory
@@ -141,6 +142,9 @@ async def exception_to_crashed_state(
 
     elif isinstance(exc, KeyboardInterrupt):
         state_message = "Execution was aborted by an interrupt signal."
+
+    elif isinstance(exc, TerminationSignal):
+        state_message = "Execution was aborted by a termination signal."
 
     elif isinstance(exc, SystemExit):
         state_message = "Execution was aborted by Python system exit call."


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/9403

When we moved the engine to a dedicated thread, we lost the ability to register signal handlers. Here we add signal handler registration to the main thread before entering the engine which is important for crash detection of SIGTERM and consequently reports of cancellation.

I implemented this by adding support for context managers to the concurrency API because async flow calls return a coroutine and we need to enter the contexts inside that coroutine or it'll exit before it actually runs.

## Example

```
12:34:14.097 | DEBUG   | prefect.profiles - Using profile 'default'
12:34:14.576 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/mz/.prefect/prefect.db
12:34:14.744 | INFO    | prefect.engine - Created flow run 'nifty-avocet' for flow 'test-flow'
12:34:14.744 | DEBUG   | Flow run 'nifty-avocet' - Starting 'ConcurrentTaskRunner'; submitted tasks will be run concurrently...
12:34:14.744 | DEBUG   | prefect.task_runner.concurrent - Starting task runner...
12:34:14.745 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/mz/.prefect/prefect.db
12:34:14.853 | DEBUG   | Flow run 'nifty-avocet' - Executing flow 'test-flow' for flow run 'nifty-avocet'...
12:34:14.853 | DEBUG   | Flow run 'nifty-avocet' - Beginning execution...
12:34:21.704 | DEBUG   | prefect.task_runner.concurrent - Shutting down task runner...
12:34:21.705 | ERROR   | Flow run 'nifty-avocet' - Crash detected! Execution was interrupted by an unexpected exception: TerminationSignal

12:34:21.707 | DEBUG   | Flow run 'nifty-avocet' - Crash details:
Traceback (most recent call last):
  File "/Users/mz/dev/prefect/src/prefect/engine.py", line 1759, in report_flow_run_crashes
    yield
  File "/Users/mz/dev/prefect/src/prefect/engine.py", line 415, in begin_flow_run
    interruptible=flow.timeout_seconds is not None,
  File "/Users/mz/dev/prefect/src/prefect/engine.py", line 708, in orchestrate_flow_run
    result = await flow_call.aresult()
  File "/Users/mz/dev/prefect/src/prefect/_internal/concurrency/calls.py", line 181, in aresult
    return await asyncio.wrap_future(self.future)
  File "/Users/mz/dev/prefect/src/prefect/_internal/concurrency/calls.py", line 194, in _run_sync
    result = self.fn(*self.args, **self.kwargs)
  File "example.py", line 6, in test_flow
    time.sleep(100)
  File "/Users/mz/dev/prefect/src/prefect/engine.py", line 1722, in cancel_flow_run
    raise TerminationSignal(signal=signal.SIGTERM)
prefect.exceptions.TerminationSignal
12:34:21.743 | DEBUG   | prefect.engine - Reported crashed flow run 'nifty-avocet' successfully!
Traceback (most recent call last):
  File "example.py", line 9, in <module>
    test_flow()
  File "/Users/mz/dev/prefect/src/prefect/flows.py", line 501, in __call__
    return_type=return_type,
  File "/Users/mz/dev/prefect/src/prefect/engine.py", line 193, in enter_flow_run_engine_from_flow_call
    contexts=contexts,
  File "/Users/mz/dev/prefect/src/prefect/_internal/concurrency/api.py", line 232, in wait_for_call_in_loop_thread
    return call.result()
  File "/Users/mz/dev/prefect/src/prefect/_internal/concurrency/calls.py", line 173, in result
    return self.future.result(timeout=timeout)
  File "/Users/mz/.pyenv/versions/3.7.16/lib/python3.7/concurrent/futures/_base.py", line 428, in result
    return self.__get_result()
  File "/Users/mz/.pyenv/versions/3.7.16/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/Users/mz/dev/prefect/src/prefect/_internal/concurrency/calls.py", line 218, in _run_async
    result = await coro
  File "/Users/mz/dev/prefect/src/prefect/client/utilities.py", line 40, in with_injected_client
    return await fn(*args, **kwargs)
  File "/Users/mz/dev/prefect/src/prefect/engine.py", line 260, in create_then_begin_flow_run
    flow=flow, flow_run=flow_run, parameters=parameters, client=client
  File "/Users/mz/dev/prefect/src/prefect/engine.py", line 415, in begin_flow_run
    interruptible=flow.timeout_seconds is not None,
  File "/Users/mz/dev/prefect/src/prefect/engine.py", line 708, in orchestrate_flow_run
    result = await flow_call.aresult()
  File "/Users/mz/dev/prefect/src/prefect/_internal/concurrency/calls.py", line 181, in aresult
    return await asyncio.wrap_future(self.future)
  File "/Users/mz/dev/prefect/src/prefect/_internal/concurrency/calls.py", line 194, in _run_sync
    result = self.fn(*self.args, **self.kwargs)
  File "example.py", line 6, in test_flow
    time.sleep(100)
  File "/Users/mz/dev/prefect/src/prefect/engine.py", line 1722, in cancel_flow_run
    raise TerminationSignal(signal=signal.SIGTERM)
prefect.exceptions.TerminationSignal

[1]  + exit 1     python example.py
```