### PR TITLE
Allow client retries when server SQLite database is busy

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -149,10 +149,10 @@ async def integrity_exception_handler(request: Request, exc: Exception):
 def is_client_retryable_exception(exc: Exception):
     if isinstance(exc, sqlalchemy.exc.OperationalError):
         # Database locked errors
-        if (
-            getattr(exc.orig, "sqlite_errorname", None) == "SQLITE_BUSY"
-            and getattr(exc.orig, "sqlite_errorcode", None) == 5
-        ):
+        if getattr(exc.orig, "sqlite_errorname", None) in {
+            "SQLITE_BUSY",
+            "SQLITE_BUSY_SNAPSHOT",
+        }:
             return True
 
     return False

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -540,6 +540,7 @@ def create_app(
         ),
         name="static",
     )
+    app.api_app = api_app
     app.mount("/api", app=api_app, name="api")
     app.mount("/", app=ui_app, name="ui")
 

--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -176,7 +176,7 @@ class ReleaseTaskConcurrencySlots(BaseUniversalTransform):
         if self.nullified_transition():
             return
 
-        if context.validated_state.type not in [
+        if context.validated_state and context.validated_state.type not in [
             states.StateType.RUNNING,
             states.StateType.CANCELLING,
         ]:

--- a/src/prefect/server/orchestration/rules.py
+++ b/src/prefect/server/orchestration/rules.py
@@ -233,12 +233,21 @@ class FlowOrchestrationContext(OrchestrationContext):
         Returns:
             None
         """
+        # (circular import)
+        from prefect.server.api.server import is_client_retryable_exception
+
         try:
             await self._validate_proposed_state()
             return
         except Exception as exc:
             logger.exception("Encountered error during state validation")
             self.proposed_state = None
+
+            if is_client_retryable_exception(exc):
+                # Do not capture retryable database exceptions, this exception will be
+                # raised as a 503 in the API layer
+                raise
+
             reason = f"Error validating state: {exc!r}"
             self.response_status = SetStateStatus.ABORT
             self.response_details = StateAbortDetails(reason=reason)
@@ -376,12 +385,21 @@ class TaskOrchestrationContext(OrchestrationContext):
         Returns:
             None
         """
+        # (circular import)
+        from prefect.server.api.server import is_client_retryable_exception
+
         try:
             await self._validate_proposed_state()
             return
         except Exception as exc:
             logger.exception("Encountered error during state validation")
             self.proposed_state = None
+
+            if is_client_retryable_exception(exc):
+                # Do not capture retryable database exceptions, this exception will be
+                # raised as a 503 in the API layer
+                raise
+
             reason = f"Error validating state: {exc!r}"
             self.response_status = SetStateStatus.ABORT
             self.response_details = StateAbortDetails(reason=reason)

--- a/tests/server/api/test_server.py
+++ b/tests/server/api/test_server.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import pytest
 import sqlalchemy as sa
 import toml
-from fastapi import APIRouter, FastAPI, status, testclient
+from fastapi import APIRouter, status, testclient
 from httpx import ASGITransport, AsyncClient
 
 from prefect.server.api.server import (
@@ -13,7 +13,7 @@ from prefect.server.api.server import (
     SERVER_API_VERSION,
     _memoize_block_auto_registration,
     create_orion_api,
-    db_locked_exception_handler,
+    create_app,
     method_paths_from_routes,
 )
 from prefect.settings import (
@@ -52,32 +52,41 @@ async def test_validation_error_handler_409(client):
     assert "Data integrity conflict" in response.json()["detail"]
 
 
-async def test_db_locked_exception_handler():
-    app = FastAPI()
-
-    @app.get("/raise_db_locked")
-    async def raise_db_locked():
-        """A route that raises a sqlite db locked error"""
+@pytest.mark.parametrize("ephemeral", [True, False])
+@pytest.mark.parametrize("errorname", ["SQLITE_BUSY", "SQLITE_BUSY_SNAPSHOT"])
+async def test_sqlite_database_locked_handler(errorname, ephemeral):
+    async def raise_busy_error():
         orig = sqlite3.OperationalError("database locked")
-        setattr(orig, "sqlite_errorname", "SQLITE_BUSY")
-        setattr(orig, "sqlite_errorcode", 5)
-        raise sa.exc.OperationalError("", "", orig=orig)
+        setattr(orig, "sqlite_errorname", errorname)
+        raise sa.exc.OperationalError(
+            "statement",
+            {"params": 1},
+            orig,
+            Exception,
+        )
 
-    @app.get("/other_sql_error")
-    async def raise_other_sql_error():
-        """A route that raises a different OperationalError"""
-        raise sa.exc.OperationalError("", "", orig=ValueError("something else"))
+    async def raise_other_error():
+        orig = sqlite3.OperationalError("database locked")
+        setattr(orig, "sqlite_errorname", "FOO")
+        raise sa.exc.OperationalError(
+            "statement",
+            {"params": 1},
+            orig,
+            Exception,
+        )
 
-    app.add_exception_handler(sa.exc.OperationalError, db_locked_exception_handler)
+    app = create_app(ephemeral=ephemeral)
+    app.api_app.add_api_route("/raise_busy_error", raise_busy_error)
+    app.api_app.add_api_route("/raise_other_error", raise_other_error)
 
     async with AsyncClient(
         transport=ASGITransport(app=app, raise_app_exceptions=False),
         base_url="https://test",
     ) as client:
-        response = await client.get("/raise_db_locked")
+        response = await client.get("/api/raise_busy_error")
         assert response.status_code == 503
 
-        response = await client.get("/other_sql_error")
+        response = await client.get("/api/raise_other_error")
         assert response.status_code == 500
 
 

--- a/tests/server/orchestration/test_rules.py
+++ b/tests/server/orchestration/test_rules.py
@@ -1,6 +1,7 @@
 import contextlib
 import random
-from itertools import permutations, product
+import sqlalchemy.exc
+from itertools import product
 from unittest.mock import MagicMock
 
 import pendulum
@@ -1530,15 +1531,12 @@ class TestOrchestrationContext:
         orm_artifact = await models.artifacts.read_artifact(ctx.session, artifact_id)
         assert orm_artifact is None
 
-    @pytest.mark.parametrize(
-        "intended_transition",
-        list(permutations([*states.StateType, None], 2)),
-        ids=transition_names,
-    )
     async def test_context_state_validation_encounters_exception(
-        self, session, run_type, intended_transition, initialize_orchestration
+        self, session, run_type, initialize_orchestration
     ):
-        initial_state_type, proposed_state_type = intended_transition
+        initial_state_type = states.StateType.PENDING
+        proposed_state_type = states.StateType.RUNNING
+        intended_transition = (initial_state_type, proposed_state_type)
         before_transition_hook = MagicMock()
         after_transition_hook = MagicMock()
         cleanup_hook = MagicMock()
@@ -1583,6 +1581,65 @@ class TestOrchestrationContext:
             ctx.response_details.reason
             == "Error validating state: RuntimeError('One time error!')"
         )
+
+    async def test_context_state_validation_encounters_sqlite_busy_exception(
+        self, session, run_type, initialize_orchestration
+    ):
+        initial_state_type = states.StateType.PENDING
+        proposed_state_type = states.StateType.RUNNING
+        intended_transition = (initial_state_type, proposed_state_type)
+        before_transition_hook = MagicMock()
+        after_transition_hook = MagicMock()
+        cleanup_hook = MagicMock()
+
+        class MockRule(BaseOrchestrationRule):
+            FROM_STATES = ALL_ORCHESTRATION_STATES
+            TO_STATES = ALL_ORCHESTRATION_STATES
+
+            async def before_transition(self, initial_state, proposed_state, context):
+                before_transition_hook(initial_state, proposed_state, context)
+
+            async def after_transition(self, initial_state, validated_state, context):
+                after_transition_hook(initial_state, validated_state, context)
+
+            async def cleanup(self, initial_state, validated_state, context):
+                cleanup_hook(initial_state, validated_state, context)
+
+        ctx = await initialize_orchestration(session, run_type, *intended_transition)
+
+        class SQLiteBusy:
+            sqlite_errorname = "SQLITE_BUSY"
+            sqlite_errorcode = 5
+
+        # Bypass pydantic mutation protection, inject an error
+        object.__setattr__(
+            ctx.session,
+            "flush",
+            AsyncMock(
+                side_effect=sqlalchemy.exc.OperationalError(
+                    "statement",
+                    {"params": 1},
+                    SQLiteBusy(),
+                    Exception,
+                )
+            ),
+        )
+
+        with pytest.raises(sqlalchemy.exc.OperationalError):
+            async with contextlib.AsyncExitStack() as stack:
+                mock_rule = MockRule(ctx, *intended_transition)
+                ctx = await stack.enter_async_context(mock_rule)
+                await ctx.validate_proposed_state()
+
+        before_transition_hook.assert_called_once()
+        if proposed_state_type is not None:
+            after_transition_hook.assert_not_called()
+            cleanup_hook.assert_called_once(), "Cleanup should be called when trasition is aborted"
+        else:
+            after_transition_hook.assert_called_once(), "Rule expected no transition"
+            cleanup_hook.assert_not_called()
+
+        assert ctx.proposed_state is None
 
 
 @pytest.mark.parametrize("run_type", ["task", "flow"])


### PR DESCRIPTION
Requires https://github.com/PrefectHQ/prefect/pull/9637
Required for https://github.com/PrefectHQ/prefect/pull/9594

Previously, if a BUSY was encountered during orchestration the rules context would eat the exception so it would never be raised. A client would receive an ABORT signal. Now, we send a 503 instead.