### PR TITLE
allow passing `payload` to `emit_instance_method_called_event`

### DIFF
--- a/src/prefect/events/instrument.py
+++ b/src/prefect/events/instrument.py
@@ -22,6 +22,7 @@ def emit_instance_method_called_event(
     instance: Any,
     method_name: str,
     successful: bool,
+    payload: Optional[Dict[str, Any]] = None,
 ):
     kind = instance._event_kind()
     resources: Optional[ResourceTuple] = instance._event_method_called_resources()
@@ -33,7 +34,10 @@ def emit_instance_method_called_event(
     result = "called" if successful else "failed"
 
     emit_event(
-        event=f"{kind}.{method_name}.{result}", resource=resource, related=related
+        event=f"{kind}.{method_name}.{result}",
+        resource=resource,
+        related=related,
+        payload=payload,
     )
 
 


### PR DESCRIPTION
It'd be nice to be able to pass through `payload` with `emit_instance_method_called_event` in situations where I don't want the whole class to be instrumented (the `_events_exclude_methods` outnumber the methods I actually want to instrument, so `@instrument_method_calls_on_class_instances` didn't feel ideal)

I could also just use `emit_event` here if that seems more sensible, just thought I would try and leverage what already exists

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
```python
class Bot(MarvinBaseModel, LoggerMixin):
    ...
    async def say(
        self, *args, response_format=None, on_token_callback: Callable = None, **kwargs
    ) -> BotResponse:
        ...
    
        bot_response = await self._say(
            messages=messages, on_token_callback=on_token_callback
        )
        emit_instance_method_called_event(
            self,
            "say",
            successful=True,
            payload={
                "user_message": user_message,
                "bot_response": bot_response,
                "total_tokens": count_tokens(user_message.content + bot_response.content),,
            }
        )
        await self.history.add_message(bot_response)
        self.logger.debug_kv("AI message", bot_response.content, "bold green")
        return bot_response
```

![image](https://github.com/PrefectHQ/prefect/assets/31014960/7aef926d-5207-424a-98bf-9dde979da8ec)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
