### PR TITLE
threshold for notifying about failing tests on main

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -18,7 +18,7 @@ on:
       - Dockerfile
   push:
     branches:
-      - ci-failure-threshold
+      - main
 
 permissions:
   contents: read
@@ -102,115 +102,115 @@ jobs:
       - name: Display current test matrix
         run: echo '${{ toJSON(matrix) }}'
 
-      # - uses: actions/checkout@v3
-      #   with:
-      #     persist-credentials: false
-      #     fetch-depth: 0
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
-      # - name: Set up Docker Buildx
-      #   if: ${{ matrix.build-docker-images }}
-      #   uses: docker/setup-buildx-action@v2
+      - name: Set up Docker Buildx
+        if: ${{ matrix.build-docker-images }}
+        uses: docker/setup-buildx-action@v2
 
-      # - name: Set up Python ${{ matrix.python-version }}
-      #   uses: actions/setup-python@v4
-      #   with:
-      #     python-version: ${{ matrix.python-version }}
-      #     cache: "pip"
-      #     cache-dependency-path: "requirements*.txt"
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "requirements*.txt"
 
-      # - name: Pin requirements to lower bounds
-      #   if: ${{ matrix.lower-bound-requirements }}
-      #   # Creates lower bound files then replaces the input files so we can do a normal install
-      #   run: |
-      #     ./scripts/generate-lower-bounds.py requirements.txt > requirements-lower.txt
-      #     ./scripts/generate-lower-bounds.py requirements-dev.txt > requirements-dev-lower.txt
-      #     mv requirements-lower.txt requirements.txt
-      #     mv requirements-dev-lower.txt requirements-dev.txt
+      - name: Pin requirements to lower bounds
+        if: ${{ matrix.lower-bound-requirements }}
+        # Creates lower bound files then replaces the input files so we can do a normal install
+        run: |
+          ./scripts/generate-lower-bounds.py requirements.txt > requirements-lower.txt
+          ./scripts/generate-lower-bounds.py requirements-dev.txt > requirements-dev-lower.txt
+          mv requirements-lower.txt requirements.txt
+          mv requirements-dev-lower.txt requirements-dev.txt
 
-      # - name: Get image tag
-      #   id: get_image_tag
-      #   if: ${{ matrix.build-docker-images }}
-      #   run: |
-      #     SHORT_SHA=$(git rev-parse --short=7 HEAD)
-      #     tmp="sha-$SHORT_SHA-python${{ matrix.python-version }}"
-      #     echo "image_tag=${tmp}" >> $GITHUB_OUTPUT
+      - name: Get image tag
+        id: get_image_tag
+        if: ${{ matrix.build-docker-images }}
+        run: |
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          tmp="sha-$SHORT_SHA-python${{ matrix.python-version }}"
+          echo "image_tag=${tmp}" >> $GITHUB_OUTPUT
 
-      # - name: Build test image
-      #   if: ${{ matrix.build-docker-images }}
-      #   uses: docker/build-push-action@v4
-      #   with:
-      #     context: .
-      #     # TODO: We do not need the UI in these tests and we may want to add a build-arg to disable building it
-      #     #       so that CI test runs are faster
-      #     build-args: |
-      #       PYTHON_VERSION=${{ matrix.python-version }}
-      #       PREFECT_EXTRAS=[dev]
-      #     tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}
-      #     outputs: type=docker,dest=/tmp/image.tar
-      #     cache-from: type=gha
-      #     cache-to: type=gha,mode=max
+      - name: Build test image
+        if: ${{ matrix.build-docker-images }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          # TODO: We do not need the UI in these tests and we may want to add a build-arg to disable building it
+          #       so that CI test runs are faster
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+            PREFECT_EXTRAS=[dev]
+          tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}
+          outputs: type=docker,dest=/tmp/image.tar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      # - name: Test Docker image
-      #   if: ${{ matrix.build-docker-images }}
-      #   run: |
-      #     docker load --input /tmp/image.tar
-      #     docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }} prefect version
+      - name: Test Docker image
+        if: ${{ matrix.build-docker-images }}
+        run: |
+          docker load --input /tmp/image.tar
+          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }} prefect version
 
