### PR TITLE
Defer import of `dateparser` to speed up CLI startup

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -10,7 +10,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-import dateparser
 import pendulum
 import typer
 import yaml
@@ -503,6 +502,8 @@ async def run(
     The flow run will be scheduled to run immediately unless `--start-in` or `--start-at` is specified.
     The flow run will not execute until an agent starts.
     """
+    import dateparser
+
     now = pendulum.now("UTC")
 
     multi_params = {}


### PR DESCRIPTION
After the changes in #9577 and #9571 this is one of the larger remaining CLI startup costs

```

----------------------------------------- benchmark 'bench_import_prefect': 2 tests -----------------------------------------
Name (time in ms)                           Mean             StdDev                 Min                 Max            Rounds
-----------------------------------------------------------------------------------------------------------------------------
bench_import_prefect (NOW)              594.2356 (1.0)      46.2595 (1.73)     555.3874 (1.0)      670.8452 (1.0)           5
bench_import_prefect (0017_0ac7dea)     646.7460 (1.09)     26.6990 (1.0)      624.5832 (1.12)     683.3596 (1.02)          5
-----------------------------------------------------------------------------------------------------------------------------

----------------------------------------- benchmark 'bench_prefect_help': 2 tests -----------------------------------------
Name (time in ms)                         Mean             StdDev                 Min                 Max            Rounds
---------------------------------------------------------------------------------------------------------------------------
bench_prefect_help (NOW)              653.3308 (1.0)       8.6646 (1.0)      644.1545 (1.0)      661.3718 (1.0)           3
bench_prefect_help (0017_0ac7dea)     828.9230 (1.27)     65.3763 (7.55)     780.0161 (1.21)     903.1775 (1.37)          3
---------------------------------------------------------------------------------------------------------------------------

------------------------------------------- benchmark 'bench_prefect_profile_ls': 2 tests --------------------------------------------
Name (time in ms)                                 Mean              StdDev                 Min                   Max            Rounds
--------------------------------------------------------------------------------------------------------------------------------------
bench_prefect_profile_ls (NOW)                600.7833 (1.0)        7.7648 (1.0)      592.1943 (1.0)        607.3058 (1.0)           3
bench_prefect_profile_ls (0017_0ac7dea)     1,151.8383 (1.92)     666.0313 (85.78)    745.3643 (1.26)     1,920.4795 (3.16)          3
--------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------- benchmark 'bench_prefect_short_version': 2 tests -----------------------------------------
Name (time in ms)                                  Mean             StdDev                 Min                 Max            Rounds
------------------------------------------------------------------------------------------------------------------------------------
bench_prefect_short_version (NOW)              594.3931 (1.0)       1.7891 (1.0)      592.8582 (1.0)      596.3580 (1.0)           3
bench_prefect_short_version (0017_0ac7dea)     803.3143 (1.35)     26.4026 (14.76)    775.6341 (1.31)     828.2202 (1.39)          3
------------------------------------------------------------------------------------------------------------------------------------

-------------------------------------- benchmark 'bench_prefect_version': 2 tests -------------------------------------
Name (time in s)                           Mean            StdDev               Min               Max            Rounds
-----------------------------------------------------------------------------------------------------------------------
bench_prefect_version (NOW)              1.2365 (1.0)      0.0481 (4.73)     1.1866 (1.0)      1.2827 (1.0)           3
bench_prefect_version (0017_0ac7dea)     1.4919 (1.21)     0.0102 (1.0)      1.4836 (1.25)     1.5033 (1.17)          3
-----------------------------------------------------------------------------------------------------------------------
```

