### PR TITLE
Remove references to `profile get`

### DIFF
--- a/docs/concepts/settings.md
+++ b/docs/concepts/settings.md
@@ -187,12 +187,6 @@ The `prefect profile` CLI commands enable you to create, review, and manage prof
 | rename | Change the name of a profile. |
 | use | Switch the active profile. |
 
-The default profile starts out empty:
-
-```bash
-$ prefect profile get
-[default]
-```
 
 If you configured settings for a profile, `prefect profile inspect` displays those settings:
 
@@ -294,33 +288,6 @@ $ prefect profile ls
 cloud
 test
 local
-```
-
-View the current profile:
-
-```bash
-$ prefect profile get
-[default]
-VAR=X
-```
-
-View another profile:
-
-```bash
-$ prefect profile get foo
-[foo]
-VAR=Y
-```
-
-View multiple profiles:
-
-```bash
-$ prefect profile get default foo
-[default]
-VAR=X
-
-[foo]
-VAR=Y
 ```
 
 View all settings for a profile:


### PR DESCRIPTION
The Profiles & Configuration docs make reference to a command, `get` that doesn't exist. Removing these references closes #10186 

### Checklist
- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