-      # - name: Build Conda flavored test image
-      #   # Not yet supported for 3.11, see note at top
-      #   if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
-      #   uses: docker/build-push-action@v4
-      #   with:
-      #     context: .
-      #     build-args: |
-      #       PYTHON_VERSION=${{ matrix.python-version }}
-      #       BASE_IMAGE=prefect-conda
-      #       PREFECT_EXTRAS=[dev]
-      #     tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda
-      #     outputs: type=docker,dest=/tmp/image-conda.tar
-      #     cache-from: type=gha
-      #     # We do not cache Conda image layers because they very big and slow to upload
-      #     # cache-to: type=gha,mode=max
+      - name: Build Conda flavored test image
+        # Not yet supported for 3.11, see note at top
+        if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+            BASE_IMAGE=prefect-conda
+            PREFECT_EXTRAS=[dev]
+          tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda
+          outputs: type=docker,dest=/tmp/image-conda.tar
+          cache-from: type=gha
+          # We do not cache Conda image layers because they very big and slow to upload
+          # cache-to: type=gha,mode=max
 
-      # - name: Test Conda flavored Docker image
-      #   # Not yet supported for 3.11, see note at top
-      #   if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
-      #   run: |
-      #     docker load --input /tmp/image-conda.tar
-      #     docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda prefect version
-      #     docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda conda --version
+      - name: Test Conda flavored Docker image
+        # Not yet supported for 3.11, see note at top
+        if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
+        run: |
+          docker load --input /tmp/image-conda.tar
+          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda prefect version
+          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda conda --version
 
-      # - name: Install packages
-      #   run: |
-      #     python -m pip install -U pip
-      #     # If using not using lower bounds, upgrade eagerly to get the latest versions despite caching
-      #     pip install ${{ ! matrix.lower-bound-requirements && '--upgrade --upgrade-strategy eager' || ''}} -e .[dev]
+      - name: Install packages
+        run: |
+          python -m pip install -U pip
+          # If using not using lower bounds, upgrade eagerly to get the latest versions despite caching
+          pip install ${{ ! matrix.lower-bound-requirements && '--upgrade --upgrade-strategy eager' || ''}} -e .[dev]
 
-      # - name: Start database container
-      #   if: ${{ startsWith(matrix.database, 'postgres') }}
-      #   run: >
-      #     docker run
-      #     --name "postgres"
-      #     --detach
-      #     --health-cmd pg_isready
-      #     --health-interval 10s
-      #     --health-timeout 5s
-      #     --health-retries 5
-      #     --publish 5432:5432
-      #     --tmpfs /var/lib/postgresql/data
-      #     --env POSTGRES_USER="prefect"
-      #     --env POSTGRES_PASSWORD="prefect"
-      #     --env POSTGRES_DB="prefect"
-      #     --env LANG="C.UTF-8"
-      #     --env LANGUAGE="C.UTF-8"
-      #     --env LC_ALL="C.UTF-8"
-      #     --env LC_COLLATE="C.UTF-8"
-      #     --env LC_CTYPE="C.UTF-8"
-      #     ${{ matrix.database }}
+      - name: Start database container
+        if: ${{ startsWith(matrix.database, 'postgres') }}
+        run: >
+          docker run
+          --name "postgres"
+          --detach
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          --publish 5432:5432
+          --tmpfs /var/lib/postgresql/data
+          --env POSTGRES_USER="prefect"
+          --env POSTGRES_PASSWORD="prefect"
+          --env POSTGRES_DB="prefect"
+          --env LANG="C.UTF-8"
+          --env LANGUAGE="C.UTF-8"
+          --env LC_ALL="C.UTF-8"
+          --env LC_COLLATE="C.UTF-8"
+          --env LC_CTYPE="C.UTF-8"
+          ${{ matrix.database }}
 
-      #     ./scripts/wait-for-healthy-container.sh postgres 30
+          ./scripts/wait-for-healthy-container.sh postgres 30
 
-      #     echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
+          echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
 
       - name: Run tests
         run: |
@@ -246,7 +246,7 @@ jobs:
 
   notify-tests-failing-on-main:
     needs: run-tests
-    if: github.ref == 'refs/heads/ci-failure-threshold' && failure()
+    if: github.ref == 'refs/heads/main' && failure()
     runs-on: ubuntu-latest
     env:
       FAILURE_THRESHOLD: 3
