### PR TITLE
Fix bug where attribute error raised on service shutdown when the app startup fails

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -499,7 +499,7 @@ def create_app(
 
     async def stop_services():
         """Ensure services are stopped before the Prefect REST API shuts down."""
-        if app.state.services:
+        if hasattr(app.state, "services") and app.state.services:
             await asyncio.gather(*[service.stop() for service in app.state.services])
             try:
                 await asyncio.gather(


### PR DESCRIPTION
If application startup fails before services are created, the `services` item is missing from the application state and another exception is added to the traceback

```python
  File "/opt/homebrew/Caskroom/miniforge/base/envs/prefect_env/lib/python3.10/site-packages/prefect/server/api/server.py", line 520, in lifespan
    await stop_services()
  File "/opt/homebrew/Caskroom/miniforge/base/envs/prefect_env/lib/python3.10/site-packages/prefect/server/api/server.py", line 502, in stop_services
    if app.state.services:
  File "/opt/homebrew/Caskroom/miniforge/base/envs/prefect_env/lib/python3.10/site-packages/starlette/datastructures.py", line 705, in __getattr__
    raise AttributeError(message.format(self.__class__.__name__, key))
AttributeError: 'State' object has no attribute 'services'
```

This is confusing for users and easy to avoid by checking for the presence of the attribute before shutdown.