### PR TITLE
Use a fixed list of known registry views rather than using the user's input

### DIFF
--- a/src/prefect/server/api/collections.py
+++ b/src/prefect/server/api/collections.py
@@ -10,12 +10,27 @@ router = PrefectRouter(prefix="/collections", tags=["Collections"])
 
 GLOBAL_COLLECTIONS_VIEW_CACHE: TTLCache = TTLCache(maxsize=200, ttl=60 * 10)
 
+REGISTRY_VIEWS = (
+    "https://raw.githubusercontent.com/PrefectHQ/prefect-collection-registry/main/views"
+)
+KNOWN_VIEWS = {
+    "aggregate-block-metadata": f"{REGISTRY_VIEWS}/aggregate-block-metadata.json",
+    "aggregate-flow-metadata": f"{REGISTRY_VIEWS}/aggregate-flow-metadata.json",
+    "aggregate-worker-metadata": f"{REGISTRY_VIEWS}/aggregate-worker-metadata.json",
+    "demo-flows": f"{REGISTRY_VIEWS}/demo-flows.json",
+}
+
 
 @router.get("/views/{view}")
 async def read_view_content(view: str) -> Dict[str, Any]:
     """Reads the content of a view from the prefect-collection-registry."""
     try:
         return await get_collection_view(view)
+    except KeyError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"View {view} not found in registry",
+        )
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code == 404:
             raise HTTPException(
@@ -30,18 +45,11 @@ async def get_collection_view(view: str):
     try:
         return GLOBAL_COLLECTIONS_VIEW_CACHE[view]
     except KeyError:
-        repo_organization = "PrefectHQ"
-        repo_name = "prefect-collection-registry"
+        pass
 
-        repo_url = (
-            f"https://raw.githubusercontent.com/{repo_organization}/{repo_name}/main"
-        )
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(KNOWN_VIEWS[view])
+        resp.raise_for_status()
 
-        view_filename = f"{view}.json"
-
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(repo_url + f"/views/{view_filename}")
-            resp.raise_for_status()
-
-            GLOBAL_COLLECTIONS_VIEW_CACHE[view] = resp.json()
-            return resp.json()
+        GLOBAL_COLLECTIONS_VIEW_CACHE[view] = resp.json()
+        return resp.json()

--- a/tests/server/api/test_collections.py
+++ b/tests/server/api/test_collections.py
@@ -63,7 +63,7 @@ class TestReadCollectionViews:
         respx_mock.get(self.collection_view_url("block")).mock(
             return_value=Response(200, json=mock_block_response)
         )
-        respx_mock.get(self.collection_view_url("collection")).mock(
+        respx_mock.get(self.collection_view_url("worker")).mock(
             return_value=Response(404, json=mock_collection_response)
         )
 
@@ -79,20 +79,18 @@ class TestReadCollectionViews:
         assert isinstance(res.json(), dict)
 
     async def test_read_collection_view_when_missing(self, client, mock_get_view):
-        res = await client.get("/collections/views/aggregate-collection-metadata")
+        res = await client.get("/collections/views/aggregate-worker-metadata")
         detail = res.json()["detail"]
 
         assert res.status_code == 404
-        assert (
-            detail == "Requested content missing for view aggregate-collection-metadata"
-        )
+        assert detail == "Requested content missing for view aggregate-worker-metadata"
 
     async def test_read_collection_view_invalid(self, client):
         res = await client.get("/collections/views/invalid")
         detail = res.json()["detail"]
 
         assert res.status_code == 404
-        assert detail == "Requested content missing for view invalid"
+        assert detail == "View invalid not found in registry"
 
     @pytest.mark.parametrize(
         "view", ["aggregate-flow-metadata", "aggregate-block-metadata"]


### PR DESCRIPTION
CodeQL identified a partial server-side request forgery with a pretty limited
blast radius.  It could be exploited to cause a bunch of 404s at Github in a
very specific repo, but not likely any further harm than that.  Using a fixed
list of known views prevents us from even attempting the request for unknown
views.
