### PR TITLE
feat: add an /api/ready check to prefect server

### DIFF
--- a/src/prefect/server/api/root.py
+++ b/src/prefect/server/api/root.py
@@ -27,4 +27,4 @@ async def peform_readiness_check(
         return is_db_connectable
 
     response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
-    return is_db_connectable
+    return "Database is not available"

--- a/src/prefect/server/api/root.py
+++ b/src/prefect/server/api/root.py
@@ -2,7 +2,6 @@
 Contains the `hello` route for testing and healthcheck purposes.
 """
 from fastapi import Depends, status
-from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from prefect.server.utilities.server import PrefectRouter
 from prefect.server.database.dependencies import provide_database_interface
@@ -26,10 +25,10 @@ async def perform_readiness_check(
     if is_db_connectable:
         return JSONResponse(
             status_code=status.HTTP_200_OK,
-            content=jsonable_encoder({"status": "OK"}),
+            content={"message": "OK"},
         )
 
     return JSONResponse(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-        content=jsonable_encoder({"status": "Database is not available"}),
+        content={"message": "Database is not available"},
     )

--- a/src/prefect/server/api/root.py
+++ b/src/prefect/server/api/root.py
@@ -1,8 +1,10 @@
 """
 Contains the `hello` route for testing and healthcheck purposes.
 """
-
+from fastapi import Depends, Response, status
 from prefect.server.utilities.server import PrefectRouter
+from prefect.server.database.dependencies import provide_database_interface
+from prefect.server.database.interface import PrefectDBInterface
 
 router = PrefectRouter(prefix="", tags=["Root"])
 
@@ -11,3 +13,18 @@ router = PrefectRouter(prefix="", tags=["Root"])
 async def hello():
     """Say hello!"""
     return "👋"
+
+
+@router.get("/ready")
+async def get_status(
+    db: PrefectDBInterface = Depends(provide_database_interface),
+    response: Response = None,
+):
+    is_db_connectable = await db.is_db_connectable()
+
+    if is_db_connectable:
+        response.status_code = status.HTTP_200_OK
+        return is_db_connectable
+
+    response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+    return is_db_connectable

--- a/src/prefect/server/api/root.py
+++ b/src/prefect/server/api/root.py
@@ -16,7 +16,7 @@ async def hello():
 
 
 @router.get("/ready")
-async def get_status(
+async def peform_readiness_check(
     db: PrefectDBInterface = Depends(provide_database_interface),
     response: Response = None,
 ):

--- a/src/prefect/server/api/root.py
+++ b/src/prefect/server/api/root.py
@@ -16,7 +16,7 @@ async def hello():
 
 
 @router.get("/ready")
-async def peform_readiness_check(
+async def perform_readiness_check(
     db: PrefectDBInterface = Depends(provide_database_interface),
     response: Response = None,
 ):

--- a/src/prefect/server/database/interface.py
+++ b/src/prefect/server/database/interface.py
@@ -75,7 +75,7 @@ class PrefectDBInterface(metaclass=DBSingleton):
         try:
             async with engine.connect():
                 return True
-        except sa.exc.OperationalError:
+        except Exception:
             return False
 
     async def engine(self):

--- a/src/prefect/server/database/interface.py
+++ b/src/prefect/server/database/interface.py
@@ -66,6 +66,18 @@ class PrefectDBInterface(metaclass=DBSingleton):
         """Run all downgrade migrations"""
         await run_sync_in_worker_thread(alembic_downgrade)
 
+    async def is_db_connectable(self):
+        """
+        Returns boolean indicating if the database is connectable.
+        This method is used to determine if the server is ready to accept requests.
+        """
+        engine = await self.engine()
+        try:
+            async with engine.connect():
+                return True
+        except sa.exc.OperationalError:
+            return False
+
     async def engine(self):
         """
         Provides a SqlAlchemy engine against a specific database.

--- a/tests/server/api/test_root.py
+++ b/tests/server/api/test_root.py
@@ -1,5 +1,5 @@
 from fastapi import status
-from unittest.mock import AsyncMock
+from prefect.testing.utilities import AsyncMock
 
 
 async def test_hello_world(client):

--- a/tests/server/api/test_root.py
+++ b/tests/server/api/test_root.py
@@ -1,7 +1,26 @@
 from fastapi import status
+from unittest.mock import AsyncMock
 
 
 async def test_hello_world(client):
     response = await client.get("/hello")
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == "👋"
+
+
+async def test_ready(client):
+    response = await client.get("/ready")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"message": "OK"}
+
+
+async def test_ready_with_unavailable_db(client, monkeypatch):
+    is_db_connectable_mock = AsyncMock(return_value=False)
+
+    monkeypatch.setattr(
+        "prefect.server.database.interface.PrefectDBInterface.is_db_connectable",
+        is_db_connectable_mock,
+    )
+    response = await client.get("/ready")
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert response.json() == {"message": "Database is not available"}


### PR DESCRIPTION
relates to https://github.com/PrefectHQ/prefect-helm/issues/132
relates to https://github.com/PrefectHQ/prefect/issues/8940

the idea is that we can continue using `GET /api/health` (or `GET /api/hello`) as a liveness check, and this new `GET /api/ready` endpoint as a readiness check, which probes to see if the database is connect-able

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
