### PR TITLE
feat: add worker `poll.*` events

### DIFF
--- a/src/prefect/cli/worker.py
+++ b/src/prefect/cli/worker.py
@@ -154,7 +154,7 @@ async def start(
                 )
             )
 
-            started_event = await worker._emit_event_worker_started()
+            started_event = await worker._emit_worker_started_event()
 
-    await worker._emit_event_worker_stopped(started_event)
+    await worker._emit_worker_stopped_event(started_event)
     app.console.print(f"Worker {worker.name!r} stopped!")

--- a/src/prefect/cli/worker.py
+++ b/src/prefect/cli/worker.py
@@ -154,7 +154,7 @@ async def start(
                 )
             )
 
-            started_event = await worker._emit_worker_started_event()
+            started_event = await worker._emit_event_worker_started()
 
-    await worker._emit_worker_stopped_event(started_event)
+    await worker._emit_event_worker_stopped(started_event)
     app.console.print(f"Worker {worker.name!r} stopped!")

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1084,7 +1084,7 @@ class BaseWorker(abc.ABC):
 
     def _emit_event_worker_poll_cancellation(self) -> Event:
         return emit_event(
-            "prefect.worker.poll.cancellation",
+            "prefect.worker.poll.cancelled-flow-run",
             resource=self._event_resource(),
             related=self._event_related_resources(),
         )

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -641,7 +641,6 @@ class BaseWorker(abc.ABC):
             await self._client.send_worker_heartbeat(
                 work_pool_name=self._work_pool_name, worker_name=self.name
             )
