### PR TITLE
Fix error in `prefect deploy` when `.prefect` folder is absent

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -420,6 +420,9 @@ async def _run_single_deploy(
                     "Could not find .prefect directory. Flow entrypoint will not be"
                     " registered."
                 )
+            flow = await run_sync_in_worker_thread(
+                load_flow_from_entrypoint, entrypoint
+            )
         flow_name = flow.name
     elif flow_name:
         app.console.print(
@@ -435,7 +438,7 @@ async def _run_single_deploy(
         prefect_dir = find_prefect_directory()
         if not prefect_dir:
             raise ValueError(
-                "No .prefect directory could be found - run [yellow]`prefect project"
+                "No .prefect directory could be found - run [yellow]`prefect"
                 " init`[/yellow] to create one."
             )
         if not (prefect_dir / "flows.json").exists():

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -1324,6 +1324,20 @@ class TestProjectDeploy:
         assert config["deployments"][0]["schedule"] == {"interval": 3600}
         assert config["deployments"][0]["work_pool"]["name"] == work_pool.name
 
+    @pytest.mark.usefixtures("project_dir")
+    async def test_deploy_with_entrypoint_does_not_fail_with_missing_prefect_folder(
+        self, work_pool
+    ):
+        Path(".prefect").rmdir()
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=f"deploy ./flows/hello.py:my_flow -n test-name -p {work_pool.name}",
+            expected_code=0,
+            expected_output_contains=[
+                "Deployment 'An important name/test-name' successfully created"
+            ],
+        )
+
 
 class TestSchedules:
     @pytest.mark.usefixtures("project_dir")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Fixes an error where `prefect deploy` would fail when a `.prefect` folder is not present in the current directory or any parent directory. We relied on `register_flow` to return a flow object, but it would raise a `FileNotFoundError` if it couldn't find a `.prefect` folder. Deploying via flow name is deprecated, so we are catching that `FileNotFoundError` to remove the requirement to have a `.prefect` folder. We need to make sure that we load the flow object when catching this exception to continue deployment.

Closes #9971

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
