### PR TITLE
Remove trailing slashes when building events/in websocket url

### DIFF
--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -101,7 +101,12 @@ class PrefectCloudEventsClient(EventsClient):
             checkpoint_every: How often the client should sync with the server to
                 confirm receipt of all previously sent events
         """
-        socket_url = api_url.replace("https://", "wss://").replace("http://", "ws://")
+        socket_url = (
+            api_url.replace("https://", "wss://")
+            .replace("http://", "ws://")
+            .rstrip("/")
+        )
+
         self._connect = connect(
             socket_url + "/events/in",
             extra_headers={"Authorization": f"bearer {api_key}"},


### PR DESCRIPTION
As described in #9662 when prefect is configured with a `PREFECT_API_URL` that has a trailing slash the URL the Cloud events client uses to connect to the websocket endpoint is incorrect and the connection fails with a 403. This updates the cloud events client to correctly handle this by stripping trailing slashes before building the full URL.

Closes #9662 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
