### PR TITLE
Add `include_submodules` option to `git_clone_project` step

### DIFF
--- a/src/prefect/projects/steps/pull.py
+++ b/src/prefect/projects/steps/pull.py
@@ -48,6 +48,40 @@ def git_clone_project(
 
     Raises:
         subprocess.CalledProcessError: if the git clone command fails for any reason
+
+    Examples:
+        Clone a public repository:
+        ```yaml
+        pull:
+            - prefect.projects.steps.git_clone_project:
+                repository: https://github.com/PrefectHQ/prefect.git
+        ```
+
+        Clone a branch of a public repository:
+        ```yaml
+        pull:
+            - prefect.projects.steps.git_clone_project:
+                repository: https://github.com/PrefectHQ/prefect.git
+                branch: my-branch
+        ```
+
+        Clone a private repository using an access token:
+        ```yaml
+        pull:
+            - prefect.projects.steps.git_clone_project:
+                repository: https://github.com/org/repo.git
+                access_token: ${{ prefect.blocks.secret.github-access-token }}
+        ```
+
+        Clone a repository with submodules:
+        ```yaml
+        pull:
+            - prefect.projects.steps.git_clone_project:
+                repository: https://github.com/org/repo.git
+                include_submodules: true
+        ```
+
+
     """
     url_components = urllib.parse.urlparse(repository)
     if url_components.scheme == "https" and access_token is not None:

--- a/src/prefect/projects/steps/pull.py
+++ b/src/prefect/projects/steps/pull.py
@@ -28,7 +28,10 @@ def set_working_directory(directory: str) -> dict:
 
 
 def git_clone_project(
-    repository: str, branch: Optional[str] = None, access_token: Optional[str] = None
+    repository: str,
+    branch: Optional[str] = None,
+    include_submodules: bool = False,
+    access_token: Optional[str] = None,
 ) -> dict:
     """
     Clones a git repository into the current working directory.
@@ -36,6 +39,7 @@ def git_clone_project(
     Args:
         repository (str): the URL of the repository to clone
         branch (str, optional): the branch to clone; if not provided, the default branch will be used
+        include_submodules (bool): whether to include git submodules when cloning the repository
         access_token (str, optional): an access token to use for cloning the repository; if not provided
             the repository will be cloned using the default git credentials
 
@@ -57,6 +61,8 @@ def git_clone_project(
     cmd = ["git", "clone", repository_url]
     if branch:
         cmd += ["-b", branch]
+    if include_submodules:
+        cmd += ["--recurse-submodules"]
 
     # Limit git history
     cmd += ["--depth", "1"]


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Adds a `include_submodules` option to `git_clone_project` which will append the `--recurse-submodules` option to the `git clone` command used to clone the repository. When `true`, `include_submodules` will initialize and clone submouldes within the base repository. 

Closes #9462

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Clone a repository with submodules:
```yaml
pull:
    - prefect.projects.steps.git_clone_project:
        repository: https://github.com/org/repo.git
        include_submodules: true
```
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
