### PR TITLE
fix variable max value update

### DIFF
--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -644,7 +644,7 @@ class VariableUpdate(ActionBaseModel):
         default=None,
         description="The value of the variable",
         example="my-value",
-        max_length=schemas.core.MAX_VARIABLE_NAME_LENGTH,
+        max_length=schemas.core.MAX_VARIABLE_VALUE_LENGTH,
     )
     tags: Optional[List[str]] = FieldFrom(schemas.core.Variable)
 

--- a/tests/server/api/test_variables.py
+++ b/tests/server/api/test_variables.py
@@ -534,6 +534,54 @@ class TestUpdateVariable:
         assert res
         assert res.status_code == 409
 
+    async def test_name_max_length(
+        self,
+        client: AsyncClient,
+        variable,
+    ):
+        max_length = 255
+
+        res = await client.patch(
+            f"/variables/{variable.id}", json={"name": "v" * max_length}
+        )
+        assert res
+        assert res.status_code == 204
+
+        max_length_plus1 = max_length + 1
+
+        res = await client.patch(
+            f"/variables/{variable.id}", json={"name": "v" * max_length_plus1}
+        )
+        assert res
+        assert res.status_code == 422
+        assert (
+            "ensure this value has at most" in res.json()["exception_detail"][0]["msg"]
+        )
+
+    async def test_value_max_length(
+        self,
+        client: AsyncClient,
+        variable,
+    ):
+        max_length = 5000
+
+        res = await client.patch(
+            f"/variables/{variable.id}", json={"value": "v" * max_length}
+        )
+        assert res
+        assert res.status_code == 204
+
+        max_length_plus1 = max_length + 1
+
+        res = await client.patch(
+            f"/variables/{variable.id}", json={"value": "v" * max_length_plus1}
+        )
+        assert res
+        assert res.status_code == 422
+        assert (
+            "ensure this value has at most" in res.json()["exception_detail"][0]["msg"]
+        )
+
 
 class TestUpdateVariableByName:
     async def test_update_variable(
@@ -583,6 +631,54 @@ class TestUpdateVariableByName:
             json=same_name_update.dict(json_compatible=True),
         )
         assert res.status_code == 409
+
+    async def test_name_max_length(
+        self,
+        client: AsyncClient,
+        variable,
+    ):
+        max_length = 255
+
+        res = await client.patch(
+            f"/variables/name/{variable.name}", json={"name": "v" * max_length}
+        )
+        assert res
+        assert res.status_code == 204
+
+        max_length_plus1 = max_length + 1
+
+        res = await client.patch(
+            f"/variables/name/{variable.name}", json={"name": "v" * max_length_plus1}
+        )
+        assert res
+        assert res.status_code == 422
+        assert (
+            "ensure this value has at most" in res.json()["exception_detail"][0]["msg"]
+        )
+
+    async def test_value_max_length(
+        self,
+        client: AsyncClient,
+        variable,
+    ):
+        max_length = 5000
+
+        res = await client.patch(
+            f"/variables/name/{variable.name}", json={"value": "v" * max_length}
+        )
+        assert res
+        assert res.status_code == 204
+
+        max_length_plus1 = max_length + 1
+
+        res = await client.patch(
+            f"/variables/name/{variable.name}", json={"value": "v" * max_length_plus1}
+        )
+        assert res
+        assert res.status_code == 422
+        assert (
+            "ensure this value has at most" in res.json()["exception_detail"][0]["msg"]
+        )
 
 
 class TestDeleteVariable:


### PR DESCRIPTION
closes: https://github.com/PrefectHQ/prefect/issues/9709

When calling `PATCH - .../api/variables/{id}` `Variables.value` can't be updated to more than 255 characters. That is the correct max length for `Variables.name`, but `Variables.value` should be max length of 5000.

### Example
The update would return a 422 before saying the max length was 255. Now this will correctly update up to 5000 characters.
```python
from prefect.client.orchestration import get_client
import asyncio


async def main():

    async with get_client() as client:
        res = await client._client.post(f"/variables/", json={"name": "foo", "value": "bar"})
        assert res.status_code == 201

        res = await client._client.patch(f"/variables/name/foo", json={"value": "b" * 257})
        assert res.status_code == 422
        print(res.json())

asyncio.run(main())
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
