### PR TITLE
Deprecate "send_to_orion" logging option in favor of "send_to_api"

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -280,7 +280,7 @@ async def create_then_begin_flow_run(
     if ui_url:
         logger.info(
             f"View at {ui_url}/flow-runs/flow-run/{flow_run.id}",
-            extra={"send_to_orion": False},
+            extra={"send_to_api": False},
         )
 
     if state.is_failed():
@@ -558,7 +558,7 @@ async def create_and_begin_subflow_run(
         if ui_url:
             logger.info(
                 f"View at {ui_url}/flow-runs/flow-run/{flow_run.id}",
-                extra={"send_to_orion": False},
+                extra={"send_to_api": False},
             )
 
         result_factory = await ResultFactory.from_flow(
@@ -820,7 +820,7 @@ async def orchestrate_flow_run(
                     f"Received new state {state} when proposing final state"
                     f" {terminal_state}"
                 ),
-                extra={"send_to_orion": False},
+                extra={"send_to_api": False},
             )
 
         if not state.is_final():
@@ -829,7 +829,7 @@ async def orchestrate_flow_run(
                     f"Received non-final state {state.name!r} when proposing final"
                     f" state {terminal_state.name!r} and will attempt to run again..."
                 ),
-                extra={"send_to_orion": False},
+                extra={"send_to_api": False},
             )
             # Attempt to enter a running state again
             state = await propose_state(client, Running(), flow_run_id=flow_run.id)
@@ -1705,7 +1705,7 @@ async def orchestrate_task_run(
                         f"Received new state {state} when proposing final state"
                         f" {terminal_state}"
                     ),
-                    extra={"send_to_orion": False},
+                    extra={"send_to_api": False},
                 )
 
             if not state.is_final():
@@ -1715,7 +1715,7 @@ async def orchestrate_task_run(
                         f" state {terminal_state.name!r} and will attempt to run"
                         " again..."
                     ),
-                    extra={"send_to_orion": False},
+                    extra={"send_to_api": False},
                 )
                 # Attempt to enter a running state again
                 state = await propose_state(client, Running(), task_run_id=task_run.id)

--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -139,8 +139,10 @@ class APILogHandler(logging.Handler):
 
             if not PREFECT_LOGGING_TO_API_ENABLED.value_from(profile.settings):
                 return  # Respect the global settings toggle
-            if not getattr(record, "send_to_orion", True):
+            if not getattr(record, "send_to_api", True):
                 return  # Do not send records that have opted out
+            if not getattr(record, "send_to_orion", True):
+                return  # Backwards compatibility
 
             log = self.prepare(record)
             APILogWorker.instance().send(log)

