### PR TITLE
Adding some safety checks to a prior optimization on task runs

### DIFF
--- a/src/prefect/server/models/task_runs.py
+++ b/src/prefect/server/models/task_runs.py
@@ -11,9 +11,9 @@ import sqlalchemy as sa
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from prefect.logging import get_logger
 import prefect.server.models as models
 import prefect.server.schemas as schemas
+from prefect.logging import get_logger
 from prefect.server.database.dependencies import inject_db
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.exceptions import ObjectNotFoundError
@@ -165,7 +165,7 @@ async def _apply_task_run_filters(
             [flow_filter, deployment_filter, work_pool_filter, work_queue_filter]
         )
     ):
-        query = query.where(db.TaskRun.flow_run_id == str(flow_run_filter.id.any_[0]))
+        query = query.where(db.TaskRun.flow_run_id.in_(flow_run_filter.id.any_))
 
         return query
 

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -507,6 +507,7 @@ class FlowRunFilter(PrefectOperatorFilterBaseModel):
     def only_filters_on_id(self):
         return (
             self.id is not None
+            and (self.id.any_ and not self.id.not_any_)
             and self.name is None
             and self.tags is None
             and self.deployment_id is None


### PR DESCRIPTION
We got an [awesome community contribution to optimize the task runs filter](https://github.com/PrefectHQ/prefect/pull/10422)
endpoint, but it needed a couple of safety guards:

* We should make sure that the ID filter is only making positive matches on
  ID (with `any_`) and not negative matches
* We should support multiple flow run IDs with an `IN` clause
