### PR TITLE
Optimize the query generated by the /task_runs endpoint

### DIFF
--- a/src/prefect/server/models/task_runs.py
+++ b/src/prefect/server/models/task_runs.py
@@ -11,6 +11,7 @@ import sqlalchemy as sa
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from prefect.logging import get_logger
 import prefect.server.models as models
 import prefect.server.schemas as schemas
 from prefect.server.database.dependencies import inject_db
@@ -21,6 +22,8 @@ from prefect.server.orchestration.global_policy import GlobalTaskPolicy
 from prefect.server.orchestration.policies import BaseOrchestrationPolicy
 from prefect.server.orchestration.rules import TaskOrchestrationContext
 from prefect.server.schemas.responses import OrchestrationResult
+
+logger = get_logger("server")
 
 
 @inject_db
@@ -153,6 +156,19 @@ async def _apply_task_run_filters(
     if task_run_filter:
         query = query.where(task_run_filter.as_sql_filter(db))
 
+    # Return a simplified query in the case that the request is ONLY asking to filter on flow_run_id (and task_run_filter)
+    # In this case there's no need to generate the complex EXISTS subqueries; the generated query here is much more efficient
+    if (
+        flow_run_filter
+        and flow_run_filter.only_filters_on_id()
+        and not any(
+            [flow_filter, deployment_filter, work_pool_filter, work_queue_filter]
+        )
+    ):
+        query = query.where(db.TaskRun.flow_run_id == str(flow_run_filter.id.any_[0]))
+
+        return query
+
     if (
         flow_filter
         or flow_run_filter
@@ -243,6 +259,7 @@ async def read_task_runs(
     if limit is not None:
         query = query.limit(limit)
 
+    logger.debug(f"In read_task_runs, query generated is:\n{query}")
     result = await session.execute(query)
     return result.scalars().unique().all()
 

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -504,6 +504,22 @@ class FlowRunFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `FlowRun.idempotency_key`"
     )
 
+    def only_filters_on_id(self):
+        return (
+            self.id is not None
+            and self.name is None
+            and self.tags is None
+            and self.deployment_id is None
+            and self.work_queue_name is None
+            and self.state is None
+            and self.flow_version is None
+            and self.start_time is None
+            and self.expected_start_time is None
+            and self.next_scheduled_start_time is None
+            and self.parent_task_run_id is None
+            and self.idempotency_key is None
+        )
+
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
         filters = []
 


### PR DESCRIPTION
We have observed poor performance of the Prefect Server in responding to the `/task_runs/filter` endpoint, and have seen mention in the Prefect Slack of other users reporting similar findings.

The code supporting `/task_runs/filter` is general enough to be able to allow filtering on lots of different criteria. For any filter criteria provided, the query generates a `WHERE EXISTS` clause based on that filter criteria.

But the main use case for this endpoint is to simply fetch the task runs for a particular `flow_run_id`. In our workload (and I suspect in many other users') this represents 99%+ of the invocations of this endpoint. However, the `WHERE EXISTS` DB query generated for this use case is much less efficient than it needs to be.

Specifically, when the endpoint is asked to simply fetch the task runs for a given `flow_run_id`, the query it generates looks like this:

```
SELECT
    task_run.task_key,
    task_run.dynamic_key,
    task_run.cache_key,
    task_run.cache_expiration,
    etc...
FROM task_run
WHERE EXISTS (
    SELECT
        flow_run.deployment_id,
        flow_run.work_queue_name,
        flow_run.flow_version,
        flow_run.parameters,
        flow_run.idempotency_key,
        flow_run.context,
        flow_run.empirical_policy,
        flow_run.tags,
        flow_run.created_by,
        flow_run.infrastructure_pid,
        flow_run.auto_scheduled,
        flow_run.flow_id,
        flow_run.infrastructure_document_id,
        flow_run.parent_task_run_id,
        flow_run.state_id,
        flow_run.work_queue_id,
        flow_run.name,
        flow_run.state_type,
        flow_run.state_name,
        flow_run.state_timestamp,
        flow_run.run_count,
        flow_run.expected_start_time,
        flow_run.next_scheduled_start_time,
        flow_run.start_time,
        flow_run.end_time,
        flow_run.total_run_time,
        flow_run.id,
        flow_run.created,
        flow_run.updated
	FROM flow_run
	WHERE flow_run.id = task_run.flow_run_id
    AND flow_run.id IN ('19f905e4-7ab7-4311-98c6-cce748e24605'::UUID) -- for example
) ORDER BY task_run.id DESC;
```

But a much more efficient -- and functionally equivalent -- way to generate that query is this:
```
SELECT
    task_run.task_key,
    task_run.dynamic_key,
    task_run.cache_key,
    task_run.cache_expiration,
    etc...
FROM task_run
WHERE task_run.flow_run_id = '19f905e4-7ab7-4311-98c6-cce748e24605'::UUID -- for example
ORDER BY task_run.id DESC;
```

In our PostgreSQL instance, the optimized query executes in about 1/56th the time as the current query. The speedup probably gets more dramatic as these tables grow larger. This is a frequently hit endpoint in our workload, so a significant performance boost is impactful here for our internal and user-facing tooling.

The code in this PR changes the `/task_runs/filter` endpoint so that, in the common case that the filter criteria is only `flow_run_id`, the more efficient version of this query above is generated.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
