### PR TITLE
fix variables

### DIFF
--- a/src/prefect/variables.py
+++ b/src/prefect/variables.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-from prefect._internal.concurrency.api import create_call, from_sync
 from prefect.client.orchestration import PrefectClient
 from prefect.client.utilities import inject_client
 from prefect.utilities.asyncutils import sync_compatible
@@ -26,9 +25,7 @@ async def get(name: str, default: str = None) -> Optional[str]:
             var = await variables.get("my_var")
     ```
     """
-    variable = from_sync.call_soon_in_loop_thread(
-        create_call(_get_variable_by_name, name)
-    ).result()
+    variable = await _get_variable_by_name(name)
     return variable.value if variable else default
 
 


### PR DESCRIPTION
closes: https://github.com/PrefectHQ/prefect/issues/9660

Fixes an issue where `variables.get` was incorrectly using `from_sync` to make a client call from an async context as well as scheduling it in the loop thread. This was only an issue when the variable was retrieved at the module level (like in the example below), where loading the flow code (which also was scheduled in a different thread) and the variable call itself would block each other.

### Example
```python
from prefect import flow, variables

bar = variables.get("foo")

@flow
def main():
    print(bar)

if __name__ == "__main__":
    main()
```
Previously this would appear to hang after downloading the flow code:
```python
Agent started! Looking for work from queue(s): default...
17:48:44.688 | INFO    | prefect.agent - Submitting flow run 'da282c0b-df76-4f03-9e8d-7f88c90447df'
17:48:45.223 | INFO    | prefect.infrastructure.process - Opening process 'celadon-weasel'...
17:48:45.326 | INFO    | prefect.agent - Completed submission of flow run 'da282c0b-df76-4f03-9e8d-7f88c90447df'
/Users/jakekaplan/opt/anaconda3/envs/demo-flows/lib/python3.10/runpy.py:126: RuntimeWarning: 'prefect.engine' found in sys.modules after import of package 'prefect', but prior to execution of 'prefect.engine'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
17:48:47.960 | INFO    | Flow run 'celadon-weasel' - Downloading flow code from storage at '/Users/jakekaplan/PycharmProjects/demo-flows'
```

Now the flow should run correctly:
```python
Agent started! Looking for work from queue(s): default...
17:47:31.886 | INFO    | prefect.agent - Submitting flow run 'ea88f08c-1e60-4f37-a491-98aec5adc535'
17:47:32.265 | INFO    | prefect.infrastructure.process - Opening process 'spectacular-tamarin'...
17:47:32.377 | INFO    | prefect.agent - Completed submission of flow run 'ea88f08c-1e60-4f37-a491-98aec5adc535'
/Users/jakekaplan/opt/anaconda3/envs/demo-flows/lib/python3.10/runpy.py:126: RuntimeWarning: 'prefect.engine' found in sys.modules after import of package 'prefect', but prior to execution of 'prefect.engine'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
17:47:35.418 | INFO    | Flow run 'spectacular-tamarin' - Downloading flow code from storage at '/Users/jakekaplan/PycharmProjects/demo-flows'
17:47:36.806 | INFO    | Flow run 'spectacular-tamarin' - Finished in state Completed()
askdjfnaksdjf
17:47:37.361 | INFO    | prefect.infrastructure.process - Process 'spectacular-tamarin' exited cleanly.
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
