### PR TITLE
Issues 9939: Flow run submission failure should result in `Crashed` state

### DIFF
--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -448,11 +448,13 @@ class PrefectAgent:
         if ready_to_submit:
             try:
                 infrastructure = await self.get_infrastructure(flow_run)
-            except Exception as exc:
+            except Exception:
                 self.logger.exception(
                     f"Failed to get infrastructure for flow run '{flow_run.id}'."
                 )
-                await self._propose_failed_state(flow_run, exc)
+                await self._propose_crashed_state(
+                    flow_run, "Flow run could not be submitted to infrastructure"
+                )
                 if self.limiter:
                     self.limiter.release_on_behalf_of(flow_run.id)
             else:

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -37,7 +37,7 @@ from prefect.exceptions import (
 from prefect.infrastructure import Infrastructure, InfrastructureResult, Process
 from prefect.logging import get_logger
 from prefect.settings import PREFECT_AGENT_PREFETCH_SECONDS
-from prefect.states import Crashed, Pending, StateType, exception_to_failed_state
+from prefect.states import Crashed, Pending, StateType
 
 
 class PrefectAgent:
@@ -572,23 +572,6 @@ class PrefectAgent:
             return False
 
         return True
-
-    async def _propose_failed_state(self, flow_run: FlowRun, exc: Exception) -> None:
-        try:
-            await propose_state(
-                self.client,
-                await exception_to_failed_state(message="Submission failed.", exc=exc),
-                flow_run_id=flow_run.id,
-            )
-        except Abort:
-            # We've already failed, no need to note the abort but we don't want it to
-            # raise in the agent process
-            pass
-        except Exception:
-            self.logger.error(
-                f"Failed to update state of flow run '{flow_run.id}'",
-                exc_info=True,
-            )
 
     async def _propose_crashed_state(self, flow_run: FlowRun, message: str) -> None:
         try:


### PR DESCRIPTION
This is a first pass at the following issue:

closes https://github.com/PrefectHQ/prefect/issues/9939

This was the suggested course of action (see report from @chrisguidry):
- [x] "Following from https://github.com/PrefectHQ/prefect/issues/9523, we should make the same adjustment for Workers, where if a flow run can't be submitted to the infrastructure, then it would be regarded as Crashed rather than Failed."
-- https://github.com/PrefectHQ/prefect/issues/9939

**PS. I'm not familiar with the prefect codebase, just grabbed a few random issues tagged with `good first issue`, so review with extreme caution :)**

### Checklist
- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
