### PR TITLE
Create files and directories with user-scoped permissions

### DIFF
--- a/flows/deployment_storage.py
+++ b/flows/deployment_storage.py
@@ -48,7 +48,9 @@ async def read_flow_run(flow_run_id):
 
 def main():
     # We must create an ignore file
-    Path(".prefectignore").touch()
+    file = Path(".prefectignore")
+    if not file.exists():
+        file.touch()
 
     # Create deployment
     deployment = Deployment.build_from_flow(

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -11,6 +11,7 @@ import warnings
 from collections import defaultdict
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -320,7 +321,8 @@ class SettingsContext(ContextModel):
         return_value = super().__enter__()
 
         try:
-            os.makedirs(self.settings.value_of(PREFECT_HOME), exist_ok=True)
+            prefect_home = Path(self.settings.value_of(PREFECT_HOME))
+            prefect_home.mkdir(mode=0o0700, exist_ok=True)
         except OSError:
             warnings.warn(
                 (

--- a/src/prefect/infrastructure/container.py
+++ b/src/prefect/infrastructure/container.py
@@ -263,7 +263,7 @@ class DockerContainer(Infrastructure):
         description=(
             "Total memory (memory + swap), -1 to disable swap. Should only be "
             "set if `mem_limit` is also set. If `mem_limit` is set, this defaults to"
-            "allowing the container to use as much swap as ry. For example, if "
+            "allowing the container to use as much swap as memory. For example, if "
             "`mem_limit` is 300m and `memswap_limit` is not set, the container can use "
             "600m in total of memory and swap."
         ),

--- a/src/prefect/infrastructure/container.py
+++ b/src/prefect/infrastructure/container.py
@@ -263,7 +263,7 @@ class DockerContainer(Infrastructure):
         description=(
             "Total memory (memory + swap), -1 to disable swap. Should only be "
             "set if `mem_limit` is also set. If `mem_limit` is set, this defaults to"
-            "allowing the container to use as much swap as memory. For example, if "
+            "allowing the container to use as much swap as ry. For example, if "
             "`mem_limit` is 300m and `memswap_limit` is not set, the container can use "
             "600m in total of memory and swap."
         ),

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -382,6 +382,9 @@ def _memoize_block_auto_registration(fn: Callable[[], Awaitable[None]]):
 
         if current_blocks_loading_hash is not None:
             try:
+                if not memo_store_path.exists():
+                    memo_store_path.touch(mode=0o0600)
+
                 memo_store_path.write_text(
                     toml.dumps({"block_auto_registration": current_blocks_loading_hash})
                 )

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -382,8 +382,12 @@ def default_database_connection_url(settings, value):
     new_default = home / "prefect.db"
 
     # If the old one exists and the new one does not, continue using the old one
-    if old_default.exists() and not new_default.exists():
-        return "sqlite+aiosqlite:///" + str(old_default)
+    if not new_default.exists():
+        if old_default.exists():
+            return "sqlite+aiosqlite:///" + str(old_default)
+
+        # Create the new default database with 0600 permissions if it does not exist
+        new_default.touch(mode=0o600)
 
     # Otherwise, return the new default
     return "sqlite+aiosqlite:///" + str(new_default)
@@ -2189,6 +2193,8 @@ def _write_profiles_to(path: Path, profiles: ProfilesCollection) -> None:
 
     Any existing data not present in the given `profiles` will be deleted.
     """
+    if not path.exists():
+        path.touch(mode=0o600)
     return path.write_text(toml.dumps(profiles.to_dict()))
 
 

--- a/src/prefect/utilities/filesystem.py
+++ b/src/prefect/utilities/filesystem.py
@@ -19,10 +19,11 @@ def create_default_ignore_file(path: str) -> bool:
     whether a file was created.
     """
     path = pathlib.Path(path)
-    if (path / ".prefectignore").exists():
+    ignore_file = path / ".prefectignore"
+    if ignore_file.exists():
         return False
-    default_file = pathlib.Path(__file__).parent / ".." / ".prefectignore"
-    with open(path / ".prefectignore", "w") as f:
+    default_file = pathlib.Path(__file__).parent.parent / ".prefectignore"
+    with ignore_file.open(mode="w") as f:
         f.write(default_file.read_text())
     return True
 

--- a/src/prefect/utilities/filesystem.py
+++ b/src/prefect/utilities/filesystem.py
@@ -9,6 +9,7 @@ from typing import Union
 
 import fsspec
 import pathspec
+import prefect
 from fsspec.core import OpenFile
 from fsspec.implementations.local import LocalFileSystem
 
@@ -22,7 +23,7 @@ def create_default_ignore_file(path: str) -> bool:
     ignore_file = path / ".prefectignore"
     if ignore_file.exists():
         return False
-    default_file = pathlib.Path(__file__).parent.parent / ".prefectignore"
+    default_file = pathlib.Path(prefect.__module_path__) / ".prefectignore"
     with ignore_file.open(mode="w") as f:
         f.write(default_file.read_text())
     return True

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -48,13 +48,15 @@ def project_dir(tmp_path):
     original_dir = os.getcwd()
     if sys.version_info >= (3, 8):
         shutil.copytree(TEST_PROJECTS_DIR, tmp_path, dirs_exist_ok=True)
-        (tmp_path / ".prefect").mkdir(exist_ok=True)
+        prefect_home = tmp_path / ".prefect"
+        prefect_home.mkdir(exist_ok=True, mode=0o0700)
         os.chdir(tmp_path)
         initialize_project()
         yield tmp_path
     else:
         shutil.copytree(TEST_PROJECTS_DIR, tmp_path / "three-seven")
-        (tmp_path / "three-seven" / ".prefect").mkdir(exist_ok=True)
+        prefect_home = tmp_path / "three-seven" / ".prefect"
+        prefect_home.mkdir(exist_ok=True, mode=0o0700)
         os.chdir(tmp_path / "three-seven")
         initialize_project()
         yield tmp_path / "three-seven"
@@ -66,7 +68,8 @@ def project_dir_with_single_deployment_format(tmp_path):
     original_dir = os.getcwd()
     if sys.version_info >= (3, 8):
         shutil.copytree(TEST_PROJECTS_DIR, tmp_path, dirs_exist_ok=True)
-        (tmp_path / ".prefect").mkdir(exist_ok=True)
+        prefect_home = tmp_path / ".prefect"
+        prefect_home.mkdir(exist_ok=True, mode=0o0700)
         os.chdir(tmp_path)
         initialize_project()
 
@@ -81,7 +84,7 @@ def project_dir_with_single_deployment_format(tmp_path):
         yield tmp_path
     else:
         shutil.copytree(TEST_PROJECTS_DIR, tmp_path / "three-seven")
-        (tmp_path / "three-seven" / ".prefect").mkdir(exist_ok=True)
+        (tmp_path / "three-seven" / ".prefect").mkdir(exist_ok=True, mode=0o0700)
         os.chdir(tmp_path / "three-seven")
         initialize_project()
 
@@ -139,7 +142,10 @@ class TestProjectDeploySingleDeploymentYAML:
         self, project_dir_with_single_deployment_format, prefect_client
     ):
         # delete deployment.yaml
-        Path(project_dir_with_single_deployment_format, "deployment.yaml").unlink()
+        deployment_file = Path(
+            project_dir_with_single_deployment_format, "deployment.yaml"
+        )
+        deployment_file.unlink()
 
         await prefect_client.create_work_pool(
             WorkPoolCreate(name="test-pool", type="test")
@@ -167,11 +173,12 @@ class TestProjectDeploySingleDeploymentYAML:
         self, project_dir_with_single_deployment_format, prefect_client
     ):
         # delete deployment.yaml and rewrite as empty
-        Path(project_dir_with_single_deployment_format, "deployment.yaml").unlink()
+        deployment_file = Path(
+            project_dir_with_single_deployment_format, "deployment.yaml"
+        )
+        deployment_file.unlink()
 
-        with open(
-            Path(project_dir_with_single_deployment_format, "deployment.yaml"), "w"
-        ) as f:
+        with deployment_file.open(mode="w") as f:
             f.write("{}")
 
         await prefect_client.create_work_pool(
@@ -198,7 +205,8 @@ class TestProjectDeploySingleDeploymentYAML:
         )
 
         # prepare a templated deployment
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deployment = yaml.safe_load(f)
 
         deployment["version"] = "{{ input }}"
@@ -206,11 +214,12 @@ class TestProjectDeploySingleDeploymentYAML:
         deployment["description"] = "{{ output1 }}"
 
         # save it back
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deployment, f)
 
-        # update prefectl.yaml to include a new build step
-        with open("prefect.yaml", "r") as f:
+        # update prefect.yaml to include a new build step
+        prefect_file = Path("prefect.yaml")
+        with prefect_file.open(mode="r") as f:
             prefect_config = yaml.safe_load(f)
 
         # test step that returns a dictionary of inputs and output1, output2
@@ -219,7 +228,7 @@ class TestProjectDeploySingleDeploymentYAML:
         ]
 
         # save it back
