### PR TITLE
Refactor deployment config selection in `prefect deploy`

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -1086,6 +1086,115 @@ def _load_deploy_configs_and_actions(ci=False) -> Tuple[List[Dict], Dict]:
     return deploy_configs, actions
 
 
+def _handle_deploy_without_name(deploy_configs):
+    # Prompt the user to select one or more deployment configurations
+    selectable_deploy_configs = [
+        deploy_config for deploy_config in deploy_configs if deploy_config.get("name")
+    ]
+    if not selectable_deploy_configs:
+        return []
+    selected_deploy_config = prompt_select_from_table(
+        app.console,
+        "Would you like to use an existing deployment configuration?",
+        [
+            {"header": "Name", "key": "name"},
+            {"header": "Entrypoint", "key": "entrypoint"},
+            {"header": "Description", "key": "description"},
+        ],
+        selectable_deploy_configs,
+        opt_out_message="No, configure a new deployment",
+        opt_out_response=None,
+    )
+    return [selected_deploy_config] if selected_deploy_config else []
+
+
+def _handle_unfound_names(unfound_names, matched_deploy_configs, names):
+    # Log unfound names
+    if unfound_names:
+        app.console.print(
+            (
+                "The following deployment(s) could not be found and will not be"
+                f" deployed: {', '.join(list(sorted(unfound_names)))}"
+            ),
+            style="yellow",
+        )
+    if not matched_deploy_configs:
+        app.console.print(
+            (
+                "Could not find any deployment configurations with the given"
+                f" name(s): {', '.join(names)}. Your flow will be deployed with a"
+                " new deployment configuration."
+            ),
+            style="yellow",
+        )
+
+
+def _prompt_user_for_deployment_choice(matching_deployments, name):
+    # Prompt the user when multiple deployment options are available
+    return prompt_select_from_table(
+        app.console,
+        (
+            "Found multiple deployment configurations with the name"
+            f" [yellow]{name}[/yellow]. Please select the one you would"
+            " like to deploy:"
+        ),
+        [
+            {"header": "Name", "key": "name"},
+            {"header": "Entrypoint", "key": "entrypoint"},
+            {"header": "Description", "key": "description"},
+        ],
+        matching_deployments,
+    )
+
+
+def _find_matching_deploy_config(name, deploy_configs):
+    # Logic to find the deploy_config matching the given name
+    # This function handles both "flow-name/deployment-name" and just "deployment-name"
+    matching_deployments = []
+    if "/" in name:
+        flow_name, deployment_name = name.split("/")
+        flow_name = flow_name.replace("-", "_")
+        matching_deployments = [
+            deploy_config
+            for deploy_config in deploy_configs
+            if deploy_config.get("name") == deployment_name
+            and deploy_config.get("entrypoint", "").split(":")[-1] == flow_name
+        ]
+    else:
+        matching_deployments = [
+            deploy_config
+            for deploy_config in deploy_configs
+            if deploy_config.get("name") == name
+        ]
+    return matching_deployments
+
+
+def _handle_deploy_with_name(deploy_configs, names, ci=False):
+    matched_deploy_configs = []
+    deployment_names = []
+    for name in names:
+        matching_deployments = _find_matching_deploy_config(name, deploy_configs)
+
+        if len(matching_deployments) > 1 and is_interactive() and not ci:
+            user_selected_matching_deployment = _prompt_user_for_deployment_choice(
+                matching_deployments, name
+            )
+            matched_deploy_configs.append(user_selected_matching_deployment)
+        elif matching_deployments:
+            matched_deploy_configs.extend(matching_deployments)
+
+        deployment_names.append(
+            name.split("/")[-1]
+        )  # Keep only the deployment_name part if any
+
+    unfound_names = set(deployment_names) - {
+        deploy_config.get("name") for deploy_config in matched_deploy_configs
+    }
+    _handle_unfound_names(unfound_names, matched_deploy_configs, names)
+
+    return matched_deploy_configs
+
+
 def _pick_deploy_configs(deploy_configs, names, deploy_all, ci=False):
     """
     Return a list of deploy configs to deploy based on the given
@@ -1102,99 +1211,25 @@ def _pick_deploy_configs(deploy_configs, names, deploy_all, ci=False):
     """
     if not deploy_configs:
         return []
+
     elif deploy_all:
         return deploy_configs
+
+    # e.g. `prefect --no-prompt deploy`
     elif (not is_interactive() or ci) and len(deploy_configs) == 1 and len(names) <= 1:
         # No name is needed if there is only one deployment configuration
         # and we are not in interactive mode
         return deploy_configs
