### PR TITLE
Improve validation for `Flow.name`

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -172,7 +172,7 @@ class Flow(Generic[P, R]):
     ):
         if name is not None and not isinstance(name, str):
             raise TypeError(
-                "Expected string for 'name'; got {} instead. {}".format(
+                "Expected string for flow parameter 'name'; got {} instead. {}".format(
                     type(name).__name__,
                     (
                         "Perhaps you meant to call it? e.g."

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -170,6 +170,19 @@ class Flow(Generic[P, R]):
         ] = None,
         on_crashed: Optional[List[Callable[[FlowSchema, FlowRun, State], None]]] = None,
     ):
+        if name is not None and not isinstance(name, str):
+            raise TypeError(
+                "Expected string for 'name'; got {} instead. {}".format(
+                    type(name).__name__,
+                    (
+                        "Perhaps you meant to call it? e.g."
+                        " '@flow(name=get_flow_run_name())'"
+                        if callable(name)
+                        else ""
+                    ),
+                )
+            )
+
         # Validate if hook passed is list and contains callables
         hook_categories = [on_completion, on_failure, on_cancellation, on_crashed]
         hook_names = ["on_completion", "on_failure", "on_cancellation", "on_crashed"]

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -385,12 +385,12 @@ class TestFlowWithOptions:
     @pytest.mark.parametrize(
         "name, match",
         [
-            (1, "Expected string for 'name'; got int instead."),
+            (1, "Expected string for flow parameter 'name'; got int instead."),
             (
                 get_flow_run_name,
                 (
-                    "Expected string for 'name'; got function instead. Perhaps you"
-                    " meant to call it?"
+                    "Expected string for flow parameter 'name'; got function instead."
+                    " Perhaps you meant to call it?"
                 ),
             ),
         ],

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -377,6 +377,54 @@ class TestFlowWithOptions:
 
         assert flow_params == with_options_params
 
+    def get_flow_run_name():
+        name = "test"
+        date = "todays_date"
+        return f"{name}-{date}"
+
+    @pytest.mark.parametrize(
+        "name, match",
+        [
+            (1, "Expected string for 'name'; got int instead."),
+            (
+                get_flow_run_name,
+                (
+                    "Expected string for 'name'; got function instead. Perhaps you"
+                    " meant to call it?"
+                ),
+            ),
+        ],
+    )
+    def test_flow_name_non_string_raises(self, name, match):
+        with pytest.raises(TypeError, match=match):
+            Flow(
+                name=name,
+                fn=lambda **kwargs: 42,
+                version="A",
+                description="B",
+                flow_run_name="hi",
+            )
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "test",
+            (get_flow_run_name()),
+        ],
+    )
+    def test_flow_name_string_succeeds(
+        self,
+        name,
+    ):
+        f = Flow(
+            name=name,
+            fn=lambda **kwargs: 42,
+            version="A",
+            description="B",
+            flow_run_name="hi",
+        )
+        assert f.name == name
+
 
 class TestFlowCall:
     async def test_call_creates_flow_run_and_runs(self):


### PR DESCRIPTION
Despite raising an error when we run a flow locally, it would be nicer to validate the name on the Flow object.

### Example of mistakenly passing in a `fn object`
```python
from prefect import flow, runtime
import datetime

def get_flow_run_name():
    date = datetime.datetime.now().isoformat()
    return f"{runtime.deployment.name}-{date}"

@flow(log_prints=True, name=get_flow_run_name)  # mistake here, should be get_flow_run_name()
def hi_named_flow(name:str="world"):
    print(f"Hi {name}")
```

### Before
```bash
❯ python flow_10023.py
13:52:48.270 | DEBUG   | prefect.profiles - Using profile 'cloud'
Traceback (most recent call last):
  File "flow_10023.py", line 10, in <module>
    def hi_named_flow(name:str="world"):
  File "/Users/bean/prefect-demo/38pyvenv/lib/python3.8/site-packages/prefect/flows.py", line 821, in flow
    Flow(
  File "/Users/bean/prefect-demo/38pyvenv/lib/python3.8/site-packages/prefect/context.py", line 179, in __register_init__
    __init__(__self__, *args, **kwargs)
  File "/Users/bean/prefect-demo/38pyvenv/lib/python3.8/site-packages/prefect/flows.py", line 206, in __init__
    raise_on_name_with_banned_characters(name)
  File "/Users/bean/prefect-demo/38pyvenv/lib/python3.8/site-packages/prefect/_internal/schemas/validators.py", line 15, in raise_on_name_with_banned_characters
    if any(c in name for c in BANNED_CHARACTERS):
  File "/Users/bean/prefect-demo/38pyvenv/lib/python3.8/site-packages/prefect/_internal/schemas/validators.py", line 15, in <genexpr>
    if any(c in name for c in BANNED_CHARACTERS):
TypeError: argument of type 'function' is not iterable
```

The error isn't super clear as the Python function also has the parameter `name`:
```python
def hi_named_flow(name:str="world"):
```

### After
```bash
❯ python flow_10023.py
16:06:26.758 | DEBUG   | prefect.profiles - Using profile 'cloud'
Traceback (most recent call last):
  File "/Users/bean/code-oss/prefect/local_work/flow_10023.py", line 10, in <module>
    def hi_named_flow(name:str="world"):
  File "/Users/bean/code-oss/prefect/src/prefect/flows.py", line 834, in flow
    Flow(
  File "/Users/bean/code-oss/prefect/src/prefect/context.py", line 179, in __register_init__
    __init__(__self__, *args, **kwargs)
  File "/Users/bean/code-oss/prefect/src/prefect/flows.py", line 174, in __init__
    raise TypeError(
TypeError: Expected string for flow parameter 'name'; got function instead. Perhaps you meant to call it? e.g. '@flow(name=get_flow_run_name())'
```

### Another example of mistakenly passing in an `int` as a flow parameter name
While probably rather uncommon, we demonstrate the abbreviated error that is generated compared to the above.
```python
from prefect import flow

@flow(log_prints=True, name=42)
def hi_named_flow(name:str="world"):
    print(f"Hi {name}")
```

```bash
❯ python flow_10023.py
16:11:13.071 | DEBUG   | prefect.profiles - Using profile 'cloud'
Traceback (most recent call last):
  File "/Users/bean/code-oss/prefect/local_work/flow_10023.py", line 10, in <module>
    def hi_named_flow(name:str="world"):
  File "/Users/bean/code-oss/prefect/src/prefect/flows.py", line 834, in flow
    Flow(
  File "/Users/bean/code-oss/prefect/src/prefect/context.py", line 179, in __register_init__
    __init__(__self__, *args, **kwargs)
  File "/Users/bean/code-oss/prefect/src/prefect/flows.py", line 174, in __init__
    raise TypeError(
TypeError: Expected string for flow parameter 'name'; got int instead. 
```

Related to and helps close: https://github.com/PrefectHQ/prefect/issues/10023

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
