### PR TITLE
Build out a proof-of-concept concurrency context manager.

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -80,7 +80,6 @@ from prefect.client.schemas.objects import (
 from prefect.client.schemas.responses import (
     DeploymentResponse,
     WorkerFlowRunResponse,
-    MinimalConcurrencyLimitResponse,
 )
 from prefect.client.schemas.schedules import SCHEDULE_TYPES
 from prefect.client.schemas.sorting import (
@@ -106,7 +105,6 @@ from prefect.settings import (
     PREFECT_UNIT_TEST_MODE,
 )
 from prefect.utilities.collections import AutoEnum
-from prefect.utilities.math import clamped_poisson_interval
 
 if TYPE_CHECKING:
     from prefect.flows import Flow as FlowObject
@@ -2539,47 +2537,21 @@ class PrefectClient:
 
         await self._client.delete(f"/automations/owned-by/{resource_id}")
 
-    async def acquire_concurrency_slots(
+    async def increment_concurrency_slots(
         self, names: List[str], slots: int
-    ) -> List[MinimalConcurrencyLimitResponse]:
-        try_count = 0
-        while True:
-            retry_seconds = None
-            try_count += 1
-            try:
-                response = await self._client.post(
-                    "/v2/concurrency_limits/increment",
-                    json={"names": names, "slots": slots},
-                )
-            except Exception as exc:
-                if exc.response.status_code == 423:
-                    # Failed to acquire lock, wait and try again.
-
-                    # TODO: The API should probably return a `Retry-After`
-                    # header that's used here instead of a clamped exponential
-                    # backoff, the tricky part is what value the API should
-                    # return.
-                    retry_seconds = clamped_poisson_interval(min(2**try_count, 30))
-                    await asyncio.sleep(retry_seconds)
-                else:
-                    raise exc
-            else:
-                return [
-                    MinimalConcurrencyLimitResponse.parse_obj(obj_)
-                    for obj_ in response.json()
-                ]
-
-    async def release_concurrency_slots(
-        self, names: List[str], slots: int
-    ) -> List[MinimalConcurrencyLimitResponse]:
-        response = await self._client.post(
-            "/v2/concurrency_limits/decrement",
+    ) -> httpx.Response:
+        return await self._client.post(
+            "/v2/concurrency_limits/increment",
             json={"names": names, "slots": slots},
         )
 
-        return [
-            MinimalConcurrencyLimitResponse.parse_obj(obj_) for obj_ in response.json()
-        ]
+    async def release_concurrency_slots(
+        self, names: List[str], slots: int
+    ) -> httpx.Response:
+        return await self._client.post(
+            "/v2/concurrency_limits/decrement",
+            json={"names": names, "slots": slots},
+        )
 
     async def __aenter__(self):
         """

--- a/src/prefect/client/schemas/responses.py
+++ b/src/prefect/client/schemas/responses.py
@@ -223,3 +223,12 @@ class DeploymentResponse(ObjectBaseModel):
         default=None,
         description="The name of the deployment's work pool.",
     )
+
+
+class MinimalConcurrencyLimitResponse(PrefectBaseModel):
+    class Config:
+        extra = "ignore"
+
+    id: UUID
+    name: str
+    limit: int

--- a/src/prefect/concurrency.py
+++ b/src/prefect/concurrency.py
@@ -1,0 +1,88 @@
+from typing import List, Literal, Union
+from contextlib import contextmanager
+
+from prefect import get_client
+from prefect.client.schemas.responses import MinimalConcurrencyLimitResponse
+from prefect.events import Event, RelatedResource, emit_event
+from prefect._internal.concurrency.api import create_call, from_sync
+from prefect._internal.concurrency.event_loop import get_running_loop
+
+
+async def acquire_concurrency_slots(
+    names: List[str], slots: int
+) -> List[MinimalConcurrencyLimitResponse]:
+    async with get_client() as client:
+        return await client.acquire_concurrency_slots(names=names, slots=slots)
+
+
+async def release_concurrency_slots(
+    names: List[str], slots: int
+) -> List[MinimalConcurrencyLimitResponse]:
+    async with get_client() as client:
+        return await client.release_concurrency_slots(names=names, slots=slots)
+
+
+def emit_concurrency_event(
+    phase: Union[Literal["acquired"], Literal["released"]],
+    primary_limit: MinimalConcurrencyLimitResponse,
+    related_limits: List[MinimalConcurrencyLimitResponse],
+    slots: int,
+    follows: Union[Event, None] = None,
+) -> Union[Event, None]:
+    resource = {
+        "prefect.resource.id": f"prefect.concurrency-limit.{primary_limit.id}",
+        "prefect.resource.name": primary_limit.name,
+        "slots-acquired": slots,
+        "limit": primary_limit.limit,
+    }
+
+    related = [
+        RelatedResource(
+            __root__={
+                "prefect.resource.id": f"prefect.concurrency-limit.{limit.id}",
+                "prefect.resource.role": "concurrency_limit",
+            }
+        )
+        for limit in related_limits
+    ]
+
+    event = emit_event(
+        f"prefect.concurrency-limit.{phase}",
+        resource=resource,
+        related=related,
+        follows=follows,
+    )
+    return event
+
+
+@contextmanager
+def concurrency(names: Union[str, List[str]], slots: int = 1):
+    if isinstance(names, str):
+        names = [names]
+
+    limits = run_async_function(acquire_concurrency_slots, names, slots)
+
+    concurrency_limit_events = {}
+
+    for limit in limits:
+        event = emit_concurrency_event("acquired", limit, limits, slots)
+        concurrency_limit_events[limit.id] = event
+
+    try:
+        yield
+    finally:
+        run_async_function(release_concurrency_slots, names, slots)
+    for limit in limits:
+        emit_concurrency_event(
+            "released", limit, limits, slots, concurrency_limit_events[limit.id]
+        )
+
+
+def run_async_function(fn, *args, **kwargs):
+    loop = get_running_loop()
+    call = create_call(fn, *args, **kwargs)
+
+    if loop is not None:
+        return from_sync.call_soon_in_loop_thread(call).result()
+    else:
+        return call()


### PR DESCRIPTION
This creates the general use `concurrency` context manager. I'm calling this a `proof-of-concept` because I'm currently unable to write useful tests as the API portion of this only exists in Cloud and that API is still in flux. Tests will be added after the API portion is ported.

### Example

```python
import sys
import asyncio
import random

from prefect import flow, task
from prefect.concurrency import concurrency
from prefect.blocks.system import String


trees = ["🌲", "🌴", "🌳"]


@task
async def get_random_tree() -> str:
    with concurrency("trees"):
        await asyncio.sleep(1)
        return random.choice(trees)


@flow
async def happy(num_trees: int):
    futures = []
    for _ in range(num_trees):
        futures.append(await get_random_tree.submit())

    for future in futures:
        tree = await future.result()
        print("Here's a happy little tree:")
        print(tree)


if __name__ == "__main__":
    num_trees = int(sys.argv[1])
    asyncio.run(happy(num_trees=num_trees))

```