### PR TITLE
Add additional user profile info to docs

### DIFF
--- a/docs/cloud/users/index.md
+++ b/docs/cloud/users/index.md
@@ -13,7 +13,7 @@ tags:
 Users can access their account in the [profile menu](https://app.prefect.cloud/my/profile), including:
 
 - Profile: Viewing and editing basic information, such as name.
-- API keys: Creating [API keys](/cloud/users/api-keys/) for connecting Prefect Cloud to their local development environment.
+- API keys: Creating [API keys](/cloud/users/api-keys/) for connecting Prefect Cloud to other environments.
 - Billing: Entering payment information, for adding additional collaborators, workspaces, or creating an [Organization](/cloud/organizations/).
 - Preferences: Managing settings, such as color mode and default time zone.
 

--- a/docs/cloud/users/index.md
+++ b/docs/cloud/users/index.md
@@ -9,6 +9,15 @@ tags:
 
 *Users* in Prefect Cloud are profiles for individuals created by signing up at [app.prefect.cloud](https://app.prefect.cloud). Each user has their own personal account, and they can also be added as a Member of other [Organizations](/cloud/organizations/) and [Workspaces](/cloud/workspaces/).
 
+## User Settings
+Users can access their settings in the [profile menu](https://app.prefect.cloud/my/profile), including:
+
+- Profile: Viewing and editing basic information like account handle.
+- API keys: Creating [API keys](/cloud/users/api-keys/) for connecting Prefect Cloud to their local development environment.
+- Billing: Entering payment information, for adding additional collaborators, workspaces, or creating an [Organization](/cloud/organizations/).
+- Preferences: Managing color mode and time zone information.
+
+## Roles
+
 Users can be granted [roles](/cloud/users/roles/) with their respective permission sets at the *Account* and *Workspace* levels. 
 
-Users can also create [API keys](/cloud/users/api-keys/) for connecting Prefect Cloud to their local development environment.

--- a/docs/cloud/users/index.md
+++ b/docs/cloud/users/index.md
@@ -10,7 +10,7 @@ tags:
 *Users* of Prefect Cloud are accounts for individuals created by signing up at [app.prefect.cloud](https://app.prefect.cloud). Users can also be added as a Member of other [Organizations](/cloud/organizations/) and [Workspaces](/cloud/workspaces/).
 
 ## User Settings
-Users can access their settings in the [profile menu](https://app.prefect.cloud/my/profile), including:
+Users can access their account in the [profile menu](https://app.prefect.cloud/my/profile), including:
 
 - Profile: Viewing and editing basic information like account handle.
 - API keys: Creating [API keys](/cloud/users/api-keys/) for connecting Prefect Cloud to their local development environment.

--- a/docs/cloud/users/index.md
+++ b/docs/cloud/users/index.md
@@ -7,7 +7,7 @@ tags:
 
 # Users <span class="badge cloud"></span>
 
-*Users* in Prefect Cloud are profiles for individuals created by signing up at [app.prefect.cloud](https://app.prefect.cloud). Each user has their own personal account, and they can also be added as a Member of other [Organizations](/cloud/organizations/) and [Workspaces](/cloud/workspaces/).
+*Users* of Prefect Cloud are accounts for individuals created by signing up at [app.prefect.cloud](https://app.prefect.cloud). Users can also be added as a Member of other [Organizations](/cloud/organizations/) and [Workspaces](/cloud/workspaces/).
 
 ## User Settings
 Users can access their settings in the [profile menu](https://app.prefect.cloud/my/profile), including:
@@ -15,7 +15,7 @@ Users can access their settings in the [profile menu](https://app.prefect.cloud/
 - Profile: Viewing and editing basic information like account handle.
 - API keys: Creating [API keys](/cloud/users/api-keys/) for connecting Prefect Cloud to their local development environment.
 - Billing: Entering payment information, for adding additional collaborators, workspaces, or creating an [Organization](/cloud/organizations/).
-- Preferences: Managing color mode and time zone information.
+- Preferences: Managing settings, such as color mode and default time zone.
 
 ## Roles
 

--- a/docs/cloud/users/index.md
+++ b/docs/cloud/users/index.md
@@ -12,7 +12,7 @@ tags:
 ## User Settings
 Users can access their account in the [profile menu](https://app.prefect.cloud/my/profile), including:
 
-- Profile: Viewing and editing basic information like account handle.
+- Profile: Viewing and editing basic information, such as name.
 - API keys: Creating [API keys](/cloud/users/api-keys/) for connecting Prefect Cloud to their local development environment.
 - Billing: Entering payment information, for adding additional collaborators, workspaces, or creating an [Organization](/cloud/organizations/).
 - Preferences: Managing settings, such as color mode and default time zone.


### PR DESCRIPTION


<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Adds user profile information to the Cloud Users landing page in docs, including what screens are behind the Profile page. This adds a direct link to the Profile page, which some users have a hard time finding.

### Example
<!-- 
Share an example of the change in action.
n/a
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x ] This pull request includes tests or only affects documentation.
- [no permission, but should be docs ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
