### PR TITLE
Allow project deployment only via entrypoint

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -365,9 +365,9 @@ async def _run_single_deploy(
             " entrypoint is in the format `path/to/file.py:flow_fn_name` and the"
             " file name and flow function name are correct."
         )
-    flow_name = flow.name  # TK: not sure if should keep
+    flow_name = flow.name
 
-    base_deploy["flow_name"] = flow_name  # TK: not sure if should keep?
+    base_deploy["flow_name"] = flow_name
     base_deploy["entrypoint"] = entrypoint
 
     if not name:
@@ -377,7 +377,7 @@ async def _run_single_deploy(
 
     ## parse parameters
     # minor optimization in case we already loaded the flow
-    if not flow:  # TK: not sure if we need this anymore?
+    if not flow:
         flow = await run_sync_in_worker_thread(
             load_flow_from_entrypoint, base_deploy["entrypoint"]
         )

--- a/src/prefect/cli/project.py
+++ b/src/prefect/cli/project.py
@@ -216,6 +216,6 @@ async def register_flow(
     Register a flow with this project.
     """
     try:
-        await register(entrypoint, force=force)
+        await register(entrypoint)
     except Exception as exc:
         exit_with_error(exc)

--- a/src/prefect/cli/project.py
+++ b/src/prefect/cli/project.py
@@ -14,7 +14,7 @@ from prefect.cli._utilities import exit_with_error
 from prefect.cli.root import app
 from prefect.client.orchestration import get_client
 from prefect.exceptions import ObjectNotFound
-from prefect.projects import find_prefect_directory, initialize_project
+from prefect.projects import initialize_project
 from prefect.projects import register_flow as register
 
 from prefect.projects.steps.core import run_steps
@@ -216,14 +216,6 @@ async def register_flow(
     Register a flow with this project.
     """
     try:
-        flow = await register(entrypoint, force=force)
+        await register(entrypoint, force=force)
     except Exception as exc:
         exit_with_error(exc)
-
-    app.console.print(
-        (
-            f"Registered flow {flow.name!r} in"
-            f" {(find_prefect_directory()/'flows.json').resolve()!s}"
-        ),
-        style="green",
-    )

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -871,7 +871,13 @@ def load_flow_from_entrypoint(entrypoint: str) -> Flow:
         block_code_execution=True,
         capture_failures=True,
     ):
-        path, func_name = entrypoint.split(":")
+        try:
+            path, func_name = entrypoint.split(":")
+        except ValueError:
+            raise ValueError(
+                f"Entrypoint {entrypoint!r} is not in the format "
+                "`path/to/file.py:flow_function`"
+            )
         try:
             flow = import_object(entrypoint)
         except AttributeError as exc:

--- a/src/prefect/projects/__init__.py
+++ b/src/prefect/projects/__init__.py
@@ -1,7 +1,6 @@
 import prefect.projects.base
 import prefect.projects.steps
 from prefect.projects.base import (
-    find_prefect_directory,
     initialize_project,
     register_flow,
 )

--- a/src/prefect/projects/base.py
+++ b/src/prefect/projects/base.py
@@ -244,7 +244,7 @@ async def register_flow(entrypoint: str):
         entrypoint (str): the entrypoint to the flow to register
     """
     try:
-        _, _ = entrypoint.rsplit(":", 1)
+        entrypoint.rsplit(":", 1)
     except ValueError as exc:
         if str(exc) == "not enough values to unpack (expected 2, got 1)":
             missing_flow_name_msg = (

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -960,7 +960,6 @@ class TestProjectDeploy:
             }
         ]
 
-    # TK: I believe it should raise now
     async def test_project_deploy_attempt_read_flow_name_from_deployment_yaml_raises(
         self, project_dir, prefect_client, work_pool
     ):

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -56,7 +56,7 @@ def project_dir(tmp_path):
         yield tmp_path
     else:
         shutil.copytree(TEST_PROJECTS_DIR, tmp_path / "three-seven")
-        prefect_home = tmp_path / "three-seven" / ".prefect"
+        prefect_home = tmp_path / "three-seven"
         prefect_home.mkdir(exist_ok=True, mode=0o0700)
         os.chdir(tmp_path / "three-seven")
         initialize_project()
@@ -85,7 +85,7 @@ def project_dir_with_single_deployment_format(tmp_path):
         yield tmp_path
     else:
         shutil.copytree(TEST_PROJECTS_DIR, tmp_path / "three-seven")
-        (tmp_path / "three-seven" / ".prefect").mkdir(exist_ok=True, mode=0o0700)
+        (tmp_path / "three-seven").mkdir(exist_ok=True, mode=0o0700)
         os.chdir(tmp_path / "three-seven")
         initialize_project()
 

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -425,8 +425,8 @@ class TestProjectDeploySingleDeploymentYAML:
             command="deploy 'An important name'",
             expected_code=1,
             expected_output_contains=(
-                "Your flow entrypoint must include the name of the function that is the"
-                " entrypoint to your flow"
+                "Entrypoint 'An important name' is not in the format"
+                " `path/to/file.py:flow_function`"
             ),
         )
 

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -94,6 +94,9 @@ class TestProjectInit:
                 # temp_dir creates a *new* nested temporary directory within tempdir
                 assert any(Path(tempdir).rglob(file))
 
+            for file in [".prefect"]:
+                assert not any(Path(tempdir).rglob(file))
+
     def test_project_init_with_recipe(self):
         with TemporaryDirectory() as tempdir:
             result = invoke_and_assert(

--- a/tests/projects/test_base.py
+++ b/tests/projects/test_base.py
@@ -26,7 +26,7 @@ def project_dir(tmp_path):
         yield tmp_path
     else:
         shutil.copytree(TEST_PROJECTS_DIR, tmp_path / "three-seven")
-        (tmp_path / "three-seven" / ".prefect").mkdir(exist_ok=True, mode=0o0700)
+        (tmp_path / "three-seven").mkdir(exist_ok=True, mode=0o0700)
         os.chdir(tmp_path / "three-seven")
         yield tmp_path / "three-seven"
     os.chdir(original_dir)


### PR DESCRIPTION
## Overview
PR 1 to close #9860
(PR 2 will target the actual removal of the word `project` from modules, the docs, and CLI)

This PR targets the section of the issue focused on modifying functionality, meaning:
🗑️ Removing creation and use of the `.prefect` folder that is currently created by `prefect project init`
🚫 Removing the ability to deploy a flow with a flow name and instead use entrypoint universally

**What does that mean for users?**
The good:
✔️ A single way to deploy a flow in projects (specifying entrypoint)
✔️ No more `.prefect` folder created
Caveats:
⚠️ A breaking change: You won't be able to deploy a flow via flow name, even if you have an existing `.prefect` folder with registered flows.

**TODO**
📚 Documentation updates regarding functionality changes

## Example
#### `prefect project init`
```bash
❯ cd hello-projects
❯ prefect project init
11:52:52.782 | DEBUG   | prefect.profiles - Using profile 'local_sqlite'
Created project in /Users/code/prefect/hello-projects with the following new files:
.prefectignore
deployment.yaml
prefect.yaml
```
#### `prefect deploy`
👍 Still correct
```bash
❯ prefect deploy flow.py:main -n 'main-deployment'
11:53:31.741 | DEBUG   | prefect.profiles - Using profile 'local_sqlite'
11:53:32.889 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/bean/.prefect/prefect.db
? Would you like to schedule when this flow runs? [y/n] (y): n
...
```

🔔 Raises new error
```bash
❯ prefect deploy -f main
11:55:50.076 | DEBUG   | prefect.profiles - Using profile 'local_sqlite'
Usage: prefect deploy [OPTIONS] [ENTRYPOINT]
Try 'prefect deploy --help' for help.
╭─ Error ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ No such option: -f    
```

🔔 Raises helpful error now instead of "not enough values to unpack (expected 2, got 1)"
```bash
❯ prefect deploy main
12:01:14.694 | DEBUG   | prefect.profiles - Using profile 'local_sqlite'
12:01:15.892 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/bean/.prefect/prefect.db
Entrypoint 'main' is not in the format `path/to/file.py:flow_function`
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
