### PR TITLE
Deprecate project deployment via `—flow/-f`

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -394,9 +394,9 @@ async def _run_single_deploy(
     elif flow_name:
         app.console.print(
             generate_deprecation_message(
-                "The `prefect deploy --flow/-f` command",
+                "The ability to deploy by flow name",
                 end_date="Jun 2023",
-                help="Use `prefect deploy` to specify an entrypoint instead.",
+                help="\nUse `prefect deploy` to specify an entrypoint instead.",
             )
         )
         prefect_dir = find_prefect_directory()

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -396,7 +396,7 @@ async def _run_single_deploy(
             generate_deprecation_message(
                 "The `prefect deploy --flow/-f` command",
                 end_date="Jun 2023",
-                help="Use `prefect deploy` instead.",
+                help="Use `prefect deploy` to specify an entrypoint instead.",
             )
         )
         prefect_dir = find_prefect_directory()

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -47,6 +47,8 @@ from prefect.utilities.slugify import slugify
 
 from prefect.client.orchestration import PrefectClient
 
+from prefect._internal.compatibility.deprecated import generate_deprecation_message
+
 
 @app.command()
 async def deploy(
@@ -390,6 +392,13 @@ async def _run_single_deploy(
                 )
         flow_name = flow.name
     elif flow_name:
+        app.console.print(
+            generate_deprecation_message(
+                "The `prefect deploy --flow/-f` command",
+                end_date="Jun 2023",
+                help="Use `prefect deploy` instead.",
+            )
+        )
         prefect_dir = find_prefect_directory()
         if not prefect_dir:
             raise ValueError(

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -396,7 +396,10 @@ async def _run_single_deploy(
             generate_deprecation_message(
                 "The ability to deploy by flow name",
                 end_date="Jun 2023",
-                help="\nUse `prefect deploy` to specify an entrypoint instead.",
+                help=(
+                    "\nUse `prefect deploy ./path/to/file.py:flow_fn_name` to specify"
+                    " an entrypoint instead."
+                ),
             )
         )
         prefect_dir = find_prefect_directory()

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -1212,6 +1212,56 @@ class TestProjectDeploy:
         assert deployment.work_pool_name == "test-created-via-deploy"
         assert deployment.entrypoint == "./flows/hello.py:my_flow"
 
+    async def test_project_deploy_with_flow_name_generate_deprecation_warning(
+        self, project_dir_with_single_deployment_format, prefect_client, work_pool
+    ):
+        await register_flow("flows/hello.py:my_flow")
+        create_default_deployment_yaml(".")
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
+            deploy_config = yaml.safe_load(f)
+
+        deploy_config["name"] = "test-name"
+        deploy_config["flow_name"] = "An important name"
+        deploy_config["work_pool"]["name"] = work_pool.name
+
+        with deployment_file.open(mode="w") as f:
+            yaml.safe_dump(deploy_config, f)
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command="deploy",
+            expected_code=0,
+            expected_output_contains=(
+                "The `prefect deploy --flow/-f` command has been deprecated"
+            ),
+        )
+
+    async def test_project_deploy_with_explicit_flow_name_flag_generates_deprecation_warning(
+        self, project_dir_with_single_deployment_format, prefect_client, work_pool
+    ):
+        await register_flow("flows/hello.py:my_flow")
+        create_default_deployment_yaml(".")
+        deployment_file = Path("deployment.yaml")
+        with deployment_file.open(mode="r") as f:
+            deploy_config = yaml.safe_load(f)
+
+        deploy_config["name"] = "test-name"
+        deploy_config["flow_name"] = "An important name"
+        deploy_config["work_pool"]["name"] = work_pool.name
+
+        with deployment_file.open(mode="w") as f:
+            yaml.safe_dump(deploy_config, f)
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command="deploy -f 'An important name'",
+            expected_code=0,
+            expected_output_contains=(
+                "The `prefect deploy --flow/-f` command has been deprecated"
+            ),
+        )
+
 
 class TestSchedules:
     async def test_passing_cron_schedules_to_deploy(

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -1233,7 +1233,7 @@ class TestProjectDeploy:
             command="deploy",
             expected_code=0,
             expected_output_contains=(
-                "The `prefect deploy --flow/-f` command has been deprecated"
+                "The ability to deploy by flow name has been deprecated"
             ),
         )
 
@@ -1258,7 +1258,7 @@ class TestProjectDeploy:
             command="deploy -f 'An important name'",
             expected_code=0,
             expected_output_contains=(
-                "The `prefect deploy --flow/-f` command has been deprecated"
+                "The ability to deploy by flow name has been deprecated"
             ),
         )
 


### PR DESCRIPTION
### Overview 
This PR adds a deprecation warning when using `deploy` with a flow name by `--flow/-f`.

It is the first step towards removal of ability to deploy via flow name, which will occur when deployment ux leaves beta. See the draft PR for that at https://github.com/PrefectHQ/prefect/pull/9881.

### Example
```bash
❯ prefect deploy -f my-deployment
08:17:37.571 | DEBUG   | prefect.profiles - Using profile 'local_sqlite'
08:17:38.802 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////Users/bean/.prefect/prefect.db
The `prefect deploy --flow/-f` command has been deprecated. It will not be available after Jun 2023. 
Use `prefect deploy` to specify an entrypoint instead.
? Would you like to schedule when this flow runs? [y/n] (y): 
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
