### PR TITLE
Accounting for a change in how `fsspec==2023.9.0` handles globs

### DIFF
--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -296,6 +296,10 @@ class TestRemoteFileSystem:
         )
         copied_files = set(fs.filesystem.glob("/flat/**"))
 
+        # fsspec>=2023.9 includes the root directory when performing a ** glob, which
+        # isn't relevant to this test, we're just looking at files beneath the root
+        copied_files.discard("/flat")
+
         assert copied_files == {
             "/flat/explicit_relative.py",
             "/flat/implicit_relative.py",
@@ -311,6 +315,10 @@ class TestRemoteFileSystem:
             ),
         )
         copied_files = set(fs.filesystem.glob("/tree/**"))
+
+        # fsspec>=2023.9 includes the root directory when performing a ** glob, which
+        # isn't relevant to this test, we're just looking at files beneath the root
+        copied_files.discard("/tree")
 
         assert copied_files == {
             "/tree/imports",


### PR DESCRIPTION
In this new version of `fsspec`, there's been [some adjustments to how globs are
processed][1], which has the side-effect of returning the base directory when
doing a glob like `/some-dir/**` (this also includes `/some-dir`).

[1]: https://github.com/fsspec/filesystem_spec/commit/c3b4bc36a8c2fa1b98429f5cd963ea0b4d04ad11