-        with open("prefect.yaml", "w") as f:
+        with prefect_file.open(mode="w") as f:
             yaml.safe_dump(prefect_config, f)
 
         result = await run_sync_in_worker_thread(
@@ -241,7 +250,8 @@ class TestProjectDeploySingleDeploymentYAML:
     async def test_project_deploy_with_default_parameters(
         self, project_dir_with_single_deployment_format, prefect_client, work_pool
     ):
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["parameters"] = {"number": 1, "message": "hello"}
@@ -249,7 +259,7 @@ class TestProjectDeploySingleDeploymentYAML:
         deploy_config["entrypoint"] = "flows/hello.py:my_flow"
         deploy_config["work_pool"]["name"] = work_pool.name
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         await run_sync_in_worker_thread(
@@ -274,7 +284,8 @@ class TestProjectDeploySingleDeploymentYAML:
         work_pool,
         option,
     ):
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["parameters"] = {"number": 1, "message": "hello"}
@@ -282,7 +293,7 @@ class TestProjectDeploySingleDeploymentYAML:
         deploy_config["entrypoint"] = "flows/hello.py:my_flow"
         deploy_config["work_pool"]["name"] = work_pool.name
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         await run_sync_in_worker_thread(
@@ -310,8 +321,9 @@ class TestProjectDeploySingleDeploymentYAML:
             WorkPoolCreate(name="test-pool", type="test")
         )
 
-        # update prefectl.yaml to include a new build step
-        with open("prefect.yaml", "r") as f:
+        # update prefect.yaml to include a new build step
+        prefect_file = Path("prefect.yaml")
+        with prefect_file.open(mode="r") as f:
             prefect_config = yaml.safe_load(f)
 
         # test step that returns a dictionary of inputs and output1, output2
@@ -328,7 +340,7 @@ class TestProjectDeploySingleDeploymentYAML:
             },
         ]
         # save it back
