### PR TITLE
Warn users with misconfigured `PREFECT_API_URL`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,8 @@ filterwarnings =
     # Required to pass --cov-config to pytest
     ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning
     ignore:Prefect will drop support for Python 3.7:FutureWarning
-
+    ignore:`PREFECT_API_URL` uses `/account/` but should use `/accounts/`.:UserWarning
+    ignore:`PREFECT_API_URL` should have `/api` after the base URL.:UserWarning
 
 [mypy]
 # TODO: We will allow definitions to be untyped for now; in the future we will want to

--- a/src/prefect/cli/config.py
+++ b/src/prefect/cli/config.py
@@ -13,6 +13,8 @@ from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error, exit_with_success
 from prefect.cli.root import app
 
+from prefect.settings import check_for_misconfigured_api_url
+
 help_message = """
     Commands for interacting with Prefect settings.
 """
@@ -68,6 +70,12 @@ def set_(settings: List[str]):
             app.console.print(
                 f"[yellow]{prefect.settings.SETTING_VARIABLES[setting].deprecated_message}."
             )
+        if setting == "PREFECT_API_URL":
+            warnings = check_for_misconfigured_api_url(value)
+
+            if warnings:
+                for warning in warnings:
+                    app.console.print(f"[yellow]{warning}")
 
     exit_with_success(f"Updated profile {new_profile.name!r}.")
 

--- a/src/prefect/cli/config.py
+++ b/src/prefect/cli/config.py
@@ -13,7 +13,6 @@ from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error, exit_with_success
 from prefect.cli.root import app
 
-from prefect.settings import check_for_misconfigured_api_url
 
 help_message = """
     Commands for interacting with Prefect settings.
@@ -70,12 +69,6 @@ def set_(settings: List[str]):
             app.console.print(
                 f"[yellow]{prefect.settings.SETTING_VARIABLES[setting].deprecated_message}."
             )
-        if setting == "PREFECT_API_URL":
-            warnings = check_for_misconfigured_api_url(value)
-
-            if warnings:
-                for warning in warnings:
-                    app.console.print(f"[yellow]{warning}")
 
     exit_with_success(f"Updated profile {new_profile.name!r}.")
 

--- a/src/prefect/cli/config.py
+++ b/src/prefect/cli/config.py
@@ -13,7 +13,6 @@ from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error, exit_with_success
 from prefect.cli.root import app
 
-
 help_message = """
     Commands for interacting with Prefect settings.
 """

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -42,6 +42,7 @@ dependent on the value of other settings or perform other dynamic effects.
 import logging
 import os
 import string
+from urllib.parse import urlparse
 import warnings
 from contextlib import contextmanager
 from datetime import timedelta
@@ -387,10 +388,6 @@ def warn_on_misconfigured_api_url(settings, values):
                 "Warning: Your PREFECT_API_URL uses */workspace/* but should use"
                 " */workspaces/*"
             ),
-            "cloud/account": (
-                "Warning: Your PREFECT_API_URL uses */cloud/account but should use"
-                " cloud/api/accounts"
-            ),
         }
 
         misconfigured_url = False
@@ -399,6 +396,14 @@ def warn_on_misconfigured_api_url(settings, values):
             if misconfig in api_url_value:
                 misconfigured_url = True
                 warnings.warn(warning)
+
+        # Check if '/api' is after the base URL
+        parsed_url = urlparse(api_url_value)
+        if parsed_url.path and not parsed_url.path.startswith("/api"):
+            misconfigured_url = True
+            warnings.warn(
+                "Warning: Your PREFECT_API_URL should have '/api' after the base URL."
+            )
 
         # If any warnings were found, add an example
         if misconfigured_url:

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -368,6 +368,36 @@ def check_for_deprecated_cloud_url(settings, value):
     return deprecated_value or value
 
 
+def check_for_misconfigured_api_url(api_url):
+    misconfigured_mappings = {
+        "app.prefect.cloud": (
+            "Warning: Your PREFECT_API_URL points to app.prefect.cloud. Did you mean"
+            " api.prefect.cloud?"
+        ),
+        "account/": (
+            "Warning: Your PREFECT_API_URL uses */account/* but should use */accounts/*"
+        ),
+        "workspace/": (
+            "Warning: Your PREFECT_API_URL uses */workspace/* but should use"
+            " */workspaces/*"
+        ),
+    }
+    warnings_list = []
+
+    for misconfig, warning in misconfigured_mappings.items():
+        if misconfig in api_url:
+            warnings_list.append(warning)
+
+    # If any warnings were found, add an example to the list
+    if warnings_list:
+        example = (
+            'e.g. PREFECT_API_URL="https://api.prefect.cloud/api/accounts/[ACCOUNT-ID]/workspaces/[WORKSPACE-ID]"'
+        )
+        warnings_list.append(example)
+
+    return warnings_list if warnings_list else None
+
+
 def default_database_connection_url(settings, value):
     templater = template_with_settings(PREFECT_HOME, PREFECT_API_DATABASE_PASSWORD)
 

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -396,7 +396,7 @@ def warn_on_misconfigured_api_url(values):
         parsed_url = urlparse(api_url)
         if parsed_url.path and not parsed_url.path.startswith("/api"):
             warnings_list.append(
-                "`PREFECT_API_URL` should have '/api' after the base URL."
+                "`PREFECT_API_URL` should have `/api` after the base URL."
             )
 
         if warnings_list:


### PR DESCRIPTION
When users misconfigure their `PREFECT_API_URL`,  we should try to let them know as soon as possible.

With this PR, when a `PREFECT_API_URL` is misconfigured, running profile CLI commands such as `prefect profile ls`, `prefect profile use <profile-name>`, and `prefect config set <profile-name>` will generate a warning.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
