### PR TITLE
Add prompt to save inputs to interactive `prefect deploy` command

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ pytz >= 2021.1
 pyyaml >= 5.4.1
 readchar >= 4.0.0
 rich >= 11.0
+ruamel.yaml >= 0.17.0
 sqlalchemy[asyncio] >= 1.4.22, != 1.4.33
 toml >= 0.10.0
 typer >= 0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ pytz >= 2021.1
 pyyaml >= 5.4.1
 readchar >= 4.0.0
 rich >= 11.0
-ruamel.yaml >= 0.17.0
+ruamel-yaml >= 0.17.0
 sqlalchemy[asyncio] >= 1.4.22, != 1.4.33
 toml >= 0.10.0
 typer >= 0.4.2

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -258,7 +258,7 @@ async def deploy(
     except FileNotFoundError:
         deployments = project.get("deployments", [])
     try:
-        if len(deployments) > 1:
+        if len(deployments) >= 1:
             if deploy_all or len(names) > 1:
                 if any(options.values()):
                     app.console.print(
@@ -321,21 +321,13 @@ async def deploy(
                     options=options,
                     ci=ci,
                 )
-        elif len(deployments) <= 1:
-            if len(names) > 1:
-                exit_with_error(
-                    "Multiple deployment names were provided, but only one deployment"
-                    " configuration was found. Please provide a single deployment"
-                    " name."
-                )
-            else:
-                options["name"] = names[0] if names else None
-                await _run_single_deploy(
-                    base_deploy=deployments[0] if deployments else {},
-                    project=project,
-                    options=options,
-                    ci=ci,
-                )
+        else:
+            await _run_single_deploy(
+                base_deploy={},
+                project=project,
+                options=options,
+                ci=ci,
+            )
     except ValueError as exc:
         exit_with_error(str(exc))
 
@@ -645,7 +637,12 @@ async def _run_single_deploy(
         ),
         console=app.console,
     ):
-        _save_deployment_to_prefect_file(deploy_config)
+        _save_deployment_to_prefect_file(
+            deploy_config,
+            build_steps=build_steps or None,
+            push_steps=push_steps or None,
+            pull_steps=pull_steps or None,
+        )
         app.console.print(
             "Deployment configuration saved to prefect.yaml",
             style="green",

--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -415,6 +415,7 @@ def _save_deployment_to_prefect_file(
                 "pull": pull_steps,
             },
         )
+        create_default_ignore_file(".")
     else:
         # use ruamel.yaml to preserve comments
         ryaml = YAML()

--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -430,8 +430,11 @@ def _save_deployment_to_prefect_file(
         if pull_steps != parsed_prefect_file_contents.get("pull"):
             deployment["pull"] = build_steps
 
-        deployments = parsed_prefect_file_contents.get("deployments", [])
-        deployments.append(deployment)
+        deployments = parsed_prefect_file_contents.get("deployments")
+        if deployments is None:
+            parsed_prefect_file_contents["deployments"] = [deployment]
+        else:
+            deployments.append(deployment)
 
         with prefect_file.open(mode="w") as f:
             ryaml.dump(parsed_prefect_file_contents, f)

--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -90,7 +90,9 @@ def create_default_prefect_yaml(
     with prefect_file.open(mode="w") as f:
         # write header
         f.write(
-            "# File for configuring project / deployment build, push and pull steps\n\n"
+            "# Welcome to your prefect.yaml file! You can you this file for storing and"
+            " managing\n# configuration for deploying your flows. We recommend"
+            " committing this file to source\n# control along with your flow code.\n\n"
         )
 
         f.write("# Generic metadata about this project\n")

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -52,7 +52,6 @@ def project_dir(tmp_path):
         prefect_home = tmp_path / ".prefect"
         prefect_home.mkdir(exist_ok=True, mode=0o0700)
         os.chdir(tmp_path)
-        print(os.getcwd())
         initialize_project()
         yield tmp_path
     else:

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -52,6 +52,7 @@ def project_dir(tmp_path):
         prefect_home = tmp_path / ".prefect"
         prefect_home.mkdir(exist_ok=True, mode=0o0700)
         os.chdir(tmp_path)
+        print(os.getcwd())
         initialize_project()
         yield tmp_path
     else:
@@ -476,7 +477,7 @@ class TestProjectDeploySingleDeploymentYAML:
         await run_sync_in_worker_thread(
             invoke_and_assert,
             command="deploy",
-            user_input="y" + readchar.key.ENTER,
+            user_input="y" + readchar.key.ENTER + "n" + readchar.key.ENTER,
             expected_code=0,
         )
 
@@ -606,7 +607,6 @@ class TestProjectDeploy:
                 }
             ]
 
-        @pytest.mark.usefixtures("interactive_console")
         async def test_project_deploy_with_no_prefect_yaml_git_repo_no_remote(
             self,
             work_pool,
@@ -648,8 +648,9 @@ class TestProjectDeploy:
                     f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
                     " --interval 60"
                 ),
-                # User rejects pulling from the remote repo
-                user_input="n" + readchar.key.ENTER,
+                # User rejects pulling from the remote repo and rejects saving the
+                # deployment configuration
+                user_input="n" + readchar.key.ENTER + "n" + readchar.key.ENTER,
                 expected_code=0,
             )
 