-        with open("prefect.yaml", "w") as f:
+        with prefect_file.open(mode="w") as f:
             yaml.safe_dump(prefect_config, f)
 
         result = await run_sync_in_worker_thread(
@@ -355,14 +367,15 @@ class TestProjectDeploySingleDeploymentYAML:
     ):
         await register_flow("flows/hello.py:my_flow")
         create_default_deployment_yaml(".")
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["name"] = "test-name"
         deploy_config["flow_name"] = "An important name"
         deploy_config["work_pool"]["name"] = work_pool.name
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         await run_sync_in_worker_thread(
@@ -376,14 +389,15 @@ class TestProjectDeploySingleDeploymentYAML:
         self, project_dir_with_single_deployment_format, prefect_client, work_pool
     ):
         create_default_deployment_yaml(".")
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["name"] = "test-name"
         deploy_config["entrypoint"] = "flows/hello.py:my_flow"
         deploy_config["work_pool"]["name"] = work_pool.name
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         await run_sync_in_worker_thread(
@@ -397,13 +411,14 @@ class TestProjectDeploySingleDeploymentYAML:
         self, project_dir_with_single_deployment_format, prefect_client, work_pool
     ):
         create_default_deployment_yaml(".")
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["name"] = "test-name"
         deploy_config["work_pool"]["name"] = work_pool.name
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         await run_sync_in_worker_thread(
@@ -420,13 +435,14 @@ class TestProjectDeploySingleDeploymentYAML:
         self, project_dir_with_single_deployment_format, prefect_client, work_pool
     ):
         create_default_deployment_yaml(".")
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["name"] = "test-name"
         deploy_config["work_pool"]["name"] = work_pool.name
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         await run_sync_in_worker_thread(
@@ -468,7 +484,8 @@ class TestProjectDeploy:
         self, project_dir, prefect_client
     ):
         # delete deployment.yaml
