### PR TITLE
Don't create unpersisted blocks remotely

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -1312,6 +1312,9 @@ class PrefectClient:
         Returns:
             A block document or None.
         """
+        assert (
+            block_document_id is not None
+        ), "Unexpected ID on block document. Was it persisted?"
         try:
             response = await self._client.get(
                 f"/block_documents/{block_document_id}",

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -118,7 +118,7 @@ class ResultFactory(pydantic.BaseModel):
     persist_result: bool
     cache_result_in_memory: bool
     serializer: Serializer
-    storage_block_id: uuid.UUID
+    storage_block_id: Optional[uuid.UUID]
     storage_block: WritableFileSystem
     storage_key_fn: Callable[[], str]
 
@@ -258,7 +258,7 @@ class ResultFactory(pydantic.BaseModel):
         client: "PrefectClient",
     ) -> Self:
         storage_block_id, storage_block = await cls.resolve_storage_block(
-            result_storage, client=client
+            result_storage, client=client, persist_result=persist_result
         )
         serializer = cls.resolve_serializer(result_serializer)
 
@@ -273,23 +273,31 @@ class ResultFactory(pydantic.BaseModel):
 
     @staticmethod
     async def resolve_storage_block(
-        result_storage: ResultStorage, client: "PrefectClient"
-    ) -> Tuple[uuid.UUID, WritableFileSystem]:
+        result_storage: ResultStorage,
+        client: "PrefectClient",
+        persist_result: bool = True,
+    ) -> Tuple[Optional[uuid.UUID], WritableFileSystem]:
         """
         Resolve one of the valid `ResultStorage` input types into a saved block
         document id and an instance of the block.
         """
         if isinstance(result_storage, Block):
             storage_block = result_storage
-            storage_block_id = (
+
+            if storage_block._block_document_id is not None:
                 # Avoid saving the block if it already has an identifier assigned
-                storage_block._block_document_id
-                # TODO: Overwrite is true to avoid issues where the save collides with
-                #       a previously saved document with a matching hash
-                or await storage_block._save(
-                    is_anonymous=True, overwrite=True, client=client
-                )
-            )
+                storage_block_id = storage_block._block_document_id
+            else:
+                if persist_result:
+                    # TODO: Overwrite is true to avoid issues where the save collides with
+                    # a previously saved document with a matching hash
+                    storage_block_id = await storage_block._save(
+                        is_anonymous=True, overwrite=True, client=client
+                    )
+                else:
+                    # a None-type UUID on unpersisted storage should not matter
+                    # since the ID is generated on the server
+                    storage_block_id = None
         elif isinstance(result_storage, str):
             storage_block = await Block.load(result_storage, client=client)
             storage_block_id = storage_block._block_document_id
@@ -486,6 +494,9 @@ class PersistedResult(BaseResult):
 
     @inject_client
     async def _read_blob(self, client: "PrefectClient") -> "PersistedResultBlob":
+        assert (
+            self.storage_block_id is not None
+        ), "Unexpected storage block ID. Was it persisted?"
         block_document = await client.read_block_document(self.storage_block_id)
         storage_block: ReadableFileSystem = Block._from_block_document(block_document)
         content = await storage_block.read_path(self.storage_key)
@@ -521,6 +532,10 @@ class PersistedResult(BaseResult):
         The object will be serialized and written to the storage block under a unique
         key. It will then be cached on the returned result.
         """
+        assert (
+            storage_block_id is not None
+        ), "Unexpected storage block ID. Was it persisted?"
+
         data = serializer.dumps(obj)
         blob = PersistedResultBlob(serializer=serializer, data=data)
 

--- a/tests/results/test_result_factory.py
+++ b/tests/results/test_result_factory.py
@@ -2,6 +2,8 @@ import uuid
 
 import pytest
 
+import prefect.exceptions
+import prefect.results
 from prefect import flow, task
 from prefect.context import get_run_context
 from prefect.filesystems import LocalFileSystem
@@ -59,7 +61,7 @@ def test_root_flow_default_result_factory():
     assert result_factory.cache_result_in_memory is True
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(result_factory.storage_block_id, uuid.UUID)
+    assert result_factory.storage_block_id is None
 
 
 def test_root_flow_default_result_serializer_can_be_overriden_by_setting():
