### PR TITLE
Add `prefect deploy` guide to guide index for visibility 

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -38,6 +38,7 @@ This section of the documentation contains guides for common workflows and use c
 
 | Title                                                  | Description                                                                                        |
 | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| [Deploying Flows to Work Pools and Workers](/guides/prefect-deploy/) | Learn how to easily manage your code and deployments. |
 | [Upgrade from Agents to Workers](/guides/upgrade-guide-agents-to-workers/) | Why and how to upgrade from Agents to Workers. |
 | [Storage](/guides/deployment/storage-guide/) | Store your code for deployed flows. |
 | [Kubernetes](/guides/deployment/kubernetes/) | Deploy flows on Kubernetes. |


### PR DESCRIPTION
We currently provide 2 links to the [prefect deploy guide](https://docs.prefect.io/latest/guides/prefect-deploy/) in our [deployments concept page](https://docs.prefect.io/latest/concepts/deployments/) but we don't include it in [our guides index](https://docs.prefect.io/latest/guides/) (the guides landing page). This PR adds the guide to the index.

### Preview
<img width="644" alt="Screenshot 2023-09-26 at 3 09 38 PM" src="https://github.com/PrefectHQ/prefect/assets/42048900/2efa34bd-e86f-4521-b888-9766ca43a715">


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
