### PR TITLE
Add `run_shell_script` step

### DIFF
--- a/docs/api-ref/prefect/projects/steps/utility.md
+++ b/docs/api-ref/prefect/projects/steps/utility.md
@@ -1,0 +1,11 @@
+---
+description: Prefect Python API for utility steps for projects.
+tags:
+    - Python API
+    - projects
+    - deployments
+    - steps
+    - shell
+---
+
+::: prefect.projects.steps.utility

--- a/docs/concepts/projects.md
+++ b/docs/concepts/projects.md
@@ -359,6 +359,24 @@ Once you've confirmed that these fields are set to their desired values, this st
 !!! note Some steps require Prefect integrations
     Note that in the build step example above, we relied on the `prefect-docker` package; in cases that deal with external services, additional packages are often required and will be auto-installed for you.
 
+!!! tip "Pass output to downstream steps"
+    Each deployment action can be composed of multiple steps.  For example, if you wanted to build a Docker image tagged with the current commit hash, you could use the `run_shell_script` step and feed the output into the `build_docker_image` step:
+
+    ```yaml
+    build:
+        - prefect.projects.steps.run_shell_script:
+            id: get-commit-hash
+            script: git rev-parse --short HEAD
+            stream_output: false
+        - prefect_docker.projects.steps.build_docker_image:
+            requires: prefect-docker
+            image_name: my-image
+            image_tag: "{{ get-commit-hash.stdout }}"
+            dockerfile: auto
+    ```
+
+    Note that the `id` field is used on the `run_shell_script` step so that its output can be referenced in the next step.
+
 ### The Push Section
 
 The push section is most critical for situations in which code is not stored on persistent filesystems or in version control.  In this scenario, code is often pushed and pulled from a Cloud storage bucket of some kind (e.g., S3, GCS, Azure Blobs, etc.).  The push section allows users to specify and customize the logic for pushing this project to arbitrary remote locations.

