### PR TITLE
Deprecate `prefect project` CLI command group

### DIFF
--- a/src/prefect/cli/project.py
+++ b/src/prefect/cli/project.py
@@ -19,8 +19,14 @@ from prefect.projects import register_flow as register
 
 from prefect.projects.steps.core import run_steps
 
+# Deprecated compatibility
 project_app = PrefectTyper(
-    name="project", help="Commands for interacting with your Prefect project."
+    name="project",
+    help="Deprecated. Use `prefect init` instead.",
+    deprecated=True,
+    deprecated_name="prefect project",
+    deprecated_start_date="Jun 2023",
+    deprecated_help="Use `prefect` instead.",
 )
 app.add_typer(project_app, aliases=["projects"])
 
@@ -28,6 +34,13 @@ recipe_app = PrefectTyper(
     name="recipe", help="Commands for interacting with project recipes."
 )
 project_app.add_typer(recipe_app, aliases=["recipes"])
+
+init_app = PrefectTyper(
+    name="init",
+    help="Commands for initializing a new project.",
+)
+app.add_typer(init_app, aliases=["init"])
+init_app.add_typer(recipe_app, aliases=["recipes"])
 
 
 @recipe_app.command()
@@ -62,6 +75,7 @@ async def ls():
     app.console.print(table)
 
 
