### PR TITLE
Fix broken link to docker guide with redirect and harmonize naming

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -39,7 +39,7 @@ This section of the documentation contains guides for common workflows and use c
 | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | [Upgrade from Agents to Workers](/guides/upgrade-guide-agents-to-workers/) | Why and how to upgrade from Agents to Workers. |
 | [Storage](/guides/deployment/storage-guide/) | Store your code for deployed flows. |
-| [Docker](/guides/deployment/docker/) | Deploy flows with Docker containers. |
+| [Docker](/guides/docker/) | Deploy flows with Docker containers. |
 | [Kubernetes](/guides/deployment/kubernetes/) | Deploy flows on Kubernetes. |
 | [Push Work Pools](/guides/deployment/push-work-pools/) |  Run flows on serverless infrastructure without a worker. |
 | [ECS](https://prefecthq.github.io/prefect-aws/ecs_guide/) |  Run flows on AWS ECS. |

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -28,6 +28,7 @@ This section of the documentation contains guides for common workflows and use c
 
 | Title                                                  | Description                                                                                        |
 | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| [Docker](/guides/docker/) | Deploy flows with Docker containers. |
 | [Webhooks](/guides/webhooks/) | Receive, observe, and react to events from other systems. |
 | [State Change Hooks](/guides/state-change-hooks/) | Execute code in response to state changes. |
 | [Dask and Ray](/guides/dask-ray-task-runners/) | Scale your flows with parallel computing frameworks. |
@@ -39,7 +40,6 @@ This section of the documentation contains guides for common workflows and use c
 | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | [Upgrade from Agents to Workers](/guides/upgrade-guide-agents-to-workers/) | Why and how to upgrade from Agents to Workers. |
 | [Storage](/guides/deployment/storage-guide/) | Store your code for deployed flows. |
-| [Docker](/guides/docker/) | Deploy flows with Docker containers. |
 | [Kubernetes](/guides/deployment/kubernetes/) | Deploy flows on Kubernetes. |
 | [Push Work Pools](/guides/deployment/push-work-pools/) |  Run flows on serverless infrastructure without a worker. |
 | [ECS](https://prefecthq.github.io/prefect-aws/ecs_guide/) |  Run flows on AWS ECS. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,6 +154,7 @@ nav:
                 - Runtime Context: guides/runtime-context.md
                 - Variables: guides/variables.md
           - Execution:
+                - Docker: guides/docker.md
                 - Webhooks: guides/webhooks.md
                 - State Change Hooks: guides/state-change-hooks.md
                 - Dask & Ray: guides/dask-ray-task-runners.md
@@ -161,7 +162,6 @@ nav:
           - Workers and agents:
                 - Upgrade from Agents to Workers: guides/upgrade-guide-agents-to-workers.md
                 - Storage: guides/deployment/storage-guide.md
-                - Docker: guides/docker.md
                 - Kubernetes: guides/deployment/kubernetes.md
                 - Serverless Push Work Pools: guides/deployment/push-work-pools.md
                 - Run a flow on AWS ECS: https://prefecthq.github.io/prefect-aws/#using-prefect-with-aws-ecs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,21 +147,21 @@ nav:
     - Guides:
           - guides/index.md
           - Development:
-            - Hosting: guides/host.md
-            - Profiles & Settings: guides/settings.md
-            - Logging: guides/logs.md
-            - Testing: guides/testing.md
-            - Runtime Context: guides/runtime-context.md
-            - Variables: guides/variables.md
-            - Running flows with Docker: guides/docker.md
+                - Hosting: guides/host.md
+                - Profiles & Settings: guides/settings.md
+                - Logging: guides/logs.md
+                - Testing: guides/testing.md
+                - Runtime Context: guides/runtime-context.md
+                - Variables: guides/variables.md
           - Execution:
-            - Webhooks: guides/webhooks.md
-            - State Change Hooks: guides/state-change-hooks.md
-            - Dask & Ray: guides/dask-ray-task-runners.md
-            - Moving data: guides/moving-data.md
+                - Webhooks: guides/webhooks.md
+                - State Change Hooks: guides/state-change-hooks.md
+                - Dask & Ray: guides/dask-ray-task-runners.md
+                - Moving data: guides/moving-data.md
           - Workers and agents:
                 - Upgrade from Agents to Workers: guides/upgrade-guide-agents-to-workers.md
                 - Storage: guides/deployment/storage-guide.md
+                - Docker: guides/docker.md
                 - Kubernetes: guides/deployment/kubernetes.md
                 - Serverless Push Work Pools: guides/deployment/push-work-pools.md
                 - Run a flow on AWS ECS: https://prefecthq.github.io/prefect-aws/#using-prefect-with-aws-ecs

--- a/netlify.toml
+++ b/netlify.toml
@@ -431,7 +431,7 @@ to = "/guides/deployment/kubernetes/"
 status = 301
 
 [[redirects]]
-from = "/guides/deployments/docker/"
+from = "/guides/deployment/docker/"
 to = "/guides/docker/"
 status = 301
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -261,12 +261,10 @@ from = "/ui/rate-limits/"
 to = "/cloud/rate-limits/"
 status = 301
 
-
 [[redirects]]
 from = "/cloud/overview/"
 to = "/cloud/"
 status = 301
-
 
 [[redirects]]
 from = "/api-ref/prefect/blocks/storage/"
@@ -276,10 +274,13 @@ status = 301
 [[redirects]]
 from = "/api-ref/prefect/deployments/"
 to = "/api-ref/prefect/deployments/deployments/"
+status = 301
 
 [[redirects]]
 from = "/tutorial/deployments-ux/"
 to = "/tutorial/deployments/"
+status = 301
+
 [[redirects]]
 from = "/ui/blocks/"
 to = "/concepts/blocks/"
@@ -425,8 +426,13 @@ to = "/concepts/deployments/"
 status = 301
 
 [[redirects]]
-from = "/guides/deployment/helm-worker"
-to = "/guides/deployment/kubernetes"
+from = "/guides/deployment/helm-worker/"
+to = "/guides/deployment/kubernetes/"
+status = 301
+
+[[redirects]]
+from = "/guides/deployments/docker/"
+to = "/guides/docker/"
 status = 301
 
 [[headers]]


### PR DESCRIPTION
Closes #10617 

Docker guide links now work and match nav.

Preview:  https://deploy-preview-10624--prefect-docs-preview.netlify.app/guides/

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [x] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