-        Path(project_dir, "deployment.yaml").unlink()
+        deployment_file = Path(project_dir, "deployment.yaml")
+        deployment_file.unlink()
 
         await prefect_client.create_work_pool(
             WorkPoolCreate(name="test-pool", type="test")
@@ -513,9 +530,10 @@ class TestProjectDeploy:
         self, project_dir, prefect_client
     ):
         # delete deployment.yaml and rewrite as empty
-        Path(project_dir, "deployment.yaml").unlink()
+        deployment_file = Path(project_dir, "deployment.yaml")
+        deployment_file.unlink()
 
-        with open(Path(project_dir, "deployment.yaml"), "w") as f:
+        with deployment_file.open(mode="w") as f:
             f.write("{}")
 
         await prefect_client.create_work_pool(
@@ -540,7 +558,8 @@ class TestProjectDeploy:
         )
 
         # prepare a templated deployment
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             contents = yaml.safe_load(f)
 
         contents["deployments"][0]["version"] = "{{ input }}"
@@ -548,11 +567,12 @@ class TestProjectDeploy:
         contents["deployments"][0]["description"] = "{{ output1 }}"
 
         # save it back
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(contents, f)
 
-        # update prefectl.yaml to include a new build step
-        with open("prefect.yaml", "r") as f:
+        # update prefect.yaml to include a new build step
+        prefect_file = Path("prefect.yaml")
+        with prefect_file.open(mode="r") as f:
             prefect_config = yaml.safe_load(f)
 
         # test step that returns a dictionary of inputs and output1, output2
@@ -561,7 +581,7 @@ class TestProjectDeploy:
         ]
 
         # save it back
