### PR TITLE
Point to ECS worker guide and not agent/infra block guide

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -21,7 +21,7 @@ This section of the documentation contains guides for common workflows and use c
 | [Docker](/guides/deployment/docker/) | Deploy flows with Docker containers. |
 | [Kubernetes](/guides/deployment/helm-worker/) | Deploy flows on Kubernetes. |
 | [Push Work Pools](/guides/deployment/push-work-pools/) |  Execute flows on serverless infrastructure like AWS ECS, Azure Container Instances, or Google Cloud Run without a worker. | 
-| [ECS](https://prefecthq.github.io/prefect-aws/#using-prefect-with-aws-ecs) |  Run flows on AWS ECS. |
+| [ECS](https://prefecthq.github.io/prefect-aws/ecs_guide/) |  Run flows on AWS ECS. |
 | [Azure Container Instances](/guides/deployment/aci/) |  Deploy flows to Azure Container Instances. |
 | [Custom Workers](/guides/deployment/developing-a-new-worker-type/) | Develop your own worker type. | 
 | [Profiles & Settings](/guides/settings/) | Configure Prefect and save your settings. |


### PR DESCRIPTION
Update index.md to point to ECS worker guide and not agent/infra block guide

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
