### PR TITLE
notify if python tests failing on `main`

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -8,9 +8,6 @@ env:
   PY_COLORS: 1
 
 on:
-  push:
-    branches:
-      - gha-notify-main-failing
   pull_request:
     paths:
       - .github/workflows/python-tests.yaml
@@ -19,9 +16,9 @@ on:
       - requirements-dev.txt
       - setup.cfg
       - Dockerfile
-  # push:
-  #   branches:
-  #     - main
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -68,153 +65,152 @@ jobs:
       matrix:
         database:
           - "postgres:13"
-        #   - "postgres:14"
-        #   - "sqlite"
-        # os:
-        #   - ${{ needs.isinternal.outputs.status == 'true' && github.event_name == 'pull_request' && 'oss-test-runner' || 'ubuntu-latest' }}
+          - "postgres:14"
+          - "sqlite"
+        os:
+          - ${{ needs.isinternal.outputs.status == 'true' && github.event_name == 'pull_request' && 'oss-test-runner' || 'ubuntu-latest' }}
         python-version:
           - "3.8"
-        #   - "3.9"
-        #   - "3.10"
-        #   - "3.11"
+          - "3.9"
+          - "3.10"
+          - "3.11"
         pytest-options:
           - "--exclude-services"
-        #   - "--only-services"
+          - "--only-services"
 
-        # include:
-        #   # Include Docker image builds on the service test run, and disallow the test
-        #   # suite from building images automaticlly in fixtures
-        #   - pytest-options: "--only-services"
-        #     build-docker-images: true
+        include:
+          # Include Docker image builds on the service test run, and disallow the test
+          # suite from building images automaticlly in fixtures
+          - pytest-options: "--only-services"
+            build-docker-images: true
 
-        # exclude:
-        #   # Do not run service tests with postgres
-        #   - database: "postgres:13"
-        #     pytest-options: "--only-services"
+        exclude:
+          # Do not run service tests with postgres
+          - database: "postgres:13"
+            pytest-options: "--only-services"
 
-        #   # Do not run service tests with postgres
-        #   - database: "postgres:14"
-        #     pytest-options: "--only-services"
+          # Do not run service tests with postgres
+          - database: "postgres:14"
+            pytest-options: "--only-services"
 
       fail-fast: false
 
-    # runs-on: ${{ matrix.os }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 75
 
     steps:
       - name: Display current test matrix
         run: echo '${{ toJSON(matrix) }}'
 
-      # - uses: actions/checkout@v3
-      #   with:
-      #     persist-credentials: false
-      #     fetch-depth: 0
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
-      # - name: Set up Docker Buildx
-      #   if: ${{ matrix.build-docker-images }}
-      #   uses: docker/setup-buildx-action@v2
+      - name: Set up Docker Buildx
+        if: ${{ matrix.build-docker-images }}
+        uses: docker/setup-buildx-action@v2
 
-      # - name: Set up Python ${{ matrix.python-version }}
-      #   uses: actions/setup-python@v4
-      #   with:
-      #     python-version: ${{ matrix.python-version }}
-      #     cache: "pip"
-      #     cache-dependency-path: "requirements*.txt"
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "requirements*.txt"
 
-      # - name: Pin requirements to lower bounds
-      #   if: ${{ matrix.lower-bound-requirements }}
-      #   # Creates lower bound files then replaces the input files so we can do a normal install
-      #   run: |
-      #     ./scripts/generate-lower-bounds.py requirements.txt > requirements-lower.txt
-      #     ./scripts/generate-lower-bounds.py requirements-dev.txt > requirements-dev-lower.txt
-      #     mv requirements-lower.txt requirements.txt
-      #     mv requirements-dev-lower.txt requirements-dev.txt
+      - name: Pin requirements to lower bounds
+        if: ${{ matrix.lower-bound-requirements }}
+        # Creates lower bound files then replaces the input files so we can do a normal install
+        run: |
+          ./scripts/generate-lower-bounds.py requirements.txt > requirements-lower.txt
+          ./scripts/generate-lower-bounds.py requirements-dev.txt > requirements-dev-lower.txt
+          mv requirements-lower.txt requirements.txt
+          mv requirements-dev-lower.txt requirements-dev.txt
 
