### PR TITLE
Support deploying by name with multiple deployments with the same name during `prefect deploy`

### DIFF
--- a/docs/concepts/deployments-ux.md
+++ b/docs/concepts/deployments-ux.md
@@ -403,6 +403,14 @@ $ prefect deploy --name deployment-1 --name deployment-2
 ```
 </div>
 
+To deploy multiple deployments with the same name you can prefix the flow name in front of the deployment name:
+
+<div class="terminal">
+```bash
+$ prefect deploy --name my_flow/deployment-1 --name my_other_flow/deployment-1
+```
+</div>
+
 To deploy all deployments you can use the `--all` flag:
 
 <div class="terminal">

--- a/docs/concepts/deployments-ux.md
+++ b/docs/concepts/deployments-ux.md
@@ -403,7 +403,7 @@ $ prefect deploy --name deployment-1 --name deployment-2
 ```
 </div>
 
-To deploy multiple deployments with the same name you can prefix the flow name in front of the deployment name:
+To deploy multiple deployments with the same name, you can prefix the deployment name with its flow name:
 
 <div class="terminal">
 ```bash

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -1105,8 +1105,7 @@ def _pick_deploy_configs(deploy_configs, names, deploy_all, ci=False):
                     deploy_config
                     for deploy_config in deploy_configs
                     if deploy_config.get("name") == deployment_name
-                    and (deploy_config.get("entrypoint") or "").split(":")[1]
-                    == flow_name
+                    and deploy_config.get("entrypoint", "").split(":")[-1] == flow_name
                 ]
                 deployment_names.append(deployment_name)
 

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -1095,6 +1095,7 @@ def _pick_deploy_configs(deploy_configs, names, deploy_all, ci=False):
         return deploy_configs
     elif len(names) >= 1:
         matched_deploy_configs = []
+        deployment_names = []
         for name in names:
             # If a user provides a deployment in a flow-name/deployment-name format
             if "/" in name:
@@ -1111,6 +1112,8 @@ def _pick_deploy_configs(deploy_configs, names, deploy_all, ci=False):
                             and entrypoint_flow_name == flow_name
                         ):
                             matched_deploy_configs.append(deploy_config)
+                deployment_names.append(deployment_name)
+
             else:
                 # If provided a deployment name, find matching deployment
                 matches_for_that_name = [
@@ -1137,15 +1140,17 @@ def _pick_deploy_configs(deploy_configs, names, deploy_all, ci=False):
                     matched_deploy_configs.append(selected_matching_deployment)
                 elif matches_for_that_name:
                     matched_deploy_configs.extend(matches_for_that_name)
+                deployment_names.append(name)
 
-        unfound_names = set(names) - {
+        unfound_names = set(deployment_names) - {
             deploy_config.get("name") for deploy_config in matched_deploy_configs
         }
+
         if unfound_names:
             app.console.print(
                 (
                     "The following deployment(s) could not be found and will not be"
-                    f" deployed: {' ,'.join(list(unfound_names))}"
+                    f" deployed: {', '.join(list(sorted(unfound_names)))}"
                 ),
                 style="yellow",
             )
@@ -1153,7 +1158,7 @@ def _pick_deploy_configs(deploy_configs, names, deploy_all, ci=False):
             app.console.print(
                 (
                     "Could not find any deployment configurations with the given"
-                    f" name(s): {' ,'.join(names)}. Your flow will be deployed with a"
+                    f" name(s): {', '.join(names)}. Your flow will be deployed with a"
                     " new deployment configuration."
                 ),
                 style="yellow",

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -1112,12 +1112,12 @@ def _pick_deploy_configs(deploy_configs, names, deploy_all, ci=False):
 
             else:
                 # If deployment-name format
-                matching_deployment_name = [
+                matching_deployment = [
                     deploy_config
                     for deploy_config in deploy_configs
                     if deploy_config.get("name") == name
                 ]
-                if len(matching_deployment_name) > 1:
+                if len(matching_deployment) > 1 and is_interactive() and not ci:
                     user_selected_matching_deployment = prompt_select_from_table(
                         app.console,
                         (
@@ -1130,11 +1130,11 @@ def _pick_deploy_configs(deploy_configs, names, deploy_all, ci=False):
                             {"header": "Entrypoint", "key": "entrypoint"},
                             {"header": "Description", "key": "description"},
                         ],
-                        matching_deployment_name,
+                        matching_deployment,
                     )
                     matched_deploy_configs.append(user_selected_matching_deployment)
-                elif matching_deployment_name:
-                    matched_deploy_configs.extend(matching_deployment_name)
+                elif matching_deployment:
+                    matched_deploy_configs.extend(matching_deployment)
                 deployment_names.append(name)
 
         unfound_names = set(deployment_names) - {

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -2965,8 +2965,6 @@ class TestMultiDeploy:
         assert deployment2.name == "test-name-2"
         assert deployment2.work_pool_name == work_pool.name
 
-        prefect_file.unlink()
-
     async def test_deploy_exits_with_multiple_deployments_with_no_name(
         self, project_dir
     ):
@@ -3988,27 +3986,31 @@ class TestCheckForMatchingDeployment:
             "name": "new_deployment",
             "entrypoint": "flows/existing_flow.py:my_flow",
         }
-        matching_deployment_exists_1 = not any(
+        matching_deployment_exists_1 = any(
             d["name"] == deployment_with_same_entrypoint_but_different_name["name"]
             and d["entrypoint"]
             == deployment_with_same_entrypoint_but_different_name["entrypoint"]
             for d in config["deployments"]
         )
 
-        assert matching_deployment_exists_1, "Found a deployment that shouldn't exist."
+        assert (
+            not matching_deployment_exists_1
+        ), "Found a deployment that shouldn't exist."
 
         deployment_with_same_name_but_different_entrypoint = {
             "name": "new_deployment",
             "entrypoint": "flows/new_flow.py:my_flow",
         }
-        matching_deployment_exists_2 = not any(
+        matching_deployment_exists_2 = any(
             d["name"] == deployment_with_same_name_but_different_entrypoint["name"]
             and d["entrypoint"]
             == deployment_with_same_name_but_different_entrypoint["entrypoint"]
             for d in config["deployments"]
         )
 
-        assert matching_deployment_exists_2, "Found a deployment that shouldn't exist."
+        assert (
+            not matching_deployment_exists_2
+        ), "Found a deployment that shouldn't exist."
 
 
 class TestDeploymentTriggerSyncing:

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -4112,7 +4112,6 @@ class TestCheckForMatchingDeployment:
                 deployment_with_same_entrypoint_but_different_name
             )
         )
-
         assert not matching_deployment_exists_1
 
         deployment_with_same_name_but_different_entrypoint = {

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -4124,7 +4124,6 @@ class TestCheckForMatchingDeployment:
                 deployment_with_same_name_but_different_entrypoint
             )
         )
-
         assert not matching_deployment_exists_2
 
 

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -4078,7 +4078,7 @@ class TestCheckForMatchingDeployment:
                 new_deployment
             )
         )
-        assert matching_deployment_exists, "No matching deployment found in the check."
+        assert matching_deployment_exists is True
 
     async def test_no_matching_deployment_in_prefect_file_returns_false(self):
         deployment = {
@@ -4101,37 +4101,31 @@ class TestCheckForMatchingDeployment:
             for d in config["deployments"]
         )
 
-        assert matching_deployment_exists, "Original deployment was not found."
+        assert matching_deployment_exists
 
         deployment_with_same_entrypoint_but_different_name = {
             "name": "new_deployment",
             "entrypoint": "flows/existing_flow.py:my_flow",
         }
-        matching_deployment_exists_1 = any(
-            d["name"] == deployment_with_same_entrypoint_but_different_name["name"]
-            and d["entrypoint"]
-            == deployment_with_same_entrypoint_but_different_name["entrypoint"]
-            for d in config["deployments"]
+        matching_deployment_exists_1 = (
+            _check_for_matching_deployment_name_and_entrypoint_in_prefect_file(
+                deployment_with_same_entrypoint_but_different_name
+            )
         )
 
-        assert (
-            not matching_deployment_exists_1
-        ), "Found a deployment that shouldn't exist."
+        assert not matching_deployment_exists_1
 
         deployment_with_same_name_but_different_entrypoint = {
             "name": "new_deployment",
             "entrypoint": "flows/new_flow.py:my_flow",
         }
-        matching_deployment_exists_2 = any(
-            d["name"] == deployment_with_same_name_but_different_entrypoint["name"]
-            and d["entrypoint"]
-            == deployment_with_same_name_but_different_entrypoint["entrypoint"]
-            for d in config["deployments"]
+        matching_deployment_exists_2 = (
+            _check_for_matching_deployment_name_and_entrypoint_in_prefect_file(
+                deployment_with_same_name_but_different_entrypoint
+            )
         )
 
-        assert (
-            not matching_deployment_exists_2
-        ), "Found a deployment that shouldn't exist."
+        assert not matching_deployment_exists_2
 
 
 class TestDeploymentTriggerSyncing:

--- a/tests/deployment/test_base.py
+++ b/tests/deployment/test_base.py
@@ -244,6 +244,11 @@ class TestDiscoverFlows:
                 "filepath": str(project_dir / "flows" / "hello.py"),
             },
             {
+                "flow_name": "my_flow2",
+                "function_name": "my_flow2",
+                "filepath": str(project_dir / "flows" / "hello.py"),
+            },
+            {
                 "flow_name": "prod_flow",
                 "function_name": "prod_flow",
                 "filepath": str(

--- a/tests/deployment/test_base.py
+++ b/tests/deployment/test_base.py
@@ -222,7 +222,7 @@ class TestRegisterFlow:
 class TestDiscoverFlows:
     async def test_find_all_flows_in_dir_tree(self, project_dir):
         flows = await _search_for_flow_functions(str(project_dir))
-        assert len(flows) == 5
+        assert len(flows) == 6
         assert sorted(flows, key=lambda f: f["function_name"]) == [
             {
                 "flow_name": "foobar",

--- a/tests/test-projects/flows/hello.py
+++ b/tests/test-projects/flows/hello.py
@@ -4,3 +4,8 @@ from prefect import flow
 @flow(name="An important name")
 def my_flow(number: int, message: str = None):
     pass
+
+
+@flow(name="Second important name")
+def my_flow2(number: int, message: str = None):
+    pass


### PR DESCRIPTION
### Overview
In the following `prefect.yaml`:

```bash
deployments:
- name: "default"
  entrypoint: "flows/hello.py:hello"

