### PR TITLE
Reduce logging noise on QueueServices startup failures and item processing failures

### DIFF
--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -3,6 +3,7 @@ import asyncio
 import atexit
 import concurrent.futures
 import contextlib
+import logging
 import queue
 import sys
 import threading
@@ -149,8 +150,12 @@ class QueueService(abc.ABC, Generic[T]):
                 logger.debug("Service %r handling item %r", self, item)
                 await self._handle(item)
             except Exception:
-                logger.exception(
-                    "Service %r failed to process item %r", type(self).__name__, item
+                log_traceback = logger.isEnabledFor(logging.DEBUG)
+                logger.error(
+                    "Service %r failed to process item %r",
+                    type(self).__name__,
+                    item,
+                    exc_info=log_traceback,
                 )
 
     @abc.abstractmethod
@@ -313,10 +318,12 @@ class BatchedQueueService(QueueService[T]):
             try:
                 await self._handle_batch(batch)
             except Exception:
-                logger.exception(
+                log_traceback = logger.isEnabledFor(logging.DEBUG)
+                logger.error(
                     "Service %r failed to process batch of size %s",
                     self,
                     batch_size,
+                    exc_info=log_traceback,
                 )
 
     @abc.abstractmethod

--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -122,10 +122,12 @@ class QueueService(abc.ABC, Generic[T]):
             self._remove_instance()
             # The logging call yields to another thread, so we must remove the instance
             # before reporting the failure to prevent retrieval of a dead instance
-            logger.exception(
+            log_traceback = logger.isEnabledFor(logging.DEBUG)
+            logger.error(
                 "Service %r failed with %s pending items.",
                 type(self).__name__,
                 self._queue.qsize(),
+                exc_info=log_traceback,
             )
         finally:
             self._remove_instance()

--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -60,7 +60,7 @@ class APILogWorker(BatchedQueueService[Dict[str, Any]]):
                     traceback.print_exc(file=sys.stderr)
                 else:
                     # Only log the exception message in non-DEBUG mode
-                    sys.stderr.write(f"{e}")
+                    sys.stderr.write(str(e))
 
     @asynccontextmanager
     async def _lifespan(self):

--- a/tests/_internal/concurrency/test_services.py
+++ b/tests/_internal/concurrency/test_services.py
@@ -16,6 +16,7 @@ from prefect._internal.concurrency.services import (
     drain_on_exit_async,
 )
 from prefect._internal.concurrency.threads import wait_for_global_loop_exit
+from prefect.settings import PREFECT_LOGGING_INTERNAL_LEVEL, temporary_settings
 
 
 class MockService(QueueService[int]):
@@ -374,3 +375,44 @@ def test_batched_queue_service_min_interval():
     IntervalMockBatchedService.mock.assert_has_calls(
         [call(instance, [1]), call(instance, [2])]
     )
+
+
+@pytest.mark.parametrize(
+    "level,expected", [("DEBUG", True), ("INFO", False), ("WARNING", False)]
+)
+def test_queue_service_contains_traceback_only_at_debug(
+    caplog: pytest.LogCaptureFixture, level: str, expected: bool
+):
+    class ExceptionOnHandleService(QueueService[int]):
+        exception_msg = "Oh no!"
+
+        async def _handle(self, _):
+            raise Exception(self.exception_msg)
+
+    with temporary_settings({PREFECT_LOGGING_INTERNAL_LEVEL: level}):
+        instance = ExceptionOnHandleService.instance()
+        instance.send(1)
+        instance.drain_all()
+
+    assert (ExceptionOnHandleService.exception_msg in caplog.text) == expected
+
+
+@pytest.mark.parametrize(
+    "level,expected", [("DEBUG", True), ("INFO", False), ("WARNING", False)]
+)
+def test_batched_queue_service_contains_traceback_only_at_debug(
+    caplog: pytest.LogCaptureFixture, level: str, expected: bool
+):
+    class ExceptionOnHandleBatchService(BatchedQueueService[int]):
+        exception_msg = "Oh no!"
+        _max_batch_size = 2
+
+        async def _handle_batch(self, _):
+            raise Exception(self.exception_msg)
+
+    with temporary_settings({PREFECT_LOGGING_INTERNAL_LEVEL: level}):
+        instance = ExceptionOnHandleBatchService.instance()
+        instance.send(1)
+        instance.drain_all()
+
+    assert (ExceptionOnHandleBatchService.exception_msg in caplog.text) == expected


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/10456

Full tracebacks for Batched/QueueServices startup/item-processing failures will only be logged if the log level is set to `DEBUG`. Otherwise, the output only contains the log message. The hope is this will make it easier to understand where errors are coming from while still allowing access to detailed information. 

### Example
Log line for an item processing failure at `DEBUG`:
```
16:39:35.649 | WARNING | GlobalEventLoopThread | prefect._internal.concurrency - Service 'ExceptionOnHandleService' failed to process item 1
Traceback (most recent call last):
  File "/Users/uriel/Projects/github.com/PrefectHQ/prefect/src/prefect/_internal/concurrency/services.py", line 151, in _main_loop
    await self._handle(item)
  File "/Users/uriel/Projects/github.com/PrefectHQ/prefect/tests/_internal/concurrency/test_services.py", line 388, in _handle
    raise Exception(self.exception_msg)
Exception: Oh no!
```

Log line for an item processing failure at `INFO` and greater:
```
WARNING  prefect._internal.concurrency:services.py:154 Service 'ExceptionOnHandleService' failed to process item 1
```
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
