### PR TITLE
Allow use of environment variables in deployment steps

### DIFF
--- a/src/prefect/utilities/templating.py
+++ b/src/prefect/utilities/templating.py
@@ -17,6 +17,7 @@ T = TypeVar("T", str, int, float, bool, dict, list, None)
 PLACEHOLDER_CAPTURE_REGEX = re.compile(r"({{\s*([\w\.\-\[\]$\]]+)\s*}})")
 BLOCK_DOCUMENT_PLACEHOLDER_PREFIX = "prefect.blocks."
 VARIABLE_PLACEHOLDER_PREFIX = "prefect.variables."
+ENV_VAR_PLACEHOLDER_PREFIX = "$"
 
 
 class PlaceholderType(enum.Enum):
@@ -46,7 +47,7 @@ def determine_placeholder_type(name: str) -> PlaceholderType:
         return PlaceholderType.BLOCK_DOCUMENT
     elif name.startswith(VARIABLE_PLACEHOLDER_PREFIX):
         return PlaceholderType.VARIABLE
-    elif name.startswith("$"):
+    elif name.startswith(ENV_VAR_PLACEHOLDER_PREFIX):
         return PlaceholderType.ENV_VAR
     else:
         return PlaceholderType.STANDARD
@@ -131,7 +132,7 @@ def apply_values(
                 if placeholder_type is PlaceholderType.STANDARD:
                     value = get_from_dict(values, name, NotSet)
                 elif placeholder_type is PlaceholderType.ENV_VAR:
-                    name = name.lstrip("$")
+                    name = name.lstrip(ENV_VAR_PLACEHOLDER_PREFIX)
                     value = os.environ.get(name, NotSet)
                 else:
                     continue

--- a/tests/utilities/test_templating.py
+++ b/tests/utilities/test_templating.py
@@ -107,11 +107,23 @@ class TestFindPlaceholders:
         types = set(p.type for p in placeholders)
         assert types == {PlaceholderType.STANDARD, PlaceholderType.ENV_VAR}
 
-    def test_invalid_env_var_placeholder(self):
-        template = "Hello {{$}}"
-        values = {"ANOTHER_ENV_VAR": "test_value"}
+    @pytest.mark.parametrize(
+        "template,expected",
+        [
+            (
+                '{"greeting": "Hello {{name}}!", "message": {"text": "{{$$}}"}}',
+                '{"greeting": "Hello Dan!", "message": {"text": ""}}',
+            ),
+            (
+                '{"greeting": "Hello {{name}}!", "message": {"text": "{{$GREETING}}"}}',
+                '{"greeting": "Hello Dan!", "message": {"text": ""}}',
+            ),
+        ],
+    )
+    def test_invalid_env_var_placeholder(self, template, expected):
+        values = {"name": "Dan"}
         result = apply_values(template, values)
-        assert result == "Hello "
+        assert result == expected
 
 
 class TestApplyValues:


### PR DESCRIPTION
### Overview
Currently, the only templating options allowed are blocks and step outputs. For example:
```yaml
pull:
    - prefect.deployments.steps.git_clone:
        id: clone-step
        repository: https://github.com/org/repo.git
        credentials: {{ prefect.blocks.github-credentials.my-github-creds-block }}
    - prefect.deployments.steps.pip_install_requirements:
        directory: {{ clone-step.directory }}
        requirements_file: requirements.txt
        stream_output: False
```
This PR allows you to load values from environment variables, allowing you to access env vars during the `pull` step at runtime, or during the `build` and `push` actions when running `prefect deploy`.

### Example usage (from user-submitted issue)
Setting the image tag of a Dockerized build by loading a environment variable:

```yaml
build:
- prefect_docker.deployments.steps.build_docker_image:
    requires: prefect-docker>0.1.0
    image_name: my-image/orion
    tag: '{{ $CUSTOM_TAG }}'
```
This custom tag can be generated at runtime to provide a new tag at each pipeline, especially useful for CI/CD builds.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
