### PR TITLE
Allow setting a work queue per flow run

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -523,8 +523,11 @@ class PrefectClient:
             name=name,
             idempotency_key=idempotency_key,
             parent_task_run_id=parent_task_run_id,
-            work_queue_name=work_queue_name,
         )
+
+        # done separately to avoid including this field in payloads sent to older API versions
+        if work_queue_name:
+            flow_run_create.work_queue_name = work_queue_name
 
         response = await self._client.post(
             f"/deployments/{deployment_id}/create_flow_run",

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -531,7 +531,7 @@ class PrefectClient:
 
         response = await self._client.post(
             f"/deployments/{deployment_id}/create_flow_run",
-            json=flow_run_create.dict(json_compatible=True),
+            json=flow_run_create.dict(json_compatible=True, exclude_unset=True),
         )
         return FlowRun.parse_obj(response.json())
 

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -479,6 +479,7 @@ class PrefectClient:
         tags: Iterable[str] = None,
         idempotency_key: str = None,
         parent_task_run_id: UUID = None,
+        work_queue_name: str = None,
     ) -> FlowRun:
         """
         Create a flow run for a deployment.
@@ -499,6 +500,9 @@ class PrefectClient:
                 be returned instead of creating a new one.
             parent_task_run_id: if a subflow run is being created, the placeholder task
                 run identifier in the parent flow
+            work_queue_name: An optional work queue name to add this run to. If not provided,
+                will default to the deployment's set work queue.  If one is provided that does not
+                exist, a new work queue will be created within the deployment's work pool.
 
         Raises:
             httpx.RequestError: if the Prefect API does not successfully create a run for any reason
@@ -519,6 +523,7 @@ class PrefectClient:
             name=name,
             idempotency_key=idempotency_key,
             parent_task_run_id=parent_task_run_id,
+            work_queue_name=work_queue_name,
         )
 
         response = await self._client.post(

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -335,6 +335,7 @@ class DeploymentFlowRunCreate(ActionBaseModel):
     tags: List[str] = FieldFrom(objects.FlowRun)
     idempotency_key: Optional[str] = FieldFrom(objects.FlowRun)
     parent_task_run_id: Optional[UUID] = FieldFrom(objects.FlowRun)
+    work_queue_name: Optional[str] = FieldFrom(objects.FlowRun)
 
 
 @copy_model_fields

--- a/src/prefect/deployments/deployments.py
+++ b/src/prefect/deployments/deployments.py
@@ -57,6 +57,7 @@ async def run_deployment(
     poll_interval: Optional[float] = 5,
     tags: Optional[Iterable[str]] = None,
     idempotency_key: Optional[str] = None,
+    work_queue_name: Optional[str] = None,
 ):
     """
     Create a flow run for a deployment and return it after completion or a timeout.
