### PR TITLE
Issue 9773: Default HTTPX  follow_redirects to true

### DIFF
--- a/src/prefect/client/cloud.py
+++ b/src/prefect/client/cloud.py
@@ -11,7 +11,11 @@ import prefect.settings
 from prefect.client.base import PrefectHttpxClient
 from prefect.client.schemas import Workspace
 from prefect.exceptions import PrefectException
-from prefect.settings import PREFECT_API_KEY, PREFECT_CLOUD_API_URL
+from prefect.settings import (
+    PREFECT_API_KEY,
+    PREFECT_CLOUD_API_URL,
+    PREFECT_UNIT_TEST_MODE,
+)
 
 
 def get_cloud_client(
@@ -57,7 +61,8 @@ class CloudClient:
         httpx_settings["headers"].setdefault("Authorization", f"Bearer {api_key}")
 
         httpx_settings.setdefault("base_url", host)
-        httpx_settings.setdefault("follow_redirects", True)
+        if not PREFECT_UNIT_TEST_MODE.value():
+            httpx_settings.setdefault("follow_redirects", True)
         self._client = PrefectHttpxClient(**httpx_settings)
 
     async def api_healthcheck(self):

--- a/src/prefect/client/cloud.py
+++ b/src/prefect/client/cloud.py
@@ -57,6 +57,7 @@ class CloudClient:
         httpx_settings["headers"].setdefault("Authorization", f"Bearer {api_key}")
 
         httpx_settings.setdefault("base_url", host)
+        httpx_settings.setdefault("follow_redirects", True)
         self._client = PrefectHttpxClient(**httpx_settings)
 
     async def api_healthcheck(self):

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -278,6 +278,7 @@ class PrefectClient:
             ),
         )
 
+        httpx_settings.setdefault("follow_redirects", True)
         self._client = PrefectHttpxClient(**httpx_settings)
         self._loop = None
 

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -99,6 +99,7 @@ from prefect.settings import (
     PREFECT_API_TLS_INSECURE_SKIP_VERIFY,
     PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
+    PREFECT_UNIT_TEST_MODE,
 )
 from prefect.utilities.collections import AutoEnum
 
@@ -278,7 +279,8 @@ class PrefectClient:
             ),
         )
 
