### PR TITLE
Ensure test DB is cleared at the end of run history tests

### DIFF
--- a/tests/server/api/test_run_history.py
+++ b/tests/server/api/test_run_history.py
@@ -40,7 +40,7 @@ def parse_response(response: Response, include=None):
 @pytest.fixture(autouse=True, scope="module")
 async def clear_db(db):
     """Prevent automatic database-clearing behavior after every test"""
-    pass  # noqa
+    yield  # noqa
     async with db.session_context(begin_transaction=True) as session:
         await session.execute(db.Agent.__table__.delete())
         # work pool has a circular dependency on pool queue; delete it first

--- a/tests/server/api/test_work_queues.py
+++ b/tests/server/api/test_work_queues.py
@@ -174,7 +174,9 @@ class TestReadWorkQueues:
         response = await client.post("/work_queues/filter")
         assert response.status_code == status.HTTP_200_OK
         # includes default work queue
-        assert len(response.json()) == 4
+        assert (
+            len(response.json()) == 4
+        ), f"Work queue names: {[wq['name'] for wq in response.json()]}"
 
     async def test_read_work_queues_applies_limit(self, work_queues, client):
         response = await client.post("/work_queues/filter", json=dict(limit=1))

--- a/tests/server/api/test_work_queues.py
+++ b/tests/server/api/test_work_queues.py
@@ -174,9 +174,7 @@ class TestReadWorkQueues:
         response = await client.post("/work_queues/filter")
         assert response.status_code == status.HTTP_200_OK
         # includes default work queue
-        assert (
-            len(response.json()) == 4
-        ), f"Work queue names: {[wq['name'] for wq in response.json()]}"
+        assert len(response.json()) == 4
 
     async def test_read_work_queues_applies_limit(self, work_queues, client):
         response = await client.post("/work_queues/filter", json=dict(limit=1))


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
The test_run_history module overrides the default `clear_db` fixture so that data hangs around for all tests in the module. The data isn't cleared, which can cause bleed over into other tests that work with work queues and work pools. This PR updates the custom `clear_db` fixture to clear data in the DB after all tests in the module are complete.

Closes #9538 
Closes #9537 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
