### PR TITLE
Fix pull step saving by preserving placeholders with missing values

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -462,7 +462,7 @@ async def _run_single_deploy(
         deploy_config=deploy_config,
         ci=ci,
     )
-    pull_steps = apply_values(pull_steps, step_outputs)
+    pull_steps = apply_values(pull_steps, step_outputs, remove_notset=False)
 
     flow_id = await client.create_flow_from_name(deploy_config["flow_name"])
 

--- a/src/prefect/testing/utilities.py
+++ b/src/prefect/testing/utilities.py
@@ -244,3 +244,8 @@ async def assert_uses_result_storage(
 def a_test_step(**kwargs):
     kwargs.update({"output1": 1, "output2": ["b", 2, 3]})
     return kwargs
+
+
+def b_test_step(**kwargs):
+    kwargs.update({"output1": 1, "output2": ["b", 2, 3]})
+    return kwargs

--- a/src/prefect/utilities/templating.py
+++ b/src/prefect/utilities/templating.py
@@ -125,9 +125,13 @@ def apply_values(
         else:
             for full_match, name, placeholder_type in placeholders:
                 if placeholder_type is PlaceholderType.STANDARD:
-                    template = template.replace(
-                        full_match, str(get_from_dict(values, name, ""))
-                    )
+                    value = get_from_dict(values, name, NotSet)
+                    if value is NotSet and not remove_notset:
+                        continue
+                    elif value is NotSet:
+                        template = template.replace(full_match, "")
+                    else:
+                        template = template.replace(full_match, str(value))
             return template
     elif isinstance(template, dict):
         updated_template = {}

--- a/tests/utilities/test_templating.py
+++ b/tests/utilities/test_templating.py
@@ -134,6 +134,14 @@ class TestApplyValues:
             "age": 30,
         }
 
+    def test_apply_values_string_with_missing_value_not_removed(self):
+        template = {"name": "Bob {{last_name}}", "age": "{{age}}"}
+        values = {"age": 30}
+        assert apply_values(template, values, remove_notset=False) == {
+            "name": "Bob {{last_name}}",
+            "age": 30,
+        }
+
     def test_apply_values_nested_with_NotSet_value_not_removed(self):
         template = [{"top_key": {"name": NotSet, "age": "{{age}}"}}]
         values = {"age": 30}


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

<!-- Include an overview here -->
Step chaining is not working in the `pull` action, because non-block placeholders are wiped out before saving a deployment's `pull` steps. This PR updates templating for `pull` steps to not remove unset placeholders.

Closes https://github.com/PrefectHQ/prefect/issues/10052

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
