### PR TITLE
Add an `is_null` filter for Deployments to flows/filter

### DIFF
--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -80,6 +80,34 @@ class FlowFilterId(PrefectFilterBaseModel):
         return filters
 
 
+class FlowFilterDeployment(PrefectOperatorFilterBaseModel):
+    """Filter by flows by deployment"""
+
+    is_null_: Optional[bool] = Field(
+        default=None,
+        description="If true, only include flow runs without deployment ids",
+    )
+
+    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+        filters = []
+
+        if self.is_null_ is not None:
+            deployments_subquery = (
+                sa.select(db.Deployment.flow_id).distinct().subquery()
+            )
+
+            if self.is_null_:
+                filters.append(
+                    db.Flow.id.not_in(sa.select(deployments_subquery.c.flow_id))
+                )
+            else:
+                filters.append(
+                    db.Flow.id.in_(sa.select(deployments_subquery.c.flow_id))
+                )
+
+        return filters
+
+
 class FlowFilterName(PrefectFilterBaseModel):
     """Filter by `Flow.name`."""
 
@@ -140,6 +168,9 @@ class FlowFilter(PrefectOperatorFilterBaseModel):
     id: Optional[FlowFilterId] = Field(
         default=None, description="Filter criteria for `Flow.id`"
     )
+    deployment: Optional[FlowFilterDeployment] = Field(
+        default=None, description="Filter criteria for Flow deployments"
+    )
     name: Optional[FlowFilterName] = Field(
         default=None, description="Filter criteria for `Flow.name`"
     )
@@ -152,6 +183,8 @@ class FlowFilter(PrefectOperatorFilterBaseModel):
 
         if self.id is not None:
             filters.append(self.id.as_sql_filter(db))
+        if self.deployment is not None:
+            filters.append(self.deployment.as_sql_filter(db))
         if self.name is not None:
             filters.append(self.name.as_sql_filter(db))
         if self.tags is not None:

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -85,7 +85,7 @@ class FlowFilterDeployment(PrefectOperatorFilterBaseModel):
 
     is_null_: Optional[bool] = Field(
         default=None,
-        description="If true, only include flow runs without deployment ids",
+        description="If true, only include flows without deployments",
     )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:

--- a/tests/server/api/test_flows.py
+++ b/tests/server/api/test_flows.py
@@ -316,6 +316,46 @@ class TestReadFlows:
         assert len(response.json()) == 1
         assert UUID(response.json()[0]["id"]) == flow_1.id
 
+    async def test_read_flows_applies_deployment_is_null(self, client, session):
+        undeployed_flow = await models.flows.create_flow(
+            session=session,
+            flow=schemas.core.Flow(name="undeployment_flow"),
+        )
+        deployed_flow = await models.flows.create_flow(
+            session=session, flow=schemas.core.Flow(name="deployed_flow")
+        )
+        await session.commit()
+
+        await models.deployments.create_deployment(
+            session=session,
+            deployment=schemas.core.Deployment(
+                name="Mr. Deployment",
+                manifest_path="file.json",
+                flow_id=deployed_flow.id,
+            ),
+        )
+        await session.commit()
+
+        deployment_filter_isnull = dict(
+            flows=schemas.filters.FlowFilter(
+                deployment=schemas.filters.FlowFilterDeployment(is_null_=True)
+            ).dict(json_compatible=True)
+        )
+        response = await client.post("/flows/filter", json=deployment_filter_isnull)
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()) == 1
+        assert UUID(response.json()[0]["id"]) == undeployed_flow.id
+
+        deployment_filter_not_isnull = dict(
+            flows=schemas.filters.FlowFilter(
+                deployment=schemas.filters.FlowFilterDeployment(is_null_=False)
+            ).dict(json_compatible=True)
+        )
+        response = await client.post("/flows/filter", json=deployment_filter_not_isnull)
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()) == 1
+        assert UUID(response.json()[0]["id"]) == deployed_flow.id
+
     async def test_read_flows_offset(self, flows, client):
         # right now this works because flows are ordered by name
         # by default, when ordering is actually implemented, this test


### PR DESCRIPTION
This adds an `is_null` filter for deployments to the flows/filter route to be able to read flows that have associated deployments or have no associated deployments.

Closes #10715 

### Example

To get all flows that have at least one associated deployment:

```
{
	"flows": {"deployment": { "is_null_": false}}
}
```

To get all flows that do not have any associated deployments:

```
{
	"flows": {"deployment": { "is_null_": true}}
}
```


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->