@@ -691,6 +692,9 @@ class TestProjectDeploy:
                     # Choose public repo
                     "n"
                     + readchar.key.ENTER
+                    # Accept saving the deployment configuration
+                    + "y"
+                    + readchar.key.ENTER
                 ),
                 expected_output_contains=[
                     "Would you like your workers to pull your flow code from its remote"
@@ -704,6 +708,16 @@ class TestProjectDeploy:
             assert deployment.pull_steps == [
                 {
                     "prefect.deployments.steps.git_clone": {
+                        "repository": "https://example.com/org/repo.git",
+                        "branch": "main",
+                    }
+                }
+            ]
+
+            prefect_file_contents = yaml.safe_load(Path("prefect.yaml").read_text())
+            assert prefect_file_contents["pull"] == [
+                {
+                    "prefect.projects.steps.git_clone": {
                         "repository": "https://example.com/org/repo.git",
                         "branch": "main",
                     }
@@ -746,6 +760,9 @@ class TestProjectDeploy:
                     +
                     # Choose public repo
                     "n"
+                    + readchar.key.ENTER
+                    # Decline saving the deployment configuration
+                    + "n"
                     + readchar.key.ENTER
                 ),
                 expected_output_contains=[
@@ -795,6 +812,9 @@ class TestProjectDeploy:
                     + readchar.key.ENTER
                     # Enter token
                     + "my-token"
+                    + readchar.key.ENTER
+                    # Decline saving the deployment configuration
+                    + "n"
                     + readchar.key.ENTER
                 ),
                 expected_output_contains=[
@@ -849,6 +869,7 @@ class TestProjectDeploy:
         with prefect_file.open(mode="r") as f:
             contents = yaml.safe_load(f)
 
+        contents["deployments"][0]["name"] = "test-name"
         contents["deployments"][0]["version"] = "{{ input }}"
         contents["deployments"][0]["tags"] = "{{ output2 }}"
         contents["deployments"][0]["description"] = "{{ output1 }}"
@@ -908,7 +929,7 @@ class TestProjectDeploy:
 
         await run_sync_in_worker_thread(
             invoke_and_assert,
-            command="deploy",
+            command="deploy -n test-name",
             expected_code=0,
             expected_output_contains="An important name/test-name",
         )
@@ -941,7 +962,7 @@ class TestProjectDeploy:
 
         await run_sync_in_worker_thread(
             invoke_and_assert,
-            command=f"deploy {option}",
+            command=f"deploy -n test-name {option}",
             expected_code=0,
             expected_output_contains="An important name/test-name",
         )
@@ -1020,7 +1041,7 @@ class TestProjectDeploy:
 
         await run_sync_in_worker_thread(
             invoke_and_assert,
-            command="deploy",
+            command="deploy -n test-name",
             expected_code=0,
             expected_output_contains="An important name/test-name",
         )
@@ -1040,7 +1061,7 @@ class TestProjectDeploy:
 
         await run_sync_in_worker_thread(
             invoke_and_assert,
-            command="deploy",
+            command="deploy -n test-name",
             expected_code=0,
             expected_output_contains="An important name/test-name",
         )
@@ -1061,7 +1082,7 @@ class TestProjectDeploy:
 
         await run_sync_in_worker_thread(
             invoke_and_assert,
-            command="deploy -f 'An important name' flows/hello.py:my_flow",
+            command="deploy -f 'An important name' -n test-name flows/hello.py:my_flow",
             expected_code=1,
             expected_output=(
                 "Received an entrypoint and a flow name for this deployment. Please"
@@ -1085,7 +1106,7 @@ class TestProjectDeploy:
 
         await run_sync_in_worker_thread(
             invoke_and_assert,
-            command="deploy",
+            command="deploy -n test-name",
             expected_code=1,
             expected_output_contains="An entrypoint or flow name must be provided.",
         )
@@ -1098,7 +1119,10 @@ class TestProjectDeploy:
                 f"deploy ./flows/hello.py:my_flow -p {work_pool.name} --interval 3600"
             ),
             expected_code=0,
-            user_input="test-prompt-name" + readchar.key.ENTER,
+            user_input="test-prompt-name"
+            + readchar.key.ENTER
+            + "n"
+            + readchar.key.ENTER,
             expected_output_contains=[
                 "Deployment name",
             ],
@@ -1131,7 +1155,7 @@ class TestProjectDeploy:
             invoke_and_assert,
             command="deploy ./flows/hello.py:my_flow -n test-name --interval 3600",
             expected_code=0,
-            user_input=readchar.key.ENTER,
+            user_input=readchar.key.ENTER + "n" + readchar.key.ENTER,
             expected_output_contains=[
                 "Which work pool would you like to deploy this flow to?",
             ],
@@ -1155,7 +1179,7 @@ class TestProjectDeploy:
                 f" {default_agent_pool.name}"
             ),
             expected_code=1,
-            expected_output=(
+            expected_output_contains=(
                 "Cannot create a project-style deployment with work pool of type"
                 " 'prefect-agent'. If you wish to use an agent with your deployment,"
                 " please use the `prefect deployment build` command."
@@ -1173,7 +1197,7 @@ class TestProjectDeploy:
                 f" {default_agent_pool.name} --interval 3600"
             ),
             expected_code=0,
-            user_input=readchar.key.ENTER,
+            user_input=readchar.key.ENTER + "n" + readchar.key.ENTER,
             expected_output_contains=[
                 (
                     "You've chosen a work pool with type 'prefect-agent' which cannot"
@@ -1207,6 +1231,9 @@ class TestProjectDeploy:
                 +
                 # Enter a name for the new work pool
                 "test-created-via-deploy"
+                + readchar.key.ENTER
+                # Decline save
+                + "n"
                 + readchar.key.ENTER
             ),
             expected_output_contains=[
@@ -1304,8 +1331,18 @@ class TestProjectDeploy:
         await run_sync_in_worker_thread(
             invoke_and_assert,
             command="deploy",
-            # accept migration
-            user_input="y" + readchar.key.ENTER,
+            user_input=(
+                # accept migration
+                "y"
+                + readchar.key.ENTER
+                +
+                # choose existing deployment configuration
+                readchar.key.ENTER
+                +
+                # accept save
+                "n"
+                + readchar.key.ENTER
+            ),
             expected_code=0,
             expected_output_contains=[
                 "Successfully copied your deployment configurations into your"
@@ -1349,6 +1386,7 @@ class TestSchedules:
         with prefect_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
+        deploy_config["deployments"][0]["name"] = "test-name"
         deploy_config["deployments"][0]["schedule"]["cron"] = "0 4 * * *"
         deploy_config["deployments"][0]["schedule"]["timezone"] = "America/Chicago"
 
@@ -1377,6 +1415,7 @@ class TestSchedules:
         with prefect_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
+        deploy_config["deployments"][0]["name"] = "test-name"
         deploy_config["deployments"][0]["schedule"]["cron"] = "0 4 * * *"
         deploy_config["deployments"][0]["schedule"]["timezone"] = "America/Chicago"
 
@@ -1425,6 +1464,7 @@ class TestSchedules:
         with prefect_yaml.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
 
+        deploy_config["deployments"][0]["name"] = "test-name"
         deploy_config["deployments"][0]["schedule"]["interval"] = 42
         deploy_config["deployments"][0]["schedule"]["anchor_date"] = "2040-02-02"
         deploy_config["deployments"][0]["schedule"]["timezone"] = "America/Chicago"
@@ -1529,7 +1569,7 @@ class TestSchedules:
             command="deploy ./flows/hello.py:my_flow -n test-name "
             + " ".join(schedules),
             expected_code=1,
-            expected_output="Only one schedule type can be provided.",
+            expected_output_contains=["Only one schedule type can be provided."],
         )
 
     @pytest.mark.usefixtures("interactive_console", "project_dir")
@@ -1558,6 +1598,9 @@ class TestSchedules:
                 +
                 # Enter valid interval
                 "42"
+                + readchar.key.ENTER
+                # Decline save
+                + "n"
                 + readchar.key.ENTER
             ),
             expected_code=0,
@@ -1602,6 +1645,10 @@ class TestSchedules:
                 +
                 # Select default timezone
                 readchar.key.ENTER
+                +
+                # Decline save
+                "n"
+                + readchar.key.ENTER
             ),
             expected_code=0,
             expected_output_contains=[
@@ -1646,6 +1693,10 @@ class TestSchedules:
                 +
                 # Select default timezone
                 readchar.key.ENTER
+                +
+                # Decline save
+                "n"
+                + readchar.key.ENTER
             ),
             expected_code=0,
         )
@@ -1668,6 +1719,9 @@ class TestSchedules:
             user_input=(
                 # Decline schedule creation
                 "n"
+                + readchar.key.ENTER
+                # Decline save
+                + "n"
                 + readchar.key.ENTER
             ),
             expected_code=0,
@@ -1952,10 +2006,12 @@ class TestMultiDeploy:
 
         with prefect_file.open(mode="w") as f:
             yaml.safe_dump(contents, f)
-        # Deploy the deployment with an invalid name
         await run_sync_in_worker_thread(
             invoke_and_assert,
-            command="deploy --name from-cli-name",
+            command=(
+                "deploy --name from-cli-name --pool"
+                f" {work_pool.name} ./flows/hello.py:my_flow"
+            ),
             expected_code=0,
             expected_output_contains=[
                 "Deployment 'An important name/from-cli-name' successfully created"
@@ -2165,7 +2221,7 @@ class TestMultiDeploy:
         # Deploy the deployment with a name
         await run_sync_in_worker_thread(
             invoke_and_assert,
-            command="deploy",
+            command="deploy -n test-name-1",
             expected_code=0,
             expected_output_contains=[
                 "An important name/test-name-1",
@@ -2306,7 +2362,7 @@ class TestMultiDeploy:
             expected_code=1,
             expected_output_contains=[
                 (
-                    "Discovered multiple deployment configurations, but"
+                    "Discovered one or more deployment configurations, but"
                     " no name was given. Please specify the name of at least one"
                     " deployment to create or update."
                 ),
@@ -2341,15 +2397,14 @@ class TestMultiDeploy:
             expected_code=1,
             expected_output_contains=[
                 (
-                    "Could not find deployment configuration with name "
-                    "'test-name-1'. Only CLI options "
-                    "will be used for this deployment."
+                    "Could not find deployment configuration with name 'test-name-1'."
+                    " Your flow will be deployed with a new deployment configuration."
                 ),
             ],
         )
 
     async def test_deploy_exits_with_single_deployment_and_multiple_names(
-        self, project_dir
+        self, project_dir, work_pool
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -2359,6 +2414,7 @@ class TestMultiDeploy:
             {
                 "name": "test-name-1",
                 "entrypoint": "./flows/hello.py:my_flow",
+                "work_pool": {"name": work_pool.name},
             }
         ]
 
@@ -2369,12 +2425,11 @@ class TestMultiDeploy:
         await run_sync_in_worker_thread(
             invoke_and_assert,
             command="deploy -n test-name-1 -n test-name-2",
-            expected_code=1,
+            expected_code=0,
             expected_output_contains=[
                 (
-                    "Multiple deployment names were provided, but only one deployment"
-                    " configuration was found. Please provide a single deployment"
-                    " name."
+                    "The following deployment(s) could not be found and will not be"
+                    " deployed: test-name-2"
                 ),
             ],
         )
@@ -2391,12 +2446,14 @@ class TestMultiDeploy:
             {
                 "name": "test-name-1",
                 "description": "test-description-1",
+                "entrypoint": "./flows/hello.py:my_flow",
                 "work_pool": {"name": work_pool.name},
                 "schedule": {"interval": 3600},
             },
             {
                 "name": "test-name-2",
                 "description": "test-description-2",
+                "entrypoint": "./flows/hello.py:my_flow",
                 "work_pool": {"name": work_pool.name},
                 "schedule": {"interval": 3600},
             },
@@ -2407,9 +2464,9 @@ class TestMultiDeploy:
 
         await run_sync_in_worker_thread(
             invoke_and_assert,
-            command="deploy ./flows/hello.py:my_flow",
+            command="deploy",
             expected_code=0,
-            user_input=readchar.key.ENTER,
+            user_input=readchar.key.ENTER + "n" + readchar.key.ENTER,
             expected_output_contains=[
                 "Would you like to use an existing deployment configuration?",
                 "test-name-1",
@@ -2484,3 +2541,266 @@ class TestMultiDeploy:
         assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
         assert config["deployments"][1]["schedule"] == {"interval": 3600}
         assert config["deployments"][1]["work_pool"]["name"] == work_pool.name
+
+
+@pytest.mark.usefixtures("interactive_console", "project_dir")
+class TestSaveUserInputs:
+    def test_save_user_inputs_no_existing_prefect_file(self):
+        prefect_file = Path("prefect.yaml")
+        prefect_file.unlink()
+        assert not prefect_file.exists()
+
+        invoke_and_assert(
+            command="deploy flows/hello.py:my_flow",
+            user_input=(
+                # Accept default deployment name
+                readchar.key.ENTER
+                +
+                # decline schedule
+                "n"
+                + readchar.key.ENTER
+                +
+                # accept create work pool
+                readchar.key.ENTER
+                +
+                # choose process work pool
+                readchar.key.ENTER
+                +
+                # enter work pool name
+                "inflatable"
+                + readchar.key.ENTER
+                +
+                # accept save user inputs
+                "y"
+                + readchar.key.ENTER
+            ),
+            expected_code=0,
+            expected_output_contains=[
+                (
+                    "Would you like to save configuration for this deployment for"
+                    " faster deployments in the future?"
+                ),
+                "Deployment configuration saved to prefect.yaml",
+            ],
+        )
+
+        assert prefect_file.exists()
+        with prefect_file.open(mode="r") as f:
+            config = yaml.safe_load(f)
+
+        assert len(config["deployments"]) == 1
+        assert config["deployments"][0]["name"] == "default"
+        assert config["deployments"][0]["entrypoint"] == "flows/hello.py:my_flow"
+        assert config["deployments"][0]["schedule"] is None
+        assert config["deployments"][0]["work_pool"]["name"] == "inflatable"
+
+    def test_save_user_inputs_existing_prefect_file(self):
+        prefect_file = Path("prefect.yaml")
+        assert prefect_file.exists()
+
+        invoke_and_assert(
+            command="deploy flows/hello.py:my_flow",
+            user_input=(
+                # Accept default deployment name
+                readchar.key.ENTER
+                +
+                # decline schedule
+                "n"
+                + readchar.key.ENTER
+                +
+                # accept create work pool
+                readchar.key.ENTER
+                +
+                # choose process work pool
+                readchar.key.ENTER
+                +
+                # enter work pool name
+                "inflatable"
+                + readchar.key.ENTER
+                +
+                # accept save user inputs
+                "y"
+                + readchar.key.ENTER
+            ),
+            expected_code=0,
+            expected_output_contains=[
+                (
+                    "Would you like to save configuration for this deployment for"
+                    " faster deployments in the future?"
+                ),
+                "Deployment configuration saved to prefect.yaml",
+            ],
+        )
+
+        with prefect_file.open(mode="r") as f:
+            config = yaml.safe_load(f)
+
+        assert len(config["deployments"]) == 2
+        assert config["deployments"][1]["name"] == "default"
+        assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
+        assert config["deployments"][1]["schedule"] is None
+        assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
+
+    def test_save_user_inputs_with_interval_schedule(self):
+        invoke_and_assert(
+            command="deploy flows/hello.py:my_flow",
+            user_input=(
+                # Accept default deployment name
+                readchar.key.ENTER
+                +
+                # accept schedule
+                readchar.key.ENTER
+                +
+                # select interval schedule
+                readchar.key.ENTER
+                +
+                # enter interval schedule
+                "3600"
+                + readchar.key.ENTER
+                +
+                # accept create work pool
+                readchar.key.ENTER
+                +
+                # choose process work pool
+                readchar.key.ENTER
+                +
+                # enter work pool name
+                "inflatable"
+                + readchar.key.ENTER
+                +
+                # accept save user inputs
+                "y"
+                + readchar.key.ENTER
+            ),
+            expected_code=0,
+            expected_output_contains=[
+                (
+                    "Would you like to save configuration for this deployment for"
+                    " faster deployments in the future?"
+                ),
+                "Deployment configuration saved to prefect.yaml",
+            ],
+        )
+
+        with open("prefect.yaml", mode="r") as f:
+            config = yaml.safe_load(f)
+
+        assert len(config["deployments"]) == 2
+        assert config["deployments"][1]["name"] == "default"
+        assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
+        assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
+        assert config["deployments"][1]["schedule"]["interval"] == 3600
+        assert config["deployments"][1]["schedule"]["timezone"] == "UTC"
+        assert config["deployments"][1]["schedule"]["anchor_date"] is not None
+
+    def test_save_user_inputs_with_cron_schedule(self):
+        invoke_and_assert(
+            command="deploy flows/hello.py:my_flow",
+            user_input=(
+                # Accept default deployment name
+                readchar.key.ENTER
+                +
+                # accept schedule
+                readchar.key.ENTER
+                +
+                # select cron schedule
+                readchar.key.DOWN
+                + readchar.key.ENTER
+                +
+                # enter cron schedule
+                "* * * * *"
+                + readchar.key.ENTER
+                +
+                # accept default timezone
+                readchar.key.ENTER
+                +
+                # accept create work pool
+                readchar.key.ENTER
+                +
+                # choose process work pool
+                readchar.key.ENTER
+                +
+                # enter work pool name
+                "inflatable"
+                + readchar.key.ENTER
+                +
+                # accept save user inputs
+                "y"
+                + readchar.key.ENTER
+            ),
+            expected_code=0,
+            expected_output_contains=[
+                (
+                    "Would you like to save configuration for this deployment for"
+                    " faster deployments in the future?"
+                ),
+                "Deployment configuration saved to prefect.yaml",
+            ],
+        )
+
+        with open("prefect.yaml", mode="r") as f:
+            config = yaml.safe_load(f)
+
+        assert len(config["deployments"]) == 2
+        assert config["deployments"][1]["name"] == "default"
+        assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
+        assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
+        assert config["deployments"][1]["schedule"]["cron"] == "* * * * *"
+        assert config["deployments"][1]["schedule"]["timezone"] == "UTC"
+        assert config["deployments"][1]["schedule"]["day_or"]
+
+    def test_save_user_inputs_with_rrule_schedule(self):
+        invoke_and_assert(
+            command="deploy flows/hello.py:my_flow",
+            user_input=(
+                # Accept default deployment name
+                readchar.key.ENTER
+                +
+                # accept schedule
+                readchar.key.ENTER
+                +
+                # select rrule schedule
+                readchar.key.DOWN
+                + readchar.key.DOWN
+                + readchar.key.ENTER
+                +
+                # enter rrule schedule
+                "FREQ=MINUTELY"
+                + readchar.key.ENTER
+                +
+                # accept default timezone
+                readchar.key.ENTER
+                +
+                # accept create work pool
+                readchar.key.ENTER
+                +
+                # choose process work pool
+                readchar.key.ENTER
+                +
+                # enter work pool name
+                "inflatable"
+                + readchar.key.ENTER
+                +
+                # accept save user inputs
+                "y"
+                + readchar.key.ENTER
+            ),
+            expected_code=0,
+            expected_output_contains=[
+                (
+                    "Would you like to save configuration for this deployment for"
+                    " faster deployments in the future?"
+                ),
+                "Deployment configuration saved to prefect.yaml",
+            ],
+        )
+
+        with open("prefect.yaml", mode="r") as f:
+            config = yaml.safe_load(f)
+
+        assert len(config["deployments"]) == 2
+        assert config["deployments"][1]["name"] == "default"
+        assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
+        assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
+        assert config["deployments"][1]["schedule"]["rrule"] == "FREQ=MINUTELY"
+        assert config["deployments"][1]["schedule"]["timezone"] == "UTC"

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -716,7 +716,7 @@ class TestProjectDeploy:
             prefect_file_contents = yaml.safe_load(Path("prefect.yaml").read_text())
             assert prefect_file_contents["pull"] == [
                 {
-                    "prefect.projects.steps.git_clone": {
+                    "prefect.deployments.steps.git_clone": {
                         "repository": "https://example.com/org/repo.git",
                         "branch": "main",
                     }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
This PR adds a prompt at the end of the interactive `prefect deploy` UX asking users if they want to save their deployment configuration for later use. If the user accepts, the CLI saves the inputs to the interactive CLI in the `prefect.yaml` file in the current working directory. If a `prefect.yaml` file does not exist, one is created in the current working directory with the user inputs and any generated `pull` steps. Users will be prompted to save only for new deployment configurations.

Closes #9858 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
[`prefect deploy` save prompt demo - Watch Video](https://www.loom.com/share/0a1ae32ad3c04085ba65e45b3e77d0e6)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
