### PR TITLE
Date Range filter not responsive on flow runs page

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12,7 +12,7 @@
         "@prefecthq/prefect-design": "1.8.2",
         "@prefecthq/prefect-ui-library": "1.6.7",
         "@prefecthq/vue-charts": "1.0.0",
-        "@prefecthq/vue-compositions": "1.5.1",
+        "@prefecthq/vue-compositions": "1.5.2",
         "@types/lodash.debounce": "4.0.7",
         "axios": "0.27.2",
         "lodash.debounce": "4.0.8",
@@ -1361,9 +1361,9 @@
       }
     },
     "node_modules/@prefecthq/vue-compositions": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.5.1.tgz",
-      "integrity": "sha512-FpS/jxTzm7jxkR/4Tnt4SlFUuOcpIstE4PjK4fE4O/EKJfY9QgTux8C46OXR6A90yRElV8qGPDl3OSe/RqOFdA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.5.2.tgz",
+      "integrity": "sha512-YIOGfMPFUtc+7qJTMUlRnolI98zk2W9z+4NmXWX64QjbmMvL4LB9SIYJCdquAIBk+M5KDQrolFE1Zh+s80gsKw==",
       "dependencies": {
         "jsdom": "^22.0.0"
       },
@@ -7356,9 +7356,9 @@
       }
     },
     "@prefecthq/vue-compositions": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.5.1.tgz",
-      "integrity": "sha512-FpS/jxTzm7jxkR/4Tnt4SlFUuOcpIstE4PjK4fE4O/EKJfY9QgTux8C46OXR6A90yRElV8qGPDl3OSe/RqOFdA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@prefecthq/vue-compositions/-/vue-compositions-1.5.2.tgz",
+      "integrity": "sha512-YIOGfMPFUtc+7qJTMUlRnolI98zk2W9z+4NmXWX64QjbmMvL4LB9SIYJCdquAIBk+M5KDQrolFE1Zh+s80gsKw==",
       "requires": {
         "jsdom": "^22.0.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,7 +15,7 @@
     "@prefecthq/prefect-design": "1.8.2",
     "@prefecthq/prefect-ui-library": "1.6.7",
     "@prefecthq/vue-charts": "1.0.0",
-    "@prefecthq/vue-compositions": "1.5.1",
+    "@prefecthq/vue-compositions": "1.5.2",
     "@types/lodash.debounce": "4.0.7",
     "axios": "0.27.2",
     "lodash.debounce": "4.0.8",


### PR DESCRIPTION
# Description
Fixes a bug where if you changed the Date Range filter on the flow runs page that new date range wouldn't be reflected on the page until you changed one of the other filters or the 30s polling interval happened. This was fixed upstream in the vue-compositions library