@@ -83,6 +84,8 @@ async def run_deployment(
             only for organizational purposes.
         idempotency_key: A unique value to recognize retries of the same run, and
             prevent creating multiple flow runs.
+        work_queue_name: The name of a work queue to use for this run. Defaults to
+            the default work queue for the deployment.
     """
     if timeout is not None and timeout < 0:
         raise ValueError("`timeout` cannot be negative")
@@ -153,6 +156,7 @@ async def run_deployment(
         tags=tags,
         idempotency_key=idempotency_key,
         parent_task_run_id=parent_task_run_id,
+        work_queue_name=work_queue_name,
     )
 
     flow_run_id = flow_run.id

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -66,22 +66,22 @@ async def create_deployment(
         if deployment.work_pool_name and deployment.work_queue_name:
             # If a specific pool name/queue name combination was provided, get the
             # ID for that work pool queue.
-            deployment_dict[
-                "work_queue_id"
-            ] = await worker_lookups._get_work_queue_id_from_name(
-                session=session,
-                work_pool_name=deployment.work_pool_name,
-                work_queue_name=deployment.work_queue_name,
-                create_queue_if_not_found=True,
+            deployment_dict["work_queue_id"] = (
+                await worker_lookups._get_work_queue_id_from_name(
+                    session=session,
+                    work_pool_name=deployment.work_pool_name,
+                    work_queue_name=deployment.work_queue_name,
+                    create_queue_if_not_found=True,
+                )
             )
         elif deployment.work_pool_name:
             # If just a pool name was provided, get the ID for its default
             # work pool queue.
-            deployment_dict[
-                "work_queue_id"
-            ] = await worker_lookups._get_default_work_queue_id_from_work_pool_name(
-                session=session,
-                work_pool_name=deployment.work_pool_name,
+            deployment_dict["work_queue_id"] = (
+                await worker_lookups._get_default_work_queue_id_from_work_pool_name(
+                    session=session,
+                    work_pool_name=deployment.work_pool_name,
+                )
             )
         elif deployment.work_queue_name:
             # If just a queue name was provided, ensure that the queue exists and
@@ -412,7 +412,7 @@ async def create_flow_run_from_deployment(
             deployment.work_queue_id = (
                 await worker_lookups._get_work_queue_id_from_name(
                     session=session,
-                    work_pool_name=deployment.work_pool_name,
+                    work_pool_name=deployment.work_queue.work_pool.name,
                     work_queue_name=flow_run.work_queue_name,
                     create_queue_if_not_found=True,
                 )
@@ -426,6 +426,7 @@ async def create_flow_run_from_deployment(
                     "parameters",
                     "tags",
                     "infrastructure_document_id",
+                    "work_queue_name",
                 }
             ),
             flow_id=deployment.flow_id,

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -66,22 +66,22 @@ async def create_deployment(
         if deployment.work_pool_name and deployment.work_queue_name:
             # If a specific pool name/queue name combination was provided, get the
             # ID for that work pool queue.
-            deployment_dict["work_queue_id"] = (
-                await worker_lookups._get_work_queue_id_from_name(
-                    session=session,
-                    work_pool_name=deployment.work_pool_name,
-                    work_queue_name=deployment.work_queue_name,
-                    create_queue_if_not_found=True,
-                )
+            deployment_dict[
+                "work_queue_id"
+            ] = await worker_lookups._get_work_queue_id_from_name(
+                session=session,
+                work_pool_name=deployment.work_pool_name,
+                work_queue_name=deployment.work_queue_name,
+                create_queue_if_not_found=True,
             )
         elif deployment.work_pool_name:
             # If just a pool name was provided, get the ID for its default
             # work pool queue.
-            deployment_dict["work_queue_id"] = (
-                await worker_lookups._get_default_work_queue_id_from_work_pool_name(
-                    session=session,
-                    work_pool_name=deployment.work_pool_name,
-                )
+            deployment_dict[
+                "work_queue_id"
+            ] = await worker_lookups._get_default_work_queue_id_from_work_pool_name(
+                session=session,
+                work_pool_name=deployment.work_pool_name,
             )
         elif deployment.work_queue_name:
             # If just a queue name was provided, ensure that the queue exists and
@@ -383,6 +383,7 @@ async def create_flow_run_from_deployment(
     flow_run: schemas.actions.DeploymentFlowRunCreate,
     deployment_id: UUID = Path(..., description="The deployment id", alias="id"),
     db: PrefectDBInterface = Depends(provide_database_interface),
+    worker_lookups: WorkerLookups = Depends(WorkerLookups),
     response: Response = None,
 ) -> schemas.responses.FlowRunResponse:
     """
@@ -406,6 +407,17 @@ async def create_flow_run_from_deployment(
 
         parameters = deployment.parameters
         parameters.update(flow_run.parameters or {})
+
+        if flow_run.work_queue_name:
+            deployment.work_queue_id = (
+                await worker_lookups._get_work_queue_id_from_name(
+                    session=session,
+                    work_pool_name=deployment.work_pool_name,
+                    work_queue_name=flow_run.work_queue_name,
+                    create_queue_if_not_found=True,
+                )
+            )
+            deployment.work_queue_name = flow_run.work_queue_name
 
         # hydrate the input model into a full flow run / state model
         flow_run = schemas.core.FlowRun(

--- a/src/prefect/server/api/workers.py
+++ b/src/prefect/server/api/workers.py
@@ -73,6 +73,24 @@ class WorkerLookups:
 
         return work_pool.default_queue_id
 
+    async def _get_work_pool_name_from_work_queue_id(
+        self, session: AsyncSession, work_queue_id: UUID
+    ):
+        """
+        Given a work queue ID, return the work pool name that it is associated with.
+        """
+        work_pool = await models.workers.read_work_pool_by_name(
+            session=session,
+            work_pool_name=work_pool_name,
+        )
+        if not work_pool:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f'Work pool "{work_pool_name}" not found.',
+            )
+
+        return work_pool.default_queue_id
+
     async def _get_work_queue_id_from_name(
         self,
         session: AsyncSession,

--- a/src/prefect/server/api/workers.py
+++ b/src/prefect/server/api/workers.py
@@ -73,24 +73,6 @@ class WorkerLookups:
 
         return work_pool.default_queue_id
 
-    async def _get_work_pool_name_from_work_queue_id(
-        self, session: AsyncSession, work_queue_id: UUID
-    ):
-        """
-        Given a work queue ID, return the work pool name that it is associated with.
-        """
-        work_pool = await models.workers.read_work_pool_by_name(
-            session=session,
-            work_pool_name=work_pool_name,
-        )
-        if not work_pool:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f'Work pool "{work_pool_name}" not found.',
-            )
-
-        return work_pool.default_queue_id
-
     async def _get_work_queue_id_from_name(
         self,
         session: AsyncSession,

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -370,6 +370,7 @@ class DeploymentFlowRunCreate(ActionBaseModel):
     tags: List[str] = FieldFrom(schemas.core.FlowRun)
     idempotency_key: Optional[str] = FieldFrom(schemas.core.FlowRun)
     parent_task_run_id: Optional[UUID] = FieldFrom(schemas.core.FlowRun)
+    work_queue_name: Optional[str] = FieldFrom(schemas.core.FlowRun)
 
 
 @copy_model_fields

--- a/tests/cli/test_start_agent.py
+++ b/tests/cli/test_start_agent.py
@@ -93,6 +93,7 @@ class TestAgentSignalForwarding:
         sys.platform == "win32",
         reason="SIGTERM is only used in non-Windows environments",
     )
+    @pytest.mark.flaky(max_runs=2)
     async def test_sigterm_sends_sigterm_directly(self, agent_process):
         agent_process.send_signal(signal.SIGTERM)
         await safe_shutdown(agent_process)


### PR DESCRIPTION
This PR exposes a `work_queue_name` field when creating a flow run for a deployment that allows users to override the queue setting on the deployment on a per-run basis.  If the queue name does not already exist, one is created within the work pool set for the deployment.

Closes #10257 
Closes #10261 

I will also work on exposing this field within the UI as a next step.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [x] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
