### PR TITLE
pass client down to recursive call of resolve block documents

### DIFF
--- a/src/prefect/utilities/templating.py
+++ b/src/prefect/utilities/templating.py
@@ -191,7 +191,9 @@ async def resolve_block_document_references(
             return block_document.data
         updated_template = {}
         for key, value in template.items():
-            updated_value = await resolve_block_document_references(value)
+            updated_value = await resolve_block_document_references(
+                value, client=client
+            )
             updated_template[key] = updated_value
         return updated_template
     elif isinstance(template, list):


### PR DESCRIPTION
If client is provided pass it to recursive call of `resolve_block_document_references`. This is already done for the other recursive call on the line below https://github.com/PrefectHQ/prefect/blob/main/src/prefect/utilities/templating.py#L193-L201