### PR TITLE
Fix default value comment in docs/concepts/variables

### DIFF
--- a/docs/concepts/variables.md
+++ b/docs/concepts/variables.md
@@ -67,7 +67,7 @@ answer = await variables.get('the_answer')
 print(answer)
 # 42
 
-# with a default value
+# without a default value
 answer = variables.get('not_the_answer')
 print(answer)
 # None


### PR DESCRIPTION
This PR only affects documentation.  Here is the current example in [concepts/variables](https://docs.prefect.io/latest/concepts/variables/):

```python
# with a default value
answer = variables.get('not_the_answer')
print(answer)
# None

# with a default value
answer = variables.get('not_the_answer', default='42')
print(answer)
# 42
```

The first comment should be: `#without a default value`.