### PR TITLE
Remove references to `flow_name` from deployments documentation

### DIFF
--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -127,7 +127,6 @@ deployments:
     schedule: null
 
     # flow-specific fields
-    flow_name: null
     entrypoint: null
     parameters: {}
 
@@ -409,7 +408,6 @@ deployments:
     schedule: null
 
     # flow-specific fields
-    flow_name: null
     entrypoint: null
     parameters: {}
 
@@ -588,8 +586,7 @@ Below are fields that can be added to each deployment declaration.
 | <span class="no-wrap">`description`</span> | An optional description for the deployment.                                                                                                                                                                                                                                              |
 | `schedule`                                 | An optional [schedule](/concepts/schedules) to assign to the deployment. Fields for this section are documented in the [Schedule Fields](#schedule-fields) section.                                                                                                                      |
 | `triggers`                                  | An optional array of [triggers](/concepts/deployments/#create-a-flow-run-with-an-event-trigger) to assign to the deployment |
-| `flow_name`                                | Deprecated: The name of a flow that has been registered in the [`.prefect` directory](#the-prefect-directory). Either `flow_name` **or** `entrypoint` is required.                                                                                                                       |
-| `entrypoint`                               | The path to the `.py` file containing the flow you want to deploy (relative to the root directory of your development folder) combined with the name of the flow function. Should be in the format `path/to/file.py:flow_function_name`. Either `flow_name` **or** `entrypoint` is required. |
+| `entrypoint`                               | Required path to the `.py` file containing the flow you want to deploy (relative to the root directory of your development folder) combined with the name of the flow function. Should be in the format `path/to/file.py:flow_function_name`. |
 | `parameters`                               | Optional default values to provide for the parameters of the deployed flow. Should be an object with key/value pairs.                                                                                                                                                                    |
 | `work_pool`                                | Information on where to schedule flow runs for the deployment. Fields for this section are documented in the [Work Pool Fields](#work-pool-fields) section.                                                                                                                              |
 


### PR DESCRIPTION
As described in the linked issue, our documentation refers to `flow_name` as a deprecated but still valid option for use in deployments, when in reality, it is no longer usable and should be removed from our documentation. 

[Preview](https://deploy-preview-10477--prefect-docs-preview.netlify.app/concepts/deployments/#deployment-fields)

<img width="649" alt="Screenshot 2023-08-23 at 10 34 05 AM" src="https://github.com/PrefectHQ/prefect/assets/42048900/2b837025-d575-4667-827c-7cd84de5c15e">

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
