### PR TITLE
By default, agents only query WorkQueues in `prefect-agent` typed WorkPools

### DIFF
--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -91,6 +91,23 @@ class PrefectAgent:
             self.default_infrastructure = Process()
             self.default_infrastructure_document_id = None
 
+    async def _select_default_agent_queues(
+        self, client: PrefectClient, queues: List[WorkQueue]
+    ) -> List[WorkQueue]:
+        """
+        Select only those WorkQueues that match the default work pool type, "prefect-agent"
+        """
+        # get the pools for each matched queue
+        wp_filter = WorkPoolFilter(
+            name=WorkPoolFilterName(any_=[q.work_pool_name for q in queues])
+        )
+        matching_pools = set()
+        for pool in await client.read_work_pools(work_pool_filter=wp_filter):
+            if pool.type == "prefect-agent":
+                matching_pools.add(pool.name)
+
+        return [q for q in queues if q.work_pool_name in matching_pools]
+
     async def update_matched_agent_work_queues(self):
         if self.work_queue_prefix:
             if self.work_pool_name:
@@ -104,6 +121,10 @@ class PrefectAgent:
                 matched_queues = await self.client.match_work_queues(
                     self.work_queue_prefix
                 )
+                matched_queues = await self._select_default_agent_queues(
+                    self.client, matched_queues
+                )
+
             matched_queues = set(q.name for q in matched_queues)
             if matched_queues != self.work_queues:
                 new_queues = matched_queues - self.work_queues

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -150,7 +150,6 @@ class PrefectAgent:
                     work_pool_name=self.work_pool_name, name=name
                 )
             except (ObjectNotFound, Exception):
-                self.logger.exception("Failed to query work queue by name.")
                 work_queue = None
 
             # if the work queue wasn't found and the agent is NOT polling

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -188,9 +188,16 @@ class PrefectAgent:
                     except Exception:
                         self.logger.exception(f"Failed to create work queue {name!r}.")
                         continue
+                else:
+                    self.logger.warning(f"Not creating missing work queue {name!r}.")
+                    work_queue = None
+            except Exception:
+                self.logger.exception(f"Failed to query work queue {name!r} by name.")
+                work_queue = None
 
