### PR TITLE
Remove boost from block-based deployments page in documentation, improve visibility of `prefect deploy`

### DIFF
--- a/docs/concepts/deployments-block-based.md
+++ b/docs/concepts/deployments-block-based.md
@@ -6,13 +6,10 @@ tags:
     - deployments
     - schedules
     - triggers
-    - prefect.yaml
     - infrastructure
     - storage
     - work pool
     - worker
-search:
-  boost: 2
 ---
 
 # Block Based Deployments

--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -148,7 +148,7 @@ There are two primary ways to deploy flows with Prefect, differentiated by how m
 
 In one setup, deploying Prefect flows is analogous to deploying a webserver - users author their workflows and then start a long-running process (often within a Docker container) that is responsible for managing all of the runs for the associated deployment(s). 
 
-In the other setup, you do a little extra up-front work to setup a work pool and a base job template that defines how individual flow runs will be submitted to infrastructure. 
+In the other setup, you do [a little extra up-front work to setup a work pool and a base job template that defines how individual flow runs will be submitted to infrastructure](/guides/prefect-deploy). 
 Workers then take these job definitions and submit them to the appropriate infrastructure with each run.
 
 Both setups can support production workloads. The choice ultimately boils down to your use case and preferences. Read further to decide which setup is right for your situation.


### PR DESCRIPTION
## Overview

#### Remove boost and `prefect.yaml` tag from block-based deployments page
All styles of deployment have a boost of 2; I think we should allow `/concepts/deployments.md` and `/guides/prefect-deploy.md` to keep the boost whilst we could it from this page along with the `prefect.yaml` tag. But, welcome to differing thoughts! 

Current search results order in documentation:
<img width="930" alt="Screenshot 2023-09-20 at 5 46 42 PM" src="https://github.com/PrefectHQ/prefect/assets/42048900/a54c9be5-01d0-4e55-82b2-7fb34cd82773">

#### Link in deployments concept page to `prefect deploy` guide
When discussing the two approaches to deployments on the deployments concept page, link to our guide to raise its visibility:
<img width="657" alt="Screenshot 2023-09-20 at 5 52 30 PM" src="https://github.com/PrefectHQ/prefect/assets/42048900/6309c8ba-e1e2-450c-a560-9a59813dec02">


**[Related community question that this stems from](https://prefect-community.slack.com/archives/CM28LL405/p1694769482045889)**



### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
