### PR TITLE
Use only the security suite from CodeQL

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,23 +1,7 @@
 query-filters:
   - exclude:
-      # this creates many false positives with our code
-      id: py/unsafe-cyclic-import
-  - exclude:
-      id: py/cyclic-import
-  - exclude:
-      id: py/unreachable-statement
-  - exclude:
       # catching base exceptions is required
       id: py/catch-base-exception
-  - exclude:
-      # too many false positives with prefect.runtime
-      id: py/undefined-export
-  - exclude:
-      # sometimes necessary for __init__ files
-      id: py/import-and-import-from
-  - exclude:
-      # we dont need CodeQL quality linting
-      id: py/mixed-returns
 
 paths-ignore:
   - tests/**/test_*.py

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql-config.yml
-          queries: security-and-quality
+          queries: security-extended
           setup-python-dependencies: false
 
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
We now use `ruff` for our quality checks, which are run via `pre-commit` for
developers locally and also during CI.  The CodeQL security checks are a
valuable signal, but they are often lost in the noise of regular linting.  Here
we downshift our use of CodeQL to the `security-extended` suite.