-            self._work_queue_cache.append(work_queue)
-            yield work_queue
+            if work_queue is not None:
+                self._work_queue_cache.append(work_queue)
+                yield work_queue
 
     async def get_and_submit_flow_runs(self) -> List[FlowRun]:
         """

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -22,6 +22,7 @@ from prefect.client.schemas.filters import (
     FlowRunFilterStateType,
     WorkPoolFilter,
     WorkPoolFilterName,
+    WorkPoolFilterType,
     WorkQueueFilter,
     WorkQueueFilterName,
 )
@@ -97,14 +98,13 @@ class PrefectAgent:
         """
         Select only those WorkQueues that match the default work pool type, "prefect-agent"
         """
-        # get the pools for each matched queue
         wp_filter = WorkPoolFilter(
-            name=WorkPoolFilterName(any_=[q.work_pool_name for q in queues])
+            name=WorkPoolFilterName(any_=[q.work_pool_name for q in queues]),
+            type=WorkPoolFilterType(any_=["prefect-agent"]),
         )
         matching_pools = set()
         for pool in await client.read_work_pools(work_pool_filter=wp_filter):
-            if pool.type == "prefect-agent":
-                matching_pools.add(pool.name)
+            matching_pools.add(pool.name)
 
         return [q for q in queues if q.work_pool_name in matching_pools]
 

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -186,8 +186,8 @@ class PrefectAgent:
                     log_str = f"Created work queue {name!r}"
                     if self.work_pool_name:
                         log_str = (
-                            f"Created work queue '{name!r}' in work pool"
-                            f" '{self.work_pool_name!r}'."
+                            f"Created work queue {name!r} in work pool"
+                            f" {self.work_pool_name!r}."
                         )
                     else:
                         log_str = f"Created work queue '{name}'."

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -26,7 +26,12 @@ from prefect.client.schemas.filters import (
     WorkQueueFilter,
     WorkQueueFilterName,
 )
-from prefect.client.schemas.objects import BlockDocument, FlowRun, WorkQueue
+from prefect.client.schemas.objects import (
+    DEFAULT_AGENT_WORK_POOL_NAME,
+    BlockDocument,
+    FlowRun,
+    WorkQueue,
+)
 from prefect.engine import propose_state
 from prefect.exceptions import (
     Abort,
@@ -119,10 +124,7 @@ class PrefectAgent:
                 )
             else:
                 matched_queues = await self.client.match_work_queues(
-                    self.work_queue_prefix
-                )
-                matched_queues = await self._select_default_agent_queues(
-                    self.client, matched_queues
+                    self.work_queue_prefix, work_pool_name=DEFAULT_AGENT_WORK_POOL_NAME
                 )
 
             matched_queues = set(q.name for q in matched_queues)

--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -22,7 +22,6 @@ from prefect.client.schemas.filters import (
     FlowRunFilterStateType,
     WorkPoolFilter,
     WorkPoolFilterName,
-    WorkPoolFilterType,
     WorkQueueFilter,
     WorkQueueFilterName,
 )
@@ -96,22 +95,6 @@ class PrefectAgent:
         else:
             self.default_infrastructure = Process()
             self.default_infrastructure_document_id = None
-
-    async def _select_default_agent_queues(
-        self, client: PrefectClient, queues: List[WorkQueue]
-    ) -> List[WorkQueue]:
-        """
-        Select only those WorkQueues that match the default work pool type, "prefect-agent"
-        """
-        wp_filter = WorkPoolFilter(
-            name=WorkPoolFilterName(any_=[q.work_pool_name for q in queues]),
-            type=WorkPoolFilterType(any_=["prefect-agent"]),
-        )
-        matching_pools = set()
-        for pool in await client.read_work_pools(work_pool_filter=wp_filter):
-            matching_pools.add(pool.name)
-
-        return [q for q in queues if q.work_pool_name in matching_pools]
 
     async def update_matched_agent_work_queues(self):
         if self.work_queue_prefix:

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -1024,12 +1024,14 @@ class PrefectClient:
     async def match_work_queues(
         self,
         prefixes: List[str],
+        work_pool_name: Optional[str] = None,
     ) -> List[WorkQueue]:
         """
         Query the Prefect API for work queues with names with a specific prefix.
 
         Args:
             prefixes: a list of strings used to match work queue name prefixes
+            work_pool_name: an optional work pool name to scope the query to
 
         Returns:
             a list of WorkQueue model representations
