### PR TITLE
Add benchmarks for `import prefect`

### DIFF
--- a/benches/bench_import.py
+++ b/benches/bench_import.py
@@ -1,0 +1,8 @@
+import subprocess
+from pytest_benchmark.fixture import BenchmarkFixture
+
+
+def bench_import_prefect(benchmark: BenchmarkFixture):
+    benchmark.pedantic(
+        subprocess.check_call, args=(["python", "-c", "import prefect"],), rounds=5
+    )


### PR DESCRIPTION
Example

```
❯ python benches benches/bench_import.py        
=========================================================================================================== test session starts ============================================================================================================
platform darwin -- Python 3.11.2, pytest-7.3.1, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=1 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/mz/dev/prefect
configfile: setup.cfg
plugins: env-0.8.1, asyncio-0.21.0, flaky-3.7.0, timeout-2.1.0, flakefinder-1.1.0, xdist-3.2.1, respx-0.20.1, cov-4.0.0, anyio-3.6.2, benchmark-4.0.0, lazy-fixture-0.6.3
asyncio: mode=Mode.AUTO
timeout: 60.0s
timeout method: signal
timeout func_only: False
collected 1 item                                                                                                                                                                                                                           

benches/bench_import.py .                                                                                                                                                                                                            [100%]


---------- benchmark 'bench_import_prefect': 1 tests ----------
Name (time in s)           Mean  StdDev     Min     Max  Rounds
---------------------------------------------------------------
bench_import_prefect     1.6827  0.1332  1.5555  1.8969       5
---------------------------------------------------------------

```