### PR TITLE
Remove deprecated `kubernetes manifest orion` command

### DIFF
--- a/src/prefect/cli/kubernetes.py
+++ b/src/prefect/cli/kubernetes.py
@@ -7,7 +7,6 @@ import typer
 import yaml
 
 import prefect
-from prefect._internal.compatibility.deprecated import generate_deprecation_message
 from prefect.cli._types import PrefectTyper, SettingsOption
 from prefect.cli.root import app
 from prefect.infrastructure import KubernetesJob
@@ -29,35 +28,6 @@ manifest_app = PrefectTyper(
     help="Commands for generating Kubernetes manifests.",
 )
 kubernetes_app.add_typer(manifest_app)
-
-
-@manifest_app.command("orion", hidden=True)
-def manifest_orion(
-    image_tag: str = typer.Option(
-        get_prefect_image_name(),
-        "-i",
-        "--image-tag",
-        help="The tag of a Docker image to use for Prefect.",
-    ),
-    namespace: str = typer.Option(
-        "default",
-        "-n",
-        "--namespace",
-        help="A Kubernetes namespace to create Prefect in.",
-    ),
-    log_level: str = SettingsOption(PREFECT_LOGGING_SERVER_LEVEL),
-):
-    app.console.print(
-        generate_deprecation_message(
-            "The `prefect kubernetes manifest orion` command",
-            start_date="Feb 2023",
-            help="Use `prefect kubernetes manifest server` instead.",
-        )
-    )
-
-    return manifest_server(
-        image_tag=image_tag, namespace=namespace, log_level=log_level
-    )
 
 
 @manifest_app.command("server")


### PR DESCRIPTION
**Note: The base branch for this PR is not `main`, it is `remove-deprecated-orion-refs`.**

Part of #10642
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
