### PR TITLE
Changes in the logic of the deploying work pools

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -629,11 +629,12 @@ async def _run_single_deploy(
                 ),
             )
 
+    work_pool_type = deploy_config.get('work_pool', {}).get('type')
     app.console.print(
         "\nTo execute flow runs from this deployment, start a worker in a"
         " separate terminal that pulls work from the"
         f" {deploy_config['work_pool']['name']!r} work pool:"
-    )
+    )if work_pool_type == 'pull' else None
     app.console.print(
         f"\n\t$ prefect worker start --pool {deploy_config['work_pool']['name']!r}",
         style="blue",


### PR DESCRIPTION
In Prefect, there are two types of work pools: push and pull. In the push mode, no external worker is required. However, in the pull mode, an external worker is necessary for polling. Unfortunately, due to some missing logic, when a user deploys a push work pool, they encounter a CLI message.

 "To execute flow runs from this deployment, start a worker in a separate terminal that pulls work from the 'gcp-push-pool' work pool:

        $ prefect worker start --pool 'gcp-push-pool'" 

Currently, there is no logic to determine whether the work pool is a pull or push. As a result, this statement gets printed regardless of any conditions, as there is no logic associated with it. It applies universally to every type of work pool. Therefore, I have added a conditional statement to check whether the pool is a push or pull, and then display the message accordingly.

Fixes: #10300 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
