### PR TITLE
Remove outdated announcement

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,24 +1,6 @@
 {% extends "base.html" %}
 
 {% block announce %}
-<div style="color: white;">
-  <a href="https://github.com/PrefectHQ/prefect/blob/main/RELEASE-NOTES.md#release-2107" style="color: #07e798;">
-    <strong>Prefect 2.10.7 is here!</strong>
-  </a> With a new and improved Flows page, and `on_crashed` state change hook for flows, and
-  <a href="https://github.com/PrefectHQ/prefect/blob/main/RELEASE-NOTES.md#release-2107" style="color: #07e798;">
-    <strong>more!</strong>
-  </a>
-</div>
-
-<!-- <div style="color: white;">
-    Looking for the 
-    <a href="http://docs-v1.prefect.io/" style="color: #07e798;">
-      <strong>Prefect 1 docs</strong>
-    </a> for Prefect 1 Core and Server? Find them at: 
-    <a href="http://docs-v1.prefect.io/" style="color: #07e798;">
-      <strong>http://docs-v1.prefect.io/</strong>
-    </a>
-  </div> -->
 {% endblock %}
 
 {% block analytics %}


### PR DESCRIPTION
We previously had announcement text, which is not visible on the page but appears in the generated HTML and thus would appear in search engines indexes.

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