@@ -276,7 +276,7 @@ jobs:
           fields: repo,message
           custom_payload: |
             {
-              text: "THIS IS A TEST: More than $FAILURE_THRESHOLD tests are failing on main :oh-noo:",
+              text: "More than ${{ env.FAILURE_THRESHOLD }} tests are failing on main :oh-noo:",
               channel: "#engineering-review",
             }
         env:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -219,16 +219,22 @@ jobs:
           # Do not run Kubernetes service tests, we do not have a cluster available
           pytest tests -vvv --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 --cov=src/ --cov=tests/ --no-cov-on-fail --cov-report=term --cov-config=setup.cfg ${{ matrix.pytest-options }}
     
-      - name: Create failure flag
+      - name: Create and Upload failure flag
         if: ${{ failure() }}
-        run: echo "Failure in ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}" > "${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}-failure.txt"
+        id: create_failure_flag
+        run: |
+          sanitized_name="${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}"
+          sanitized_name="${sanitized_name//:/-}"
+          echo "Failure in $sanitized_name" > "${sanitized_name}-failure.txt"
+          echo "artifact_name=${sanitized_name}-failure" >> $GITHUB_OUTPUT
+        continue-on-error: true
 
       - name: Upload failure flag
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
-          name: "${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}-failure"
-          path: "${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}-failure.txt"
+          name: ${{ steps.create_failure_flag.outputs.artifact_name }}
+          path: "${{ steps.create_failure_flag.outputs.artifact_name }}.txt"
 
       - name: Check database container
         # Only applicable for Postgres, but we want this to run even when tests fail

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -18,7 +18,7 @@ on:
       - Dockerfile
   push:
     branches:
-      - main
+      - ci-failure-threshold
 
 permissions:
   contents: read
@@ -102,115 +102,115 @@ jobs:
       - name: Display current test matrix
         run: echo '${{ toJSON(matrix) }}'
 
-      - uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-          fetch-depth: 0
+      # - uses: actions/checkout@v3
+      #   with:
+      #     persist-credentials: false
+      #     fetch-depth: 0
 
-      - name: Set up Docker Buildx
-        if: ${{ matrix.build-docker-images }}
-        uses: docker/setup-buildx-action@v2
+      # - name: Set up Docker Buildx
+      #   if: ${{ matrix.build-docker-images }}
+      #   uses: docker/setup-buildx-action@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: "requirements*.txt"
+      # - name: Set up Python ${{ matrix.python-version }}
+      #   uses: actions/setup-python@v4
+      #   with:
+      #     python-version: ${{ matrix.python-version }}
+      #     cache: "pip"
+      #     cache-dependency-path: "requirements*.txt"
 
-      - name: Pin requirements to lower bounds
-        if: ${{ matrix.lower-bound-requirements }}
-        # Creates lower bound files then replaces the input files so we can do a normal install
-        run: |
-          ./scripts/generate-lower-bounds.py requirements.txt > requirements-lower.txt
-          ./scripts/generate-lower-bounds.py requirements-dev.txt > requirements-dev-lower.txt
-          mv requirements-lower.txt requirements.txt
-          mv requirements-dev-lower.txt requirements-dev.txt
+      # - name: Pin requirements to lower bounds
+      #   if: ${{ matrix.lower-bound-requirements }}
+      #   # Creates lower bound files then replaces the input files so we can do a normal install
+      #   run: |
+      #     ./scripts/generate-lower-bounds.py requirements.txt > requirements-lower.txt
+      #     ./scripts/generate-lower-bounds.py requirements-dev.txt > requirements-dev-lower.txt
+      #     mv requirements-lower.txt requirements.txt
+      #     mv requirements-dev-lower.txt requirements-dev.txt
 
-      - name: Get image tag
-        id: get_image_tag
-        if: ${{ matrix.build-docker-images }}
-        run: |
-          SHORT_SHA=$(git rev-parse --short=7 HEAD)
-          tmp="sha-$SHORT_SHA-python${{ matrix.python-version }}"
-          echo "image_tag=${tmp}" >> $GITHUB_OUTPUT
+      # - name: Get image tag
+      #   id: get_image_tag
+      #   if: ${{ matrix.build-docker-images }}
+      #   run: |
+      #     SHORT_SHA=$(git rev-parse --short=7 HEAD)
+      #     tmp="sha-$SHORT_SHA-python${{ matrix.python-version }}"
+      #     echo "image_tag=${tmp}" >> $GITHUB_OUTPUT
 
