### PR TITLE
Flow run filter for fetching the (first-level) subflows of a given flow

### DIFF
--- a/src/prefect/client/schemas/filters.py
+++ b/src/prefect/client/schemas/filters.py
@@ -235,6 +235,14 @@ class FlowRunFilterNextScheduledStartTime(PrefectBaseModel):
     )
 
 
+class FlowRunFilterParentFlowRunId(PrefectBaseModel, OperatorMixin):
+    """Filter for subflows of the given flow runs"""
+
+    any_: Optional[List[UUID]] = Field(
+        default=None, description="A list of flow run parents to include"
+    )
+
+
 class FlowRunFilterParentTaskRunId(PrefectBaseModel, OperatorMixin):
     """Filter by `FlowRun.parent_task_run_id`."""
 


### PR DESCRIPTION
Adds a filter where, given the ID of a flow run, it filters all the direct
subflows of that flow (not recursive).

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
