### PR TITLE
Pause task runs

### DIFF
--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -90,6 +90,10 @@ class PausedRun(PrefectException):
     Raised when the result from a paused run is retrieved.
     """
 
+    def __init__(self, *args, state=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.state = state
+
 
 class UnfinishedRun(PrefectException):
     """

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -78,7 +78,7 @@ async def _get_state_result(state: State[R], raise_on_failure: bool) -> R:
     """
     if state.is_paused():
         # Paused states are not truly terminal and do not have results associated with them
-        raise PausedRun("Run is paused, its result is not available.")
+        raise PausedRun("Run is paused, its result is not available.", state=state)
 
     if not state.is_final():
         raise UnfinishedRun(


### PR DESCRIPTION
Currently you cannot pause task runs; this was originally designed this way because task runs cannot be individually resumed.  However, if a user explicitly puts a task run into a Paused state, the flow run should pause likewise using the same settings, and now the flow run can resume as intended.

This PR allows task runs to explicitly return `Paused` states, and the flow run will behave as expected.

Closes https://github.com/PrefectHQ/prefect/issues/8442

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
```python
from prefect import task, flow
from prefect.states import Paused

@task
def pause_sometimes(pause):
    import random
    if random.random() > 0.5:
        return Paused()

@flow 
def pause_flow():
    pause_sometimes()
    return 42
```

If you execute this using your favorite method, you'll find that half the time the task run will enter a Paused state, and likewise so will the flow run.  Previously, this code would have generated an infinite loop.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [x] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
