### PR TITLE
Allows use of Prefect variables in `job_variables` section of deploy config in `prefect.yaml`

### DIFF
--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -904,6 +904,24 @@ async def test_job_configuration_from_template_overrides_with_block():
         "arbitrary_block": {"a": 1, "b": "hello", "block_type_slug": "arbitraryblock"},
     }
 
+    config = await ArbitraryJobConfiguration.from_template_and_values(
+        base_job_template=template,
+        values={
+            "var1": "woof!",
+            "arbitrary_block": "{{ prefect.blocks.arbitraryblock.arbitrary-block }}",
+        },
+    )
+
+    assert config.dict() == {
+        "command": None,
+        "env": {},
+        "labels": {},
+        "name": None,
+        "var1": "woof!",
+        # block_type_slug is added by Block.dict()
+        "arbitrary_block": {"a": 1, "b": "hello", "block_type_slug": "arbitraryblock"},
+    }
+
 
 @pytest.mark.usefixtures("variables")
 async def test_job_configuration_from_template_overrides_with_remote_variables():


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Adds call to `resolve_variables` when preparing a flow run configuration for a worker. This will resolve any Prefect variables that are present in either the `base_job_template` for a worker or the `infra_overrides` defined on the deployment.

Closes https://github.com/PrefectHQ/prefect/issues/10071

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
The reproduction outlined in the linked issue now correctly prints the value of the configured variable.

A deploy config like the following will use the underlying value of the Prefect variable rather than the placeholder itself:
```yaml
# the deployments section allows you to provide configuration for deploying flows
deployments:
- name: foo
  entrypoint: flow.py:main
  work_pool:
    name: foo-process
    job_variables:
      env:
        FOO: "{{ prefect.variables.foo }}"
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
