### PR TITLE
Add `work_pool_name` to `Deployment.build_from_flow` in docs

### DIFF
--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -384,6 +384,7 @@ deployment = Deployment.build_from_flow(
     name="example-deployment", 
     version=1, 
     work_queue_name="demo",
+    work_pool_name="default-agent-pool",
 )
 deployment.apply()
 ```
@@ -402,6 +403,7 @@ deployment = Deployment.build_from_flow(
     name="s3-example",
     version=2,
     work_queue_name="aws",
+    work_pool_name="default-agent-pool",
     storage=storage,
     infra_overrides={
         "env": {


### PR DESCRIPTION
Users can specify a work pool when building a deployment from a flow yet this is not represented in the docs. This PR adds `work_pool_name` to the examples in the deployment page.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
