### PR TITLE
make more sqlite locking retryable

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -87,6 +87,8 @@ API_ROUTERS = (
     api.root.router,
 )
 
+SQLITE_LOCKED_MSG = "database is locked"
+
 
 class SPAStaticFiles(StaticFiles):
     """
@@ -157,7 +159,7 @@ def is_client_retryable_exception(exc: Exception):
         if getattr(exc.orig, "sqlite_errorname", None) in {
             "SQLITE_BUSY",
             "SQLITE_BUSY_SNAPSHOT",
-        }:
+        } or SQLITE_LOCKED_MSG in getattr(exc.orig, "args", []):
             return True
         else:
             # Avoid falling through to the generic `DBAPIError` case below


### PR DESCRIPTION
closes: https://github.com/PrefectHQ/prefect/issues/9923

SQLite transaction behavior was improved in https://github.com/PrefectHQ/prefect/pull/9594. A consequence of this is that in order to guarantee the expected behavior, the database must be locked for certain operations. In order to respect this without erroring, the API will send a 503 to tell the client to retry later if the database is locked.

The original pr covered the main locked cases, where a `SQLITE_BUSY` or `SQLITE_BUSY_SNAPSHOT` was being raised by sqlite and attached as the original exception when `sqlalchemy` would raise `sqlalchemy.exc.OperationalError`.

There appears more cases involving concurrent access where `sqlite3` will raise `sqlite3.OperationalError("database is locked")` with no attached original exception. I could not determine the root cause of this but it seems like `sqlite3` is only optionally passing the original sqlite error names back up.

This pr adds this "generic" locked case to the function that determines a retry-able exception. 

### Example
```
from prefect.client.orchestration import get_client
from prefect.client.schemas.actions import WorkPoolCreate
import asyncio

async def main():
    async with get_client() as client:
        await asyncio.gather(*[client.create_work_pool(WorkPoolCreate(name=f"work-pool-{i}")) for i in range(20)])
        work_pools = await client.read_work_pools()
        await asyncio.gather(*[client.delete_work_pool(work_pool.name) for work_pool in work_pools])

if __name__ == '__main__':
    asyncio.run(main())
```

### Pre change:
```
prefect.exceptions.PrefectHTTPStatusError: Server error '500 Internal Server Error' for url 'http://ephemeral-prefect/api/work_pools/work-pool-11'
Response: {'exception_message': 'Internal Server Error'}
For more information check: https://httpstatuses.com/500
```
### Post change:
```
09:40:41.602 | DEBUG   | prefect.client - Received response with retryable status code 503. Another attempt will be made in 1.7550290977850425s. This is attempt 1/6.
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
