### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_general_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_general_bug_report.yaml
@@ -1,6 +1,6 @@
 name: 🐞 Report a bug
 description: Errors and regression reports with complete reproducing test cases and/or stack traces.
-labels: ["status:triage", "bug"]
+labels: ["needs:triage", "bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2_ui_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/2_ui_bug_report.yaml
@@ -1,6 +1,6 @@
 name: 🖼️ Report a bug with the Prefect UI
 description: Errors and display issues with the Prefect web interface.
-labels: ["status:triage", "ui", "bug"]
+labels: ["needs:triage", "ui", "bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/3_feature_enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/3_feature_enhancement.yaml
@@ -1,6 +1,6 @@
 name: 🚀 Propose a feature enhancement
 description: Propose a new feature or an enhancement to an existing feature.
-labels: ["status:triage", "enhancement"]
+labels: ["needs:triage", "enhancement"]
 body:
   - type: checkboxes
     id: checks

--- a/.github/ISSUE_TEMPLATE/4_docs_change.yaml
+++ b/.github/ISSUE_TEMPLATE/4_docs_change.yaml
@@ -1,6 +1,6 @@
 name: 📝 Suggest a change to documentation
 description: Propose edits, enhancements, or fixes to Prefect documentation
-labels: ["docs", "status:triage"]
+labels: ["docs", "needs:triage"]
 body:
   - type: checkboxes
     id: checks

--- a/.github/ISSUE_TEMPLATE/5_maintenance_ticket.yaml
+++ b/.github/ISSUE_TEMPLATE/5_maintenance_ticket.yaml
@@ -1,6 +1,6 @@
 name: 🛠️ Track a maintenence task
 description: These are for changes that are not user or product related for maintenance of this repository.
-labels: ["status:backlog", "maintenance"]
+labels: ["maintenance"]
 body:
   - type: checkboxes
     id: checks


### PR DESCRIPTION
Our issue templates can't reference the non-existent `status:triage` label. This PR updates the auto-label for issues to `needs:triage`.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
