### PR TITLE
Respect priority passed when creating a work queue

### DIFF
--- a/src/prefect/server/models/work_queues.py
+++ b/src/prefect/server/models/work_queues.py
@@ -16,7 +16,10 @@ import prefect.server.schemas as schemas
 from prefect.server.database.dependencies import inject_db
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.exceptions import ObjectNotFoundError
-from prefect.server.models.workers import DEFAULT_AGENT_WORK_POOL_NAME
+from prefect.server.models.workers import (
+    DEFAULT_AGENT_WORK_POOL_NAME,
+    bulk_update_work_queue_priorities,
+)
 from prefect.server.schemas.states import StateType
 
 
@@ -39,7 +42,7 @@ async def create_work_queue(
         db.WorkQueue: the newly-created or updated WorkQueue
 
     """
-    data = work_queue.dict(exclude={"priority"})
+    data = work_queue.dict()
 
     if data.get("work_pool_id") is None:
         # If no work pool is provided, get or create the default agent work pool
@@ -66,15 +69,40 @@ async def create_work_queue(
 
     # Set the priority to be the max priority + 1
     # This will make the new queue the lowest priority
-    max_priority_query = sa.select(
-        sa.func.coalesce(sa.func.max(db.WorkQueue.priority), 0)
-    ).where(db.WorkQueue.work_pool_id == data["work_pool_id"])
-    priority = (await session.execute(max_priority_query)).scalar()
+    if data["priority"] is None:
+        # Set the priority to be the first priority value that isn't already taken
+        priorities_query = sa.select(db.WorkQueue.priority).where(
+            db.WorkQueue.work_pool_id == data["work_pool_id"]
+        )
+        priorities = (await session.execute(priorities_query)).scalars().all()
 
-    model = db.WorkQueue(**data, priority=priority + 1)
+        priority = None
+        for i, p in enumerate(sorted(priorities)):
+            # if a rank was skipped (e.g. the set priority is different than the
+            # enumerated priority) then we can "take" that spot for this work
+            # queue
+            if i + 1 != p:
+                priority = i + 1
+                break
+
+        # otherwise take the maximum priority plus one
+        if priority is None:
+            priority = max(priorities, default=0) + 1
+
+        data["priority"] = priority
+
+    model = db.WorkQueue(**data)
 
     session.add(model)
     await session.flush()
+
+    if work_queue.priority:
+        await bulk_update_work_queue_priorities(
+            session=session,
+            work_pool_id=data["work_pool_id"],
+            new_priorities={model.id: work_queue.priority},
+            db=db,
+        )
 
     return model
 

--- a/src/prefect/server/models/workers.py
+++ b/src/prefect/server/models/workers.py
@@ -259,18 +259,30 @@ async def create_work_queue(
         db.WorkQueue: the newly-created WorkQueue
 
     """
+    data = work_queue.dict(exclude={"work_pool_id"})
+    if work_queue.priority is None:
+        # Set the priority to be the first priority value that isn't already taken
+        priorities_query = sa.select(db.WorkQueue.priority).where(
+            db.WorkQueue.work_pool_id == work_pool_id
+        )
+        priorities = (await session.execute(priorities_query)).scalars().all()
 
-    max_priority_query = sa.select(
-        sa.func.coalesce(sa.func.max(db.WorkQueue.priority), 0)
-    ).where(db.WorkQueue.work_pool_id == work_pool_id)
-    priority = (await session.execute(max_priority_query)).scalar()
+        priority = None
+        for i, p in enumerate(sorted(priorities)):
+            # if a rank was skipped (e.g. the set priority is different than the
+            # enumerated priority) then we can "take" that spot for this work
+            # queue
+            if i + 1 != p:
+                priority = i + 1
+                break
 
-    model = db.WorkQueue(
-        **work_queue.dict(exclude={"priority", "work_pool_id"}),
-        work_pool_id=work_pool_id,
-        # initialize the priority as the current max priority + 1
-        priority=priority + 1
-    )
+        # otherwise take the maximum priority plus one
+        if priority is None:
+            priority = max(priorities, default=0) + 1
+
+        data["priority"] = priority
+
+    model = db.WorkQueue(**data, work_pool_id=work_pool_id)
 
     session.add(model)
     await session.flush()
@@ -293,11 +305,16 @@ async def bulk_update_work_queue_priorities(
     db: PrefectDBInterface,
 ):
     """
-    This is a brute force update of all work pool queue priorities for a given worker
+    This is a brute force update of all work pool queue priorities for a given work
     pool.
 
     It loads all queues fully into memory, sorts them, and flushes the update to
-    the db.
+    the db. The algorithm ensures that priorities are unique integers > 0, and
+    makes the minimum number of changes required to satisfy the provided
+    `new_priorities`. For example, if no queues currently have the provided
+    `new_priorities`, then they are assigned without affecting other queues. If
+    they are held by other queues, then those queues' priorities are
+    incremented as necessary.
 
     Updating queue priorities is not a common operation (happens on the same scale as
     queue modification, which is significantly less than reading from queues),
@@ -308,6 +325,7 @@ async def bulk_update_work_queue_priorities(
     if len(set(new_priorities.values())) != len(new_priorities):
         raise ValueError("Duplicate target priorities provided")
 
+    # get all the work queues, sorted by priority
     work_queues_query = (
         sa.select(db.WorkQueue)
         .where(db.WorkQueue.work_pool_id == work_pool_id)
@@ -316,14 +334,31 @@ async def bulk_update_work_queue_priorities(
     result = await session.execute(work_queues_query)
     all_work_queues = result.scalars().all()
 
+    # split the queues into those that need to be updated and those that don't
     work_queues = [wq for wq in all_work_queues if wq.id not in new_priorities]
     updated_queues = [wq for wq in all_work_queues if wq.id in new_priorities]
 
+    # update queue priorities and insert them into the appropriate place in the
+    # full list of queues
     for queue in sorted(updated_queues, key=lambda wq: new_priorities[wq.id]):
-        work_queues.insert(new_priorities[queue.id] - 1, queue)
+        queue.priority = new_priorities[queue.id]
+        for i, wq in enumerate(work_queues):
+            if wq.priority >= new_priorities[queue.id]:
+                work_queues.insert(i, queue)
+                break
 
-    for i, queue in enumerate(work_queues):
-        queue.priority = i + 1
+    # walk through the queues and update their priorities such that the
+    # priorities are sequential. Do this by tracking that last priority seen and
+    # ensuring that each successive queue's priority is higher than it. This
+    # will maintain queue order and ensure increasing priorities with minimal
+    # changes.
+    last_priority = 0
+    for queue in work_queues:
+        if queue.priority <= last_priority:
+            last_priority += 1
+            queue.priority = last_priority
+        else:
+            last_priority = queue.priority
 
     await session.flush()
 

--- a/tests/server/models/test_workers.py
+++ b/tests/server/models/test_workers.py
@@ -336,8 +336,8 @@ class TestReadWorkQueues:
         assert len(result) == 4
         assert (result[0].name, result[0].priority) == ("default", 1)
         assert (result[1].name, result[1].priority) == ("C", 2)
-        assert (result[2].name, result[2].priority) == ("B", 3)
-        assert (result[3].name, result[3].priority) == ("A", 4)
+        assert (result[2].name, result[2].priority) == ("B", 4)
+        assert (result[3].name, result[3].priority) == ("A", 100)
 
 
 class TestUpdateWorkQueue:
@@ -374,19 +374,6 @@ class TestUpdateWorkQueue:
             session=session, work_queue_id=work_queue.id
         )
         assert result.concurrency_limit == 0
-
-    async def test_update_work_queue_priority_is_normalized_for_number_of_queues(
-        self, session, work_queue_1
-    ):
-        assert await models.workers.update_work_queue(
-            session=session,
-            work_queue_id=work_queue_1.id,
-            work_queue=schemas.actions.WorkQueueUpdate(priority=100),
-        )
-        result = await models.workers.read_work_queue(
-            session=session, work_queue_id=work_queue_1.id
-        )
-        assert result.priority == 2
 
 
 class TestUpdateWorkQueuePriorities:
@@ -517,8 +504,8 @@ class TestUpdateWorkQueuePriorities:
         assert {q.name: q.priority for q in all_queues} == {
             "A": 1,
             "B": 2,
-            "D": 3,
-            "E": 4,
+            "D": 4,
+            "E": 5,
         }
 
 
@@ -569,7 +556,7 @@ class TestDeleteWorkQueue:
         assert len(result) == 3
         assert (result[0].name, result[0].priority) == ("default", 1)
         assert (result[1].name, result[1].priority) == ("A", 2)
-        assert (result[2].name, result[2].priority) == ("C", 3)
+        assert (result[2].name, result[2].priority) == ("C", 4)
 
 
 class TestWorkerHeartbeat:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Work queue priorities are currently kept in sequential order. If there are 3 queues with priorities 1 and 2, and the user set one of their priorities to be 20, it is actually set to 3 before the queue is written to the DB. From a user perspective it looks like we aren't respecting their specified priority.

With this PR users can set any value and it is respected. If the user sets a priority that conflicts with the priority of another queue, then existing queue priorities are incremented to ensure all their values are unique.

Ports functionality from https://github.com/PrefectHQ/nebula/pull/3778

Closes #9794 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