- name: "default"
  entrypoint: "flows/hello.py:hello_parallel"
```

Running `prefect deploy -n default` currently deploys both flows. It would be ideal to prompt the user on which flow to deploy if in interactive mode, and at least allow users to deploy by `flow-name/deployment-name`. This PR does both.

### `prefect deploy -n default` in interactive mode prompts user to choose flow to deploy

<img width="567" alt="Screenshot 2023-07-10 at 10 42 02 AM" src="https://github.com/PrefectHQ/prefect/assets/42048900/d829c581-ddae-45b5-9c68-47d8d915e8ea">

### Support for deploying a deployment prefixed with flow name: `prefect deploy -n hello/default`
Regardless of whether a user opts to use the wizard or not, this PR adds support for deploying a deployment prefixed with the flow name. This way users do not need to resort to workarounds like [prefixing their flow name **inside** of their deployment name](https://github.com/PrefectHQ/prefect/issues/9913#issuecomment-1593604049). 

```bash
❯ prefect deploy -n log-flow/default
? Your Prefect workers will need access to this flow's code in order to run it. Would you like your workers to pull your flow code from its remote 
repository when running this flow? [y/n] (y): n
Your Prefect workers will attempt to load your flow from: /Users/bean/code/prefect/hello-projects/flows/log_flow.py. To see more options for managing 
your flow's code, run:

        $ prefect project recipes ls

╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Deployment 'log-flow/default' successfully created with id 'decbad5f-6721-4ef8-b1a7-a18174ea5f17'.                                                      │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

To execute flow runs from this deployment, start a worker in a separate terminal that pulls work from the 'local-work' work pool:

        $ prefect worker start --pool 'local-work'

To schedule a run for this deployment, use the following command:

        $ prefect deployment run 'log-flow/default'
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
