### PR TITLE
Fix LocalFileSystem.get_directory with basepath behaviour 

### DIFF
--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -132,7 +132,7 @@ class LocalFileSystem(WritableFileSystem, WritableDeploymentStorage):
         if not from_path:
             from_path = Path(self.basepath).expanduser().resolve()
         else:
-            from_path = Path(from_path).resolve()
+            from_path = self._resolve_path(from_path)
 
         if not local_path:
             local_path = Path(".").resolve()

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -93,11 +93,24 @@ class TestLocalFileSystem:
         parent_contents, child_contents = setup_test_directory(tmp_path, sub_dir_name)
         # move file contents to tmp_dst
         with TemporaryDirectory() as tmp_dst:
-            f = LocalFileSystem()
+            f = LocalFileSystem(basepath=str(tmp_path))
 
             await f.get_directory(from_path=tmp_path, local_path=tmp_dst)
             assert set(os.listdir(tmp_dst)) == set(parent_contents)
             assert set(os.listdir(Path(tmp_dst) / sub_dir_name)) == set(child_contents)
+
+    async def test_dir_contents_copied_correctly_with_get_directory_relative_from_path(
+        self, tmp_path
+    ):
+        sub_dir_name = "puppy"
+
+        _, child_contents = setup_test_directory(tmp_path, sub_dir_name)
+        # move file contents to tmp_dst
+        with TemporaryDirectory() as tmp_dst:
+            f = LocalFileSystem(basepath=str(tmp_path))
+
+            await f.get_directory(from_path=sub_dir_name, local_path=tmp_dst)
+            assert set(os.listdir(tmp_dst)) == set(child_contents)
 
     async def test_dir_contents_copied_correctly_with_put_directory(self, tmp_path):
         sub_dir_name = "puppy"
@@ -345,7 +358,7 @@ class TestRemoteFileSystem:
         cwd = tmp_path / "working"
         cwd.mkdir()
 
-        fs = LocalFileSystem()
+        fs = LocalFileSystem(basepath=str(tmp_path))
         with tmpchdir(cwd):
             await fs.get_directory(from_path=str(from_path), local_path=null_value)
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

Closes https://github.com/PrefectHQ/prefect/issues/10254

When a `LocalFileSystem` was specified with a `basepath`, `get_directory` would fail when provided with a relative `from_path`. In addition, no checks were performed to ensure `from_path` was within the `basepath`. Both of these issues are addressed by using `LocalFileSystem._resolve_path`, as is done in `RemoteFileSystem.get_directory`.

A test was added for using `get_directory` with a relative `from_path`. In addition, two tests relied on the missing check above, so were fixed:
* `test_dir_contents_copied_correctly_with_get_directory`
* `test_get_directory_empty_local_path_uses_cwd`

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

``` python
fs = LocalFileSystem(basepath="path/with/subdirectory")
# Copy files/folders from subdirectory to current working directory
fs.get_directory(from_path="subdirectory") # Previously failed
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
