### PR TITLE
Fix exception raised in `prefect init` command when no recipe is selected

### DIFF
--- a/src/prefect/cli/project.py
+++ b/src/prefect/cli/project.py
@@ -114,18 +114,15 @@ async def init(
                     recipe_description = recipe_data.get(
                         "description", "(no description available)"
                     )
-                    recipe_name = {
+                    recipe_dict = {
                         "name": recipe_name,
                         "description": recipe_description,
                     }
-                    recipes.append(recipe_name)
+                    recipes.append(recipe_dict)
 
         selected_recipe = prompt_select_from_table(
             app.console,
-            (
-                "You haven't specified a deployment configuration recipe. Would you"
-                " like to see a list of available recipes?"
-            ),
+            "Would you like to initialize your deployment configuration with a recipe?",
             columns=[
                 {"header": "Name", "key": "name"},
                 {"header": "Description", "key": "description"},

--- a/src/prefect/cli/project.py
+++ b/src/prefect/cli/project.py
@@ -114,11 +114,11 @@ async def init(
                     recipe_description = recipe_data.get(
                         "description", "(no description available)"
                     )
-                    recipe = {
+                    recipe_name = {
                         "name": recipe_name,
                         "description": recipe_description,
                     }
-                    recipes.append(recipe)
+                    recipes.append(recipe_name)
 
         selected_recipe = prompt_select_from_table(
             app.console,

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -235,6 +235,7 @@ class TestProjectInit:
             assert result.exit_code == 0
             assert any(Path(tempdir).rglob("prefect.yaml"))
 
+    @pytest.mark.usefixtures("interactive_console")
     def test_project_init_use_first_recipe(self):
         with TemporaryDirectory() as tempdir:
             result = invoke_and_assert(


### PR DESCRIPTION
Closes #9962 

Fix bug where `recipe` variable reassigned in loop

cc @discdiver 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
