### PR TITLE
Update worker to be able to include itself as a related resource

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -990,7 +990,9 @@ class BaseWorker(abc.ABC):
         }
 
     def _event_related_resources(
-        self, configuration: Optional[BaseJobConfiguration] = None
+        self,
+        configuration: Optional[BaseJobConfiguration] = None,
+        include_self: bool = False,
     ) -> List[RelatedResource]:
         related = []
         if configuration:
@@ -1002,6 +1004,11 @@ class BaseWorker(abc.ABC):
                     kind="work-pool", role="work-pool", object=self._work_pool
                 )
             )
+
+        if include_self:
+            worker_resource = self._event_resource()
+            worker_resource["prefect.resource.role"] = "worker"
+            related.append(RelatedResource(__root__=worker_resource))
 
         return related
 


### PR DESCRIPTION
This adds an `include_self` kwarg to the Worker's `_event_related_resources` method that will make the worker include itself as a related resource when this method is called. This should be a more elegant solution for the downstream libraries instead of the [3 line dance](https://github.com/PrefectHQ/prefect-kubernetes/blob/main/prefect_kubernetes/events.py#L51-L53) they do now.