### PR TITLE
Adds `/deployments/get_scheduled_flow_runs` endpoint

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -78,6 +78,7 @@ from prefect.client.schemas.objects import (
 )
 from prefect.client.schemas.responses import (
     DeploymentResponse,
+    FlowRunResponse,
     WorkerFlowRunResponse,
 )
 from prefect.client.schemas.schedules import SCHEDULE_TYPES
@@ -2353,6 +2354,25 @@ class PrefectClient:
             response = await self._client.post("/work_queues/filter", json=json)
 
         return pydantic.parse_obj_as(List[WorkQueue], response.json())
+
+    async def get_scheduled_flow_runs_for_deployments(
+        self,
+        deployment_ids: List[UUID],
+        scheduled_before: Optional[datetime.datetime] = None,
+        limit: Optional[int] = None,
+    ):
+        body: Dict[str, Any] = dict(deployment_ids=[str(id) for id in deployment_ids])
+        if scheduled_before:
+            body["scheduled_before"] = str(scheduled_before)
+        if limit:
+            body["limit"] = limit
+
+        response = await self._client.post(
+            "/deployments/get_scheduled_flow_runs",
+            json=body,
+        )
+
+        return pydantic.parse_obj_as(List[FlowRunResponse], response.json())
 
     async def get_scheduled_flow_runs_for_work_pool(
         self,

--- a/src/prefect/client/schemas/responses.py
+++ b/src/prefect/client/schemas/responses.py
@@ -154,6 +154,7 @@ class FlowRunResponse(ObjectBaseModel):
     flow_id: UUID = FieldFrom(objects.FlowRun)
     state_id: Optional[UUID] = FieldFrom(objects.FlowRun)
     deployment_id: Optional[UUID] = FieldFrom(objects.FlowRun)
+    work_queue_id: Optional[UUID] = FieldFrom(objects.FlowRun)
     work_queue_name: Optional[str] = FieldFrom(objects.FlowRun)
     flow_version: Optional[str] = FieldFrom(objects.FlowRun)
     parameters: dict = FieldFrom(objects.FlowRun)
@@ -176,6 +177,7 @@ class FlowRunResponse(ObjectBaseModel):
     infrastructure_document_id: Optional[UUID] = FieldFrom(objects.FlowRun)
     infrastructure_pid: Optional[str] = FieldFrom(objects.FlowRun)
     created_by: Optional[CreatedBy] = FieldFrom(objects.FlowRun)
+    work_pool_id: Optional[UUID] = FieldFrom(objects.FlowRun)
     work_pool_name: Optional[str] = Field(
         default=None,
         description="The name of the flow run's work pool.",

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -284,6 +284,46 @@ async def read_deployments(
         ]
 
 
+@router.post("/get_scheduled_flow_runs")
+async def get_scheduled_flow_runs_for_deployments(
+    deployment_ids: List[UUID] = Body(
+        default=..., description="The deployment IDs to get scheduled runs for"
+    ),
+    scheduled_before: DateTimeTZ = Body(
+        None, description="The maximum time to look for scheduled flow runs"
+    ),
+    limit: int = dependencies.LimitBody(),
+    db: PrefectDBInterface = Depends(provide_database_interface),
+) -> List[schemas.responses.FlowRunResponse]:
+    """
+    Get scheduled runs for a set of deployments. Used by a runner to poll for work.
+    """
+    async with db.session_context() as session:
+        orm_flow_runs = await models.flow_runs.read_flow_runs(
+            session=session,
+            limit=limit,
+            deployment_filter=schemas.filters.DeploymentFilter(
+                id=schemas.filters.DeploymentFilterId(any_=deployment_ids),
+            ),
+            flow_run_filter=schemas.filters.FlowRunFilter(
+                next_scheduled_start_time=schemas.filters.FlowRunFilterNextScheduledStartTime(
+                    before_=scheduled_before
+                ),
+                state=schemas.filters.FlowRunFilterState(
+                    type=schemas.filters.FlowRunFilterStateType(
+                        any_=[schemas.states.StateType.SCHEDULED]
+                    )
+                ),
+            ),
+            sort=schemas.sorting.FlowRunSort.NEXT_SCHEDULED_START_TIME_ASC,
+        )
+
+        return [
+            schemas.responses.FlowRunResponse.from_orm(orm_flow_run=orm_flow_run)
+            for orm_flow_run in orm_flow_runs
+        ]
+
+
 @router.post("/count")
 async def count_deployments(
     flows: schemas.filters.FlowFilter = None,

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -349,8 +349,12 @@ class FlowRunFilterStateName(PrefectFilterBaseModel):
 class FlowRunFilterState(PrefectOperatorFilterBaseModel):
     """Filter by `FlowRun.state_type` and `FlowRun.state_name`."""
 
-    type: Optional[FlowRunFilterStateType]
-    name: Optional[FlowRunFilterStateName]
+    type: Optional[FlowRunFilterStateType] = Field(
+        default=None, description="Filter criteria for `FlowRun.state_type`"
+    )
+    name: Optional[FlowRunFilterStateName] = Field(
+        default=None, description="Filter criteria for `FlowRun.state_name`"
+    )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
         filters = []


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

Adds a new route for retrieving the scheduled flow runs for a set of deployments. This moves the filters used by runners server-side and will be used to track deployments that are actively being polled by a runner. Updates `Runner` class to use the new route. Status tracking for deployments will be added in a later PR.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
