### PR TITLE
Allow Python classes as flow/task type hints

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -279,7 +279,7 @@ class Flow(Generic[P, R]):
             # We cannot, however, store the validated function on the flow because it
             # is not picklable in some environments
             try:
-                ValidatedFunction(self.fn, config=None)
+                ValidatedFunction(self.fn, config={"arbitrary_types_allowed": True})
             except pydantic.ConfigError as exc:
                 raise ValueError(
                     "Flow function is not compatible with `validate_parameters`. "
@@ -443,7 +443,9 @@ class Flow(Generic[P, R]):
         Raises:
             ParameterTypeError: if the provided parameters are not valid
         """
-        validated_fn = ValidatedFunction(self.fn, config=None)
+        validated_fn = ValidatedFunction(
+            self.fn, config={"arbitrary_types_allowed": True}
+        )
         args, kwargs = parameters_to_args_kwargs(self.fn, parameters)
 
         try:

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1367,6 +1367,17 @@ class TestFlowParameterTypes:
         # See #1638.
         assert my_flow(data) == data
 
+    def test_flow_parameter_annotations_can_be_non_pydantic_classes(self):
+        class Test:
+            pass
+
+        @flow
+        def my_flow(instance: Test):
+            return instance
+
+        instance = my_flow(Test())
+        assert isinstance(instance, Test)
+
     def test_subflow_parameters_can_be_pydantic_types(self):
         @flow
         def my_flow():
@@ -1409,6 +1420,21 @@ class TestFlowParameterTypes:
             return x
 
         assert my_flow() == ParameterTestModel(data=1)
+
+    def test_subflow_parameter_annotations_can_be_non_pydantic_classes(self):
+        class Test:
+            pass
+
+        @flow
+        def my_flow(i: Test):
+            return my_subflow(i)
+
+        @flow
+        def my_subflow(i: Test):
+            return i
+
+        instance = my_flow(Test())
+        assert isinstance(instance, Test)
 
 
 class TestSubflowTaskInputs:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3393,6 +3393,22 @@ async def test_sets_run_name_once_per_call():
     assert generate_task_run_name.call_count == 2
 
 
+def test_task_parameter_annotations_can_be_non_pydantic_classes():
+    class Test:
+        pass
+
+    @task
+    def my_task(instance: Test):
+        return instance
+
+    @flow
+    def my_flow(instance: Test):
+        return my_task(instance)
+
+    instance = my_flow(Test())
+    assert isinstance(instance, Test)
+
+
 def create_hook(mock_obj):
     def my_hook(task, task_run, state):
         mock_obj()


### PR DESCRIPTION
When we parse a function using the `flow` decorator and later when we try to run it using some input, we do some `pydantic`-based validation to ensure that the arguments provided match with what the decorated function expects as input. The validation introspects the function signature to understand what needs validating and how to validate it. When dealing with builtins or `BaseModels` as type hints, `pydantic` knows how to perform validation. The problem comes from using _plain_ Python classes as type hints because `pydantic` can't do deep validation on _plain_ classes so it will raise an error `RuntimeError: no validator found for <class 'ase.atoms.Atoms'>`

This PR changes the validation config to include `arbitrary_types_allowed` which will change the type of validation  `pydantic` tries to perform to a simple `ininstance` on _plain_ Python classes.

**NOTE** 
This problem would only happen on flow-decorated functions that used a non-pydantic class as a type annotation, Un-annotated parameters on functions have always worked fine.

Resolves #9266 

### Example
This works now instead of failing on a `RuntimeError`
```python
class Test:
    name = "test"


@flow
def foo(i: Test):
    return i.name


foo(Test())
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
- [X] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
