### PR TITLE
Fix bug where ephemeral server raised exceptions client-side

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -563,6 +563,7 @@ def create_app(
         ),
         name="static",
     )
+    app.api_app = api_app
     app.mount("/api", app=api_app, name="api")
     app.mount("/", app=ui_app, name="ui")
 

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -22,7 +22,6 @@ from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException
-from starlette.middleware.exceptions import ExceptionMiddleware
 
 import prefect
 import prefect.server.api as api
@@ -195,7 +194,6 @@ def create_orion_api(
     version_check_path: str = "/version",
     fast_api_app_kwargs: dict = None,
     router_overrides: Mapping[str, Optional[APIRouter]] = None,
-    ephemeral: bool = False,
 ) -> FastAPI:
     """
     Create a FastAPI app that includes the Prefect REST API
@@ -215,22 +213,6 @@ def create_orion_api(
     fast_api_app_kwargs = fast_api_app_kwargs or {}
     api_app = FastAPI(title=API_TITLE, **fast_api_app_kwargs)
     api_app.add_middleware(GZipMiddleware)
-
-    # FastAPI treats exception handlers that capture `Exception` as `ServerErrorMiddleware`
-    # instead of `ExceptionMiddleware`. The key difference here is that `ServerErrorMiddleware`
-    # will always raise an encountered exception after returning the response. When
-    # using an ephemeral server, this causes server-side exceptions to be raised
-    # client-side breaking all of our response error code handling. To work around this,
-    # we insert our exception handler directly as middleware to bypass FastAPI's logic.
-    # refs:
-    # - https://github.com/encode/starlette/blob/d3a11205ed35f8e5a58a711db0ff59c86fa7bb31/starlette/middleware/errors.py#L184
-    # - https://github.com/tiangolo/fastapi/blob/8cc967a7605d3883bd04ceb5d25cc94ae079612f/fastapi/applications.py#L163-L164
-    if ephemeral:
-        api_app.add_middleware(
-            ExceptionMiddleware, handlers={Exception: custom_internal_exception_handler}
-        )
-    else:
-        api_app.add_exception_handler(Exception, custom_internal_exception_handler)
 
     @api_app.get(health_check_path, tags=["Root"])
     async def health_check():
@@ -523,14 +505,14 @@ def create_app(
     api_app = create_orion_api(
         fast_api_app_kwargs={
             "exception_handlers": {
-                # The generic "Exception" handler is set in `create_orion_api` instead
-                # because FastAPI special cases it
+                # NOTE: FastAPI special cases the generic `Exception` handler and
+                #       registers it as a separate middleware from the others
+                Exception: custom_internal_exception_handler,
                 RequestValidationError: validation_exception_handler,
                 sa.exc.IntegrityError: integrity_exception_handler,
                 ObjectNotFoundError: prefect_object_not_found_exception_handler,
             }
         },
-        ephemeral=ephemeral,
     )
     ui_app = create_ui_app(ephemeral)
 

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -1787,3 +1787,17 @@ class TestVariables:
         res = await orion_client.read_variables(limit=1)
         assert len(res) == 1
         assert res[0].name == variables[0].name
+
+
+async def test_server_error_does_not_raise_on_client():
+    async def raise_error():
+        raise ValueError("test")
+
+    app = create_app(ephemeral=True)
+    app.api_app.add_api_route("/raise_error", raise_error)
+
+    async with PrefectClient(
+        api=app,
+    ) as client:
+        with pytest.raises(prefect.exceptions.HTTPStatusError, match="500"):
+            await client._client.get("/raise_error")

--- a/tests/client/test_orion_client.py
+++ b/tests/client/test_orion_client.py
@@ -1190,7 +1190,7 @@ async def test_prefect_api_tls_insecure_skip_verify_setting_set_to_true(monkeypa
     mock.assert_called_once_with(
         headers=ANY,
         verify=False,
-        app=ANY,
+        transport=ANY,
         base_url=ANY,
         timeout=ANY,
     )
@@ -1204,7 +1204,7 @@ async def test_prefect_api_tls_insecure_skip_verify_setting_set_to_false(monkeyp
 
     mock.assert_called_once_with(
         headers=ANY,
-        app=ANY,
+        transport=ANY,
         base_url=ANY,
         timeout=ANY,
     )
@@ -1216,7 +1216,7 @@ async def test_prefect_api_tls_insecure_skip_verify_default_setting(monkeypatch)
     get_client()
     mock.assert_called_once_with(
         headers=ANY,
-        app=ANY,
+        transport=ANY,
         base_url=ANY,
         timeout=ANY,
     )

--- a/tests/server/api/test_server.py
+++ b/tests/server/api/test_server.py
@@ -1,7 +1,7 @@
 import sqlite3
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
-
+from contextlib import nullcontext
 import pytest
 import sqlalchemy as sa
 import toml
@@ -13,6 +13,7 @@ from prefect.server.api.server import (
     SERVER_API_VERSION,
     _memoize_block_auto_registration,
     create_orion_api,
+    create_app,
     db_locked_exception_handler,
     method_paths_from_routes,
 )
@@ -79,6 +80,27 @@ async def test_db_locked_exception_handler():
 
         response = await client.get("/other_sql_error")
         assert response.status_code == 500
+
+
+@pytest.mark.parametrize("ephemeral", [True, False])
+async def test_server_error_raise_on_client(ephemeral):
+    async def raise_error():
+        raise ValueError("test")
+
+    app = create_app(ephemeral=ephemeral)
+    app.api_app.add_api_route("/raise_error", raise_error)
+
+    expect_error = (
+        pytest.raises(ValueError, match="test") if not ephemeral else nullcontext()
+    )
+
+    async with AsyncClient(
+        app=app,
+        base_url="https://test",
+    ) as client:
+        with expect_error:
+            response = await client.get("/api/raise_error")
+            assert response.status_code == 500
 
 
 async def test_health_check_route(client):


### PR DESCRIPTION
While working on #9632 we noticed that the database error was being raised client-side.

@jakekaplan and I discovered that FastAPI treats [exception handlers that capture `Exception` as `ServerErrorMiddleware` instead of `ExceptionMiddleware`](https://github.com/tiangolo/fastapi/blob/8cc967a7605d3883bd04ceb5d25cc94ae079612f/fastapi/applications.py#L163-L164). The key difference here is that [`ServerErrorMiddleware` will always raise an encountered exception after returning the response](https://github.com/encode/starlette/blob/d3a11205ed35f8e5a58a711db0ff59c86fa7bb31/starlette/middleware/errors.py#L184). When using an ephemeral server, this causes server-side exceptions to be raised client-side breaking all of our response error code handling. To work around this, we can either insert our exception handler directly as middleware to bypass FastAPI's logic server-side (https://github.com/PrefectHQ/prefect/pull/9637/commits/37a1c4b817941e8cb6b2bf34465466fb2f89918c) or define a special transport client-side (https://github.com/PrefectHQ/prefect/pull/9637/commits/50c03fdca386051bc452fdd8c5a7dab18c08fef3). Here, we opt for the transport with error raising disabled client-side.

We don't change this behavior for non-ephemeral servers because (in theory) it's nice to have the exceptions bubble up in the server to be reported by external error handlers (e.g. GCP will track the internal server errors).