-      - name: Build test image
-        if: ${{ matrix.build-docker-images }}
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          # TODO: We do not need the UI in these tests and we may want to add a build-arg to disable building it
-          #       so that CI test runs are faster
-          build-args: |
-            PYTHON_VERSION=${{ matrix.python-version }}
-            PREFECT_EXTRAS=[dev]
-          tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}
-          outputs: type=docker,dest=/tmp/image.tar
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # - name: Build test image
+      #   if: ${{ matrix.build-docker-images }}
+      #   uses: docker/build-push-action@v4
+      #   with:
+      #     context: .
+      #     # TODO: We do not need the UI in these tests and we may want to add a build-arg to disable building it
+      #     #       so that CI test runs are faster
+      #     build-args: |
+      #       PYTHON_VERSION=${{ matrix.python-version }}
+      #       PREFECT_EXTRAS=[dev]
+      #     tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}
+      #     outputs: type=docker,dest=/tmp/image.tar
+      #     cache-from: type=gha
+      #     cache-to: type=gha,mode=max
 
-      - name: Test Docker image
-        if: ${{ matrix.build-docker-images }}
-        run: |
-          docker load --input /tmp/image.tar
-          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }} prefect version
+      # - name: Test Docker image
+      #   if: ${{ matrix.build-docker-images }}
+      #   run: |
+      #     docker load --input /tmp/image.tar
+      #     docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }} prefect version
 
-      - name: Build Conda flavored test image
-        # Not yet supported for 3.11, see note at top
-        if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          build-args: |
-            PYTHON_VERSION=${{ matrix.python-version }}
-            BASE_IMAGE=prefect-conda
-            PREFECT_EXTRAS=[dev]
-          tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda
-          outputs: type=docker,dest=/tmp/image-conda.tar
-          cache-from: type=gha
-          # We do not cache Conda image layers because they very big and slow to upload
-          # cache-to: type=gha,mode=max
+      # - name: Build Conda flavored test image
+      #   # Not yet supported for 3.11, see note at top
+      #   if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
+      #   uses: docker/build-push-action@v4
+      #   with:
+      #     context: .
+      #     build-args: |
+      #       PYTHON_VERSION=${{ matrix.python-version }}
+      #       BASE_IMAGE=prefect-conda
+      #       PREFECT_EXTRAS=[dev]
+      #     tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda
+      #     outputs: type=docker,dest=/tmp/image-conda.tar
+      #     cache-from: type=gha
+      #     # We do not cache Conda image layers because they very big and slow to upload
+      #     # cache-to: type=gha,mode=max
 
-      - name: Test Conda flavored Docker image
-        # Not yet supported for 3.11, see note at top
-        if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
-        run: |
-          docker load --input /tmp/image-conda.tar
-          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda prefect version
-          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda conda --version
+      # - name: Test Conda flavored Docker image
+      #   # Not yet supported for 3.11, see note at top
+      #   if: ${{ matrix.build-docker-images && matrix.python-version != '3.11' }}
+      #   run: |
+      #     docker load --input /tmp/image-conda.tar
+      #     docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda prefect version
+      #     docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}-conda conda --version
 
-      - name: Install packages
-        run: |
-          python -m pip install -U pip
-          # If using not using lower bounds, upgrade eagerly to get the latest versions despite caching
-          pip install ${{ ! matrix.lower-bound-requirements && '--upgrade --upgrade-strategy eager' || ''}} -e .[dev]
+      # - name: Install packages
+      #   run: |
+      #     python -m pip install -U pip
+      #     # If using not using lower bounds, upgrade eagerly to get the latest versions despite caching
+      #     pip install ${{ ! matrix.lower-bound-requirements && '--upgrade --upgrade-strategy eager' || ''}} -e .[dev]
 
