### PR TITLE
Allow table artifacts as list of lists

### DIFF
--- a/docs/concepts/artifacts.md
+++ b/docs/concepts/artifacts.md
@@ -145,6 +145,9 @@ After running the above flow, you should see your "gtm-report" artifact in the A
 
 You can create a table artifact by calling `create_table_artifact()`. To create multiple versions of the same artifact and/or view them on the Artifacts page of the Prefect UI, provide a `key` argument to the `create_table_artifact()` function to track an artifact's history over time. Without a `key`, the artifact will only be visible in the artifacts tab of the associated flow run or task run."
 
+!!! note
+    The `create_table_artifact()` function accepts a `table` argument, which can be provided as either a list of lists, a list of dictionaries, or a dictionary of lists.
+
 ```python
 from prefect.artifacts import create_table_artifact
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -295,6 +295,22 @@ class TestCreateArtifacts:
         result_data = json.loads(result.data)
         assert result_data == my_table
 
+    async def test_create_and_read_list_of_list_table_artifact_succeeds(
+        self, artifact, client
+    ):
+        my_table = [[1, 2], [None, 4]]
+
+        artifact_id = await create_table_artifact(
+            key=artifact.key,
+            table=my_table,
+            description=artifact.description,
+        )
+
+        response = await client.get(f"/artifacts/{artifact_id}")
+        result = pydantic.parse_obj_as(schemas.core.Artifact, response.json())
+        result_data = json.loads(result.data)
+        assert result_data == my_table
+
     async def test_create_table_artifact_in_task_succeeds(self, client):
         @task
         def my_special_task():


### PR DESCRIPTION
### Overview
We're able to render table artifacts in the UI where the input is a `list[list]`, and we should allow it.


<!-- Include an overview here -->

### Example

```python
@task
def my_table_task():
    create_table_artifact(
        key="sales-data-table",
        table=[
            ["Region", "Revenue"],
            ["North America", 500000],
            ["Europe", 250000],
            ["Asia", 150000],
            ["South America", 75000],
            ["Africa", 25000],
        ],
        description="## Sales by Region",
    )
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
