### PR TITLE
Allow client retries when database errors are encountered

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -4,6 +4,7 @@ Defines the Prefect REST API FastAPI app.
 
 import asyncio
 import mimetypes
+import asyncpg
 import os
 from contextlib import asynccontextmanager
 from functools import partial, wraps
@@ -13,6 +14,7 @@ from typing import Awaitable, Callable, Dict, List, Mapping, Optional, Tuple
 import anyio
 import sqlalchemy as sa
 import sqlalchemy.exc
+import sqlalchemy.orm.exc
 from fastapi import APIRouter, Depends, FastAPI, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
@@ -154,6 +156,20 @@ def is_client_retryable_exception(exc: Exception):
             "SQLITE_BUSY_SNAPSHOT",
         }:
             return True
+
+    if isinstance(
+        exc,
+        (
+            sqlalchemy.exc.DBAPIError,
+            asyncio.exceptions.TimeoutError,
+            asyncpg.exceptions.QueryCanceledError,
+            asyncpg.exceptions.ConnectionDoesNotExistError,
+            asyncpg.exceptions.CannotConnectNowError,
+            sqlalchemy.exc.InvalidRequestError,
+            sqlalchemy.orm.exc.DetachedInstanceError,
+        ),
+    ):
+        return True
 
     return False
 

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -166,7 +166,6 @@ def is_client_retryable_exception(exc: Exception):
         exc,
         (
             sqlalchemy.exc.DBAPIError,
-            asyncio.exceptions.TimeoutError,
             asyncpg.exceptions.QueryCanceledError,
             asyncpg.exceptions.ConnectionDoesNotExistError,
             asyncpg.exceptions.CannotConnectNowError,

--- a/tests/server/api/test_server.py
+++ b/tests/server/api/test_server.py
@@ -87,10 +87,8 @@ async def test_sqlite_database_locked_handler(errorname, ephemeral):
         response = await client.get("/api/raise_busy_error")
         assert response.status_code == 503
 
-        # Following https://github.com/PrefectHQ/prefect/pull/9633 a 503 is expected
-        # for all operational errors regardless of the SQLite internal error message
         response = await client.get("/api/raise_other_error")
-        assert response.status_code == 503
+        assert response.status_code == 500
 
 
 @pytest.mark.parametrize(

--- a/tests/server/api/test_server.py
+++ b/tests/server/api/test_server.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 import pytest
 import sqlalchemy as sa
-import asyncio
 import asyncpg
 import toml
 from fastapi import APIRouter, status, testclient
@@ -95,7 +94,6 @@ async def test_sqlite_database_locked_handler(errorname, ephemeral):
     "exc",
     (
         sa.exc.DBAPIError("statement", {"params": 0}, ValueError("orig")),
-        asyncio.exceptions.TimeoutError(),
         asyncpg.exceptions.QueryCanceledError(),
         asyncpg.exceptions.ConnectionDoesNotExistError(),
         asyncpg.exceptions.CannotConnectNowError(),


### PR DESCRIPTION
Extends https://github.com/PrefectHQ/prefect/pull/9632 to include all of the retryable database exceptions that we use in Cloud.

This improves resilience for all open source server users.