### PR TITLE
Improve default Prefect image tag when using development versions

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -112,6 +112,13 @@ jobs:
           mv requirements-lower.txt requirements.txt
           mv requirements-dev-lower.txt requirements-dev.txt
 
+      - name: Get image tag
+        id: get_image_tag
+        if: ${{ matrix.build-docker-images }}
+        run: |
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          echo "image_tag="sha-$SHORT_SHA-python${{ matrix.python-version }}" >> $GITHUB_OUTPUT
+
       - name: Build test image
         if: ${{ matrix.build-docker-images }}
         uses: docker/build-push-action@v4
@@ -122,7 +129,7 @@ jobs:
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
             PREFECT_EXTRAS=[dev]
-          tags: prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python${{ matrix.python-version }}
+          tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}
           outputs: type=docker,dest=/tmp/image.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -131,7 +138,7 @@ jobs:
         if: ${{ matrix.build-docker-images }}
         run: |
           docker load --input /tmp/image.tar
-          docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python${{ matrix.python-version }} prefect version
+          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }} prefect version
 
       - name: Build Conda flavored test image
         # Not yet supported for 3.11, see note at top
@@ -143,7 +150,7 @@ jobs:
             PYTHON_VERSION=${{ matrix.python-version }}
             BASE_IMAGE=prefect-conda
             PREFECT_EXTRAS=[dev]
-          tags: prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python${{ matrix.python-version }}-conda
+          tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda
           outputs: type=docker,dest=/tmp/image-conda.tar
           cache-from: type=gha
           # We do not cache Conda image layers because they very big and slow to upload
@@ -154,8 +161,8 @@ jobs:
         if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
         run: |
           docker load --input /tmp/image-conda.tar
-          docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python${{ matrix.python-version }}-conda prefect version
-          docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python${{ matrix.python-version }}-conda conda --version
+          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda prefect version
+          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda conda --version
 
       - name: Install packages
         run: |

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -139,7 +139,8 @@ jobs:
         if: ${{ matrix.build-docker-images }}
         run: |
           SHORT_SHA=$(git rev-parse --short=7 HEAD)
-          echo "image_tag="sha-$SHORT_SHA-python${{ matrix.python-version }}" >> $GITHUB_OUTPUT
+          tmp="sha-$SHORT_SHA-python${{ matrix.python-version }}"
+          echo "image_tag=${tmp}" >> $GITHUB_OUTPUT
 
       - name: Build test image
         if: ${{ matrix.build-docker-images }}

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -122,7 +122,7 @@ jobs:
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
             PREFECT_EXTRAS=[dev]
-          tags: prefecthq/prefect:dev-python${{ matrix.python-version }}
+          tags: prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python${{ matrix.python-version }}
           outputs: type=docker,dest=/tmp/image.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -131,7 +131,7 @@ jobs:
         if: ${{ matrix.build-docker-images }}
         run: |
           docker load --input /tmp/image.tar
-          docker run --rm prefecthq/prefect:dev-python${{ matrix.python-version }} prefect version
+          docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python${{ matrix.python-version }} prefect version
 
       - name: Build Conda flavored test image
         # Not yet supported for 3.11, see note at top
@@ -143,7 +143,7 @@ jobs:
             PYTHON_VERSION=${{ matrix.python-version }}
             BASE_IMAGE=prefect-conda
             PREFECT_EXTRAS=[dev]
-          tags: prefecthq/prefect:dev-python${{ matrix.python-version }}-conda
+          tags: prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python${{ matrix.python-version }}-conda
           outputs: type=docker,dest=/tmp/image-conda.tar
           cache-from: type=gha
           # We do not cache Conda image layers because they very big and slow to upload
@@ -154,8 +154,8 @@ jobs:
         if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
         run: |
           docker load --input /tmp/image-conda.tar
-          docker run --rm prefecthq/prefect:dev-python${{ matrix.python-version }}-conda prefect version
-          docker run --rm prefecthq/prefect:dev-python${{ matrix.python-version }}-conda conda --version
+          docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python${{ matrix.python-version }}-conda prefect version
+          docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python${{ matrix.python-version }}-conda conda --version
 
       - name: Install packages
         run: |

--- a/docs/concepts/infrastructure.md
+++ b/docs/concepts/infrastructure.md
@@ -102,7 +102,7 @@ infrastructure:
   - python
   - -m
   - prefect.engine
-  image: prefecthq/prefect:dev-python3.9
+  image: prefecthq/prefect:2-latest
   image_pull_policy: null
   networks: []
   network_mode: null