--- a/docs/concepts/projects.md
+++ b/docs/concepts/projects.md
@@ -375,7 +375,7 @@ Once you've confirmed that these fields are set to their desired values, this st
             dockerfile: auto
     ```
 
-    Note that the `id` field is used on the `run_shell_script` step so that its output can be referenced in the next step.
+    Note that the `id` field is used in the `run_shell_script` step so that its output can be referenced in the next step.
 
 ### The Push Section
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -196,6 +196,7 @@ nav:
                 - 'prefect.projects.base': api-ref/prefect/projects/base.md
                 - 'prefect.projects.steps.core': api-ref/prefect/projects/steps/core.md
                 - 'prefect.projects.steps.pull': api-ref/prefect/projects/steps/pull.md
+                - 'prefect.projects.steps.utility': api-ref/prefect/projects/steps/utility.md
             - 'prefect.runtime':
                 - 'prefect.runtime.flow_run': api-ref/prefect/runtime/flow_run.md
                 - 'prefect.runtime.deployment': api-ref/prefect/runtime/deployment.md

--- a/src/prefect/projects/steps/__init__.py
+++ b/src/prefect/projects/steps/__init__.py
@@ -1,2 +1,3 @@
 from .core import run_step
 from .pull import git_clone_project, set_working_directory
+from .utility import run_shell_script

--- a/src/prefect/projects/steps/core.py
+++ b/src/prefect/projects/steps/core.py
@@ -65,7 +65,7 @@ async def run_step(step: Dict, upstream_outputs: Optional[Dict] = None) -> Dict:
 
     Steps are assumed to be in the format `{"importable.func.name": {"kwarg1": "value1", ...}}`.
 
-    The 'id and 'requires' keywords is reserved for specific purposes and will be removed from the
+    The 'id and 'requires' keywords are reserved for specific purposes and will be removed from the
     inputs before passing to the step function:
 
     This keyword is used to specify packages that should be installed before running the step.

--- a/src/prefect/projects/steps/core.py
+++ b/src/prefect/projects/steps/core.py
@@ -75,6 +75,7 @@ async def run_step(step: dict) -> dict:
     inputs = await resolve_variables(inputs)
 
     step_func = _get_function_for_step(fqn, requires=keywords.get("requires"))
-    return await from_async.call_soon_in_new_thread(
+    result = await from_async.call_soon_in_new_thread(
         Call.new(step_func, **inputs)
     ).aresult()
+    return result if isinstance(result, dict) else {}

--- a/src/prefect/projects/steps/core.py
+++ b/src/prefect/projects/steps/core.py
@@ -10,18 +10,30 @@ Whenever a step is run, the following actions are taken:
 - The step's function is called with the resolved inputs
 - The step's output is returned and used to resolve inputs for subsequent steps
 """
+from copy import deepcopy
 import subprocess
 import sys
-from typing import Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from prefect._internal.concurrency.api import Call, from_async
 from prefect.utilities.importtools import import_object
 from prefect.utilities.templating import (
+    apply_values,
     resolve_block_document_references,
     resolve_variables,
 )
 
-RESERVED_KEYWORDS = {"requires"}
+from prefect.settings import PREFECT_DEBUG_MODE
+
+from prefect.logging.loggers import get_logger
+
+RESERVED_KEYWORDS = {"id", "requires"}
+
+
+class StepExecutionError(Exception):
+    """
+    Raised when a step fails to execute.
+    """
 
 
 def _get_function_for_step(fully_qualified_name: str, requires: Optional[str] = None):
@@ -47,22 +59,23 @@ def _get_function_for_step(fully_qualified_name: str, requires: Optional[str] = 
     return step_func
 
 
-async def run_step(step: dict) -> dict:
+async def run_step(step: Dict, upstream_outputs: Optional[Dict] = None) -> Dict:
     """
     Runs a step, returns the step's output.
 
     Steps are assumed to be in the format `{"importable.func.name": {"kwarg1": "value1", ...}}`.
 
-    The 'requires' keyword is reserved for specific purposes and will be removed from the
+    The 'id and 'requires' keywords is reserved for specific purposes and will be removed from the
     inputs before passing to the step function:
 
     This keyword is used to specify packages that should be installed before running the step.
     """
-    fqn, inputs = step.popitem()
+    fqn, inputs = _get_step_fully_qualified_name_and_inputs(step)
+    upstream_outputs = upstream_outputs or {}
 
-    if step:
+    if len(step.keys()) > 1:
         raise ValueError(
-            f"Step has unexpected additional keys: {', '.join(step.keys())}"
+            f"Step has unexpected additional keys: {', '.join(list(step.keys())[1:])}"
         )
 
     keywords = {
@@ -71,6 +84,7 @@ async def run_step(step: dict) -> dict:
         if keyword in inputs
     }
 
+    inputs = apply_values(inputs, upstream_outputs)
     inputs = await resolve_block_document_references(inputs)
     inputs = await resolve_variables(inputs)
 
@@ -78,4 +92,40 @@ async def run_step(step: dict) -> dict:
     result = await from_async.call_soon_in_new_thread(
         Call.new(step_func, **inputs)
     ).aresult()
-    return result if isinstance(result, dict) else {}
+    return result
+
+
+async def run_steps(
+    steps: List[Dict[str, Any]],
+    upstream_outputs: Optional[Dict[str, Any]] = None,
+    print_function: Any = print,
+):
+    upstream_outputs = deepcopy(upstream_outputs) if upstream_outputs else {}
+    for step in steps:
+        if not step:
+            continue
+        fqn, inputs = _get_step_fully_qualified_name_and_inputs(step)
+        step_name = fqn.split(".")[-1]
+        print_function(f" > Running {step_name} step...")
+        try:
+            step_output = await run_step(step, upstream_outputs)
+            if not isinstance(step_output, dict):
+                if PREFECT_DEBUG_MODE:
+                    get_logger().warning(
+                        "Step function %s returned unexpected type: %s",
+                        fqn,
+                        type(step_output),
+                    )
+                continue
+            # store step output under step id to prevent clobbering
+            if inputs.get("id"):
+                upstream_outputs[inputs.get("id")] = step_output
+            upstream_outputs.update(step_output)
+        except Exception as exc:
+            raise StepExecutionError(f"Encountered error while running {fqn}") from exc
+    return upstream_outputs
+
+
+def _get_step_fully_qualified_name_and_inputs(step: Dict) -> Tuple[str, Dict]:
+    step = deepcopy(step)
+    return step.popitem()

--- a/src/prefect/projects/steps/utility.py
+++ b/src/prefect/projects/steps/utility.py
@@ -1,0 +1,36 @@
+"""
+Utility project steps that are useful for managing a project's deployment lifecycle.
+"""
+import os
+import shlex
+from typing import Optional, Dict
+
+from prefect.utilities.processutils import run_process
+
+
+async def run_shell_script(
+    script: str,
+    directory: Optional[str] = None,
+    env: Optional[Dict[str, str]] = None,
+    stream_output: bool = True,
+):
+    """
+    Runs a shell script.
+
+    Args:
+        script: The script to run
+        directory: The directory to run the script in. Defaults to the current working directory.
+        env: A dictionary of environment variables to set for the script
+        stream_output: Whether to stream the output of the script to stdout/stderr
+    """
+    current_env = os.environ.copy()
+    current_env.update(env or {})
+
+    commands = script.splitlines()
+    for command in commands:
+        await run_process(
+            shlex.split(command),
+            cwd=directory,
+            env=current_env,
+            stream_output=stream_output,
+        )

--- a/src/prefect/projects/steps/utility.py
+++ b/src/prefect/projects/steps/utility.py
@@ -58,7 +58,7 @@ async def run_shell_script(
     stream_output: bool = True,
 ) -> RunShellScriptResult:
     """
-    Runs a one or more shell commands in a subprocess. Returns the standard
+    Runs one or more shell commands in a subprocess. Returns the standard
     output and standard error of the script.
 
     Args:

--- a/src/prefect/projects/steps/utility.py
+++ b/src/prefect/projects/steps/utility.py
@@ -130,11 +130,15 @@ async def run_shell_script(
     stderr_sink = io.StringIO()
 
     for command in commands:
+        split_command = shlex.split(command)
+        if not split_command:
+            continue
         async with open_process(
-            shlex.split(command),
+            split_command,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=directory,
+            env=current_env,
         ) as process:
             await _stream_capture_process_output(
                 process,

--- a/src/prefect/projects/steps/utility.py
+++ b/src/prefect/projects/steps/utility.py
@@ -1,5 +1,23 @@
 """
 Utility project steps that are useful for managing a project's deployment lifecycle.
+
+Steps within this module can be used within a `build`, `push`, or `pull` deployment action.
+
+Example:
+    Use the `run_shell_script` setp to retrieve the short Git commit hash of the current 
+        repository and use it as a Docker image tag:
+    ```yaml
+    build:
+        - prefect.projects.steps.run_shell_script:
+            id: get-commit-hash
+            script: git rev-parse --short HEAD
+            stream_output: false
+        - prefect_docker.projects.steps.build_docker_image:
+            requires: prefect-docker
+            image_name: my-image
+            image_tag: "{{ get-commit-hash.stdout }}"
+            dockerfile: auto
+    ```
 """
 from typing_extensions import TypedDict
 from anyio import create_task_group
@@ -82,7 +100,7 @@ async def run_shell_script(
                 id: get-commit-hash
                 script: git rev-parse --short HEAD
                 stream_output: false
-            - prefect.projects.steps.build_docker_image:
+            - prefect_docker.projects.steps.build_docker_image:
                 requires: prefect-docker
                 image_name: my-image
                 image_tag: "{{ get-commit-hash.stdout }}"

--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -410,3 +410,18 @@ def distinct(
             continue
         seen.add(key(item))
         yield item
+
+
+def get_from_dict(dct: Dict, keys: Union[str, List[str]], default: Any = None) -> Any:
+    if isinstance(keys, str):
+        keys = keys.replace("[", ".").replace("]", "").split(".")
+    try:
+        for key in keys:
+            try:
+                key = int(key)
+            except ValueError:
+                pass
+            dct = dct[key]
+        return dct
+    except (TypeError, KeyError, IndexError):
+        return default

--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -413,13 +413,44 @@ def distinct(
 
 
 def get_from_dict(dct: Dict, keys: Union[str, List[str]], default: Any = None) -> Any:
+    """
+    Fetch a value from a nested dictionary or list using a sequence of keys.
+
+    This function allows to fetch a value from a deeply nested structure
+    of dictionaries and lists using either a dot-separated string or a list
+    of keys. If a requested key does not exist, the function returns the
+    provided default value.
+
+    Args:
+        dct: The nested dictionary or list from which to fetch the value.
+        keys: The sequence of keys to use for access. Can be a
+            dot-separated string or a list of keys. List indices can be included
+            in the sequence as either integer keys or as string indices in square
+            brackets.
+        default: The default value to return if the requested key path does not
+            exist. Defaults to None.
+
+    Returns:
+        The fetched value if the key exists, or the default value if it does not.
+
+    Examples:
+    >>> get_from_dict({'a': {'b': {'c': [1, 2, 3, 4]}}}, 'a.b.c[1]')
+    2
+    >>> get_from_dict({'a': {'b': [0, {'c': [1, 2]}]}}, ['a', 'b', 1, 'c', 1])
+    2
+    >>> get_from_dict({'a': {'b': [0, {'c': [1, 2]}]}}, 'a.b.1.c.2', 'default')
+    'default'
+    """
     if isinstance(keys, str):
         keys = keys.replace("[", ".").replace("]", "").split(".")
     try:
         for key in keys:
             try:
+                # Try to cast to int to handle list indices
                 key = int(key)
             except ValueError:
+                # If it's not an int, use the key as-is
+                # for dict lookup
                 pass
             dct = dct[key]
         return dct

--- a/src/prefect/utilities/templating.py
+++ b/src/prefect/utilities/templating.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 T = TypeVar("T", str, int, float, bool, dict, list, None)
 
-PLACEHOLDER_CAPTURE_REGEX = re.compile(r"({{\s*([\w\.-\[\]]+)\s*}})")
+PLACEHOLDER_CAPTURE_REGEX = re.compile(r"({{\s*([\w\.\-\[\]]+)\s*}})")
 BLOCK_DOCUMENT_PLACEHOLDER_PREFIX = "prefect.blocks."
 VARIABLE_PLACEHOLDER_PREFIX = "prefect.variables."
 

--- a/src/prefect/utilities/templating.py
+++ b/src/prefect/utilities/templating.py
@@ -93,9 +93,9 @@ def apply_values(
     multiple placeholders, the placeholders will be replaced with the
     corresponding variable values.
 
-    If a template contains a placeholder that is not in `values`, UNSET will
+    If a template contains a placeholder that is not in `values`, NotSet will
     be returned to signify that no placeholder replacement occurred. If
-    `template` is a dictionary that contains a key with a value of UNSET,
+    `template` is a dictionary that contains a key with a value of NotSet,
     the key will be removed in the return value unless `remove_notset` is set to False.
 
     Args:
@@ -124,10 +124,7 @@ def apply_values(
             return get_from_dict(values, list(placeholders)[0].name, NotSet)
         else:
             for full_match, name, placeholder_type in placeholders:
-                if (
-                    get_from_dict(values, name) is not None
-                    and placeholder_type is PlaceholderType.STANDARD
-                ):
+                if placeholder_type is PlaceholderType.STANDARD:
                     template = template.replace(
                         full_match, str(get_from_dict(values, name, ""))
                     )

--- a/tests/utilities/test_collections.py
+++ b/tests/utilities/test_collections.py
@@ -13,6 +13,7 @@ from prefect.utilities.collections import (
     StopVisiting,
     dict_to_flatdict,
     flatdict_to_dict,
+    get_from_dict,
     isiterable,
     remove_nested_keys,
     visit_collection,
@@ -516,3 +517,25 @@ class TestIsIterable:
     @pytest.mark.parametrize("obj", [5, Exception(), True, "hello", bytes()])
     def test_not_iterable(self, obj):
         assert not isiterable(obj)
+
+
+class TestGetFromDict:
+    @pytest.mark.parametrize(
+        "dct, keys, expected, default",
+        [
+            ({}, "a.b.c", None, None),
+            ({"a": {"b": {"c": [1, 2, 3, 4]}}}, "a.b.c[1]", 2, None),
+            ({"a": {"b": {"c": [1, 2, 3, 4]}}}, "a.b.c.1", 2, None),
+            ({"a": {"b": [0, {"c": [1, 2]}]}}, "a.b.1.c.1", 2, None),
+            ({"a": {"b": [0, {"c": [1, 2]}]}}, ["a", "b", 1, "c", 1], 2, None),
+            ({"a": {"b": [0, {"c": [1, 2]}]}}, "a.b.1.c.2", None, None),
+            (
+                {"a": {"b": [0, {"c": [1, 2]}]}},
+                "a.b.1.c.2",
+                "default_value",
+                "default_value",
+            ),
+        ],
+    )
+    def test_get_from_dict(self, dct, keys, expected, default):
+        assert get_from_dict(dct, keys, default) == expected

--- a/tests/utilities/test_templating.py
+++ b/tests/utilities/test_templating.py
@@ -173,6 +173,30 @@ class TestApplyValues:
         template = "Hello {{prefect.blocks.document.name}}!"
         assert apply_values(template, {"name": "Alice"}) == template
 
+    def test_apply_values_with_dot_delimited_placeholder_str(self):
+        template = "Hello {{ person.name }}!"
+        assert apply_values(template, {"person": {"name": "Arthur"}}) == "Hello Arthur!"
+
+    def test_apply_values_with_dot_delimited_placeholder_str_with_list(self):
+        template = "Hello {{ people[0].name }}!"
+        assert (
+            apply_values(template, {"people": [{"name": "Arthur"}]}) == "Hello Arthur!"
+        )
+
+    def test_apply_values_with_dot_delimited_placeholder_dict(self):
+        template = {"right now we need": "{{ people.superman }}"}
+        values = {"people": {"superman": {"first_name": "Superman", "age": 30}}}
+        assert apply_values(template, values) == {
+            "right now we need": {"first_name": "Superman", "age": 30}
+        }
+
+    def test_apply_values_with_dot_delimited_placeholder_with_list(self):
+        template = {"right now we need": "{{ people[0] }}"}
+        values = {"people": [{"first_name": "Superman", "age": 30}]}
+        assert apply_values(template, values) == {
+            "right now we need": {"first_name": "Superman", "age": 30}
+        }
+
 
 class TestResolveBlockDocumentReferences:
     @pytest.fixture


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Adds a deployment lifecycle step that allows users to run shell commands as part of their deployment process. The step captures the stdout and stderr of the commands that are run so that they can be used as inputs to later steps.

This PR updates `utilities.processutils.stream_text` to accept multiple sinks for stdout and std error to support capturing process output while streaming the output back to stdout and stderr.

Closes #9783

To make the `run_shell_script` step more useful, this PR also implements passing outputs to downstream steps in the same action. To avoid overwriting outputs of upstream tasks, users can now add an `id` to each step and use it to reference step outputs in downstream steps. See the YAML snippet below for an example of this functionality.

Closes #9346

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Retrieve the short Git commit hash of the current repository to use as a Docker image tag:
```yaml
build:
    - prefect.projects.steps.run_shell_script:
        id: get-commit-hash
        script: git rev-parse --short HEAD
        stream_output: false
    - prefect.projects.steps.build_docker_image:
        requires: prefect-docker
        image_name: my-image
        image_tag: "{{ get-commit-hash.stdout }}"
        dockerfile: auto
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
