### PR TITLE
Remove deprecated `create_orion_api`

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -30,7 +30,6 @@ import prefect
 import prefect.server.api as api
 import prefect.server.services as services
 import prefect.settings
-from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect._internal.compatibility.experimental import enabled_experiments
 from prefect.logging import get_logger
 from prefect.server.api.dependencies import EnforceMinimumAPIVersion
@@ -210,11 +209,6 @@ async def prefect_object_not_found_exception_handler(
     return JSONResponse(
         content={"exception_message": str(exc)}, status_code=status.HTTP_404_NOT_FOUND
     )
-
-
-@deprecated_callable(start_date="May 2023", help="Use `create_api_app` instead.")
-def create_orion_api(*args, **kwargs) -> FastAPI:
-    return create_orion_api(*args, **kwargs)
 
 
 def create_api_app(

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -49,7 +49,6 @@ API_TITLE = "Prefect Prefect REST API"
 UI_TITLE = "Prefect Prefect REST API UI"
 API_VERSION = prefect.__version__
 SERVER_API_VERSION = "0.8.4"
-ORION_API_VERSION = SERVER_API_VERSION  # Deprecated. Available for compatibility.
 
 logger = get_logger("server")
 


### PR DESCRIPTION
**Note: The base branch for this PR is not `main`, it is `remove-deprecated-orion-refs`.**

Part of #10642

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