-      - name: Start database container
-        if: ${{ startsWith(matrix.database, 'postgres') }}
-        run: >
-          docker run
-          --name "postgres"
-          --detach
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-          --publish 5432:5432
-          --tmpfs /var/lib/postgresql/data
-          --env POSTGRES_USER="prefect"
-          --env POSTGRES_PASSWORD="prefect"
-          --env POSTGRES_DB="prefect"
-          --env LANG="C.UTF-8"
-          --env LANGUAGE="C.UTF-8"
-          --env LC_ALL="C.UTF-8"
-          --env LC_COLLATE="C.UTF-8"
-          --env LC_CTYPE="C.UTF-8"
-          ${{ matrix.database }}
+      # - name: Start database container
+      #   if: ${{ startsWith(matrix.database, 'postgres') }}
+      #   run: >
+      #     docker run
+      #     --name "postgres"
+      #     --detach
+      #     --health-cmd pg_isready
+      #     --health-interval 10s
+      #     --health-timeout 5s
+      #     --health-retries 5
+      #     --publish 5432:5432
+      #     --tmpfs /var/lib/postgresql/data
+      #     --env POSTGRES_USER="prefect"
+      #     --env POSTGRES_PASSWORD="prefect"
+      #     --env POSTGRES_DB="prefect"
+      #     --env LANG="C.UTF-8"
+      #     --env LANGUAGE="C.UTF-8"
+      #     --env LC_ALL="C.UTF-8"
+      #     --env LC_COLLATE="C.UTF-8"
+      #     --env LC_CTYPE="C.UTF-8"
+      #     ${{ matrix.database }}
 
-          ./scripts/wait-for-healthy-container.sh postgres 30
+      #     ./scripts/wait-for-healthy-container.sh postgres 30
 
-          echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
+      #     echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
 
       - name: Run tests
         run: |
@@ -218,6 +218,17 @@ jobs:
           # Do not allow the test suite to build images, as we want the prebuilt images to be tested
           # Do not run Kubernetes service tests, we do not have a cluster available
           pytest tests -vvv --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 --cov=src/ --cov=tests/ --no-cov-on-fail --cov-report=term --cov-config=setup.cfg ${{ matrix.pytest-options }}
+    
+      - name: Create failure flag
+        if: ${{ failure() }}
+        run: echo "Failure in ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}" > "${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}-failure.txt"
+
+      - name: Upload failure flag
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: "${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}-failure"
+          path: "${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}-failure.txt"
 
       - name: Check database container
         # Only applicable for Postgres, but we want this to run even when tests fail
@@ -229,19 +240,46 @@ jobs:
 
   notify-tests-failing-on-main:
     needs: run-tests
-    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && failure()
-
+    runs-on: ubuntu-latest
     steps:
-      - name: Send Slack Notification
-        uses: 8398a7/action-slack@v3
+      - name: Download all failure flags
+        uses: actions/download-artifact@v2
         with:
-          status: custom
-          fields: repo,message
-          custom_payload: |
-            {
-              text: "Unit tests are failing on the main branch!",
-              channel: "#engineering-review",
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ENGINEERING_REVIEW_SLACK_WEBHOOK_URL }}
+          path: failure-flags/
+
+      - name: Check for failure flags and print their content
+        id: check_failure
+        run: |
+          ls -al failure-flags/*  # List directory to debug
+          failure_count=$(ls -1q failure-flags/*/*.txt | wc -l)
+          failed_tests=$(basename -a failure-flags/*/*.txt | tr '\n' ', ')
+          
+          echo "Failure Count: $failure_count"  # Debug print
+          echo "Failed Tests: $failed_tests"  # Debug print
+          
+          if [ $failure_count -gt 1 ]; then
+            too_many_tests_failed="true"
+          else
+            too_many_tests_failed="false"
+          fi
+          echo "too_many_tests_failed=$too_many_tests_failed" >> $GITHUB_OUTPUT
+
+      # - name: Send Slack Notification
+      #   if: ${{ steps.check_failure.outputs.too_many_tests_failed == 'true' }}
+      #   uses: 8398a7/action-slack@v3
+      #   with:
+      #     status: custom
+      #     fields: repo,message
+      #     custom_payload: |
+      #       {
+      #         text: "Exceeded threshold of unit tests failing on the main branch!",
+      #         channel: "#engineering-review",
+      #       }
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.ENGINEERING_REVIEW_SLACK_WEBHOOK_URL }}
+
+      - name: Failure Notification
+        if: steps.check_failure.outputs.too_many_tests_failed == 'true'
+        run: |
+          echo "More than 1 unit tests failed on main."

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -246,7 +246,7 @@ jobs:
 
   notify-tests-failing-on-main:
     needs: run-tests
-    if: github.ref == 'refs/heads/main' && failure()
+    if: github.ref == 'refs/heads/ci-failure-threshold' && failure()
     runs-on: ubuntu-latest
     steps:
       - name: Download all failure flags
@@ -270,20 +270,6 @@ jobs:
             too_many_tests_failed="false"
           fi
           echo "too_many_tests_failed=$too_many_tests_failed" >> $GITHUB_OUTPUT
-
-      # - name: Send Slack Notification
-      #   if: ${{ steps.check_failure.outputs.too_many_tests_failed == 'true' }}
-      #   uses: 8398a7/action-slack@v3
-      #   with:
-      #     status: custom
-      #     fields: repo,message
-      #     custom_payload: |
-      #       {
-      #         text: "Exceeded threshold of unit tests failing on the main branch!",
-      #         channel: "#engineering-review",
-      #       }
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.ENGINEERING_REVIEW_SLACK_WEBHOOK_URL }}
 
       - name: Failure Notification
         if: steps.check_failure.outputs.too_many_tests_failed == 'true'

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -275,7 +275,7 @@ jobs:
           fields: repo,message
           custom_payload: |
             {
-              text: "More than ${{ env.FAILURE_THRESHOLD }} tests are failing on main :oh-noo:",
+              text: "More than ${{ env.FAILURE_THRESHOLD }} unit test jobs are failing on main :oh-noo:",
               channel: "#engineering-review",
             }
         env:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -227,7 +227,6 @@ jobs:
           sanitized_name="${sanitized_name//:/-}"
           echo "Failure in $sanitized_name" > "${sanitized_name}-failure.txt"
           echo "artifact_name=${sanitized_name}-failure" >> $GITHUB_OUTPUT
-        continue-on-error: true
 
       - name: Upload failure flag
         if: ${{ failure() }}

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -268,7 +268,16 @@ jobs:
           fi
           echo "too_many_tests_failed=$too_many_tests_failed" >> $GITHUB_OUTPUT
 
-      - name: Failure Notification
-        if: steps.check_failure.outputs.too_many_tests_failed == 'true'
-        run: |
-          echo "More than $FAILURE_THRESHOLD tests failed on main branch."
+      - name: Send Slack Notification
+        if: ${{ steps.check_failure.outputs.too_many_tests_failed == 'true' }}
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: repo,message
+          custom_payload: |
+            {
+              text: "THIS IS A TEST: More than $FAILURE_THRESHOLD tests are failing on main :oh-noo:",
+              channel: "#engineering-review",
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ENGINEERING_REVIEW_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -248,6 +248,8 @@ jobs:
     needs: run-tests
     if: github.ref == 'refs/heads/ci-failure-threshold' && failure()
     runs-on: ubuntu-latest
+    env:
+      FAILURE_THRESHOLD: 3
     steps:
       - name: Download all failure flags
         uses: actions/download-artifact@v2
@@ -257,14 +259,9 @@ jobs:
       - name: Check for failure flags and print their content
         id: check_failure
         run: |
-          ls -al failure-flags/*  # List directory to debug
           failure_count=$(ls -1q failure-flags/*/*.txt | wc -l)
-          failed_tests=$(basename -a failure-flags/*/*.txt | tr '\n' ', ')
           
-          echo "Failure Count: $failure_count"  # Debug print
-          echo "Failed Tests: $failed_tests"  # Debug print
-          
-          if [ $failure_count -gt 1 ]; then
+          if [ $failure_count -gt $FAILURE_THRESHOLD ]; then
             too_many_tests_failed="true"
           else
             too_many_tests_failed="false"
@@ -274,4 +271,4 @@ jobs:
       - name: Failure Notification
         if: steps.check_failure.outputs.too_many_tests_failed == 'true'
         run: |
-          echo "More than 1 unit tests failed on main."
+          echo "More than $FAILURE_THRESHOLD tests failed on main branch."

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -256,7 +256,7 @@ jobs:
         with:
           path: failure-flags/
 
-      - name: Check for failure flags and print their content
+      - name: Check for failure flags
         id: check_failure
         run: |
           failure_count=$(ls -1q failure-flags/*/*.txt | wc -l)


### PR DESCRIPTION
previously this notification was sent anytime any CI failed on main, which was needlessly noisy

this PR implements a threshold with github artifacts (its surprisingly annoying to share data across matrixed jobs)

I've set `FAILURE_THRESHOLD: 3` on the `env` of the notification job - let me know if a different value is more appropriate