### PR TITLE
Update to `Deployment` docstring

### DIFF
--- a/src/prefect/deployments/deployments.py
+++ b/src/prefect/deployments/deployments.py
@@ -262,6 +262,7 @@ class Deployment(BaseModel):
         schedule: A schedule to run this deployment on, once registered
         is_schedule_active: Whether or not the schedule is active
         work_queue_name: The work queue that will handle this deployment's runs
+        work_pool_name: The work pool for the deployment
         flow_name: The name of the flow this deployment encapsulates
         parameters: A dictionary of parameter values to pass to runs created from this
             deployment


### PR DESCRIPTION
The documentation for `prefect.deployments.Deployment` currently has no mention of `work_pool_name`. This small PR adds this to the docstring.

### Example
 Documentation change only.

### Checklist
- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
