### PR TITLE
Upgrade docker image to use Debian 12 bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG NODE_VERSION=16.15
 ARG EXTRA_PIP_PACKAGES=""
 
 # Build the UI distributable.
-FROM node:${NODE_VERSION}-bullseye-slim as ui-builder
+FROM node:${NODE_VERSION}-bookworm-slim as ui-builder
 
 WORKDIR /opt/ui
 


### PR DESCRIPTION
### Example

Upgrades from Debian 11 to Debian 12 for the node image.
The python docker image was already changed this night to use Debian 12 instead of 11.

e.g. [3.10.12-slim-bookworm, 3.10-slim-bookworm, 3.10.12-slim, 3.10-slim](https://github.com/docker-library/python/blob/5d908b0477c003712550c84ac4d133367b912f78/3.10/slim-bookworm/Dockerfile) are all the same.

### Checklist
- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.