### PR TITLE
Run tasks on the main thread

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ dateparser >= 1.1.1
 docker >= 4.0
 fastapi >= 0.93
 fsspec >= 2022.5.0
+greenback >= 1.0
 griffe >= 0.20.0
 httpx[http2] >= 0.23, != 0.23.2
 importlib_metadata >= 4.4; python_version < '3.10'

--- a/src/prefect/_internal/concurrency/api.py
+++ b/src/prefect/_internal/concurrency/api.py
@@ -6,6 +6,7 @@ import asyncio
 import concurrent.futures
 import contextlib
 import threading
+import greenback
 from typing import (
     Awaitable,
     Callable,
@@ -29,6 +30,7 @@ from prefect._internal.concurrency.waiters import (
     SyncWaiter,
     get_waiter_for_thread,
 )
+from prefect._internal.concurrency.event_loop import get_running_loop
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -179,7 +181,7 @@ class from_async(_base):
             for context in contexts or []:
                 stack.enter_context(context)
             await waiter.wait()
-            return call.result()
+            return await call.aresult()
 
     @staticmethod
     async def wait_for_call_in_new_thread(
@@ -193,7 +195,7 @@ class from_async(_base):
             waiter.add_done_callback(callback)
         _base.call_soon_in_new_thread(call, timeout=timeout)
         await waiter.wait()
-        return call.result()
+        return await call.aresult()
 
     @staticmethod
     def call_in_waiting_thread(
@@ -231,6 +233,24 @@ class from_sync(_base):
         done_callbacks: Optional[Iterable[Call]] = None,
         contexts: Optional[Iterable[ContextManager]] = None,
     ) -> Awaitable[T]:
+        # Check for a running event loop to prevent blocking
+        if get_running_loop():
+            if not greenback.has_portal():
+                raise RuntimeError(
+                    "Detected unsafe call to `from_sync` from thread with event loop. "
+                    "Call `await greenback.ensure_portal()` to allow functionality."
+                )
+
+            # Use greenback to avoid blocking the event loop while waiting
+            return greenback.await_(
+                from_async.wait_for_call_in_loop_thread(
+                    __call,
+                    timeout=timeout,
+                    done_callbacks=done_callbacks,
+                    contexts=contexts,
+                )
+            )
+
         call = _cast_to_call(__call)
         waiter = SyncWaiter(call)
         _base.call_soon_in_loop_thread(call, timeout=timeout)
@@ -262,6 +282,10 @@ class from_sync(_base):
         thread: threading.Thread,
         timeout: Optional[float] = None,
     ) -> T:
+        if get_running_loop():
+            raise RuntimeError(
+                "Detected unsafe call to `from_sync` from thread with event loop."
+            )
         call = _base.call_soon_in_waiting_thread(__call, thread, timeout=timeout)
         return call.result()
 
@@ -269,6 +293,10 @@ class from_sync(_base):
     def call_in_new_thread(
         __call: Union[Callable[[], T], Call[T]], timeout: Optional[float] = None
     ) -> T:
+        if get_running_loop():
+            raise RuntimeError(
+                "Detected unsafe call to `from_sync` from thread with event loop."
+            )
         call = _base.call_soon_in_new_thread(__call, timeout=timeout)
         return call.result()
 
@@ -282,6 +310,11 @@ class from_sync(_base):
             # blocked waiting for the call
             call = _cast_to_call(__call)
             return call()
+
+        if get_running_loop():
+            raise RuntimeError(
+                "Detected unsafe call to `from_sync` from thread with event loop."
+            )
 
         call = _base.call_soon_in_loop_thread(__call, timeout=timeout)
         return call.result()

--- a/src/prefect/_internal/concurrency/threads.py
+++ b/src/prefect/_internal/concurrency/threads.py
@@ -257,11 +257,12 @@ def in_global_loop() -> bool:
     """
     Check if called from the global loop.
     """
-    if GLOBAL_LOOP is None:
+    loop = get_running_loop()
+    if GLOBAL_LOOP is None or not loop:
         # Avoid creating a global loop if there isn't one
         return False
 
-    return get_global_loop()._loop == get_running_loop()
+    return GLOBAL_LOOP._loop == loop
 
 
 def wait_for_global_loop_exit(timeout: Optional[float] = None) -> None:

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1675,20 +1675,23 @@ async def orchestrate_task_run(
                 call = create_call(task.fn, *args, **kwargs)
 
                 flow_run_context = FlowRunContext.get()
-
-                if flow_run_context and user_thread(
-                    # Async and sync tasks can be executed on synchronous flows
-                    # if the task runner is sequential; if the task is sync and a
-                    # concurrent task runner is used, we must execute it in a worker
-                    # thread instead.
-                    (
-                        concurrency_type == TaskConcurrencyType.SEQUENTIAL
-                        and not flow_run_context.flow.isasync
+                if (
+                    flow_run_context
+                    and user_thread
+                    and (
+                        # Async and sync tasks can be executed on synchronous flows
+                        # if the task runner is sequential; if the task is sync and a
+                        # concurrent task runner is used, we must execute it in a worker
+                        # thread instead.
+                        (
+                            concurrency_type == TaskConcurrencyType.SEQUENTIAL
+                            and not flow_run_context.flow.isasync
+                        )
+                        # Async tasks can always be executed on asynchronous flow; if the
+                        # flow is async we do not want to block the event loop with
+                        # synchronous tasks
+                        or (flow_run_context.flow.isasync and task.isasync)
                     )
-                    # Async tasks can always be executed on asynchronous flow; if the
-                    # flow is async we do not want to block the event loop with
-                    # synchronous tasks
-                    or (flow_run_context.flow.isasync and task.isasync)
                 ):
                     from_async.call_soon_in_waiting_thread(
                         call, thread=user_thread, timeout=task.timeout_seconds

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1676,20 +1676,19 @@ async def orchestrate_task_run(
 
                 flow_run_context = FlowRunContext.get()
 
-                if flow_run_context and (
-                    # Async and sync tasks can get executed on synchronous flows
-                    # if the task runner is sequential.
-                    # If the task is sync and a concurrent task runner is used, we must
-                    # execute it in a worker thread.
+                if flow_run_context and user_thread(
+                    # Async and sync tasks can be executed on synchronous flows
+                    # if the task runner is sequential; if the task is sync and a
+                    # concurrent task runner is used, we must execute it in a worker
+                    # thread instead.
                     (
                         concurrency_type == TaskConcurrencyType.SEQUENTIAL
                         and not flow_run_context.flow.isasync
                     )
-                    # Async tasks can get executed on asynchronous flows if the
-                    # task runner is concurrent
-                    or (flow_run_context.flow.isasync and task.isasync)
-                    # If the flow is async we do not want to block the event loop with
+                    # Async tasks can always be executed on asynchronous flow; if the
+                    # flow is async we do not want to block the event loop with
                     # synchronous tasks
+                    or (flow_run_context.flow.isasync and task.isasync)
                 ):
                     from_async.call_soon_in_waiting_thread(
                         call, thread=user_thread, timeout=task.timeout_seconds

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1565,6 +1565,7 @@ async def orchestrate_task_run(
     Returns:
         The final state of the run
     """
+    flow_run_context = FlowRunContext.get()
     flow_run = await client.read_flow_run(task_run.flow_run_id)
     logger = task_run_logger(task_run, task=task, flow_run=flow_run)
 
@@ -1674,7 +1675,6 @@ async def orchestrate_task_run(
 
                 call = create_call(task.fn, *args, **kwargs)
 
-                flow_run_context = FlowRunContext.get()
                 if (
                     flow_run_context
                     and user_thread

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,6 +216,7 @@ def event_loop(request):
 
     try:
         yield loop
+
     finally:
         loop.close()
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -615,6 +615,8 @@ class TestOrchestrateTaskRun:
                 interruptible=False,
                 client=prefect_client,
                 log_prints=False,
+                concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                user_thread=threading.current_thread(),
             )
 
         assert state.is_completed()
@@ -659,6 +661,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         mock_anyio_sleep.assert_not_called()
@@ -710,6 +714,8 @@ class TestOrchestrateTaskRun:
                 interruptible=False,
                 client=prefect_client,
                 log_prints=False,
+                concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                user_thread=threading.current_thread(),
             )
 
         # Check for a proper final result
@@ -772,6 +778,8 @@ class TestOrchestrateTaskRun:
                 interruptible=False,
                 client=prefect_client,
                 log_prints=False,
+                concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                user_thread=threading.current_thread(),
             )
 
         assert mock_anyio_sleep.await_count == 3
@@ -824,6 +832,8 @@ class TestOrchestrateTaskRun:
                 interruptible=False,
                 client=prefect_client,
                 log_prints=False,
+                concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                user_thread=threading.current_thread(),
             )
 
         assert mock_anyio_sleep.await_count == 3
@@ -878,6 +888,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         assert mock_anyio_sleep.await_count == 10
@@ -946,6 +958,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         # The task did not run
@@ -995,6 +1009,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         # The task ran with the unqoted data
@@ -1045,6 +1061,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         # The task ran with the state as its input
@@ -1096,6 +1114,8 @@ class TestOrchestrateTaskRun:
                     interruptible=False,
                     client=prefect_client,
                     log_prints=False,
+                    concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                    user_thread=threading.current_thread(),
                 )
 
 


### PR DESCRIPTION
When feasible, task runs are now executed on the main thread instead of a worker thread. Previously, all task runs were run in a new worker thread. This should significantly improve performance in asynchronous and sequential use cases. This allows objects to be passed to and from tasks without worrying about thread safety unless you have opted into concurrency. For example, an HTTP client or database connection can be shared between a flow and its tasks now (unless synchronous concurrency is being used).

Tasks are run in the main thread when:
- The task and flow are both asynchronous
- The flow is synchronous and the task run is sequential

In a kind of funny way, this causes _deadlocks_ when asynchronous and synchronous tasks are mixed in an asynchronous flow because if a synchronous task depends on an asynchronous task it will block the event loop waiting for the upstream to finish but the upstream cannot run since it is now on the same event loop. For example:

```python
@flow
async def foo():
    upstream = await async_task.submit(42)  # Running in the background on the main thread event loop
    sync_task(upstream) # Blocks the event loop because there's no `await`
    # If the upstream is not done when `sync_task` is called, we deadlock

await foo()
```

To resolve this, I've added `greenback` 🤮 as a dependency. We no longer block the event loop when synchronous tasks are called from asynchronous flows which resolves this issue _and_ addresses general performance concerns when calling synchronous tasks from asynchronous flows.

Closes https://github.com/PrefectHQ/prefect/issues/9412

## Example

```python
import asyncio
import threading

from prefect import flow, task


@task
def sync_task():
    print(threading.current_thread())


@task
async def async_task():
    print(threading.current_thread())


@flow(log_prints=True)
def sync_flow():
    print(threading.current_thread())

    sync_task()  # Runs on main thread
    async_task()  # Runs on main thread
    sync_task.submit()  # Runs on worker thread
    async_task.submit()  # Runs on worker thread


@flow(log_prints=True)
async def async_flow():
    print(threading.current_thread())

    sync_task()  # Runs on worker thread
    sync_task.submit()  # Runs on worker thread
    await async_task()  # Runs on main thread
    await async_task.submit()  # Runs on main thread


sync_flow()
print("---")
asyncio.run(async_flow())
```

```
❯ python example.py
12:34:50.735 | INFO    | prefect.engine - Created flow run 'organic-wallaby' for flow 'sync-flow'
12:34:50.799 | INFO    | Flow run 'organic-wallaby' - <_MainThread(MainThread, started 8725699392)>
12:34:50.814 | INFO    | Flow run 'organic-wallaby' - Created task run 'sync_task-0' for task 'sync_task'
12:34:50.814 | INFO    | Flow run 'organic-wallaby' - Executing 'sync_task-0' immediately...
12:34:50.843 | INFO    | Task run 'sync_task-0' - <_MainThread(MainThread, started 8725699392)>
12:34:50.856 | INFO    | Task run 'sync_task-0' - Finished in state Completed()
12:34:50.870 | INFO    | Flow run 'organic-wallaby' - Created task run 'async_task-0' for task 'async_task'
12:34:50.871 | INFO    | Flow run 'organic-wallaby' - Executing 'async_task-0' immediately...
12:34:50.895 | INFO    | Task run 'async_task-0' - <_MainThread(MainThread, started 8725699392)>
12:34:50.911 | INFO    | Task run 'async_task-0' - Finished in state Completed()
12:34:50.924 | INFO    | Flow run 'organic-wallaby' - Created task run 'sync_task-1' for task 'sync_task'
12:34:50.925 | INFO    | Flow run 'organic-wallaby' - Submitted task run 'sync_task-1' for execution.
12:34:50.935 | INFO    | Flow run 'organic-wallaby' - Created task run 'async_task-1' for task 'async_task'
12:34:50.935 | INFO    | Flow run 'organic-wallaby' - Submitted task run 'async_task-1' for execution.
12:34:50.958 | INFO    | Task run 'sync_task-1' - <Thread(WorkerThread-0, started 6246838272)>
12:34:50.973 | INFO    | Task run 'async_task-1' - <Thread(WorkerThread-1, started 10804703232)>
12:34:50.977 | INFO    | Task run 'sync_task-1' - Finished in state Completed()
12:34:50.988 | INFO    | Task run 'async_task-1' - Finished in state Completed()
12:34:51.003 | INFO    | Flow run 'organic-wallaby' - Finished in state Completed('All states completed.')
---
12:34:51.071 | INFO    | prefect.engine - Created flow run 'melodic-bullfinch' for flow 'async-flow'
12:34:51.115 | INFO    | Flow run 'melodic-bullfinch' - <_MainThread(MainThread, started 8725699392)>
12:34:51.130 | INFO    | Flow run 'melodic-bullfinch' - Created task run 'sync_task-0' for task 'sync_task'
12:34:51.130 | INFO    | Flow run 'melodic-bullfinch' - Executing 'sync_task-0' immediately...
12:34:51.154 | INFO    | Task run 'sync_task-0' - <Thread(WorkerThread-2, started 10771050496)>
12:34:51.174 | INFO    | Task run 'sync_task-0' - Finished in state Completed()
12:34:51.186 | INFO    | Flow run 'melodic-bullfinch' - Created task run 'sync_task-1' for task 'sync_task'
12:34:51.187 | INFO    | Flow run 'melodic-bullfinch' - Submitted task run 'sync_task-1' for execution.
12:34:51.193 | INFO    | Flow run 'melodic-bullfinch' - Created task run 'async_task-0' for task 'async_task'
12:34:51.193 | INFO    | Flow run 'melodic-bullfinch' - Executing 'async_task-0' immediately...
12:34:51.219 | INFO    | Task run 'sync_task-1' - <Thread(WorkerThread-3, started 6263664640)>
12:34:51.231 | INFO    | Task run 'async_task-0' - <_MainThread(MainThread, started 8725699392)>
12:34:51.239 | INFO    | Task run 'sync_task-1' - Finished in state Completed()
12:34:51.248 | INFO    | Task run 'async_task-0' - Finished in state Completed()
12:34:51.259 | INFO    | Flow run 'melodic-bullfinch' - Created task run 'async_task-1' for task 'async_task'
12:34:51.259 | INFO    | Flow run 'melodic-bullfinch' - Submitted task run 'async_task-1' for execution.
12:34:51.282 | INFO    | Task run 'async_task-1' - <_MainThread(MainThread, started 8725699392)>
12:34:51.295 | INFO    | Task run 'async_task-1' - Finished in state Completed()
12:34:51.309 | INFO    | Flow run 'melodic-bullfinch' - Finished in state Completed('All states completed.')
```

Now possible, previously would fail with event loop errors

```python
from prefect import flow, task
import asyncio
import httpx


@task()
async def query_api(client: httpx.AsyncClient):
    resp = await client.get("data")
    return resp


@flow()
async def my_flow():
    async with httpx.AsyncClient(base_url="https://example.com") as client:
        print(await query_api(client))


if __name__ == "__main__":
    asyncio.run(my_flow())
```
