### PR TITLE
Implement `rate_limit` function to block execution while acquiring slots

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2538,11 +2538,11 @@ class PrefectClient:
         await self._client.delete(f"/automations/owned-by/{resource_id}")
 
     async def increment_concurrency_slots(
-        self, names: List[str], slots: int
+        self, names: List[str], slots: int, mode: str
     ) -> httpx.Response:
         return await self._client.post(
             "/v2/concurrency_limits/increment",
-            json={"names": names, "slots": slots},
+            json={"names": names, "slots": slots, "mode": mode},
         )
 
     async def release_concurrency_slots(


### PR DESCRIPTION
This implements the `rate_limit` form of concurrency limits where there is no explicit decrement and a slot decay is used instead. Much like the `concurrency` context manager this PR includes no tests and will be 'codified' when the API is ported to OSS.

### Example
```python
import asyncio
import datetime

from prefect.concurrency import rate_limit


def resource_hog():
    rate_limit("hog")
    print(datetime.datetime.now())


async def main():
    await asyncio.gather(*[resource_hog() for _ in range(3)])


if __name__ == "__main__":
    asyncio.run(main())
```
