### PR TITLE
When dependabot makes a PR, treat it as an internal user

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -45,6 +45,12 @@ jobs:
       - name: Is internal team?
         id: isinternal
         run: |
+          # Treat dependabot as an internal user
+          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+            echo "status=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           echo "actor: ${{ github.actor }}"
           curl -iL \
             -H "Accept: application/vnd.github+json" \
@@ -218,7 +224,7 @@ jobs:
           # Do not allow the test suite to build images, as we want the prebuilt images to be tested
           # Do not run Kubernetes service tests, we do not have a cluster available
           pytest tests -vvv --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 --cov=src/ --cov=tests/ --no-cov-on-fail --cov-report=term --cov-config=setup.cfg ${{ matrix.pytest-options }}
-    
+
       - name: Create and Upload failure flag
         if: ${{ failure() }}
         id: create_failure_flag
@@ -259,7 +265,7 @@ jobs:
         id: check_failure
         run: |
           failure_count=$(ls -1q failure-flags/*/*.txt | wc -l)
-          
+
           if [ $failure_count -gt $FAILURE_THRESHOLD ]; then
             too_many_tests_failed="true"
           else


### PR DESCRIPTION
I noticed that a dependabot PR failed to run the test suite because our
"isinternal" check to see if the user is a PrefectHQ organization member was
including the `[bot]` suffix and causing an error from cURL.  This check is
used to decide whether the PR is run on our faster internal machines, which we
would want for dependabot, so we'll shortcut the API call and just treat them
as internal.

https://github.com/PrefectHQ/prefect/actions/runs/6078894220/job/16490683120?pr=10622
