### PR TITLE
Add `serve` example and logs for schedule pausing

### DIFF
--- a/src/prefect/runner.py
+++ b/src/prefect/runner.py
@@ -251,8 +251,8 @@ class Runner:
             run_once: If True, the runner will through one query loop and then exit.
 
         Examples:
-
             Initialize a Runner, add two flows, and serve them by starting the Runner:
+
             ```python
             from prefect import flow, Runner
 

--- a/src/prefect/runner.py
+++ b/src/prefect/runner.py
@@ -141,7 +141,7 @@ class Runner:
         if name and ("/" in name or "%" in name):
             raise ValueError("Runner name cannot contain '/' or '%'")
         self.name = Path(name).stem if name is not None else f"runner-{uuid4()}"
-        self._logger = get_logger()
+        self._logger = get_logger("runner")
 
         self.started = False
         self.pause_on_shutdown = pause_on_shutdown
@@ -485,8 +485,11 @@ class Runner:
         """
         Pauses all deployment schedules.
         """
+        self._logger.info("Pausing schedules for all deployments...")
         for deployment_id in self._deployment_ids:
+            self._logger.debug(f"Pausing schedule for deployment '{deployment_id}'")
             await self._client.update_schedule(deployment_id, active=False)
+        self._logger.info("All deployment schedules have been paused!")
 
     async def _get_and_submit_flow_runs(self):
         runs_response = await self._get_scheduled_flow_runs()

--- a/src/prefect/runner.py
+++ b/src/prefect/runner.py
@@ -897,6 +897,36 @@ async def serve(
         pause_on_shutdown: A boolean for whether or not to automatically pause
             deployment schedules on shutdown.
         **kwargs: Additional keyword arguments to pass to the runner.
+
+    Examples:
+        Prepare two deployments and serve them:
+
+        ```python
+        import datetime
+
+        from prefect import flow, serve
+
+        @flow
+        def my_flow(name):
+            print(f"hello {name}")
+
+        @flow
+        def my_other_flow(name):
+            print(f"goodbye {name}")
+
+        if __name__ == "__main__":
+            # Run once a day
+            hello_deploy = my_flow.to_deployment(
+                "hello", tags=["dev"], interval=datetime.timedelta(days=1)
+            )
+
+            # Run every Sunday at 4:05 AM
+            bye_deploy = my_other_flow.to_deployment(
+                "goodbye", tags=["dev"], cron="0 4 * * sun"
+            )
+
+            serve(hello_deploy, bye_deploy)
+        ```
     """
     runner = Runner(pause_on_shutdown=pause_on_shutdown, **kwargs)
     for deployment in args:

--- a/src/prefect/runner.py
+++ b/src/prefect/runner.py
@@ -923,7 +923,7 @@ async def serve(
                 "hello", tags=["dev"], interval=datetime.timedelta(days=1)
             )
 
-            # Run every Sunday at 4:05 AM
+            # Run every Sunday at 4:00 AM
             bye_deploy = my_other_flow.to_deployment(
                 "goodbye", tags=["dev"], cron="0 4 * * sun"
             )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -159,7 +159,7 @@ class TestRunner:
         assert deployment_2.schedule.cron == "* * * * *"
 
     async def test_runner_can_pause_schedules_on_stop(
-        self, prefect_client: PrefectClient
+        self, prefect_client: PrefectClient, caplog
     ):
         runner = Runner()
 
@@ -192,6 +192,9 @@ class TestRunner:
         assert not deployment_1.is_schedule_active
 
         assert not deployment_2.is_schedule_active
+
+        assert "Pausing schedules for all deployments" in caplog.text
+        assert "All deployment schedules have been paused" in caplog.text
 
     @pytest.mark.usefixtures("use_hosted_api_server")
     async def test_runner_executes_flow_runs(self, prefect_client: PrefectClient):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
- Adds missing example to `serve` docstring
- Update runner to log when pausing schedules for deployments
- Fixes misformatted example in `Runner.start()` docstring

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