-        with open("prefect.yaml", "w") as f:
+        with prefect_file.open(mode="w") as f:
             yaml.safe_dump(prefect_config, f)
 
         result = await run_sync_in_worker_thread(
@@ -583,7 +603,8 @@ class TestProjectDeploy:
     async def test_project_deploy_with_default_parameters(
         self, project_dir, prefect_client, work_pool
     ):
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["deployments"][0]["parameters"] = {
@@ -594,7 +615,7 @@ class TestProjectDeploy:
         deploy_config["deployments"][0]["entrypoint"] = "flows/hello.py:my_flow"
         deploy_config["deployments"][0]["work_pool"]["name"] = work_pool.name
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         await run_sync_in_worker_thread(
@@ -615,7 +636,8 @@ class TestProjectDeploy:
     async def test_project_deploy_with_default_parameters_from_cli(
         self, project_dir, prefect_client, work_pool, option
     ):
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["deployments"][0]["parameters"] = {
@@ -626,7 +648,7 @@ class TestProjectDeploy:
         deploy_config["deployments"][0]["entrypoint"] = "flows/hello.py:my_flow"
         deploy_config["deployments"][0]["work_pool"]["name"] = work_pool.name
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         await run_sync_in_worker_thread(
@@ -654,8 +676,9 @@ class TestProjectDeploy:
             WorkPoolCreate(name="test-pool", type="test")
         )
 
-        # update prefectl.yaml to include a new build step
-        with open("prefect.yaml", "r") as f:
+        # update prefect.yaml to include a new build step
+        prefect_file = Path("prefect.yaml")
+        with prefect_file.open(mode="r") as f:
             prefect_config = yaml.safe_load(f)
 
         # test step that returns a dictionary of inputs and output1, output2
@@ -672,7 +695,7 @@ class TestProjectDeploy:
             },
         ]
         # save it back
-        with open("prefect.yaml", "w") as f:
+        with prefect_file.open(mode="w") as f:
             yaml.safe_dump(prefect_config, f)
 
         result = await run_sync_in_worker_thread(
@@ -699,14 +722,15 @@ class TestProjectDeploy:
     ):
         await register_flow("flows/hello.py:my_flow")
         create_default_deployment_yaml(".")
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["deployments"][0]["name"] = "test-name"
         deploy_config["deployments"][0]["flow_name"] = "An important name"
         deploy_config["deployments"][0]["work_pool"]["name"] = work_pool.name
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         await run_sync_in_worker_thread(
@@ -720,14 +744,15 @@ class TestProjectDeploy:
         self, project_dir, prefect_client, work_pool
     ):
         create_default_deployment_yaml(".")
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["deployments"][0]["name"] = "test-name"
         deploy_config["deployments"][0]["entrypoint"] = "flows/hello.py:my_flow"
         deploy_config["deployments"][0]["work_pool"]["name"] = work_pool.name
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         await run_sync_in_worker_thread(
@@ -741,13 +766,14 @@ class TestProjectDeploy:
         self, project_dir, prefect_client, work_pool
     ):
         create_default_deployment_yaml(".")
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["deployments"][0]["name"] = "test-name"
         deploy_config["deployments"][0]["work_pool"]["name"] = work_pool.name
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         await run_sync_in_worker_thread(
@@ -764,13 +790,14 @@ class TestProjectDeploy:
         self, project_dir, prefect_client, work_pool
     ):
         create_default_deployment_yaml(".")
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["deployments"][0]["name"] = "test-name"
         deploy_config["deployments"][0]["work_pool"]["name"] = work_pool.name
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         await run_sync_in_worker_thread(
@@ -945,13 +972,14 @@ class TestSchedules:
         self, project_dir, work_pool, prefect_client
     ):
         create_default_deployment_yaml(".")
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["deployments"][0]["schedule"]["cron"] = "0 4 * * *"
         deploy_config["deployments"][0]["schedule"]["timezone"] = "America/Chicago"
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         result = await run_sync_in_worker_thread(
@@ -972,13 +1000,14 @@ class TestSchedules:
         self, project_dir, work_pool, prefect_client
     ):
         create_default_deployment_yaml(".")
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["deployments"][0]["schedule"]["cron"] = "0 4 * * *"
         deploy_config["deployments"][0]["schedule"]["timezone"] = "America/Chicago"
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         result = await run_sync_in_worker_thread(
@@ -1020,14 +1049,15 @@ class TestSchedules:
         self, project_dir, prefect_client, work_pool
     ):
         create_default_deployment_yaml(".")
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["deployments"][0]["schedule"]["interval"] = 42
         deploy_config["deployments"][0]["schedule"]["anchor_date"] = "2040-02-02"
         deploy_config["deployments"][0]["schedule"]["timezone"] = "America/Chicago"
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         result = await run_sync_in_worker_thread(
@@ -1080,14 +1110,15 @@ class TestSchedules:
 
     async def test_rrule_deployment_yaml(self, project_dir, work_pool, prefect_client):
         create_default_deployment_yaml(".")
-        with open("deployment.yaml", "r") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
         deploy_config["deployments"][0]["schedule"][
             "rrule"
         ] = "DTSTART:20220910T110000\nRRULE:FREQ=HOURLY;BYDAY=MO,TU,WE,TH,FR,SA;BYHOUR=9,10,11,12,13,14,15,16,17"
 
-        with open("deployment.yaml", "w") as f:
+        with deployment_file.open(mode="w") as f:
             yaml.safe_dump(deploy_config, f)
 
         await run_sync_in_worker_thread(
@@ -1148,7 +1179,8 @@ class TestMultiDeploy:
         }
 
         # Save deployments to deployment.yaml
-        with open("deployment.yaml", "w") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="w") as f:
             yaml.dump(deployments, f)
 
         # Deploy all
@@ -1206,7 +1238,8 @@ class TestMultiDeploy:
         }
 
         # Save deployments to deployment.yaml
-        with open("deployment.yaml", "w") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="w") as f:
             yaml.dump(deployments, f)
 
         # Deploy only two deployments by name
