### PR TITLE
Increase timeout to an hour to prevent cancellation failures on main

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -97,7 +97,7 @@ jobs:
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     steps:
       - name: Display current test matrix


### PR DESCRIPTION
Our `main` branch is _never_ healthy due to these job cancellations; increasing timeout to 60 minutes as a bandaid.