### PR TITLE
Defer loading of prefect collections until necessary

### DIFF
--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -73,10 +73,7 @@ prefect.client.schemas.State.update_forward_refs(
     BaseResult=BaseResult, DataDocument=prefect.deprecated.data_documents.DataDocument
 )
 
-# Ensure collections are imported and have the opportunity to register types
-import prefect.plugins
 
-prefect.plugins.load_prefect_collections()
 prefect.plugins.load_extra_entrypoints()
 
 # Configure logging

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -11,6 +11,7 @@ import anyio.abc
 import anyio.to_process
 import pendulum
 
+import prefect.plugins
 from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect._internal.compatibility.experimental import experimental_parameter
 from prefect.blocks.core import Block
@@ -626,6 +627,10 @@ class PrefectAgent:
 
     async def start(self):
         self.started = True
+
+        # Ensure collections are imported and have the opportunity to register types
+        prefect.plugins.load_prefect_collections()
+
         self.task_group = anyio.create_task_group()
         self.limiter = (
             anyio.CapacityLimiter(self.limit) if self.limit is not None else None

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -11,7 +11,6 @@ import anyio.abc
 import anyio.to_process
 import pendulum
 
-import prefect.plugins
 from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect._internal.compatibility.experimental import experimental_parameter
 from prefect.blocks.core import Block
@@ -627,10 +626,6 @@ class PrefectAgent:
 
     async def start(self):
         self.started = True
-
-        # Ensure collections are imported and have the opportunity to register types
-        prefect.plugins.load_prefect_collections()
-
         self.task_group = anyio.create_task_group()
         self.limiter = (
             anyio.CapacityLimiter(self.limit) if self.limit is not None else None

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -611,10 +611,6 @@ class Block(BaseModel, ABC):
                 "Unable to determine block schema for provided block document"
             )
 
-        # Ensure collections are imported and have the opportunity to register types
-        # before loading the block class
-        prefect.plugins.load_prefect_collections()
-
         block_cls = (
             cls
             if cls.__name__ != "Block"
@@ -673,6 +669,10 @@ class Block(BaseModel, ABC):
         """
         Retieve the block class implementation given a schema.
         """
+        # Ensure collections are imported and have the opportunity to register types
+        # before looking up the block class
+        prefect.plugins.load_prefect_collections()
+
         return lookup_type(cls, block_schema_to_key(schema))
 
     def _define_metadata_on_nested_blocks(

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -611,6 +611,10 @@ class Block(BaseModel, ABC):
                 "Unable to determine block schema for provided block document"
             )
 
+        # Ensure collections are imported and have the opportunity to register types
+        # before loading the block class
+        prefect.plugins.load_prefect_collections()
+
         block_cls = (
             cls
             if cls.__name__ != "Block"

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -19,6 +19,7 @@ import asyncio
 import logging
 import os
 import signal
+import prefect.plugins
 import contextlib
 import sys
 import time
@@ -205,6 +206,11 @@ def enter_flow_run_engine_from_subprocess(flow_run_id: UUID) -> State:
     Additionally, this assumes that the caller is always in a context without an event
     loop as this should be called from a fresh process.
     """
+
+    # Ensure collections are imported and have the opportunity to register types before
+    # loading the user code from the deployment
+    prefect.plugins.load_prefect_collections()
+
     setup_logging()
 
     state = from_sync.wait_for_call_in_loop_thread(

--- a/tests/blocks/test_core.py
+++ b/tests/blocks/test_core.py
@@ -4,6 +4,7 @@ import warnings
 from textwrap import dedent
 from typing import Dict, Type, Union
 from uuid import UUID, uuid4
+from unittest.mock import Mock
 
 import pytest
 from packaging.version import Version
@@ -862,6 +863,17 @@ class TestAPICompatibility:
         assert my_block._block_type_id == block_document.block_type_id
         assert my_block._block_schema_id == block_document.block_schema_id
         assert my_block.foo == "bar"
+
+    async def test_block_load_pulls_collections(
+        self, test_block, block_document, monkeypatch
+    ):
+        mock_load_prefect_collections = Mock()
+        monkeypatch.setattr(
+            prefect.plugins, "load_prefect_collections", mock_load_prefect_collections
+        )
+
+        await test_block.load(block_document.name)
+        mock_load_prefect_collections.assert_called_once()
 
     async def test_load_from_block_base_class(self):
         class Custom(Block):

--- a/tests/blocks/test_core.py
+++ b/tests/blocks/test_core.py
@@ -18,7 +18,7 @@ from prefect.client import PrefectClient
 from prefect.exceptions import PrefectHTTPStatusError
 from prefect.server import models
 from prefect.server.schemas.actions import BlockDocumentCreate
-from prefect.server.schemas.core import DEFAULT_BLOCK_SCHEMA_VERSION
+from prefect.server.schemas.core import DEFAULT_BLOCK_SCHEMA_VERSION, BlockDocument
 from prefect.testing.utilities import AsyncMock
 from prefect.utilities.dispatch import lookup_type, register_type
 from prefect.utilities.names import obfuscate_string
@@ -864,15 +864,15 @@ class TestAPICompatibility:
         assert my_block._block_schema_id == block_document.block_schema_id
         assert my_block.foo == "bar"
 
-    async def test_block_load_pulls_collections(
-        self, test_block, block_document, monkeypatch
+    async def test_block_load_loads__collections(
+        self, test_block, block_document: BlockDocument, monkeypatch
     ):
         mock_load_prefect_collections = Mock()
         monkeypatch.setattr(
             prefect.plugins, "load_prefect_collections", mock_load_prefect_collections
         )
 
-        await test_block.load(block_document.name)
+        await Block.load(block_document.block_type.slug + "/" + block_document.name)
         mock_load_prefect_collections.assert_called_once()
 
     async def test_load_from_block_base_class(self):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -248,7 +248,7 @@ def test_load_extra_entrypoints_missing_attribute(capsys):
     )
 
 
-def test_plugins_load_on_prefect_package_init(monkeypatch):
+def test_plugin_load_on_prefect_package_init(monkeypatch):
     mock_load_prefect_collections = Mock()
     mock_load_extra_entrypoints = Mock()
 
@@ -261,5 +261,5 @@ def test_plugins_load_on_prefect_package_init(monkeypatch):
 
     importlib.reload(prefect)
 
-    mock_load_prefect_collections.assert_called_once()
+    mock_load_prefect_collections.assert_not_called()  # We no longer load collections on import due to high performance cost
     mock_load_extra_entrypoints.assert_called_once()


### PR DESCRIPTION
Removes `prefect.plugins.load_prefect_collections()` from the main `__init__` to improve performance of `import prefect` and the CLI. Instead, we call this at places where we need to ensure that collections have been loaded such as before:

- Executing a deployed flow run
- Loading a saved block

Otherwise as the number of installed collections grows, so does the time of running any CLI command. In cases where multiple Cloud provider packages are installed, this can be greater than 5s.

On my machine, with `prefect-dask`, `prefect-aws`, and `prefect-docker` I see major improvements:

```
------------------------------------- benchmark 'bench_import_prefect': 2 tests --------------------------------------
Name (time in s)                          Mean            StdDev               Min               Max            Rounds
----------------------------------------------------------------------------------------------------------------------
bench_import_prefect (NOW)              1.6482 (1.0)      0.2049 (1.0)      1.4185 (1.0)      1.9568 (1.0)           5
bench_import_prefect (0011_1b5f698)     2.5295 (1.53)     0.3757 (1.83)     2.0390 (1.44)     2.9487 (1.51)          5
----------------------------------------------------------------------------------------------------------------------

------------------------------------- benchmark 'bench_prefect_help': 2 tests --------------------------------------
Name (time in s)                        Mean            StdDev               Min               Max            Rounds
--------------------------------------------------------------------------------------------------------------------
bench_prefect_help (NOW)              1.6942 (1.0)      0.2376 (1.71)     1.4644 (1.0)      1.9389 (1.0)           3
bench_prefect_help (0011_1b5f698)     2.1495 (1.27)     0.1392 (1.0)      1.9961 (1.36)     2.2677 (1.17)          3
--------------------------------------------------------------------------------------------------------------------

------------------------------------- benchmark 'bench_prefect_profile_ls': 2 tests --------------------------------------
Name (time in s)                              Mean            StdDev               Min               Max            Rounds
--------------------------------------------------------------------------------------------------------------------------
bench_prefect_profile_ls (NOW)              1.5147 (1.0)      0.1173 (1.0)      1.4148 (1.0)      1.6439 (1.0)           3
bench_prefect_profile_ls (0011_1b5f698)     2.6390 (1.74)     0.2977 (2.54)     2.3740 (1.68)     2.9612 (1.80)          3
--------------------------------------------------------------------------------------------------------------------------

-------------------------------------- benchmark 'bench_prefect_short_version': 2 tests -------------------------------------
Name (time in s)                                 Mean            StdDev               Min               Max            Rounds
-----------------------------------------------------------------------------------------------------------------------------
bench_prefect_short_version (NOW)              1.4665 (1.0)      0.1522 (1.16)     1.3720 (1.0)      1.6421 (1.0)           3
bench_prefect_short_version (0011_1b5f698)     2.0437 (1.39)     0.1312 (1.0)      1.9165 (1.40)     2.1785 (1.33)          3
-----------------------------------------------------------------------------------------------------------------------------

-------------------------------------- benchmark 'bench_prefect_version': 2 tests -------------------------------------
Name (time in s)                           Mean            StdDev               Min               Max            Rounds
-----------------------------------------------------------------------------------------------------------------------
bench_prefect_version (NOW)              1.6730 (1.0)      0.2915 (1.0)      1.4922 (1.0)      2.0092 (1.0)           3
bench_prefect_version (0011_1b5f698)     2.6898 (1.61)     0.3572 (1.23)     2.3079 (1.55)     3.0157 (1.50)          3
-----------------------------------------------------------------------------------------------------------------------
```

On CI machines without collections installed, the changes also appear to be significant

```
------------------------------------- benchmark 'bench_import_prefect': 2 tests --------------------------------------
Name (time in s)                          Mean            StdDev               Min               Max            Rounds
----------------------------------------------------------------------------------------------------------------------
bench_import_prefect (NOW)              2.1833 (1.0)      0.0155 (1.0)      2.1614 (1.0)      2.2025 (1.0)           5
bench_import_prefect (0177_main-4d)     3.2575 (1.49)     0.3855 (24.90)    2.7898 (1.29)     3.6507 (1.66)          5
----------------------------------------------------------------------------------------------------------------------

------------------------------------- benchmark 'bench_prefect_help': 2 tests --------------------------------------
Name (time in s)                        Mean            StdDev               Min               Max            Rounds
--------------------------------------------------------------------------------------------------------------------
bench_prefect_help (NOW)              2.7150 (1.0)      0.0186 (1.0)      2.6940 (1.0)      2.7296 (1.0)           3
bench_prefect_help (0177_main-4d)     4.1296 (1.52)     0.2689 (14.45)    3.8265 (1.42)     4.3395 (1.59)          3
--------------------------------------------------------------------------------------------------------------------

------------------------------------- benchmark 'bench_prefect_profile_ls': 2 tests --------------------------------------
Name (time in s)                              Mean            StdDev               Min               Max            Rounds
--------------------------------------------------------------------------------------------------------------------------
bench_prefect_profile_ls (NOW)              2.7323 (1.0)      0.0100 (1.0)      2.7214 (1.0)      2.7411 (1.0)           3
bench_prefect_profile_ls (0177_main-4d)     4.0545 (1.48)     0.1747 (17.43)    3.8581 (1.42)     4.1927 (1.53)          3
--------------------------------------------------------------------------------------------------------------------------

-------------------------------------- benchmark 'bench_prefect_short_version': 2 tests -------------------------------------
Name (time in s)                                 Mean            StdDev               Min               Max            Rounds
-----------------------------------------------------------------------------------------------------------------------------
bench_prefect_short_version (NOW)              2.7158 (1.0)      0.0374 (2.51)     2.6938 (1.0)      2.7590 (1.0)           3
bench_prefect_short_version (0177_main-4d)     4.1885 (1.54)     0.0149 (1.0)      4.1762 (1.55)     4.2051 (1.52)          3
-----------------------------------------------------------------------------------------------------------------------------

-------------------------------------- benchmark 'bench_prefect_version': 2 tests -------------------------------------
Name (time in s)                           Mean            StdDev               Min               Max            Rounds
-----------------------------------------------------------------------------------------------------------------------
bench_prefect_version (NOW)              2.7714 (1.0)      0.0209 (1.0)      2.7546 (1.0)      2.7948 (1.0)           3
bench_prefect_version (0177_main-4d)     4.0613 (1.47)     0.3556 (17.03)    3.6514 (1.33)     4.2862 (1.53)          3
-----------------------------------------------------------------------------------------------------------------------