### PR TITLE
Add interactive schedule prompting to `prefect deploy`

### DIFF
--- a/src/prefect/cli/_prompts.py
+++ b/src/prefect/cli/_prompts.py
@@ -230,17 +230,17 @@ def prompt_schedule_type(console):
         ],
         [
             {
-                "type": "Cron",
-                "description": (
-                    "Allows you to define recurring flow runs based on a specified"
-                    " pattern using cron syntax."
-                ),
-            },
-            {
                 "type": "Interval",
                 "description": (
                     "Allows you to set flow runs to be executed at fixed time"
                     " intervals."
+                ),
+            },
+            {
+                "type": "Cron",
+                "description": (
+                    "Allows you to define recurring flow runs based on a specified"
+                    " pattern using cron syntax."
                 ),
             },
             {

--- a/src/prefect/cli/_prompts.py
+++ b/src/prefect/cli/_prompts.py
@@ -133,7 +133,9 @@ class IntervalValuePrompt(PromptBase[timedelta]):
 
 def prompt_interval_schedule(console):
     interval = IntervalValuePrompt.ask(
-        "[bold][green]?[/] Interval (in seconds)", console=console, default="3600"
+        "[bold][green]?[/] Duration between scheduled runs (in seconds)",
+        console=console,
+        default="3600",
     )
     return IntervalSchedule(interval=interval)
 

--- a/src/prefect/cli/_prompts.py
+++ b/src/prefect/cli/_prompts.py
@@ -133,7 +133,7 @@ class IntervalValuePrompt(PromptBase[timedelta]):
 
 def prompt_interval_schedule(console):
     interval = IntervalValuePrompt.ask(
-        "[bold][green]?[/] Duration between scheduled runs (in seconds)",
+        "[bold][green]?[/] Seconds between scheduled runs",
         console=console,
         default="3600",
     )

--- a/src/prefect/cli/_prompts.py
+++ b/src/prefect/cli/_prompts.py
@@ -132,6 +132,9 @@ class IntervalValuePrompt(PromptBase[timedelta]):
 
 
 def prompt_interval_schedule(console):
+    """
+    Prompt the user for an interval in seconds.
+    """
     interval = IntervalValuePrompt.ask(
         "[bold][green]?[/] Seconds between scheduled runs",
         console=console,
@@ -168,6 +171,9 @@ class CronTimezonePrompt(PromptBase[str]):
 
 
 def prompt_cron_schedule(console):
+    """
+    Prompt the user for a cron string and timezone.
+    """
     cron = CronStringPrompt.ask(
         "[bold][green]?[/] Cron string",
         console=console,
@@ -207,6 +213,9 @@ class RRuleTimezonePrompt(PromptBase[str]):
 
 
 def prompt_rrule_schedule(console):
+    """
+    Prompts the user to enter an RRule string and timezone.
+    """
     rrule = RRuleStringPrompt.ask(
         "[bold][green]?[/] RRule string",
         console=console,
@@ -222,7 +231,9 @@ def prompt_rrule_schedule(console):
 
 
 def prompt_schedule_type(console):
-    """ """
+    """
+    Prompts the user to select a schedule type from a list of options.
+    """
     selection = prompt_select_from_table(
         console,
         "What type of schedule would you like to use?",

--- a/src/prefect/cli/_prompts.py
+++ b/src/prefect/cli/_prompts.py
@@ -1,0 +1,271 @@
+"""
+Utilities for prompting the user for input
+"""
+from datetime import timedelta
+from rich.prompt import PromptBase, InvalidResponse
+
+from prefect.client.schemas.schedules import (
+    SCHEDULE_TYPES,
+    CronSchedule,
+    IntervalSchedule,
+    RRuleSchedule,
+)
+
+from typing import Dict, List, Optional
+import readchar
+
+from rich.table import Table
+from rich.live import Live
+from rich.prompt import Prompt, Confirm
+from prefect.cli._utilities import exit_with_error
+
+
+def prompt(message, **kwargs):
+    """Utility to prompt the user for input with consistent styling"""
+    return Prompt.ask(f"[bold][green]?[/] {message}[/]", **kwargs)
+
+
+def confirm(message, **kwargs):
+    """Utility to prompt the user for confirmation with consistent styling"""
+    return Confirm.ask(f"[bold][green]?[/] {message}[/]", **kwargs)
+
+
+def prompt_select_from_table(
+    console,
+    prompt: str,
+    columns: List[Dict],
+    data: List[Dict],
+    table_kwargs: Optional[Dict] = None,
+) -> Dict:
+    """
+    Given a list of columns and some data, display options to user in a table
+    and prompt them to select one.
+
+    Args:
+        prompt: A prompt to display to the user before the table.
+        columns: A list of dicts with keys `header` and `key` to display in
+            the table. The `header` value will be displayed in the table header
+            and the `key` value will be used to lookup the value for each row
+            in the provided data.
+        data: A list of dicts with keys corresponding to the `key` values in
+            the `columns` argument.
+        table_kwargs: Additional kwargs to pass to the `rich.Table` constructor.
+    Returns:
+        dict: Data representation of the selected row
+    """
+    current_idx = 0
+    selected_row = None
+    first_run = True
+    table_kwargs = table_kwargs or {}
+
+    def build_table() -> Table:
+        """
+        Generate a table of options. The `current_idx` will be highlighted.
+        """
+
+        nonlocal first_run
+        if first_run:
+            console.print(
+                f"[bold][green]?[/] {prompt} [bright_blue][Use arrows to move; enter to"
+                " select][/]"
+            )
+        table = Table(**table_kwargs)
+        table.add_column()
+        for column in columns:
+            table.add_column(column.get("header", ""))
+
+        rows = []
+        for item in data:
+            rows.append(tuple(item.get(column.get("key")) for column in columns))
+
+        for i, row in enumerate(rows):
+            if i == current_idx:
+                # Use blue for selected options
+                table.add_row("[bold][blue]>", f"[bold][blue]{row[0]}[/]", *row[1:])
+            else:
+                table.add_row("  ", *row)
+        first_run = False
+        return table
+
+    with Live(build_table(), auto_refresh=False, console=console) as live:
+        while selected_row is None:
+            key = readchar.readkey()
+
+            if key == readchar.key.UP:
+                current_idx = current_idx - 1
+                # wrap to bottom if at the top
+                if current_idx < 0:
+                    current_idx = len(data) - 1
+            elif key == readchar.key.DOWN:
+                current_idx = current_idx + 1
+                # wrap to top if at the bottom
+                if current_idx >= len(data):
+                    current_idx = 0
+            elif key == readchar.key.CTRL_C:
+                # gracefully exit with no message
+                exit_with_error("")
+            elif key == readchar.key.ENTER or key == readchar.key.CR:
+                selected_row = data[current_idx]
+
+            live.update(build_table(), refresh=True)
+
+        return selected_row
+
+
+# Interval schedule prompting utilities
+
+
+class IntervalValuePrompt(PromptBase[timedelta]):
+    response_type = timedelta
+    validate_error_message = (
+        "[prompt.invalid]Please enter a valid interval denoted in seconds"
+    )
+
+    def process_response(self, value: str) -> timedelta:
+        try:
+            int_value = int(value)
+            if int_value <= 0:
+                raise InvalidResponse("[prompt.invalid]Interval must be greater than 0")
+            return timedelta(seconds=int_value)
+        except ValueError:
+            raise InvalidResponse(self.validate_error_message)
+
+
+def prompt_interval_schedule(console):
+    interval = IntervalValuePrompt.ask(
+        "[bold][green]?[/] Interval (in seconds)", console=console, default="3600"
+    )
+    return IntervalSchedule(interval=interval)
+
+
+# Cron schedule prompting utilities
+
+
+class CronStringPrompt(PromptBase[str]):
+    response_type = str
+    validate_error_message = "[prompt.invalid]Please enter a valid cron string"
+
+    def process_response(self, value: str) -> str:
+        try:
+            CronSchedule.valid_cron_string(value)
+            return value
+        except ValueError:
+            raise InvalidResponse(self.validate_error_message)
+
+
+class CronTimezonePrompt(PromptBase[str]):
+    response_type = str
+    validate_error_message = "[prompt.invalid]Please enter a valid timezone."
+
+    def process_response(self, value: str) -> str:
+        try:
+            CronSchedule.valid_timezone(value)
+            return value
+        except ValueError:
+            raise InvalidResponse(self.validate_error_message)
+
+
+def prompt_cron_schedule(console):
+    cron = CronStringPrompt.ask(
+        "[bold][green]?[/] Cron string",
+        console=console,
+        default="0 0 * * *",
+    )
+    timezone = CronTimezonePrompt.ask(
+        "[bold][green]?[/] Timezone", console=console, default="UTC"
+    )
+    return CronSchedule(cron=cron, timezone=timezone)
+
+
+# RRule schedule prompting utilities
+
+
+class RRuleStringPrompt(PromptBase[str]):
+    response_type = str
+    validate_error_message = "[prompt.invalid]Please enter a valid RRule string"
+
+    def process_response(self, value: str) -> str:
+        try:
+            RRuleSchedule.validate_rrule_str(value)
+            return value
+        except ValueError:
+            raise InvalidResponse(self.validate_error_message)
+
+
+class RRuleTimezonePrompt(PromptBase[str]):
+    response_type = str
+    validate_error_message = "[prompt.invalid]Please enter a valid timezone."
+
+    def process_response(self, value: str) -> str:
+        try:
+            RRuleSchedule.valid_timezone(value)
+            return value
+        except ValueError:
+            raise InvalidResponse(self.validate_error_message)
+
+
+def prompt_rrule_schedule(console):
+    rrule = RRuleStringPrompt.ask(
+        "[bold][green]?[/] RRule string",
+        console=console,
+        default="RRULE:FREQ=DAILY;INTERVAL=1",
+    )
+    timezone = CronTimezonePrompt.ask(
+        "[bold][green]?[/] Timezone", console=console, default="UTC"
+    )
+    return RRuleSchedule(rrule=rrule, timezone=timezone)
+
+
+# Schedule type prompting utilities
+
+
+def prompt_schedule_type(console):
+    """ """
+    selection = prompt_select_from_table(
+        console,
+        "What type of schedule would you like to use?",
+        [
+            {"header": "Schedule Type", "key": "type"},
+            {"header": "Description", "key": "description"},
+        ],
+        [
+            {
+                "type": "Cron",
+                "description": (
+                    "Allows you to define recurring flow runs based on a specified"
+                    " pattern using cron syntax."
+                ),
+            },
+            {
+                "type": "Interval",
+                "description": (
+                    "Allows you to set flow runs to be executed at fixed time"
+                    " intervals."
+                ),
+            },
+            {
+                "type": "RRule",
+                "description": (
+                    "Allows you to define recurring flow runs using RFC 2445 recurrence"
+                    " rules."
+                ),
+            },
+        ],
+    )
+    return selection["type"]
+
+
+def prompt_schedule(console) -> SCHEDULE_TYPES:
+    """
+    Prompt the user for a schedule type. Once a schedule type is selected, prompt
+    the user for the schedule details and return the schedule.
+    """
+    schedule_type = prompt_schedule_type(console)
+    if schedule_type == "Cron":
+        return prompt_cron_schedule(console)
+    elif schedule_type == "Interval":
+        return prompt_interval_schedule(console)
+    elif schedule_type == "RRule":
+        return prompt_rrule_schedule(console)
+    else:
+        raise Exception("Invalid schedule type")

--- a/src/prefect/cli/_utilities.py
+++ b/src/prefect/cli/_utilities.py
@@ -3,15 +3,10 @@ Utilities for Prefect CLI commands
 """
 import functools
 import traceback
-from typing import Dict, List, Optional
-import readchar
 
 import typer
 import typer.core
 from click.exceptions import ClickException
-from rich.table import Table
-from rich.live import Live
-from rich.prompt import Prompt, Confirm
 
 from prefect.exceptions import MissingProfileError
 from prefect.settings import PREFECT_TEST_MODE
@@ -55,95 +50,3 @@ def with_cli_exception_handling(fn):
             exit_with_error("An exception occurred.")
 
     return wrapper
-
-
-def prompt(message, **kwargs):
-    """Utility to prompt the user for input with consistent styling"""
-    return Prompt.ask(f"[bold][green]?[/] {message}[/]", **kwargs)
-
-
-def confirm(message, **kwargs):
-    """Utility to prompt the user for confirmation with consistent styling"""
-    return Confirm.ask(f"[bold][green]?[/] {message}[/]", **kwargs)
-
-
-def prompt_select_from_table(
-    console,
-    prompt: str,
-    columns: List[Dict],
-    data: List[Dict],
-    table_kwargs: Optional[Dict] = None,
-) -> Dict:
-    """
-    Given a list of columns and some data, display options to user in a table
-    and prompt them to select one.
-
-    Args:
-        prompt: A prompt to display to the user before the table.
-        columns: A list of dicts with keys `header` and `key` to display in
-            the table. The `header` value will be displayed in the table header
-            and the `key` value will be used to lookup the value for each row
-            in the provided data.
-        data: A list of dicts with keys corresponding to the `key` values in
-            the `columns` argument.
-        table_kwargs: Additional kwargs to pass to the `rich.Table` constructor.
-    Returns:
-        dict: Data representation of the selected row
-    """
-    current_idx = 0
-    selected_row = None
-    first_run = True
-    table_kwargs = table_kwargs or {}
-
-    def build_table() -> Table:
-        """
-        Generate a table of options. The `current_idx` will be highlighted.
-        """
-
-        nonlocal first_run
-        if first_run:
-            console.print(
-                f"[bold][green]?[/] {prompt} [bright_blue][Use arrows to move; enter to"
-                " select][/]"
-            )
-        table = Table(**table_kwargs)
-        table.add_column()
-        for column in columns:
-            table.add_column(column.get("header", ""))
-
-        rows = []
-        for item in data:
-            rows.append(tuple(item.get(column.get("key")) for column in columns))
-
-        for i, row in enumerate(rows):
-            if i == current_idx:
-                # Use blue for selected options
-                table.add_row("[bold][blue]>", f"[bold][blue]{row[0]}[/]", *row[1:])
-            else:
-                table.add_row("  ", *row)
-        first_run = False
-        return table
-
-    with Live(build_table(), auto_refresh=False, console=console) as live:
-        while selected_row is None:
-            key = readchar.readkey()
-
-            if key == readchar.key.UP:
-                current_idx = current_idx - 1
-                # wrap to bottom if at the top
-                if current_idx < 0:
-                    current_idx = len(data) - 1
-            elif key == readchar.key.DOWN:
-                current_idx = current_idx + 1
-                # wrap to top if at the bottom
-                if current_idx >= len(data):
-                    current_idx = 0
-            elif key == readchar.key.CTRL_C:
-                # gracefully exit with no message
-                exit_with_error("")
-            elif key == readchar.key.ENTER or key == readchar.key.CR:
-                selected_row = data[current_idx]
-
-            live.update(build_table(), refresh=True)
-
-        return selected_row

--- a/src/prefect/cli/_utilities.py
+++ b/src/prefect/cli/_utilities.py
@@ -11,7 +11,7 @@ import typer.core
 from click.exceptions import ClickException
 from rich.table import Table
 from rich.live import Live
-from rich.prompt import Prompt
+from rich.prompt import Prompt, Confirm
 
 from prefect.exceptions import MissingProfileError
 from prefect.settings import PREFECT_TEST_MODE
@@ -60,6 +60,11 @@ def with_cli_exception_handling(fn):
 def prompt(message, **kwargs):
     """Utility to prompt the user for input with consistent styling"""
     return Prompt.ask(f"[bold][green]?[/] {message}[/]", **kwargs)
+
+
+def confirm(message, **kwargs):
+    """Utility to prompt the user for confirmation with consistent styling"""
+    return Confirm.ask(f"[bold][green]?[/] {message}[/]", **kwargs)
 
 
 def prompt_select_from_table(

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -589,7 +589,7 @@ async def _run_single_deploy(
                 style="blue",
             )
             app.console.print(
-                "\nTo schedule an run for this deployment, use the following command:"
+                "\nTo schedule a run for this deployment, use the following command:"
             )
             app.console.print(
                 (

--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -7,6 +7,7 @@ import sys
 
 import pendulum
 import rich.console
+from rich.theme import Theme
 import typer
 import typer.core
 
@@ -75,6 +76,7 @@ def main(
     app.console = rich.console.Console(
         highlight=False,
         color_system="auto" if PREFECT_CLI_COLORS else None,
+        theme=Theme({"prompt.choices": "bold blue"}),
         # `soft_wrap` disables wrapping when `True`
         soft_wrap=not PREFECT_CLI_WRAP_LINES.value(),
     )

--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -11,8 +11,8 @@ from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import (
     exit_with_error,
     exit_with_success,
-    prompt_select_from_table,
 )
+from prefect.cli._prompts import prompt_select_from_table
 from prefect.cli.root import app, is_interactive
 from prefect.client.collections import get_collections_metadata_client
 from prefect.client.schemas.actions import WorkPoolCreate, WorkPoolUpdate

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -1187,7 +1187,7 @@ class TestSchedules:
             ),
             expected_code=0,
             expected_output_contains=[
-                "? Interval (in seconds)",
+                "? Seconds between scheduled runs",
                 "Please enter a valid interval denoted in seconds",
                 "Interval must be greater than 0",
             ],


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
### Summary
Adds interactive prompts for adding a schedule to a deployment when running `prefect deploy`. When running `prefect deploy` without a schedule specified via the CLI or `deployment.yaml`, the user is asked if they want to assign a schedule to the new deployment. If the user accepts they will see options for **Interval**, **Cron**, and **RRule** schedules. After selecting a schedule type, the user will be prompted to enter the details specific to their deployment. Inputs for schedule details are validated on input and the user is re-prompted if an invalid value is supplied.

This PR also adds a `--ci` flag to `prefect deploy`. The `--ci` flag is intended for CI/CD use cases where interactive prompts are unnecessary. This allows deployments to be created without a schedule without triggering the interactive schedule prompts.

To better organize prompting functionality, this PR moves all prompt utils to the new `prefect.ci._prompts` module.

**Note:** some optional schedule details are difficult to create intuitive prompts for (`IntervalSchedule.anchor_date` and `CronSchedule.day_or`) and have been excluded from the interactive experience for now. These values can still be set via CLI flags or `deployments.yaml`. The interactive experience will be revisited later to include these fields.

Closes #9823 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

[Interactive deploy with schedule demo - Watch Video](https://www.loom.com/share/3be4a4397b8e43a8bd1af4d1543f8dbb)

#### Interval Schedule Example
![interval-example](https://github.com/PrefectHQ/prefect/assets/12350579/760f46ba-f9b3-4f0e-b54c-43d022de681a)


#### Cron Schedule Example
![cron-example](https://github.com/PrefectHQ/prefect/assets/12350579/5ad682a9-e489-4aea-9734-b0254961cd45)

#### RRule Schedule Example
![rrule-example](https://github.com/PrefectHQ/prefect/assets/12350579/1351d965-ce3b-4890-8d8e-ffc11d434b1d)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
