### PR TITLE
Make `resolve_futures_to_data` function raise on failure by default (#9361)

### DIFF
--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -306,7 +306,8 @@ def _collect_futures(futures, expr, context):
 
 
 async def resolve_futures_to_data(
-    expr: Union[PrefectFuture[R, Any], Any]
+    expr: Union[PrefectFuture[R, Any], Any],
+    raise_on_failure: bool = True,
 ) -> Union[R, Any]:
     """
     Given a Python built-in collection, recursively find `PrefectFutures` and build a
@@ -332,7 +333,7 @@ async def resolve_futures_to_data(
         *[
             # We must wait for the future in the thread it was created in
             from_async.call_soon_in_loop_thread(
-                create_call(future._result, raise_on_failure=False)
+                create_call(future._result, raise_on_failure=raise_on_failure)
             ).aresult()
             for future in futures
         ]

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -7,9 +7,10 @@ import pytest
 from prefect.client import PrefectClient
 from prefect.flows import flow
 from prefect.futures import PrefectFuture, resolve_futures_to_data
-from prefect.states import Completed
+from prefect.states import Completed, Failed
 from prefect.tasks import task
 from prefect.testing.utilities import assert_does_not_warn
+from prefect.exceptions import FailedRun
 
 mock_client = MagicMock(spec=PrefectClient)()
 mock_client.read_flow_run_states.return_value = [Completed()]
@@ -177,3 +178,38 @@ def test_raise_warning_futures_in_condition():
 
     with assert_does_not_warn():
         if_result_flow._run()
+
+
+async def test_resolve_futures_to_data_raises_exception_default(task_run):
+    future = PrefectFuture(
+        key=str(task_run.id),
+        name="foo",
+        task_runner=None,
+        _final_state=Failed(data="foo"),
+    )
+    future.task_run = task_run
+    future._submitted.set()
+
+    def failed_fun():
+        yield future
+
+    with pytest.raises(FailedRun) as excinfo:
+        await resolve_futures_to_data(failed_fun())
+
+    assert "foo" in str(excinfo.value)
+
+
+async def test_resolve_futures_to_data_dont_raises_exception(task_run):
+    future = PrefectFuture(
+        key=str(task_run.id),
+        name="foo",
+        task_runner=None,
+        _final_state=Failed(data="foo"),
+    )
+    future.task_run = task_run
+    future._submitted.set()
+
+    def failed_fun():
+        yield future
+
+    assert await resolve_futures_to_data(failed_fun(), raise_on_failure=False) == []


### PR DESCRIPTION
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

closes #9361 
