### PR TITLE
Add project_dir fixture to brittle test

### DIFF
--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -2935,6 +2935,7 @@ class TestMultiDeploy:
             ("my-flow/test-name-3", "my-flow/test-name-4"),
         ],
     )
+    @pytest.mark.usefixtures("project_dir")
     async def test_deploy_multiple_nonexistent_deployments_raises(
         self, deploy_names, work_pool, prefect_client
     ):


### PR DESCRIPTION
I keep seeing this test fail on essentially every PR; every other test in this repository uses the `project_dir` fixture to ensure a stable path, so I'm taking an educated guess that this is causing the `FileNotFoundError`s we're seeing non-deterministically.  Time will tell.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [x] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
