### PR TITLE
Create automations when applying deployments that have trigger specifications

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -20,7 +20,7 @@ from prefect.blocks.core import Block
 from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error, exit_with_success
 from prefect.cli.root import app
-from prefect.client.orchestration import PrefectClient, get_client
+from prefect.client.orchestration import PrefectClient, ServerType, get_client
 from prefect.client.schemas.filters import FlowFilter
 from prefect.client.schemas.schedules import (
     CronSchedule,
@@ -684,6 +684,7 @@ async def apply(
     """
     Create or update a deployment from a YAML file.
     """
+    deployment = None
     async with get_client() as client:
         for path in paths:
             try:
@@ -695,6 +696,8 @@ async def apply(
                 exit_with_error(
                     f"'{path!s}' did not conform to deployment spec: {exc!r}"
                 )
+
+            assert deployment
 
             await create_work_queue_and_set_concurrency_limit(
                 deployment.work_queue_name,
@@ -727,6 +730,17 @@ async def apply(
             await check_work_pool_exists(
                 work_pool_name=deployment.work_pool_name, client=client
             )
+
+            if client.server_type != ServerType.CLOUD and deployment.triggers:
+                app.console.print(
+                    (
+                        "Deployment triggers are not supported outside of "
+                        f"Prefect Cloud. Triggers defined in {path!r} will be "
+                        "ignored."
+                    ),
+                    style="red",
+                )
+
             deployment_id = await deployment.apply()
             app.console.print(
                 (

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -734,7 +734,7 @@ async def apply(
             if client.server_type != ServerType.CLOUD and deployment.triggers:
                 app.console.print(
                     (
-                        "Deployment triggers are not supported outside of "
+                        "Deployment triggers are only supported on "
                         f"Prefect Cloud. Triggers defined in {path!r} will be "
                         "ignored."
                     ),

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -88,6 +88,7 @@ from prefect.client.schemas.sorting import (
     TaskRunSort,
 )
 from prefect.deprecated.data_documents import DataDocument
+from prefect.events.schemas import Automation
 from prefect.logging import get_logger
 from prefect.settings import (
     PREFECT_API_DATABASE_CONNECTION_URL,
@@ -2492,6 +2493,24 @@ class PrefectClient:
         response = await self._client.get("collections/views/aggregate-worker-metadata")
         response.raise_for_status()
         return response.json()
+
+    async def create_automation(self, automation: Automation) -> UUID:
+        """Creates an automation in Prefect Cloud."""
+        if self.server_type != ServerType.CLOUD:
+            raise RuntimeError("Automations are only supported for Prefect Cloud.")
+
+        response = await self._client.post(
+            "/automations/",
+            json=automation.dict(json_compatible=True),
+        )
+
+        return UUID(response.json()["id"])
+
+    async def delete_resource_owned_automations(self, resource_id: str):
+        if self.server_type != ServerType.CLOUD:
+            raise RuntimeError("Automations are only supported for Prefect Cloud.")
+
+        await self._client.delete(f"/automations/owned-by/{resource_id}")
 
     async def __aenter__(self):
         """

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -20,11 +20,12 @@ from pydantic import BaseModel, Field, parse_obj_as, validator
 from prefect._internal.compatibility.experimental import experimental_field
 from prefect.blocks.core import Block
 from prefect.blocks.fields import SecretDict
-from prefect.client.orchestration import PrefectClient, get_client
+from prefect.client.orchestration import PrefectClient, ServerType, get_client
 from prefect.client.schemas.objects import DEFAULT_AGENT_WORK_POOL_NAME, FlowRun
 from prefect.client.schemas.schedules import SCHEDULE_TYPES
 from prefect.client.utilities import inject_client
 from prefect.context import FlowRunContext, PrefectObjectRegistry
+from prefect.events.schemas import DeploymentTrigger
 from prefect.exceptions import (
     BlockMissingCapabilities,
     ObjectAlreadyExists,
@@ -469,6 +470,10 @@ class Deployment(BaseModel):
         description="The parameter schema of the flow, including defaults.",
     )
     timestamp: datetime = Field(default_factory=partial(pendulum.now, "UTC"))
+    triggers: List[DeploymentTrigger] = Field(
+        default_factory=list,
+        description="The triggers that should cause this deployment to run.",
+    )
 
     @validator("infrastructure", pre=True)
     def infrastructure_must_have_capabilities(cls, value):
@@ -514,11 +519,19 @@ class Deployment(BaseModel):
             return ParameterSchema()
         return value
 
+    @validator("triggers")
+    def validate_automation_names(cls, field_value, values, field, config):
+        """Ensure that each trigger has a name for its automation if none is provided."""
+        for i, trigger in enumerate(field_value, start=1):
+            if trigger.name is None:
+                trigger.name = f"{values['name']}__automation_{i}"
+
+        return field_value
+
     @classmethod
     @sync_compatible
     async def load_from_yaml(cls, path: str):
         data = yaml.safe_load(await anyio.Path(path).read_bytes())
-
         # load blocks from server to ensure secret values are properly hydrated
         if data.get("storage"):
             block_doc_name = data["storage"].get("_block_document_name")
@@ -716,6 +729,19 @@ class Deployment(BaseModel):
                 infrastructure_document_id=infrastructure_document_id,
                 parameter_openapi_schema=self.parameter_openapi_schema.dict(),
             )
+
+            if client.server_type == ServerType.CLOUD:
+                # The triggers defined in the deployment spec are, essentially,
+                # anonymous and attempting truly sync them with cloud is not
+                # feasible. Instead, we remove all automations that are owned
+                # by the deployment, meaning that they were created via this
+                # mechanism below, and then recreate them.
+                await client.delete_resource_owned_automations(
+                    f"prefect.deployment.{deployment_id}"
+                )
+                for trigger in self.triggers:
+                    trigger.set_deployment_id(deployment_id)
+                    await client.create_automation(trigger.as_automation())
 
             return deployment_id
 

--- a/src/prefect/deployments.py
+++ b/src/prefect/deployments.py
@@ -575,7 +575,7 @@ class Deployment(BaseModel):
                     )
 
                 excluded_fields = self.__fields_set__.union(
-                    {"infrastructure", "storage", "timestamp"}
+                    {"infrastructure", "storage", "timestamp", "triggers"}
                 )
                 for field in set(self.__fields__.keys()) - excluded_fields:
                     new_value = getattr(deployment, field)

--- a/src/prefect/events/actions.py
+++ b/src/prefect/events/actions.py
@@ -1,0 +1,30 @@
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import Field
+
+from prefect._internal.schemas.bases import PrefectBaseModel
+
+
+class Action(PrefectBaseModel):
+    """An Action that may be performed when an Automation is triggered"""
+
+    type: str
+
+
+class RunDeployment(Action):
+    """Run the given deployment with the given parameters"""
+
+    type: Literal["run-deployment"] = "run-deployment"
+    source: Literal["selected"] = "selected"
+    parameters: dict[str, Any] | None = Field(
+        None,
+        description=(
+            "The parameters to pass to the deployment, or None to use the "
+            "deployment's default parameters"
+        ),
+    )
+    deployment_id: UUID = Field(..., description="The identifier of the deployment")
+
+
+ActionTypes = RunDeployment

--- a/src/prefect/events/actions.py
+++ b/src/prefect/events/actions.py
@@ -1,4 +1,5 @@
-from typing import Any, Literal
+from typing import Any, Dict, Optional
+from typing_extensions import Literal
 from uuid import UUID
 
 from pydantic import Field
@@ -17,7 +18,7 @@ class RunDeployment(Action):
 
     type: Literal["run-deployment"] = "run-deployment"
     source: Literal["selected"] = "selected"
-    parameters: dict[str, Any] | None = Field(
+    parameters: Optional[Dict[str, Any]] = Field(
         None,
         description=(
             "The parameters to pass to the deployment, or None to use the "

--- a/src/prefect/events/schemas.py
+++ b/src/prefect/events/schemas.py
@@ -1,15 +1,30 @@
 from typing import Any, Dict, Iterable, List, Optional, Tuple, cast
 from uuid import UUID, uuid4
+from datetime import timedelta
 
 import pendulum
-from pydantic import Field, root_validator, validator
+from pydantic import Extra, Field, PrivateAttr, root_validator, validator
+from pydantic.fields import ModelField
 
 from prefect._internal.schemas.bases import PrefectBaseModel
 from prefect._internal.schemas.fields import DateTimeTZ
+from prefect._internal.schemas.transformations import FieldFrom, copy_model_fields
+from prefect.events.actions import ActionTypes, RunDeployment
+from prefect.utilities.collections import AutoEnum
+
 
 # These are defined by Prefect Cloud
 MAXIMUM_LABELS_PER_RESOURCE = 500
 MAXIMUM_RELATED_RESOURCES = 500
+
+
+class Posture(AutoEnum):
+    Reactive = "Reactive"
+    Proactive = "Proactive"
+
+
+class ResourceSpecification(PrefectBaseModel):
+    __root__: dict[str, str | list[str]]
 
 
 class Labelled(PrefectBaseModel):
@@ -141,3 +156,186 @@ class Event(PrefectBaseModel):
             )
 
         return value
+
+
+class Trigger(PrefectBaseModel):
+    """Defines the criteria for the events and conditions under which an Automation
+    will trigger an action"""
+
+    match: ResourceSpecification = Field(
+        default_factory=lambda: ResourceSpecification(__root__={}),
+        description="Labels for resources which this Automation will match.",
+    )
+    match_related: ResourceSpecification = Field(
+        default_factory=lambda: ResourceSpecification(__root__={}),
+        description="Labels for related resources which this Automation will match.",
+    )
+
+    after: set[str] = Field(
+        default_factory=set,
+        description=(
+            "The event(s) which must first been seen to start this automation.  If "
+            "empty, then start this Automation immediately.  Events may include "
+            "trailing wildcards, like `prefect.flow-run.*`"
+        ),
+    )
+    expect: set[str] = Field(
+        default_factory=set,
+        description=(
+            "The event(s) this automation is expecting to see.  If empty, this "
+            "automation will match any event.  Events may include trailing wildcards, "
+            "like `prefect.flow-run.*`"
+        ),
+    )
+
+    for_each: set[str] = Field(
+        default_factory=set,
+        description=(
+            "Evalute the Automation separately for each distinct value of these labels "
+            "on the resource"
+        ),
+    )
+    posture: Posture = Field(
+        Posture.Reactive,
+        description=(
+            "The posture of this Automation, either Reactive or Proactive.  Reactive "
+            "automations respond to the _presence_ of the expected events, while "
+            "Proactive  automations respond to the _absence_ of those expected events."
+        ),
+    )
+    threshold: int = Field(
+        1,
+        description=(
+            "The number of events required for this Automation to trigger (for "
+            "Reactive automations), or the number of events expected (for Proactive "
+            "automations)"
+        ),
+    )
+    within: timedelta = Field(
+        timedelta(0),
+        minimum=0.0,
+        exclusiveMinimum=False,
+        description=(
+            "The time period over which the events must occur.  For Reactive triggers, "
+            "this may be as low as 0 seconds, but must be at least 10 seconds for "
+            "Proactive triggers"
+        ),
+    )
+
+    @validator("within")
+    def enforce_minimum_within(
+        cls, value: timedelta, values, config, field: ModelField
+    ):
+        minimum = field.field_info.extra["minimum"]
+        if value.total_seconds() < minimum:
+            raise ValueError("The minimum within is 0 seconds")
+        return value
+
+    @root_validator(skip_on_failure=True)
+    def enforce_minimum_within_for_proactive_triggers(cls, values: dict[str, Any]):
+        posture: Posture | None = values.get("posture")
+        within: timedelta | None = values.get("within")
+
+        if posture == Posture.Proactive:
+            if not within or within == timedelta(0):
+                values["within"] = timedelta(seconds=10.0)
+            elif within < timedelta(seconds=10.0):
+                raise ValueError(
+                    "The minimum within for Proactive triggers is 10 seconds"
+                )
+
+        return values
+
+
+class Automation(PrefectBaseModel):
+    """Defines an action a user wants to take when a certain number of events
+    do or don't happen to the matching resources"""
+
+    class Config:
+        extra = Extra.ignore
+
+    name: str = Field(..., description="The name of this automation")
+    description: str = Field("", description="A longer description of this automation")
+
+    enabled: bool = Field(True, description="Whether this automation will be evaluated")
+
+    trigger: Trigger = Field(
+        ...,
+        description=(
+            "The criteria for which events this Automation covers and how it will "
+            "respond to the presence or absence of those events"
+        ),
+    )
+
+    actions: list[ActionTypes] = Field(
+        ...,
+        description="The actions to perform when this Automation triggers",
+    )
+    owner_resource: str | None = Field(
+        default=None, description="The owning resource of this automation"
+    )
+
+
+@copy_model_fields
+class ResourceTrigger(PrefectBaseModel):
+    name: str | None = Field(
+        None, description="The name to give to the automation created for this trigger."
+    )
+    description: str = FieldFrom(Automation)
+    enabled: bool = FieldFrom(Automation)
+
+    match: ResourceSpecification = FieldFrom(Trigger)
+    match_related: ResourceSpecification = FieldFrom(Trigger)
+    after: set[str] = FieldFrom(Trigger)
+    expect: set[str] = FieldFrom(Trigger)
+    for_each: set[str] = FieldFrom(Trigger)
+    posture: Posture = FieldFrom(Trigger)
+    threshold: int = FieldFrom(Trigger)
+    within: timedelta = FieldFrom(Trigger)
+
+    def as_automation(self) -> Automation:
+        assert self.name
+        return Automation(
+            name=self.name,
+            description=self.description,
+            enabled=self.enabled,
+            trigger=Trigger(
+                match=self.match,
+                match_related=self.match_related,
+                after=self.after,
+                expect=self.expect,
+                for_each=self.for_each,
+                posture=self.posture,
+                threshold=self.threshold,
+                within=self.within,
+            ),
+            actions=self.actions(),
+            owner_resource=self.owner_resource(),
+        )
+
+    def owner_resource(self) -> str | None:
+        return None
+
+    def actions(self) -> list[ActionTypes]:
+        raise NotImplementedError
+
+
+@copy_model_fields
+class DeploymentTrigger(ResourceTrigger):
+    _deployment_id: UUID | None = PrivateAttr(default=None)
+    parameters: dict[str, Any] | None = FieldFrom(RunDeployment)
+
+    def set_deployment_id(self, deployment_id: UUID):
+        self._deployment_id = deployment_id
+
+    def owner_resource(self) -> str | None:
+        return f"prefect.deployment.{self._deployment_id}"
+
+    def actions(self) -> list[ActionTypes]:
+        assert self._deployment_id
+        return [
+            RunDeployment(
+                parameters=self.parameters,
+                deployment_id=self._deployment_id,
+            )
+        ]

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -1,3 +1,4 @@
+import json
 import os
 import random
 import threading
@@ -14,6 +15,7 @@ import httpx
 import pendulum
 import pydantic
 import pytest
+import respx
 from fastapi import Depends, FastAPI, status
 from fastapi.security import HTTPBearer
 
@@ -29,6 +31,7 @@ from prefect.client.schemas.responses import (
 )
 from prefect.client.utilities import inject_client
 from prefect.deprecated.data_documents import DataDocument
+from prefect.events.schemas import Automation, Posture, Trigger
 from prefect.server.api.server import SERVER_API_VERSION, create_app
 from prefect.client.schemas.actions import (
     ArtifactCreate,
@@ -1798,6 +1801,65 @@ class TestVariables:
         res = await prefect_client.read_variables(limit=1)
         assert len(res) == 1
         assert res[0].name == variables[0].name
+
+
+class TestAutomations:
+    @pytest.fixture
+    def automation(self):
+        return Automation(
+            name="test-automation",
+            trigger=Trigger(
+                match={"flow_run_id": "123"},
+                posture=Posture.Reactive,
+                threshold=1,
+                within=0,
+            ),
+            actions=[],
+        )
+
+    async def test_create_not_cloud_runtime_error(
+        self, prefect_client, automation: Automation
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match="Automations are only supported for Prefect Cloud.",
+        ):
+            await prefect_client.create_automation(automation)
+
+    async def test_create_automation(self, cloud_client, automation: Automation):
+        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+            created_automation = automation.dict(json_compatible=True)
+            created_automation["id"] = str(uuid4())
+            create_route = router.post("/automations/").mock(
+                return_value=httpx.Response(200, json=created_automation)
+            )
+
+            automation_id = await cloud_client.create_automation(automation)
+
+            assert create_route.called
+            assert json.loads(create_route.calls[0].request.content) == automation.dict(
+                json_compatible=True
+            )
+            assert automation_id == UUID(created_automation["id"])
+
+    async def test_delete_owned_automations_not_cloud_runtime_error(
+        self, prefect_client
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match="Automations are only supported for Prefect Cloud.",
+        ):
+            resource_id = f"prefect.deployment.{uuid4()}"
+            await prefect_client.delete_resource_owned_automations(resource_id)
+
+    async def test_delete_owned_automations(self, cloud_client):
+        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+            resource_id = f"prefect.deployment.{uuid4()}"
+            delete_route = router.delete(f"/automations/owned-by/{resource_id}").mock(
+                return_value=httpx.Response(204)
+            )
+            await cloud_client.delete_resource_owned_automations(resource_id)
+            assert delete_route.called
 
 
 async def test_server_error_does_not_raise_on_client():

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -2,13 +2,20 @@ import pytest
 
 from prefect import flow
 from prefect.blocks.core import Block
-from prefect.client.orchestration import get_client
+from prefect.client.orchestration import PrefectClient, get_client
+from prefect.settings import PREFECT_CLOUD_API_URL
 
 
 @pytest.fixture
 async def prefect_client(test_database_connection_url):
     async with get_client() as client:
         yield client
+
+
+@pytest.fixture
+async def cloud_client(prefect_client):
+    async with PrefectClient(PREFECT_CLOUD_API_URL.value()) as cloud_client:
+        yield cloud_client
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This adds support for users defining triggers as part of their deployment specification. The spec for the triggers is an abbreviated form of the full Automation specification and results in an implicit `RunDeployment` action for the deployment that they're creating. It uses a wipe and create mechanism to ensure that duplicate automations are not created. 

Closes #9883 


### Example
```
name: my-deployment
...
triggers:
  - enabled: true
    match:
      prefect.resource.id: prefect.flow-run.*
    expect:
      - prefect.flow-run.Completed
    match_related:
      prefect.resource.id: prefect.flow.<uuid>
      prefect.resource.role: flow
    parameters:
      fast: true
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
