### PR TITLE
Add `work_pool_name` to work queue API responses

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -17,7 +17,9 @@ import prefect.exceptions
 import prefect.settings
 import prefect.states
 from prefect._internal.compatibility.deprecated import deprecated_callable
-from prefect.client.schemas import FlowRun, OrchestrationResult, TaskRun
+from prefect.client.schemas import FlowRun, OrchestrationResult, TaskRun, WorkQueue
+from prefect.deprecated.data_documents import DataDocument
+from prefect.logging import get_logger
 from prefect.client.schemas.actions import (
     ArtifactCreate,
     BlockDocumentCreate,
@@ -75,7 +77,6 @@ from prefect.client.schemas.objects import (
     Variable,
     Worker,
     WorkPool,
-    WorkQueue,
 )
 from prefect.client.schemas.responses import DeploymentResponse, WorkerFlowRunResponse
 from prefect.client.schemas.schedules import SCHEDULE_TYPES
@@ -841,7 +842,7 @@ class PrefectClient:
             httpx.RequestError: If request fails
 
         Returns:
-            UUID: The UUID of the newly created workflow
+            The created work queue
         """
         if tags:
             warnings.warn(

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -17,7 +17,7 @@ import prefect.exceptions
 import prefect.settings
 import prefect.states
 from prefect._internal.compatibility.deprecated import deprecated_callable
-from prefect.client.schemas import FlowRun, OrchestrationResult, TaskRun, WorkQueue
+from prefect.client.schemas import FlowRun, OrchestrationResult, TaskRun
 from prefect.deprecated.data_documents import DataDocument
 from prefect.logging import get_logger
 from prefect.client.schemas.actions import (
@@ -76,6 +76,7 @@ from prefect.client.schemas.objects import (
     TaskRunResult,
     Variable,
     Worker,
+    WorkQueue,
     WorkPool,
 )
 from prefect.client.schemas.responses import DeploymentResponse, WorkerFlowRunResponse
@@ -89,9 +90,7 @@ from prefect.client.schemas.sorting import (
     LogSort,
     TaskRunSort,
 )
-from prefect.deprecated.data_documents import DataDocument
 from prefect.events.schemas import Automation
-from prefect.logging import get_logger
 from prefect.settings import (
     PREFECT_API_DATABASE_CONNECTION_URL,
     PREFECT_API_ENABLE_HTTP2,

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -1153,6 +1153,7 @@ class WorkQueue(ObjectBaseModel):
             "The queue's priority. Lower values are higher priority (1 is the highest)."
         ),
     )
+    work_pool_name: Optional[str] = Field(default=None)
     # Will be required after a future migration
     work_pool_id: Optional[UUID] = Field(
         description="The work pool with which the queue is associated."

--- a/src/prefect/server/models/work_queues.py
+++ b/src/prefect/server/models/work_queues.py
@@ -95,6 +95,7 @@ async def create_work_queue(
 
     session.add(model)
     await session.flush()
+    await session.refresh(model)
 
     if work_queue.priority:
         await bulk_update_work_queue_priorities(

--- a/src/prefect/server/models/workers.py
+++ b/src/prefect/server/models/workers.py
@@ -286,6 +286,7 @@ async def create_work_queue(
 
     session.add(model)
     await session.flush()
+    await session.refresh(model)
 
     if work_queue.priority:
         await bulk_update_work_queue_priorities(

--- a/src/prefect/server/schemas/responses.py
+++ b/src/prefect/server/schemas/responses.py
@@ -267,3 +267,18 @@ class DeploymentResponse(ORMBaseModel):
                 response.work_pool_name = orm_deployment.work_queue.work_pool.name
 
         return response
+
+
+class WorkQueueResponse(schemas.core.WorkQueue.subclass()):
+    work_pool_name: Optional[str] = Field(
+        default=None,
+        description="The name of the work pool the work pool resides within.",
+    )
+
+    @classmethod
+    def from_orm(cls, orm_work_queue):
+        response = super().from_orm(orm_work_queue)
+        if orm_work_queue.work_pool:
+            response.work_pool_name = orm_work_queue.work_pool.name
+
+        return response

--- a/tests/server/api/test_work_queues.py
+++ b/tests/server/api/test_work_queues.py
@@ -24,6 +24,7 @@ class TestCreateWorkQueue:
         assert response.json()["filter"] is None
         assert pendulum.parse(response.json()["created"]) >= now
         assert pendulum.parse(response.json()["updated"]) >= now
+        assert response.json()["work_pool_name"] == "default-agent-pool"
         work_queue_id = response.json()["id"]
 
         work_queue = await models.work_queues.read_work_queue(
@@ -146,6 +147,7 @@ class TestReadWorkQueue:
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["id"] == str(work_queue.id)
         assert response.json()["name"] == "wq-1"
+        assert response.json()["work_pool_name"] == "default-agent-pool"
 
     async def test_read_work_queue_returns_404_if_does_not_exist(self, client):
         response = await client.get(f"/work_queues/{uuid4()}")
@@ -158,6 +160,7 @@ class TestReadWorkQueueByName:
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["id"] == str(work_queue.id)
         assert response.json()["name"] == work_queue.name
+        assert response.json()["work_pool_name"] == "default-agent-pool"
 
     async def test_read_work_queue_returns_404_if_does_not_exist(self, client):
         response = await client.get("/work_queues/name/some-made-up-work-queue")
@@ -227,6 +230,8 @@ class TestReadWorkQueues:
         assert response.status_code == status.HTTP_200_OK
         # includes default work queue
         assert len(response.json()) == 4
+        for wq in response.json():
+            assert wq["work_pool_name"] == "default-agent-pool"
 
     async def test_read_work_queues_applies_limit(self, work_queues, client):
         response = await client.post("/work_queues/filter", json=dict(limit=1))

--- a/tests/server/api/test_workers.py
+++ b/tests/server/api/test_workers.py
@@ -8,8 +8,7 @@ from fastapi import status
 import prefect
 from prefect.server import models, schemas
 from prefect.server.schemas.actions import WorkPoolCreate
-from prefect.server.schemas.core import WorkPool
-from prefect.client.schemas import WorkQueue
+from prefect.server.schemas.core import WorkPool, WorkQueue
 
 RESERVED_POOL_NAMES = [
     "Prefect",

--- a/tests/server/api/test_workers.py
+++ b/tests/server/api/test_workers.py
@@ -8,7 +8,8 @@ from fastapi import status
 import prefect
 from prefect.server import models, schemas
 from prefect.server.schemas.actions import WorkPoolCreate
-from prefect.server.schemas.core import WorkPool, WorkQueue
+from prefect.server.schemas.core import WorkPool
+from prefect.client.schemas import WorkQueue
 
 RESERVED_POOL_NAMES = [
     "Prefect",
@@ -470,6 +471,7 @@ class TestCreateWorkQueue:
         result = pydantic.parse_obj_as(WorkQueue, response.json())
         assert result.name == "test-queue"
         assert result.description == "test queue"
+        assert result.work_pool_name == work_pool.name
 
     async def test_create_work_queue_with_priority(
         self,
@@ -546,6 +548,7 @@ class TestReadWorkQueue:
         result = pydantic.parse_obj_as(WorkQueue, read_response.json())
         assert result.name == "test-queue"
         assert result.description == "test queue"
+        assert result.work_pool_name == work_pool.name
 
 
 class TestUpdateWorkQueue:

--- a/tests/server/api/test_workers.py
+++ b/tests/server/api/test_workers.py
@@ -7,8 +7,8 @@ from fastapi import status
 
 import prefect
 from prefect.server import models, schemas
-from prefect.server.schemas.actions import WorkPoolCreate
-from prefect.server.schemas.core import WorkPool, WorkQueue
+from prefect.client.schemas.actions import WorkPoolCreate
+from prefect.client.schemas.objects import WorkPool, WorkQueue
 
 RESERVED_POOL_NAMES = [
     "Prefect",


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Work pools can only be retrieved via their name, so if reading work queues directly, like in https://github.com/PrefectHQ/prefect-ui-library/pull/1428, an extra call is required to determine the name of the work pool that a work queue resides in. This PR adds `work_pool_name` to the response for work queue API routes to make it easier to get work pool information when starting with a work queue.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
