### PR TITLE
Add benchmarks for CLI commands

### DIFF
--- a/benches/bench_cli.py
+++ b/benches/bench_cli.py
@@ -1,0 +1,22 @@
+import subprocess
+from pytest_benchmark.fixture import BenchmarkFixture
+
+
+def bench_prefect_help(benchmark: BenchmarkFixture):
+    benchmark.pedantic(subprocess.check_call, args=(["prefect", "--help"],), rounds=3)
+
+
+def bench_prefect_version(benchmark: BenchmarkFixture):
+    benchmark.pedantic(subprocess.check_call, args=(["prefect", "version"],), rounds=3)
+
+
+def bench_prefect_short_version(benchmark: BenchmarkFixture):
+    benchmark.pedantic(
+        subprocess.check_call, args=(["prefect", "--version"],), rounds=3
+    )
+
+
+def bench_prefect_profile_ls(benchmark: BenchmarkFixture):
+    benchmark.pedantic(
+        subprocess.check_call, args=(["prefect", "profile", "ls"],), rounds=3
+    )


### PR DESCRIPTION
Example

```
❯ python benches benches/bench_cli.py                                         
=========================================================================================================== test session starts ============================================================================================================
platform darwin -- Python 3.11.2, pytest-7.3.1, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=1 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/mz/dev/prefect
configfile: setup.cfg
plugins: env-0.8.1, asyncio-0.21.0, flaky-3.7.0, timeout-2.1.0, flakefinder-1.1.0, xdist-3.2.1, respx-0.20.1, cov-4.0.0, anyio-3.6.2, benchmark-4.0.0, lazy-fixture-0.6.3
asyncio: mode=Mode.AUTO
timeout: 60.0s
timeout method: signal
timeout func_only: False
collected 4 items                                                                                                                                                                                                                          

benches/bench_cli.py ....                                                                                                                                                                                                            [100%]


---------- benchmark 'bench_prefect_help': 1 tests ----------
Name (time in s)         Mean  StdDev     Min     Max  Rounds
-------------------------------------------------------------
bench_prefect_help     1.7842  0.0796  1.7135  1.8704       3
-------------------------------------------------------------

---------- benchmark 'bench_prefect_profile_ls': 1 tests ----------
Name (time in s)               Mean  StdDev     Min     Max  Rounds
-------------------------------------------------------------------
bench_prefect_profile_ls     1.7409  0.0179  1.7279  1.7613       3
-------------------------------------------------------------------

---------- benchmark 'bench_prefect_short_version': 1 tests ----------
Name (time in s)                  Mean  StdDev     Min     Max  Rounds
----------------------------------------------------------------------
bench_prefect_short_version     1.8146  0.0086  1.8054  1.8223       3
----------------------------------------------------------------------

---------- benchmark 'bench_prefect_version': 1 tests ----------
Name (time in s)            Mean  StdDev     Min     Max  Rounds
----------------------------------------------------------------
bench_prefect_version     1.7455  0.0572  1.6900  1.8042       3
```