### PR TITLE
Improve `prefect deploy` error message

### DIFF
--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -326,7 +326,6 @@ async def register_flow(entrypoint: str, force: bool = False):
                 f" {flow.name!r}.\nExisting entrypoint: {flows[flow.name]}"
                 f"\nAttempted entrypoint: {entrypoint}"
             )
-
     flows[flow.name] = entrypoint
 
     with flows_file.open(mode="w") as f:

--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -326,7 +326,7 @@ async def register_flow(entrypoint: str, force: bool = False):
                 f" {flow.name!r}.\nExisting entrypoint: {flows[flow.name]}"
                 f"\nAttempted entrypoint: {entrypoint}"
             )
-        # Entrypoint for
+
     flows[flow.name] = entrypoint
 
     with flows_file.open(mode="w") as f:

--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -323,8 +323,10 @@ async def register_flow(entrypoint: str, force: bool = False):
         if not force:
             raise ValueError(
                 "Conflicting entry found for flow with name"
-                f" {flow.name!r}:\n{flow.name}: {flows[flow.name]}"
+                f" {flow.name!r}.\nExisting entrypoint: {flows[flow.name]}"
+                f"\nAttempted entrypoint: {entrypoint}"
             )
+        # Entrypoint for
     flows[flow.name] = entrypoint
 
     with flows_file.open(mode="w") as f:


### PR DESCRIPTION
### Overview
Currently when we've got a conflicting entrypoint we see the following message:
<img width="577" alt="Screenshot 2023-07-07 at 11 31 39 AM" src="https://github.com/PrefectHQ/prefect/assets/42048900/44c22292-35be-48e2-aa1c-6f72d64bd4d0">

This PR aims to improve the message by making the difference in current working directory obvious:
<img width="578" alt="Screenshot 2023-07-07 at 11 31 08 AM" src="https://github.com/PrefectHQ/prefect/assets/42048900/b49c7e6b-e4b0-4fd4-8b06-42d9dc05f314">

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
