### PR TITLE
Add prompt to `prefect deploy` to allow user to select from list of discovered flows

### DIFF
--- a/src/prefect/cli/_prompts.py
+++ b/src/prefect/cli/_prompts.py
@@ -102,17 +102,23 @@ def prompt_select_from_table(
         return table
 
     with Live(build_table(), auto_refresh=False, console=console) as live:
-        live.console.print(
+        instructions_message = (
             f"[bold][green]?[/] {prompt} [bright_blue][Use arrows to move; enter to"
-            " select][/]"
+            " select"
         )
+        if opt_out_message:
+            instructions_message += "; n to select none"
+        instructions_message += "]"
+        live.console.print(instructions_message)
         while selected_row is None:
             key = readchar.readkey()
 
             if key == readchar.key.UP:
                 current_idx = current_idx - 1
                 # wrap to bottom if at the top
-                if current_idx < 0:
+                if opt_out_message and current_idx < 0:
+                    current_idx = len(data)
+                elif not opt_out_message and current_idx < 0:
                     current_idx = len(data) - 1
             elif key == readchar.key.DOWN:
                 current_idx = current_idx + 1
@@ -129,6 +135,8 @@ def prompt_select_from_table(
                     return opt_out_response
                 else:
                     selected_row = data[current_idx]
+            elif key == "n" and opt_out_message:
+                return opt_out_response
 
             live.update(build_table(), refresh=True)
 

--- a/src/prefect/cli/_prompts.py
+++ b/src/prefect/cli/_prompts.py
@@ -126,7 +126,7 @@ def prompt_select_from_table(
                 exit_with_error("")
             elif key == readchar.key.ENTER or key == readchar.key.CR:
                 if current_idx >= len(data):
-                    selected_row = opt_out_response
+                    return opt_out_response
                 else:
                     selected_row = data[current_idx]
 
@@ -395,6 +395,7 @@ class EntrypointPrompt(PromptBase[str]):
                 f"[prompt.invalid]Failed to load flow from entrypoint {value!r}."
                 f" {self.validate_error_message}"
             )
+        return value
 
 
 async def prompt_entrypoint(console: Console) -> str:
@@ -421,5 +422,14 @@ async def prompt_entrypoint(console: Console) -> str:
             {"header": "Location", "key": "filepath"},
         ],
         data=discovered_flows,
+        opt_out_message="Enter a flow entrypoint manually",
     )
+    if selected_flow is None:
+        return EntrypointPrompt.ask(
+            (
+                "[bold][green]?[/] Flow entrypoint (expected format"
+                " path/to/file.py:function_name)"
+            ),
+            console=console,
+        )
     return f"{selected_flow['filepath']}:{selected_flow['function_name']}"

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -298,16 +298,16 @@ async def _run_single_deploy(
 
     if not deploy_config.get("flow_name") and not deploy_config.get("entrypoint"):
         if not is_interactive() and not ci:
-          raise ValueError(
-              "An entrypoint or flow name must be provided.\n\nDeploy a flow by"
-              " entrypoint:\n\n\t[yellow]prefect deploy"
-              " path/to/file.py:flow_function[/]\n\nDeploy a flow by"
-              " name:\n\n\t[yellow]prefect project register-flow"
-              " path/to/file.py:flow_function\n\tprefect deploy --flow"
-              " registered-flow-name[/]\n\nYou can also provide an entrypoint or flow"
-              " name in this project's prefect.yaml file."
-          )
-        entrypoint = await prompt_entrypoint(app.console)
+            raise ValueError(
+                "An entrypoint or flow name must be provided.\n\nDeploy a flow by"
+                " entrypoint:\n\n\t[yellow]prefect deploy"
+                " path/to/file.py:flow_function[/]\n\nDeploy a flow by"
+                " name:\n\n\t[yellow]prefect project register-flow"
+                " path/to/file.py:flow_function\n\tprefect deploy --flow"
+                " registered-flow-name[/]\n\nYou can also provide an entrypoint or flow"
+                " name in this project's prefect.yaml file."
+            )
+        deploy_config["entrypoint"] = await prompt_entrypoint(app.console)
     if deploy_config.get("flow_name") and deploy_config.get("entrypoint"):
         raise ValueError(
             "Received an entrypoint and a flow name for this deployment. Please provide"

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -21,6 +21,7 @@ from prefect.cli._prompts import (
     prompt_select_from_table,
     prompt_schedule,
     prompt_select_work_pool,
+    prompt_entrypoint,
 )
 from prefect.cli.root import app, is_interactive
 from prefect.client.schemas.schedules import (
@@ -406,15 +407,17 @@ async def _run_single_deploy(
         raise ValueError("Only one schedule type can be provided.")
 
     if not flow_name and not entrypoint:
-        raise ValueError(
-            "An entrypoint or flow name must be provided.\n\nDeploy a flow by"
-            " entrypoint:\n\n\t[yellow]prefect deploy"
-            " path/to/file.py:flow_function[/]\n\nDeploy a flow by"
-            " name:\n\n\t[yellow]prefect project register-flow"
-            " path/to/file.py:flow_function\n\tprefect deploy --flow"
-            " registered-flow-name[/]\n\nYou can also provide an entrypoint or flow"
-            " name in this project's prefect.yaml file."
-        )
+        if not is_interactive() and not ci:
+            raise ValueError(
+                "An entrypoint or flow name must be provided.\n\nDeploy a flow by"
+                " entrypoint:\n\n\t[yellow]prefect deploy"
+                " path/to/file.py:flow_function[/]\n\nDeploy a flow by"
+                " name:\n\n\t[yellow]prefect project register-flow"
+                " path/to/file.py:flow_function\n\tprefect deploy --flow"
+                " registered-flow-name[/]\n\nYou can also provide an entrypoint or flow"
+                " name in this project's prefect.yaml file."
+            )
+        entrypoint = await prompt_entrypoint(app.console)
     if flow_name and entrypoint:
         raise ValueError(
             "Received an entrypoint and a flow name for this deployment. Please provide"

--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -5,6 +5,8 @@ build system for managing flows and deployments.
 To get started, follow along with [the project tutorial](/tutorials/projects/).
 """
 from copy import deepcopy
+import ast
+import asyncio
 import json
 import os
 import subprocess
@@ -16,10 +18,13 @@ from pydantic import BaseModel
 import yaml
 from ruamel.yaml import YAML
 
+import anyio
 from prefect.flows import load_flow_from_entrypoint
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.filesystem import create_default_ignore_file
 from prefect.utilities.templating import apply_values
+from prefect.settings import PREFECT_DEBUG_MODE
+from prefect.logging import get_logger
 
 from prefect.client.schemas.schedules import IntervalSchedule
 
@@ -439,3 +444,86 @@ def _save_deployment_to_prefect_file(
 
         with prefect_file.open(mode="w") as f:
             ryaml.dump(parsed_prefect_file_contents, f)
+
+
+async def _find_flow_functions_in_file(filename: str) -> List[Dict]:
+    decorator_name = "flow"
+    decorator_module = "prefect"
+    decorated_functions = []
+    async with await anyio.open_file(filename) as f:
+        try:
+            tree = ast.parse(await f.read())
+        except SyntaxError:
+            if PREFECT_DEBUG_MODE:
+                get_logger().debug(
+                    f"Could not parse {filename} as a Python file. Skipping."
+                )
+            return decorated_functions
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            for decorator in node.decorator_list:
+                # handles @flow
+                is_name_match = (
+                    isinstance(decorator, ast.Name) and decorator.id == decorator_name
+                )
+                # handles @flow()
+                is_func_name_match = (
+                    isinstance(decorator, ast.Call)
+                    and isinstance(decorator.func, ast.Name)
+                    and decorator.func.id == decorator_name
+                )
+                # handles @prefect.flow
+                is_module_attribute_match = (
+                    isinstance(decorator, ast.Attribute)
+                    and decorator.value.id == decorator_module
+                    and decorator.attr == decorator_name
+                )
+                # handles @prefect.flow()
+                is_module_attribute_func_match = (
+                    isinstance(decorator, ast.Call)
+                    and isinstance(decorator.func, ast.Attribute)
+                    and decorator.func.attr == decorator_name
+                    and isinstance(decorator.func.value, ast.Name)
+                    and decorator.func.value.id == decorator_module
+                )
+                if is_name_match or is_module_attribute_match:
+                    decorated_functions.append(
+                        {
+                            "flow_name": node.name,
+                            "function_name": node.name,
+                            "filepath": str(filename),
+                        }
+                    )
+                if is_func_name_match or is_module_attribute_func_match:
+                    name_kwarg_node = next(
+                        (kw for kw in decorator.keywords if kw.arg == "name"), None
+                    )
+                    flow_name = (
+                        name_kwarg_node.value.value
+                        if isinstance(name_kwarg_node, ast.Constant)
+                        else node.name
+                    )
+                    decorated_functions.append(
+                        {
+                            "flow_name": flow_name,
+                            "function_name": node.name,
+                            "filepath": str(filename),
+                        }
+                    )
+    return decorated_functions
+
+
+async def _search_for_flow_functions():
+    """
+    Search for flow functions in the current directory.
+
+    Returns:
+        List[Dict]: the flow name, function name, and filepath of all flow functions found
+    """
+    path = anyio.Path(".")
+    coros = []
+    async for file in path.rglob("*.py"):
+        coros.append(_find_flow_functions_in_file(file))
+
+    return [fn for file_fns in await asyncio.gather(*coros) for fn in file_fns]

--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -514,14 +514,15 @@ async def _find_flow_functions_in_file(filename: str) -> List[Dict]:
     return decorated_functions
 
 
-async def _search_for_flow_functions():
+async def _search_for_flow_functions(directory: str = "."):
     """
-    Search for flow functions in the current directory.
+    Search for flow functions in the provided directory. If no directory is provided,
+    the current working directory is used.
 
     Returns:
         List[Dict]: the flow name, function name, and filepath of all flow functions found
     """
-    path = anyio.Path(".")
+    path = anyio.Path(directory)
     coros = []
     async for file in path.rglob("*.py"):
         coros.append(_find_flow_functions_in_file(file))

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -477,7 +477,11 @@ class TestProjectDeploySingleDeploymentYAML:
         await run_sync_in_worker_thread(
             invoke_and_assert,
             command="deploy",
-            user_input="y" + readchar.key.ENTER + "n" + readchar.key.ENTER,
+            user_input="y"
+            + readchar.key.ENTER
+            + readchar.key.ENTER
+            + "n"
+            + readchar.key.ENTER,
             expected_code=0,
         )
 

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -2855,12 +2855,9 @@ class TestDeployWithoutEntrypoint:
                 "nested-project/explicit_relative.py",
                 "my_flow",
                 "flows/hello.py",
-                "Deployment 'test/default' successfully created",
+                "successfully created",
             ],
         )
-
-        deployment = await prefect_client.read_deployment_by_name(name="test/default")
-        assert deployment.entrypoint == "import-project/my_module/flow.py:test_flow"
 
     async def test_deploy_without_entrypoint_manually_enter(
         self, prefect_client: PrefectClient

--- a/tests/deployment/test_base.py
+++ b/tests/deployment/test_base.py
@@ -13,6 +13,7 @@ from prefect.deployments.base import (
     find_prefect_directory,
     initialize_project,
     register_flow,
+    _search_for_flow_functions,
 )
 
 TEST_PROJECTS_DIR = prefect.__development_base_path__ / "tests" / "test-projects"
@@ -213,3 +214,44 @@ class TestRegisterFlow:
             force=True,
         )
         assert f.name == "test"
+
+
+class TestDiscoverFlows:
+    async def test_find_all_flows_in_dir_tree(self, project_dir):
+        flows = await _search_for_flow_functions(str(project_dir))
+        assert len(flows) == 5
+        assert sorted(flows, key=lambda f: f["function_name"]) == [
+            {
+                "flow_name": "foobar",
+                "function_name": "foobar",
+                "filepath": str(
+                    project_dir / "nested-project" / "implicit_relative.py"
+                ),
+            },
+            {
+                "flow_name": "foobar",
+                "function_name": "foobar",
+                "filepath": str(
+                    project_dir / "nested-project" / "explicit_relative.py"
+                ),
+            },
+            {
+                "flow_name": "my_flow",
+                "function_name": "my_flow",
+                "filepath": str(project_dir / "flows" / "hello.py"),
+            },
+            {
+                "flow_name": "prod_flow",
+                "function_name": "prod_flow",
+                "filepath": str(
+                    project_dir / "import-project" / "my_module" / "flow.py"
+                ),
+            },
+            {
+                "flow_name": "test_flow",
+                "function_name": "test_flow",
+                "filepath": str(
+                    project_dir / "import-project" / "my_module" / "flow.py"
+                ),
+            },
+        ]

--- a/tests/test-projects/import-project/my_module/flow.py
+++ b/tests/test-projects/import-project/my_module/flow.py
@@ -1,13 +1,13 @@
-from prefect import flow
+import prefect
 
 from .utils import get_output
 
 
-@flow(name="test")
+@prefect.flow(name="test")
 def test_flow():
     return get_output()
 
 
-@flow(name="test")
+@prefect.flow(name="test")
 def prod_flow():
     return get_output()

--- a/tests/test-projects/nested-project/implicit_relative.py
+++ b/tests/test-projects/nested-project/implicit_relative.py
@@ -1,9 +1,9 @@
 from shared_libs.bar import bar
 from shared_libs.foo import foo
 
-from prefect import flow
+import prefect
 
 
-@flow
+@prefect.flow
 def foobar():
     return foo() + bar()


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
This PR adds prompts to `prefect deploy` when run without a flow entrypoint. The CLI will recursively scan the current working directory and any sub-directories for flow functions and present the user with a list of discovered flow to choose from. The selected flow will be the one deployed.

If a user does not see the flow they want to deploy, they will have the option to select none of the flows and manually enter a flow entrypoint.

If no flows are discovered, the user is prompted to enter a flow entrypoint. The entrypoint prompt will validate that a flow can be loaded from the entrypoint before proceeding.

Closes #9909 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Example of a list of flows presented to a user:
![Screenshot 2023-06-20 at 9 20 17 AM](https://github.com/PrefectHQ/prefect/assets/12350579/d89916d4-cbf1-408e-9959-45df94a35f8d)

Example of entry point validation:
![Screenshot 2023-06-20 at 9 25 37 AM](https://github.com/PrefectHQ/prefect/assets/12350579/06f9d287-b4f3-4e0e-a0b3-a67d57cce106)

[`prefect deploy` run without an entrypoint - Watch Video](https://www.loom.com/share/66ebc5dc4f7348c1ae829b870846d840)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