-      # - name: Get image tag
-      #   id: get_image_tag
-      #   if: ${{ matrix.build-docker-images }}
-      #   run: |
-      #     SHORT_SHA=$(git rev-parse --short=7 HEAD)
-      #     tmp="sha-$SHORT_SHA-python${{ matrix.python-version }}"
-      #     echo "image_tag=${tmp}" >> $GITHUB_OUTPUT
+      - name: Get image tag
+        id: get_image_tag
+        if: ${{ matrix.build-docker-images }}
+        run: |
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          tmp="sha-$SHORT_SHA-python${{ matrix.python-version }}"
+          echo "image_tag=${tmp}" >> $GITHUB_OUTPUT
 
-      # - name: Build test image
-      #   if: ${{ matrix.build-docker-images }}
-      #   uses: docker/build-push-action@v4
-      #   with:
-      #     context: .
-      #     # TODO: We do not need the UI in these tests and we may want to add a build-arg to disable building it
-      #     #       so that CI test runs are faster
-      #     build-args: |
-      #       PYTHON_VERSION=${{ matrix.python-version }}
-      #       PREFECT_EXTRAS=[dev]
-      #     tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}
-      #     outputs: type=docker,dest=/tmp/image.tar
-      #     cache-from: type=gha
-      #     cache-to: type=gha,mode=max
+      - name: Build test image
+        if: ${{ matrix.build-docker-images }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          # TODO: We do not need the UI in these tests and we may want to add a build-arg to disable building it
+          #       so that CI test runs are faster
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+            PREFECT_EXTRAS=[dev]
+          tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}
+          outputs: type=docker,dest=/tmp/image.tar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      # - name: Test Docker image
-      #   if: ${{ matrix.build-docker-images }}
-      #   run: |
-      #     docker load --input /tmp/image.tar
-      #     docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }} prefect version
+      - name: Test Docker image
+        if: ${{ matrix.build-docker-images }}
+        run: |
+          docker load --input /tmp/image.tar
+          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }} prefect version
 
-      # - name: Build Conda flavored test image
-      #   # Not yet supported for 3.11, see note at top
-      #   if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
-      #   uses: docker/build-push-action@v4
-      #   with:
-      #     context: .
-      #     build-args: |
-      #       PYTHON_VERSION=${{ matrix.python-version }}
-      #       BASE_IMAGE=prefect-conda
-      #       PREFECT_EXTRAS=[dev]
-      #     tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda
-      #     outputs: type=docker,dest=/tmp/image-conda.tar
-      #     cache-from: type=gha
-      #     # We do not cache Conda image layers because they very big and slow to upload
-      #     # cache-to: type=gha,mode=max
+      - name: Build Conda flavored test image
+        # Not yet supported for 3.11, see note at top
+        if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+            BASE_IMAGE=prefect-conda
+            PREFECT_EXTRAS=[dev]
+          tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda
+          outputs: type=docker,dest=/tmp/image-conda.tar
+          cache-from: type=gha
+          # We do not cache Conda image layers because they very big and slow to upload
+          # cache-to: type=gha,mode=max
 
-      # - name: Test Conda flavored Docker image
-      #   # Not yet supported for 3.11, see note at top
-      #   if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
-      #   run: |
-      #     docker load --input /tmp/image-conda.tar
-      #     docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda prefect version
-      #     docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda conda --version
+      - name: Test Conda flavored Docker image
+        # Not yet supported for 3.11, see note at top
+        if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
+        run: |
+          docker load --input /tmp/image-conda.tar
+          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda prefect version
+          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda conda --version
 
