### PR TITLE
Add ability to create work pools with a base template

### DIFF
--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -2,7 +2,6 @@
 Command line interface for working with work queues.
 """
 import json
-from pathlib import Path
 
 import pendulum
 import typer
@@ -34,12 +33,13 @@ app.add_typer(work_pool_app, aliases=["work-pool"])
 @work_pool_app.command()
 async def create(
     name: str = typer.Argument(..., help="The name of the work pool."),
-    base_job_template: str = typer.Option(
+    base_job_template: typer.FileText = typer.Option(
         None,
         "--base-job-template",
         help=(
-            "The base job template to use. If unspecified, Prefect will use the default"
-            " base job template."
+            "The path to a JSON file containing the base job template to use. If"
+            " unspecified, Prefect will use the default base job template for the given"
+            " worker type."
         ),
     ),
     paused: bool = typer.Option(
@@ -98,7 +98,7 @@ async def create(
             type
         )
     else:
-        template_contents = json.loads(Path(base_job_template).read_text("utf-8"))
+        template_contents = json.load(base_job_template)
 
     async with get_client() as client:
         try:

--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -2,6 +2,7 @@
 Command line interface for working with work queues.
 """
 import json
+from pathlib import Path
 
 import pendulum
 import typer
@@ -33,6 +34,14 @@ app.add_typer(work_pool_app, aliases=["work-pool"])
 @work_pool_app.command()
 async def create(
     name: str = typer.Argument(..., help="The name of the work pool."),
+    base_job_template: str = typer.Option(
+        None,
+        "--base-job-template",
+        help=(
+            "The base job template to use. If unspecified, Prefect will use the default"
+            " base job template."
+        ),
+    ),
     paused: bool = typer.Option(
         False,
         "--paused",
@@ -49,10 +58,11 @@ async def create(
     Examples:
         $ prefect work-pool create "my-pool" --paused
     """
-    async with get_collections_metadata_client() as collections_client:
-        if not name.lower().strip("'\" "):
-            exit_with_error("Work pool name cannot be empty.")
-        if type is None:
+    if not name.lower().strip("'\" "):
+        exit_with_error("Work pool name cannot be empty.")
+
+    if type is None:
+        async with get_collections_metadata_client() as collections_client:
             if not is_interactive():
                 exit_with_error(
                     "When not using an interactive terminal, you must supply a `--type`"
@@ -74,21 +84,28 @@ async def create(
                 table_kwargs={"show_lines": True},
             )
             type = worker["type"]
-        base_job_template = await get_default_base_job_template_for_infrastructure_type(
+
+    available_work_pool_types = await get_available_work_pool_types()
+    if type not in available_work_pool_types:
+        exit_with_error(
+            f"Unknown work pool type {type!r}. "
+            "Please choose from"
+            f" {', '.join(available_work_pool_types)}."
+        )
+
+    if base_job_template is None:
+        template_contents = await get_default_base_job_template_for_infrastructure_type(
             type
         )
-        if base_job_template is None:
-            exit_with_error(
-                f"Unknown work pool type {type!r}. "
-                "Please choose from"
-                f" {', '.join(await get_available_work_pool_types())}."
-            )
+    else:
+        template_contents = json.loads(Path(base_job_template).read_text("utf-8"))
+
     async with get_client() as client:
         try:
             wp = WorkPoolCreate(
                 name=name,
                 type=type,
-                base_job_template=base_job_template,
+                base_job_template=template_contents,
                 is_paused=paused,
             )
             work_pool = await client.create_work_pool(work_pool=wp)

--- a/tests/cli/base-job-templates/process-worker.json
+++ b/tests/cli/base-job-templates/process-worker.json
@@ -1,0 +1,21 @@
+{
+  "job_configuration": {
+    "command": "{{ command }}",
+    "name": "{{ name }}"
+  },
+  "variables": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "title": "Name",
+        "description": "Description.",
+        "type": "string"
+      },
+      "command": {
+        "title": "Command",
+        "description": "Command to run.",
+        "type": "string"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds a --base-job-template feature when creating work pools, rather than using the default base job template.

Related to #9576

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
