### PR TITLE
Update rate limit docs to include /set_state and /flows endpoint for Prefect Cloud

### DIFF
--- a/docs/cloud/rate-limits.md
+++ b/docs/cloud/rate-limits.md
@@ -20,7 +20,7 @@ Prefect Cloud enforces the following rate limits:
 
 ## Flow and task creation rate limits
 
-Prefect Cloud limits creation of flow and task runs to: 
+Prefect Cloud limits requests to the `flow_runs`, `task_runs`, `flows`, and `set_state` endpoints at the following levels, expressed per endpoint:
 
 - 400 per minute for personal accounts
 - 2,000 per minute for organization accounts

--- a/docs/cloud/rate-limits.md
+++ b/docs/cloud/rate-limits.md
@@ -20,7 +20,7 @@ Prefect Cloud enforces the following rate limits:
 
 ## Flow and task creation rate limits
 
-Prefect Cloud limits requests to the `flow_runs`, `task_runs`, `flows`, and `set_state` endpoints at the following levels, expressed per endpoint:
+Prefect Cloud limits the `flow_runs`, `task_runs`, and `flows` endpoints and their subroutes at the following levels:
 
 - 400 per minute for personal accounts
 - 2,000 per minute for organization accounts


### PR DESCRIPTION
Adding /set_state and /flows to endpoint rate limits in documentation for Prefect Cloud.

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
