### PR TITLE
Add default option to new_parameters.pop in `explode_variadic_parameter` used to handle `**kwargs` in task mapping

### DIFF
--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -92,7 +92,7 @@ def explode_variadic_parameter(
         return parameters
 
     new_parameters = parameters.copy()
-    for key, value in new_parameters.pop(variadic_key).items():
+    for key, value in new_parameters.pop(variadic_key, {}).items():
         new_parameters[key] = value
 
     return new_parameters

--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -131,6 +131,10 @@ def collapse_variadic_parameters(
             "but parameters were given that are not present in the signature."
         )
 
+    if variadic_key and not missing_parameters:
+        # variadic key is present but no missing parameters, return parameters unchanged
+        return parameters
+
     new_parameters = parameters.copy()
     if variadic_key:
         new_parameters[variadic_key] = {}

--- a/tests/utilities/test_callables.py
+++ b/tests/utilities/test_callables.py
@@ -507,3 +507,70 @@ class TestGetCallParameters:
 
         with pytest.raises(ParameterBindError):
             callables.get_call_parameters(dog, call_args=(), call_kwargs={"x": "y"})
+
+
+class TestExplodeVariadicParameter:
+    def test_no_error_if_no_variadic_parameter(self):
+        def foo(a, b):
+            pass
+
+        parameters = {"a": 1, "b": 2}
+        new_params = callables.explode_variadic_parameter(foo, parameters)
+
+        assert parameters == new_params
+
+    def test_no_error_if_variadic_parameter_and_kwargs_provided(self):
+        def foo(a, b, **kwargs):
+            pass
+
+        parameters = {"a": 1, "b": 2, "kwargs": {"c": 3, "d": 4}}
+        new_params = callables.explode_variadic_parameter(foo, parameters)
+
+        assert new_params == {"a": 1, "b": 2, "c": 3, "d": 4}
+
+    def test_no_error_if_variadic_parameter_and_no_kwargs_provided(self):
+        def foo(a, b, **kwargs):
+            pass
+
+        parameters = {"a": 1, "b": 2}
+        new_params = callables.explode_variadic_parameter(foo, parameters)
+
+        assert new_params == parameters
+
+
+class TestCollapseVariadicParameter:
+    def test_no_error_if_no_variadic_parameter(self):
+        def foo(a, b):
+            pass
+
+        parameters = {"a": 1, "b": 2}
+        new_params = callables.collapse_variadic_parameters(foo, parameters)
+
+        assert new_params == parameters
+
+    def test_no_error_if_variadic_parameter_and_kwargs_provided(self):
+        def foo(a, b, **kwargs):
+            pass
+
+        parameters = {"a": 1, "b": 2, "c": 3, "d": 4}
+        new_params = callables.collapse_variadic_parameters(foo, parameters)
+
+        assert new_params == {"a": 1, "b": 2, "kwargs": {"c": 3, "d": 4}}
+
+    def test_params_unchanged_if_variadic_parameter_and_no_kwargs_provided(self):
+        def foo(a, b, **kwargs):
+            pass
+
+        parameters = {"a": 1, "b": 2}
+        new_params = callables.collapse_variadic_parameters(foo, parameters)
+
+        assert new_params == parameters
+
+    def test_value_error_raised_if_extra_args_but_no_variadic_parameter(self):
+        def foo(a, b):
+            pass
+
+        parameters = {"a": 1, "b": 2, "kwargs": {"c": 3, "d": 4}}
+
+        with pytest.raises(ValueError):
+            callables.collapse_variadic_parameters(foo, parameters)


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/10066

<!-- Include an overview here -->

### Example
Adds a default value to fix the issue of KeyError exception being raised if a mapped task accepts `**kwargs` but does not use them.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
