### PR TITLE
Use orjson_dumps_extra_compatible when serializing in `build_from_flow` (#10216) 

### DIFF
--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -17,7 +17,7 @@ from pydantic.json import custom_pydantic_encoder
 
 from prefect._internal.compatibility.experimental import experiment_enabled
 from prefect._internal.schemas.fields import DateTimeTZ
-from prefect._internal.schemas.serializers import orjson_dumps
+from prefect._internal.schemas.serializers import orjson_dumps_extra_compatible
 
 T = TypeVar("T")
 
@@ -60,7 +60,7 @@ class PrefectBaseModel(BaseModel):
 
         # Use orjson for serialization
         json_loads = orjson.loads
-        json_dumps = orjson_dumps
+        json_dumps = orjson_dumps_extra_compatible
 
     def _reset_fields(self) -> Set[str]:
         """A set of field names that are reset when the PrefectBaseModel is copied.

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import pytest
 
 from prefect import flow
@@ -25,6 +27,17 @@ def flow_function():
         return param
 
     return client_test_flow
+
+
+@pytest.fixture(scope="session")
+def flow_function_dict_parameter():
+    @flow(
+        version="test", description="A test function with a dictionary as a parameter"
+    )
+    def client_test_flow_dict_parameter(dict_param: Dict[int, str]):
+        return dict_param
+
+    return client_test_flow_dict_parameter
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -689,6 +689,23 @@ class TestDeploymentApply:
                     create_route.calls[0].request.content
                 ) == trigger.as_automation().dict(json_compatible=True)
 
+    async def test_deployment_apply_with_dict_parameter(
+        self, flow_function_dict_parameter, prefect_client
+    ):
+        d = await Deployment.build_from_flow(
+            flow_function_dict_parameter,
+            name="foo",
+            parameters=dict(dict_param={1: "a", 2: "b"}),
+        )
+
+        assert d.flow_name == flow_function_dict_parameter.name
+        assert d.name == "foo"
+
+        dep_id = await d.apply()
+        dep = await prefect_client.read_deployment(dep_id)
+
+        assert dep is not None
+
 
 class TestRunDeployment:
     @pytest.mark.parametrize(


### PR DESCRIPTION
The function `orjson_dumps_extra_compatible` was created for dumping a value to JSON using orjson, the purpose is to allow for more complex keys (from the [documentation](https://github.com/PrefectHQ/prefect/blob/4c8d8e4fe055cec7fa07da80cc21ff08e32f03f6/src/prefect/_internal/schemas/serializers.py#L15)):

> 1) non-string keys: this is helpful for situations like pandas dataframes,
    which can result in non-string keys 

Using it to solve the bug in question, seems fitting. 

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

closes #10216 