-      # - name: Install packages
-      #   run: |
-      #     python -m pip install -U pip
-      #     # If using not using lower bounds, upgrade eagerly to get the latest versions despite caching
-      #     pip install ${{ ! matrix.lower-bound-requirements && '--upgrade --upgrade-strategy eager' || ''}} -e .[dev]
+      - name: Install packages
+        run: |
+          python -m pip install -U pip
+          # If using not using lower bounds, upgrade eagerly to get the latest versions despite caching
+          pip install ${{ ! matrix.lower-bound-requirements && '--upgrade --upgrade-strategy eager' || ''}} -e .[dev]
 
-      # - name: Start database container
-      #   if: ${{ startsWith(matrix.database, 'postgres') }}
-      #   run: >
-      #     docker run
-      #     --name "postgres"
-      #     --detach
-      #     --health-cmd pg_isready
-      #     --health-interval 10s
-      #     --health-timeout 5s
-      #     --health-retries 5
-      #     --publish 5432:5432
-      #     --tmpfs /var/lib/postgresql/data
-      #     --env POSTGRES_USER="prefect"
-      #     --env POSTGRES_PASSWORD="prefect"
-      #     --env POSTGRES_DB="prefect"
-      #     --env LANG="C.UTF-8"
-      #     --env LANGUAGE="C.UTF-8"
-      #     --env LC_ALL="C.UTF-8"
-      #     --env LC_COLLATE="C.UTF-8"
-      #     --env LC_CTYPE="C.UTF-8"
-      #     ${{ matrix.database }}
+      - name: Start database container
+        if: ${{ startsWith(matrix.database, 'postgres') }}
+        run: >
+          docker run
+          --name "postgres"
+          --detach
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          --publish 5432:5432
+          --tmpfs /var/lib/postgresql/data
+          --env POSTGRES_USER="prefect"
+          --env POSTGRES_PASSWORD="prefect"
+          --env POSTGRES_DB="prefect"
+          --env LANG="C.UTF-8"
+          --env LANGUAGE="C.UTF-8"
+          --env LC_ALL="C.UTF-8"
+          --env LC_COLLATE="C.UTF-8"
+          --env LC_CTYPE="C.UTF-8"
+          ${{ matrix.database }}
 
-      #     ./scripts/wait-for-healthy-container.sh postgres 30
+          ./scripts/wait-for-healthy-container.sh postgres 30
 
-      #     echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
+          echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
 
       - name: Run tests
         run: |
@@ -223,18 +219,18 @@ jobs:
           # Do not run Kubernetes service tests, we do not have a cluster available
           pytest tests -vvv --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 --cov=src/ --cov=tests/ --no-cov-on-fail --cov-report=term --cov-config=setup.cfg ${{ matrix.pytest-options }}
 
-      # - name: Check database container
-      #   # Only applicable for Postgres, but we want this to run even when tests fail
-      #   if: always()
-      #   run: >
-      #     docker container inspect postgres
-      #     && docker container logs postgres
-      #     || echo "Ignoring bad exit code"
+      - name: Check database container
+        # Only applicable for Postgres, but we want this to run even when tests fail
+        if: always()
+        run: >
+          docker container inspect postgres
+          && docker container logs postgres
+          || echo "Ignoring bad exit code"
 
   notify:
     needs: run-tests
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/gha-notify-main-failing' && failure()
+    if: github.ref == 'refs/heads/main' && failure()
 
     steps:
       - name: Send Slack Notification

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -8,6 +8,9 @@ env:
   PY_COLORS: 1
 
 on:
+  push:
+    branches:
+      - gha-notify-main-failing
   pull_request:
     paths:
       - .github/workflows/python-tests.yaml
@@ -16,9 +19,9 @@ on:
       - requirements-dev.txt
       - setup.cfg
       - Dockerfile
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
 
 permissions:
   contents: read
@@ -61,38 +64,37 @@ jobs:
   run-tests:
     name: python:${{ matrix.python-version }}, ${{ matrix.database }}, ${{ matrix.pytest-options }}
     needs: isinternal
