### PR TITLE
Remove deprecated `prefect orion` CLI

### DIFF
--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -38,26 +38,6 @@ database_app = PrefectTyper(
 server_app.add_typer(database_app)
 app.add_typer(server_app)
 
-# Deprecated compatiblity
-orion_app = PrefectTyper(
-    name="orion",
-    help="Deprecated. Use 'prefect server' instead.",
-    deprecated=True,
-    deprecated_name="prefect orion",
-    deprecated_start_date="Feb 2023",
-    deprecated_help="Use 'prefect server' instead.",
-)
-orion_database_app = PrefectTyper(
-    name="database",
-    help="Deprecated. Use 'prefect server database' instead.",
-    deprecated=True,
-    deprecated_name="prefect orion database",
-    deprecated_start_date="Feb 2023",
-    deprecated_help="Use 'prefect server database' instead.",
-)
-orion_app.add_typer(orion_database_app)
-app.add_typer(orion_app, hidden=True)
-
 logger = get_logger(__name__)
 
 
@@ -106,7 +86,6 @@ def generate_welcome_blurb(base_url, ui_enabled: bool):
     return blurb
 
 
-@orion_app.command()
 @server_app.command()
 async def start(
     host: str = SettingsOption(PREFECT_SERVER_API_HOST),
@@ -173,7 +152,6 @@ async def start(
     app.console.print("Server stopped!")
 
 
-@orion_database_app.command()
 @database_app.command()
 async def reset(yes: bool = typer.Option(False, "--yes", "-y")):
     """Drop and recreate all Prefect database tables"""
@@ -195,7 +173,6 @@ async def reset(yes: bool = typer.Option(False, "--yes", "-y")):
     exit_with_success(f'Prefect database "{engine.url!r}" reset!')
 
 
-@orion_database_app.command()
 @database_app.command()
 async def upgrade(
     yes: bool = typer.Option(False, "--yes", "-y"),
@@ -235,7 +212,6 @@ async def upgrade(
     exit_with_success(f"Prefect database at {engine.url!r} upgraded!")
 
 
-@orion_database_app.command()
 @database_app.command()
 async def downgrade(
     yes: bool = typer.Option(False, "--yes", "-y"),
@@ -279,7 +255,6 @@ async def downgrade(
     exit_with_success(f"Prefect database at {engine.url!r} downgraded!")
 
 
-@orion_database_app.command()
 @database_app.command()
 async def revision(
     message: str = typer.Option(
@@ -302,7 +277,6 @@ async def revision(
     exit_with_success("Creating new migration file succeeded!")
 
 
-@orion_database_app.command()
 @database_app.command()
 async def stamp(revision: str):
     """Stamp the revision table with the given revision; don't run any migrations"""

--- a/tests/cli/test_server.py
+++ b/tests/cli/test_server.py
@@ -21,7 +21,7 @@ def mock_run_process(monkeypatch: pytest.MonkeyPatch):
     yield mock
 
 
-@pytest.mark.parametrize("command_group", ["orion", "server"])
+@pytest.mark.parametrize("command_group", ["server"])
 def test_start_no_options(mock_run_process: AsyncMock, command_group: str):
     invoke_and_assert(
         [command_group, "start"],


### PR DESCRIPTION
**Note: The base branch for this PR is not main, it is remove-deprecated-orion-refs.**

Removes deprecated `prefect orion` command group in favor of `prefect server`.

```bash
❯ prefect orion start
Usage: prefect [OPTIONS] COMMAND [ARGS]...
Try 'prefect --help' for help.
╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ No such command 'orion'.                                                                                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
