### PR TITLE
Fix bug where event loop shutdown hooks could fail due to early garbage collection

### DIFF
--- a/src/prefect/utilities/asyncutils.py
+++ b/src/prefect/utilities/asyncutils.py
@@ -328,7 +328,7 @@ async def add_event_loop_shutdown_callback(coroutine_fn: Callable[[], Awaitable]
         except GeneratorExit:
             await coroutine_fn()
             # Remove self from the garbage collection set
-            local_event_loop_gc_refs.pop(key)
+            EVENT_LOOP_GC_REFS.pop(key)
 
     # Create the iterator and store it in a global variable so it is not garbage
     # collected. If the iterator is garbage collected before the event loop closes, the
@@ -336,10 +336,10 @@ async def add_event_loop_shutdown_callback(coroutine_fn: Callable[[], Awaitable]
     # loop that is calling it, a reference with global scope is necessary to ensure
     # garbage collection does not occur until after event loop closure.
     key = id(on_shutdown)
-    local_event_loop_gc_refs[key] = on_shutdown(key)
+    EVENT_LOOP_GC_REFS[key] = on_shutdown(key)
 
     # Begin iterating so it will be cleaned up as an incomplete generator
-    await local_event_loop_gc_refs[key].__anext__()
+    await EVENT_LOOP_GC_REFS[key].__anext__()
 
 
 class GatherIncomplete(RuntimeError):


### PR DESCRIPTION
# Summary

It seems like it's possible for `EVENT_LOOP_GC_REFS` to be garbage collected earlier than `add_event_loop_shutdown_callback` expects. As a result, you can get the following error (as seen in [this issue](https://github.com/PrefectHQ/prefect/issues/7709#issuecomment-1560021109)):

```
Exception ignored in: <async_generator object add_event_loop_shutdown_callback.<locals>.on_shutdown at 0x16fe264c0>
Traceback (most recent call last):
  File "/Users/ryanmorshead/.mambaforge/envs/***/lib/python3.10/site-packages/prefect/utilities/asyncutils.py", line 326, in on_shutdown
AttributeError: 'NoneType' object has no attribute 'pop'
Exception ignored in: <async_generator object add_event_loop_shutdown_callback.<locals>.on_shutdown at 0x28fcfb640>
Traceback (most recent call last):
  File "/Users/ryanmorshead/.mambaforge/envs/***/lib/python3.10/site-packages/prefect/utilities/asyncutils.py", line 326, in on_shutdown
AttributeError: 'NoneType' object has no attribute 'pop'
```

This change creates a reference to `EVENT_LOOP_GC_REFS` inside `on_shutdown` so that it survives for at least the lifetime of the coroutine.

I have no idea how to test this unfortunately.