@@ -1041,6 +1043,7 @@ class PrefectClient:
 
         while True:
             new_queues = await self.read_work_queues(
+                work_pool_name=work_pool_name,
                 offset=current_page * page_length,
                 limit=page_length,
                 work_queue_filter=WorkQueueFilter(

--- a/tests/agent/test_agent_queue_selection.py
+++ b/tests/agent/test_agent_queue_selection.py
@@ -1,0 +1,61 @@
+from prefect.agent import PrefectAgent
+from prefect.client.orchestration import PrefectClient
+from prefect.client.schemas.actions import WorkPoolCreate
+
+
+async def test_select_default_agent_queues_only_returns_default_queues(
+    prefect_client: PrefectClient,
+):
+    p1 = await prefect_client.create_work_pool(WorkPoolCreate(name="t1", type="ecs"))
+    p2 = await prefect_client.create_work_pool(
+        WorkPoolCreate(name="t2", type="prefect-agent")
+    )
+    q1 = await prefect_client.create_work_queue(
+        name="prod-deployment-1", work_pool_name=p1.name
+    )
+    q2 = await prefect_client.create_work_queue(
+        name="prod-deployment-2", work_pool_name=p2.name
+    )
+
+    async with PrefectAgent(work_queues=[q1.name, q2.name]) as agent:
+        results = await agent._select_default_agent_queues(prefect_client, [q1, q2])
+
+    # verify we only selected the queue with the default "prefect-agent" work pool
+    assert results == [q2]
+
+
+async def test_get_work_queues_returns_default_queues(prefect_client: PrefectClient):
+    import random
+
+    from prefect.server.models.workers import DEFAULT_AGENT_WORK_POOL_NAME
+
+    # delete the default WorkPool if it exists, otherwise WorkQueue queries will
+    # always search within it
+    try:
+        await prefect_client.delete_work_pool(DEFAULT_AGENT_WORK_POOL_NAME)
+    except Exception:
+        pass
+
+    # two WorkPools to associate with our WorkQueues
+    p1 = await prefect_client.create_work_pool(WorkPoolCreate(name="p1", type="ecs"))
+    agent_pool = await prefect_client.create_work_pool(
+        WorkPoolCreate(name="p2", type="prefect-agent")
+    )
+
+    # create WorkQueues, associating them with a pool at random
+    expected = set()
+    for i in range(10):
+        random_pool = random.choice([p1, agent_pool])
+        q = await prefect_client.create_work_queue(
+            name="test-{i}".format(i=i), work_pool_name=random_pool.name
+        )
+        if random_pool == agent_pool:
+            expected.add(q.name)
+
+    # create an agent with a prefix that matches all of the created queues
+    async with PrefectAgent(work_queue_prefix=["test-"]) as agent:
+        results = {q.name async for q in agent.get_work_queues()}
+
+    # verify that only WorkQueues with a default pool type are returned for
+    # this agent since it does not have a work pool name
+    assert results == expected

--- a/tests/agent/test_agent_queue_selection.py
+++ b/tests/agent/test_agent_queue_selection.py
@@ -6,27 +6,6 @@ from prefect.client.schemas.actions import WorkPoolCreate
 from prefect.server.models.workers import DEFAULT_AGENT_WORK_POOL_NAME
 
 
-async def test_select_default_agent_queues_only_returns_default_queues(
-    prefect_client: PrefectClient,
-):
-    p1 = await prefect_client.create_work_pool(WorkPoolCreate(name="t1", type="ecs"))
-    p2 = await prefect_client.create_work_pool(
-        WorkPoolCreate(name="t2", type="prefect-agent")
-    )
-    q1 = await prefect_client.create_work_queue(
-        name="prod-deployment-1", work_pool_name=p1.name
-    )
-    q2 = await prefect_client.create_work_queue(
-        name="prod-deployment-2", work_pool_name=p2.name
-    )
-
-    async with PrefectAgent(work_queues=[q1.name, q2.name]) as agent:
-        results = await agent._select_default_agent_queues(prefect_client, [q1, q2])
-
-    # verify we only selected the queue with the default "prefect-agent" work pool
-    assert results == [q2]
-
-
 async def test_get_work_queues_returns_default_queues(prefect_client: PrefectClient):
     # create WorkPools to associate with our WorkQueues
     default = await prefect_client.create_work_pool(

--- a/tests/agent/test_agent_queue_selection.py
+++ b/tests/agent/test_agent_queue_selection.py
@@ -1,6 +1,9 @@
+import random
+
 from prefect.agent import PrefectAgent
 from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.actions import WorkPoolCreate
+from prefect.server.models.workers import DEFAULT_AGENT_WORK_POOL_NAME
 
 
 async def test_select_default_agent_queues_only_returns_default_queues(
@@ -25,19 +28,11 @@ async def test_select_default_agent_queues_only_returns_default_queues(
 
 
 async def test_get_work_queues_returns_default_queues(prefect_client: PrefectClient):
-    import random
-
-    from prefect.server.models.workers import DEFAULT_AGENT_WORK_POOL_NAME
-
-    # delete the default WorkPool if it exists, otherwise WorkQueue queries will
-    # always search within it
-    try:
-        await prefect_client.delete_work_pool(DEFAULT_AGENT_WORK_POOL_NAME)
-    except Exception:
-        pass
-
-    # two WorkPools to associate with our WorkQueues
-    p1 = await prefect_client.create_work_pool(WorkPoolCreate(name="p1", type="ecs"))
+    # create WorkPools to associate with our WorkQueues
+    default = await prefect_client.create_work_pool(
+        WorkPoolCreate(name=DEFAULT_AGENT_WORK_POOL_NAME, type="prefect-agent")
+    )
+    ecs = await prefect_client.create_work_pool(WorkPoolCreate(name="p1", type="ecs"))
     agent_pool = await prefect_client.create_work_pool(
         WorkPoolCreate(name="p2", type="prefect-agent")
     )
@@ -45,17 +40,17 @@ async def test_get_work_queues_returns_default_queues(prefect_client: PrefectCli
     # create WorkQueues, associating them with a pool at random
     expected = set()
     for i in range(10):
-        random_pool = random.choice([p1, agent_pool])
+        random_pool = random.choice([default, ecs, agent_pool])
         q = await prefect_client.create_work_queue(
             name="test-{i}".format(i=i), work_pool_name=random_pool.name
         )
-        if random_pool == agent_pool:
+        if random_pool == default:
             expected.add(q.name)
 
     # create an agent with a prefix that matches all of the created queues
     async with PrefectAgent(work_queue_prefix=["test-"]) as agent:
         results = {q.name async for q in agent.get_work_queues()}
 
-    # verify that only WorkQueues with a default pool type are returned for
+    # verify that only WorkQueues with in the default pool are returned for
     # this agent since it does not have a work pool name
     assert results == expected

--- a/tests/agent/test_agent_run_submission.py
+++ b/tests/agent/test_agent_run_submission.py
@@ -10,6 +10,8 @@ from prefect import flow
 from prefect.agent import PrefectAgent
 from prefect.blocks.core import Block
 from prefect.client.orchestration import PrefectClient
+from prefect.client.schemas.actions import WorkPoolCreate
+from prefect.client.schemas.objects import DEFAULT_AGENT_WORK_POOL_NAME
 from prefect.exceptions import Abort, CrashedRun, FailedRun
 from prefect.infrastructure.base import Infrastructure
 from prefect.server import models, schemas
@@ -282,8 +284,12 @@ async def test_agent_creates_work_queue_if_doesnt_exist_in_work_pool(
 
 
 async def test_agent_does_not_create_work_queues_if_matching_with_prefix(
-    session, prefect_caplog
+    session, prefect_caplog, prefect_client: PrefectClient
 ):
+    await prefect_client.create_work_pool(
+        WorkPoolCreate(name=DEFAULT_AGENT_WORK_POOL_NAME, type="prefect-agent")
+    )
+
     name = "hello-there"
     assert not await models.work_queues.read_work_queue_by_name(
         session=session, name=name

--- a/tests/cli/test_start_agent.py
+++ b/tests/cli/test_start_agent.py
@@ -6,6 +6,8 @@ import tempfile
 import anyio
 import pytest
 
+import prefect.server.models as models
+import prefect.server.schemas as schemas
 from prefect.settings import get_current_settings
 from prefect.utilities.processutils import open_process
 
@@ -22,6 +24,24 @@ async def safe_shutdown(process):
         # try twice in case process.wait() hangs
         with anyio.fail_after(SHUTDOWN_TIMEOUT):
             await process.wait()
+
+
+@pytest.fixture(autouse=True)
+async def ensure_default_agent_pool_exists(session):
+    # The default agent work pool is created by a migration, but is cleared on
+    # consecutive test runs. This fixture ensures that the default agent work
+    # pool exists before each test.
+    default_work_pool = await models.workers.read_work_pool_by_name(
+        session=session, work_pool_name=models.workers.DEFAULT_AGENT_WORK_POOL_NAME
+    )
+    if default_work_pool is None:
+        await models.workers.create_work_pool(
+            session=session,
+            work_pool=schemas.actions.WorkPoolCreate(
+                name=models.workers.DEFAULT_AGENT_WORK_POOL_NAME, type="prefect-agent"
+            ),
+        )
+        await session.commit()
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Resolves https://github.com/PrefectHQ/prefect/issues/10743

From the issue:
> When you start an agent listening to only a queue (e.g. prefect agent start -q default) it polls for flow runs across all work pools of all types (as opposed to only the prefect-agent type)

This PR updates the agent's behavior so that it will poll for flow runs in `prefect-agent` type WorkPools if no WorkPool is explicitly passed to the agent. This will should help prevent the agent from accidentally picking up work meant for other agents.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
