### PR TITLE
Add feedback widget for docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -303,6 +303,21 @@ extra:
         property: G-3M31G9B0QJ
         amplitude_key: !ENV [AMPLITUDE_API_KEY, ""]
         amplitude_url: !ENV [AMPLITUDE_URL, "https://api2.amplitude.com/2/httpapi"]
+        feedback:
+          title: Was this page helpful?
+          ratings:
+            - icon: material/emoticon-happy-outline
+              name: This page was helpful
+              data: 1
+              note: >-
+                Thank you for your feedback!
+            - icon: material/emoticon-sad-outline
+              name: This page could be improved
+              data: 0
+              note: >- 
+                Thank you for your feedback! Feel free to 
+                <a href="https://github.com/PrefectHQ/prefect/issues/new?assignees=&labels=docs%2Cstatus%3Atriage&projects=&template=4_docs_change.yaml" 
+                target="_blank"> open an issue </a> with more detail.
     social:
         - icon: fontawesome/brands/slack
           link: https://www.prefect.io/slack/


### PR DESCRIPTION
Adds a feedback widget to bottom of docs pages. 

Goal is to help provide information so we can improve docs where the need is greatest.

Closes #6687. 

Clicking on the sad face gives you a link to create an issue with the docs change template.

### Example

See the [preview Netlify site](https://deploy-preview-9836--prefect-docs-preview.netlify.app/) or Loom [video demo](https://www.loom.com/share/96f179e7b2294d45871798bf603ecf32). 


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
