### PR TITLE
update wizard recommendation when no `pull` step selected

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -965,7 +965,7 @@ async def _generate_default_pull_action(
             "Your Prefect workers will attempt to load your flow from:"
             f" [green]{(Path.cwd()/Path(entrypoint_path)).absolute().resolve()}[/]. To"
             " see more options for managing your flow's code, run:\n\n\t[blue]$"
-            " prefect project recipes ls[/]\n"
+            " prefect init[/]\n"
         )
         return [
             {


### PR DESCRIPTION
with the `project` command group deprecated, we should direct the user to `prefect init` for more for information around flow storage / `prefect.yaml` setup