-
     strategy:
       matrix:
         database:
           - "postgres:13"
-          - "postgres:14"
-          - "sqlite"
-        os:
-          - ${{ needs.isinternal.outputs.status == 'true' && github.event_name == 'pull_request' && 'oss-test-runner' || 'ubuntu-latest' }}
+        #   - "postgres:14"
+        #   - "sqlite"
+        # os:
+        #   - ${{ needs.isinternal.outputs.status == 'true' && github.event_name == 'pull_request' && 'oss-test-runner' || 'ubuntu-latest' }}
         python-version:
           - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
+        #   - "3.9"
+        #   - "3.10"
+        #   - "3.11"
         pytest-options:
           - "--exclude-services"
-          - "--only-services"
+        #   - "--only-services"
 
-        include:
-          # Include Docker image builds on the service test run, and disallow the test
-          # suite from building images automaticlly in fixtures
-          - pytest-options: "--only-services"
-            build-docker-images: true
+        # include:
+        #   # Include Docker image builds on the service test run, and disallow the test
+        #   # suite from building images automaticlly in fixtures
+        #   - pytest-options: "--only-services"
+        #     build-docker-images: true
 
-        exclude:
-          # Do not run service tests with postgres
-          - database: "postgres:13"
-            pytest-options: "--only-services"
+        # exclude:
+        #   # Do not run service tests with postgres
+        #   - database: "postgres:13"
+        #     pytest-options: "--only-services"
 
-          # Do not run service tests with postgres
-          - database: "postgres:14"
-            pytest-options: "--only-services"
+        #   # Do not run service tests with postgres
+        #   - database: "postgres:14"
+        #     pytest-options: "--only-services"
 
       fail-fast: false
 
@@ -103,115 +105,115 @@ jobs:
       - name: Display current test matrix
         run: echo '${{ toJSON(matrix) }}'
 
-      - uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-          fetch-depth: 0
+      # - uses: actions/checkout@v3
+      #   with:
+      #     persist-credentials: false
+      #     fetch-depth: 0
 
-      - name: Set up Docker Buildx
-        if: ${{ matrix.build-docker-images }}
-        uses: docker/setup-buildx-action@v2
+      # - name: Set up Docker Buildx
+      #   if: ${{ matrix.build-docker-images }}
+      #   uses: docker/setup-buildx-action@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: "requirements*.txt"
+      # - name: Set up Python ${{ matrix.python-version }}
+      #   uses: actions/setup-python@v4
+      #   with:
+      #     python-version: ${{ matrix.python-version }}
+      #     cache: "pip"
+      #     cache-dependency-path: "requirements*.txt"
 
-      - name: Pin requirements to lower bounds
-        if: ${{ matrix.lower-bound-requirements }}
-        # Creates lower bound files then replaces the input files so we can do a normal install
-        run: |
-          ./scripts/generate-lower-bounds.py requirements.txt > requirements-lower.txt
-          ./scripts/generate-lower-bounds.py requirements-dev.txt > requirements-dev-lower.txt
-          mv requirements-lower.txt requirements.txt
-          mv requirements-dev-lower.txt requirements-dev.txt
+      # - name: Pin requirements to lower bounds
+      #   if: ${{ matrix.lower-bound-requirements }}
+      #   # Creates lower bound files then replaces the input files so we can do a normal install
+      #   run: |
+      #     ./scripts/generate-lower-bounds.py requirements.txt > requirements-lower.txt
+      #     ./scripts/generate-lower-bounds.py requirements-dev.txt > requirements-dev-lower.txt
+      #     mv requirements-lower.txt requirements.txt
+      #     mv requirements-dev-lower.txt requirements-dev.txt
 
