### PR TITLE
Update `prefect version` command to avoid creating the database if it does not exist

### DIFF
--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -118,8 +118,10 @@ async def version():
     server_type: str
 
     try:
-        async with prefect.get_client() as client:
-            server_type = client.server_type.value
+        # We do not context manage the client because when using an ephemeral app we do not
+        # want to create the database or run migrations
+        client = prefect.get_client()
+        server_type = client.server_type.value
     except Exception:
         server_type = "<client error>"
 


### PR DESCRIPTION
When using the ephemeral app, database migrations are run during a `prefect version` call. There's no reason to be running migrations when retrieving version information and it has caused a corrupted database in https://github.com/PrefectHQ/prefect/issues/9493

Closes https://github.com/PrefectHQ/prefect/issues/9493