### PR TITLE
logging work pool instead of worker

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -652,9 +652,9 @@ class BaseWorker(abc.ABC):
                 work_pool = await self._client.create_work_pool(
                     work_pool=WorkPoolCreate(name=self._work_pool_name, type=self.type)
                 )
-                self._logger.info(f"Worker pool {self._work_pool_name!r} created.")
+                self._logger.info(f"Work pool {self._work_pool_name!r} created.")
             else:
-                self._logger.warning(f"Worker pool {self._work_pool_name!r} not found!")
+                self._logger.warning(f"Work pool {self._work_pool_name!r} not found!")
                 return
 
         # if the remote config type changes (or if it's being loaded for the


### PR DESCRIPTION
We still refer to worker pool in some comments and tests, but this at least corrects the CLI experience which is the most user facing:

<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [x] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
