### PR TITLE
Fix windows file limit check

### DIFF
--- a/src/prefect/utilities/filesystem.py
+++ b/src/prefect/utilities/filesystem.py
@@ -124,12 +124,18 @@ def relative_path_to_current_platform(path_str: str) -> Path:
 def get_open_file_limit() -> int:
     """Get the maximum number of open files allowed for the current process"""
 
-    if os.name == "nt":
-        import ctypes
+    try:
+        if os.name == "nt":
+            import ctypes
 
-        return ctypes.cdll.ucrtbase._getmaxstdio()
-    else:
-        import resource
+            return ctypes.cdll.ucrtbase._getmaxstdio()
+        else:
+            import resource
 
-        soft_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
-        return soft_limit
+            soft_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+            return soft_limit
+    except Exception:
+        # Catch all exceptions, as ctypes can raise several errors
+        # depending on what went wrong. Return a safe default if we
+        # can't get the limit from the OS.
+        return 200

--- a/src/prefect/utilities/filesystem.py
+++ b/src/prefect/utilities/filesystem.py
@@ -2,7 +2,6 @@
 Utilities for working with file systems
 """
 import os
-import resource
 import pathlib
 from contextlib import contextmanager
 from pathlib import Path, PureWindowsPath
@@ -122,6 +121,15 @@ def relative_path_to_current_platform(path_str: str) -> Path:
     return Path(PureWindowsPath(path_str).as_posix())
 
 
-def get_open_file_limit():
-    soft_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
-    return soft_limit
+def get_open_file_limit() -> int:
+    """Get the maximum number of open files allowed for the current process"""
+
+    if os.name == "nt":
+        import ctypes
+
+        return ctypes.cdll.ucrtbase._getmaxstdio()
+    else:
+        import resource
+
+        soft_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+        return soft_limit

--- a/tests/utilities/test_filesystem.py
+++ b/tests/utilities/test_filesystem.py
@@ -172,6 +172,10 @@ def test_get_open_file_limit():
     # It shouldn't be possible to have a negative open file limit.
     assert limit >= 0
 
+    # The open file limit should not equal the default value of 200
+    # returned if an error occurs. 
+    assert limit != 200
+
 
 @pytest.mark.skipif(os.name == "nt", reason="This is a Unix-specific test")
 def test_get_open_file_limit_exception_unix(monkeypatch):

--- a/tests/utilities/test_filesystem.py
+++ b/tests/utilities/test_filesystem.py
@@ -3,7 +3,11 @@ from pathlib import Path, PosixPath, WindowsPath
 
 import pytest
 
-from prefect.utilities.filesystem import filter_files, relative_path_to_current_platform
+from prefect.utilities.filesystem import (
+    filter_files,
+    relative_path_to_current_platform,
+    get_open_file_limit,
+)
 
 
 class TestFilterFiles:
@@ -149,3 +153,14 @@ class TestPlatformSpecificRelpath:
 
         assert isinstance(new_path, WindowsPath)
         assert str(new_path) == expected
+
+
+def test_get_open_file_limit():
+    """
+    Test that we can get the open file limit. Although this is a simple test, it
+    ensures that the function works as expected on both Windows and Unix.
+    """
+
+    limit = get_open_file_limit()
+    assert type(limit) == int
+    assert limit > 0

--- a/tests/utilities/test_filesystem.py
+++ b/tests/utilities/test_filesystem.py
@@ -173,7 +173,7 @@ def test_get_open_file_limit():
     assert limit >= 0
 
     # The open file limit should not equal the default value of 200
-    # returned if an error occurs. 
+    # returned if an error occurs.
     assert limit != 200
 
 
@@ -211,5 +211,7 @@ def test_get_open_file_limit_exception_windows(monkeypatch):
     monkeypatch.setattr(ctypes.cdll.ucrtbase, "_getmaxstdio", mock_getmaxstdio_missing)
     assert get_open_file_limit() == 200
 
-    monkeypatch.setattr(ctypes.cdll.ucrtbase, "_getmaxstdio", mock_getmaxstdio_invalid_args)
+    monkeypatch.setattr(
+        ctypes.cdll.ucrtbase, "_getmaxstdio", mock_getmaxstdio_invalid_args
+    )
     assert get_open_file_limit() == 200

--- a/tests/utilities/test_filesystem.py
+++ b/tests/utilities/test_filesystem.py
@@ -162,5 +162,11 @@ def test_get_open_file_limit():
     """
 
     limit = get_open_file_limit()
+
+    # The functions that check the open file limit on either Windows or Unix
+    # have an 'Any' return type, so this assertion ensures any changes to the
+    # function don't break its contract.
     assert type(limit) == int
-    assert limit > 0
+
+    # It shouldn't be possible to have a negative open file limit.
+    assert limit >= 0


### PR DESCRIPTION
Prefect 2.10.17 added a Unix only import in `utilities/filesystem.py` that breaks when running Prefect server or an agent on Windows. 

Credit to @grenzi for suggesting a solution to this; this PR only differs from their PR #10055 in calling `getmaxstdio` without adding a dependency on `pywin32`.

This PR calls a function in the Windows Universal C runtime to perform the same check on Windows, and scopes the `resource` module import to ensure it won't run on Windows. Using `ctypes` in this instance should be safe, as Microsoft is unlikely to remove the Universal C runtime DLL from Windows given how many of their own applications depend on it.

See https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/getmaxstdio for more detail.

Closes #10054
Closes #10058

Although this PR adds a test for `get_open_file_limit`, many other tests in `tests/utilities/test_filesystem.py` fail on Windows due to hardcoded Unix file paths. In case it is useful, I opened a draft PR (#10065) with a potential solution that makes the failing tests work cross-platform. 

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

### Example
Before: run `prefect server start` on Windows and get an error: `ImportError: No module named 'resource'`
After: `prefect server start` works as expected.

The same applies for the `prefect agent start` command.
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
