### PR TITLE
Add `prefect.runtime.deployment.schedule`

### DIFF
--- a/src/prefect/runtime/deployment.py
+++ b/src/prefect/runtime/deployment.py
@@ -33,7 +33,7 @@ from prefect.context import FlowRunContext
 
 from .flow_run import _get_flow_run
 
-__all__ = ["id", "flow_run_id", "name", "parameters", "version"]
+__all__ = ["id", "flow_run_id", "name", "parameters", "version", "schedule"]
 
 CACHED_DEPLOYMENT = {}
 
@@ -108,6 +108,18 @@ def get_name() -> dict:
     return deployment.name
 
 
+def get_schedule() -> dict:
+    dep_id = get_id()
+
+    if dep_id is None:
+        return None
+
+    deployment = from_sync.call_soon_in_loop_thread(
+        create_call(_get_deployment, dep_id)
+    ).result()
+    return deployment.schedule
+
+
 def get_version() -> dict:
     dep_id = get_id()
 
@@ -130,4 +142,5 @@ FIELDS = {
     "parameters": get_parameters,
     "name": get_name,
     "version": get_version,
+    "schedule": get_schedule,
 }

--- a/tests/runtime/test_deployment.py
+++ b/tests/runtime/test_deployment.py
@@ -172,5 +172,5 @@ class TestSchedule:
         schedule = deployment.schedule
 
         assert isinstance(schedule, IntervalSchedule)
-        assert schedule.interval == datetime.timedelta(60)
+        assert schedule.interval == datetime.timedelta(seconds=60)
         schedule.get_dates(n=1)

--- a/tests/runtime/test_deployment.py
+++ b/tests/runtime/test_deployment.py
@@ -173,4 +173,3 @@ class TestSchedule:
 
         assert isinstance(schedule, IntervalSchedule)
         assert schedule.interval == datetime.timedelta(seconds=60)
-        schedule.get_dates(n=1)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

Adds support to retrieve the deployment's schedule from the runtime.

Prompted by https://prefecthq.slack.com/archives/C046WGGKF4P/p1685643356397549

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

This would be useful for getting the next scheduled start time e.g. `runtime.deployment.schedule.get_dates(n=1)` but the client-side schemas do not support `get_dates` yet. We could duplicate this functionality from server -> client if desired.

We could add follow-up runtime attributes such as `next_scheduled_time` / `prev_scheduled_time` that use the flow run scheduled time to calculate the values for the user.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
