### PR TITLE
Flush logs before exiting deployed flow run processes

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -199,9 +199,12 @@ def enter_flow_run_engine_from_subprocess(flow_run_id: UUID) -> State:
     """
     setup_logging()
 
-    return from_sync.wait_for_call_in_loop_thread(
+    state = from_sync.wait_for_call_in_loop_thread(
         create_call(retrieve_flow_then_begin_flow_run, flow_run_id)
     )
+
+    APILogHandler.flush()
+    return state
 
 
 @inject_client


### PR DESCRIPTION
Sometimes `retrieve_flow_then_begin_flow_run` can exit without orchestrating the flow run which means that logs are not flushed and can be missing but they are generally useful for debugging the failure so let's flush those things!