### PR TITLE
Add `Block.get_block_class_from_key` and replace external uses of `lookup_type`

### DIFF
--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -669,11 +669,18 @@ class Block(BaseModel, ABC):
         """
         Retieve the block class implementation given a schema.
         """
+        return cls.get_block_class_from_key(block_schema_to_key(schema))
+
+    @classmethod
+    def get_block_class_from_key(cls: Type[Self], key: str) -> Type[Self]:
+        """
+        Retieve the block class implementation given a key.
+        """
         # Ensure collections are imported and have the opportunity to register types
         # before looking up the block class
         prefect.plugins.load_prefect_collections()
 
-        return lookup_type(cls, block_schema_to_key(schema))
+        return lookup_type(cls, key)
 
     def _define_metadata_on_nested_blocks(
         self, block_document_references: Dict[str, Dict[str, Any]]

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -43,7 +43,7 @@ from prefect.settings import PREFECT_UI_URL
 from prefect.states import Scheduled
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.collections import listrepr
-from prefect.utilities.dispatch import get_registry_for_type, lookup_type
+from prefect.utilities.dispatch import get_registry_for_type
 from prefect.utilities.filesystem import create_default_ignore_file
 
 
@@ -1031,7 +1031,7 @@ async def build(
         infrastructure = await Block.load(infra_block)
     elif infra_type:
         # Create an instance of the given type
-        infrastructure = lookup_type(Block, infra_type.value)()
+        infrastructure = Block.get_block_class_from_key(infra_type.value)()
     else:
         # will reset to a default of Process is no infra is present on the
         # server-side definition of this deployment

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -39,7 +39,6 @@ from prefect.states import Scheduled
 from prefect.tasks import Task
 from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
 from prefect.utilities.callables import ParameterSchema, parameter_schema
-from prefect.utilities.dispatch import lookup_type
 from prefect.utilities.filesystem import relative_path_to_current_platform, tmpchdir
 from prefect.utilities.slugify import slugify
 
@@ -494,7 +493,7 @@ class Deployment(BaseModel):
     @validator("storage", pre=True)
     def storage_must_have_capabilities(cls, value):
         if isinstance(value, dict):
-            block_type = lookup_type(Block, value.pop("_block_type_slug"))
+            block_type = Block.get_block_class_from_key(value.pop("_block_type_slug"))
             block = block_type(**value)
         elif value is None:
             return value


### PR DESCRIPTION
Follow-up to #9571 ensuring that some additional cases where we rely on dispatch go through the code path that loads collections