### PR TITLE
Update filesystem utilities tests to work on both Unix and Windows

### DIFF
--- a/tests/utilities/test_filesystem.py
+++ b/tests/utilities/test_filesystem.py
@@ -1,5 +1,4 @@
 import sys
-from os.path import normpath
 from pathlib import Path, PosixPath, WindowsPath
 
 import pytest

--- a/tests/utilities/test_filesystem.py
+++ b/tests/utilities/test_filesystem.py
@@ -135,7 +135,7 @@ class TestFilterFiles:
         )
         assert "__init__.py" in filtered
         expected = (
-            {str(Path("utilities/__pycache__")), str(Path("venv/__pycache__"))}
+            _path_set("utilities/__pycache__", "venv/__pycache__")
             if include_dirs
             else set()
         )

--- a/tests/utilities/test_filesystem.py
+++ b/tests/utilities/test_filesystem.py
@@ -11,7 +11,7 @@ def _path_set(*args: str):
     Takes one or more paths and converts them to a set of paths in the
     current platform's format.
     """
-    return {str(Path(p)) for p in args}
+    return {str(relative_path_to_current_platform(p)) for p in args}
 
 
 class TestFilterFiles:
@@ -124,7 +124,7 @@ class TestFilterFiles:
         filtered = filter_files(
             tmpdir, ignore_patterns=["venv/**"], include_dirs=include_dirs
         )
-        assert str(Path("utilities/venv")) in filtered
+        assert str(relative_path_to_current_platform("utilities/venv")) in filtered
         expected = {"venv"} if include_dirs else set()
         assert {f for f in filtered if f.startswith("venv")} == expected
 


### PR DESCRIPTION
Some of the tests for `prefect.utilities.filesystem:filter_files` currently fail on Windows. The tests check for hardcoded Unix-style paths with forward slashes, but `filter_files` returns a set of paths with backslashes on Windows. 

The current behavior of `filter_files` appears correct based on how it is used in the codebase, so this PR updates the tests to tailor the expected output of `filter_files` to match the platform the tests are running on.

### Example
Before:
```terminal
> pytest test_filesystem.py

test_filesystem.py ..FFF.FFFFF.ssss....                                                                         [100%]

===================== 8 failed, 8 passed, 4 skipped in 28.76s =====================
```

After:
```terminal
> pytest test_filesystem.py

test_filesystem.py ............ssss....                                                                          [100%]

===================== 16 passed, 4 skipped in 28.41s =====================
```

Everything passes on Linux and MacOS before and after the changes in this PR.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- I don't think this is big enough to need an issue but I can open one if needed.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
