### PR TITLE
Provide a default `DTSTART` to anchor `RRULE` schedules

### DIFF
--- a/src/prefect/client/schemas/schedules.py
+++ b/src/prefect/client/schemas/schedules.py
@@ -144,6 +144,9 @@ class CronSchedule(PrefectBaseModel):
         return v
 
 
+DEFAULT_ANCHOR_DATE = pendulum.date(2020, 1, 1)
+
+
 class RRuleSchedule(PrefectBaseModel):
     """
     RRule schedule, based on the iCalendar standard
@@ -240,7 +243,11 @@ class RRuleSchedule(PrefectBaseModel):
         Since rrule doesn't properly serialize/deserialize timezones, we localize dates
         here
         """
-        rrule = dateutil.rrule.rrulestr(self.rrule, cache=True)
+        rrule = dateutil.rrule.rrulestr(
+            self.rrule,
+            dtstart=DEFAULT_ANCHOR_DATE,
+            cache=True,
+        )
         timezone = dateutil.tz.gettz(self.timezone)
         if isinstance(rrule, dateutil.rrule.rrule):
             kwargs = dict(dtstart=rrule._dtstart.replace(tzinfo=timezone))

--- a/src/prefect/server/schemas/schedules.py
+++ b/src/prefect/server/schemas/schedules.py
@@ -358,6 +358,9 @@ class CronSchedule(PrefectBaseModel):
             counter += 1
 
 
+DEFAULT_ANCHOR_DATE = pendulum.date(2020, 1, 1)
+
+
 class RRuleSchedule(PrefectBaseModel):
     """
     RRule schedule, based on the iCalendar standard
@@ -454,7 +457,11 @@ class RRuleSchedule(PrefectBaseModel):
         Since rrule doesn't properly serialize/deserialize timezones, we localize dates
         here
         """
-        rrule = dateutil.rrule.rrulestr(self.rrule, cache=True)
+        rrule = dateutil.rrule.rrulestr(
+            self.rrule,
+            dtstart=DEFAULT_ANCHOR_DATE,
+            cache=True,
+        )
         timezone = dateutil.tz.gettz(self.timezone)
         if isinstance(rrule, dateutil.rrule.rrule):
             kwargs = dict(dtstart=rrule._dtstart.replace(tzinfo=timezone))

--- a/tests/server/schemas/test_schedules.py
+++ b/tests/server/schemas/test_schedules.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime as pydatetime
 from datetime import timedelta
 from unittest import mock
@@ -960,3 +961,101 @@ class TestRRuleSchedule:
             dt.add(days=8),
             dt.add(days=9),
         ]
+
+
+@pytest.fixture
+async def weekly_on_friday() -> RRuleSchedule:
+    return RRuleSchedule(rrule="FREQ=WEEKLY;INTERVAL=1;BYDAY=FR", timezone="UTC")
+
+
+async def test_unanchored_rrule_schedules_are_idempotent(
+    weekly_on_friday: RRuleSchedule,
+):
+    """Regression test for an issue discovered in Prefect Cloud, where a schedule with
+    an RRULE that didn't anchor to a specific time was being rescheduled every time the
+    scheduler loop picked it up.  This is because when a user does not provide a DTSTART
+    in their rule, then the current time is assumed to be the DTSTART.
+
+    This test confirms the behavior when a user does _not_ provide a DTSTART.
+    """
+    start = pendulum.datetime(2023, 6, 8)
+    end = start.add(days=21)
+
+    assert start.day_of_week == pendulum.THURSDAY
+
+    first_set = await weekly_on_friday.get_dates(
+        n=3,
+        start=start,
+        end=end,
+    )
+
+    # Sleep long enough that a full second definitely ticks over, because the RRULE
+    # precision is only to the second.
+    await asyncio.sleep(1.1)
+
+    second_set = await weekly_on_friday.get_dates(
+        n=3,
+        start=start,
+        end=end,
+    )
+
+    assert first_set == second_set
+
+    assert [dt.date() for dt in first_set] == [
+        pendulum.date(2023, 6, 9),
+        pendulum.date(2023, 6, 16),
+        pendulum.date(2023, 6, 23),
+    ]
+    for date in first_set:
+        assert date.day_of_week == pendulum.FRIDAY
+
+
+@pytest.fixture
+async def weekly_at_1pm_fridays() -> RRuleSchedule:
+    return RRuleSchedule(
+        rrule="DTSTART:20230608T130000\nFREQ=WEEKLY;INTERVAL=1;BYDAY=FR",
+        timezone="UTC",
+    )
+
+
+async def test_rrule_schedules_can_have_embedded_anchors(
+    weekly_at_1pm_fridays: RRuleSchedule,
+):
+    """Regression test for an issue discovered in Prefect Cloud, where a schedule with
+    an RRULE that didn't anchor to a specific time was being rescheduled every time the
+    scheduler loop picked it up.  This is because when a user does not provide a DTSTART
+    in their rule, then the current time is assumed to be the DTSTART.
+
+    This case confirms that if a user provides an alternative DTSTART it will be
+    respected.
+    """
+    start = pendulum.datetime(2023, 6, 8)
+    end = start.add(days=21)
+
+    assert start.day_of_week == pendulum.THURSDAY
+
+    first_set = await weekly_at_1pm_fridays.get_dates(
+        n=3,
+        start=start,
+        end=end,
+    )
+
+    # Sleep long enough that a full second definitely ticks over, because the RRULE
+    # precision is only to the second.
+    await asyncio.sleep(1.1)
+
+    second_set = await weekly_at_1pm_fridays.get_dates(
+        n=3,
+        start=start,
+        end=end,
+    )
+
+    assert first_set == second_set
+
+    assert first_set == [
+        pendulum.datetime(2023, 6, 9, 13),
+        pendulum.datetime(2023, 6, 16, 13),
+        pendulum.datetime(2023, 6, 23, 13),
+    ]
+    for date in first_set:
+        assert date.day_of_week == pendulum.FRIDAY


### PR DESCRIPTION
We discovered that `RRULE` schedules that didn't include their own embedded
`DTSTART` were prone to producing a ton of extraneous schedules.  Each time
you asked one of these `RRULE` schedules to generate dates, it used the current
time as the anchor, so some types of rules would produce duplicates over and
over again because they weren't idempotent.

Adding a fixed `DTSTART` (which is only used if the rule doesn't have an
embedded one) makes sure that we always produce a stable set of dates/times no
matter when we ask.
