### PR TITLE
Add status to work pools and workers

### DIFF
--- a/src/prefect/cli/worker.py
+++ b/src/prefect/cli/worker.py
@@ -132,6 +132,7 @@ async def start(
         work_queues=work_queues,
         limit=limit,
         prefetch_seconds=prefetch_seconds,
+        heartbeat_interval_seconds=PREFECT_WORKER_HEARTBEAT_SECONDS.value(),
     ) as worker:
         app.console.print(f"Worker {worker.name!r} started!", style="green")
         async with anyio.create_task_group() as tg:
@@ -153,7 +154,7 @@ async def start(
                 partial(
                     critical_service_loop,
                     workload=worker.sync_with_backend,
-                    interval=PREFECT_WORKER_HEARTBEAT_SECONDS.value(),
+                    interval=worker.heartbeat_interval_seconds,
                     run_once=run_once,
                     printer=app.console.print,
                     jitter_range=0.3,

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2140,7 +2140,12 @@ class PrefectClient:
 
         return await resolve_inner(datadoc)
 
-    async def send_worker_heartbeat(self, work_pool_name: str, worker_name: str):
+    async def send_worker_heartbeat(
+        self,
+        work_pool_name: str,
+        worker_name: str,
+        heartbeat_interval_seconds: Optional[float] = None,
+    ):
         """
         Sends a worker heartbeat for a given work pool.
 
@@ -2150,7 +2155,10 @@ class PrefectClient:
         """
         await self._client.post(
             f"/work_pools/{work_pool_name}/workers/heartbeat",
-            json={"name": worker_name},
+            json={
+                "name": worker_name,
+                "heartbeat_interval_seconds": heartbeat_interval_seconds,
+            },
         )
 
     async def read_workers_for_work_pool(

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -67,16 +67,16 @@ class StateType(AutoEnum):
 class WorkPoolStatus(AutoEnum):
     """Enumeration of work pool statuses."""
 
-    READY = "READY"
-    NOT_READY = "NOT_READY"
-    PAUSED = "PAUSED"
+    READY = AutoEnum.auto()
+    NOT_READY = AutoEnum.auto()
+    PAUSED = AutoEnum.auto()
 
 
 class WorkerStatus(AutoEnum):
     """Enumeration of worker statuses."""
 
-    ONLINE = "ONLINE"
-    OFFLINE = "OFFLINE"
+    ONLINE = AutoEnum.auto()
+    OFFLINE = AutoEnum.auto()
 
 
 class StateDetails(PrefectBaseModel):

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -64,6 +64,21 @@ class StateType(AutoEnum):
     CANCELLING = AutoEnum.auto()
 
 
+class WorkPoolStatus(AutoEnum):
+    """Enumeration of work pool statuses."""
+
+    READY = "READY"
+    NOT_READY = "NOT_READY"
+    PAUSED = "PAUSED"
+
+
+class WorkerStatus(AutoEnum):
+    """Enumeration of worker statuses."""
+
+    ONLINE = "ONLINE"
+    OFFLINE = "OFFLINE"
+
+
 class StateDetails(PrefectBaseModel):
     flow_run_id: UUID = None
     task_run_id: UUID = None
@@ -1311,6 +1326,9 @@ class WorkPool(ObjectBaseModel):
     concurrency_limit: Optional[conint(ge=0)] = Field(
         default=None, description="A concurrency limit for the work pool."
     )
+    status: Optional[WorkPoolStatus] = Field(
+        default=None, description="The current status of the work pool."
+    )
 
     # this required field has a default of None so that the custom validator
     # below will be called and produce a more helpful error message
@@ -1357,6 +1375,16 @@ class Worker(ObjectBaseModel):
     )
     last_heartbeat_time: datetime.datetime = Field(
         None, description="The last time the worker process sent a heartbeat."
+    )
+    heartbeat_interval_seconds: Optional[int] = Field(
+        default=None,
+        description=(
+            "The number of seconds to expect between heartbeats sent by the worker."
+        ),
+    )
+    status: WorkerStatus = Field(
+        WorkerStatus.OFFLINE,
+        description="Current status of the worker.",
     )
 
 

--- a/src/prefect/server/api/workers.py
+++ b/src/prefect/server/api/workers.py
@@ -528,6 +528,9 @@ async def delete_work_queue(
 async def worker_heartbeat(
     work_pool_name: str = Path(..., description="The work pool name"),
     name: str = Body(..., description="The worker process name", embed=True),
+    heartbeat_interval_seconds: Optional[int] = Body(
+        None, description="The worker's heartbeat interval in seconds", embed=True
+    ),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: PrefectDBInterface = Depends(provide_database_interface),
 ):
@@ -540,6 +543,7 @@ async def worker_heartbeat(
             session=session,
             work_pool_id=work_pool_id,
             worker_name=name,
+            heartbeat_interval_seconds=heartbeat_interval_seconds,
             db=db,
         )
 

--- a/src/prefect/server/database/migrations/MIGRATION-NOTES.md
+++ b/src/prefect/server/database/migrations/MIGRATION-NOTES.md
@@ -8,6 +8,10 @@ Each time a database migration is written, an entry is included here with:
 
 This gives us a history of changes and will create merge conflicts if two migrations are made at once, flagging situations where a branch needs to be updated before merging.
 
+# Add heartbeat_interval_seconds to worker table
+SQLite: `c2d001b7dd06`
+Postgres: `50f8c182c3ca`
+
 # Create Concurrency Limit V2 table
 SQLite: `5b0bd3b41a23`
 Postgres: `5f623ddbf7fe`

--- a/src/prefect/server/database/migrations/versions/postgresql/2023_09_06_085747_50f8c182c3ca_.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2023_09_06_085747_50f8c182c3ca_.py
@@ -1,0 +1,25 @@
+"""Adds heartbeat_interval_seconds column to worker table
+
+Revision ID: 50f8c182c3ca
+Revises: 5f623ddbf7fe
+Create Date: 2023-09-06 08:57:47.166983
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "50f8c182c3ca"
+down_revision = "5f623ddbf7fe"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "worker", sa.Column("heartbeat_interval_seconds", sa.Integer(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("worker", "heartbeat_interval_seconds")

--- a/src/prefect/server/database/migrations/versions/sqlite/2023_09_06_084729_c2d001b7dd06_.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2023_09_06_084729_c2d001b7dd06_.py
@@ -1,0 +1,35 @@
+"""Adds heartbeat_interval_seconds column to worker table
+
+Revision ID: c2d001b7dd06
+Revises: 5b0bd3b41a23
+Create Date: 2023-09-06 08:47:29.381718
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c2d001b7dd06"
+down_revision = "5b0bd3b41a23"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("PRAGMA foreign_keys=OFF")
+
+    with op.batch_alter_table("worker", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("heartbeat_interval_seconds", sa.Integer(), nullable=True)
+        )
+
+    op.execute("PRAGMA foreign_keys=ON")
+
+
+def downgrade():
+    op.execute("PRAGMA foreign_keys=OFF")
+
+    with op.batch_alter_table("worker", schema=None) as batch_op:
+        batch_op.drop_column("heartbeat_interval_seconds")
+
+    op.execute("PRAGMA foreign_keys=ON")

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -1254,6 +1254,7 @@ class ORMWorker:
         default=lambda: pendulum.now("UTC"),
         index=True,
     )
+    heartbeat_interval_seconds = sa.Column(sa.Integer, nullable=True)
 
     @declared_attr
     def __table_args__(cls):

--- a/src/prefect/server/schemas/__init__.py
+++ b/src/prefect/server/schemas/__init__.py
@@ -1,4 +1,13 @@
-from . import core, actions, filters, responses, schedules, sorting, states  # noqa
+from . import (
+    core,
+    actions,
+    filters,
+    responses,
+    schedules,
+    sorting,
+    states,
+    statuses,
+)  # noqa
 
 __all__ = [
     "actions",
@@ -8,4 +17,5 @@ __all__ = [
     "schedules",
     "sorting",
     "states",
+    "statuses",
 ]

--- a/src/prefect/server/schemas/__init__.py
+++ b/src/prefect/server/schemas/__init__.py
@@ -1,12 +1,12 @@
 from . import (
-    core,
-    actions,
-    filters,
-    responses,
-    schedules,
-    sorting,
     states,
     statuses,
+    schedules,
+    core,
+    sorting,
+    filters,
+    responses,
+    actions,
 )  # noqa
 
 __all__ = [

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -1052,7 +1052,6 @@ class WorkPool(ORMBaseModel):
     concurrency_limit: Optional[conint(ge=0)] = Field(
         default=None, description="A concurrency limit for the work pool."
     )
-
     # this required field has a default of None so that the custom validator
     # below will be called and produce a more helpful error message
     default_queue_id: UUID = Field(
@@ -1094,6 +1093,12 @@ class Worker(ORMBaseModel):
     )
     last_heartbeat_time: datetime.datetime = Field(
         None, description="The last time the worker process sent a heartbeat."
+    )
+    heartbeat_interval_seconds: Optional[int] = Field(
+        default=None,
+        description=(
+            "The number of seconds to expect between heartbeats sent by the worker."
+        ),
     )
 
 

--- a/src/prefect/server/schemas/responses.py
+++ b/src/prefect/server/schemas/responses.py
@@ -282,3 +282,16 @@ class WorkQueueResponse(schemas.core.WorkQueue.subclass()):
             response.work_pool_name = orm_work_queue.work_pool.name
 
         return response
+
+
+class WorkPoolResponse(schemas.core.WorkPool.subclass()):
+    status: Optional[schemas.statuses.WorkPoolStatus] = Field(
+        default=None, description="The current status of the work pool."
+    )
+
+
+class WorkerResponse(schemas.core.Worker.subclass()):
+    status: schemas.statuses.WorkerStatus = Field(
+        schemas.statuses.WorkerStatus.OFFLINE,
+        description="Current status of the worker.",
+    )

--- a/src/prefect/server/schemas/responses.py
+++ b/src/prefect/server/schemas/responses.py
@@ -284,13 +284,13 @@ class WorkQueueResponse(schemas.core.WorkQueue.subclass()):
         return response
 
 
-class WorkPoolResponse(schemas.core.WorkPool.subclass()):
+class WorkPoolResponse(schemas.core.WorkPool):
     status: Optional[schemas.statuses.WorkPoolStatus] = Field(
         default=None, description="The current status of the work pool."
     )
 
 
-class WorkerResponse(schemas.core.Worker.subclass()):
+class WorkerResponse(schemas.core.Worker):
     status: schemas.statuses.WorkerStatus = Field(
         schemas.statuses.WorkerStatus.OFFLINE,
         description="Current status of the worker.",

--- a/src/prefect/server/schemas/statuses.py
+++ b/src/prefect/server/schemas/statuses.py
@@ -1,0 +1,16 @@
+from prefect.utilities.collections import AutoEnum
+
+
+class WorkPoolStatus(AutoEnum):
+    """Enumeration of work pool statuses."""
+
+    READY = "READY"
+    NOT_READY = "NOT_READY"
+    PAUSED = "PAUSED"
+
+
+class WorkerStatus(AutoEnum):
+    """Enumeration of worker statuses."""
+
+    ONLINE = "ONLINE"
+    OFFLINE = "OFFLINE"

--- a/src/prefect/server/schemas/statuses.py
+++ b/src/prefect/server/schemas/statuses.py
@@ -4,13 +4,13 @@ from prefect.utilities.collections import AutoEnum
 class WorkPoolStatus(AutoEnum):
     """Enumeration of work pool statuses."""
 
-    READY = "READY"
-    NOT_READY = "NOT_READY"
-    PAUSED = "PAUSED"
+    READY = AutoEnum.auto()
+    NOT_READY = AutoEnum.auto()
+    PAUSED = AutoEnum.auto()
 
 
 class WorkerStatus(AutoEnum):
     """Enumeration of worker statuses."""
 
-    ONLINE = "ONLINE"
-    OFFLINE = "OFFLINE"
+    ONLINE = AutoEnum.auto()
+    OFFLINE = AutoEnum.auto()

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -37,7 +37,11 @@ from prefect.exceptions import (
 )
 from prefect.logging.loggers import PrefectLogAdapter, flow_run_logger, get_logger
 from prefect.plugins import load_prefect_collections
-from prefect.settings import PREFECT_WORKER_PREFETCH_SECONDS, get_current_settings
+from prefect.settings import (
+    PREFECT_WORKER_HEARTBEAT_SECONDS,
+    PREFECT_WORKER_PREFETCH_SECONDS,
+    get_current_settings,
+)
 from prefect.states import Crashed, Pending, exception_to_failed_state
 from prefect.utilities.dispatch import get_registry_for_type, register_base_type
 from prefect.utilities.slugify import slugify
@@ -320,6 +324,7 @@ class BaseWorker(abc.ABC):
         prefetch_seconds: Optional[float] = None,
         create_pool_if_not_found: bool = True,
         limit: Optional[int] = None,
+        heartbeat_interval_seconds: Optional[int] = None,
     ):
         """
         Base class for all Prefect workers.
@@ -352,6 +357,9 @@ class BaseWorker(abc.ABC):
 
         self._prefetch_seconds: float = (
             prefetch_seconds or PREFECT_WORKER_PREFETCH_SECONDS.value()
+        )
+        self.heartbeat_interval_seconds = (
+            heartbeat_interval_seconds or PREFECT_WORKER_HEARTBEAT_SECONDS.value()
         )
 
         self._work_pool: Optional[WorkPool] = None
@@ -678,7 +686,9 @@ class BaseWorker(abc.ABC):
     async def _send_worker_heartbeat(self):
         if self._work_pool:
             await self._client.send_worker_heartbeat(
-                work_pool_name=self._work_pool_name, worker_name=self.name
+                work_pool_name=self._work_pool_name,
+                worker_name=self.name,
+                heartbeat_interval_seconds=self.heartbeat_interval_seconds,
             )
 
     async def sync_with_backend(self):

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -161,6 +161,7 @@ def test_start_worker_with_work_queue_names(monkeypatch, process_work_pool):
         work_queues=["a", "b"],
         prefetch_seconds=ANY,
         limit=None,
+        heartbeat_interval_seconds=30,
     )
 
 
@@ -188,6 +189,7 @@ def test_start_worker_with_prefetch_seconds(monkeypatch):
         work_queues=[],
         prefetch_seconds=30,
         limit=None,
+        heartbeat_interval_seconds=30,
     )
 
 
@@ -214,6 +216,7 @@ def test_start_worker_with_prefetch_seconds_from_setting_by_default(monkeypatch)
         work_queues=[],
         prefetch_seconds=100,
         limit=None,
+        heartbeat_interval_seconds=30,
     )
 
 
@@ -241,6 +244,7 @@ def test_start_worker_with_limit(monkeypatch):
         work_queues=[],
         prefetch_seconds=10,
         limit=5,
+        heartbeat_interval_seconds=30,
     )
 
 
@@ -361,7 +365,7 @@ async def test_start_worker_without_type_creates_process_work_pool(
 
 
 @pytest.mark.usefixtures("use_hosted_api_server")
-async def test_worker_reports_heartbeat_interval(session, kubernetes_work_pool):
+async def test_worker_reports_heartbeat_interval(session, process_work_pool):
     await run_sync_in_worker_thread(
         invoke_and_assert,
         command=[
@@ -369,7 +373,7 @@ async def test_worker_reports_heartbeat_interval(session, kubernetes_work_pool):
             "start",
             "--run-once",
             "-p",
-            kubernetes_work_pool.name,
+            process_work_pool.name,
             "-n",
             "test-worker",
         ],
@@ -381,7 +385,7 @@ async def test_worker_reports_heartbeat_interval(session, kubernetes_work_pool):
     )
 
     workers = await models.workers.read_workers(
-        session=session, work_pool_id=kubernetes_work_pool.id
+        session=session, work_pool_id=process_work_pool.id
     )
     assert len(workers) == 1
     assert workers[0].name == "test-worker"

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -14,7 +14,6 @@ from typer import Exit
 import prefect
 from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.actions import WorkPoolCreate
-from prefect.server import models
 from prefect.settings import (
     PREFECT_API_URL,
     PREFECT_WORKER_PREFETCH_SECONDS,
@@ -365,7 +364,9 @@ async def test_start_worker_without_type_creates_process_work_pool(
 
 
 @pytest.mark.usefixtures("use_hosted_api_server")
-async def test_worker_reports_heartbeat_interval(session, process_work_pool):
+async def test_worker_reports_heartbeat_interval(
+    prefect_client: PrefectClient, process_work_pool
+):
     await run_sync_in_worker_thread(
         invoke_and_assert,
         command=[
@@ -384,8 +385,8 @@ async def test_worker_reports_heartbeat_interval(session, process_work_pool):
         ],
     )
 
-    workers = await models.workers.read_workers(
-        session=session, work_pool_id=process_work_pool.id
+    workers = await prefect_client.read_workers_for_work_pool(
+        work_pool_name=process_work_pool.name
     )
     assert len(workers) == 1
     assert workers[0].name == "test-worker"

--- a/tests/server/api/test_workers.py
+++ b/tests/server/api/test_workers.py
@@ -463,6 +463,7 @@ class TestReadWorkPool:
         result = pydantic.parse_obj_as(WorkPool, response.json())
         assert result.name == work_pool.name
         assert result.id == work_pool.id
+        assert result.status == schemas.statuses.WorkPoolStatus.NOT_READY.value
 
     async def test_read_invalid_config(self, client):
         response = await client.get("/work_pools/does-not-exist")
@@ -636,6 +637,76 @@ class TestUpdateWorkQueue:
         assert result.is_paused
 
 
+class TestWorkPoolStatus:
+    async def test_work_pool_status_with_online_worker(self, client, work_pool):
+        """Work pools with an online work should have a status of READY."""
+        await client.post(
+            f"/work_pools/{work_pool.name}/workers/heartbeat",
+            json=dict(name="test-worker"),
+        )
+
+        response = await client.get(f"/work_pools/{work_pool.name}")
+        assert response.status_code == status.HTTP_200_OK
+
+        result = pydantic.parse_obj_as(WorkPool, response.json())
+        assert result.status == schemas.statuses.WorkPoolStatus.READY
+
+    async def test_work_pool_status_with_offline_worker(
+        self, client, work_pool, session, db
+    ):
+        """Work pools with an offline worker should have a status of NOT_READY."""
+        now = pendulum.now("UTC")
+
+        insert_stmt = (await db.insert(db.Worker)).values(
+            name="old-worker",
+            work_pool_id=work_pool.id,
+            last_heartbeat_time=now.subtract(minutes=5),
+        )
+
+        await session.execute(insert_stmt)
+        await session.commit()
+
+        response = await client.get(f"/work_pools/{work_pool.name}")
+        result = pydantic.parse_obj_as(WorkPool, response.json())
+
+        assert result.status == schemas.statuses.WorkPoolStatus.NOT_READY
+
+    async def test_work_pool_status_with_no_workers(self, client, work_pool):
+        """Work pools with no workers should have a status of NOT_READY."""
+        response = await client.get(f"/work_pools/{work_pool.name}")
+        result = pydantic.parse_obj_as(WorkPool, response.json())
+
+        assert result.status == schemas.statuses.WorkPoolStatus.NOT_READY
+
+    async def test_work_pool_status_for_paused_work_pool(self, client, work_pool):
+        """Work pools that are paused should have a status of PAUSED."""
+        # Pause work pool
+        await client.patch(f"/work_pools/{work_pool.name}", json=dict(is_paused=True))
+
+        # Heartbeat worker
+        await client.post(
+            f"/work_pools/{work_pool.name}/workers/heartbeat",
+            json=dict(name="test-worker"),
+        )
+
+        response = await client.get(f"/work_pools/{work_pool.name}")
+        assert response.status_code == status.HTTP_200_OK
+
+        result = pydantic.parse_obj_as(WorkPool, response.json())
+        assert result.is_paused
+        assert result.status == schemas.statuses.WorkPoolStatus.PAUSED
+
+    async def test_work_pool_status_for_prefect_agent_work_pool(
+        self, client, prefect_agent_work_pool
+    ):
+        """Work pools that are Prefect Agent work pools should have `null` for status."""
+        response = await client.get(f"/work_pools/{prefect_agent_work_pool.name}")
+        assert response.status_code == status.HTTP_200_OK
+
+        result = pydantic.parse_obj_as(WorkPool, response.json())
+        assert result.status is None
+
+
 class TestWorkerProcess:
     async def test_heartbeat_worker(self, client, work_pool):
         workers_response = await client.post(
@@ -658,6 +729,7 @@ class TestWorkerProcess:
         assert len(workers_response.json()) == 1
         assert workers_response.json()[0]["name"] == "test-worker"
         assert pendulum.parse(workers_response.json()[0]["last_heartbeat_time"]) > dt
+        assert workers_response.json()[0]["status"] == "ONLINE"
 
     async def test_heartbeat_worker_requires_name(self, client, work_pool):
         response = await client.post(f"/work_pools/{work_pool.name}/workers/heartbeat")
@@ -692,19 +764,65 @@ class TestWorkerProcess:
         assert len(workers_response.json()) == 1
         assert workers_response.json()[0]["name"] == "another-worker"
 
-    async def test_heartbeat_accepts_heartbeat_interval(
-        self, client, work_pool, session
-    ):
+    async def test_heartbeat_accepts_heartbeat_interval(self, client, work_pool):
         await client.post(
             f"/work_pools/{work_pool.name}/workers/heartbeat",
             json=dict(name="test-worker", heartbeat_interval_seconds=60),
         )
 
-        workers = await models.workers.read_workers(
-            session=session, work_pool_id=work_pool.id
+        workers_response = await client.post(
+            f"/work_pools/{work_pool.name}/workers/filter",
         )
-        assert len(workers) == 1
-        assert workers[0].heartbeat_interval_seconds == 60
+        assert len(workers_response.json()) == 1
+        assert workers_response.json()[0]["heartbeat_interval_seconds"] == 60
+
+    async def test_worker_with_old_heartbeat_has_offline_status(
+        self, client, work_pool, session, db
+    ):
+        now = pendulum.now("UTC")
+
+        insert_stmt = (await db.insert(db.Worker)).values(
+            name="old-worker",
+            work_pool_id=work_pool.id,
+            last_heartbeat_time=now.subtract(minutes=5),
+        )
+
+        await session.execute(insert_stmt)
+        await session.commit()
+
+        workers_response = await client.post(
+            f"/work_pools/{work_pool.name}/workers/filter",
+        )
+        assert len(workers_response.json()) == 1
+        assert workers_response.json()[0]["status"] == "OFFLINE"
+
+    async def test_worker_status_accounts_for_heartbeat_interval(
+        self, client, work_pool, session, db
+    ):
+        """
+        Worker status should use the heartbeat interval to determine if a worker is
+        offline.
+
+        This test sets an abnormally small heartbeat interval and then checks that the
+        worker is still considered offline than it would by default.
+        """
+        now = pendulum.now("UTC")
+
+        insert_stmt = (await db.insert(db.Worker)).values(
+            name="old-worker",
+            work_pool_id=work_pool.id,
+            last_heartbeat_time=now.subtract(seconds=10),
+            heartbeat_interval_seconds=1,
+        )
+
+        await session.execute(insert_stmt)
+        await session.commit()
+
+        workers_response = await client.post(
+            f"/work_pools/{work_pool.name}/workers/filter",
+        )
+        assert len(workers_response.json()) == 1
+        assert workers_response.json()[0]["status"] == "OFFLINE"
 
 
 class TestGetScheduledRuns:

--- a/tests/server/api/test_workers.py
+++ b/tests/server/api/test_workers.py
@@ -692,6 +692,20 @@ class TestWorkerProcess:
         assert len(workers_response.json()) == 1
         assert workers_response.json()[0]["name"] == "another-worker"
 
+    async def test_heartbeat_accepts_heartbeat_interval(
+        self, client, work_pool, session
+    ):
+        await client.post(
+            f"/work_pools/{work_pool.name}/workers/heartbeat",
+            json=dict(name="test-worker", heartbeat_interval_seconds=60),
+        )
+
+        workers = await models.workers.read_workers(
+            session=session, work_pool_id=work_pool.id
+        )
+        assert len(workers) == 1
+        assert workers[0].heartbeat_interval_seconds == 60
+
 
 class TestGetScheduledRuns:
     @pytest.fixture(autouse=True)

--- a/tests/server/api/test_workers.py
+++ b/tests/server/api/test_workers.py
@@ -654,7 +654,7 @@ class TestWorkPoolStatus:
     async def test_work_pool_status_with_offline_worker(
         self, client, work_pool, session, db
     ):
-        """Work pools with an offline worker should have a status of NOT_READY."""
+        """Work pools with only offline workers should have a status of NOT_READY."""
         now = pendulum.now("UTC")
 
         insert_stmt = (await db.insert(db.Worker)).values(

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -9,7 +9,7 @@ import pytest
 from pydantic import Field
 
 import prefect
-import prefect.server.schemas as schemas
+import prefect.client.schemas as schemas
 from prefect.blocks.core import Block
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas import FlowRun
@@ -477,7 +477,7 @@ async def test_base_worker_gets_job_configuration_when_syncing_with_backend_with
     response = await client.post(
         "/work_pools/", json=dict(name=pool_name, type="test-type")
     )
-    result = pydantic.parse_obj_as(schemas.core.WorkPool, response.json())
+    result = pydantic.parse_obj_as(schemas.objects.WorkPool, response.json())
     model = await models.workers.read_work_pool(session=session, work_pool_id=result.id)
     assert model.name == pool_name
 
@@ -516,7 +516,7 @@ async def test_base_worker_gets_job_configuration_when_syncing_with_backend_with
     response = await client.post(
         "/work_pools/", json=dict(name=pool_name, type="test-type")
     )
-    result = pydantic.parse_obj_as(schemas.core.WorkPool, response.json())
+    result = pydantic.parse_obj_as(schemas.objects.WorkPool, response.json())
     model = await models.workers.read_work_pool(session=session, work_pool_id=result.id)
     assert model.name == pool_name
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
This PR adds status to both work pools and workers. Work pool and worker status will be displayed in the UI to help users debug when work isn't being executed as expected.

Workers have two statuses: `ONLINE` and `OFFLINE`. A worker is online if it sends regular heartbeat messages to the Prefect API. If a worker has missed three heartbeats, it will be considered offline. In the default case, a worker would be considered offline a maximum of 90 seconds after it stopped sending heartbeats.

Work pools have three statuses: `READY`, `NOT_READY`, and `PAUSED`. A work pool is considered ready if it has at least one online worker sending heartbeats to the work pool. If a work pool has no online workers, it is considered not ready to execute work. If a work pool is paused, it will have a paused status. After resuming the work pool, it will reassigned the appropriate status.

`prefect-agent` typed work pools have no status because workers do no join `prefect-agent` typed work pools.

### Examples
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
The following are examples of where work pool and worker status will be displayed in the UI

#### Work pool details

<img width="259" alt="Screenshot 2023-09-05 at 9 24 04 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/12350579/b2182899-2af3-4fbd-814e-748e0aab5fc8">

#### Work pool cards

<img width="1166" alt="Screenshot 2023-09-05 at 9 24 24 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/12350579/fdc2d7c5-0bf2-41de-9124-34c18d237683">

#### Dashboard work pool cards

<img width="559" alt="Screenshot 2023-09-05 at 9 24 46 PM" src="https://github.com/PrefectHQ/prefect-ui-library/assets/12350579/7fae81e0-1b1a-460b-9fc5-92d969326d22">

#### Workers Table

![Screenshot 2023-09-05 at 3 13 19 PM](https://github.com/PrefectHQ/prefect-ui-library/assets/12350579/c8a03c06-2b48-47c5-be93-1dbde0e5bf0d)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
