### PR TITLE
Change language when run prefect deploy to not recommend running a de…

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -76,7 +76,7 @@ async def deploy(
         None,
         "--flow",
         "-f",
-        help="The name of a registered flow to create a deployment for.",
+        help="DEPRECATED: The name of a registered flow to create a deployment for.",
     ),
     names: List[str] = typer.Option(
         None, "--name", "-n", help="The name to give the deployment."
@@ -301,13 +301,10 @@ async def _run_single_deploy(
     if not deploy_config.get("flow_name") and not deploy_config.get("entrypoint"):
         if not is_interactive() and not ci:
             raise ValueError(
-                "An entrypoint or flow name must be provided.\n\nDeploy a flow by"
-                " entrypoint:\n\n\t[yellow]prefect deploy"
-                " path/to/file.py:flow_function[/]\n\nDeploy a flow by"
-                " name:\n\n\t[yellow]prefect project register-flow"
-                " path/to/file.py:flow_function\n\tprefect deploy --flow"
-                " registered-flow-name[/]\n\nYou can also provide an entrypoint or flow"
-                " name in this project's prefect.yaml file."
+                "An entrypoint must be provided:\n\n"
+                " \t[yellow]prefect deploy path/to/file.py:flow_function\n\n"
+                " You can also provide an entrypoint in a prefect.yaml"
+                " file located in the current working directory."
             )
         deploy_config["entrypoint"] = await prompt_entrypoint(app.console)
     if deploy_config.get("flow_name") and deploy_config.get("entrypoint"):


### PR DESCRIPTION
DESCRIPTION OF THE PULL REQUEST:

I have made changes to the 'deploy.py' file. Previously, when running 'prefect deploy --help', the '--flow' command indicated that we could deploy using just the flow name. However, this is no longer true as it has been deprecated. Therefore, I added a prefix of the DEPRECATED text to reflect this change.

Additionally, I modified the behavior when running 'prefect deploy' without an entrypoint in non-interactive mode. Previously, it would display the older method, which was incorrect. Instead, I updated it to display the new and correct method for deployment, which involves providing the full entrypoint rather than just the flow name.

Fixes:#9984

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `https://github.com/PrefectHQ/prefect/issues/9984`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
