### PR TITLE
Add another improvement to `prefect deploy` message

### DIFF
--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -325,8 +325,8 @@ async def register_flow(entrypoint: str, force: bool = False):
                 "Conflicting entry found for flow with name"
                 f" {flow.name!r}.\nExisting entrypoint: {flows[flow.name]}"
                 f"\nAttempted entrypoint: {entrypoint}"
-                "\n\nIf you have an existing ~/.prefect/flows.json file, you can"
-                f" try removing the entry for {flow.name!r}."
+                "\n\nIf you have a ~/.prefect/flows.json file, you can"
+                f" try removing the existing entry for {flow.name!r}."
             )
     flows[flow.name] = entrypoint
 

--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -325,6 +325,8 @@ async def register_flow(entrypoint: str, force: bool = False):
                 "Conflicting entry found for flow with name"
                 f" {flow.name!r}.\nExisting entrypoint: {flows[flow.name]}"
                 f"\nAttempted entrypoint: {entrypoint}"
+                "\n\nIf you have an existing ~/.prefect/flows.json file, you can"
+                f" try removing the entry for {flow.name!r}."
             )
     flows[flow.name] = entrypoint
 

--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -322,12 +322,12 @@ async def register_flow(entrypoint: str, force: bool = False):
     if flow.name in flows and flows[flow.name] != entrypoint:
         if not force:
             raise ValueError(
-                f"Conflicting entry found for flow with name {flow.name!r}. You can try"
-                f" removing the existing entry for {flow.name!r} from your"
-                f' [yellow]~./prefect/flows.json[/yellow]:\n\ne.g.\n\n[yellow]{{\n\t"{flow.name}":'
-                f' "{flows[flow.name]}"\n}}[/yellow]\n\nwould'
-                " become\n\n[yellow]{\n}[/yellow]"
+                f"Conflicting entry found for flow with name {flow.name!r}.\nExisting"
+                f" entrypoint: {flows[flow.name]}\nAttempted entrypoint:"
+                f" {entrypoint}\n\nYou can try removing the existing entry for"
+                f" {flow.name!r} from your [yellow]~./prefect/flows.json[/yellow]."
             )
+
     flows[flow.name] = entrypoint
 
     with flows_file.open(mode="w") as f:

--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -322,11 +322,11 @@ async def register_flow(entrypoint: str, force: bool = False):
     if flow.name in flows and flows[flow.name] != entrypoint:
         if not force:
             raise ValueError(
-                "Conflicting entry found for flow with name"
-                f" {flow.name!r}.\nExisting entrypoint: {flows[flow.name]}"
-                f"\nAttempted entrypoint: {entrypoint}"
-                "\n\nIf you have a ~/.prefect/flows.json file, you can"
-                f" try removing the existing entry for {flow.name!r}."
+                f"Conflicting entry found for flow with name {flow.name!r}. You can try"
+                f" removing the existing entry for {flow.name!r} from your"
+                f' [yellow]~./prefect/flows.json[/yellow]:\n\ne.g.\n\n[yellow]{{\n\t"{flow.name}":'
+                f' "{flows[flow.name]}"\n}}[/yellow]\n\nwould'
+                " become\n\n[yellow]{\n}[/yellow]"
             )
     flows[flow.name] = entrypoint
 


### PR DESCRIPTION
### Overview
We should remove the dead end from this error message by providing the workaround documented in this Discourse article.

https://discourse.prefect.io/t/after-changing-the-location-of-my-flow-file-i-get-an-error-when-trying-to-run-prefect-deploy-conflicting-entry-found-for-flow-with-name/3188

### Example
<img width="643" alt="Screenshot 2023-07-07 at 1 59 58 PM" src="https://github.com/PrefectHQ/prefect/assets/42048900/16c290d5-ff1c-45f6-af8c-5ff187575242">


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
