### PR TITLE
fix process worker `documentation_url`

### DIFF
--- a/src/prefect/workers/process.py
+++ b/src/prefect/workers/process.py
@@ -138,7 +138,7 @@ class ProcessWorker(BaseWorker):
     )
     _display_name = "Local Subprocess"
     _documentation_url = (
-        "https://docs.prefect.io/latest/api-ref/prefect/workers/process/",
+        "https://docs.prefect.io/latest/api-ref/prefect/workers/process/"
     )
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/39WQhVu4JK40rZWltGqhuC/d15be6189a0cb95949a6b43df00dcb9b/image5.png?h=250"
     _is_beta = True


### PR DESCRIPTION
extra comma made the multiline string a tuple and therefore was failing against registry json schema validation

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
