### PR TITLE
Update `git_clone` deployment step example in documentation

### DIFF
--- a/docs/guides/prefect-deploy.md
+++ b/docs/guides/prefect-deploy.md
@@ -343,12 +343,11 @@ Below is an example of installing dependencies from a `requirements.txt` file af
 ```yaml
 pull:
     - prefect.deployments.steps.git_clone:
-        id: clone-step
+        id: clone-step  # needed in order to be referenced in subsequent steps
         repository: https://github.com/org/repo.git
     - prefect.deployments.steps.pip_install_requirements:
-        directory: {{ clone-step.directory }}
+        directory: {{ clone-step.directory }}  #  `clone-step` is a user-provided `id` field
         requirements_file: requirements.txt
-        stream_output: False
 ```
 
 Below is an example that retrieves an access token from a 3rd party Key Vault and uses it in a private clone step:

--- a/docs/guides/prefect-deploy.md
+++ b/docs/guides/prefect-deploy.md
@@ -346,7 +346,7 @@ pull:
         id: clone-step  # needed in order to be referenced in subsequent steps
         repository: https://github.com/org/repo.git
     - prefect.deployments.steps.pip_install_requirements:
-        directory: {{ clone-step.directory }}  #  `clone-step` is a user-provided `id` field
+        directory: {{ clone-step.directory }}  # `clone-step` is a user-provided `id` field
         requirements_file: requirements.txt
 ```
 


### PR DESCRIPTION
This PR updates the example `git_clone` step to make some clarifications:
- `stream_output` is default `true`. I think we shouldn't suggest setting it to `false` through our example.
- add comments so that users do not think that `id` is a field that is automatically set.

[Relevant community thread](https://prefect-community.slack.com/archives/CL09KU1K7/p1695682647749099?thread_ts=1695675921.948819&cid=CL09KU1K7)

### Preview
<img width="649" alt="Screenshot 2023-09-26 at 3 06 52 PM" src="https://github.com/PrefectHQ/prefect/assets/42048900/2a5b56bc-121c-4a92-8432-15d677704a1a">


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
