### PR TITLE
`no-copy` output code block in docs agents concept page

### DIFF
--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -57,7 +57,7 @@ prefect agent start -p [work pool name]
 
 For example:
 
-```{.output .no-select}
+```{.output .no-copy}
 Starting agent with ephemeral API...
   ___ ___ ___ ___ ___ ___ _____     _   ___ ___ _  _ _____
  | _ \ _ \ __| __| __/ __|_   _|   /_\ / __| __| \| |_   _|

--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -51,17 +51,13 @@ You must start an agent within an environment that can access or create the infr
 
 Use the `prefect agent start` CLI command to start an agent. You must pass at least one work pool name or match string that the agent will poll for work. If the work pool does not exist, it will be created.
 
-<div class="terminal">
 ```bash
-$ prefect agent start -p [work pool name]
+prefect agent start -p [work pool name]
 ```
-</div>
 
 For example:
 
-<div class="terminal">
-```bash
-$ prefect agent start -p "my-pool"
+```{.output .no-select}
 Starting agent with ephemeral API...
   ___ ___ ___ ___ ___ ___ _____     _   ___ ___ _  _ _____
  | _ \ _ \ __| __| __/ __|_   _|   /_\ / __| __| \| |_   _|
@@ -70,9 +66,6 @@ Starting agent with ephemeral API...
 
 Agent started! Looking for work from work pool 'my-pool'...
 ```
-</div>
-
-In this case, Prefect automatically created a new `my-queue` work queue.
 
 By default, the agent polls the API specified by the `PREFECT_API_URL` environment variable. To configure the agent to poll from a different server location, use the `--api` flag, specifying the URL of the server.
 
@@ -80,14 +73,14 @@ In addition, agents can match multiple queues in a work pool by providing a `--m
 
 For example:
 
-<div class="terminal">
 ```bash
-$ prefect agent start --match "foo-"
+prefect agent start --match "foo-"
 ```
-</div>
 
 This example will poll every work queue that starts with "foo-".
 
 ### Configuring prefetch
 
-By default, the agent begins submission of flow runs a short time (10 seconds) before they are scheduled to run. This allows time for the infrastructure to be created, so the flow run can start on time. In some cases, infrastructure will take longer than this to actually start the flow run. In these cases, the prefetch can be increased using the `--prefetch-seconds` option or the `PREFECT_AGENT_PREFETCH_SECONDS` setting. Submission can begin an arbitrary amount of time before the flow run is scheduled to start. If this value is _larger_ than the amount of time it takes for the infrastructure to start, the flow run will _wait_ until its scheduled start time. This allows flow runs to start exactly on time.
+By default, the agent begins submission of flow runs a short time (10 seconds) before they are scheduled to run. This allows time for the infrastructure to be created, so the flow run can start on time. In some cases, infrastructure will take longer than this to actually start the flow run. In these cases, the prefetch can be increased using the `--prefetch-seconds` option or the `PREFECT_AGENT_PREFETCH_SECONDS` setting.
+
+Submission can begin an arbitrary amount of time before the flow run is scheduled to start. If this value is _larger_ than the amount of time it takes for the infrastructure to start, the flow run will _wait_ until its scheduled start time. This allows flow runs to start exactly on time.


### PR DESCRIPTION
Improves formatting of bash output in code blocks on concepts/agents page. 

Makes other minor improvements to the page (including removing mention of work-queue where it doesn't make sense).

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ n/a] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
