### PR TITLE
To pause is not to fail

### DIFF
--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -78,7 +78,7 @@ async def _get_state_result(state: State[R], raise_on_failure: bool) -> R:
     """
     if state.is_paused():
         # Paused states are not truly terminal and do not have results associated with them
-        raise PausedRun("Run paused.")
+        raise PausedRun("Run is paused, its result is not available.")
 
     if not state.is_final():
         raise UnfinishedRun(

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -265,6 +265,8 @@ async def return_value_to_state(retval: R, result_factory: ResultFactory) -> Sta
             new_state_type = StateType.COMPLETED
         elif states.any_cancelled():
             new_state_type = StateType.CANCELLED
+        elif states.any_paused():
+            new_state_type = StateType.PAUSED
         else:
             new_state_type = StateType.FAILED
 
@@ -273,6 +275,8 @@ async def return_value_to_state(retval: R, result_factory: ResultFactory) -> Sta
             message = "All states completed."
         elif states.any_cancelled():
             message = f"{states.cancelled_count}/{states.total_count} states cancelled."
+        elif states.any_paused():
+            message = f"{states.paused_count}/{states.total_count} states paused."
         elif states.any_failed():
             message = f"{states.fail_count}/{states.total_count} states failed."
         elif not states.all_final():
@@ -430,6 +434,7 @@ class StateGroup:
         self.cancelled_count = self.type_counts[StateType.CANCELLED]
         self.final_count = sum(state.is_final() for state in states)
         self.not_final_count = self.total_count - self.final_count
+        self.paused_count = self.type_counts[StateType.PAUSED]
 
     @property
     def fail_count(self):
@@ -446,6 +451,9 @@ class StateGroup:
             self.type_counts[StateType.FAILED] > 0
             or self.type_counts[StateType.CRASHED] > 0
         )
+
+    def any_paused(self) -> bool:
+        return self.paused_count > 0
 
     def all_final(self) -> bool:
         return self.final_count == self.total_count

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -32,7 +32,14 @@ from prefect.server.schemas.core import TaskRunResult
 from prefect.server.schemas.filters import FlowFilter, FlowRunFilter
 from prefect.server.schemas.sorting import FlowRunSort
 from prefect.settings import temporary_settings, PREFECT_FLOW_DEFAULT_RETRIES
-from prefect.states import Cancelled, State, StateType, raise_state_exception
+from prefect.states import (
+    Cancelled,
+    Paused,
+    PausedRun,
+    State,
+    StateType,
+    raise_state_exception,
+)
 from prefect.task_runners import ConcurrentTaskRunner, SequentialTaskRunner
 from prefect.testing.utilities import (
     exceptions_equal,
@@ -629,6 +636,17 @@ class TestFlowCall:
         with PrefectObjectRegistry(block_code_execution=True):
             state = foo(1, 2)
             assert state is None
+
+    def test_flow_can_end_in_paused_state(self):
+        @flow
+        def my_flow():
+            return Paused()
+
+        with pytest.raises(PausedRun, match="result is not available"):
+            my_flow()
+
+        flow_state = my_flow(return_state=True)
+        assert flow_state.is_paused()
 
     def test_flow_can_end_in_cancelled_state(self):
         @flow

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -16,6 +16,7 @@ from prefect.states import (
     Crashed,
     Failed,
     Pending,
+    Paused,
     Running,
     State,
     StateGroup,
@@ -277,6 +278,21 @@ class TestStateGroup:
 
         assert not StateGroup(states).any_cancelled()
 
+    def test_any_paused(self):
+        states = [
+            Paused(),
+            Failed(data=ValueError("1")),
+        ]
+
+        assert StateGroup(states).any_paused()
+
+        states = [
+            Completed(data="test"),
+            Failed(data=ValueError("1")),
+        ]
+
+        assert not StateGroup(states).any_paused()
+
     def test_any_failed(self):
         states = [
             Completed(data="test"),
@@ -308,6 +324,16 @@ class TestStateGroup:
             Crashed(data=ValueError("crashed")),
             Completed(data="complete"),
             Cancelled(data="cancelled"),
+            Running(),
+        ]
+
+        assert not StateGroup(states).all_final()
+
+        states = [
+            Failed(data=ValueError("failed")),
+            Crashed(data=ValueError("crashed")),
+            Completed(data="complete"),
+            Paused(data="paused"),
             Running(),
         ]
 


### PR DESCRIPTION
Currently there are numerous issues with pausing flow runs:
- if any task run is paused mid-run, the flow run gets incorrectly marked as failed
- returning a `Paused` state from a flow run causes an infinite execution loop that never has a terminating condition
- `Paused` states without timeouts set cause an error due to a log message that assumes a non-null `timeout`

This PR addresses all three of these issues.

Closes https://github.com/PrefectHQ/prefect/issues/9824

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->