-            self._emit_event_worker_heartbeat()
 
     async def sync_with_backend(self):
         """
@@ -1066,13 +1065,6 @@ class BaseWorker(abc.ABC):
             resource=self._event_resource(),
             related=related,
             follows=submitted_event,
-        )
-
-    def _emit_event_worker_heartbeat(self) -> Event:
-        return emit_event(
-            "prefect.worker.heartbeat",
-            resource=self._event_resource(),
-            related=self._event_related_resources(),
         )
 
     def _emit_event_worker_poll_flow_run(self) -> Event:

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -536,7 +536,7 @@ class BaseWorker(abc.ABC):
 
         cancelling_flow_runs = named_cancelling_flow_runs + typed_cancelling_flow_runs
 
-        self._emit_event_worker_poll_cancellation()
+        self._emit_event_worker_poll_cancelled_flow_run()
 
         if cancelling_flow_runs:
             self._logger.info(
@@ -1082,7 +1082,7 @@ class BaseWorker(abc.ABC):
             related=self._event_related_resources(),
         )
 
-    def _emit_event_worker_poll_cancellation(self) -> Event:
+    def _emit_event_worker_poll_cancelled_flow_run(self) -> Event:
         return emit_event(
             "prefect.worker.poll.cancelled-flow-run",
             resource=self._event_resource(),

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1069,7 +1069,7 @@ class BaseWorker(abc.ABC):
             follows=submitted_event,
         )
 
-    async def _emit_worker_heartbeat_event(self, heartbeat_origin: str) -> Event:
+    def _emit_worker_heartbeat_event(self, heartbeat_origin: str) -> Event:
         return emit_event(
             "prefect.worker.heartbeat",
             resource=self._event_resource(),

--- a/tests/events/instrumentation/test_events_workers_instrumentation.py
+++ b/tests/events/instrumentation/test_events_workers_instrumentation.py
@@ -250,7 +250,7 @@ def test_lifecycle_events(
     flow_run_poll_event = asserting_events_worker._client.events[2]
     cancellation_poll_event = asserting_events_worker._client.events[3]
     assert flow_run_poll_event.event == "prefect.worker.poll.flow-run"
-    assert cancellation_poll_event.event == "prefect.worker.poll.cancellation"
+    assert cancellation_poll_event.event == "prefect.worker.poll.cancelled-flow-run"
 
     # last event should be `prefect.worker.stopped`
     stopped_event = asserting_events_worker._client.events[
@@ -307,7 +307,7 @@ async def test_worker_emits_cancelled_event(
     assert heartbeat_event.event == "prefect.worker.heartbeat"
 
     cancellation_poll_event = asserting_events_worker._client.events[1]
-    assert cancellation_poll_event.event == "prefect.worker.poll.cancellation"
+    assert cancellation_poll_event.event == "prefect.worker.poll.cancelled-flow-run"
 
     cancelled_event = asserting_events_worker._client.events[2]
     assert cancelled_event.event == "prefect.worker.cancelled-flow-run"

--- a/tests/events/instrumentation/test_events_workers_instrumentation.py
+++ b/tests/events/instrumentation/test_events_workers_instrumentation.py
@@ -51,7 +51,7 @@ async def test_worker_emits_submitted_event(
 
     assert isinstance(asserting_events_worker._client, AssertingEventsClient)
 
-    # When a worker submits a flow-run, it first dispatches a 'worker.hearbeat' event.
+    # When a worker submits a flow-run, it first dispatches a 'worker.heartbeat' event.
     # it then monitors that flow run until it's complete.
     # When it's complete, it fires a third 'monitored' event, which
     # is covered by the test_worker_emits_monitored_event below.
@@ -134,7 +134,7 @@ async def test_worker_emits_executed_event(
 
     assert isinstance(asserting_events_worker._client, AssertingEventsClient)
 
-    # When a worker submits a flow-run, it first dispatches a 'worker.hearbeat' event.
+    # When a worker submits a flow-run, it first dispatches a 'worker.heartbeat' event.
     # it then monitors that flow run until it's complete.
     # When it's complete, it fires a third 'sumbitted' event, which
     # is covered by the test_worker_emits_submitted_event below.

--- a/tests/events/instrumentation/test_events_workers_instrumentation.py
+++ b/tests/events/instrumentation/test_events_workers_instrumentation.py
@@ -217,12 +217,9 @@ def test_lifecycle_events(
 
     assert isinstance(asserting_events_worker._client, AssertingEventsClient)
 
-    assert len(asserting_events_worker._client.events) == 6
+    assert len(asserting_events_worker._client.events) == 4
 
-    heartbeat_event = asserting_events_worker._client.events[0]
-    assert heartbeat_event.event == "prefect.worker.heartbeat"
-
-    started_event = asserting_events_worker._client.events[1]
+    started_event = asserting_events_worker._client.events[0]
     assert started_event.event == "prefect.worker.started"
 
     assert dict(started_event.resource.items()) == {
@@ -247,8 +244,8 @@ def test_lifecycle_events(
     # two 'worker.poll.*' events are dispatched in a lifecycle
     # one for when scheduled flow runs are checked, and
     # one for when cancelled flow runs are checked
-    flow_run_poll_event = asserting_events_worker._client.events[2]
-    cancellation_poll_event = asserting_events_worker._client.events[3]
+    flow_run_poll_event = asserting_events_worker._client.events[1]
+    cancellation_poll_event = asserting_events_worker._client.events[2]
     assert flow_run_poll_event.event == "prefect.worker.poll.flow-run"
     assert cancellation_poll_event.event == "prefect.worker.poll.cancelled-flow-run"
 
@@ -301,15 +298,12 @@ async def test_worker_emits_cancelled_event(
 
     assert isinstance(asserting_events_worker._client, AssertingEventsClient)
 
-    assert len(asserting_events_worker._client.events) == 3
+    assert len(asserting_events_worker._client.events) == 2
 
-    heartbeat_event = asserting_events_worker._client.events[0]
-    assert heartbeat_event.event == "prefect.worker.heartbeat"
-
-    cancellation_poll_event = asserting_events_worker._client.events[1]
+    cancellation_poll_event = asserting_events_worker._client.events[0]
     assert cancellation_poll_event.event == "prefect.worker.poll.cancelled-flow-run"
 
-    cancelled_event = asserting_events_worker._client.events[2]
+    cancelled_event = asserting_events_worker._client.events[1]
     assert cancelled_event.event == "prefect.worker.cancelled-flow-run"
 
     assert dict(cancelled_event.resource.items()) == {


### PR DESCRIPTION
relates to https://github.com/PrefectHQ/platform/issues/3841

this PR adds:
* a `prefect.worker.poll.flow-run` event, to be dispatched when grabbing flow runs
* a `prefect.worker.poll.cancelled-flow-run` event (similar)

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
