### PR TITLE
Always use quote for work pool and work queue names in cli commands

### DIFF
--- a/ui/src/pages/WorkPool.vue
+++ b/ui/src/pages/WorkPool.vue
@@ -67,7 +67,7 @@
     }
     return `Your work pool ${workPool.value.name} is ready to go!`
   })
-  const codeBannerCliCommand = computed(() => `prefect ${isAgentWorkPool.value ? 'agent' : 'worker'} start --pool ${workPool.value?.name}`)
+  const codeBannerCliCommand = computed(() => `prefect ${isAgentWorkPool.value ? 'agent' : 'worker'} start --pool "${workPool.value?.name}"`)
   const codeBannerSubtitle = computed(() => `Work pools organize work that ${isAgentWorkPool.value ? 'Prefect agents' : 'Prefect workers'} can pull from.`)
 
   const { filter: flowRunFilter } = useFlowRunsFilter({

--- a/ui/src/pages/WorkPoolQueue.vue
+++ b/ui/src/pages/WorkPoolQueue.vue
@@ -59,7 +59,7 @@
     }
     return `Your work pool ${workPoolQueue.value.name} is ready to go!`
   })
-  const codeBannerCliCommand = computed(() => `prefect ${isAgentWorkPool.value ? 'agent' : 'worker'} start --pool ${workPoolName.value} --work-queue ${workPoolQueueName.value}`)
+  const codeBannerCliCommand = computed(() => `prefect ${isAgentWorkPool.value ? 'agent' : 'worker'} start --pool "${workPoolName.value}" --work-queue "${workPoolQueueName.value}"`)
   const codeBannerSubtitle = computed(() => `Work queues are scoped to a work pool to allow ${isAgentWorkPool.value ? 'agents' : 'workers'} to pull from groups of queues with different priorities.`)
 
   const { filter: flowRunFilter } = useFlowRunsFilter({


### PR DESCRIPTION
# Description
Fixes an issue where names with spaces in them would cause the command to not be valid and not run.