-      - name: Get image tag
-        id: get_image_tag
-        if: ${{ matrix.build-docker-images }}
-        run: |
-          SHORT_SHA=$(git rev-parse --short=7 HEAD)
-          tmp="sha-$SHORT_SHA-python${{ matrix.python-version }}"
-          echo "image_tag=${tmp}" >> $GITHUB_OUTPUT
+      # - name: Get image tag
+      #   id: get_image_tag
+      #   if: ${{ matrix.build-docker-images }}
+      #   run: |
+      #     SHORT_SHA=$(git rev-parse --short=7 HEAD)
+      #     tmp="sha-$SHORT_SHA-python${{ matrix.python-version }}"
+      #     echo "image_tag=${tmp}" >> $GITHUB_OUTPUT
 
-      - name: Build test image
-        if: ${{ matrix.build-docker-images }}
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          # TODO: We do not need the UI in these tests and we may want to add a build-arg to disable building it
-          #       so that CI test runs are faster
-          build-args: |
-            PYTHON_VERSION=${{ matrix.python-version }}
-            PREFECT_EXTRAS=[dev]
-          tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}
-          outputs: type=docker,dest=/tmp/image.tar
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # - name: Build test image
+      #   if: ${{ matrix.build-docker-images }}
+      #   uses: docker/build-push-action@v4
+      #   with:
+      #     context: .
+      #     # TODO: We do not need the UI in these tests and we may want to add a build-arg to disable building it
+      #     #       so that CI test runs are faster
+      #     build-args: |
+      #       PYTHON_VERSION=${{ matrix.python-version }}
+      #       PREFECT_EXTRAS=[dev]
+      #     tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}
+      #     outputs: type=docker,dest=/tmp/image.tar
+      #     cache-from: type=gha
+      #     cache-to: type=gha,mode=max
 
-      - name: Test Docker image
-        if: ${{ matrix.build-docker-images }}
-        run: |
-          docker load --input /tmp/image.tar
-          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }} prefect version
+      # - name: Test Docker image
+      #   if: ${{ matrix.build-docker-images }}
+      #   run: |
+      #     docker load --input /tmp/image.tar
+      #     docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }} prefect version
 
-      - name: Build Conda flavored test image
-        # Not yet supported for 3.11, see note at top
-        if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          build-args: |
-            PYTHON_VERSION=${{ matrix.python-version }}
-            BASE_IMAGE=prefect-conda
-            PREFECT_EXTRAS=[dev]
-          tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda
-          outputs: type=docker,dest=/tmp/image-conda.tar
-          cache-from: type=gha
-          # We do not cache Conda image layers because they very big and slow to upload
-          # cache-to: type=gha,mode=max
+      # - name: Build Conda flavored test image
+      #   # Not yet supported for 3.11, see note at top
+      #   if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
+      #   uses: docker/build-push-action@v4
+      #   with:
+      #     context: .
+      #     build-args: |
+      #       PYTHON_VERSION=${{ matrix.python-version }}
+      #       BASE_IMAGE=prefect-conda
+      #       PREFECT_EXTRAS=[dev]
+      #     tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda
+      #     outputs: type=docker,dest=/tmp/image-conda.tar
+      #     cache-from: type=gha
+      #     # We do not cache Conda image layers because they very big and slow to upload
+      #     # cache-to: type=gha,mode=max
 
-      - name: Test Conda flavored Docker image
-        # Not yet supported for 3.11, see note at top
-        if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
-        run: |
-          docker load --input /tmp/image-conda.tar
-          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda prefect version
-          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda conda --version
+      # - name: Test Conda flavored Docker image
+      #   # Not yet supported for 3.11, see note at top
+      #   if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
+      #   run: |
+      #     docker load --input /tmp/image-conda.tar
+      #     docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda prefect version
+      #     docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda conda --version
 
-      - name: Install packages
-        run: |
-          python -m pip install -U pip
-          # If using not using lower bounds, upgrade eagerly to get the latest versions despite caching
-          pip install ${{ ! matrix.lower-bound-requirements && '--upgrade --upgrade-strategy eager' || ''}} -e .[dev]
+      # - name: Install packages
+      #   run: |
+      #     python -m pip install -U pip
+      #     # If using not using lower bounds, upgrade eagerly to get the latest versions despite caching
+      #     pip install ${{ ! matrix.lower-bound-requirements && '--upgrade --upgrade-strategy eager' || ''}} -e .[dev]
 