@@ -103,7 +105,11 @@ def test_root_flow_custom_persist_setting(toggle):
     assert result_factory.persist_result is toggle
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(result_factory.storage_block_id, uuid.UUID)
+
+    if toggle:
+        assert isinstance(result_factory.storage_block_id, uuid.UUID)
+    else:
+        assert result_factory.storage_block_id is None
 
 
 @pytest.mark.parametrize("options", [{"cache_result_in_memory": False}])
@@ -132,7 +138,7 @@ def test_root_flow_can_opt_out_of_persistence_when_flow_uses_feature(options):
     assert result_factory.persist_result is False
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(result_factory.storage_block_id, uuid.UUID)
+    assert result_factory.storage_block_id is None
 
 
 @pytest.mark.parametrize("toggle", [True, False])
@@ -149,7 +155,11 @@ def test_root_flow_custom_cache_setting(toggle):
     assert result_factory.cache_result_in_memory is toggle
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(result_factory.storage_block_id, uuid.UUID)
+
+    if toggle:
+        assert result_factory.storage_block_id is None
+    else:
+        assert isinstance(result_factory.storage_block_id, uuid.UUID)
 
 
 def test_root_flow_custom_serializer_by_type_string():
@@ -161,7 +171,7 @@ def test_root_flow_custom_serializer_by_type_string():
     assert result_factory.persist_result is False
     assert result_factory.serializer == JSONSerializer()
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(result_factory.storage_block_id, uuid.UUID)
+    assert result_factory.storage_block_id is None
 
 
 def test_root_flow_custom_serializer_by_instance():
@@ -173,7 +183,7 @@ def test_root_flow_custom_serializer_by_instance():
     assert result_factory.persist_result is False
     assert result_factory.serializer == JSONSerializer(jsonlib="orjson")
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(result_factory.storage_block_id, uuid.UUID)
+    assert result_factory.storage_block_id is None
 
 
 def test_root_flow_custom_storage_by_slug(tmp_path):
@@ -210,12 +220,14 @@ def test_root_flow_custom_storage_by_instance_presaved(tmp_path):
 async def test_root_flow_custom_storage_by_instance_unsaved(prefect_client, tmp_path):
     storage = LocalFileSystem(basepath=tmp_path)
 
-    @flow(result_storage=storage)
+    @flow(
+        result_storage=storage, cache_result_in_memory=False
+    )  # use a feature that requires persistence
     def foo():
         return get_run_context().result_factory
 
     result_factory = foo()
-    assert result_factory.persist_result is False
+    assert result_factory.persist_result is True
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert result_factory.storage_block == storage
     assert result_factory.storage_block._is_anonymous is True
@@ -241,7 +253,7 @@ def test_child_flow_inherits_default_result_settings():
     assert child_factory.persist_result is False
     assert child_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(child_factory.storage_block_id, uuid.UUID)
+    assert child_factory.storage_block_id is None
 
 
 def test_child_flow_default_result_serializer_can_be_overriden_by_setting():
@@ -326,7 +338,11 @@ def test_child_flow_custom_cache_setting(toggle):
     assert child_factory.cache_result_in_memory is toggle
     assert child_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(child_factory.storage_block_id, uuid.UUID)
+
+    if toggle:
+        assert child_factory.storage_block_id is None
+    else:
+        assert isinstance(child_factory.storage_block_id, uuid.UUID)
 
 
 @pytest.mark.parametrize("options", [{"retries": 3}])
@@ -361,7 +377,7 @@ def test_child_flow_can_opt_out_of_result_persistence_when_parent_uses_feature()
     assert child_factory.persist_result is False
     assert child_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(child_factory.storage_block_id, uuid.UUID)
+    assert child_factory.storage_block_id is None
 
 
 @pytest.mark.parametrize("options", [{"cache_result_in_memory": False}])
@@ -401,7 +417,7 @@ def test_child_flow_can_opt_out_of_result_persistence_when_child_uses_feature():
     assert child_factory.cache_result_in_memory is False
     assert child_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(child_factory.storage_block_id, uuid.UUID)
+    assert child_factory.storage_block_id is None
 
 
 def test_child_flow_inherits_custom_serializer():
@@ -417,7 +433,7 @@ def test_child_flow_inherits_custom_serializer():
     assert child_factory.persist_result is False
     assert child_factory.serializer == parent_factory.serializer
     assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(child_factory.storage_block_id, uuid.UUID)
