### PR TITLE
Fix: Bump prefect-ui-library to 2.0.16

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@prefecthq/graphs": "1.1.0",
         "@prefecthq/prefect-design": "2.0.11",
-        "@prefecthq/prefect-ui-library": "2.0.15",
+        "@prefecthq/prefect-ui-library": "2.0.16",
         "@prefecthq/vue-charts": "2.0.3",
         "@prefecthq/vue-compositions": "1.6.3",
         "@types/lodash.debounce": "4.0.7",
@@ -1338,9 +1338,9 @@
       }
     },
     "node_modules/@prefecthq/prefect-ui-library": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.0.15.tgz",
-      "integrity": "sha512-eJReLnSY0pWLhuwiIkNIGI2ELrZ1guKixzWbrhzlSj3cjIYyQltTq9GMAYqdwDDTe5VojLe29Uef2OtOqAf5cA==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.0.16.tgz",
+      "integrity": "sha512-t4t8ANdEjQ60Zx54z194TDPXJizW9Y209sFso+HaJv7TAaQr7RAXC1gG5ITE3u/moeugIe9xFMaUCqfaIqzpCQ==",
       "dependencies": {
         "@prefecthq/graphs": "1.1.0",
         "@types/lodash.isequal": "4.5.6",
@@ -7221,9 +7221,9 @@
       }
     },
     "@prefecthq/prefect-ui-library": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.0.15.tgz",
-      "integrity": "sha512-eJReLnSY0pWLhuwiIkNIGI2ELrZ1guKixzWbrhzlSj3cjIYyQltTq9GMAYqdwDDTe5VojLe29Uef2OtOqAf5cA==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.0.16.tgz",
+      "integrity": "sha512-t4t8ANdEjQ60Zx54z194TDPXJizW9Y209sFso+HaJv7TAaQr7RAXC1gG5ITE3u/moeugIe9xFMaUCqfaIqzpCQ==",
       "requires": {
         "@prefecthq/graphs": "1.1.0",
         "@types/lodash.isequal": "4.5.6",

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@prefecthq/graphs": "1.1.0",
     "@prefecthq/prefect-design": "2.0.11",
-    "@prefecthq/prefect-ui-library": "2.0.15",
+    "@prefecthq/prefect-ui-library": "2.0.16",
     "@prefecthq/vue-charts": "2.0.3",
     "@prefecthq/vue-compositions": "1.6.3",
     "@types/lodash.debounce": "4.0.7",


### PR DESCRIPTION
This PR brings in a fix for a minor issue where the custom flow run filter option is erroneously tagged as (default).

Upstream fix - https://github.com/PrefectHQ/prefect-ui-library/pull/1786

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