--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -29,7 +29,7 @@ class PrefectLogAdapter(logging.LoggerAdapter):
     """
 
     def process(self, msg, kwargs):
-        kwargs["extra"] = {**self.extra, **(kwargs.get("extra") or {})}
+        kwargs["extra"] = {**(self.extra or {}), **(kwargs.get("extra") or {})}
 
         from prefect._internal.compatibility.deprecated import (
             generate_deprecation_message,

--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -4,6 +4,7 @@ import sys
 from builtins import print
 from contextlib import contextmanager
 from functools import lru_cache
+import warnings
 from typing import TYPE_CHECKING, Dict, Optional, Union
 
 import prefect
@@ -29,6 +30,23 @@ class PrefectLogAdapter(logging.LoggerAdapter):
 
     def process(self, msg, kwargs):
         kwargs["extra"] = {**self.extra, **(kwargs.get("extra") or {})}
+
+        from prefect._internal.compatibility.deprecated import (
+            generate_deprecation_message,
+            PrefectDeprecationWarning,
+        )
+
+        if "send_to_orion" in kwargs["extra"]:
+            warnings.warn(
+                generate_deprecation_message(
+                    'The "send_to_orion" option',
+                    start_date="May 2023",
+                    help='Use "send_to_api" instead.',
+                ),
+                PrefectDeprecationWarning,
+                stacklevel=4,
+            )
+
         return (msg, kwargs)
 
     def getChild(

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1544,13 +1544,13 @@ class TestFlowRunLogs:
         assert "Traceback" in error_log
         assert "ValueError: Hello!" in error_log, "References the exception"
 
-    async def test_opt_out_logs_are_not_sent_to_orion(self, prefect_client):
+    async def test_opt_out_logs_are_not_sent_to_api(self, prefect_client):
         @flow
         def my_flow():
             logger = get_run_logger()
             logger.info(
                 "Hello world!",
-                extra={"send_to_orion": False},
+                extra={"send_to_api": False},
             )
 
         my_flow()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -475,7 +475,9 @@ class TestAPILogHandler:
                     ' available after Nov 2023. Use "send_to_api" instead.'
                 ),
             ):
-                PrefectLogAdapter(logger).info("test", extra={"send_to_orion": False})
+                PrefectLogAdapter(logger, extra={}).info(
+                    "test", extra={"send_to_orion": False}
+                )
 
         mock_log_worker.instance().send.assert_not_called()
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -475,7 +475,7 @@ class TestAPILogHandler:
                     ' available after Nov 2023. Use "send_to_api" instead.'
                 ),
             ):
-                logger.info("test", extra={"send_to_orion": False})
+                PrefectLogAdapter(logger).info("test", extra={"send_to_orion": False})
 
         mock_log_worker.instance().send.assert_not_called()
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -22,6 +22,7 @@ from prefect import flow, task
 from prefect.context import FlowRunContext, TaskRunContext
 from prefect.deprecated.data_documents import _retrieve_result
 from prefect.exceptions import MissingContextError
+from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
 from prefect.infrastructure import Process
 from prefect._internal.concurrency.api import create_call, from_sync
 from prefect.logging.configuration import (
@@ -459,7 +460,22 @@ class TestAPILogHandler:
 
     def test_does_not_send_logs_that_opt_out(self, logger, mock_log_worker, task_run):
         with TaskRunContext.construct(task_run=task_run):
-            logger.info("test", extra={"send_to_orion": False})
+            logger.info("test", extra={"send_to_api": False})
+
+        mock_log_worker.instance().send.assert_not_called()
+
+    def test_does_not_send_logs_that_opt_out_deprecated(
+        self, logger, mock_log_worker, task_run
+    ):
+        with TaskRunContext.construct(task_run=task_run):
+            with pytest.warns(
+                PrefectDeprecationWarning,
+                match=(
+                    'The "send_to_orion" option has been deprecated. It will not be'
+                    ' available after Nov 2023. Use "send_to_api" instead.'
+                ),
+            ):
+                logger.info("test", extra={"send_to_orion": False})
 
         mock_log_worker.instance().send.assert_not_called()
 
@@ -631,7 +647,7 @@ class TestAPILogHandler:
     def test_does_not_write_error_for_logs_outside_run_context_that_opt_out(
         self, logger, mock_log_worker, capsys
     ):
-        logger.info("test", extra={"send_to_orion": False})
+        logger.info("test", extra={"send_to_api": False})
 
         mock_log_worker.instance().send.assert_not_called()
         output = capsys.readouterr()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2431,11 +2431,11 @@ class TestTaskRunLogs:
         assert "NameError" in error_log
         assert "x + y" in error_log
 
-    async def test_opt_out_logs_are_not_sent_to_orion(self, prefect_client):
+    async def test_opt_out_logs_are_not_sent_to_api(self, prefect_client):
         @task
         def my_task():
             logger = get_run_logger()
-            logger.info("Hello world!", extra={"send_to_orion": False})
+            logger.info("Hello world!", extra={"send_to_api": False})
 
         @flow
         def my_flow():


### PR DESCRIPTION
Follow-up to https://github.com/PrefectHQ/prefect/pull/8454

```python
from prefect import flow, get_run_logger


@flow
def test():
    get_run_logger().info("Hello world!", extra={"send_to_orion": False})


test()

```
```
13:16:40.132 | INFO    | prefect.engine - Created flow run 'premium-jackdaw' for flow 'test'
/Users/mz/dev/prefect/example.py:6: PrefectDeprecationWarning: The "send_to_orion" option has been deprecated. It will not be available after Nov 2023. Use "send_to_api" instead.
  get_run_logger().info("Hello world!", extra={"send_to_orion": False})
13:16:40.202 | INFO    | Flow run 'premium-jackdaw' - Hello world!
13:16:40.219 | INFO    | Flow run 'premium-jackdaw' - Finished in state Completed()
```