### PR TITLE
Fix `CronSchedules` and DST

### DIFF
--- a/src/prefect/server/schemas/schedules.py
+++ b/src/prefect/server/schemas/schedules.py
@@ -324,6 +324,10 @@ class CronSchedule(PrefectBaseModel):
         # as an event (if it meets the cron criteria)
         start = start.subtract(seconds=1)
 
+        # Respect microseconds by rounding up
+        if start.microsecond > 0:
+            start += datetime.timedelta(seconds=1)
+
         # croniter's DST logic interferes with all other datetime libraries except pytz
         start_localized = pytz.timezone(start.tz.name).localize(
             datetime.datetime(
@@ -336,17 +340,21 @@ class CronSchedule(PrefectBaseModel):
                 microsecond=start.microsecond,
             )
         )
+        start_naive_tz = start.naive()
 
-        # Respect microseconds by rounding up
-        if start_localized.microsecond > 0:
-            start_localized += datetime.timedelta(seconds=1)
-
-        cron = croniter(self.cron, start_localized, day_or=self.day_or)  # type: ignore
+        cron = croniter(self.cron, start_naive_tz, day_or=self.day_or)  # type: ignore
         dates = set()
         counter = 0
 
         while True:
-            next_date = pendulum.instance(cron.get_next(datetime.datetime))
+            # croniter does not handle DST properly when the start time is
+            # in and around when the actual shift occurs. To work around this,
+            # we use the naive start time to get the next cron date delta, then
+            # add that time to the original scheduling anchor.
+            next_time = cron.get_next(datetime.datetime)
+            delta = next_time - start_naive_tz
+            next_date = pendulum.instance(start_localized + delta)
+
             # if the end date was exceeded, exit
             if end and next_date > end:
                 break

--- a/tests/server/schemas/test_schedules.py
+++ b/tests/server/schemas/test_schedules.py
@@ -480,6 +480,22 @@ class TestCronScheduleDaylightSavingsTime:
         assert [d.in_tz("America/New_York").hour for d in dates] == [9, 9, 9, 9, 9]
         assert [d.in_tz("UTC").hour for d in dates] == [13, 13, 13, 14, 14]
 
+    async def test_cron_schedule_handles_scheduling_near_dst_boundary(self):
+        """
+        Regression test for  https://github.com/PrefectHQ/nebula/issues/4048
+        `croniter` does not generate expected schedules when given a start
+        time on the day DST occurs but before the time shift actually happens.
+        Daylight savings occurs at 2023-03-12T02:00:00-05:00 and clocks jump
+        ahead to 2023-03-12T03:00:00-04:00. The timestamp below is in the 2-hour
+        window where it is 2023-03-12, but the DST shift has not yet occurred.
+        """
+        dt = pendulum.datetime(2023, 3, 12, 5, 10, 2, tz="UTC")
+        s = CronSchedule(cron="10 0 * * *", timezone="America/Montreal")
+        dates = await s.get_dates(n=5, start=dt)
+
+        assert [d.in_tz("America/New_York").hour for d in dates] == [0, 0, 0, 0, 0]
+        assert [d.in_tz("UTC").hour for d in dates] == [4, 4, 4, 4, 4]
+
 
 class TestRRuleScheduleDaylightSavingsTime:
     async def test_rrule_schedule_hourly_daylight_savings_time_forward_with_UTC(


### PR DESCRIPTION
Re-adding a DST fix for `CronSchedules`. The original pr description is copied below. [An experiment in cloud](https://github.com/PrefectHQ/nebula/pull/5549) has been run for 2 weeks to give high confidence that there are no unintended differences.
***
closes: https://github.com/PrefectHQ/nebula/issues/4048

`croniter` does not generate expected schedules when given a start time on the day DST occurs but before the time shift actually happens. In the example below you can see a time inside of the 2 hours window where it scheduling on the incorrect hour interval. To mitigate this we use `croniter` with a naive start time and get the delta to the next timestamp, then add it back to the original localize start time.

### Example
```python
# Daylight savings occurs at 2023-03-12T02:00:00-05:00
# and clocks jump ahead to 2023-03-12T03:00:00-04:00

# the below datetime occurs in the period when it is 2023-03-12, 
# after the scheduled event on that day, but before the shift occurs.
dt = pendulum.datetime(2023, 3, 12, 5, 10, 2, tz="UTC")
s = CronSchedule(cron="10 0 * * *", timezone="America/Montreal")
dates = await s.get_dates(n=4, start=dt)
for d in dates:
    print(d)

# Before Change
# 2023-03-13T01:10:00-04:00
# 2023-03-13T23:10:00-04:00
# 2023-03-14T00:10:00-04:00
# 2023-03-15T00:10:00-04:00

# After Change
# 2023-03-13T00:10:00-04:00
# 2023-03-14T00:10:00-04:00
# 2023-03-15T00:10:00-04:00
# 2023-03-16T00:10:00-04:00
```
