### PR TITLE
Add hint to "Invalid timezone" error message

### DIFF
--- a/src/prefect/client/schemas/schedules.py
+++ b/src/prefect/client/schemas/schedules.py
@@ -104,7 +104,8 @@ class CronSchedule(PrefectBaseModel):
 
     Args:
         cron (str): a valid cron string
-        timezone (str): a valid timezone string
+        timezone (str): a valid timezone string in IANA tzdata format (for example,
+            America/New_York).
         day_or (bool, optional): Control how croniter handles `day` and `day_of_week`
             entries. Defaults to True, matching cron which connects those values using
             OR. If the switch is set to False, the values are connected using AND. This
@@ -128,7 +129,10 @@ class CronSchedule(PrefectBaseModel):
     @validator("timezone")
     def valid_timezone(cls, v):
         if v and v not in pendulum.tz.timezones:
-            raise ValueError(f'Invalid timezone: "{v}"')
+            raise ValueError(
+                f'Invalid timezone: "{v}" (specify in IANA tzdata format, for example,'
+                " America/New_York)"
+            )
         return v
 
     @validator("cron")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

If the error message does not appear to be a valid IANA tzdata timezone specifier, then we return an "Invalid timezone" error, but do not provide any hints to resolve.

This change updates the error message and documentation string to indicate that the timezone is to be specified in IANA tzdata format, such as America/New_York.

Closes: #10006
<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```
>>> from prefect.client.schemas.schedules import CronSchedule

>>> CronSchedule(cron="0 0 * * *", timezone="PST")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for CronSchedule
timezone
  Invalid timezone: "PST" (specify in IANA tzdata format, for example, America/New_York) (type=value_error)
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
