### PR TITLE
Configure base job template during worker startup

### DIFF
--- a/src/prefect/cli/worker.py
+++ b/src/prefect/cli/worker.py
@@ -1,3 +1,4 @@
+import json
 import os
 import threading
 from enum import Enum
@@ -101,6 +102,15 @@ async def start(
         help="Install policy to use workers from Prefect integration packages.",
         case_sensitive=False,
     ),
+    base_job_template: typer.FileText = typer.Option(
+        None,
+        "--base-job-template",
+        help=(
+            "The path to a JSON file containing the base job template to use. If"
+            " unspecified, Prefect will use the default base job template for the given"
+            " worker type. If the work pool already exists, this will be ignored."
+        ),
+    ),
 ):
     """
     Start a worker process to poll a work pool for flow runs.
@@ -129,6 +139,10 @@ async def start(
         worker_process_id, f"the {worker_type} worker", app.console.print
     )
 
+    template_contents = None
+    if base_job_template is not None:
+        template_contents = json.load(fp=base_job_template)
+
     async with worker_cls(
         name=worker_name,
         work_pool_name=work_pool_name,
@@ -136,6 +150,7 @@ async def start(
         limit=limit,
         prefetch_seconds=prefetch_seconds,
         heartbeat_interval_seconds=PREFECT_WORKER_HEARTBEAT_SECONDS.value(),
+        base_job_template=template_contents,
     ) as worker:
         app.console.print(f"Worker {worker.name!r} started!", style="green")
         async with anyio.create_task_group() as tg:

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -325,6 +325,8 @@ class BaseWorker(abc.ABC):
         create_pool_if_not_found: bool = True,
         limit: Optional[int] = None,
         heartbeat_interval_seconds: Optional[int] = None,
+        *,
+        base_job_template: Optional[Dict[str, Any]] = None,
     ):
         """
         Base class for all Prefect workers.
@@ -344,6 +346,8 @@ class BaseWorker(abc.ABC):
                 ensure that work pools are not created accidentally.
             limit: The maximum number of flow runs this worker should be running at
                 a given time.
+            base_job_template: If creating the work pool, provide the base job
+                template to use. Logs a warning if the pool already exists.
         """
         if name and ("/" in name or "%" in name):
             raise ValueError("Worker name cannot contain '/' or '%'")
@@ -352,6 +356,7 @@ class BaseWorker(abc.ABC):
 
         self.is_setup = False
         self._create_pool_if_not_found = create_pool_if_not_found
+        self._base_job_template = base_job_template
         self._work_pool_name = work_pool_name
         self._work_queues: Set[str] = set(work_queues) if work_queues else set()
 
@@ -656,12 +661,22 @@ class BaseWorker(abc.ABC):
             )
         except ObjectNotFound:
             if self._create_pool_if_not_found:
-                work_pool = await self._client.create_work_pool(
-                    work_pool=WorkPoolCreate(name=self._work_pool_name, type=self.type)
+                wp = WorkPoolCreate(
+                    name=self._work_pool_name,
+                    type=self.type,
                 )
+                if self._base_job_template is not None:
+                    wp.base_job_template = self._base_job_template
+
+                work_pool = await self._client.create_work_pool(work_pool=wp)
                 self._logger.info(f"Work pool {self._work_pool_name!r} created.")
             else:
                 self._logger.warning(f"Work pool {self._work_pool_name!r} not found!")
+                if self._base_job_template is not None:
+                    self._logger.warning(
+                        "Ignoring supplied base job template because the work pool"
+                        " already exists"
+                    )
                 return
 
         # if the remote config type changes (or if it's being loaded for the

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -207,6 +207,7 @@ def test_start_worker_with_work_queue_names(monkeypatch, process_work_pool):
         prefetch_seconds=ANY,
         limit=None,
         heartbeat_interval_seconds=30,
+        base_job_template=None,
     )
 
 
@@ -235,6 +236,7 @@ def test_start_worker_with_prefetch_seconds(monkeypatch):
         prefetch_seconds=30,
         limit=None,
         heartbeat_interval_seconds=30,
+        base_job_template=None,
     )
 
 
@@ -262,6 +264,7 @@ def test_start_worker_with_prefetch_seconds_from_setting_by_default(monkeypatch)
         prefetch_seconds=100,
         limit=None,
         heartbeat_interval_seconds=30,
+        base_job_template=None,
     )
 
 
@@ -290,6 +293,7 @@ def test_start_worker_with_limit(monkeypatch):
         prefetch_seconds=10,
         limit=5,
         heartbeat_interval_seconds=30,
+        base_job_template=None,
     )
 
 


### PR DESCRIPTION
On "prefect worker start", allow users to pass in the base job template instead of using the default.

Related to #9576

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation. (Note: I couldn't find any tests for `prefect worker start`
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
