### PR TITLE
Emit task run state change events when orchestrating a task run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 sdist/
 
 # Test artifacts
+.benchmarks/
 .coverage
 .coverage.*.*
 .prefect-results

--- a/benches/conftest.py
+++ b/benches/conftest.py
@@ -1,4 +1,25 @@
+import traceback
+
 import pytest
+import pytest_benchmark.plugin
+
+_handle_saving = pytest_benchmark.session.BenchmarkSession.handle_saving
+
+
+@pytest.hookimpl(hookwrapper=True)
+def handle_saving(*args, **kwargs):
+    """
+    Patches pytest-benchmark's save handler to avoid raising exceptions on failure.
+    An upstream bug causes failures to generate the benchmark JSON when tests fail.
+    """
+    try:
+        return _handle_saving(*args, **kwargs)
+    except Exception:
+        print("Failed to save benchmark results:")
+        traceback.print_exc()
+
+
+pytest_benchmark.session.BenchmarkSession.handle_saving = handle_saving
 
 
 @pytest.fixture(autouse=True)

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -60,6 +60,7 @@ from prefect.context import (
     TaskRunContext,
 )
 from prefect.deployments import load_flow_from_flow_run
+from prefect.events import Event, emit_event
 from prefect.exceptions import (
     Abort,
     FlowPauseTimeout,
@@ -121,6 +122,7 @@ from prefect.utilities.callables import (
 )
 from prefect.utilities.collections import StopVisiting, isiterable, visit_collection
 from prefect.utilities.pydantic import PartialModel
+from prefect.utilities.text import truncated_to
 
 R = TypeVar("R")
 EngineReturnType = Literal["future", "state", "result"]
@@ -1568,6 +1570,12 @@ async def orchestrate_task_run(
         else PREFECT_TASKS_REFRESH_CACHE.value()
     )
 
+    # Emit an event to capture that the task run was in the `PENDING` state.
+    last_event = _emit_task_run_state_change_event(
+        task_run=task_run, initial_state=None, validated_state=task_run.state
+    )
+    last_state = task_run.state
+
     # Transition from `PENDING` -> `RUNNING`
     state = await propose_state(
         client,
@@ -1576,6 +1584,15 @@ async def orchestrate_task_run(
         ),
         task_run_id=task_run.id,
     )
+
+    # Emit an event to capture the result of proposing a `RUNNING` state.
+    last_event = _emit_task_run_state_change_event(
+        task_run=task_run,
+        initial_state=last_state,
+        validated_state=state,
+        follows=last_event,
+    )
+    last_state = state
 
     # flag to ensure we only update the task run name once
     run_name_set = False
@@ -1668,6 +1685,13 @@ async def orchestrate_task_run(
                     terminal_state.state_details.cache_key = cache_key
 
             state = await propose_state(client, terminal_state, task_run_id=task_run.id)
+            last_event = _emit_task_run_state_change_event(
+                task_run=task_run,
+                initial_state=last_state,
+                validated_state=state,
+                follows=last_event,
+            )
+            last_state = state
 
             await _run_task_hooks(
                 task=task,
@@ -1695,6 +1719,13 @@ async def orchestrate_task_run(
                 )
                 # Attempt to enter a running state again
                 state = await propose_state(client, Running(), task_run_id=task_run.id)
+                last_event = _emit_task_run_state_change_event(
+                    task_run=task_run,
+                    initial_state=last_state,
+                    validated_state=state,
+                    follows=last_event,
+                )
+                last_state = state
 
     # If debugging, use the more complete `repr` than the usual `str` description
     display_state = repr(state) if PREFECT_DEBUG_MODE else str(state)
@@ -2051,6 +2082,8 @@ async def propose_state(
     # Parse the response to return the new state
     if response.status == SetStateStatus.ACCEPT:
         # Update the state with the details if provided
+        state.id = response.state.id
+        state.timestamp = response.state.timestamp
         if response.state.state_details:
             state.state_details = response.state.state_details
         return state
@@ -2290,6 +2323,60 @@ async def check_api_reachable(client: PrefectClient, fail_message: str):
 
     # Create a 10 minute cache for the healthy response
     API_HEALTHCHECKS[api_url] = get_deadline(60 * 10)
+
+
+def _emit_task_run_state_change_event(
+    task_run: TaskRun,
+    initial_state: Optional[State],
+    validated_state: State,
+    follows: Optional[Event] = None,
+) -> Event:
+    state_message_truncation_length = 100_000
+
+    return emit_event(
+        id=validated_state.id,
+        occurred=validated_state.timestamp,
+        event=f"prefect.task-run.{validated_state.name}",
+        payload={
+            "intended": {
+                "from": str(initial_state.type.value) if initial_state else None,
+                "to": str(validated_state.type.value) if validated_state else None,
+            },
+            "initial_state": (
+                {
+                    "type": str(initial_state.type.value),
+                    "name": initial_state.name,
+                    "message": truncated_to(
+                        state_message_truncation_length, initial_state.message
+                    ),
+                }
+                if initial_state
+                else None
+            ),
+            "validated_state": {
+                "type": str(validated_state.type.value),
+                "name": validated_state.name,
+                "message": truncated_to(
+                    state_message_truncation_length, validated_state.message
+                ),
+            },
+        },
+        resource={
+            "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+            "prefect.resource.name": task_run.name,
+            "prefect.state-message": truncated_to(
+                state_message_truncation_length, validated_state.message
+            ),
+            "prefect.state-name": validated_state.name or "",
+            "prefect.state-timestamp": (
+                validated_state.timestamp.isoformat()
+                if validated_state and validated_state.timestamp
+                else ""
+            ),
+            "prefect.state-type": str(validated_state.type.value),
+        },
+        follows=follows,
+    )
 
 
 if __name__ == "__main__":

--- a/src/prefect/events/worker.py
+++ b/src/prefect/events/worker.py
@@ -19,13 +19,13 @@ class EventsWorker(QueueService[Event]):
         self, client_type: Type[EventsClient], client_options: Tuple[Tuple[str, Any]]
     ):
         super().__init__(client_type, client_options)
-        self._client_type = client_type
-        self._client_options = client_options
+        self.client_type = client_type
+        self.client_options = client_options
         self._client: EventsClient
 
     @asynccontextmanager
     async def _lifespan(self):
-        self._client = self._client_type(**{k: v for k, v in self._client_options})
+        self._client = self.client_type(**{k: v for k, v in self.client_options})
 
         async with self._client:
             yield
@@ -45,7 +45,9 @@ class EventsWorker(QueueService[Event]):
         event.related += await related_resources_from_run_context(exclude=exclude)
 
     @classmethod
-    def instance(cls: Type[Self], client_type: Optional[EventsClient] = None) -> Self:
+    def instance(
+        cls: Type[Self], client_type: Optional[Type[EventsClient]] = None
+    ) -> Self:
         client_kwargs = {}
 
         # Select a client type for this worker based on settings

--- a/src/prefect/utilities/text.py
+++ b/src/prefect/utilities/text.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+
+def truncated_to(length: int, value: Optional[str]) -> str:
+    if not value:
+        return ""
+
+    if len(value) <= length:
+        return value
+
+    half = length // 2
+
+    beginning = value[:half]
+    end = value[-half:]
+    omitted = len(value) - (len(beginning) + len(end))
+
+    proposed = f"{beginning}...{omitted} additional characters...{end}"
+
+    return proposed if len(proposed) < len(value) else value

--- a/tests/events/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/instrumentation/test_task_run_state_change_events.py
@@ -6,7 +6,7 @@ from prefect.events.worker import EventsWorker
 async def test_task_state_change_happy_path(
     asserting_events_worker: EventsWorker,
     reset_worker_events,
-    orion_client,
+    prefect_client,
 ):
     @task
     def happy_little_tree():
@@ -20,8 +20,8 @@ async def test_task_state_change_happy_path(
 
     task_state = await flow_state.result()
     task_run_id = task_state.state_details.task_run_id
-    task_run = await orion_client.read_task_run(task_run_id)
-    task_run_states = await orion_client.read_task_run_states(task_run_id)
+    task_run = await prefect_client.read_task_run(task_run_id)
+    task_run_states = await prefect_client.read_task_run_states(task_run_id)
 
     await asserting_events_worker.drain()
     assert isinstance(asserting_events_worker._client, AssertingEventsClient)
@@ -70,7 +70,7 @@ async def test_task_state_change_happy_path(
 async def test_task_state_change_task_failure(
     asserting_events_worker: EventsWorker,
     reset_worker_events,
-    orion_client,
+    prefect_client,
 ):
     @task
     def happy_little_tree():
@@ -84,8 +84,8 @@ async def test_task_state_change_task_failure(
 
     task_state = await flow_state.result(raise_on_failure=False)
     task_run_id = task_state.state_details.task_run_id
-    task_run = await orion_client.read_task_run(task_run_id)
-    task_run_states = await orion_client.read_task_run_states(task_run_id)
+    task_run = await prefect_client.read_task_run(task_run_id)
+    task_run_states = await prefect_client.read_task_run_states(task_run_id)
 
     await asserting_events_worker.drain()
     assert isinstance(asserting_events_worker._client, AssertingEventsClient)

--- a/tests/events/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/instrumentation/test_task_run_state_change_events.py
@@ -1,0 +1,131 @@
+from prefect import flow, task
+from prefect.events.clients import AssertingEventsClient
+from prefect.events.worker import EventsWorker
+
+
+async def test_task_state_change_happy_path(
+    asserting_events_worker: EventsWorker,
+    reset_worker_events,
+    orion_client,
+):
+    @task
+    def happy_little_tree():
+        return "🌳"
+
+    @flow
+    def happy_path():
+        return happy_little_tree._run()
+
+    flow_state = happy_path._run()
+
+    task_state = await flow_state.result()
+    task_run_id = task_state.state_details.task_run_id
+    task_run = await orion_client.read_task_run(task_run_id)
+    task_run_states = await orion_client.read_task_run_states(task_run_id)
+
+    await asserting_events_worker.drain()
+    assert isinstance(asserting_events_worker._client, AssertingEventsClient)
+    assert len(task_run_states) == len(asserting_events_worker._client.events) == 3
+
+    last_state = None
+    for i, task_run_state in enumerate(task_run_states):
+        event = asserting_events_worker._client.events[i]
+
+        assert event.id == task_run_state.id
+        assert event.occurred == task_run_state.timestamp
+        assert event.event == f"prefect.task-run.{task_run_state.name}"
+        assert event.payload == {
+            "intended": {
+                "from": str(last_state.type.value) if last_state else None,
+                "to": str(task_run_state.type.value) if task_run_state else None,
+            },
+            "initial_state": (
+                {
+                    "type": last_state.type.value,
+                    "name": last_state.name,
+                    "message": last_state.message or "",
+                }
+                if last_state
+                else None
+            ),
+            "validated_state": {
+                "type": task_run_state.type.value,
+                "name": task_run_state.name,
+                "message": task_run_state.message or "",
+            },
+        }
+        assert event.follows == (last_state.id if last_state else None)
+        assert dict(event.resource.items()) == {
+            "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+            "prefect.resource.name": task_run.name,
+            "prefect.state-message": task_run_state.message or "",
+            "prefect.state-name": task_run_state.name,
+            "prefect.state-timestamp": task_run_state.timestamp.isoformat(),
+            "prefect.state-type": str(task_run_state.type.value),
+        }
+
+        last_state = task_run_state
+
+
+async def test_task_state_change_task_failure(
+    asserting_events_worker: EventsWorker,
+    reset_worker_events,
+    orion_client,
+):
+    @task
+    def happy_little_tree():
+        raise ValueError("Here's a happy little accident.")
+
+    @flow
+    def happy_path():
+        return happy_little_tree._run()
+
+    flow_state = happy_path._run()
+
+    task_state = await flow_state.result(raise_on_failure=False)
+    task_run_id = task_state.state_details.task_run_id
+    task_run = await orion_client.read_task_run(task_run_id)
+    task_run_states = await orion_client.read_task_run_states(task_run_id)
+
+    await asserting_events_worker.drain()
+    assert isinstance(asserting_events_worker._client, AssertingEventsClient)
+    assert len(task_run_states) == len(asserting_events_worker._client.events) == 3
+
+    last_state = None
+    for i, task_run_state in enumerate(task_run_states):
+        event = asserting_events_worker._client.events[i]
+
+        assert event.id == task_run_state.id
+        assert event.occurred == task_run_state.timestamp
+        assert event.event == f"prefect.task-run.{task_run_state.name}"
+        assert event.payload == {
+            "intended": {
+                "from": str(last_state.type.value) if last_state else None,
+                "to": str(task_run_state.type.value) if task_run_state else None,
+            },
+            "initial_state": (
+                {
+                    "type": last_state.type.value,
+                    "name": last_state.name,
+                    "message": last_state.message or "",
+                }
+                if last_state
+                else None
+            ),
+            "validated_state": {
+                "type": task_run_state.type.value,
+                "name": task_run_state.name,
+                "message": task_run_state.message or "",
+            },
+        }
+        assert event.follows == (last_state.id if last_state else None)
+        assert dict(event.resource.items()) == {
+            "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+            "prefect.resource.name": task_run.name,
+            "prefect.state-message": task_run_state.message or "",
+            "prefect.state-name": task_run_state.name,
+            "prefect.state-timestamp": task_run_state.timestamp.isoformat(),
+            "prefect.state-type": str(task_run_state.type.value),
+        }
+
+        last_state = task_run_state

--- a/tests/events/test_events_emit_event.py
+++ b/tests/events/test_events_emit_event.py
@@ -4,9 +4,10 @@ from uuid import UUID
 import pendulum
 
 from prefect.events import emit_event
-from prefect.events.clients import AssertingEventsClient
+from prefect.events.clients import AssertingEventsClient, NullEventsClient
 from prefect.events.worker import EventsWorker
 from prefect.server.utilities.schemas import DateTimeTZ
+from prefect.settings import PREFECT_API_URL, temporary_settings
 
 
 def test_emits_simple_event(asserting_events_worker: EventsWorker, reset_worker_events):
@@ -105,3 +106,17 @@ def test_does_not_set_follows_not_tight_timing(
 
     asserting_events_worker.drain()
     assert read_event.follows is None
+
+
+def test_noop_with_null_events_client():
+    with temporary_settings(updates={PREFECT_API_URL: None}):
+        worker = EventsWorker.instance()
+        assert worker.client_type == NullEventsClient
+
+        assert (
+            emit_event(
+                event="vogon.poetry.read",
+                resource={"prefect.resource.id": "vogon.poem.oh-freddled-gruntbuggly"},
+            )
+            is None
+        )

--- a/tests/events/test_events_related_from_context.py
+++ b/tests/events/test_events_related_from_context.py
@@ -5,7 +5,7 @@ import pytest
 
 from prefect import flow, task
 from prefect.client.orchestration import get_client
-from prefect.context import FlowRunContext, TaskRunContext
+from prefect.context import FlowRunContext
 from prefect.events.related import (
     MAX_CACHE_SIZE,
     related_resources_from_run_context,
@@ -192,26 +192,6 @@ async def test_caches_related_objects(spy_client):
 
     await test_flow()
 
-    spy_client.client.read_flow.assert_called_once()
-
-
-async def test_caches_from_task_run_context(spy_client):
-    @task
-    async def test_task():
-        FlowRunContext.__var__.set(None)
-        task_run_context = TaskRunContext.get()
-        assert task_run_context is not None
-        with mock.patch("prefect.client.orchestration.get_client", lambda: spy_client):
-            await related_resources_from_run_context()
-            await related_resources_from_run_context()
-
-    @flow
-    async def test_flow():
-        return await test_task()
-
-    await test_flow()
-
-    spy_client.client.read_flow_run.assert_called_once()
     spy_client.client.read_flow.assert_called_once()
 
 

--- a/tests/events/test_events_worker.py
+++ b/tests/events/test_events_worker.py
@@ -38,13 +38,13 @@ def test_emits_event_via_client(asserting_events_worker: EventsWorker, event: Ev
 def test_worker_instance_null_client_no_api_url():
     with temporary_settings(updates={PREFECT_API_URL: None}):
         worker = EventsWorker.instance()
-        assert worker._client_type == NullEventsClient
+        assert worker.client_type == NullEventsClient
 
 
 def test_worker_instance_null_client_non_cloud_api_url():
     with temporary_settings(updates={PREFECT_API_URL: "http://localhost:8080/api"}):
         worker = EventsWorker.instance()
-        assert worker._client_type == NullEventsClient
+        assert worker.client_type == NullEventsClient
 
 
 def test_worker_instance_null_client_cloud_api_url_experiment_disabled():
@@ -56,7 +56,7 @@ def test_worker_instance_null_client_cloud_api_url_experiment_disabled():
         }
     ):
         worker = EventsWorker.instance()
-        assert worker._client_type == NullEventsClient
+        assert worker.client_type == NullEventsClient
 
 
 def test_worker_instance_null_client_cloud_api_url_experiment_enabled():
@@ -68,7 +68,7 @@ def test_worker_instance_null_client_cloud_api_url_experiment_enabled():
         }
     ):
         worker = EventsWorker.instance()
-        assert worker._client_type == PrefectCloudEventsClient
+        assert worker.client_type == PrefectCloudEventsClient
 
 
 async def test_includes_related_resources_from_run_context(

--- a/tests/results/test_flow_results.py
+++ b/tests/results/test_flow_results.py
@@ -398,11 +398,13 @@ def test_flow_state_result_is_respected(persist_result, return_state):
     state = my_flow(return_state=True)
     assert state.type == return_state.type
 
-    # State details must be excluded as the flow state includes ids
-    # Data must be excluded as it will have been updated to a result
-    assert state.dict(exclude={"state_details", "data"}) == return_state.dict(
-        exclude={"state_details", "data"}
-    )
+    # id, timestamp, and state details must be excluded as they are copied from
+    # the API version of the state and will not match the state created for
+    # this test. Data must be excluded as it will have been updated to a
+    # result.
+    assert state.dict(
+        exclude={"id", "timestamp", "state_details", "data"}
+    ) == return_state.dict(exclude={"id", "timestamp", "state_details", "data"})
 
     if return_state.data:
         assert state.result(raise_on_failure=False) == return_state.data
@@ -428,11 +430,13 @@ def test_flow_server_state_schema_result_is_respected(persist_result, return_sta
 
     assert state.type == return_state.type
 
-    # State details must be excluded as the flow state includes ids
-    # Data must be excluded as it will have been updated to a result
-    assert state.dict(exclude={"state_details", "data"}) == return_state.dict(
-        exclude={"state_details", "data"}
-    )
+    # id, timestamp, and state details must be excluded as they are copied from
+    # the API version of the state and will not match the state created for
+    # this test. Data must be excluded as it will have been updated to a
+    # result.
+    assert state.dict(
+        exclude={"id", "timestamp", "state_details", "data"}
+    ) == return_state.dict(exclude={"id", "timestamp", "state_details", "data"})
 
     if return_state.data:
         with pytest.warns(DeprecationWarning, match="use `prefect.states.State`"):


### PR DESCRIPTION
This updates the engine to emit an event when a task run changes states. 

Closes #9651 

### Example
<img width="1118" alt="Screenshot 2023-05-22 at 4 50 01 PM" src="https://github.com/PrefectHQ/prefect/assets/354286/f98aac63-efc9-4190-89fd-868f5f883961">
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
