### PR TITLE
Correctly pass optional parameters to API in create_work_queue

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -804,7 +804,8 @@ class PrefectClient:
             create_model.concurrency_limit = concurrency_limit
         if priority is not None:
             create_model.priority = priority
-        data = WorkQueueCreate(name=name, filter=filter).dict(json_compatible=True)
+
+        data = create_model.dict(json_compatible=True)
         try:
             if work_pool_name is not None:
                 response = await self._client.post(

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -1435,6 +1435,19 @@ class TestClientWorkQueues:
         assert lookup.name == "foo"
         assert lookup.id == queue.id
 
+    async def test_create_queue_with_settings(self, orion_client):
+        queue = await orion_client.create_work_queue(
+            name="foo",
+            concurrency_limit=1,
+            is_paused=True,
+            priority=2,
+            description="such queue",
+        )
+        assert queue.concurrency_limit == 1
+        assert queue.is_paused is True
+        assert queue.priority == 2
+        assert queue.description == "such queue"
+
     async def test_create_then_match_work_queues(self, orion_client):
         await orion_client.create_work_queue(
             name="one of these things is not like the other"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

I noticed that when using the `create_work_queue` method in the python client that the work queue would get created but without any of the parameters that were set to non-default values. I guess this was an oversight or rebase issue when the params were [first added here](https://github.com/PrefectHQ/prefect/commit/839cc3e#diff-ed60480b777e77bdeeced26ed733ea8d0da54e3da5a6dce53054258a1625b004R696).

This PR just builds the API request from the object that I assume should have been used all along and adds a test to check the extra params were used.


### Example

```python
# this was succeeding but the work queue was being created without the concurrency limit
async with get_client() as prefect_client:
    await prefect_client.create_work_queue(
        name="my-queue",
        concurrency_limit=1,
    )
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