+    assert child_factory.storage_block_id is None
 
 
 def test_child_flow_inherits_custom_storage(tmp_path):
@@ -453,7 +469,7 @@ def test_child_flow_custom_serializer():
     assert child_factory.persist_result is False
     assert child_factory.serializer == JSONSerializer()
     assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(child_factory.storage_block_id, uuid.UUID)
+    assert child_factory.storage_block_id is None
 
 
 def test_child_flow_custom_storage(tmp_path):
@@ -479,12 +495,14 @@ def test_child_flow_custom_storage(tmp_path):
 async def test_child_flow_custom_storage_by_instance_unsaved(prefect_client, tmp_path):
     storage = LocalFileSystem(basepath=tmp_path)
 
-    @flow()
+    @flow(cache_result_in_memory=False)  # use a feature that requires persistence
     def foo():
+        print(f"In parent, persist={get_run_context().result_factory.persist_result}")
         return get_run_context().result_factory, bar()
 
-    @flow(result_storage=storage)
+    @flow(result_storage=storage, cache_result_in_memory=False)
     def bar():
+        print(f"In child, persist={get_run_context().result_factory.persist_result}")
         return get_run_context().result_factory
 
     parent_factory, child_factory = foo()
@@ -505,7 +523,7 @@ async def test_child_flow_custom_storage_by_instance_unsaved(prefect_client, tmp
     assert LocalFileSystem._from_block_document(storage_block_document) == storage
 
     # Other settings should not be changed
-    assert child_factory.persist_result is False
+    assert child_factory.persist_result is True
     assert child_factory.serializer == DEFAULT_SERIALIZER()
 
 
@@ -522,7 +540,7 @@ def test_task_inherits_default_result_settings():
     assert task_factory.persist_result is False
     assert task_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(task_factory.storage_block_id, uuid.UUID)
+    assert task_factory.storage_block_id is None
 
 
 def test_task_default_result_serializer_can_be_overriden_by_setting():
@@ -592,7 +610,11 @@ def test_task_custom_cache_setting(toggle):
     assert task_factory.cache_result_in_memory is toggle
     assert task_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(task_factory.storage_block_id, uuid.UUID)
+
+    if toggle:
+        assert task_factory.storage_block_id is None
+    else:
+        assert isinstance(task_factory.storage_block_id, uuid.UUID)
 
 
 @pytest.mark.parametrize("options", [{"retries": 3}])
@@ -647,7 +669,7 @@ def test_task_can_opt_out_of_result_persistence_when_flow_uses_feature():
     assert task_factory.persist_result is False
     assert task_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(task_factory.storage_block_id, uuid.UUID)
+    assert task_factory.storage_block_id is None
 
 
 def test_task_can_opt_out_when_persist_result_default_is_overriden_by_setting():
@@ -678,7 +700,7 @@ def test_task_inherits_custom_serializer():
     assert task_factory.persist_result is False
     assert task_factory.serializer == flow_factory.serializer
     assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(task_factory.storage_block_id, uuid.UUID)
+    assert task_factory.storage_block_id is None
 
 
 def test_task_inherits_custom_storage(tmp_path):
@@ -714,7 +736,7 @@ def test_task_custom_serializer():
     assert task_factory.persist_result is False
     assert task_factory.serializer == JSONSerializer()
     assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(task_factory.storage_block_id, uuid.UUID)
+    assert task_factory.storage_block_id is None
 
 
 def test_task_custom_storage(tmp_path):
@@ -740,11 +762,11 @@ def test_task_custom_storage(tmp_path):
 async def test_task_custom_storage_by_instance_unsaved(prefect_client, tmp_path):
     storage = LocalFileSystem(basepath=tmp_path)
 
-    @flow()
+    @flow(cache_result_in_memory=False)
     def foo():
         return get_run_context().result_factory, bar()
 
-    @flow(result_storage=storage)
+    @flow(result_storage=storage, cache_result_in_memory=False)
     def bar():
         return get_run_context().result_factory
 
@@ -766,5 +788,107 @@ async def test_task_custom_storage_by_instance_unsaved(prefect_client, tmp_path)
     assert LocalFileSystem._from_block_document(storage_block_document) == storage
 
     # Other settings should not be changed
-    assert task_factory.persist_result is False
+    assert task_factory.persist_result is True
     assert task_factory.serializer == DEFAULT_SERIALIZER()
+
+
+async def _verify_default_storage_creation_with_persistence(
+    prefect_client,
+    result_factory: prefect.results.ResultFactory,
+):
+    # check that the default block was created
+    assert result_factory.storage_block is not None
+    assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
+
+    # verify storage settings are correctly set
+    assert result_factory.persist_result is True
+    assert isinstance(result_factory.storage_block_id, uuid.UUID)
+
+    # verify the remote block exists
+    storage_block_document = await prefect_client.read_block_document(
+        result_factory.storage_block_id
+    )
+    # unnecessary since the read_block_document call above will fail if the
+    # block doesn't exist
+    assert storage_block_document
+
+
+async def _verify_default_storage_creation_without_persistence(
+    result_factory: prefect.results.ResultFactory,
+):
+    # check that the default block was created
+    assert result_factory.storage_block is not None
+    assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
+
+    # verify storage settings are correctly set
+    assert result_factory.storage_block._is_anonymous is None
+    assert result_factory.persist_result is False
+    assert result_factory.storage_block_id is None
+
+
+@pytest.mark.parametrize(
+    "options", [{"persist_result": True}, {"cache_result_in_memory": False}]
+)
+async def test_default_storage_creation_for_flow_with_persistence_features(
+    prefect_client, options
+):
+    @flow(**options)
+    def foo():
+        return get_run_context().result_factory
+
+    result_factory = foo()
+    await _verify_default_storage_creation_with_persistence(
+        prefect_client, result_factory
+    )
+
+
+async def test_default_storage_creation_for_flow_without_persistence_features():
+    @flow()
+    def foo():
+        return get_run_context().result_factory
+
+    result_factory = foo()
+    await _verify_default_storage_creation_without_persistence(result_factory)
+
+
+async def test_default_storage_creation_for_task_with_persistence_features(
+    prefect_client,
+):
+    @task
+    def my_task_1():
+        return get_run_context().result_factory
+
+    @flow(retries=2)
+    def my_flow_1():
+        return my_task_1()
+
+    result_factory = my_flow_1()
+    await _verify_default_storage_creation_with_persistence(
+        prefect_client, result_factory
+    )
+
+    @task(cache_key_fn=lambda *_: "always")
+    def my_task_2():
+        return get_run_context().result_factory
+
+    @flow
+    def my_flow_2():
+        return my_task_2()
+
+    result_factory = my_flow_2()
+    await _verify_default_storage_creation_with_persistence(
+        prefect_client, result_factory
+    )
+
+
+async def test_default_storage_creation_for_task_without_persistence_features():
+    @task
+    def my_task():
+        return get_run_context().result_factory
+
+    @flow()
+    def my_flow():
+        return my_task()
+
+    result_factory = my_flow()
+    await _verify_default_storage_creation_without_persistence(result_factory)

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -160,8 +160,10 @@ class TestReturnValueToState:
         assert isinstance(result_state.data, UnpersistedResult)
         assert await result_state.result() is None
 
-    async def test_returns_single_state_with_data_to_persist(self, factory):
-        factory.persist_result = True
+    async def test_returns_single_state_with_data_to_persist(self, prefect_client):
+        factory = await ResultFactory.default_factory(
+            client=prefect_client, persist_result=True
+        )
         state = Completed(data=1)
         result_state = await return_value_to_state(state, factory)
         assert result_state is state


### PR DESCRIPTION
New `LocalFilesystem` block documents were being created and saved on every flow run, which led to unbounded DB table growth.

This PR changes the behavior of our `ResultFactory` so that it will not create a remote storage block for flows (and tasks) unless features that require persistence are enabled (flow retries, task caching, `persist_results=True`, etc). This will cut down on DB table growth __unless__ the user is actually asking for features that require it. 

This PR has been improved by adding defensive checks to <LOUDLY> let us know where storage block ids set to `None` can cause problems. See https://github.com/PrefectHQ/prefect/pull/10649#discussion_r1319157753

Resolves #10358 and resolves #9950

### Example

Repeated runs for this flow will not create any entries in the DB's `block_document` table:
```python
from prefect import flow

@flow(log_prints=True)
def my_flow():
    print(42)

if __name__ == "__main__":
    my_flow()
```

If we require persistence, the block is added to the DB's `block_document` table:

 ```python
from prefect import flow

@flow(log_prints=True, persist_result=True)
def my_flow():
    print(42)

if __name__ == "__main__":
    my_flow()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
