### PR TITLE
Improve language around `prefect deploy` to not recommend creating a deployment by flow name

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -81,7 +81,7 @@ async def deploy(
         None,
         "--flow",
         "-f",
-        help="The name of a registered flow to create a deployment for.",
+        help="DEPRECATED: The name of a registered flow to create a deployment for.",
     ),
     names: List[str] = typer.Option(
         None, "--name", "-n", help="The name to give the deployment."
@@ -306,13 +306,10 @@ async def _run_single_deploy(
     if not deploy_config.get("flow_name") and not deploy_config.get("entrypoint"):
         if not is_interactive() and not ci:
             raise ValueError(
-                "An entrypoint or flow name must be provided.\n\nDeploy a flow by"
-                " entrypoint:\n\n\t[yellow]prefect deploy"
-                " path/to/file.py:flow_function[/]\n\nDeploy a flow by"
-                " name:\n\n\t[yellow]prefect project register-flow"
-                " path/to/file.py:flow_function\n\tprefect deploy --flow"
-                " registered-flow-name[/]\n\nYou can also provide an entrypoint or flow"
-                " name in this project's prefect.yaml file."
+                "An entrypoint must be provided:\n\n"
+                " \t[yellow]prefect deploy path/to/file.py:flow_function\n\n"
+                " You can also provide an entrypoint in a prefect.yaml"
+                " file located in the current working directory."
             )
         deploy_config["entrypoint"] = await prompt_entrypoint(app.console)
     if deploy_config.get("flow_name") and deploy_config.get("entrypoint"):

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -308,7 +308,7 @@ async def _run_single_deploy(
             raise ValueError(
                 "An entrypoint must be provided:\n\n"
                 " \t[yellow]prefect deploy path/to/file.py:flow_function\n\n"
-                " You can also provide an entrypoint in a prefect.yaml"
+                "You can also provide an entrypoint in a prefect.yaml"
                 " file located in the current working directory."
             )
         deploy_config["entrypoint"] = await prompt_entrypoint(app.console)

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -521,7 +521,7 @@ class TestProjectDeploySingleDeploymentYAML:
             invoke_and_assert,
             command="deploy",
             expected_code=1,
-            expected_output_contains="An entrypoint must be provided:"
+            expected_output_contains="An entrypoint must be provided:",
         )
 
     @pytest.mark.usefixtures(
@@ -1524,7 +1524,7 @@ class TestProjectDeploy:
             invoke_and_assert,
             command="deploy -n test-name",
             expected_code=1,
-            expected_output_contains="An entrypoint must be provided:"
+            expected_output_contains="An entrypoint must be provided:",
         )
 
     @pytest.mark.usefixtures("interactive_console", "project_dir")

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -521,7 +521,7 @@ class TestProjectDeploySingleDeploymentYAML:
             invoke_and_assert,
             command="deploy",
             expected_code=1,
-            expected_output_contains="An entrypoint or flow name must be provided.",
+            expected_output_contains="An entrypoint must be provided:"
         )
 
     @pytest.mark.usefixtures(
@@ -1524,7 +1524,7 @@ class TestProjectDeploy:
             invoke_and_assert,
             command="deploy -n test-name",
             expected_code=1,
-            expected_output_contains="An entrypoint or flow name must be provided.",
+            expected_output_contains="An entrypoint must be provided:"
         )
 
     @pytest.mark.usefixtures("interactive_console", "project_dir")
@@ -2720,7 +2720,7 @@ class TestMultiDeploy:
             command="deploy",
             expected_code=1,
             expected_output_contains=[
-                "An entrypoint or flow name must be provided.",
+                "An entrypoint must be provided:",
             ],
         )
 


### PR DESCRIPTION
DESCRIPTION OF THE PULL REQUEST:

Changes have been made in two files: 'test_deploy.py' and 'deploy.py'. Since code deployment through flow names is no longer possible and has been deprecated, the 'prefect deploy --help' command needs to be updated accordingly. Additionally, the 'ValueError' in the 'deploy.py' file has been modified to match the same error in the 'test_deploy.py' file, ensuring consistency and maintaining the integrity of the tests.

![12](https://github.com/PrefectHQ/prefect/assets/121633121/da3fd0b0-9aac-44fe-a31b-7c35a5dcd9c3)

Fixes:#9984



### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
