### PR TITLE
Turn workspace dashboard flag on by default

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1234,7 +1234,7 @@ PREFECT_EXPERIMENTAL_WARN_ARTIFACTS = Setting(bool, default=False)
 Whether or not to warn when experimental Prefect artifacts are used.
 """
 
-PREFECT_EXPERIMENTAL_ENABLE_WORKSPACE_DASHBOARD = Setting(bool, default=False)
+PREFECT_EXPERIMENTAL_ENABLE_WORKSPACE_DASHBOARD = Setting(bool, default=True)
 """
 Whether or not to enable the experimental workspace dashboard.
 """

--- a/tests/_internal/compatibility/test_experimental.py
+++ b/tests/_internal/compatibility/test_experimental.py
@@ -465,6 +465,7 @@ def test_enabled_experiments_with_opt_in():
         "workers",
         "artifacts",
         "events_client",
+        "workspace_dashboard",
     }
 
 
@@ -474,4 +475,5 @@ def test_enabled_experiments_without_opt_in():
         "workers",
         "artifacts",
         "events_client",
+        "workspace_dashboard",
     }

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -29,7 +29,13 @@ def test_app_exposes_ui_settings():
     response.raise_for_status()
     json = response.json()
     assert json["api_url"] == PREFECT_UI_API_URL.value()
-    assert set(json["flags"]) == {"artifacts", "workers", "work_pools", "events_client"}
+    assert set(json["flags"]) == {
+        "artifacts",
+        "workers",
+        "work_pools",
+        "events_client",
+        "workspace_dashboard",
+    }
 
 
 @pytest.mark.usefixtures("enable_prefect_experimental_test_opt_in_setting")
@@ -46,4 +52,5 @@ def test_app_exposes_ui_settings_with_experiments_enabled():
         "workers",
         "artifacts",
         "events_client",
+        "workspace_dashboard",
     }


### PR DESCRIPTION
In advance of releasing the feature, this sets the default for `WORKSPACE_DASHBOARD` to `True`.