### PR TITLE
Show cli message for the paused work-pool 

### DIFF
--- a/src/prefect/cli/worker.py
+++ b/src/prefect/cli/worker.py
@@ -101,8 +101,8 @@ async def start(
         case_sensitive=False,
     ),
 ):
-    """ "
-    Checks if a work-pool is paused or not
+    """
+    Start a worker process to poll a work pool for flow runs.
     """
 
     is_paused = await _check_work_pool_paused(work_pool_name)
@@ -115,9 +115,6 @@ async def start(
             style="yellow",
         )
 
-    """
-    Start a worker process to poll a work pool for flow runs.
-    """
     worker_cls = await _get_worker_class(worker_type, work_pool_name, install_policy)
     if worker_cls is None:
         exit_with_error(
@@ -201,9 +198,6 @@ async def _check_work_pool_paused(work_pool_name: str) -> bool:
             work_pool = await client.read_work_pool(work_pool_name=work_pool_name)
             return work_pool.is_paused
     except ObjectNotFound:
-        typer.secho(
-            f"Work pool {work_pool_name!r} does not exist.", fg=typer.colors.RED
-        )
         return False
 
 
@@ -269,6 +263,9 @@ async def _get_worker_class(
 
     if worker_type is None:
         worker_type = await _retrieve_worker_type_from_pool(work_pool_name)
+
+    if worker_type == "prefect-agent":
+        return None
 
     if install_policy == InstallPolicy.ALWAYS:
         package = await _find_package_for_worker_type(worker_type)

--- a/src/prefect/cli/worker.py
+++ b/src/prefect/cli/worker.py
@@ -265,7 +265,10 @@ async def _get_worker_class(
         worker_type = await _retrieve_worker_type_from_pool(work_pool_name)
 
     if worker_type == "prefect-agent":
-        return None
+        exit_with_error(
+            "'prefect-agent' typed work pools work with Prefect Agents instead of"
+            " Workers. Please use the 'prefect agent start' to start a Prefect Agent."
+        )
 
     if install_policy == InstallPolicy.ALWAYS:
         package = await _find_package_for_worker_type(worker_type)

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -31,6 +31,7 @@ from prefect.workers.base import BaseJobConfiguration, BaseWorker
 
 from unittest.mock import patch
 from prefect.cli.worker import _get_worker_class
+import subprocess
 
 
 class MockKubernetesWorker(BaseWorker):
@@ -549,6 +550,32 @@ class TestInstallPolicyOption:
         )
 
         run_process_mock.assert_not_called()
+
+        @pytest.mark.parametrize("worker_type", ["prefect-agent"])
+        def test_start_with_prefect_agent_type(worker_type):
+            # Run the CLI command with the specified worker_type
+            result = subprocess.run(
+                ["python", "worker.py", "worker", "start", "--type", worker_type],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+
+            if worker_type == "prefect-agent":
+                assert result.returncode == 1
+
+                assert (
+                    "prefect-agent' typed work pools work with Prefect Agents"
+                    " instead of"
+                    in result.stderr
+                )
+            else:
+                assert result.returncode != 1
+                assert (
+                    "prefect-agent' typed work pools work with Prefect Agents"
+                    " instead of"
+                    not in result.stderr
+                )
 
 
 POLL_INTERVAL = 0.5

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -29,6 +29,9 @@ from typer import Exit
 
 from prefect.workers.base import BaseJobConfiguration, BaseWorker
 
+from unittest.mock import patch
+from prefect.cli.worker import _get_worker_class
+
 
 class MockKubernetesWorker(BaseWorker):
     type = "kubernetes"
@@ -334,6 +337,20 @@ async def test_start_worker_without_type_creates_process_work_pool(
 
     workers = await prefect_client.read_workers_for_work_pool(work_pool_name="not-here")
     assert workers[0].name == "test-worker"
+
+
+@patch("worker.exit_with_error")
+def test_prefect_agent_exit(self, mock_exit_with_error):
+    worker_type = "prefect-agent"
+    work_pool_name = "test"
+    install_policy = "always"
+
+    # Call the function with the mock inputs
+    _get_worker_class(worker_type, work_pool_name, install_policy)
+    mock_exit_with_error.assert_called_once_with(
+        "'prefect-agent' typed work pools work with Prefect Agents instead of Workers."
+        " Please use the 'prefect agent start' to start a Prefect Agent."
+    )
 
 
 @pytest.mark.usefixtures("use_hosted_api_server")


### PR DESCRIPTION
DESCRIPTION OF THE PULL REQUEST:

Currently in Prefect, if a user pauses a work-pool using the CLI command, the user can start the worker for polling on the paused work-pool. This way, the user will get confused about why the worker is not polling from the work-pool. The change I have made is to add a CLI message to inform the user that the work-pool is paused.

I have implemented a logic to check if the worker is paused or not. If it is paused, a message is displayed indicating that the work-pool is paused, and the worker execution is aborted. Therefore, the user must resume the work-pool before starting with the polling. I have tested this modification on the Prefect agent so far

Fixes: #10308 

https://github.com/PrefectHQ/prefect/assets/121633121/9e0d39b9-fdc2-4f12-ae77-248d363d9636

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
