### PR TITLE
Switch token to access_token in cli wizard

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -934,7 +934,7 @@ async def _generate_default_pull_action(
         }
 
         if token_secret_block_name:
-            git_clone_step["prefect.deployments.steps.git_clone"]["token"] = (
+            git_clone_step["prefect.deployments.steps.git_clone"]["access_token"] = (
                 "{{ prefect.blocks.secret." + token_secret_block_name + " }}"
             )
 

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -830,7 +830,7 @@ class TestProjectDeploy:
                     "prefect.deployments.steps.git_clone": {
                         "repository": "https://example.com/org/repo.git",
                         "branch": "main",
-                        "token": (
+                        "access_token": (
                             "{{ prefect.blocks.secret.deployment-test-name-an-important-name-repo-token }}"
                         ),
                     }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Switches the input for the deployments git_clone pull step created by the cli wizard to access_token rather than token.  Using the cli I was getting the following error in my runs: `TypeError: git_clone() got an unexpected keyword argument 'token'`


### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
