### PR TITLE
raise `RuntimeError` if `pip_install_requirements` fails

### DIFF
--- a/src/prefect/deployments/steps/utility.py
+++ b/src/prefect/deployments/steps/utility.py
@@ -247,7 +247,7 @@ async def pip_install_requirements(
 
         if process.returncode != 0:
             raise RuntimeError(
-                f"pip install failed with error code {process.returncode}:"
+                f"pip_install_requirements failed with error code {process.returncode}:"
                 f" {stderr_sink.getvalue()}"
             )
 

--- a/src/prefect/deployments/steps/utility.py
+++ b/src/prefect/deployments/steps/utility.py
@@ -245,6 +245,12 @@ async def pip_install_requirements(
         )
         await process.wait()
 
+        if process.returncode != 0:
+            raise RuntimeError(
+                f"pip install failed with error code {process.returncode}:"
+                f" {stderr_sink.getvalue()}"
+            )
+
     return {
         "stdout": stdout_sink.getvalue().strip(),
         "stderr": stderr_sink.getvalue().strip(),

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -1189,7 +1189,7 @@ class TestPipInstallRequirements:
                 }
             )
         assert (
-            "pip install failed with error code 1: ERROR: Could not open "
+            "pip_install_requirements failed with error code 1: ERROR: Could not open "
             "requirements file: [Errno 2] No such file or directory: "
             "'doesnt-exist.txt'"
             in str(exc.value)

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -1178,7 +1178,7 @@ class TestPipInstallRequirements:
             stdout=ANY,
         )
 
-    async def test_pip_install_fails_on_error(self, monkeypatch):
+    async def test_pip_install_fails_on_error(self):
         with pytest.raises(RuntimeError) as exc:
             await run_step(
                 {

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -1052,9 +1052,23 @@ class TestRunShellScript:
         assert result["stderr"] == ""
 
 
+class MockProcess:
+    def __init__(self, returncode=0):
+        self.returncode = returncode
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def wait(self):
+        pass
+
+
 class TestPipInstallRequirements:
     async def test_pip_install_reqs_runs_expected_command(self, monkeypatch):
-        open_process_mock = MagicMock()
+        open_process_mock = MagicMock(return_value=MockProcess(0))
         monkeypatch.setattr(
             "prefect.deployments.steps.utility.open_process",
             open_process_mock,
@@ -1083,7 +1097,7 @@ class TestPipInstallRequirements:
         )
 
     async def test_pip_install_reqs_custom_requirements_file(self, monkeypatch):
-        open_process_mock = MagicMock()
+        open_process_mock = MagicMock(return_value=MockProcess(0))
         monkeypatch.setattr(
             "prefect.deployments.steps.utility.open_process",
             open_process_mock,
@@ -1121,7 +1135,7 @@ class TestPipInstallRequirements:
             subprocess_mock,
         )
 
-        open_process_mock = MagicMock()
+        open_process_mock = MagicMock(return_value=MockProcess(0))
         monkeypatch.setattr(
             "prefect.deployments.steps.utility.open_process",
             open_process_mock,

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -1177,3 +1177,20 @@ class TestPipInstallRequirements:
             stderr=ANY,
             stdout=ANY,
         )
+
+    async def test_pip_install_fails_on_error(self, monkeypatch):
+        with pytest.raises(RuntimeError) as exc:
+            await run_step(
+                {
+                    "prefect.deployments.steps.pip_install_requirements": {
+                        "id": "pip-install-step",
+                        "requirements_file": "doesnt-exist.txt",
+                    }
+                }
+            )
+        assert (
+            "pip install failed with error code 1: ERROR: Could not open "
+            "requirements file: [Errno 2] No such file or directory: "
+            "'doesnt-exist.txt'"
+            in str(exc.value)
+        )


### PR DESCRIPTION
Previously `pip_install_requirements` would silently fail. This would lead to `ModuleNotFound` errors in user flows.
This pr updates it to raise a `RuntimeError` similar to the other utility steps to indicate that something has happened

closes: https://github.com/PrefectHQ/prefect/issues/10822

Example:
```
18:24:17.652 | ERROR   | Flow run 'truthful-pronghorn' - Flow could not be retrieved from deployment.
Traceback (most recent call last):
  File "/Users/jakekaplan/PycharmProjects/prefect/src/prefect/deployments/steps/core.py", line 124, in run_steps
    step_output = await run_step(step, upstream_outputs)
  File "/Users/jakekaplan/PycharmProjects/prefect/src/prefect/deployments/steps/core.py", line 95, in run_step
    result = await from_async.call_soon_in_new_thread(
  File "/Users/jakekaplan/PycharmProjects/prefect/src/prefect/_internal/concurrency/calls.py", line 291, in aresult
    return await asyncio.wrap_future(self.future)
  File "/Users/jakekaplan/PycharmProjects/prefect/src/prefect/_internal/concurrency/calls.py", line 345, in _run_async
    result = await coro
  File "/Users/jakekaplan/PycharmProjects/prefect/src/prefect/deployments/steps/utility.py", line 248, in pip_install_requirements
    raise RuntimeError(
RuntimeError: pip install failed with error code 1. ERROR: Could not find a version that satisfies the requirement alkdsmfajksdnf (from versions: none)
ERROR: No matching distribution found for alkdsmfajksdnf


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/jakekaplan/PycharmProjects/prefect/src/prefect/engine.py", line 394, in retrieve_flow_then_begin_flow_run
    flow = await load_flow_from_flow_run(flow_run, client=client)
  File "/Users/jakekaplan/PycharmProjects/prefect/src/prefect/client/utilities.py", line 51, in with_injected_client
    return await fn(*args, **kwargs)
  File "/Users/jakekaplan/PycharmProjects/prefect/src/prefect/deployments/deployments.py", line 217, in load_flow_from_flow_run
    output = await run_steps(deployment.pull_steps)
  File "/Users/jakekaplan/PycharmProjects/prefect/src/prefect/deployments/steps/core.py", line 152, in run_steps
    raise StepExecutionError(f"Encountered error while running {fqn}") from exc
prefect.deployments.steps.core.StepExecutionError: Encountered error while running prefect.deployments.steps.pip_install_requirements
```