### PR TITLE
Various concurrency tooling improvements

### DIFF
--- a/src/prefect/_internal/concurrency/api.py
+++ b/src/prefect/_internal/concurrency/api.py
@@ -121,8 +121,8 @@ class _base(abc.ABC):
         if waiter is None:
             raise RuntimeError(f"No waiter found for thread {thread}.")
 
-        waiter.submit(call)
         call.set_timeout(timeout)
+        waiter.submit(call)
         return call
 
     @staticmethod

--- a/src/prefect/_internal/concurrency/api.py
+++ b/src/prefect/_internal/concurrency/api.py
@@ -100,7 +100,7 @@ class _base(abc.ABC):
         return call
 
     @staticmethod
-    def call_soon_in_waiter_thread(
+    def call_soon_in_waiting_thread(
         __call: Union[Callable[[], T], Call[T]], timeout: Optional[float] = None
     ) -> Call[T]:
         """
@@ -119,7 +119,7 @@ class _base(abc.ABC):
         return call
 
     @staticmethod
-    def call_in_waiter_thread(
+    def call_in_waiting_thread(
         __call: Union[Callable[[], T], Call[T]], timeout: Optional[float] = None
     ) -> T:
         """
@@ -187,10 +187,10 @@ class from_async(_base):
         return call.result()
 
     @staticmethod
-    def call_in_waiter_thread(
+    def call_in_waiting_thread(
         __call: Union[Callable[[], T], Call[T]], timeout: Optional[float] = None
     ) -> Awaitable[T]:
-        call = _base.call_soon_in_waiter_thread(__call, timeout=timeout)
+        call = _base.call_soon_in_waiting_thread(__call, timeout=timeout)
         return call.aresult()
 
     @staticmethod
@@ -246,10 +246,10 @@ class from_sync(_base):
         return call.result()
 
     @staticmethod
-    def call_in_waiter_thread(
+    def call_in_waiting_thread(
         __call: Union[Callable[[], T], Call[T]], timeout: Optional[float] = None
     ) -> T:
-        call = _base.call_soon_in_waiter_thread(__call, timeout=timeout)
+        call = _base.call_soon_in_waiting_thread(__call, timeout=timeout)
         return call.result()
 
     @staticmethod

--- a/src/prefect/_internal/concurrency/calls.py
+++ b/src/prefect/_internal/concurrency/calls.py
@@ -64,7 +64,6 @@ class Call(Generic[T]):
         default_factory=lambda: CancelContext(timeout=None)
     )
     runner: Optional["Portal"] = None
-    waiter: Optional["Portal"] = None
 
     @classmethod
     def new(cls, __fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> "Call[T]":
@@ -96,15 +95,6 @@ class Call(Generic[T]):
             raise RuntimeError("The portal is already set for this call.")
 
         self.runner = portal
-
-    def set_waiter(self, portal: "Portal") -> None:
-        """
-        Set a portal to run callbacks while waiting for this call.
-        """
-        if self.waiter is not None:
-            raise RuntimeError("A waiter has already been set for this call.")
-
-        self.waiter = portal
 
     def run(self) -> Optional[Awaitable[T]]:
         """

--- a/src/prefect/_internal/concurrency/calls.py
+++ b/src/prefect/_internal/concurrency/calls.py
@@ -106,18 +106,6 @@ class Call(Generic[T]):
 
         self.waiter = portal
 
-    def add_waiting_callback(self, call: "Call") -> None:
-        """
-        Send a callback to the waiter.
-        """
-        if self.waiter is None:
-            raise RuntimeError("No waiter has been configured.")
-
-        if self.future.done():
-            raise RuntimeError("The call is already done.")
-
-        self.waiter.submit(call)
-
     def run(self) -> Optional[Awaitable[T]]:
         """
         Execute the call and place the result on the future.

--- a/src/prefect/_internal/concurrency/calls.py
+++ b/src/prefect/_internal/concurrency/calls.py
@@ -79,7 +79,7 @@ class Call(Generic[T]):
         """
         Set the timeout for the call.
 
-        WARNING: The timeout begins immediately, not when the call starts.
+        The timeout begins when the call starts.
         """
         if self.future.done() or self.future.running():
             raise RuntimeError("Timeouts cannot be added when the call has started.")
@@ -167,6 +167,7 @@ class Call(Generic[T]):
     def _run_sync(self):
         try:
             with set_current_call(self):
+                self.cancel_context.start()
                 with cancel_sync_at(self.cancel_context.deadline) as ctx:
                     ctx.chain(self.cancel_context, bidirectional=True)
                     result = self.fn(*self.args, **self.kwargs)

--- a/src/prefect/_internal/concurrency/waiters.py
+++ b/src/prefect/_internal/concurrency/waiters.py
@@ -31,7 +31,7 @@ logger = get_logger("prefect._internal.concurrency.waiters")
 
 
 # Waiters are stored in a stack for each thread
-_WAITERS_BY_THREAD: weakref.WeakKeyDictionary[threading.Thread, deque["Waiter"]] = (
+_WAITERS_BY_THREAD: "weakref.WeakKeyDictionary[threading.Thread, deque[Waiter]]" = (
     weakref.WeakKeyDictionary()
 )
 

--- a/src/prefect/_internal/concurrency/waiters.py
+++ b/src/prefect/_internal/concurrency/waiters.py
@@ -25,7 +25,6 @@ from prefect.logging import get_logger
 
 T = TypeVar("T")
 
-# TODO: We should update the format for this logger to include the current thread
 logger = get_logger("prefect._internal.concurrency.waiters")
 
 

--- a/src/prefect/_internal/concurrency/waiters.py
+++ b/src/prefect/_internal/concurrency/waiters.py
@@ -151,6 +151,7 @@ class SyncWaiter(Waiter[T]):
 
         with self._handle_done_callbacks():
             # Cancel work sent to the waiter if the future exceeds its timeout
+            self._call.cancel_context.start()
             with cancel_sync_at(self._call.cancel_context.deadline) as ctx:
                 self._handle_waiting_callbacks(ctx)
 
@@ -268,6 +269,7 @@ class AsyncWaiter(Waiter[T]):
 
         async with self._handle_done_callbacks():
             # Cancel work sent to the waiter if the future exceeds its timeout
+            self._call.cancel_context.start()
             with cancel_async_at(self._call.cancel_context.deadline) as ctx:
                 await self._handle_waiting_callbacks(ctx)
 

--- a/src/prefect/_internal/concurrency/waiters.py
+++ b/src/prefect/_internal/concurrency/waiters.py
@@ -68,7 +68,6 @@ class Waiter(Portal, abc.ABC, Generic[T]):
         if not isinstance(call, Call):  # Guard against common mistake
             raise TypeError(f"Expected call of type `Call`; got {call!r}.")
 
-        call.set_waiter(self)
         self._call = call
         self._owner_thread = threading.current_thread()
 

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -21,6 +21,7 @@ import logging
 import os
 import signal
 import prefect.plugins
+import threading
 import sys
 import time
 from contextlib import AsyncExitStack, asynccontextmanager, nullcontext
@@ -175,6 +176,7 @@ def enter_flow_run_engine_from_flow_call(
         wait_for=wait_for,
         return_type=return_type,
         client=parent_flow_run_context.client if is_subflow_run else None,
+        user_thread=threading.current_thread(),
     )
 
     # On completion of root flows, wait for the global thread to ensure that
@@ -229,7 +231,11 @@ def enter_flow_run_engine_from_subprocess(flow_run_id: UUID) -> State:
     setup_logging()
 
     state = from_sync.wait_for_call_in_loop_thread(
-        create_call(retrieve_flow_then_begin_flow_run, flow_run_id),
+        create_call(
+            retrieve_flow_then_begin_flow_run,
+            flow_run_id,
+            user_thread=threading.current_thread(),
+        ),
         contexts=[capture_sigterm()],
     )
 
@@ -244,6 +250,7 @@ async def create_then_begin_flow_run(
     wait_for: Optional[Iterable[PrefectFuture]],
     return_type: EngineReturnType,
     client: PrefectClient,
+    user_thread: threading.Thread,
 ) -> Any:
     """
     Async entrypoint for flow calls
@@ -291,7 +298,11 @@ async def create_then_begin_flow_run(
         )
     else:
         state = await begin_flow_run(
-            flow=flow, flow_run=flow_run, parameters=parameters, client=client
+            flow=flow,
+            flow_run=flow_run,
+            parameters=parameters,
+            client=client,
+            user_thread=user_thread,
         )
 
     if return_type == "state":
@@ -304,7 +315,9 @@ async def create_then_begin_flow_run(
 
 @inject_client
 async def retrieve_flow_then_begin_flow_run(
-    flow_run_id: UUID, client: PrefectClient
+    flow_run_id: UUID,
+    client: PrefectClient,
+    user_thread: threading.Thread,
 ) -> State:
     """
     Async entrypoint for flow runs that have been submitted for execution by an agent
@@ -367,6 +380,7 @@ async def retrieve_flow_then_begin_flow_run(
         flow_run=flow_run,
         parameters=parameters,
         client=client,
+        user_thread=user_thread,
     )
 
 
@@ -375,6 +389,7 @@ async def begin_flow_run(
     flow_run: FlowRun,
     parameters: Dict[str, Any],
     client: PrefectClient,
+    user_thread: threading.Thread,
 ) -> State:
     """
     Begins execution of a flow run; blocks until completion of the flow run
@@ -447,6 +462,7 @@ async def begin_flow_run(
             partial_flow_run_context=flow_run_context,
             # Orchestration needs to be interruptible if it has a timeout
             interruptible=flow.timeout_seconds is not None,
+            user_thread=user_thread,
         )
 
     if terminal_or_paused_state.is_paused():
@@ -486,6 +502,7 @@ async def create_and_begin_subflow_run(
     wait_for: Optional[Iterable[PrefectFuture]],
     return_type: EngineReturnType,
     client: PrefectClient,
+    user_thread: threading.Thread,
 ) -> Any:
     """
     Async entrypoint for flows calls within a flow run
@@ -617,6 +634,7 @@ async def create_and_begin_subflow_run(
                         result_factory=result_factory,
                         log_prints=log_prints,
                     ),
+                    user_thread=user_thread,
                 )
 
     # Display the full state (including the result) if debugging
@@ -645,6 +663,7 @@ async def orchestrate_flow_run(
     interruptible: bool,
     client: PrefectClient,
     partial_flow_run_context: PartialModel[FlowRunContext],
+    user_thread: threading.Thread,
 ) -> State:
     """
     Executes a flow run.
@@ -729,7 +748,7 @@ async def orchestrate_flow_run(
                 flow_call = create_call(flow.fn, *args, **kwargs)
 
                 # This check for a parent call is needed for cases where the engine
-                # was entered directly; such as during testing _or_ deployment runs
+                # was entered directly during testing
                 parent_call = get_current_call()
 
                 if parent_call and (
@@ -740,7 +759,7 @@ async def orchestrate_flow_run(
                     )
                 ):
                     from_async.call_soon_in_waiting_thread(
-                        flow_call, timeout=flow.timeout_seconds
+                        flow_call, thread=user_thread, timeout=flow.timeout_seconds
                     )
                 else:
                     from_async.call_soon_in_new_thread(

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -739,7 +739,7 @@ async def orchestrate_flow_run(
                         and parent_flow_run_context.flow.isasync == flow.isasync
                     )
                 ):
-                    from_async.call_soon_in_waiter_thread(
+                    from_async.call_soon_in_waiting_thread(
                         flow_call, timeout=flow.timeout_seconds
                     )
                 else:

--- a/src/prefect/utilities/asyncutils.py
+++ b/src/prefect/utilities/asyncutils.py
@@ -239,7 +239,7 @@ def sync_compatible(async_fn: T) -> T:
             return async_fn(*args, **kwargs)
         elif current_call and current_call.waiter and not is_async_fn(current_call.fn):
             logger.debug(f"{async_fn} --> run async in callback portal")
-            return from_sync.call_soon_in_waiter_thread(
+            return from_sync.call_soon_in_waiting_thread(
                 create_call(async_fn, *args, **kwargs)
             ).result()
         elif in_async_worker_thread():

--- a/src/prefect/utilities/asyncutils.py
+++ b/src/prefect/utilities/asyncutils.py
@@ -237,11 +237,6 @@ def sync_compatible(async_fn: T) -> T:
             # In the main async context; return the coro for them to await
             logger.debug(f"{async_fn} --> return coroutine for user await")
             return async_fn(*args, **kwargs)
-        elif current_call and current_call.waiter and not is_async_fn(current_call.fn):
-            logger.debug(f"{async_fn} --> run async in callback portal")
-            return from_sync.call_soon_in_waiting_thread(
-                create_call(async_fn, *args, **kwargs)
-            ).result()
         elif in_async_worker_thread():
             # In a sync context but we can access the event loop thread; send the async
             # call to the parent

--- a/tests/_internal/concurrency/test_timeouts.py
+++ b/tests/_internal/concurrency/test_timeouts.py
@@ -27,6 +27,27 @@ async def test_cancel_context():
     cancel.assert_called_once_with()
 
 
+async def test_cancel_context_deadline_not_set_yet():
+    cancel = MagicMock()
+    ctx = CancelContext(timeout=1, cancel=cancel)
+    with pytest.raises(RuntimeError, match="Deadline accessed before `start` called"):
+        ctx.deadline
+
+
+async def test_cancel_context_deadline_set_on_start():
+    cancel = MagicMock()
+    ctx = CancelContext(timeout=1, cancel=cancel)
+    ctx.start()
+    assert ctx.deadline == pytest.approx(time.monotonic() + 1, abs=0.25)
+
+
+async def test_cancel_context_deadline_set_on_context_manager():
+    cancel = MagicMock()
+    ctx = CancelContext(timeout=1, cancel=cancel)
+    with ctx:
+        assert ctx.deadline == pytest.approx(time.monotonic() + 1, abs=0.25)
+
+
 async def test_cancel_context_chain():
     cancel1 = MagicMock()
     cancel2 = MagicMock()

--- a/tests/_internal/concurrency/test_waiters.py
+++ b/tests/_internal/concurrency/test_waiters.py
@@ -139,7 +139,7 @@ def test_sync_waiter_timeout_in_main_thread():
 
         def on_worker_thread():
             callback = Call.new(time.sleep, 1)
-            call.add_waiting_callback(callback)
+            waiter.submit(callback)
             return callback
 
         call = Call.new(on_worker_thread)
@@ -201,9 +201,9 @@ async def test_async_waiter_timeout_in_main_thread():
 
         def on_worker_thread():
             nonlocal callback
-            # Send sleep to the main thread
+            # Send sleep to the main thread but do not wait for it
             callback = Call.new(asyncio.sleep, 1)
-            call.add_waiting_callback(callback)
+            waiter.submit(callback)
 
         call = Call.new(on_worker_thread)
 
@@ -290,7 +290,7 @@ async def test_async_waiter_base_exception_in_main_thread(exception_cls, raise_f
         def on_worker_thread():
             # Send exception to the main thread
             callback = Call.new(raise_fn, exception_cls("test"))
-            call.add_waiting_callback(callback)
+            waiter.submit(callback)
             return callback
 
         call = Call.new(on_worker_thread)
@@ -350,7 +350,7 @@ def test_sync_waiter_base_exception_in_main_thread(exception_cls, raise_fn):
         def on_worker_thread():
             # Send exception to the main thread
             callback = Call.new(raise_fn, exception_cls("test"))
-            call.add_waiting_callback(callback)
+            waiter.submit(callback)
             return callback
 
         call = Call.new(on_worker_thread)


### PR DESCRIPTION
When sending work back to a waiting thread you must explicitly specify the target thread instead of inferring the target from the parent call stashed in the context. This allows us to drop `Call.waiter` for simplicity and will allow us to send calls to threads that are not the parent of the current call. This is the first step towards running tasks on the main thread. An example of the change can be viewed in [the diff for a basic test](https://github.com/PrefectHQ/prefect/pull/9809/commits/e9307966db94b1604ac33a1c65c04999e8ac1762#diff-0cf9fe1b4f9ee85ee8f4ba257123ba25fbea801e382d9e1efe67570b8cfce62cR99-R111).

Cancellation deadlines for calls are now calculated at call start time instead of at `timeout` set time. This required the addition of a "started" concept to cancel contexts.
