### PR TITLE
Enhance `prefect deploy nonexistent-entrypoint` `ValueError` with possible solution

### DIFF
--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -293,7 +293,9 @@ async def register_flow(entrypoint: str, force: bool = False):
         if str(exc) == "not enough values to unpack (expected 2, got 1)":
             missing_flow_name_msg = (
                 "Your flow entrypoint must include the name of the function that is"
-                f" the entrypoint to your flow.\nTry {entrypoint}:<flow_name>"
+                f" the entrypoint to your flow.\nTry {entrypoint}:<flow_name> as your"
+                f" entrypoint. If you meant to specify '{entrypoint}' as the deployment"
+                f" name, try `prefect deploy -n {entrypoint}`."
             )
             raise ValueError(missing_flow_name_msg)
         else:


### PR DESCRIPTION
If a user forgets use `-n` when running the `prefect deploy` command, e.g. `prefect deploy default` when they mean to run `prefect deploy -n default`, they will be prompted to use the wizard to select a deployment; then they will receive an error because the second positional argument is entrypoint, not deployment name. This PR is a stopgap, improving the error messaging to guide users who mistakenly forget to use `-n`.

<!-- Include an overview here -->

### Example

<img width="952" alt="Screenshot 2023-07-12 at 2 28 14 PM" src="https://github.com/PrefectHQ/prefect/assets/42048900/d2c27bdf-39d8-43e0-a1bd-5ca26319bdb5">

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
