### PR TITLE
Remove deprecated `OrionRouter` and `OrionAPIRoute`

### DIFF
--- a/src/prefect/server/utilities/server.py
+++ b/src/prefect/server/utilities/server.py
@@ -9,8 +9,6 @@ from typing import Any, Callable, Coroutine, Iterable, Set, get_type_hints
 from fastapi import APIRouter, Request, Response, status
 from fastapi.routing import APIRoute
 
-from prefect._internal.compatibility.deprecated import deprecated_callable
-
 
 def method_paths_from_routes(routes: Iterable[APIRoute]) -> Set[str]:
     """
@@ -136,17 +134,3 @@ class PrefectRouter(APIRouter):
         if kwargs.get("response_model") is None:
             kwargs["response_model"] = get_type_hints(endpoint).get("return")
         return super().add_api_route(path, endpoint, **kwargs)
-
-
-@deprecated_callable(start_date="Feb 2023", help="Use `PrefectRouter` instead.")
-class OrionRouter(PrefectRouter):
-    """
-    Deprecated. Use `PrefectRouter` instead.
-    """
-
-
-@deprecated_callable(start_date="Feb 2023", help="Use `PrefectAPIRoute` instead.")
-class OrionAPIRoute(PrefectAPIRoute):
-    """
-    Deprecated. Use `PrefectAPIRoute` instead.
-    """


### PR DESCRIPTION
**Note: The base branch for this PR is not `main`, it is `remove-deprecated-orion-refs`.**

Part of #10642
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
