### PR TITLE
Add task-run as a related object to emitted events

### DIFF
--- a/src/prefect/events/related.py
+++ b/src/prefect/events/related.py
@@ -80,15 +80,33 @@ async def related_resources_from_run_context(
         async def dummy_read():
             return {}
 
-        related_objects = [
-            await _get_and_cache_related_object(
-                kind="flow-run",
-                role="flow-run",
-                client_method=client.read_flow_run,
-                obj_id=flow_run_id,
-                cache=RESOURCE_CACHE,
+        if flow_run_context:
+            related_objects.append(
+                {
+                    "kind": "flow-run",
+                    "role": "flow-run",
+                    "object": flow_run_context.flow_run,
+                },
             )
-        ]
+        else:
+            related_objects.append(
+                await _get_and_cache_related_object(
+                    kind="flow-run",
+                    role="flow-run",
+                    client_method=client.read_flow_run,
+                    obj_id=flow_run_id,
+                    cache=RESOURCE_CACHE,
+                )
+            )
+
+        if task_run_context:
+            related_objects.append(
+                {
+                    "kind": "task-run",
+                    "role": "task-run",
+                    "object": task_run_context.task_run,
+                },
+            )
 
         flow_run = related_objects[0]["object"]
 


### PR DESCRIPTION
This adds the current task run from the TaskRunContext (if it exists) to emitted events. It also changes the logic a bit to grab the flow run from the flow-run context if it exists rather than always asking the API.

Closes #9758

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
