### PR TITLE
add ability to hide subflow runs on flow runs page

### DIFF
--- a/ui/src/pages/FlowRuns.vue
+++ b/ui/src/pages/FlowRuns.vue
@@ -29,10 +29,11 @@
               <FlowRunsDeleteButton :selected="selectedFlowRuns" @delete="deleteFlowRuns" />
             </div>
 
+            <p-toggle v-model="parentTaskRunIdNull" class="flow-runs__subflows-toggle" append="Hide subflows" />
             <template v-if="media.md">
               <SearchInput v-model="flowRunNameLike" placeholder="Search by run name" label="Search by run name" />
             </template>
-            <FlowRunsSort v-model="filter.sort" />
+            <FlowRunsSort v-model="filter.sort" class="flow-runs__sort" />
           </div>
 
           <FlowRunList v-model:selected="selectedFlowRuns" selectable :flow-runs="flowRuns" @bottom="loadMoreFlowRuns" />
@@ -76,6 +77,14 @@
       nameLike: flowRunNameLikeDebounced,
     },
   })
+  const parentTaskRunIdNull = computed({
+    get() {
+      return filter.flowRuns.parentTaskRunIdNull
+    },
+    set(val) {
+      filter.flowRuns.parentTaskRunIdNull = val ? true : undefined
+    },
+  })
 
   const subscriptionOptions = {
     interval: 30000,
@@ -98,7 +107,7 @@
 
   const classes = computed(() => ({
     listControls: {
-      'flow-runs__list-controls--stuck': stuck.value,
+      'flow-runs__list-controls--stuck': stuck.value && media.md,
     },
   }))
 
@@ -123,16 +132,22 @@
 
 .flow-runs__list-controls { @apply
   flex
+  flex-wrap
   gap-2
+  gap-y-4
   items-center
-  px-2
   py-3
-  sticky
-  top-0
-  z-10
+  rounded-b-default
+  border-t
+  border-t-divider
+  md:border-t-0
+  md:sticky
+  md:top-0
+  md:z-10
 }
 
 .flow-runs__list-controls--stuck { @apply
+  px-2
   bg-floating-sticky
   backdrop-blur-sm
   shadow-md
@@ -147,5 +162,14 @@
 
 .flow-runs__chart {
   height: 275px;
+}
+
+.flow-runs__subflows-toggle { @apply
+  mr-2
+}
+
+.flow-runs__sort { @apply
+  w-full
+  md:w-auto
 }
 </style>


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Resolves https://github.com/PrefectHQ/prefect/issues/10272

Adds the ability to toggle away subflow runs from the flow runs list. Also cleans up a bit of the mobile styles.

<img width="1242" alt="image" src="https://github.com/PrefectHQ/prefect/assets/6776415/e35f3cd0-5535-4183-97ce-74315a68c116">

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
