### PR TITLE
Fix incorrect path in error message

### DIFF
--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -327,7 +327,7 @@ async def register_flow(entrypoint: str, force: bool = False):
                 f"Conflicting entry found for flow with name {flow.name!r}.\nExisting"
                 f" entrypoint: {flows[flow.name]}\nAttempted entrypoint:"
                 f" {entrypoint}\n\nYou can try removing the existing entry for"
-                f" {flow.name!r} from your [yellow]~./prefect/flows.json[/yellow]."
+                f" {flow.name!r} from your [yellow]~/.prefect/flows.json[/yellow]."
             )
 
     flows[flow.name] = entrypoint


### PR DESCRIPTION

~./prefect should be ~/.prefect in duplicate deploy error message. Bug found by Raoul B. at PACC.

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [n/a] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [n/a] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