+@app.command()
 @project_app.command()
 async def init(
     name: str = None,

--- a/src/prefect/cli/project.py
+++ b/src/prefect/cli/project.py
@@ -3,7 +3,6 @@ Command line interface for working with projects.
 """
 from pathlib import Path
 from typing import List
-from prefect.cli._prompts import confirm
 from prefect._internal.compatibility.deprecated import generate_deprecation_message
 
 import typer
@@ -15,7 +14,7 @@ from prefect.cli._prompts import prompt_select_from_table
 import prefect
 from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error
-from prefect.cli.root import app
+from prefect.cli.root import app, is_interactive
 from prefect.client.orchestration import get_client
 from prefect.exceptions import ObjectNotFound
 from prefect.projects import find_prefect_directory, initialize_project
@@ -103,45 +102,40 @@ async def init(
         key, value = field.split("=")
         inputs[key] = value
 
-    if not recipe:
-        if confirm(
+    if not recipe or is_interactive():
+        recipe_paths = prefect.__module_path__ / "projects" / "recipes"
+        recipes = []
+
+        for r in recipe_paths.iterdir():
+            if r.is_dir() and (r / "prefect.yaml").exists():
+                with open(r / "prefect.yaml") as f:
+                    recipe_data = yaml.safe_load(f)
+                    recipe_name = r.name
+                    recipe_description = recipe_data.get(
+                        "description", "(no description available)"
+                    )
+                    recipe = {
+                        "name": recipe_name,
+                        "description": recipe_description,
+                    }
+                    recipes.append(recipe)
+
+        selected_recipe = prompt_select_from_table(
+            app.console,
             (
-                "You haven't specified a recipe. Would you like to see a list of"
-                " available recipes?"
+                "You haven't specified a deployment configuration recipe. Would you"
+                " like to see a list of available recipes?"
             ),
-            default=True,
-            console=app.console,
-        ):
-            recipe_paths = prefect.__module_path__ / "projects" / "recipes"
-            recipes = []
-
-            for r in recipe_paths.iterdir():
-                if r.is_dir() and (r / "prefect.yaml").exists():
-                    with open(r / "prefect.yaml") as f:
-                        recipe_data = yaml.safe_load(f)
-                        recipe_name = r.name
-                        recipe_description = recipe_data.get(
-                            "description", "(no description available)"
-                        )
-                        recipe = {
-                            "name": recipe_name,
-                            "description": recipe_description,
-                        }
-                        recipes.append(recipe)
-
-            selected_recipe = prompt_select_from_table(
-                app.console,
-                "",
-                columns=[
-                    {"header": "Name", "key": "name"},
-                    {"header": "Description", "key": "description"},
-                ],
-                data=recipes,
-                opt_out_message="No, I'll use the default deployment configuration.",
-                opt_out_response={},
-            )
-            if selected_recipe != {}:
-                recipe = selected_recipe["name"]
+            columns=[
+                {"header": "Name", "key": "name"},
+                {"header": "Description", "key": "description"},
+            ],
+            data=recipes,
+            opt_out_message="No, I'll use the default deployment configuration.",
+            opt_out_response={},
+        )
+        if selected_recipe != {}:
+            recipe = selected_recipe["name"]
 
     if recipe and (recipe_paths / recipe / "prefect.yaml").exists():
         with open(recipe_paths / recipe / "prefect.yaml") as f:

--- a/src/prefect/cli/project.py
+++ b/src/prefect/cli/project.py
@@ -102,7 +102,7 @@ async def init(
         key, value = field.split("=")
         inputs[key] = value
 
-    if not recipe or is_interactive():
+    if not recipe and is_interactive():
         recipe_paths = prefect.__module_path__ / "projects" / "recipes"
         recipes = []
 

--- a/src/prefect/cli/project.py
+++ b/src/prefect/cli/project.py
@@ -185,8 +185,8 @@ async def init(
     except ValueError as exc:
         if "Unknown recipe" in str(exc):
             exit_with_error(
-                f"Unknown recipe {recipe!r} provided - run [yellow]`prefect project"
-                " recipe ls`[/yellow] to see all available recipes."
+                f"Unknown recipe {recipe!r} provided - run [yellow]`prefect init"
+                "`[/yellow] to see all available recipes."
             )
         else:
             raise

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -87,17 +87,19 @@ class TestProjectInit:
     def test_project_init(self):
         with TemporaryDirectory() as tempdir:
             result = invoke_and_assert(
-                "project init --name test_project", temp_dir=str(tempdir)
+                "init --name test_project ", temp_dir=str(tempdir), user_input="n"
             )
             assert result.exit_code == 0
             for file in ["prefect.yaml", "deployment.yaml", ".prefectignore"]:
                 # temp_dir creates a *new* nested temporary directory within tempdir
                 assert any(Path(tempdir).rglob(file))
 
-    def test_project_init_with_recipe(self):
+    def test_project_init_with_recipe_x(self):
         with TemporaryDirectory() as tempdir:
             result = invoke_and_assert(
-                "project init --name test_project --recipe local", temp_dir=str(tempdir)
+                "init --name test_project --recipe local",
+                temp_dir=str(tempdir),
+                user_input="n",
             )
             assert result.exit_code == 0
 
@@ -105,7 +107,7 @@ class TestProjectInit:
     def test_project_init_with_interactive_recipe(self):
         with TemporaryDirectory() as tempdir:
             invoke_and_assert(
-                "project init --name test_project --recipe docker",
+                "init --name test_project --recipe docker",
                 expected_code=0,
                 temp_dir=str(tempdir),
                 user_input="my-image/foo"
@@ -138,7 +140,7 @@ class TestProjectInit:
     def test_project_init_with_partial_interactive_recipe(self):
         with TemporaryDirectory() as tempdir:
             invoke_and_assert(
-                "project init --name test_project --recipe docker --field tag=my-tag",
+                "init --name test_project --recipe docker --field tag=my-tag",
                 expected_code=0,
                 temp_dir=str(tempdir),
                 user_input="my-image/foo" + readchar.key.ENTER,
@@ -167,7 +169,7 @@ class TestProjectInit:
         with TemporaryDirectory() as tempdir:
             invoke_and_assert(
                 (
-                    "project init --name test_project --recipe docker --field"
+                    "init --name test_project --recipe docker --field"
                     " tag=my-tag --field image_name=my-image/foo"
                 ),
                 expected_code=0,
@@ -201,11 +203,11 @@ class TestProjectInit:
 
     def test_project_init_with_unknown_recipe(self):
         result = invoke_and_assert(
-            "project init --name test_project --recipe def-not-a-recipe",
+            "init --name test_project --recipe def-not-a-recipe",
             expected_code=1,
         )
         assert result.exit_code == 1
-        assert "prefect project recipe ls" in result.output
+        assert "prefect init" in result.output
 
 
 class TestProjectClone:

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -94,7 +94,7 @@ class TestProjectInit:
                 # temp_dir creates a *new* nested temporary directory within tempdir
                 assert any(Path(tempdir).rglob(file))
 
-    def test_project_init_with_recipe_x(self):
+    def test_project_init_with_recipe(self):
         with TemporaryDirectory() as tempdir:
             result = invoke_and_assert(
                 "init --name test_project --recipe local",

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -87,7 +87,7 @@ class TestProjectInit:
     def test_project_init(self):
         with TemporaryDirectory() as tempdir:
             result = invoke_and_assert(
-                "init --name test_project ", temp_dir=str(tempdir), user_input="n"
+                "init --name test_project", temp_dir=str(tempdir)
             )
             assert result.exit_code == 0
             for file in ["prefect.yaml", "deployment.yaml", ".prefectignore"]:
@@ -99,7 +99,6 @@ class TestProjectInit:
             result = invoke_and_assert(
                 "init --name test_project --recipe local",
                 temp_dir=str(tempdir),
-                user_input="n",
             )
             assert result.exit_code == 0
 


### PR DESCRIPTION
## Overview

- Deprecates `prefect project init`
- Deprecates `prefect project recipe ls`
- Deprecates `prefect project clone`

There will be a follow-up PR to deprecate the `projects` module and rename the `git_clone_project` step.

## Examples
`prefect project init`
```bash
❯ prefect project
16:03:11.382 | DEBUG   | prefect.profiles - Using profile 'local_sqlite'
                                                                                                                                                              
 Usage: prefect project [OPTIONS] COMMAND [ARGS]...                                                                                                           
                                                                                                                                                              
 Deprecated. Use `prefect init` instead.                                                                                                                      
                                                                                                                                                              
╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --help          Show this message and exit.                                                                                                                │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ clone                              Clone an existing project for a given deployment.                                                                       │
│ init                               Initialize a new project.                                                                                               │
│ recipe                             Commands for interacting with project recipes.                                                                          │
│ register-flow                      Register a flow with this project.     
```
`prefect project clone`
```bash
❯ prefect project clone --id a
16:05:37.747 | DEBUG   | prefect.profiles - Using profile 'local_sqlite'
WARNING: The 'prefect project' command group has been deprecated. It will not be available after Dec 2023. Use `prefect` instead.
The `prefect project clone` command has been deprecated. It will not be available after Dec 2023.
...
```
`prefect project recipe ls`
```bash
❯ prefect project recipe ls
19:44:02.725 | DEBUG   | prefect.profiles - Using profile 'local_sqlite'
WARNING: The 'prefect project recipe' command group has been deprecated. It will not be available after Dec 2023. Use `prefect init` instead.
                                    Available project recipes     
...    
```

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
