### PR TITLE
Move and reference Agents -> Workers upgrade guide

### DIFF
--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -7,7 +7,11 @@ search:
   boost: 2
 ---
 
-# Agents 
+# Agents
+
+!!! note "Workers are reccomended"
+    Agents are part of the block-based deployment model. [Work Pools and Workers](/concepts/work-pools/) simplify the specification of each flow's infrastructure and runtime environment. If you have existing agents, you can [upgrade from agents to workers](/guides/upgrade-guide-agents-to-workers/) to significantly enhance the experience of deploying flows.
+
 ## Agent overview
 
 Agent processes are lightweight polling services that get scheduled work from a [work pool](#work-pool-overview) and deploy the corresponding flow runs.

--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -10,7 +10,7 @@ search:
 # Agents
 
 !!! note "Workers are reccomended"
-    Agents are part of the block-based deployment model. [Work Pools and Workers](/concepts/work-pools/) simplify the specification of each flow's infrastructure and runtime environment. If you have existing agents, you can [upgrade from agents to workers](/guides/upgrade-guide-agents-to-workers/) to significantly enhance the experience of deploying flows.
+    Agents are part of the block-based deployment model. [Work Pools and Workers](/concepts/work-pools/) simplify the specification of a flow's infrastructure and runtime environment. If you have existing agents, you can [upgrade from agents to workers](/guides/upgrade-guide-agents-to-workers/) to significantly enhance the experience of deploying flows.
 
 ## Agent overview
 

--- a/docs/concepts/deployments-block-based.md
+++ b/docs/concepts/deployments-block-based.md
@@ -17,6 +17,9 @@ search:
 
 # Block Based Deployments
 
+!!! note "Workers are reccomended"
+    This page is about the block-based deployment model. The [Work Pools and Workers](/concepts/work-pools/) based [deployment model](/concepts/deployments/) simplifies the specification of flow's infrastructure and runtime environment. If you have existing agents, you can [upgrade from agents to workers](/guides/upgrade-guide-agents-to-workers/) to significantly enhance the experience of deploying flows.
+
 We encourage you to check out the new [deployment experience](/concepts/deployments/) with guided command line prompts and convenient CI/CD with `prefect.yaml` files.
 
 With remote storage blocks, you can package not only your flow code script but also any supporting files, including your custom modules, SQL scripts and any configuration files needed in your project.

--- a/docs/concepts/deployments-block-based.md
+++ b/docs/concepts/deployments-block-based.md
@@ -18,7 +18,7 @@ search:
 # Block Based Deployments
 
 !!! note "Workers are reccomended"
-    This page is about the block-based deployment model. The [Work Pools and Workers](/concepts/work-pools/) based [deployment model](/concepts/deployments/) simplifies the specification of flow's infrastructure and runtime environment. If you have existing agents, you can [upgrade from agents to workers](/guides/upgrade-guide-agents-to-workers/) to significantly enhance the experience of deploying flows.
+    This page is about the block-based deployment model. The [Work Pools and Workers](/concepts/work-pools/) based [deployment model](/concepts/deployments/) simplifies the specification of a flow's infrastructure and runtime environment. If you have existing agents, you can [upgrade from agents to workers](/guides/upgrade-guide-agents-to-workers/) to significantly enhance the experience of deploying flows.
 
 We encourage you to check out the new [deployment experience](/concepts/deployments/) with guided command line prompts and convenient CI/CD with `prefect.yaml` files.
 

--- a/docs/concepts/infrastructure.md
+++ b/docs/concepts/infrastructure.md
@@ -16,6 +16,9 @@ search:
 
 # Infrastructure
 
+!!! note "Workers are reccomended"
+    Infrastructure blocks are part of the agent based deployment model. [Work Pools and Workers](/concepts/work-pools/) simplify the specification of each flow's infrastructure and runtime environment. If you have existing agents, you can [upgrade from agents to workers](/guides/upgrade-guide-agents-to-workers/) to significantly enhance the experience of deploying flows.
+
 Users may specify an [infrastructure](/api-ref/prefect/infrastructure/) block when creating a deployment. This block will be used to specify infrastructure for flow runs created by the deployment at runtime.
 
 Infrastructure can only be used with a [deployment](/concepts/deployments/). When you run a flow directly by calling the flow yourself, you are responsible for the environment in which the flow executes.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -20,6 +20,7 @@ This section of the documentation contains guides for common workflows and use c
 | [Storage](/guides/deployment/storage-guide/) | Store your code for deployed flows. |
 | [Docker](/guides/deployment/docker/) | Deploy flows with Docker containers. |
 | [Kubernetes](/guides/deployment/helm-worker/) | Deploy flows on Kubernetes. |
+| [Upgrade from Agents to Workers](/guides/upgrade-guide-agents-to-workers/) | Why and how to upgrade from Agents to Workers. |
 | [Push Work Pools](/guides/deployment/push-work-pools/) |  Execute flows on serverless infrastructure like AWS ECS, Azure Container Instances, or Google Cloud Run without a worker. | 
 | [ECS](https://prefecthq.github.io/prefect-aws/ecs_guide/) |  Run flows on AWS ECS. |
 | [Azure Container Instances](/guides/deployment/aci/) |  Deploy flows to Azure Container Instances. |

--- a/docs/guides/upgrade-guide-agents-to-workers.md
+++ b/docs/guides/upgrade-guide-agents-to-workers.md
@@ -1,4 +1,4 @@
-# How to Upgrade from Agents to Workers
+# Upgrade from Agents to Workers
 
 Upgrading from agents to workers significantly enhances the experience of deploying flows. It simplifies the specification of each flow's infrastructure and runtime environment. 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
           - Deployment:
                 - Storage: guides/deployment/storage-guide.md
                 - Docker: guides/deployment/docker.md
+                - Upgrade from Agents to Workers: guides/upgrade-guide-agents-to-workers.md
                 - Kubernetes Worker with Helm: guides/deployment/helm-worker.md
                 - Serverless Push Work Pools: guides/deployment/push-work-pools.md
                 - Run a flow on AWS ECS: https://prefecthq.github.io/prefect-aws/#using-prefect-with-aws-ecs
@@ -179,7 +180,6 @@ nav:
           - Automations: concepts/automations.md
           - Filesystems: concepts/filesystems.md
           - Block and Agent-Based Deployments:
-                - Upgrade from Agents to Workers: guides/upgrade-guide-agents-to-workers.md
                 - Deployments: concepts/deployments-block-based.md
                 - Infrastructure: concepts/infrastructure.md
                 - Storage: concepts/storage.md


### PR DESCRIPTION
The agents Agents -> Workers upgrade guide belongs in the guide section. We can link to it from wherever we'd like. I've added links to the top of the agents, infrastructure, and block based deployment pages.