+
+    # e.g. `prefect deploy -n flow-name/deployment-name -n deployment-name`
     elif len(names) >= 1:
-        matched_deploy_configs = []
-        deployment_names = []
-        for name in names:
-            # if flow-name/deployment-name format
-            if "/" in name:
-                flow_name, deployment_name = name.split("/")
-                flow_name = flow_name.replace("-", "_")
-                matched_deploy_configs += [
-                    deploy_config
-                    for deploy_config in deploy_configs
-                    if deploy_config.get("name") == deployment_name
-                    and deploy_config.get("entrypoint", "").split(":")[-1] == flow_name
-                ]
-                deployment_names.append(deployment_name)
+        return _handle_deploy_with_name(deploy_configs, names, ci=ci)
 
-            else:
-                # If deployment-name format
-                matching_deployment = [
-                    deploy_config
-                    for deploy_config in deploy_configs
-                    if deploy_config.get("name") == name
-                ]
-                if len(matching_deployment) > 1 and is_interactive() and not ci:
-                    user_selected_matching_deployment = prompt_select_from_table(
-                        app.console,
-                        (
-                            "Found multiple deployment configurations with the name"
-                            f" [yellow]{name}[/yellow]. Please select the one you would"
-                            " like to deploy:"
-                        ),
-                        [
-                            {"header": "Name", "key": "name"},
-                            {"header": "Entrypoint", "key": "entrypoint"},
-                            {"header": "Description", "key": "description"},
-                        ],
-                        matching_deployment,
-                    )
-                    matched_deploy_configs.append(user_selected_matching_deployment)
-                elif matching_deployment:
-                    matched_deploy_configs.extend(matching_deployment)
-                deployment_names.append(name)
-
-        unfound_names = set(deployment_names) - {
-            deploy_config.get("name") for deploy_config in matched_deploy_configs
-        }
-
-        if unfound_names:
-            app.console.print(
-                (
-                    "The following deployment(s) could not be found and will not be"
-                    f" deployed: {', '.join(list(sorted(unfound_names)))}"
-                ),
-                style="yellow",
-            )
-        if not matched_deploy_configs:
-            app.console.print(
-                (
-                    "Could not find any deployment configurations with the given"
-                    f" name(s): {', '.join(names)}. Your flow will be deployed with a"
-                    " new deployment configuration."
-                ),
-                style="yellow",
-            )
-        return matched_deploy_configs
+    # e.g. `prefect deploy`
     elif is_interactive() and not ci:
-        # Prompt the user to select one or more deployment configurations
-        selectable_deploy_configs = [
-            deploy_config
-            for deploy_config in deploy_configs
-            if deploy_config.get("name")
-        ]
-        if not selectable_deploy_configs:
-            return []
-        selected_deploy_config = prompt_select_from_table(
-            app.console,
-            "Would you like to use an existing deployment configuration?",
-            [
-                {"header": "Name", "key": "name"},
-                {"header": "Entrypoint", "key": "entrypoint"},
-                {"header": "Description", "key": "description"},
-            ],
-            selectable_deploy_configs,
-            opt_out_message="No, configure a new deployment",
-            opt_out_response=None,
-        )
-        return [selected_deploy_config] if selected_deploy_config else []
+        return _handle_deploy_without_name(deploy_configs)
+
+    # e.g `prefect --no-prompt deploy` where we have multiple deployment configurations
     elif len(deploy_configs) > 1:
         raise ValueError(
             "Discovered one or more deployment configurations, but"

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -1108,13 +1108,13 @@ def _handle_deploy_without_name(deploy_configs):
     return [selected_deploy_config] if selected_deploy_config else []
 
 
-def _handle_unfound_names(unfound_names, matched_deploy_configs, names):
+def _log_missing_deployment_names(missing_names, matched_deploy_configs, names):
     # Log unfound names
-    if unfound_names:
+    if missing_names:
         app.console.print(
             (
                 "The following deployment(s) could not be found and will not be"
-                f" deployed: {', '.join(list(sorted(unfound_names)))}"
+                f" deployed: {', '.join(list(sorted(missing_names)))}"
             ),
             style="yellow",
         )
@@ -1190,7 +1190,7 @@ def _handle_deploy_with_name(deploy_configs, names, ci=False):
     unfound_names = set(deployment_names) - {
         deploy_config.get("name") for deploy_config in matched_deploy_configs
     }
-    _handle_unfound_names(unfound_names, matched_deploy_configs, names)
+    _log_missing_deployment_names(unfound_names, matched_deploy_configs, names)
 
     return matched_deploy_configs
 

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -1086,7 +1086,7 @@ def _load_deploy_configs_and_actions(ci=False) -> Tuple[List[Dict], Dict]:
     return deploy_configs, actions
 
 
-def _handle_deploy_without_name(deploy_configs):
+def _handle_pick_deploy_without_name(deploy_configs):
     # Prompt the user to select one or more deployment configurations
     selectable_deploy_configs = [
         deploy_config for deploy_config in deploy_configs if deploy_config.get("name")
@@ -1129,7 +1129,7 @@ def _log_missing_deployment_names(missing_names, matched_deploy_configs, names):
         )
 
 
-def _find_matching_deploy_config(name, deploy_configs):
+def _filter_matching_deploy_config(name, deploy_configs):
     # Logic to find the deploy_config matching the given name
     # This function handles both "flow-name/deployment-name" and just "deployment-name"
     matching_deployments = []
@@ -1151,11 +1151,11 @@ def _find_matching_deploy_config(name, deploy_configs):
     return matching_deployments
 
 
-def _handle_deploy_with_name(deploy_configs, names, ci=False):
+def _handle_pick_deploy_with_name(deploy_configs, names, ci=False):
     matched_deploy_configs = []
     deployment_names = []
     for name in names:
-        matching_deployments = _find_matching_deploy_config(name, deploy_configs)
+        matching_deployments = _filter_matching_deploy_config(name, deploy_configs)
 
         if len(matching_deployments) > 1 and is_interactive() and not ci:
             user_selected_matching_deployment = prompt_select_from_table(
@@ -1216,11 +1216,11 @@ def _pick_deploy_configs(deploy_configs, names, deploy_all, ci=False):
 
     # e.g. `prefect deploy -n flow-name/deployment-name -n deployment-name`
     elif len(names) >= 1:
-        return _handle_deploy_with_name(deploy_configs, names, ci=ci)
+        return _handle_pick_deploy_with_name(deploy_configs, names, ci=ci)
 
     # e.g. `prefect deploy`
     elif is_interactive() and not ci:
-        return _handle_deploy_without_name(deploy_configs)
+        return _handle_pick_deploy_without_name(deploy_configs)
 
     # e.g `prefect --no-prompt deploy` where we have multiple deployment configurations
     elif len(deploy_configs) > 1:

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -1129,24 +1129,6 @@ def _log_missing_deployment_names(missing_names, matched_deploy_configs, names):
         )
 
 
-def _prompt_user_for_deployment_choice(matching_deployments, name):
-    # Prompt the user when multiple deployment options are available
-    return prompt_select_from_table(
-        app.console,
-        (
-            "Found multiple deployment configurations with the name"
-            f" [yellow]{name}[/yellow]. Please select the one you would"
-            " like to deploy:"
-        ),
-        [
-            {"header": "Name", "key": "name"},
-            {"header": "Entrypoint", "key": "entrypoint"},
-            {"header": "Description", "key": "description"},
-        ],
-        matching_deployments,
-    )
-
-
 def _find_matching_deploy_config(name, deploy_configs):
     # Logic to find the deploy_config matching the given name
     # This function handles both "flow-name/deployment-name" and just "deployment-name"
@@ -1176,8 +1158,19 @@ def _handle_deploy_with_name(deploy_configs, names, ci=False):
         matching_deployments = _find_matching_deploy_config(name, deploy_configs)
 
         if len(matching_deployments) > 1 and is_interactive() and not ci:
-            user_selected_matching_deployment = _prompt_user_for_deployment_choice(
-                matching_deployments, name
+            user_selected_matching_deployment = prompt_select_from_table(
+                app.console,
+                (
+                    "Found multiple deployment configurations with the name"
+                    f" [yellow]{name}[/yellow]. Please select the one you would"
+                    " like to deploy:"
+                ),
+                [
+                    {"header": "Name", "key": "name"},
+                    {"header": "Entrypoint", "key": "entrypoint"},
+                    {"header": "Description", "key": "description"},
+                ],
+                matching_deployments,
             )
             matched_deploy_configs.append(user_selected_matching_deployment)
         elif matching_deployments:


### PR DESCRIPTION
This PR has no user-facing change but refactors `_pick_deploy_configs` which encapsulates how we determine which deploy configs to deploy. The helper function has grown to the point that I felt refactoring it an important first step in increasing readability before further development/improvements in `_pick_deploy_configs`.

There are no test changes. 

A few helper functions have been added:
- `_handle_pick_deploy_with_name`
  - `_find_matching_deploy_config`
  - `_log_missing_deployment_names`
- `_handle_pick_deploy_without_name`

If these helper function names are ambiguous, I'd always appreciate more name suggestions.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
