### PR TITLE
Remove deprecated `send_to_orion`

### DIFF
--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -146,8 +146,6 @@ class APILogHandler(logging.Handler):
                 return  # Respect the global settings toggle
             if not getattr(record, "send_to_api", True):
                 return  # Do not send records that have opted out
-            if not getattr(record, "send_to_orion", True):
-                return  # Backwards compatibility
 
             log = self.prepare(record)
             APILogWorker.instance().send(log)

--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -1,7 +1,6 @@
 import io
 import logging
 import sys
-import warnings
 from builtins import print
 from contextlib import contextmanager
 from functools import lru_cache
@@ -30,22 +29,6 @@ class PrefectLogAdapter(logging.LoggerAdapter):
 
     def process(self, msg, kwargs):
         kwargs["extra"] = {**(self.extra or {}), **(kwargs.get("extra") or {})}
-
-        from prefect._internal.compatibility.deprecated import (
-            PrefectDeprecationWarning,
-            generate_deprecation_message,
-        )
-
-        if "send_to_orion" in kwargs["extra"]:
-            warnings.warn(
-                generate_deprecation_message(
-                    'The "send_to_orion" option',
-                    start_date="May 2023",
-                    help='Use "send_to_api" instead.',
-                ),
-                PrefectDeprecationWarning,
-                stacklevel=4,
-            )
 
         return (msg, kwargs)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -19,7 +19,6 @@ import prefect
 import prefect.logging.configuration
 import prefect.settings
 from prefect import flow, task
-from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
 from prefect._internal.concurrency.api import create_call, from_sync
 from prefect.context import FlowRunContext, TaskRunContext
 from prefect.deprecated.data_documents import _retrieve_result
@@ -461,23 +460,6 @@ class TestAPILogHandler:
     def test_does_not_send_logs_that_opt_out(self, logger, mock_log_worker, task_run):
         with TaskRunContext.construct(task_run=task_run):
             logger.info("test", extra={"send_to_api": False})
-
-        mock_log_worker.instance().send.assert_not_called()
-
-    def test_does_not_send_logs_that_opt_out_deprecated(
-        self, logger, mock_log_worker, task_run
-    ):
-        with TaskRunContext.construct(task_run=task_run):
-            with pytest.warns(
-                PrefectDeprecationWarning,
-                match=(
-                    'The "send_to_orion" option has been deprecated. It will not be'
-                    ' available after Nov 2023. Use "send_to_api" instead.'
-                ),
-            ):
-                PrefectLogAdapter(logger, extra={}).info(
-                    "test", extra={"send_to_orion": False}
-                )
 
         mock_log_worker.instance().send.assert_not_called()
 


### PR DESCRIPTION
It looks like we should wait until November for this one.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
