### PR TITLE
Improve timeout display message for calls

### DIFF
--- a/src/prefect/_internal/concurrency/calls.py
+++ b/src/prefect/_internal/concurrency/calls.py
@@ -240,10 +240,10 @@ class Call(Generic[T]):
             return None
 
         logger.debug(
-            "Running call %r in thread %r with timeout %s",
+            "Running call %r in thread %r%s",
             self,
             threading.current_thread().name,
-            self.timeout,
+            f" with timeout of {self.timeout}s" if self.timeout is not None else "",
         )
 
         coro = self.context.run(self._run_sync)

--- a/tests/server/services/test_flow_run_notifications.py
+++ b/tests/server/services/test_flow_run_notifications.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 import sqlalchemy as sa
 
 from prefect.server import models, schemas
@@ -149,7 +150,7 @@ async def test_service_does_not_send_notifications_without_policy(
 async def test_service_sends_many_notifications_and_clears_queue(
     session, db, flow_run, completed_policy, capsys, flow
 ):
-    COUNT = 200
+    COUNT = 20 if os.environ.get("CI") else 200
 
     for _ in range(COUNT):
         # set a completed state repeatedly


### PR DESCRIPTION
Instead of "timeout of None" we just won't display that text if there is no timeout.