### PR TITLE
Update `git_clone` documentation with examples of using `credentials` field

### DIFF
--- a/docs/concepts/deployments-ux.md
+++ b/docs/concepts/deployments-ux.md
@@ -215,6 +215,24 @@ There are three main types of steps that typically show up in a `pull` section:
 !!! tip "Use block and variable references"
     All [block and variable references](#templating-options) within your pull step will remain unresolved until runtime and will be pulled each time your deployment is run. This allows you to avoid storing sensitive information insecurely; it also allows you to manage certain types of configuration from the API and UI without having to rebuild your deployment every time.
 
+Below is an example of how to use an existing `GitHubCredentials` block to clone a private GitHub repository:
+
+```yaml
+pull:
+    - prefect.deployments.steps.git_clone:
+        repository: https://github.com/org/repo.git
+        credentials: "{{ prefect.blocks.github-credentials.my-credentials }}"
+```
+
+Alternatively, you can specify a `BitBucketCredentials` or `GitLabCredentials` block to clone from Bitbucket or GitLab. In lieu of a credentials block, you can also provide a GitHub, GitLab, or Bitbucket token directly to the  'access_token` field. You can use a Secret block to do this securely:
+
+```yaml
+pull:
+    - prefect.deployments.steps.git_clone:
+        repository: https://bitbucket.org/org/repo.git
+        access_token: "{{ prefect.blocks.secret.bitbucket-token }}"
+```
+
 #### Utility Steps
 Utility steps can be used within a build, push, or pull action to assist in managing the deployment lifecycle:
 

--- a/docs/concepts/deployments-ux.md
+++ b/docs/concepts/deployments-ux.md
@@ -224,7 +224,7 @@ pull:
         credentials: "{{ prefect.blocks.github-credentials.my-credentials }}"
 ```
 
-Alternatively, you can specify a `BitBucketCredentials` or `GitLabCredentials` block to clone from Bitbucket or GitLab. In lieu of a credentials block, you can also provide a GitHub, GitLab, or Bitbucket token directly to the  'access_token` field. You can use a Secret block to do this securely:
+Alternatively, you can specify a `BitBucketCredentials` or `GitLabCredentials` block to clone from Bitbucket or GitLab. In lieu of a credentials block, you can also provide a GitHub, GitLab, or Bitbucket token directly to the 'access_token` field. You can use a Secret block to do this securely:
 
 ```yaml
 pull:


### PR DESCRIPTION
With the new `credentials` field available in the `git_clone` step, we'll want to ensure our documentation shows how to do this in the variety of possible ways (`GitHubCredentials` block, `Secret` block, etc.)

Part of closing #9918

### Preview
<img width="1075" alt="Screenshot 2023-07-06 at 11 08 40 AM" src="https://github.com/PrefectHQ/prefect/assets/42048900/08ff0391-fcbd-4287-9c6a-1110894c3649">


<!-- Include an overview here -->


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
