### PR TITLE
Update `prefect deploy` to skip building docker image prompt if `build` key explicitly set to null in `prefect.yaml`

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -451,7 +451,11 @@ async def _run_single_deploy(
 
     update_work_pool_image = False
 
-    if is_interactive() and not docker_build_step_exists:
+    build_step_set_to_null = (
+        True if "build" in deploy_config and deploy_config["build"] is None else False
+    )
+
+    if is_interactive() and not docker_build_step_exists and not build_step_set_to_null:
         work_pool = await client.read_work_pool(deploy_config["work_pool"]["name"])
         docker_based_infrastructure = "image" in work_pool.base_job_template.get(
             "variables", {}

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -451,9 +451,7 @@ async def _run_single_deploy(
 
     update_work_pool_image = False
 
-    build_step_set_to_null = (
-        True if "build" in deploy_config and deploy_config["build"] is None else False
-    )
+    build_step_set_to_null = "build" in deploy_config and deploy_config["build"] is None
 
     if is_interactive() and not docker_build_step_exists and not build_step_set_to_null:
         work_pool = await client.read_work_pool(deploy_config["work_pool"]["name"])

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -1885,6 +1885,41 @@ class TestProjectDeploy:
         )
         assert deployment.schedule is None
 
+    @pytest.mark.parametrize("build_value", [None, {}])
+    @pytest.mark.usefixtures("project_dir", "interactive_console")
+    async def test_deploy_does_not_prompt_build_docker_image_when_empty_build_action_prefect_yaml(
+        self, build_value, work_pool, prefect_client
+    ):
+        prefect_yaml_file = Path("prefect.yaml")
+        with prefect_yaml_file.open(mode="r") as f:
+            deploy_config = yaml.safe_load(f)
+
+        deploy_config["deployments"] = [
+            {
+                "name": "test-name",
+                "entrypoint": "flows/hello.py:my_flow",
+                "work_pool": {
+                    "name": work_pool.name,
+                },
+                "build": build_value,
+                "schedule": {},
+            }
+        ]
+
+        with prefect_yaml_file.open(mode="w") as f:
+            yaml.safe_dump(deploy_config, f)
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command="deploy -n test-name",
+            expected_code=0,
+            expected_output_does_not_contain="Would you like to build a Docker image?",
+        )
+
+        assert await prefect_client.read_deployment_by_name(
+            "An important name/test-name"
+        )
+
 
 class TestSchedules:
     @pytest.mark.usefixtures("project_dir")


### PR DESCRIPTION
Skip build docker image prompt when a deployment has explicitly set the `build` step to `null` in `prefect.yaml`. See the attached issue for an example. Previously if `build` was set to `null`, users would still see prompts to build a docker image on every interactive `prefect deploy` run for that deployment. This change allows users to configure deployments without running a build step and without needing to opt out of the prompt every time.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