--- a/docs/contributing/testing-flow-runners.md.old
+++ b/docs/contributing/testing-flow-runners.md.old
@@ -68,7 +68,7 @@ for testing.
 ## Building an image
 
 As with the `DockerFlowRunner`, the `KubernetesFlowRunner` test assumes that you have an
-image named `prefecthq/prefect:dev-python3.9` available on the Docker daemon, and that
+image named `prefecthq/prefect-dev:sha-COMMITSHA-python3.9` available on the Docker daemon, and that
 it includes and installation of the same version of `prefect` that you are currently
 testing.  You can build a compatible image from your source tree with:
 

--- a/scripts/build-all-dev-images
+++ b/scripts/build-all-dev-images
@@ -21,7 +21,7 @@ for python in 3.8 3.9 3.10 3.11; do
 
         echo
         echo "---- expecting Python $python$flavor_desc ----"
-        docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python$python$flavor_tag python --version
+        docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short=7 HEAD)-python$python$flavor_tag python --version
         echo "---- expecting Prefect $expected_prefect ----"
         docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python$python$flavor_tag prefect --version
 

--- a/scripts/build-all-dev-images
+++ b/scripts/build-all-dev-images
@@ -5,7 +5,7 @@ set -e
 
 expected_prefect=`prefect --version`
 
-for python in 3.8 3.9 3.10; do
+for python in 3.8 3.9 3.10 3.11; do
     for flavor in '' 'conda'; do
         flavor_arg=''
         flavor_tag=''
@@ -21,13 +21,13 @@ for python in 3.8 3.9 3.10; do
 
         echo
         echo "---- expecting Python $python$flavor_desc ----"
-        docker run --rm prefecthq/prefect:dev-python$python$flavor_tag python --version
+        docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python$python$flavor_tag python --version
         echo "---- expecting Prefect $expected_prefect ----"
-        docker run --rm prefecthq/prefect:dev-python$python$flavor_tag prefect --version
+        docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python$python$flavor_tag prefect --version
 
         if [ "$flavor" = "conda" ]; then
             echo "---- expecting Conda ----"
-            docker run --rm prefecthq/prefect:dev-python$python$flavor_tag conda --version
+            docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python$python$flavor_tag conda --version
         fi
 
         echo

--- a/scripts/build-all-dev-images
+++ b/scripts/build-all-dev-images
@@ -23,11 +23,11 @@ for python in 3.8 3.9 3.10 3.11; do
         echo "---- expecting Python $python$flavor_desc ----"
         docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short=7 HEAD)-python$python$flavor_tag python --version
         echo "---- expecting Prefect $expected_prefect ----"
-        docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python$python$flavor_tag prefect --version
+        docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short=7 HEAD)-python$python$flavor_tag prefect --version
 
         if [ "$flavor" = "conda" ]; then
             echo "---- expecting Conda ----"
-            docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short HEAD)-python$python$flavor_tag conda --version
+            docker run --rm prefecthq/prefect-dev:sha-$(git rev-parse --short=7 HEAD)-python$python$flavor_tag conda --version
         fi
 
         echo

--- a/src/prefect/docker.py
+++ b/src/prefect/docker.py
@@ -49,7 +49,12 @@ def get_prefect_image_name(
         flavor: An optional alternative image flavor to build, like 'conda'
     """
     parsed_version = (prefect_version or prefect.__version__).split("+")
-    prefect_version = parsed_version[0] if len(parsed_version) == 1 else "dev"
+    is_prod_build = len(parsed_version) == 1
+    prefect_version = (
+        parsed_version[0]
+        if is_prod_build
+        else "sha-" + prefect.__version_info__["full-revisionid"][:7]
+    )
 
     python_version = python_version or python_version_minor()
 
@@ -61,7 +66,8 @@ def get_prefect_image_name(
         regex_pattern=r"[^a-zA-Z0-9_.-]+",
     )
 
-    return f"prefecthq/prefect:{tag}"
+    image = "prefect" if is_prod_build else "prefect-dev"
+    return f"prefecthq/{image}:{tag}"
 
 
 @contextmanager


### PR DESCRIPTION
Previously, if you were using a non-release version of Prefect we'd generate the special tag `prefect:dev-pythonX.X` to use a local image. This image should never be available on DockerHub so you'd need to build your local development image as needed.

However, this can be confusing and since we're publishing images on merge to `main` we can do a bit better! Now we generate the tag `prefect-dev:sha-XXXXX-pythonX.X` so you'll get an image that matches the most recent commit for your local version. If your commit is not available, you'll need to build an image for it or specify a different image than the default.