### PR TITLE
Remove deprecated `OrionHandler` and  `OrionLogWorker`

### DIFF
--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -14,7 +14,6 @@ from rich.theme import Theme
 from typing_extensions import Self
 
 import prefect.context
-from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect._internal.concurrency.api import create_call, from_sync
 from prefect._internal.concurrency.event_loop import get_running_loop
 from prefect._internal.concurrency.services import BatchedQueueService
@@ -283,17 +282,3 @@ class PrefectConsoleHandler(logging.StreamHandler):
             raise
         except Exception:
             self.handleError(record)
-
-
-@deprecated_callable(start_date="Feb 2023", help="Use `APILogHandler` instead.")
-class OrionHandler(APILogHandler):
-    """
-    Deprecated. Use `APILogHandler` instead.
-    """
-
-
-@deprecated_callable(start_date="Feb 2023", help="Use `APILogWorker` instead.")
-class OrionLogWorker(APILogWorker):
-    """
-    Deprecated. Use `APILogWorker` instead.
-    """


### PR DESCRIPTION
**Note: The base branch for this PR is not `main`, it is `remove-deprecated-orion-refs`.**

Part of #10642

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