@@ -1276,7 +1309,8 @@ class TestMultiDeploy:
         }
 
         # Save deployments to deployment.yaml
-        with open("deployment.yaml", "w") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="w") as f:
             yaml.dump(deployments, f)
 
         # Deploy a single deployment with a cron schedule
@@ -1331,7 +1365,8 @@ class TestMultiDeploy:
         }
 
         # Save deployments to deployment.yaml
-        with open("deployment.yaml", "w") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="w") as f:
             yaml.dump(deployments, f)
 
         # Deploy multiple deployments with CLI options
@@ -1381,7 +1416,8 @@ class TestMultiDeploy:
         }
 
         # Save the deployment to deployment.yaml
-        with open("deployment.yaml", "w") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="w") as f:
             yaml.dump(deployment, f)
 
         # Deploy the deployment with an invalid name
@@ -1426,7 +1462,8 @@ class TestMultiDeploy:
         }
 
         # Save deployments to deployment.yaml
-        with open("deployment.yaml", "w") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="w") as f:
             yaml.dump(deployments, f)
 
         # Attempt to deploy all
@@ -1639,7 +1676,8 @@ class TestMultiDeploy:
         }
 
         # Save the deployment to deployment.yaml
-        with open("deployment.yaml", "w") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="w") as f:
             yaml.dump(deployment, f)
 
         # Deploy the deployment with a name
@@ -1684,7 +1722,8 @@ class TestMultiDeploy:
         }
 
         # Save the deployment to deployment.yaml
-        with open("deployment.yaml", "w") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="w") as f:
             yaml.dump(deployment, f)
 
         # Deploy the deployment with a name
@@ -1722,7 +1761,8 @@ class TestMultiDeploy:
         }
 
         # Save the deployment to deployment.yaml
-        with open("deployment.yaml", "w") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="w") as f:
             yaml.dump(deployment, f)
 
         # Deploy the deployment with a name
@@ -1757,7 +1797,8 @@ class TestMultiDeploy:
         }
 
         # Save the deployment to deployment.yaml
-        with open("deployment.yaml", "w") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="w") as f:
             yaml.dump(deployment, f)
 
         # Deploy the deployment with a name
@@ -1788,7 +1829,8 @@ class TestMultiDeploy:
         }
 
         # Save the deployment to deployment.yaml
-        with open("deployment.yaml", "w") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="w") as f:
             yaml.dump(deployment, f)
 
         # Deploy the deployment with a name
@@ -1826,7 +1868,8 @@ class TestMultiDeploy:
         }
 
         # Save deployments to deployment.yaml
-        with open("deployment.yaml", "w") as f:
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="w") as f:
             yaml.dump(deployments, f)
 
         await run_sync_in_worker_thread(

--- a/tests/projects/test_base.py
+++ b/tests/projects/test_base.py
@@ -23,12 +23,12 @@ def project_dir(tmp_path):
     original_dir = os.getcwd()
     if sys.version_info >= (3, 8):
         shutil.copytree(TEST_PROJECTS_DIR, tmp_path, dirs_exist_ok=True)
-        (tmp_path / ".prefect").mkdir(exist_ok=True)
+        (tmp_path / ".prefect").mkdir(exist_ok=True, mode=0o0700)
         os.chdir(tmp_path)
         yield tmp_path
     else:
         shutil.copytree(TEST_PROJECTS_DIR, tmp_path / "three-seven")
-        (tmp_path / "three-seven" / ".prefect").mkdir(exist_ok=True)
+        (tmp_path / "three-seven" / ".prefect").mkdir(exist_ok=True, mode=0o0700)
         os.chdir(tmp_path / "three-seven")
         yield tmp_path / "three-seven"
     os.chdir(original_dir)
@@ -183,7 +183,8 @@ class TestRegisterFlow:
         )
         assert f.name == "test"
 
