### PR TITLE
Bring back mkdocs title changes

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,7 @@ nav:
     - Getting Started:
           - index.md
           - Installation: getting-started/installation.md
+          - Quickstart: getting-started/quickstart.md
     - Tutorial:
           - tutorial/index.md
           - Flows: tutorial/flows.md
@@ -144,7 +145,7 @@ nav:
           - Deploying Flows: tutorial/deployments.md
     - Guides:
           - guides/index.md
-          - Deployment:
+          - Worker Deployment:
                 - Storage: guides/deployment/storage-guide.md
                 - Docker: guides/deployment/docker.md
                 - Upgrade from Agents to Workers: guides/upgrade-guide-agents-to-workers.md
@@ -179,7 +180,6 @@ nav:
           - Task Runners: concepts/task-runners.md
           - Events: concepts/events.md
           - Automations: concepts/automations.md
-          - Filesystems: concepts/filesystems.md
           - Block and Agent-Based Deployments:
                 - Deployments: concepts/deployments-block-based.md
                 - Infrastructure: concepts/infrastructure.md
@@ -203,9 +203,9 @@ nav:
           - integrations/index.md
           - Using Integrations: integrations/usage.md
           - Contributing Integrations: integrations/contribute.md
-    - API References:
+    - API Reference:
           - api-ref/index.md
-          - Python SDK API:
+          - Python SDK:
                 - api-ref/python/index.md
                 - "prefect.agent": api-ref/prefect/agent.md
                 - "prefect.artifacts": api-ref/prefect/artifacts.md


### PR DESCRIPTION
Not sure what happened but #10545 reverted some changes to `mkdocs.yml` that this PR brings back