### PR TITLE
Add command for updating work pools

### DIFF
--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -241,6 +241,63 @@ async def resume(
 
 
 @work_pool_app.command()
+async def update(
+    name: str = typer.Argument(..., help="The name of the work pool to update."),
+    base_job_template: typer.FileText = typer.Option(
+        None,
+        "--base-job-template",
+        help=(
+            "The path to a JSON file containing the base job template to use. If"
+            " unspecified, Prefect will use the default base job template for the given"
+            " worker type. If None, the base job template will not be modified."
+        ),
+    ),
+    concurrency_limit: int = typer.Option(
+        None,
+        "--concurrency-limit",
+        help=(
+            "The concurrency limit for the work pool. If None, the concurrency limit"
+            " will not be modified."
+        ),
+    ),
+    description: str = typer.Option(
+        None,
+        "--description",
+        help=(
+            "The description for the work pool. If None, the description will not be"
+            " modified."
+        ),
+    ),
+):
+    """
+    Update a work pool.
+
+    \b
+    Examples:
+        $ prefect work-pool update "my-pool"
+
+    """
+    wp = WorkPoolUpdate()
+    if base_job_template:
+        wp.base_job_template = json.load(base_job_template)
+    if concurrency_limit:
+        wp.concurrency_limit = concurrency_limit
+    if description:
+        wp.description = description
+
+    async with get_client() as client:
+        try:
+            await client.update_work_pool(
+                work_pool_name=name,
+                work_pool=wp,
+            )
+        except ObjectNotFound:
+            exit_with_error("Work pool named {name!r} does not exist.")
+
+        exit_with_success(f"Updated work pool {name!r}")
+
+
+@work_pool_app.command()
 async def delete(
     name: str = typer.Argument(..., help="The name of the work pool to delete."),
 ):


### PR DESCRIPTION
This adds a command that allows several work pool properties to be updated, including the base job template, concurrency limit, description, or combinations thereof.

Related to #9576

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
