### PR TITLE
fix base client test

### DIFF
--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -469,5 +469,6 @@ class TestPrefectHttpxClient:
         base_client_send.return_value = RESPONSE_400
         with pytest.raises(PrefectHTTPStatusError) as exc:
             await client.post(url="fake.url/fake/route", data={"evenmorefake": "data"})
+        breakpoint()
         expected = "Response: {'extra_info': [{'message': 'a test error message'}]}"
-        assert expected in str(exc)
+        assert expected in str(exc.exconly())

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -469,6 +469,5 @@ class TestPrefectHttpxClient:
         base_client_send.return_value = RESPONSE_400
         with pytest.raises(PrefectHTTPStatusError) as exc:
             await client.post(url="fake.url/fake/route", data={"evenmorefake": "data"})
-        breakpoint()
         expected = "Response: {'extra_info': [{'message': 'a test error message'}]}"
         assert expected in str(exc.exconly())


### PR DESCRIPTION
With the latest realse of `httpx==0.25.0`, the documentation url for response codes has changed: https://github.com/encode/httpx/blob/master/CHANGELOG.md#0250-11th-sep-2023

This breaks a test as it makes the str version of an exception slightly longer, and the value we are checking for is truncated. 
```
<ExceptionInfo PrefectHTTPStatusError("Client error '400 Bad Request' for url 'fake.url/fake/route'\nResponse: {'extra_info': [{'mess...: 'a test error message'}]}\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400") tblen=5>
```

This fixes it by using `str(exc.exconly())` to get the full string.