### PR TITLE
chore: add httpx request method to CloudClient

### DIFF
--- a/src/prefect/client/cloud.py
+++ b/src/prefect/client/cloud.py
@@ -70,12 +70,10 @@ class CloudClient:
             await self.read_workspaces()
 
     async def read_workspaces(self) -> List[Workspace]:
-        return pydantic.parse_obj_as(
-            List[Workspace], await self.request("GET", "/me/workspaces")
-        )
+        return pydantic.parse_obj_as(List[Workspace], await self.get("/me/workspaces"))
 
     async def read_worker_metadata(self) -> Dict[str, Any]:
-        return await self.request("GET", "collections/views/aggregate-worker-metadata")
+        return await self.get("collections/views/aggregate-worker-metadata")
 
     async def __aenter__(self):
         await self._client.__aenter__()
@@ -92,6 +90,9 @@ class CloudClient:
 
     def __exit__(self, *_):
         assert False, "This should never be called but must be defined for __enter__"
+
+    async def get(self, route, **kwargs):
+        return await self.request("GET", route, **kwargs)
 
     async def request(self, method, route, **kwargs):
         try:

--- a/src/prefect/client/cloud.py
+++ b/src/prefect/client/cloud.py
@@ -93,21 +93,6 @@ class CloudClient:
     def __exit__(self, *_):
         assert False, "This should never be called but must be defined for __enter__"
 
-    async def get(self, route, **kwargs):
-        try:
-            res = await self._client.get(route, **kwargs)
-            res.raise_for_status()
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code in (
-                status.HTTP_401_UNAUTHORIZED,
-                status.HTTP_403_FORBIDDEN,
-            ):
-                raise CloudUnauthorizedError
-            else:
-                raise exc
-
-        return res.json()
-
     async def request(self, method, route, **kwargs):
         try:
             res = await self._client.request(method, route, **kwargs)


### PR DESCRIPTION
our Prefect Cloud http client wraps the httpx.AsyncClient, so the `get()` method just proxied to the AsyncClient's `get()` method and threw a Cloud-specific exception on 401/403s

here, im defining a base `request()` method, so we can use it for more method types for an upcoming set of `prefect cloud` CLI commands, and invoking it from the existing `get()` method

relates to https://github.com/PrefectHQ/nebula/issues/4817

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
