### PR TITLE
Work pool name validation

### DIFF
--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -48,6 +48,8 @@ async def create(
         $ prefect work-pool create "my-pool" --paused
     """
     async with get_collections_metadata_client() as collections_client:
+        if not name.lower().strip("'\" "):
+            exit_with_error("Work pool name cannot be empty.")
         if type is None:
             if not is_interactive():
                 exit_with_error(

--- a/src/prefect/server/api/workers.py
+++ b/src/prefect/server/api/workers.py
@@ -130,6 +130,12 @@ async def create_work_pool(
     name already exists, an error will be raised.
     """
 
+    if not work_pool.name.lower().strip("' \""):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Work pools must have non-trivial names.",
+        )
+
     if work_pool.name.lower().startswith("prefect"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/src/prefect/server/api/workers.py
+++ b/src/prefect/server/api/workers.py
@@ -133,7 +133,7 @@ async def create_work_pool(
     if not work_pool.name.lower().strip("' \""):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Work pools must have non-trivial names.",
+            detail="Work pool name cannot be empty.",
         )
 
     if work_pool.name.lower().startswith("prefect"):

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -94,6 +94,16 @@ class TestCreate:
         assert client_res.base_job_template == {}
         assert isinstance(client_res, WorkPool)
 
+    async def test_create_work_pool_with_empty_name(
+        self, prefect_client, mock_collection_registry
+    ):
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            "work-pool create '' -t prefect-agent",
+            expected_code=1,
+            expected_output_contains=["name cannot be empty"],
+        )
+
     async def test_create_work_pool_name_conflict(
         self, prefect_client, mock_collection_registry
     ):

--- a/tests/server/api/test_workers.py
+++ b/tests/server/api/test_workers.py
@@ -92,7 +92,7 @@ class TestCreateWorkPool:
     async def test_create_work_pool_with_empty_name(self, client, name):
         response = await client.post("/work_pools/", json=dict(name=name))
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "must have non-trivial name" in response.json()["detail"]
+        assert "name cannot be empty" in response.json()["detail"]
 
     @pytest.mark.parametrize("type", ["PROCESS", "K8S", "AGENT"])
     async def test_create_typed_work_pool(self, session, client, type):

--- a/tests/server/api/test_workers.py
+++ b/tests/server/api/test_workers.py
@@ -88,6 +88,12 @@ class TestCreateWorkPool:
         response = await client.post("/work_pools/", json=dict(name=name))
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
+    @pytest.mark.parametrize("name", ["", "''", " ", "' ' "])
+    async def test_create_work_pool_with_empty_name(self, client, name):
+        response = await client.post("/work_pools/", json=dict(name=name))
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "must have non-trivial name" in response.json()["detail"]
+
     @pytest.mark.parametrize("type", ["PROCESS", "K8S", "AGENT"])
     async def test_create_typed_work_pool(self, session, client, type):
         response = await client.post(
@@ -111,8 +117,7 @@ class TestCreateWorkPool:
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         assert (
             "The `base_job_template` must contain both a `job_configuration` key and a"
-            " `variables` key."
-            in response.json()["exception_detail"][0]["msg"]
+            " `variables` key." in response.json()["exception_detail"][0]["msg"]
         )
 
     async def test_create_work_pool_template_validation_missing_variables(self, client):
@@ -332,8 +337,7 @@ class TestUpdateWorkPool:
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         assert (
             "The `base_job_template` must contain both a `job_configuration` key and a"
-            " `variables` key."
-            in response.json()["exception_detail"][0]["msg"]
+            " `variables` key." in response.json()["exception_detail"][0]["msg"]
         )
 
     async def test_update_work_pool_template_validation_missing_variables(

--- a/tests/server/api/test_workers.py
+++ b/tests/server/api/test_workers.py
@@ -117,7 +117,8 @@ class TestCreateWorkPool:
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         assert (
             "The `base_job_template` must contain both a `job_configuration` key and a"
-            " `variables` key." in response.json()["exception_detail"][0]["msg"]
+            " `variables` key."
+            in response.json()["exception_detail"][0]["msg"]
         )
 
     async def test_create_work_pool_template_validation_missing_variables(self, client):
@@ -337,7 +338,8 @@ class TestUpdateWorkPool:
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         assert (
             "The `base_job_template` must contain both a `job_configuration` key and a"
-            " `variables` key." in response.json()["exception_detail"][0]["msg"]
+            " `variables` key."
+            in response.json()["exception_detail"][0]["msg"]
         )
 
     async def test_update_work_pool_template_validation_missing_variables(


### PR DESCRIPTION
Currently it is possible for users to create work pools with empty string names; this is a problem for a number of reasons, one of which is that these work pools cannot be deleted due to this creating invalid path specs for the delete route.  This PR adds validation to both the OSS server as well as the CLI for protecting against users getting into this situation.

Closes https://github.com/PrefectHQ/prefect/issues/10193

## Note

We raise 422 for other name-validation failures, but I don't think that is correct; 422 should be for unprocessable entities, meaning payloads with unknown or missing fields, not for payloads with "bad" values.  For that situation we should raise 400.  I didn't change the other status codes here because that would _technically_ be a breaking change, but wanted to call it out.  For another example of a client that follows this pattern, [check out GitHub's client errors docs](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#client-errors).

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
