### PR TITLE
Adding explicit tests for the format of the `PREFECT__FLOW_RUN_ID` env var

### DIFF
--- a/tests/server/api/test_flow_runs.py
+++ b/tests/server/api/test_flow_runs.py
@@ -1,4 +1,5 @@
 from typing import List
+from unittest import mock
 from uuid import UUID, uuid4
 
 import pendulum
@@ -259,6 +260,34 @@ class TestReadFlowRun:
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["id"] == str(flow_run.id)
         assert response.json()["flow_id"] == str(flow.id)
+
+    async def test_read_flow_run_like_the_engine_does(self, flow, flow_run, client):
+        """Regression test for the hex format of UUIDs in `PREFECT__FLOW_RUN_ID`
+
+        The only route that is requested in this way is `GET /flow_runs/{id}`; other
+        methods aren't affected because they are based on prior requests for flow runs
+        and will use a fully-formatted UUID with dashes.
+        """
+
+        flow_run_id = flow_run.id.hex
+        assert "-" not in flow_run_id
+        assert len(flow_run_id) == 32
+
+        response = await client.get(f"/flow_runs/{flow_run.id}")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["id"] == str(flow_run.id)
+        assert response.json()["flow_id"] == str(flow.id)
+
+    async def test_read_flow_run_with_invalid_id_is_rejected(self, client):
+        """Additional safety check with for the above regression test to confirm that
+        we're not attempting query with any old string as a flow run ID."""
+        with mock.patch("prefect.server.models.flow_runs.read_flow_run") as mock_read:
+            response = await client.get("/flow_runs/THISAINTIT")
+            # Ideally this would be a 404, but we're letting FastAPI take care of this
+            # at the parameter parsing level, so it's a 422
+            assert response.status_code == 422
+
+        mock_read.assert_not_called()
 
     async def test_read_flow_run_with_state(self, flow_run, client, session):
         state_id = uuid4()


### PR DESCRIPTION
We had an incident where we caused a large number of 404s because we changed the
`read_flow_run` route to use the specifier `{id:uuid}`. This specifier expects
UUIDs to have dashes, but the `PREFECT__FLOW_RUN_ID` variable is produced with
`flow_run.id.hex` and will be a 32-character hex string without dashes.

This test makes it explicit that we're supporting that unexpected format so we
don't accidentally break this again.

Related to #10851
