### PR TITLE
Use "eager" upgrade strategy when upgrading requirements in Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN python -m pip install --no-cache-dir pip==22.3.1
 
 # Install the base requirements separately so they cache
 COPY requirements.txt ./
-RUN pip install --upgrade --no-cache-dir -r requirements.txt
+RUN pip install --upgrade --upgrade-strategy eager --no-cache-dir -r requirements.txt
 
 # Install prefect from the sdist
 COPY --from=python-builder /opt/prefect/dist ./dist


### PR DESCRIPTION
Otherwise pip may choose not to upgrade some dependencies. We also need caching turned off or our release builds will not upgrade requirements unless the `requirements.txt` changes.