### PR TITLE
adding workspace handle to connection confirmation

### DIFF
--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -105,10 +105,35 @@ async def use(name: str):
     """
     Set the given profile to active.
     """
+
+    profiles = prefect.settings.load_profiles()
+    if name not in profiles.names:
+        exit_with_error(f"Profile {name!r} not found.")
+
+    profiles.set_active(name)
+    prefect.settings.save_profiles(profiles)
+
+    async with get_cloud_client() as client:
+        try:
+            workspaces = await client.read_workspaces()
+        except CloudUnauthorizedError:
+            exit_with_error(
+                "Unable to authenticate. Please ensure your credentials are correct."
+            )
+
+    current_api_url = prefect.settings.PREFECT_API_URL.value()
+
+    for workspace in workspaces:
+        if workspace.api_url() == current_api_url:
+            workspace_handle = workspace.handle
+
     status_messages = {
         ConnectionStatus.CLOUD_CONNECTED: (
             exit_with_success,
-            f"Connected to Prefect Cloud using profile {name!r}",
+            (
+                f"Connected to Prefect Cloud workspace {workspace_handle!r} using"
+                f" profile {name!r}"
+            ),
         ),
         ConnectionStatus.CLOUD_ERROR: (
             exit_with_error,
@@ -138,13 +163,6 @@ async def use(name: str):
             "Error connecting to Prefect API URL",
         ),
     }
-
-    profiles = prefect.settings.load_profiles()
-    if name not in profiles.names:
-        exit_with_error(f"Profile {name!r} not found.")
-
-    profiles.set_active(name)
-    prefect.settings.save_profiles(profiles)
 
     with Progress(
         SpinnerColumn(),


### PR DESCRIPTION
adds the workspace handle to connection confirmation in the prefect profile use command

### Example
```
➜  prefect git:(add-accoun-workspace-to-profile-confirmation) ✗ prefect profile use prod
⠹ Checking API connectivity...
Connected to Prefect Cloud workspace 'prefect-sandbox/willy' using profile 'prod'
```

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
