### PR TITLE
Make `slot_decay_per_second` not nullable

### DIFF
--- a/src/prefect/server/database/migrations/MIGRATION-NOTES.md
+++ b/src/prefect/server/database/migrations/MIGRATION-NOTES.md
@@ -8,6 +8,10 @@ Each time a database migration is written, an entry is included here with:
 
 This gives us a history of changes and will create merge conflicts if two migrations are made at once, flagging situations where a branch needs to be updated before merging.
 
+# Make slot_decay_per_second not nullable
+SQLite: `8167af8df781`
+Postgres: `4e9a6f93eb6c`
+
 # Add heartbeat_interval_seconds to worker table
 SQLite: `c2d001b7dd06`
 Postgres: `50f8c182c3ca`

--- a/src/prefect/server/database/migrations/versions/postgresql/2023_09_21_130125_4e9a6f93eb6c_make_slot_decay_per_second_not_nullable.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2023_09_21_130125_4e9a6f93eb6c_make_slot_decay_per_second_not_nullable.py
@@ -1,0 +1,37 @@
+"""Make slot_decay_per_second not nullable
+
+Revision ID: 4e9a6f93eb6c
+Revises: db0eb3973a54
+Create Date: 2023-09-21 13:01:25.580703
+
+"""
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "4e9a6f93eb6c"
+down_revision = "db0eb3973a54"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        "UPDATE concurrency_limit_v2 SET slot_decay_per_second = 0.0 WHERE"
+        " slot_decay_per_second is null"
+    )
+    op.alter_column(
+        "concurrency_limit_v2",
+        "slot_decay_per_second",
+        existing_type=postgresql.DOUBLE_PRECISION(precision=53),
+        nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "concurrency_limit_v2",
+        "slot_decay_per_second",
+        existing_type=postgresql.DOUBLE_PRECISION(precision=53),
+        nullable=True,
+    )

--- a/src/prefect/server/database/migrations/versions/sqlite/2023_09_21_121806_8167af8df781_make_slot_decay_per_second_not_nullable.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2023_09_21_121806_8167af8df781_make_slot_decay_per_second_not_nullable.py
@@ -1,0 +1,33 @@
+"""Make slot_decay_per_second not nullable
+
+Revision ID: 8167af8df781
+Revises: ef674d598dd3
+Create Date: 2023-09-21 12:18:06.722322
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "8167af8df781"
+down_revision = "ef674d598dd3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        "UPDATE concurrency_limit_v2 SET slot_decay_per_second = 0.0 WHERE"
+        " slot_decay_per_second is null"
+    )
+    with op.batch_alter_table("concurrency_limit_v2", schema=None) as batch_op:
+        batch_op.alter_column(
+            "slot_decay_per_second", existing_type=sa.FLOAT(), nullable=False
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("concurrency_limit_v2", schema=None) as batch_op:
+        batch_op.alter_column(
+            "slot_decay_per_second", existing_type=sa.FLOAT(), nullable=True
+        )

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -977,7 +977,7 @@ class ORMConcurrencyLimitV2:
     active_slots = sa.Column(sa.Integer, nullable=False)
     denied_slots = sa.Column(sa.Integer, nullable=False, default=0)
 
-    slot_decay_per_second = sa.Column(sa.Float, default=0.0, nullable=True)
+    slot_decay_per_second = sa.Column(sa.Float, default=0.0, nullable=False)
     avg_slot_occupancy_seconds = sa.Column(sa.Float, default=2.0, nullable=False)
 
     __table_args__ = (sa.UniqueConstraint("name"),)


### PR DESCRIPTION
This updates the `slot_decay_per_second` column on the global concurrency limit table to not allow null values. Having null values causes validation errors when retrieving concurrency limits from the API. 

Related to #10779 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
