### PR TITLE
Guard against changing the profile path from `prefect config set`

### DIFF
--- a/src/prefect/cli/config.py
+++ b/src/prefect/cli/config.py
@@ -38,6 +38,13 @@ def set_(settings: List[str]):
         if setting not in prefect.settings.SETTING_VARIABLES:
             exit_with_error(f"Unknown setting name {setting!r}.")
 
+        # Guard against changing settings that tweak config locations
+        if setting in {"PREFECT_HOME", "PREFECT_PROFILES_PATH"}:
+            exit_with_error(
+                f"Setting {setting!r} cannot be changed with this command. "
+                "Use an environment variable instead."
+            )
+
         parsed_settings[setting] = value
 
     try:

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -74,6 +74,19 @@ def test_set_with_unknown_setting():
     )
 
 
+@pytest.mark.parametrize("setting", ["PREFECT_HOME", "PREFECT_PROFILES_PATH"])
+def test_set_with_disallowed_setting(setting):
+    save_profiles(ProfilesCollection([Profile(name="foo", settings={})], active=None))
+
+    invoke_and_assert(
+        ["--profile", "foo", "config", "set", f"{setting}=BAR"],
+        expected_output=f"""                
+            Setting {setting!r} cannot be changed with this command. Use an environment variable instead.
+            """,
+        expected_code=1,
+    )
+
+
 def test_set_with_invalid_value_type():
     save_profiles(ProfilesCollection([Profile(name="foo", settings={})], active=None))
 


### PR DESCRIPTION
Changing `PREFECT_HOME` or `PREFECT_PROFILES_PATH` via the config will result in a new config path that would not be respected — very confusing for a user.

## Example

```
❯ prefect config set PREFECT_HOME="test"        
Setting 'PREFECT_HOME' cannot be changed with this command. Use an environment variable instead.
```