-        with open(project_dir / ".prefect" / "flows.json", "r") as f:
+        flows_file = project_dir / ".prefect" / "flows.json"
+        with flows_file.open(mode="r") as f:
             flows = json.load(f)
 
         assert flows["test"] == "import-project/my_module/flow.py:test_flow"


### PR DESCRIPTION
When creating ~/.prefect and other files, use restrictive (user-only) permissions to improve privacy on shared systems.

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

---

I tested this by removing my `~/.prefect` directory and running `prefect server`:

```
$ ls -al ~ | grep "prefect"
drwx------    5 jawnsy staff  160 May 30 13:06 .prefect
drwxr-xr-x    8 jawnsy staff  256 May 27 14:07 .prefect.bak
-rw-------    1 jawnsy staff  31K May 17 10:38 .psql_history-prefect_cloud

$ ls -al ~/.prefect
total 836K
drwx------    4 jawnsy staff  128 May 30 13:06 .
drwxr-x---+ 165 jawnsy staff 5.2K May 30 13:06 ..
-rw-------    1 jawnsy staff   93 May 30 13:06 memo_store.toml
-rw-------    1 jawnsy staff 784K May 30 13:06 prefect.db
```

I also tested `prefect cloud login` would create `profiles.toml` with `0644` permissions:

```
$ ls -al ~/.prefect
total 840K
drwx------    5 jawnsy staff  160 May 30 13:07 .
drwxr-x---+ 165 jawnsy staff 5.2K May 30 13:06 ..
-rw-------    1 jawnsy staff   93 May 30 13:06 memo_store.toml
-rw-------    1 jawnsy staff 784K May 30 13:06 prefect.db
-rw-------    1 jawnsy staff  244 May 30 13:07 profiles.toml
```

I also tested that making these files broad works OK:

```
$ chmod 755 ~/.prefect/*
mode of '/Users/jawnsy/.prefect/memo_store.toml' changed from 0600 (rw-------) to 0755 (rwxr-xr-x)
mode of '/Users/jawnsy/.prefect/prefect.db' changed from 0600 (rw-------) to 0755 (rwxr-xr-x)
mode of '/Users/jawnsy/.prefect/profiles.toml' changed from 0600 (rw-------) to 0755 (rwxr-xr-x)

$ chmod 755 ~/.prefect
mode of '/Users/jawnsy/.prefect' changed from 0700 (rwx------) to 0755 (rwxr-xr-x)

$ ls -al ~ | grep .prefect
drwxr-xr-x    5 jawnsy staff  160 May 30 13:07 .prefect
drwxr-xr-x    8 jawnsy staff  256 May 27 14:07 .prefect.bak
-rw-------    1 jawnsy staff  31K May 17 10:38 .psql_history-prefect_cloud

$ ls -al ~/.prefect
total 840K
drwxr-xr-x    5 jawnsy staff  160 May 30 13:07 .
drwxr-x---+ 165 jawnsy staff 5.2K May 30 13:06 ..
-rwxr-xr-x    1 jawnsy staff   93 May 30 13:06 memo_store.toml
-rwxr-xr-x    1 jawnsy staff 784K May 30 13:06 prefect.db
-rwxr-xr-x    1 jawnsy staff  244 May 30 13:07 profiles.toml

$ prefect server start

 ___ ___ ___ ___ ___ ___ _____ 
| _ \ _ \ __| __| __/ __|_   _| 
|  _/   / _|| _|| _| (__  | |  
|_| |_|_\___|_| |___\___| |_|  

Configure Prefect to communicate with the server with:

    prefect config set PREFECT_API_URL=http://127.0.0.1:4200/api

View the API reference documentation at http://127.0.0.1:4200/docs

The dashboard is not built. It looks like you're on a development version.
See `prefect dev` for development commands.
```