### PR TITLE
Limit the number of files opened concurrently by `prefect deploy`

### DIFF
--- a/src/prefect/cli/_prompts.py
+++ b/src/prefect/cli/_prompts.py
@@ -6,6 +6,7 @@ from prefect.deployments.base import _search_for_flow_functions
 from prefect.flows import load_flow_from_entrypoint
 from rich.prompt import PromptBase, InvalidResponse
 from rich.text import Text
+from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from prefect.client.schemas.schedules import (
     SCHEDULE_TYPES,
@@ -413,7 +414,17 @@ async def prompt_entrypoint(console: Console) -> str:
     from a list of discovered flows. If no flows are found, the user will be prompted
     to enter a flow entrypoint manually.
     """
-    discovered_flows = await _search_for_flow_functions()
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        transient=True,
+    ) as progress:
+        task_id = progress.add_task(
+            description="Scanning for flows...",
+            total=1,
+        )
+        discovered_flows = await _search_for_flow_functions()
+        progress.update(task_id, completed=1)
     if not discovered_flows:
         return EntrypointPrompt.ask(
             (

--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 import ast
 import asyncio
 import json
+import math
 import os
 import subprocess
 import sys
@@ -21,7 +22,7 @@ from ruamel.yaml import YAML
 import anyio
 from prefect.flows import load_flow_from_entrypoint
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
-from prefect.utilities.filesystem import create_default_ignore_file
+from prefect.utilities.filesystem import create_default_ignore_file, get_open_file_limit
 from prefect.utilities.templating import apply_values
 from prefect.settings import PREFECT_DEBUG_MODE
 from prefect.logging import get_logger
@@ -446,19 +447,25 @@ def _save_deployment_to_prefect_file(
             ryaml.dump(parsed_prefect_file_contents, f)
 
 
+# Only allow half of the open file limit to be open at once to allow for other
+# actors to open files.
+OPEN_FILE_SEMAPHORE = asyncio.Semaphore(math.floor(get_open_file_limit() * 0.5))
+
+
 async def _find_flow_functions_in_file(filename: str) -> List[Dict]:
     decorator_name = "flow"
     decorator_module = "prefect"
     decorated_functions = []
-    async with await anyio.open_file(filename) as f:
-        try:
-            tree = ast.parse(await f.read())
-        except SyntaxError:
-            if PREFECT_DEBUG_MODE:
-                get_logger().debug(
-                    f"Could not parse {filename} as a Python file. Skipping."
-                )
-            return decorated_functions
+    async with OPEN_FILE_SEMAPHORE:
+        async with await anyio.open_file(filename) as f:
+            try:
+                tree = ast.parse(await f.read())
+            except SyntaxError:
+                if PREFECT_DEBUG_MODE:
+                    get_logger().debug(
+                        f"Could not parse {filename} as a Python file. Skipping."
+                    )
+                return decorated_functions
 
     for node in ast.walk(tree):
         if isinstance(node, ast.FunctionDef):
@@ -476,6 +483,7 @@ async def _find_flow_functions_in_file(filename: str) -> List[Dict]:
                 # handles @prefect.flow
                 is_module_attribute_match = (
                     isinstance(decorator, ast.Attribute)
+                    and isinstance(decorator.value, ast.Name)
                     and decorator.value.id == decorator_module
                     and decorator.attr == decorator_name
                 )

--- a/src/prefect/utilities/filesystem.py
+++ b/src/prefect/utilities/filesystem.py
@@ -2,6 +2,7 @@
 Utilities for working with file systems
 """
 import os
+import resource
 import pathlib
 from contextlib import contextmanager
 from pathlib import Path, PureWindowsPath
@@ -119,3 +120,8 @@ def relative_path_to_current_platform(path_str: str) -> Path:
     """
 
     return Path(PureWindowsPath(path_str).as_posix())
+
+
+def get_open_file_limit():
+    soft_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+    return soft_limit

--- a/tests/deployment/test_base.py
+++ b/tests/deployment/test_base.py
@@ -255,3 +255,7 @@ class TestDiscoverFlows:
                 ),
             },
         ]
+
+    async def test_find_all_flows_works_on_large_directory_structures(self):
+        flows = await _search_for_flow_functions(str(prefect.__development_base_path__))
+        assert len(flows) > 500

--- a/tests/deployment/test_base.py
+++ b/tests/deployment/test_base.py
@@ -14,7 +14,10 @@ from prefect.deployments.base import (
     initialize_project,
     register_flow,
     _search_for_flow_functions,
+    _find_flow_functions_in_file,
 )
+
+from prefect.settings import PREFECT_DEBUG_MODE, temporary_settings
 
 TEST_PROJECTS_DIR = prefect.__development_base_path__ / "tests" / "test-projects"
 
@@ -259,3 +262,10 @@ class TestDiscoverFlows:
     async def test_find_all_flows_works_on_large_directory_structures(self):
         flows = await _search_for_flow_functions(str(prefect.__development_base_path__))
         assert len(flows) > 500
+
+    async def test_find_flow_functions_in_file_returns_empty_list_on_file_error(
+        self, caplog
+    ):
+        with temporary_settings({PREFECT_DEBUG_MODE: True}):
+            assert await _find_flow_functions_in_file("foo.py") == []
+            assert "Could not open foo.py" in caplog.text


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Adds an `asyncio.semaphore` for use across invocations of `_find_flow_functions_in_file` for cases where many files are being scanned for flows. Previously, users would encounter an `OSError` saying that too many files were open. This PR also adds a spinner to display while scanning for flows to show the CLI is working while scanning large directories.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
![scanning_spinner](https://github.com/PrefectHQ/prefect/assets/12350579/c1b56355-9ea3-4a7f-9258-310b0fd40b7e)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
