### PR TITLE
Update to bot workflows

### DIFF
--- a/.github/workflows/issue-bot.yaml
+++ b/.github/workflows/issue-bot.yaml
@@ -10,12 +10,6 @@ jobs:
     steps:
       - name: Remove status labels on close
         if: github.event.action == 'closed'
-        run: gh issue edit --repo prefecthq/prefect ${{ github.event.issue.number }} --remove-label "status:triage" --remove-label "status:in-progress" --remove-label "status:accepted"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Remove triage label on status change
-        if: github.event.action == 'labeled' && startsWith(github.event.label.name, 'status:') && github.event.label.name != 'status:triage'
-        run: gh issue edit --repo prefecthq/prefect ${{ github.event.issue.number }} --remove-label "status:triage"
+        run: gh issue edit --repo prefecthq/prefect ${{ github.event.issue.number }} --remove-label "needs:triage" --remove-label "needs:attention"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,15 +9,13 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
-          stale-issue-message: "This issue is stale because it has been open 30 days with no activity. To keep this issue open remove stale label or comment."
-          stale-issue-label: "status:stale"
-          close-issue-message: "This issue was closed because it has been stale for 14 days with no activity. If this issue is important or you have more to add feel free to re-open it."
-          days-before-stale: 30
-          stale-pr-message: "This pull request is stale because it has been open 60 days with no activity. To keep this pull request open remove stale label or comment."
+          days-before-stale: -1
+          days-before-close: -1
+          stale-pr-message: "This pull request is stale because it has been open 14 days with no activity. To keep this pull request open remove stale label or comment."
           stale-pr-label: "status:stale"
           close-pr-message: "This pull request was closed because it has been stale for 14 days with no activity. If this pull request is important or you have more to add feel free to re-open it."
-          days-before-pr-stale: 60
-          days-before-close: 14
-          exempt-issue-labels: "status:in-progress,status:roadmap,status:accepted,needs:product feedback"
+          days-before-pr-stale: 14
+          days-before-pr-close: 14
+          exempt-issue-labels: "needs:attention,needs:triage,blocked"
           ascending: true # https://github.com/actions/stale#ascending
           operations-per-run: 500


### PR DESCRIPTION
This PR updates our bot rules to be:
- mark PRs with no activity stale after 14 days
- close PRs with no activity after 14 days (marking the PR as "stale" counts as activity)
- never auto-close an issue