-        httpx_settings.setdefault("follow_redirects", True)
+        if not PREFECT_UNIT_TEST_MODE:
+            httpx_settings.setdefault("follow_redirects", True)
         self._client = PrefectHttpxClient(**httpx_settings)
         self._loop = None
 

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -503,7 +503,7 @@ PREFECT_TEST_MODE = Setting(
     default=False,
 )
 """If `True`, places the API in test mode. This may modify
-behavior to faciliate testing. Defaults to `False`.
+behavior to facilitate testing. Defaults to `False`.
 """
 
 PREFECT_TEST_SETTING = Setting(
@@ -512,7 +512,7 @@ PREFECT_TEST_SETTING = Setting(
     value_callback=only_return_value_in_test_mode,
 )
 """
-This variable only exists to faciliate testing of settings.
+This variable only exists to facilitate testing of settings.
 If accessed when `PREFECT_TEST_MODE` is not set, `None` is returned.
 """
 
@@ -864,7 +864,7 @@ PREFECT_ASYNC_FETCH_STATE_RESULT = Setting(bool, default=False)
 """
 Determines whether `State.result()` fetches results automatically or not.
 In Prefect 2.6.0, the `State.result()` method was updated to be async
-to faciliate automatic retrieval of results from storage which means when 
+to facilitate automatic retrieval of results from storage which means when
 writing async code you must `await` the call. For backwards compatibility, 
 the result is not retrieved by default for async users. You may opt into this
 per call by passing  `fetch=True` or toggle this setting to change the behavior

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -510,7 +510,10 @@ PREFECT_UNIT_TEST_MODE = Setting(
     bool,
     default=False,
 )
-"""If `True`, code is executing in a unit test context. Defaults to `False`."""
+"""
+This variable only exists to facilitate unit testing. If `True`,
+code is executing in a unit test context. Defaults to `False`.
+"""
 
 PREFECT_TEST_SETTING = Setting(
     Any,

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -506,6 +506,12 @@ PREFECT_TEST_MODE = Setting(
 behavior to facilitate testing. Defaults to `False`.
 """
 
+PREFECT_UNIT_TEST_MODE = Setting(
+    bool,
+    default=False,
+)
+"""If `True`, code is executing in a unit test context. Defaults to `False`."""
+
 PREFECT_TEST_SETTING = Setting(
     Any,
     default=None,

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -39,43 +39,6 @@ def disable_jitter():
         yield
 
 
-def redirects(request: httpx.Request) -> httpx.Response:
-    """
-    Taken from:
-        https://github.com/encode/httpx/blob/master/tests/client/test_redirects.py
-    """
-    if request.url.path == "/redirect_301":
-        status_code = httpx.codes.MOVED_PERMANENTLY
-        content = b"<a href='https://example.org/'>here</a>"
-        headers = {"location": "https://example.org/"}
-        return httpx.Response(status_code, headers=headers, content=content)
-
-    elif request.url.path == "/redirect_302":
-        status_code = httpx.codes.FOUND
-        headers = {"location": "https://example.org/redirected_302"}
-        return httpx.Response(status_code, headers=headers)
-
-    elif request.url.path == "/redirect_303":
-        status_code = httpx.codes.SEE_OTHER
-        headers = {"location": "https://example.org/redirected_303"}
-        return httpx.Response(status_code, headers=headers)
-
-    elif request.url.path == "/redirect_307":
-        status_code = httpx.codes.TEMPORARY_REDIRECT
-        headers = {"location": "https://example.org/redirected_307"}
-        return httpx.Response(status_code, headers=headers)
-
-    elif request.url.path == "/redirect_308":
-        status_code = httpx.codes.PERMANENT_REDIRECT
-        headers = {"location": "https://example.org/redirected_308"}
-        return httpx.Response(status_code, headers=headers)
-
-    if request.method == "HEAD":
-        return httpx.Response(200)
-
-    return httpx.Response(200, html="<html><body>Hello, world!</body></html>")
-
-
 class TestPrefectHttpxClient:
     @pytest.mark.usefixtures("mock_anyio_sleep", "disable_jitter")
     @pytest.mark.parametrize(
@@ -507,38 +470,4 @@ class TestPrefectHttpxClient:
         with pytest.raises(PrefectHTTPStatusError) as exc:
             await client.post(url="fake.url/fake/route", data={"evenmorefake": "data"})
         expected = "Response: {'extra_info': [{'message': 'a test error message'}]}"
-        assert expected in str(exc)
-
-    @pytest.mark.parametrize(
-        "mock_redirects",
-        [
-            ["https://example.org/redirect_301", "https://example.org/"],
-            ["https://example.org/redirect_302", "https://example.org/redirected_302"],
-            ["https://example.org/redirect_307", "https://example.org/redirected_307"],
-            ["https://example.org/redirect_308", "https://example.org/redirected_308"],
-        ],
-    )
-    async def test_prefect_httpx_client_follow_redirect_true(self, mock_redirects):
-        mock_transport = httpx.MockTransport(redirects)
-        client = PrefectHttpxClient(follow_redirects=True, transport=mock_transport)
-        original_url, redirected_url = mock_redirects
-        response = await client.get(original_url)
-        assert response.url == redirected_url
-
-    @pytest.mark.parametrize(
-        "mock_redirects",
-        [
-            ["https://example.org/redirect_301", "301 Moved Permanently"],
-            ["https://example.org/redirect_302", "302 Found"],
-            ["https://example.org/redirect_307", "307 Temporary Redirect"],
-            ["https://example.org/redirect_308", "308 Permanent Redirect"],
-        ],
-    )
-    async def test_prefect_httpx_client_follow_redirect_false(self, mock_redirects):
-        mock_transport = httpx.MockTransport(redirects)
-        client = PrefectHttpxClient(follow_redirects=False, transport=mock_transport)
-        original_url, redirect_response = mock_redirects
-        with pytest.raises(PrefectHTTPStatusError) as exc:
-            await client.get(original_url)
-        expected = f"Redirect response '{redirect_response}' for url '{original_url}'"
         assert expected in str(exc)

--- a/tests/client/test_cloud_client.py
+++ b/tests/client/test_cloud_client.py
@@ -1,14 +1,21 @@
 from prefect.client.cloud import get_cloud_client
+from prefect.settings import PREFECT_UNIT_TEST_MODE, temporary_settings
 
 
-async def test_cloud_client_follow_redirects():
-    async with get_cloud_client() as client:
-        assert client._client.follow_redirects is True
-
+async def test_cloud_client_follow_redirects(monkeypatch):
     httpx_settings = {"follow_redirects": True}
     async with get_cloud_client(httpx_settings=httpx_settings) as client:
         assert client._client.follow_redirects is True
 
     httpx_settings = {"follow_redirects": False}
     async with get_cloud_client(httpx_settings=httpx_settings) as client:
+        assert client._client.follow_redirects is False
+
+    # follow redirects by default
+    with temporary_settings({PREFECT_UNIT_TEST_MODE: False}):
+        async with get_cloud_client() as client:
+            assert client._client.follow_redirects is True
+
+    # do not follow redirects by default during unit tests
+    async with get_cloud_client() as client:
         assert client._client.follow_redirects is False

--- a/tests/client/test_cloud_client.py
+++ b/tests/client/test_cloud_client.py
@@ -2,7 +2,7 @@ from prefect.client.cloud import get_cloud_client
 from prefect.settings import PREFECT_UNIT_TEST_MODE, temporary_settings
 
 
-async def test_cloud_client_follow_redirects(monkeypatch):
+async def test_cloud_client_follow_redirects():
     httpx_settings = {"follow_redirects": True}
     async with get_cloud_client(httpx_settings=httpx_settings) as client:
         assert client._client.follow_redirects is True

--- a/tests/client/test_cloud_client.py
+++ b/tests/client/test_cloud_client.py
@@ -1,0 +1,14 @@
+from prefect.client.cloud import get_cloud_client
+
+
+async def test_cloud_client_follow_redirects():
+    async with get_cloud_client() as client:
+        assert client._client.follow_redirects is True
+
+    httpx_settings = {"follow_redirects": True}
+    async with get_cloud_client(httpx_settings=httpx_settings) as client:
+        assert client._client.follow_redirects is True
+
+    httpx_settings = {"follow_redirects": False}
+    async with get_cloud_client(httpx_settings=httpx_settings) as client:
+        assert client._client.follow_redirects is False

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -1874,3 +1874,17 @@ async def test_server_error_does_not_raise_on_client():
     ) as client:
         with pytest.raises(prefect.exceptions.HTTPStatusError, match="500"):
             await client._client.get("/raise_error")
+
+
+async def test_prefect_client_follow_redirects():
+    app = create_app(ephemeral=True)
+    async with PrefectClient(api=app) as client:
+        assert client._client.follow_redirects is True
+
+    httpx_settings = {"follow_redirects": True}
+    async with PrefectClient(api=app, httpx_settings=httpx_settings) as client:
+        assert client._client.follow_redirects is True
+
+    httpx_settings = {"follow_redirects": False}
+    async with PrefectClient(api=app, httpx_settings=httpx_settings) as client:
+        assert client._client.follow_redirects is False

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -1217,6 +1217,7 @@ async def test_prefect_api_tls_insecure_skip_verify_setting_set_to_true(monkeypa
         transport=ANY,
         base_url=ANY,
         timeout=ANY,
+        follow_redirects=True,
     )
 
 
@@ -1231,6 +1232,7 @@ async def test_prefect_api_tls_insecure_skip_verify_setting_set_to_false(monkeyp
         transport=ANY,
         base_url=ANY,
         timeout=ANY,
+        follow_redirects=True,
     )
 
 
@@ -1243,6 +1245,7 @@ async def test_prefect_api_tls_insecure_skip_verify_default_setting(monkeypatch)
         transport=ANY,
         base_url=ANY,
         timeout=ANY,
+        follow_redirects=True,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ from prefect.settings import (
     PREFECT_MEMOIZE_BLOCK_AUTO_REGISTRATION,
     PREFECT_PROFILES_PATH,
     PREFECT_SERVER_ANALYTICS_ENABLED,
+    PREFECT_UNIT_TEST_MODE,
 )
 from prefect.utilities.dispatch import get_registry_for_type
 
@@ -309,6 +310,8 @@ def pytest_sessionstart(session):
             PREFECT_MEMOIZE_BLOCK_AUTO_REGISTRATION: False,
             # Disable auto-registration of block types as they can conflict
             PREFECT_API_BLOCKS_REGISTER_ON_START: False,
+            # Code is being executed in a unit test context
+            PREFECT_UNIT_TEST_MODE: True,
         },
         source=__file__,
     )


### PR DESCRIPTION
This is a first pass at the following issue:

closes https://github.com/PrefectHQ/prefect/issues/9773

This was the suggested course of action (see comment from @zanieb):
- [x] "Set this to `True` by default"
- [x] "Set this to `False` during test runs to ensure that we are not making calls to our API that require extra routing"
- [x] "I'm not sure if we need a dedicated `PREFECT_CLIENT_FOLLOW_REDIRECTS` setting. I'd rather not if feasible."
-- https://github.com/PrefectHQ/prefect/issues/9773#issuecomment-1568779492

**PS. I'm not familiar with the prefect codebase, just grabbed a few random issues tagged with `good first issue`, so review with extreme caution :)**

### Checklist
- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
