### PR TITLE
Experimental Dashboard UI

### DIFF
--- a/ui/src/maps/featureFlag.ts
+++ b/ui/src/maps/featureFlag.ts
@@ -11,7 +11,7 @@ export const mapFlagResponseToFeatureFlag: MapFunction<FlagResponse, FeatureFlag
       return 'access:work_pools'
     case 'artifacts':
       return 'access:artifacts'
-    case 'enable-workspace-dashboard':
+    case 'workspace_dashboard':
       return 'access:dashboard'
     default:
       return null

--- a/ui/src/pages/Dashboard.vue
+++ b/ui/src/pages/Dashboard.vue
@@ -1,5 +1,83 @@
 <template>
   <p-layout-default class="workspace-dashboard">
-    Dashboard
+    <PageHeading :crumbs="crumbs">
+      <template v-if="!empty" #actions>
+        <FlowRunTagsInput v-model:selected="tags" :filter="{}" empty-message="All tags" class="workspace-dashboard__tags" />
+        <DashboardTimeSpanFilter v-model:selected="timeSpanInSeconds" />
+      </template>
+    </PageHeading>
+    <template v-if="loaded">
+      <template v-if="empty">
+        <FlowRunsPageEmptyState />
+      </template>
+      <template v-else>
+        <div class="workspace-dashboard__grid">
+          <WorkspaceDashboardFlowRunsCard :filter="filter" />
+          <div class="workspace-dashboard__side">
+            <WorkspaceDashboardTaskRunsCard :filter="filter" />
+            <DashboardWorkPoolsCard class="workspace-dashboard__work-pools" :filter="filter" />
+          </div>
+        </div>
+      </template>
+    </template>
   </p-layout-default>
 </template>
+
+<script setup lang="ts">
+  import { Crumb } from '@prefecthq/prefect-design'
+  import {
+    DashboardTimeSpanFilter,
+    DashboardWorkPoolsCard,
+    WorkspaceDashboardFilter,
+    WorkspaceDashboardFlowRunsCard,
+    WorkspaceDashboardTaskRunsCard,
+    PageHeading,
+    FlowRunTagsInput,
+    FlowRunsPageEmptyState,
+    useWorkspaceApi
+  } from '@prefecthq/prefect-ui-library'
+  import { NumberRouteParam, useRouteQueryParam, useSubscription } from '@prefecthq/vue-compositions'
+  import { secondsInHour } from 'date-fns'
+  import { computed } from 'vue'
+
+  const api = useWorkspaceApi()
+  const flowRunsCountAllSubscription = useSubscription(api.flowRuns.getFlowRunsCount, [{}])
+  const loaded = computed(() => flowRunsCountAllSubscription.executed)
+  const empty = computed(() => flowRunsCountAllSubscription.response === 0)
+
+  const crumbs: Crumb[] = [{ text: 'Dashboard' }]
+
+  const timeSpanInSeconds = useRouteQueryParam('span', NumberRouteParam, secondsInHour * 24)
+  const tags = useRouteQueryParam('tags', [])
+
+  const filter = computed<WorkspaceDashboardFilter>(() => ({
+    timeSpanInSeconds: timeSpanInSeconds.value,
+    tags: tags.value,
+  }))
+</script>
+
+<style>
+.workspace-dashboard__tags { @apply
+  w-full
+  max-w-xs
+}
+
+.workspace-dashboard__grid { @apply
+  grid
+  grid-cols-1
+  gap-4
+  items-start
+}
+
+@screen xl {
+  .workspace-dashboard__grid { @apply
+    grid-cols-2
+  }
+}
+
+.workspace-dashboard__side { @apply
+  grid
+  grid-cols-1
+  gap-4
+}
+</style>

--- a/ui/src/types/flagResponse.ts
+++ b/ui/src/types/flagResponse.ts
@@ -2,4 +2,4 @@ export type FlagResponse =
 | 'workers'
 | 'work_pools'
 | 'artifacts'
-| 'enable-workspace-dashboard'
+| 'workspace_dashboard'


### PR DESCRIPTION
# Description
Adds the ui for the experimental dashboard that has flow run, task run, and work pool information. This will become the default view once it is no longer experimental.

<img width="1307" alt="image" src="https://github.com/PrefectHQ/prefect/assets/6200442/ada8e781-9498-4929-a3b6-4d0f62e4d1c9">