-      - name: Start database container
-        if: ${{ startsWith(matrix.database, 'postgres') }}
-        run: >
-          docker run
-          --name "postgres"
-          --detach
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-          --publish 5432:5432
-          --tmpfs /var/lib/postgresql/data
-          --env POSTGRES_USER="prefect"
-          --env POSTGRES_PASSWORD="prefect"
-          --env POSTGRES_DB="prefect"
-          --env LANG="C.UTF-8"
-          --env LANGUAGE="C.UTF-8"
-          --env LC_ALL="C.UTF-8"
-          --env LC_COLLATE="C.UTF-8"
-          --env LC_CTYPE="C.UTF-8"
-          ${{ matrix.database }}
+      # - name: Start database container
+      #   if: ${{ startsWith(matrix.database, 'postgres') }}
+      #   run: >
+      #     docker run
+      #     --name "postgres"
+      #     --detach
+      #     --health-cmd pg_isready
+      #     --health-interval 10s
+      #     --health-timeout 5s
+      #     --health-retries 5
+      #     --publish 5432:5432
+      #     --tmpfs /var/lib/postgresql/data
+      #     --env POSTGRES_USER="prefect"
+      #     --env POSTGRES_PASSWORD="prefect"
+      #     --env POSTGRES_DB="prefect"
+      #     --env LANG="C.UTF-8"
+      #     --env LANGUAGE="C.UTF-8"
+      #     --env LC_ALL="C.UTF-8"
+      #     --env LC_COLLATE="C.UTF-8"
+      #     --env LC_CTYPE="C.UTF-8"
+      #     ${{ matrix.database }}
 
-          ./scripts/wait-for-healthy-container.sh postgres 30
+      #     ./scripts/wait-for-healthy-container.sh postgres 30
 
-          echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
+      #     echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
 
       - name: Run tests
         run: |
@@ -220,10 +222,29 @@ jobs:
           # Do not run Kubernetes service tests, we do not have a cluster available
           pytest tests -vvv --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 --cov=src/ --cov=tests/ --no-cov-on-fail --cov-report=term --cov-config=setup.cfg ${{ matrix.pytest-options }}
 
-      - name: Check database container
-        # Only applicable for Postgres, but we want this to run even when tests fail
-        if: always()
-        run: >
-          docker container inspect postgres
-          && docker container logs postgres
-          || echo "Ignoring bad exit code"
+      # - name: Check database container
+      #   # Only applicable for Postgres, but we want this to run even when tests fail
+      #   if: always()
+      #   run: >
+      #     docker container inspect postgres
+      #     && docker container logs postgres
+      #     || echo "Ignoring bad exit code"
+
+  notify:
+    needs: run-tests
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && failure()
+
+    steps:
+      - name: Send Slack Notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: repo,message
+          custom_payload: |
+            {
+              text: "Python tests are failing on the main branch!",
+              channel: "#engineering-review",
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -98,7 +98,8 @@ jobs:
 
       fail-fast: false
 
-    runs-on: ${{ matrix.os }}
+    # runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 75
 
     steps:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -234,7 +234,7 @@ jobs:
   notify:
     needs: run-tests
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && failure()
+    if: github.ref == 'refs/heads/gha-notify-main-failing' && failure()
 
     steps:
       - name: Send Slack Notification


### PR DESCRIPTION
this PR adds a step to `~/.github/workflows/python-tests.yaml` that will run on `main` (will not run on feature branch's CI) to check if any unit tests have failed.

If it fails, it will send a slack notification to `#engineering-review` (happy to revisit this choice).

Note that this will likely produce false alarms, for example when a flaky test causes a job in the matrix to fail. Open to suggestions on how to implement a threshold so we could mitigate this.