### PR TITLE
fix: use counts for worker events instrumentation tests

### DIFF
--- a/tests/events/instrumentation/test_events_workers_instrumentation.py
+++ b/tests/events/instrumentation/test_events_workers_instrumentation.py
@@ -273,8 +273,9 @@ def test_lifecycle_events(
     # two 'worker.poll.*' events are dispatched in a lifecycle
     # one for when scheduled flow runs are checked, and
     # one for when cancelled flow runs are checked
-    # NOTE: here, we'll do a count check, as the order of these events
-    # is non-deterministic / guaranteed
+
+    # NOTE: here, we'll do count checks for non-starting/ending events,
+    # as the order of these events is non-deterministic / non-guaranteed
     flow_run_poll_events = list(
         filter(
             lambda e: e.event == "prefect.worker.poll.flow-run",

--- a/tests/events/instrumentation/test_events_workers_instrumentation.py
+++ b/tests/events/instrumentation/test_events_workers_instrumentation.py
@@ -57,22 +57,32 @@ async def test_worker_emits_submitted_event(
     # is covered by the test_worker_emits_monitored_event below.
     assert len(asserting_events_worker._client.events) == 3
 
-    flow_run_poll_event = asserting_events_worker._client.events[0]
-    assert flow_run_poll_event.event == "prefect.worker.poll.flow-run"
+    flow_run_poll_events = list(
+        filter(
+            lambda e: e.event == "prefect.worker.poll.flow-run",
+            asserting_events_worker._client.events,
+        )
+    )
+    assert len(flow_run_poll_events) == 1
 
-    submit_event = asserting_events_worker._client.events[1]
-    assert submit_event.event == "prefect.worker.submitted-flow-run"
+    submit_events = list(
+        filter(
+            lambda e: e.event == "prefect.worker.submitted-flow-run",
+            asserting_events_worker._client.events,
+        )
+    )
+    assert len(submit_events) == 1
 
-    assert dict(submit_event.resource.items()) == {
+    assert dict(submit_events[0].resource.items()) == {
         "prefect.resource.id": f"prefect.worker.events-test.{worker.get_name_slug()}",
         "prefect.resource.name": worker.name,
         "prefect.version": str(__version__),
         "prefect.worker-type": worker.type,
     }
 
-    assert len(submit_event.related) == 6
+    assert len(submit_events[0].related) == 6
 
-    related = [dict(r.items()) for r in submit_event.related]
+    related = [dict(r.items()) for r in submit_events[0].related]
 
     assert related == [
         {
@@ -139,24 +149,42 @@ async def test_worker_emits_executed_event(
     # is covered by the test_worker_emits_submitted_event below.
     assert len(asserting_events_worker._client.events) == 3
 
-    flow_run_poll_event = asserting_events_worker._client.events[0]
-    assert flow_run_poll_event.event == "prefect.worker.poll.flow-run"
+    flow_run_poll_events = list(
+        filter(
+            lambda e: e.event == "prefect.worker.poll.flow-run",
+            asserting_events_worker._client.events,
+        )
+    )
+    assert len(flow_run_poll_events) == 1
 
-    submitted_event = asserting_events_worker._client.events[1]
-    executed_event = asserting_events_worker._client.events[2]
+    submitted_events = list(
+        filter(
+            lambda e: e.event == "prefect.worker.submitted-flow-run",
+            asserting_events_worker._client.events,
+        )
+    )
+    assert len(submitted_events) == 1
 
-    assert executed_event.event == "prefect.worker.executed-flow-run"
+    executed_events = list(
+        filter(
+            lambda e: e.event == "prefect.worker.executed-flow-run",
+            asserting_events_worker._client.events,
+        )
+    )
+    assert len(executed_events) == 1
 
-    assert dict(executed_event.resource.items()) == {
+    assert executed_events[0].event == "prefect.worker.executed-flow-run"
+
+    assert dict(executed_events[0].resource.items()) == {
         "prefect.resource.id": f"prefect.worker.events-test.{worker.get_name_slug()}",
         "prefect.resource.name": worker.name,
         "prefect.version": str(__version__),
         "prefect.worker-type": worker.type,
     }
 
-    assert len(executed_event.related) == 6
+    assert len(executed_events[0].related) == 6
 
-    related = [dict(r.items()) for r in executed_event.related]
+    related = [dict(r.items()) for r in executed_events[0].related]
 
     assert related == [
         {
@@ -191,7 +219,7 @@ async def test_worker_emits_executed_event(
         },
     ]
 
-    assert executed_event.follows == submitted_event.id
+    assert executed_events[0].follows == submitted_events[0].id
 
 
 @pytest.mark.usefixtures("use_hosted_api_server")
@@ -219,6 +247,7 @@ def test_lifecycle_events(
 
     assert len(asserting_events_worker._client.events) == 4
 
+    # first event will always be `prefect.worker.started`
     started_event = asserting_events_worker._client.events[0]
     assert started_event.event == "prefect.worker.started"
 
@@ -244,10 +273,23 @@ def test_lifecycle_events(
     # two 'worker.poll.*' events are dispatched in a lifecycle
     # one for when scheduled flow runs are checked, and
     # one for when cancelled flow runs are checked
-    flow_run_poll_event = asserting_events_worker._client.events[1]
-    cancellation_poll_event = asserting_events_worker._client.events[2]
-    assert flow_run_poll_event.event == "prefect.worker.poll.flow-run"
-    assert cancellation_poll_event.event == "prefect.worker.poll.cancelled-flow-run"
+    # NOTE: here, we'll do a count check, as the order of these events
+    # is non-deterministic / guaranteed
+    flow_run_poll_events = list(
+        filter(
+            lambda e: e.event == "prefect.worker.poll.flow-run",
+            asserting_events_worker._client.events,
+        )
+    )
+    assert len(flow_run_poll_events) == 1
+
+    cancellation_poll_events = list(
+        filter(
+            lambda e: e.event == "prefect.worker.poll.cancelled-flow-run",
+            asserting_events_worker._client.events,
+        )
+    )
+    assert len(cancellation_poll_events) == 1
 
     # last event should be `prefect.worker.stopped`
     stopped_event = asserting_events_worker._client.events[
@@ -300,20 +342,30 @@ async def test_worker_emits_cancelled_event(
 
     assert len(asserting_events_worker._client.events) == 2
 
-    cancellation_poll_event = asserting_events_worker._client.events[0]
-    assert cancellation_poll_event.event == "prefect.worker.poll.cancelled-flow-run"
+    cancellation_poll_events = list(
+        filter(
+            lambda e: e.event == "prefect.worker.poll.cancelled-flow-run",
+            asserting_events_worker._client.events,
+        )
+    )
+    assert len(cancellation_poll_events) == 1
 
-    cancelled_event = asserting_events_worker._client.events[1]
-    assert cancelled_event.event == "prefect.worker.cancelled-flow-run"
+    cancelled_events = list(
+        filter(
+            lambda e: e.event == "prefect.worker.cancelled-flow-run",
+            asserting_events_worker._client.events,
+        )
+    )
+    assert len(cancelled_events) == 1
 
-    assert dict(cancelled_event.resource.items()) == {
+    assert dict(cancelled_events[0].resource.items()) == {
         "prefect.resource.id": f"prefect.worker.events-test.{worker.get_name_slug()}",
         "prefect.resource.name": worker.name,
         "prefect.version": str(__version__),
         "prefect.worker-type": worker.type,
     }
 
-    related = [dict(r.items()) for r in cancelled_event.related]
+    related = [dict(r.items()) for r in cancelled_events[0].related]
 
     assert related == [
         {


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

After adding `poll.*` events from #9702, this uncovered that some of our event test assertions expected consistent ordering, when they are not - this led to some test flakiness

Here, we'll use `len()` checks instead, to assert the count of events we'd expect.  In some cases, we'll still use positional identifiers to check single-member sub-lists, but I think this is OK

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
