### PR TITLE
Re-enable the retrieval of existing clients from flow and task run contexts when safe

### DIFF
--- a/src/prefect/client/utilities.py
+++ b/src/prefect/client/utilities.py
@@ -7,6 +7,7 @@ Utilities for working with clients.
 from functools import wraps
 
 from prefect.utilities.asyncutils import asyncnullcontext
+from prefect._internal.concurrency.event_loop import get_running_loop
 
 
 def inject_client(fn):
@@ -21,13 +22,27 @@ def inject_client(fn):
     @wraps(fn)
     async def with_injected_client(*args, **kwargs):
         from prefect.client.orchestration import get_client
+        from prefect.context import FlowRunContext, TaskRunContext
 
+        flow_run_context = FlowRunContext.get()
+        task_run_context = TaskRunContext.get()
         client = None
 
         if "client" in kwargs and kwargs["client"] is not None:
             # Client provided in kwargs
             client = kwargs["client"]
             client_context = asyncnullcontext()
+
+        elif flow_run_context and flow_run_context.client._loop == get_running_loop():
+            # Client available from flow run context
+            client = flow_run_context.client
+            client_context = asyncnullcontext()
+
+        elif task_run_context and task_run_context.client._loop == get_running_loop():
+            # Client available from task run context
+            client = task_run_context.client
+            client_context = asyncnullcontext()
+
         else:
             # A new client is needed
             client_context = get_client()

--- a/src/prefect/client/utilities.py
+++ b/src/prefect/client/utilities.py
@@ -27,21 +27,17 @@ def inject_client(fn):
         flow_run_context = FlowRunContext.get()
         task_run_context = TaskRunContext.get()
         client = None
+        client_context = asyncnullcontext()
 
         if "client" in kwargs and kwargs["client"] is not None:
             # Client provided in kwargs
             client = kwargs["client"]
-            client_context = asyncnullcontext()
-
         elif flow_run_context and flow_run_context.client._loop == get_running_loop():
             # Client available from flow run context
             client = flow_run_context.client
-            client_context = asyncnullcontext()
-
         elif task_run_context and task_run_context.client._loop == get_running_loop():
             # Client available from task run context
             client = task_run_context.client
-            client_context = asyncnullcontext()
 
         else:
             # A new client is needed

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -209,25 +209,25 @@ class TestInjectClient:
         assert client is prefect_client, "Client should be the same object"
         assert not client._closed, "Client should not be closed after function returns"
 
-    async def test_does_not_use_existing_client_from_flow_run_ctx(self, prefect_client):
+    async def test_use_existing_client_from_flow_run_ctx(self, prefect_client):
         with prefect.context.FlowRunContext.construct(client=prefect_client):
             client = await TestInjectClient.injected_func()
-        assert client is not prefect_client, "Client should not be the same object"
-        assert client._closed, "Client should be closed after function returns"
+        assert client is prefect_client, "Client should be the same object"
+        assert not client._closed, "Client should not be closed after function returns"
 
-    async def test_does_not_use_existing_client_from_task_run_ctx(self, prefect_client):
+    async def test_use_existing_client_from_task_run_ctx(self, prefect_client):
         with prefect.context.FlowRunContext.construct(client=prefect_client):
             client = await TestInjectClient.injected_func()
-        assert client is not prefect_client, "Client should not be the same object"
-        assert client._closed, "Client should be closed after function returns"
+        assert client is prefect_client, "Client should be the same object"
+        assert not client._closed, "Client should not be closed after function returns"
 
-    async def test_does_not_use_existing_client_from_flow_run_ctx_with_null_kwarg(
+    async def test_use_existing_client_from_flow_run_ctx_with_null_kwarg(
         self, prefect_client
     ):
         with prefect.context.FlowRunContext.construct(client=prefect_client):
             client = await TestInjectClient.injected_func(client=None)
-        assert client is not prefect_client, "Client should not be the same object"
-        assert client._closed, "Client should be closed after function returns"
+        assert client is prefect_client, "Client should be the same object"
+        assert not client._closed, "Client should not be closed after function returns"
 
 
 def not_enough_open_files() -> bool:


### PR DESCRIPTION
Previously, we pulled clients from the flow and task run contexts for `inject_client`. We stopped doing this once clients could span multiple threads during the engine event loop work (ref https://github.com/PrefectHQ/prefect/pull/8702/commits/a7033b0a8903ace51413ed3a3f92942f65a81401). However, this means that we've been instantiating more clients e.g. when creating results. We can safely allow `inject_client` to pull a client from the context if they share a common event loop.