### PR TITLE
Run clients with ephemeral applications on the global event loop thread

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -224,7 +224,7 @@ jobs:
           # Parallelize tests by scope to reduce expensive service fixture duplication
           # Do not allow the test suite to build images, as we want the prebuilt images to be tested
           # Do not run Kubernetes service tests, we do not have a cluster available
-          pytest tests -vvv --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 --cov=src/ --cov=tests/ --no-cov-on-fail --cov-report=term --cov-config=setup.cfg ${{ matrix.pytest-options }}
+          pytest tests -x -vvv --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 --cov=src/ --cov=tests/ --no-cov-on-fail --cov-report=term --cov-config=setup.cfg ${{ matrix.pytest-options }}
 
       - name: Check database container
         # Only applicable for Postgres, but we want this to run even when tests fail

--- a/src/prefect/_internal/concurrency/api.py
+++ b/src/prefect/_internal/concurrency/api.py
@@ -168,12 +168,15 @@ class from_async(_base):
         __call: Union[Callable[[], Awaitable[T]], Call[Awaitable[T]]],
         timeout: Optional[float] = None,
         done_callbacks: Optional[Iterable[Call]] = None,
+        cancel_callbacks: Optional[Iterable[Call]] = None,
         contexts: Optional[Iterable[ContextManager]] = None,
     ) -> Awaitable[T]:
         call = _cast_to_call(__call)
         waiter = AsyncWaiter(call)
         for callback in done_callbacks or []:
             waiter.add_done_callback(callback)
+        for callback in cancel_callbacks or []:
+            waiter.add_cancel_callback(callback)
         _base.call_soon_in_loop_thread(call, timeout=timeout)
         with contextlib.ExitStack() as stack:
             for context in contexts or []:

--- a/src/prefect/_internal/concurrency/threads.py
+++ b/src/prefect/_internal/concurrency/threads.py
@@ -217,6 +217,13 @@ class EventLoopThread(Portal):
         # Wait for all calls to finish
         concurrent.futures.wait(self._futures)
 
+    def cancel(self):
+        """
+        Cancel all outstanding calls.
+        """
+        for future in self._futures:
+            future.cancel()
+
     def shutdown(self) -> None:
         """
         Shutdown the worker thread. Does not wait for the thread to stop.
@@ -326,3 +333,11 @@ def drain_global_loop(timeout: Optional[float] = None) -> None:
     """
     loop_thread = get_global_loop()
     loop_thread.drain()
+
+
+def cancel_global_loop() -> None:
+    """
+    Cancel all outstanding work in the global loop.
+    """
+    loop_thread = get_global_loop()
+    loop_thread.cancel()

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -40,7 +40,9 @@ import prefect.plugins
 from prefect.states import is_state
 from prefect._internal.concurrency.api import create_call, from_async, from_sync
 from prefect._internal.concurrency.calls import get_current_call
-from prefect._internal.concurrency.threads import wait_for_global_loop_exit
+from prefect._internal.concurrency.threads import (
+    drain_global_loop,
+)
 from prefect._internal.concurrency.cancellation import CancelledError, get_deadline
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas import FlowRun, OrchestrationResult, TaskRun
@@ -181,9 +183,7 @@ def enter_flow_run_engine_from_flow_call(
 
     # On completion of root flows, wait for the global thread to ensure that
     # any work there is complete
-    done_callbacks = (
-        [create_call(wait_for_global_loop_exit)] if not is_subflow_run else None
-    )
+    done_callbacks = [create_call(drain_global_loop)] if not is_subflow_run else None
 
     # WARNING: You must define any context managers here to pass to our concurrency
     # api instead of entering them in here in the engine entrypoint. Otherwise, async

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -396,7 +396,7 @@ class TestClientContextManager:
         assert startup.call_count == shutdown.call_count
         assert startup.call_count > 0
 
-    @pytest.mark.skipif(os.environ.get("CI"), reason="Too slow for CI")
+    @pytest.mark.skipif(os.environ.get("CI") is not None, reason="Too slow for CI")
     async def test_client_context_lifespan_is_robust_to_high_async_concurrency(self):
         startup, shutdown = MagicMock(), MagicMock()
         app = FastAPI(lifespan=make_lifespan(startup, shutdown))

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -396,6 +396,7 @@ class TestClientContextManager:
         assert startup.call_count == shutdown.call_count
         assert startup.call_count > 0
 
+    @pytest.mark.skipif(os.environ.get("CI"), reason="Too slow for CI")
     async def test_client_context_lifespan_is_robust_to_high_async_concurrency(self):
         startup, shutdown = MagicMock(), MagicMock()
         app = FastAPI(lifespan=make_lifespan(startup, shutdown))


### PR DESCRIPTION
When a client is hooked to an ephemeral application, its moved to the global event loop instead of the event loop it is created on. We do this by sending the underlying httpx client's context manager to the global event loop and patch the `client.request` method to send coroutines to the other thread. This is a good stepping stone towards providing a singleton client that runs on the global event loop as well as towards providing a synchronous client.

Enabling this only for the ephemeral application is motivated by #9855 which requires SQLAlchemy to be managed on a separate thread than user code.