### PR TITLE
Chore: Fix AKS docs JSON section

### DIFF
--- a/docs/guides/deployment/kubernetes.md
+++ b/docs/guides/deployment/kubernetes.md
@@ -254,7 +254,7 @@ Typically this setting is used when a worker is deployed to a cluster that is di
       ...,
       "resources": {
         "requests": {
-          "cpu": {{ cpu_request }}"
+          "cpu": "{{ cpu_request }}"
         }
       }
     }

--- a/docs/guides/deployment/kubernetes.md
+++ b/docs/guides/deployment/kubernetes.md
@@ -236,31 +236,31 @@ Typically this setting is used when a worker is deployed to a cluster that is di
 
   For example, to set a CPU request, add the following section under variables:
 
-    ```json
-      "cpu_request": {
-        "title": "CPU Request",
-        "description": "The CPU allocation to request for this pod.",
-        "default": "default",
-        "type": "string"
-      },
-    ```
+  ```json
+  "cpu_request": {
+    "title": "CPU Request",
+    "description": "The CPU allocation to request for this pod.",
+    "default": "default",
+    "type": "string"
+  },
+  ```
 
   Next add the following to the first `containers` item under `job_configuration`:
 
-    ```json
-            ...
-            "containers": [
-              {
-                ...,
-                "resources": {
-                  "requests": {
-                    "cpu": {{ cpu_request }}"
-                  }
-                }
-              }
-            ],
-            ...
-    ```
+  ```json
+  ...
+  "containers": [
+    {
+      ...,
+      "resources": {
+        "requests": {
+          "cpu": {{ cpu_request }}"
+        }
+      }
+    }
+  ],
+  ...
+  ```
 
   Running deployments with this work pool will now request the specified CPU.
 


### PR DESCRIPTION
Currently, the indentation shows the ` ```json ... ` part of formatting as text.
https://docs.prefect.io/latest/guides/deployment/kubernetes/

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
