### PR TITLE
Add custom pull step examples with variables

### DIFF
--- a/docs/concepts/deployments-ux.md
+++ b/docs/concepts/deployments-ux.md
@@ -264,7 +264,7 @@ pull:
     access_token: "{{ get-access-token.stdout }}"
 ```
 
-An additional way to run custom steps that are not defined is provided below. `retrieve_secrets` is a custom python module that has been packaged into the default working directory of a docker image (which is /opt/prefect by default). `main` is the function entry point, which returns an access token (e.g. `return {"access_token": access_token}`) like the preceding example, but utilizing the Azure Python SDK for retrieval. 
+You can also run custom steps by packaging them. In the example below, `retrieve_secrets` is a custom python module that has been packaged into the default working directory of a docker image (which is /opt/prefect by default). `main` is the function entry point, which returns an access token (e.g. `return {"access_token": access_token}`) like the preceding example, but utilizing the Azure Python SDK for retrieval.
 
 ```yaml
 - retrieve_secrets.main:

--- a/docs/concepts/deployments-ux.md
+++ b/docs/concepts/deployments-ux.md
@@ -250,6 +250,31 @@ pull:
         stream_output: False
 ```
 
+Below is an example that retrieves an access token from a 3rd party keyvault and uses it for a private clone step:
+
+```yaml
+pull:
+- prefect.deployments.steps.run_shell_script:
+    id: get-access-token
+    script: az keyvault secret show --name <secret name> --vault-name <secret vault> --query "value" --output tsv
+    stream_output: false
+- prefect.deployments.steps.git_clone:
+    repository: https://bitbucket.org/samples/deployments.git
+    branch: master
+    access_token: "{{ get-access-token.stdout }}"
+```
+
+An additional way to run custom steps that are not defined is provided below. `retrieve_secrets` is a custom python module that has been packaged into the default working directory of a docker image (which is /opt/prefect by default). `main` is the function entry point, which returns an access token (e.g. `return {"access_token": access_token}`) like the preceding example, but utilizing the Azure Python SDK for retrieval. 
+
+```yaml
+- retrieve_secrets.main:
+    id: get-access-token
+- prefect.deployments.steps.git_clone:
+    repository: https://bitbucket.org/samples/deployments.git
+    branch: master
+    access_token: '{{ get-access-token.access_token }}'
+```
+
 ### Templating Options
 
 Values that you place within your `prefect.yaml` file can reference dynamic values in two different ways:

--- a/docs/concepts/deployments-ux.md
+++ b/docs/concepts/deployments-ux.md
@@ -250,7 +250,7 @@ pull:
         stream_output: False
 ```
 
-Below is an example that retrieves an access token from a 3rd party keyvault and uses it for a private clone step:
+Below is an example that retrieves an access token from a 3rd party Key Vault and uses it in a private clone step:
 
 ```yaml
 pull:


### PR DESCRIPTION
Adds two additional pull step examples using a run_shell_script, and an arbitrary function call.

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Provide a short overview of the change and the value it adds.
This simply provides a few more examples for pull step usage that might be popular.
1. Uses a run_shell_script to retrieve an access credential and uses for a private repository.
2. Uses a self-written python module utilizing the azure SDK to perform the same function. This extends the pull step, but is not native (that is, not part of the deployment API / documentation).

- Share an example to help us understand the change in user experience.
Examples shared.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x ] This pull request includes tests or only affects documentation.
- [x ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
