### PR TITLE
Vendoring FastAPI as a first step toward `pydantic>2` support

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -21,3 +21,6 @@ ignore = ["E501"]
 
 # Do not enforce line length limits in migrations
 "src/prefect/server/database/migrations/**/*" = ["E501"]
+
+[isort]
+known-third-party = ["prefect._vendor"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiosqlite >= 0.17.0
 alembic >= 1.7.5, < 2.0.0
-anyio >= 3.4.0, < 4.0.0
+anyio >= 3.7.1, < 4.0.0
 apprise >= 1.1.0, < 2.0.0
 asgi-lifespan >= 1.0, < 3.0
 asyncpg >= 0.23
@@ -11,7 +11,6 @@ croniter >= 1.0.12, < 2.0.0
 cryptography >= 36.0.1
 dateparser >= 1.1.1, < 2.0.0
 docker >= 4.0, < 7.0
-fastapi >= 0.93
 fsspec >= 2022.5.0
 graphviz >= 0.20.1
 griffe >= 0.20.0
@@ -25,7 +24,8 @@ orjson >= 3.7, < 4.0
 packaging >= 21.3, < 24.3
 pathspec >= 0.8.0
 pendulum >= 2.1.2, < 3.0.0
-pydantic >= 1.10.0, < 2.0.0
+# the version constraints for pydantic are merged with those from fastapi 0.103.2
+pydantic>=1.10.0,< 2.0.0,>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0
 python-slugify >= 5.0, < 9.0
 pytz >= 2021.1, < 2024
 pyyaml >= 5.4.1, < 7.0.0
@@ -33,8 +33,9 @@ readchar >= 4.0.0, < 5.0.0
 rich >= 11.0, < 14.0
 ruamel-yaml >= 0.17.0
 sqlalchemy[asyncio] >= 1.4.22, != 1.4.33, < 3.0.0
+starlette >= 0.27.0, < 0.28.0
 toml >= 0.10.0
 typer >= 0.4.2
-typing_extensions >= 4.1.0, < 5.0.0
+typing_extensions >= 4.5.0, < 5.0.0
 uvicorn >= 0.14.0
 websockets >= 10.4

--- a/src/prefect/_vendor/README.md
+++ b/src/prefect/_vendor/README.md
@@ -1,0 +1,26 @@
+# Vendored dependencies of `prefect`
+
+## FastAPI, vendored from tiangolo/fastapi@0.103.2
+
+We are temporarily vendoring `fastapi` to help us untangle `pydantic` requirements as we
+gradually bring `pydantic>2` support to `prefect`.  FastAPI's compatibility layer
+makes a strong assumption that having `pydantic>2` installed means that all of your
+models are v2 models.  We will be adjusting that compatibility layer accordingly.
+
+If we do need to update the version before we're done with it:
+
+```
+VERSION=0.103.2
+rm -Rf /tmp/fastapi
+git clone https://github.com/tiangolo/fastapi -b $VERSION /tmp/fastapi
+rsync -ravdP /tmp/fastapi/fastapi/ src/prefect/_vendor/fastapi/
+```
+
+After syncing the files up, replace any internal references to `fastapi` within FastAPI
+to refer to the module as `prefect._vendor.fastapi`.  So replace all:
+
+* `import fastapi` -> `import prefect._vendor.fastapi`
+* `from fastapi` -> `from prefect._vendor.fastapi`
+
+Please also review `/tmp/fastapi/pyproject.toml` to review the `dependencies` section to
+see if our versions need to be updated too.

--- a/src/prefect/_vendor/fastapi/__init__.py
+++ b/src/prefect/_vendor/fastapi/__init__.py
@@ -1,0 +1,25 @@
+"""FastAPI framework, high performance, easy to learn, fast to code, ready for production"""
+
+__version__ = "0.103.2"
+
+from starlette import status as status
+
+from .applications import FastAPI as FastAPI
+from .background import BackgroundTasks as BackgroundTasks
+from .datastructures import UploadFile as UploadFile
+from .exceptions import HTTPException as HTTPException
+from .exceptions import WebSocketException as WebSocketException
+from .param_functions import Body as Body
+from .param_functions import Cookie as Cookie
+from .param_functions import Depends as Depends
+from .param_functions import File as File
+from .param_functions import Form as Form
+from .param_functions import Header as Header
+from .param_functions import Path as Path
+from .param_functions import Query as Query
+from .param_functions import Security as Security
+from .requests import Request as Request
+from .responses import Response as Response
+from .routing import APIRouter as APIRouter
+from .websockets import WebSocket as WebSocket
+from .websockets import WebSocketDisconnect as WebSocketDisconnect

--- a/src/prefect/_vendor/fastapi/_compat.py
+++ b/src/prefect/_vendor/fastapi/_compat.py
@@ -1,0 +1,629 @@
+from collections import deque
+from copy import copy
+from dataclasses import dataclass, is_dataclass
+from enum import Enum
+from typing import (
+    Any,
+    Callable,
+    Deque,
+    Dict,
+    FrozenSet,
+    List,
+    Mapping,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
+
+from prefect._vendor.fastapi.exceptions import RequestErrorModel
+from prefect._vendor.fastapi.types import IncEx, ModelNameMap, UnionType
+from pydantic import BaseModel, create_model
+from pydantic.version import VERSION as PYDANTIC_VERSION
+from starlette.datastructures import UploadFile
+from typing_extensions import Annotated, Literal, get_args, get_origin
+
+PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
+
+
+sequence_annotation_to_type = {
+    Sequence: list,
+    List: list,
+    list: list,
+    Tuple: tuple,
+    tuple: tuple,
+    Set: set,
+    set: set,
+    FrozenSet: frozenset,
+    frozenset: frozenset,
+    Deque: deque,
+    deque: deque,
+}
+
+sequence_types = tuple(sequence_annotation_to_type.keys())
+
+if PYDANTIC_V2:
+    from pydantic import PydanticSchemaGenerationError as PydanticSchemaGenerationError
+    from pydantic import TypeAdapter
+    from pydantic import ValidationError as ValidationError
+    from pydantic._internal._schema_generation_shared import (  # type: ignore[attr-defined]
+        GetJsonSchemaHandler as GetJsonSchemaHandler,
+    )
+    from pydantic._internal._typing_extra import eval_type_lenient
+    from pydantic._internal._utils import lenient_issubclass as lenient_issubclass
+    from pydantic.fields import FieldInfo
+    from pydantic.json_schema import GenerateJsonSchema as GenerateJsonSchema
+    from pydantic.json_schema import JsonSchemaValue as JsonSchemaValue
+    from pydantic_core import CoreSchema as CoreSchema
+    from pydantic_core import PydanticUndefined, PydanticUndefinedType
+    from pydantic_core import Url as Url
+
+    try:
+        from pydantic_core.core_schema import (
+            with_info_plain_validator_function as with_info_plain_validator_function,
+        )
+    except ImportError:  # pragma: no cover
+        from pydantic_core.core_schema import (
+            general_plain_validator_function as with_info_plain_validator_function,  # noqa: F401
+        )
+
+    Required = PydanticUndefined
+    Undefined = PydanticUndefined
+    UndefinedType = PydanticUndefinedType
+    evaluate_forwardref = eval_type_lenient
+    Validator = Any
+
+    class BaseConfig:
+        pass
+
+    class ErrorWrapper(Exception):
+        pass
+
+    @dataclass
+    class ModelField:
+        field_info: FieldInfo
+        name: str
+        mode: Literal["validation", "serialization"] = "validation"
+
+        @property
+        def alias(self) -> str:
+            a = self.field_info.alias
+            return a if a is not None else self.name
+
+        @property
+        def required(self) -> bool:
+            return self.field_info.is_required()
+
+        @property
+        def default(self) -> Any:
+            return self.get_default()
+
+        @property
+        def type_(self) -> Any:
+            return self.field_info.annotation
+
+        def __post_init__(self) -> None:
+            self._type_adapter: TypeAdapter[Any] = TypeAdapter(
+                Annotated[self.field_info.annotation, self.field_info]
+            )
+
+        def get_default(self) -> Any:
+            if self.field_info.is_required():
+                return Undefined
+            return self.field_info.get_default(call_default_factory=True)
+
+        def validate(
+            self,
+            value: Any,
+            values: Dict[str, Any] = {},  # noqa: B006
+            *,
+            loc: Tuple[Union[int, str], ...] = (),
+        ) -> Tuple[Any, Union[List[Dict[str, Any]], None]]:
+            try:
+                return (
+                    self._type_adapter.validate_python(value, from_attributes=True),
+                    None,
+                )
+            except ValidationError as exc:
+                return None, _regenerate_error_with_loc(
+                    errors=exc.errors(), loc_prefix=loc
+                )
+
+        def serialize(
+            self,
+            value: Any,
+            *,
+            mode: Literal["json", "python"] = "json",
+            include: Union[IncEx, None] = None,
+            exclude: Union[IncEx, None] = None,
+            by_alias: bool = True,
+            exclude_unset: bool = False,
+            exclude_defaults: bool = False,
+            exclude_none: bool = False,
+        ) -> Any:
+            # What calls this code passes a value that already called
+            # self._type_adapter.validate_python(value)
+            return self._type_adapter.dump_python(
+                value,
+                mode=mode,
+                include=include,
+                exclude=exclude,
+                by_alias=by_alias,
+                exclude_unset=exclude_unset,
+                exclude_defaults=exclude_defaults,
+                exclude_none=exclude_none,
+            )
+
+        def __hash__(self) -> int:
+            # Each ModelField is unique for our purposes, to allow making a dict from
+            # ModelField to its JSON Schema.
+            return id(self)
+
+    def get_annotation_from_field_info(
+        annotation: Any, field_info: FieldInfo, field_name: str
+    ) -> Any:
+        return annotation
+
+    def _normalize_errors(errors: Sequence[Any]) -> List[Dict[str, Any]]:
+        return errors  # type: ignore[return-value]
+
+    def _model_rebuild(model: Type[BaseModel]) -> None:
+        model.model_rebuild()
+
+    def _model_dump(
+        model: BaseModel, mode: Literal["json", "python"] = "json", **kwargs: Any
+    ) -> Any:
+        return model.model_dump(mode=mode, **kwargs)
+
+    def _get_model_config(model: BaseModel) -> Any:
+        return model.model_config
+
+    def get_schema_from_model_field(
+        *,
+        field: ModelField,
+        schema_generator: GenerateJsonSchema,
+        model_name_map: ModelNameMap,
+        field_mapping: Dict[
+            Tuple[ModelField, Literal["validation", "serialization"]], JsonSchemaValue
+        ],
+        separate_input_output_schemas: bool = True,
+    ) -> Dict[str, Any]:
+        override_mode: Union[Literal["validation"], None] = (
+            None if separate_input_output_schemas else "validation"
+        )
+        # This expects that GenerateJsonSchema was already used to generate the definitions
+        json_schema = field_mapping[(field, override_mode or field.mode)]
+        if "$ref" not in json_schema:
+            # TODO remove when deprecating Pydantic v1
+            # Ref: https://github.com/pydantic/pydantic/blob/d61792cc42c80b13b23e3ffa74bc37ec7c77f7d1/pydantic/schema.py#L207
+            json_schema["title"] = (
+                field.field_info.title or field.alias.title().replace("_", " ")
+            )
+        return json_schema
+
+    def get_compat_model_name_map(fields: List[ModelField]) -> ModelNameMap:
+        return {}
+
+    def get_definitions(
+        *,
+        fields: List[ModelField],
+        schema_generator: GenerateJsonSchema,
+        model_name_map: ModelNameMap,
+        separate_input_output_schemas: bool = True,
+    ) -> Tuple[
+        Dict[
+            Tuple[ModelField, Literal["validation", "serialization"]], JsonSchemaValue
+        ],
+        Dict[str, Dict[str, Any]],
+    ]:
+        override_mode: Union[Literal["validation"], None] = (
+            None if separate_input_output_schemas else "validation"
+        )
+        inputs = [
+            (field, override_mode or field.mode, field._type_adapter.core_schema)
+            for field in fields
+        ]
+        field_mapping, definitions = schema_generator.generate_definitions(
+            inputs=inputs
+        )
+        return field_mapping, definitions  # type: ignore[return-value]
+
+    def is_scalar_field(field: ModelField) -> bool:
+        from prefect._vendor.fastapi import params
+
+        return field_annotation_is_scalar(
+            field.field_info.annotation
+        ) and not isinstance(field.field_info, params.Body)
+
+    def is_sequence_field(field: ModelField) -> bool:
+        return field_annotation_is_sequence(field.field_info.annotation)
+
+    def is_scalar_sequence_field(field: ModelField) -> bool:
+        return field_annotation_is_scalar_sequence(field.field_info.annotation)
+
+    def is_bytes_field(field: ModelField) -> bool:
+        return is_bytes_or_nonable_bytes_annotation(field.type_)
+
+    def is_bytes_sequence_field(field: ModelField) -> bool:
+        return is_bytes_sequence_annotation(field.type_)
+
+    def copy_field_info(*, field_info: FieldInfo, annotation: Any) -> FieldInfo:
+        return type(field_info).from_annotation(annotation)
+
+    def serialize_sequence_value(*, field: ModelField, value: Any) -> Sequence[Any]:
+        origin_type = (
+            get_origin(field.field_info.annotation) or field.field_info.annotation
+        )
+        assert issubclass(origin_type, sequence_types)  # type: ignore[arg-type]
+        return sequence_annotation_to_type[origin_type](value)  # type: ignore[no-any-return]
+
+    def get_missing_field_error(loc: Tuple[str, ...]) -> Dict[str, Any]:
+        error = ValidationError.from_exception_data(
+            "Field required", [{"type": "missing", "loc": loc, "input": {}}]
+        ).errors()[0]
+        error["input"] = None
+        return error  # type: ignore[return-value]
+
+    def create_body_model(
+        *, fields: Sequence[ModelField], model_name: str
+    ) -> Type[BaseModel]:
+        field_params = {f.name: (f.field_info.annotation, f.field_info) for f in fields}
+        BodyModel: Type[BaseModel] = create_model(model_name, **field_params)  # type: ignore[call-overload]
+        return BodyModel
+
+else:
+    from prefect._vendor.fastapi.openapi.constants import REF_PREFIX as REF_PREFIX
+    from pydantic import AnyUrl as Url  # noqa: F401
+    from pydantic import (  # type: ignore[assignment]
+        BaseConfig as BaseConfig,  # noqa: F401
+    )
+    from pydantic import ValidationError as ValidationError  # noqa: F401
+    from pydantic.class_validators import (  # type: ignore[no-redef]
+        Validator as Validator,  # noqa: F401
+    )
+    from pydantic.error_wrappers import (  # type: ignore[no-redef]
+        ErrorWrapper as ErrorWrapper,  # noqa: F401
+    )
+    from pydantic.errors import MissingError
+    from pydantic.fields import (  # type: ignore[attr-defined]
+        SHAPE_FROZENSET,
+        SHAPE_LIST,
+        SHAPE_SEQUENCE,
+        SHAPE_SET,
+        SHAPE_SINGLETON,
+        SHAPE_TUPLE,
+        SHAPE_TUPLE_ELLIPSIS,
+    )
+    from pydantic.fields import FieldInfo as FieldInfo
+    from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
+        ModelField as ModelField,  # noqa: F401
+    )
+    from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
+        Required as Required,  # noqa: F401
+    )
+    from pydantic.fields import (  # type: ignore[no-redef,attr-defined]
+        Undefined as Undefined,
+    )
+    from pydantic.fields import (  # type: ignore[no-redef, attr-defined]
+        UndefinedType as UndefinedType,  # noqa: F401
+    )
+    from pydantic.schema import (
+        field_schema,
+        get_flat_models_from_fields,
+        get_model_name_map,
+        model_process_schema,
+    )
+    from pydantic.schema import (  # type: ignore[no-redef]  # noqa: F401
+        get_annotation_from_field_info as get_annotation_from_field_info,
+    )
+    from pydantic.typing import (  # type: ignore[no-redef]
+        evaluate_forwardref as evaluate_forwardref,  # noqa: F401
+    )
+    from pydantic.utils import (  # type: ignore[no-redef]
+        lenient_issubclass as lenient_issubclass,  # noqa: F401
+    )
+
+    GetJsonSchemaHandler = Any  # type: ignore[assignment,misc]
+    JsonSchemaValue = Dict[str, Any]  # type: ignore[misc]
+    CoreSchema = Any  # type: ignore[assignment,misc]
+
+    sequence_shapes = {
+        SHAPE_LIST,
+        SHAPE_SET,
+        SHAPE_FROZENSET,
+        SHAPE_TUPLE,
+        SHAPE_SEQUENCE,
+        SHAPE_TUPLE_ELLIPSIS,
+    }
+    sequence_shape_to_type = {
+        SHAPE_LIST: list,
+        SHAPE_SET: set,
+        SHAPE_TUPLE: tuple,
+        SHAPE_SEQUENCE: list,
+        SHAPE_TUPLE_ELLIPSIS: list,
+    }
+
+    @dataclass
+    class GenerateJsonSchema:  # type: ignore[no-redef]
+        ref_template: str
+
+    class PydanticSchemaGenerationError(Exception):  # type: ignore[no-redef]
+        pass
+
+    def with_info_plain_validator_function(  # type: ignore[misc]
+        function: Callable[..., Any],
+        *,
+        ref: Union[str, None] = None,
+        metadata: Any = None,
+        serialization: Any = None,
+    ) -> Any:
+        return {}
+
+    def get_model_definitions(
+        *,
+        flat_models: Set[Union[Type[BaseModel], Type[Enum]]],
+        model_name_map: Dict[Union[Type[BaseModel], Type[Enum]], str],
+    ) -> Dict[str, Any]:
+        definitions: Dict[str, Dict[str, Any]] = {}
+        for model in flat_models:
+            m_schema, m_definitions, m_nested_models = model_process_schema(
+                model, model_name_map=model_name_map, ref_prefix=REF_PREFIX
+            )
+            definitions.update(m_definitions)
+            model_name = model_name_map[model]
+            if "description" in m_schema:
+                m_schema["description"] = m_schema["description"].split("\f")[0]
+            definitions[model_name] = m_schema
+        return definitions
+
+    def is_pv1_scalar_field(field: ModelField) -> bool:
+        from prefect._vendor.fastapi import params
+
+        field_info = field.field_info
+        if not (
+            field.shape == SHAPE_SINGLETON  # type: ignore[attr-defined]
+            and not lenient_issubclass(field.type_, BaseModel)
+            and not lenient_issubclass(field.type_, dict)
+            and not field_annotation_is_sequence(field.type_)
+            and not is_dataclass(field.type_)
+            and not isinstance(field_info, params.Body)
+        ):
+            return False
+        if field.sub_fields:  # type: ignore[attr-defined]
+            if not all(
+                is_pv1_scalar_field(f)
+                for f in field.sub_fields  # type: ignore[attr-defined]
+            ):
+                return False
+        return True
+
+    def is_pv1_scalar_sequence_field(field: ModelField) -> bool:
+        if (field.shape in sequence_shapes) and not lenient_issubclass(  # type: ignore[attr-defined]
+            field.type_, BaseModel
+        ):
+            if field.sub_fields is not None:  # type: ignore[attr-defined]
+                for sub_field in field.sub_fields:  # type: ignore[attr-defined]
+                    if not is_pv1_scalar_field(sub_field):
+                        return False
+            return True
+        if _annotation_is_sequence(field.type_):
+            return True
+        return False
+
+    def _normalize_errors(errors: Sequence[Any]) -> List[Dict[str, Any]]:
+        use_errors: List[Any] = []
+        for error in errors:
+            if isinstance(error, ErrorWrapper):
+                new_errors = ValidationError(  # type: ignore[call-arg]
+                    errors=[error], model=RequestErrorModel
+                ).errors()
+                use_errors.extend(new_errors)
+            elif isinstance(error, list):
+                use_errors.extend(_normalize_errors(error))
+            else:
+                use_errors.append(error)
+        return use_errors
+
+    def _model_rebuild(model: Type[BaseModel]) -> None:
+        model.update_forward_refs()
+
+    def _model_dump(
+        model: BaseModel, mode: Literal["json", "python"] = "json", **kwargs: Any
+    ) -> Any:
+        return model.dict(**kwargs)
+
+    def _get_model_config(model: BaseModel) -> Any:
+        return model.__config__  # type: ignore[attr-defined]
+
+    def get_schema_from_model_field(
+        *,
+        field: ModelField,
+        schema_generator: GenerateJsonSchema,
+        model_name_map: ModelNameMap,
+        field_mapping: Dict[
+            Tuple[ModelField, Literal["validation", "serialization"]], JsonSchemaValue
+        ],
+        separate_input_output_schemas: bool = True,
+    ) -> Dict[str, Any]:
+        # This expects that GenerateJsonSchema was already used to generate the definitions
+        return field_schema(  # type: ignore[no-any-return]
+            field, model_name_map=model_name_map, ref_prefix=REF_PREFIX
+        )[0]
+
+    def get_compat_model_name_map(fields: List[ModelField]) -> ModelNameMap:
+        models = get_flat_models_from_fields(fields, known_models=set())
+        return get_model_name_map(models)  # type: ignore[no-any-return]
+
+    def get_definitions(
+        *,
+        fields: List[ModelField],
+        schema_generator: GenerateJsonSchema,
+        model_name_map: ModelNameMap,
+        separate_input_output_schemas: bool = True,
+    ) -> Tuple[
+        Dict[
+            Tuple[ModelField, Literal["validation", "serialization"]], JsonSchemaValue
+        ],
+        Dict[str, Dict[str, Any]],
+    ]:
+        models = get_flat_models_from_fields(fields, known_models=set())
+        return {}, get_model_definitions(
+            flat_models=models, model_name_map=model_name_map
+        )
+
+    def is_scalar_field(field: ModelField) -> bool:
+        return is_pv1_scalar_field(field)
+
+    def is_sequence_field(field: ModelField) -> bool:
+        return field.shape in sequence_shapes or _annotation_is_sequence(field.type_)  # type: ignore[attr-defined]
+
+    def is_scalar_sequence_field(field: ModelField) -> bool:
+        return is_pv1_scalar_sequence_field(field)
+
+    def is_bytes_field(field: ModelField) -> bool:
+        return lenient_issubclass(field.type_, bytes)
+
+    def is_bytes_sequence_field(field: ModelField) -> bool:
+        return field.shape in sequence_shapes and lenient_issubclass(field.type_, bytes)  # type: ignore[attr-defined]
+
+    def copy_field_info(*, field_info: FieldInfo, annotation: Any) -> FieldInfo:
+        return copy(field_info)
+
+    def serialize_sequence_value(*, field: ModelField, value: Any) -> Sequence[Any]:
+        return sequence_shape_to_type[field.shape](value)  # type: ignore[no-any-return,attr-defined]
+
+    def get_missing_field_error(loc: Tuple[str, ...]) -> Dict[str, Any]:
+        missing_field_error = ErrorWrapper(MissingError(), loc=loc)  # type: ignore[call-arg]
+        new_error = ValidationError([missing_field_error], RequestErrorModel)
+        return new_error.errors()[0]  # type: ignore[return-value]
+
+    def create_body_model(
+        *, fields: Sequence[ModelField], model_name: str
+    ) -> Type[BaseModel]:
+        BodyModel = create_model(model_name)
+        for f in fields:
+            BodyModel.__fields__[f.name] = f  # type: ignore[index]
+        return BodyModel
+
+
+def _regenerate_error_with_loc(
+    *, errors: Sequence[Any], loc_prefix: Tuple[Union[str, int], ...]
+) -> List[Dict[str, Any]]:
+    updated_loc_errors: List[Any] = [
+        {**err, "loc": loc_prefix + err.get("loc", ())}
+        for err in _normalize_errors(errors)
+    ]
+
+    return updated_loc_errors
+
+
+def _annotation_is_sequence(annotation: Union[Type[Any], None]) -> bool:
+    if lenient_issubclass(annotation, (str, bytes)):
+        return False
+    return lenient_issubclass(annotation, sequence_types)
+
+
+def field_annotation_is_sequence(annotation: Union[Type[Any], None]) -> bool:
+    return _annotation_is_sequence(annotation) or _annotation_is_sequence(
+        get_origin(annotation)
+    )
+
+
+def value_is_sequence(value: Any) -> bool:
+    return isinstance(value, sequence_types) and not isinstance(value, (str, bytes))  # type: ignore[arg-type]
+
+
+def _annotation_is_complex(annotation: Union[Type[Any], None]) -> bool:
+    return (
+        lenient_issubclass(annotation, (BaseModel, Mapping, UploadFile))
+        or _annotation_is_sequence(annotation)
+        or is_dataclass(annotation)
+    )
+
+
+def field_annotation_is_complex(annotation: Union[Type[Any], None]) -> bool:
+    origin = get_origin(annotation)
+    if origin is Union or origin is UnionType:
+        return any(field_annotation_is_complex(arg) for arg in get_args(annotation))
+
+    return (
+        _annotation_is_complex(annotation)
+        or _annotation_is_complex(origin)
+        or hasattr(origin, "__pydantic_core_schema__")
+        or hasattr(origin, "__get_pydantic_core_schema__")
+    )
+
+
+def field_annotation_is_scalar(annotation: Any) -> bool:
+    # handle Ellipsis here to make tuple[int, ...] work nicely
+    return annotation is Ellipsis or not field_annotation_is_complex(annotation)
+
+
+def field_annotation_is_scalar_sequence(annotation: Union[Type[Any], None]) -> bool:
+    origin = get_origin(annotation)
+    if origin is Union or origin is UnionType:
+        at_least_one_scalar_sequence = False
+        for arg in get_args(annotation):
+            if field_annotation_is_scalar_sequence(arg):
+                at_least_one_scalar_sequence = True
+                continue
+            elif not field_annotation_is_scalar(arg):
+                return False
+        return at_least_one_scalar_sequence
+    return field_annotation_is_sequence(annotation) and all(
+        field_annotation_is_scalar(sub_annotation)
+        for sub_annotation in get_args(annotation)
+    )
+
+
+def is_bytes_or_nonable_bytes_annotation(annotation: Any) -> bool:
+    if lenient_issubclass(annotation, bytes):
+        return True
+    origin = get_origin(annotation)
+    if origin is Union or origin is UnionType:
+        for arg in get_args(annotation):
+            if lenient_issubclass(arg, bytes):
+                return True
+    return False
+
+
+def is_uploadfile_or_nonable_uploadfile_annotation(annotation: Any) -> bool:
+    if lenient_issubclass(annotation, UploadFile):
+        return True
+    origin = get_origin(annotation)
+    if origin is Union or origin is UnionType:
+        for arg in get_args(annotation):
+            if lenient_issubclass(arg, UploadFile):
+                return True
+    return False
+
+
+def is_bytes_sequence_annotation(annotation: Any) -> bool:
+    origin = get_origin(annotation)
+    if origin is Union or origin is UnionType:
+        at_least_one = False
+        for arg in get_args(annotation):
+            if is_bytes_sequence_annotation(arg):
+                at_least_one = True
+                continue
+        return at_least_one
+    return field_annotation_is_sequence(annotation) and all(
+        is_bytes_or_nonable_bytes_annotation(sub_annotation)
+        for sub_annotation in get_args(annotation)
+    )
+
+
+def is_uploadfile_sequence_annotation(annotation: Any) -> bool:
+    origin = get_origin(annotation)
+    if origin is Union or origin is UnionType:
+        at_least_one = False
+        for arg in get_args(annotation):
+            if is_uploadfile_sequence_annotation(arg):
+                at_least_one = True
+                continue
+        return at_least_one
+    return field_annotation_is_sequence(annotation) and all(
+        is_uploadfile_or_nonable_uploadfile_annotation(sub_annotation)
+        for sub_annotation in get_args(annotation)
+    )

--- a/src/prefect/_vendor/fastapi/applications.py
+++ b/src/prefect/_vendor/fastapi/applications.py
@@ -1,0 +1,948 @@
+from enum import Enum
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+)
+
+from prefect._vendor.fastapi import routing
+from prefect._vendor.fastapi.datastructures import Default, DefaultPlaceholder
+from prefect._vendor.fastapi.exception_handlers import (
+    http_exception_handler,
+    request_validation_exception_handler,
+    websocket_request_validation_exception_handler,
+)
+from prefect._vendor.fastapi.exceptions import (
+    RequestValidationError,
+    WebSocketRequestValidationError,
+)
+from prefect._vendor.fastapi.logger import logger
+from prefect._vendor.fastapi.middleware.asyncexitstack import AsyncExitStackMiddleware
+from prefect._vendor.fastapi.openapi.docs import (
+    get_redoc_html,
+    get_swagger_ui_html,
+    get_swagger_ui_oauth2_redirect_html,
+)
+from prefect._vendor.fastapi.openapi.utils import get_openapi
+from prefect._vendor.fastapi.params import Depends
+from prefect._vendor.fastapi.types import DecoratedCallable, IncEx
+from prefect._vendor.fastapi.utils import generate_unique_id
+from starlette.applications import Starlette
+from starlette.datastructures import State
+from starlette.exceptions import HTTPException
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.errors import ServerErrorMiddleware
+from starlette.middleware.exceptions import ExceptionMiddleware
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse, Response
+from starlette.routing import BaseRoute
+from starlette.types import ASGIApp, Lifespan, Receive, Scope, Send
+
+AppType = TypeVar("AppType", bound="FastAPI")
+
+
+class FastAPI(Starlette):
+    def __init__(
+        self: AppType,
+        *,
+        debug: bool = False,
+        routes: Optional[List[BaseRoute]] = None,
+        title: str = "FastAPI",
+        summary: Optional[str] = None,
+        description: str = "",
+        version: str = "0.1.0",
+        openapi_url: Optional[str] = "/openapi.json",
+        openapi_tags: Optional[List[Dict[str, Any]]] = None,
+        servers: Optional[List[Dict[str, Union[str, Any]]]] = None,
+        dependencies: Optional[Sequence[Depends]] = None,
+        default_response_class: Type[Response] = Default(JSONResponse),
+        redirect_slashes: bool = True,
+        docs_url: Optional[str] = "/docs",
+        redoc_url: Optional[str] = "/redoc",
+        swagger_ui_oauth2_redirect_url: Optional[str] = "/docs/oauth2-redirect",
+        swagger_ui_init_oauth: Optional[Dict[str, Any]] = None,
+        middleware: Optional[Sequence[Middleware]] = None,
+        exception_handlers: Optional[
+            Dict[
+                Union[int, Type[Exception]],
+                Callable[[Request, Any], Coroutine[Any, Any, Response]],
+            ]
+        ] = None,
+        on_startup: Optional[Sequence[Callable[[], Any]]] = None,
+        on_shutdown: Optional[Sequence[Callable[[], Any]]] = None,
+        lifespan: Optional[Lifespan[AppType]] = None,
+        terms_of_service: Optional[str] = None,
+        contact: Optional[Dict[str, Union[str, Any]]] = None,
+        license_info: Optional[Dict[str, Union[str, Any]]] = None,
+        openapi_prefix: str = "",
+        root_path: str = "",
+        root_path_in_servers: bool = True,
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        webhooks: Optional[routing.APIRouter] = None,
+        deprecated: Optional[bool] = None,
+        include_in_schema: bool = True,
+        swagger_ui_parameters: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
+            generate_unique_id
+        ),
+        separate_input_output_schemas: bool = True,
+        **extra: Any,
+    ) -> None:
+        self.debug = debug
+        self.title = title
+        self.summary = summary
+        self.description = description
+        self.version = version
+        self.terms_of_service = terms_of_service
+        self.contact = contact
+        self.license_info = license_info
+        self.openapi_url = openapi_url
+        self.openapi_tags = openapi_tags
+        self.root_path_in_servers = root_path_in_servers
+        self.docs_url = docs_url
+        self.redoc_url = redoc_url
+        self.swagger_ui_oauth2_redirect_url = swagger_ui_oauth2_redirect_url
+        self.swagger_ui_init_oauth = swagger_ui_init_oauth
+        self.swagger_ui_parameters = swagger_ui_parameters
+        self.servers = servers or []
+        self.separate_input_output_schemas = separate_input_output_schemas
+        self.extra = extra
+        self.openapi_version = "3.1.0"
+        self.openapi_schema: Optional[Dict[str, Any]] = None
+        if self.openapi_url:
+            assert self.title, "A title must be provided for OpenAPI, e.g.: 'My API'"
+            assert self.version, "A version must be provided for OpenAPI, e.g.: '2.1.0'"
+        # TODO: remove when discarding the openapi_prefix parameter
+        if openapi_prefix:
+            logger.warning(
+                '"openapi_prefix" has been deprecated in favor of "root_path", which '
+                "follows more closely the ASGI standard, is simpler, and more "
+                "automatic. Check the docs at "
+                "https://fastapi.tiangolo.com/advanced/sub-applications/"
+            )
+        self.webhooks = webhooks or routing.APIRouter()
+        self.root_path = root_path or openapi_prefix
+        self.state: State = State()
+        self.dependency_overrides: Dict[Callable[..., Any], Callable[..., Any]] = {}
+        self.router: routing.APIRouter = routing.APIRouter(
+            routes=routes,
+            redirect_slashes=redirect_slashes,
+            dependency_overrides_provider=self,
+            on_startup=on_startup,
+            on_shutdown=on_shutdown,
+            lifespan=lifespan,
+            default_response_class=default_response_class,
+            dependencies=dependencies,
+            callbacks=callbacks,
+            deprecated=deprecated,
+            include_in_schema=include_in_schema,
+            responses=responses,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+        self.exception_handlers: Dict[
+            Any, Callable[[Request, Any], Union[Response, Awaitable[Response]]]
+        ] = ({} if exception_handlers is None else dict(exception_handlers))
+        self.exception_handlers.setdefault(HTTPException, http_exception_handler)
+        self.exception_handlers.setdefault(
+            RequestValidationError, request_validation_exception_handler
+        )
+        self.exception_handlers.setdefault(
+            WebSocketRequestValidationError,
+            # Starlette still has incorrect type specification for the handlers
+            websocket_request_validation_exception_handler,  # type: ignore
+        )
+
+        self.user_middleware: List[Middleware] = (
+            [] if middleware is None else list(middleware)
+        )
+        self.middleware_stack: Union[ASGIApp, None] = None
+        self.setup()
+
+    def build_middleware_stack(self) -> ASGIApp:
+        # Duplicate/override from Starlette to add AsyncExitStackMiddleware
+        # inside of ExceptionMiddleware, inside of custom user middlewares
+        debug = self.debug
+        error_handler = None
+        exception_handlers = {}
+
+        for key, value in self.exception_handlers.items():
+            if key in (500, Exception):
+                error_handler = value
+            else:
+                exception_handlers[key] = value
+
+        middleware = (
+            [Middleware(ServerErrorMiddleware, handler=error_handler, debug=debug)]
+            + self.user_middleware
+            + [
+                Middleware(
+                    ExceptionMiddleware, handlers=exception_handlers, debug=debug
+                ),
+                # Add FastAPI-specific AsyncExitStackMiddleware for dependencies with
+                # contextvars.
+                # This needs to happen after user middlewares because those create a
+                # new contextvars context copy by using a new AnyIO task group.
+                # The initial part of dependencies with 'yield' is executed in the
+                # FastAPI code, inside all the middlewares. However, the teardown part
+                # (after 'yield') is executed in the AsyncExitStack in this middleware.
+                # If the AsyncExitStack lived outside of the custom middlewares and
+                # contextvars were set in a dependency with 'yield' in that internal
+                # contextvars context, the values would not be available in the
+                # outer context of the AsyncExitStack.
+                # By placing the middleware and the AsyncExitStack here, inside all
+                # user middlewares, the code before and after 'yield' in dependencies
+                # with 'yield' is executed in the same contextvars context. Thus, all values
+                # set in contextvars before 'yield' are still available after 'yield,' as
+                # expected.
+                # Additionally, by having this AsyncExitStack here, after the
+                # ExceptionMiddleware, dependencies can now catch handled exceptions,
+                # e.g. HTTPException, to customize the teardown code (e.g. DB session
+                # rollback).
+                Middleware(AsyncExitStackMiddleware),
+            ]
+        )
+
+        app = self.router
+        for cls, options in reversed(middleware):
+            app = cls(app=app, **options)
+        return app
+
+    def openapi(self) -> Dict[str, Any]:
+        if not self.openapi_schema:
+            self.openapi_schema = get_openapi(
+                title=self.title,
+                version=self.version,
+                openapi_version=self.openapi_version,
+                summary=self.summary,
+                description=self.description,
+                terms_of_service=self.terms_of_service,
+                contact=self.contact,
+                license_info=self.license_info,
+                routes=self.routes,
+                webhooks=self.webhooks.routes,
+                tags=self.openapi_tags,
+                servers=self.servers,
+                separate_input_output_schemas=self.separate_input_output_schemas,
+            )
+        return self.openapi_schema
+
+    def setup(self) -> None:
+        if self.openapi_url:
+            urls = (server_data.get("url") for server_data in self.servers)
+            server_urls = {url for url in urls if url}
+
+            async def openapi(req: Request) -> JSONResponse:
+                root_path = req.scope.get("root_path", "").rstrip("/")
+                if root_path not in server_urls:
+                    if root_path and self.root_path_in_servers:
+                        self.servers.insert(0, {"url": root_path})
+                        server_urls.add(root_path)
+                return JSONResponse(self.openapi())
+
+            self.add_route(self.openapi_url, openapi, include_in_schema=False)
+        if self.openapi_url and self.docs_url:
+
+            async def swagger_ui_html(req: Request) -> HTMLResponse:
+                root_path = req.scope.get("root_path", "").rstrip("/")
+                openapi_url = root_path + self.openapi_url
+                oauth2_redirect_url = self.swagger_ui_oauth2_redirect_url
+                if oauth2_redirect_url:
+                    oauth2_redirect_url = root_path + oauth2_redirect_url
+                return get_swagger_ui_html(
+                    openapi_url=openapi_url,
+                    title=self.title + " - Swagger UI",
+                    oauth2_redirect_url=oauth2_redirect_url,
+                    init_oauth=self.swagger_ui_init_oauth,
+                    swagger_ui_parameters=self.swagger_ui_parameters,
+                )
+
+            self.add_route(self.docs_url, swagger_ui_html, include_in_schema=False)
+
+            if self.swagger_ui_oauth2_redirect_url:
+
+                async def swagger_ui_redirect(req: Request) -> HTMLResponse:
+                    return get_swagger_ui_oauth2_redirect_html()
+
+                self.add_route(
+                    self.swagger_ui_oauth2_redirect_url,
+                    swagger_ui_redirect,
+                    include_in_schema=False,
+                )
+        if self.openapi_url and self.redoc_url:
+
+            async def redoc_html(req: Request) -> HTMLResponse:
+                root_path = req.scope.get("root_path", "").rstrip("/")
+                openapi_url = root_path + self.openapi_url
+                return get_redoc_html(
+                    openapi_url=openapi_url, title=self.title + " - ReDoc"
+                )
+
+            self.add_route(self.redoc_url, redoc_html, include_in_schema=False)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if self.root_path:
+            scope["root_path"] = self.root_path
+        await super().__call__(scope, receive, send)
+
+    def add_api_route(
+        self,
+        path: str,
+        endpoint: Callable[..., Coroutine[Any, Any, Response]],
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        methods: Optional[List[str]] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Union[Type[Response], DefaultPlaceholder] = Default(
+            JSONResponse
+        ),
+        name: Optional[str] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> None:
+        self.router.add_api_route(
+            path,
+            endpoint=endpoint,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            methods=methods,
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def api_route(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        methods: Optional[List[str]] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        def decorator(func: DecoratedCallable) -> DecoratedCallable:
+            self.router.add_api_route(
+                path,
+                func,
+                response_model=response_model,
+                status_code=status_code,
+                tags=tags,
+                dependencies=dependencies,
+                summary=summary,
+                description=description,
+                response_description=response_description,
+                responses=responses,
+                deprecated=deprecated,
+                methods=methods,
+                operation_id=operation_id,
+                response_model_include=response_model_include,
+                response_model_exclude=response_model_exclude,
+                response_model_by_alias=response_model_by_alias,
+                response_model_exclude_unset=response_model_exclude_unset,
+                response_model_exclude_defaults=response_model_exclude_defaults,
+                response_model_exclude_none=response_model_exclude_none,
+                include_in_schema=include_in_schema,
+                response_class=response_class,
+                name=name,
+                openapi_extra=openapi_extra,
+                generate_unique_id_function=generate_unique_id_function,
+            )
+            return func
+
+        return decorator
+
+    def add_api_websocket_route(
+        self,
+        path: str,
+        endpoint: Callable[..., Any],
+        name: Optional[str] = None,
+        *,
+        dependencies: Optional[Sequence[Depends]] = None,
+    ) -> None:
+        self.router.add_api_websocket_route(
+            path,
+            endpoint,
+            name=name,
+            dependencies=dependencies,
+        )
+
+    def websocket(
+        self,
+        path: str,
+        name: Optional[str] = None,
+        *,
+        dependencies: Optional[Sequence[Depends]] = None,
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        def decorator(func: DecoratedCallable) -> DecoratedCallable:
+            self.add_api_websocket_route(
+                path,
+                func,
+                name=name,
+                dependencies=dependencies,
+            )
+            return func
+
+        return decorator
+
+    def include_router(
+        self,
+        router: routing.APIRouter,
+        *,
+        prefix: str = "",
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[Depends]] = None,
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        include_in_schema: bool = True,
+        default_response_class: Type[Response] = Default(JSONResponse),
+        callbacks: Optional[List[BaseRoute]] = None,
+        generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> None:
+        self.router.include_router(
+            router,
+            prefix=prefix,
+            tags=tags,
+            dependencies=dependencies,
+            responses=responses,
+            deprecated=deprecated,
+            include_in_schema=include_in_schema,
+            default_response_class=default_response_class,
+            callbacks=callbacks,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def get(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.router.get(
+            path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def put(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.router.put(
+            path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def post(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.router.post(
+            path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def delete(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.router.delete(
+            path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def options(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.router.options(
+            path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def head(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.router.head(
+            path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def patch(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.router.patch(
+            path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def trace(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[routing.APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.router.trace(
+            path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def websocket_route(
+        self, path: str, name: Union[str, None] = None
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        def decorator(func: DecoratedCallable) -> DecoratedCallable:
+            self.router.add_websocket_route(path, func, name=name)
+            return func
+
+        return decorator
+
+    def on_event(
+        self, event_type: str
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.router.on_event(event_type)
+
+    def middleware(
+        self, middleware_type: str
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        def decorator(func: DecoratedCallable) -> DecoratedCallable:
+            self.add_middleware(BaseHTTPMiddleware, dispatch=func)
+            return func
+
+        return decorator
+
+    def exception_handler(
+        self, exc_class_or_status_code: Union[int, Type[Exception]]
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        def decorator(func: DecoratedCallable) -> DecoratedCallable:
+            self.add_exception_handler(exc_class_or_status_code, func)
+            return func
+
+        return decorator

--- a/src/prefect/_vendor/fastapi/background.py
+++ b/src/prefect/_vendor/fastapi/background.py
@@ -1,0 +1,1 @@
+from starlette.background import BackgroundTasks as BackgroundTasks  # noqa

--- a/src/prefect/_vendor/fastapi/concurrency.py
+++ b/src/prefect/_vendor/fastapi/concurrency.py
@@ -1,0 +1,40 @@
+from contextlib import AsyncExitStack as AsyncExitStack  # noqa
+from contextlib import asynccontextmanager as asynccontextmanager
+from typing import AsyncGenerator, ContextManager, TypeVar
+
+import anyio
+from anyio import CapacityLimiter
+from starlette.concurrency import iterate_in_threadpool as iterate_in_threadpool  # noqa
+from starlette.concurrency import run_in_threadpool as run_in_threadpool  # noqa
+from starlette.concurrency import (  # noqa
+    run_until_first_complete as run_until_first_complete,
+)
+
+_T = TypeVar("_T")
+
+
+@asynccontextmanager
+async def contextmanager_in_threadpool(
+    cm: ContextManager[_T],
+) -> AsyncGenerator[_T, None]:
+    # blocking __exit__ from running waiting on a free thread
+    # can create race conditions/deadlocks if the context manager itself
+    # has its own internal pool (e.g. a database connection pool)
+    # to avoid this we let __exit__ run without a capacity limit
+    # since we're creating a new limiter for each call, any non-zero limit
+    # works (1 is arbitrary)
+    exit_limiter = CapacityLimiter(1)
+    try:
+        yield await run_in_threadpool(cm.__enter__)
+    except Exception as e:
+        ok = bool(
+            await anyio.to_thread.run_sync(
+                cm.__exit__, type(e), e, None, limiter=exit_limiter
+            )
+        )
+        if not ok:
+            raise e
+    else:
+        await anyio.to_thread.run_sync(
+            cm.__exit__, None, None, None, limiter=exit_limiter
+        )

--- a/src/prefect/_vendor/fastapi/datastructures.py
+++ b/src/prefect/_vendor/fastapi/datastructures.py
@@ -1,0 +1,83 @@
+from typing import Any, Callable, Dict, Iterable, Type, TypeVar, cast
+
+from prefect._vendor.fastapi._compat import (
+    PYDANTIC_V2,
+    CoreSchema,
+    GetJsonSchemaHandler,
+    JsonSchemaValue,
+    with_info_plain_validator_function,
+)
+from starlette.datastructures import URL as URL  # noqa: F401
+from starlette.datastructures import Address as Address  # noqa: F401
+from starlette.datastructures import FormData as FormData  # noqa: F401
+from starlette.datastructures import Headers as Headers  # noqa: F401
+from starlette.datastructures import QueryParams as QueryParams  # noqa: F401
+from starlette.datastructures import State as State  # noqa: F401
+from starlette.datastructures import UploadFile as StarletteUploadFile
+
+
+class UploadFile(StarletteUploadFile):
+    @classmethod
+    def __get_validators__(cls: Type["UploadFile"]) -> Iterable[Callable[..., Any]]:
+        yield cls.validate
+
+    @classmethod
+    def validate(cls: Type["UploadFile"], v: Any) -> Any:
+        if not isinstance(v, StarletteUploadFile):
+            raise ValueError(f"Expected UploadFile, received: {type(v)}")
+        return v
+
+    @classmethod
+    def _validate(cls, __input_value: Any, _: Any) -> "UploadFile":
+        if not isinstance(__input_value, StarletteUploadFile):
+            raise ValueError(f"Expected UploadFile, received: {type(__input_value)}")
+        return cast(UploadFile, __input_value)
+
+    if not PYDANTIC_V2:
+
+        @classmethod
+        def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
+            field_schema.update({"type": "string", "format": "binary"})
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        return {"type": "string", "format": "binary"}
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source: Type[Any], handler: Callable[[Any], CoreSchema]
+    ) -> CoreSchema:
+        return with_info_plain_validator_function(cls._validate)
+
+
+class DefaultPlaceholder:
+    """
+    You shouldn't use this class directly.
+
+    It's used internally to recognize when a default value has been overwritten, even
+    if the overridden default value was truthy.
+    """
+
+    def __init__(self, value: Any):
+        self.value = value
+
+    def __bool__(self) -> bool:
+        return bool(self.value)
+
+    def __eq__(self, o: object) -> bool:
+        return isinstance(o, DefaultPlaceholder) and o.value == self.value
+
+
+DefaultType = TypeVar("DefaultType")
+
+
+def Default(value: DefaultType) -> DefaultType:
+    """
+    You shouldn't use this function directly.
+
+    It's used internally to recognize when a default value has been overwritten, even
+    if the overridden default value was truthy.
+    """
+    return DefaultPlaceholder(value)  # type: ignore

--- a/src/prefect/_vendor/fastapi/dependencies/models.py
+++ b/src/prefect/_vendor/fastapi/dependencies/models.py
@@ -1,0 +1,58 @@
+from typing import Any, Callable, List, Optional, Sequence
+
+from prefect._vendor.fastapi._compat import ModelField
+from prefect._vendor.fastapi.security.base import SecurityBase
+
+
+class SecurityRequirement:
+    def __init__(
+        self, security_scheme: SecurityBase, scopes: Optional[Sequence[str]] = None
+    ):
+        self.security_scheme = security_scheme
+        self.scopes = scopes
+
+
+class Dependant:
+    def __init__(
+        self,
+        *,
+        path_params: Optional[List[ModelField]] = None,
+        query_params: Optional[List[ModelField]] = None,
+        header_params: Optional[List[ModelField]] = None,
+        cookie_params: Optional[List[ModelField]] = None,
+        body_params: Optional[List[ModelField]] = None,
+        dependencies: Optional[List["Dependant"]] = None,
+        security_schemes: Optional[List[SecurityRequirement]] = None,
+        name: Optional[str] = None,
+        call: Optional[Callable[..., Any]] = None,
+        request_param_name: Optional[str] = None,
+        websocket_param_name: Optional[str] = None,
+        http_connection_param_name: Optional[str] = None,
+        response_param_name: Optional[str] = None,
+        background_tasks_param_name: Optional[str] = None,
+        security_scopes_param_name: Optional[str] = None,
+        security_scopes: Optional[List[str]] = None,
+        use_cache: bool = True,
+        path: Optional[str] = None,
+    ) -> None:
+        self.path_params = path_params or []
+        self.query_params = query_params or []
+        self.header_params = header_params or []
+        self.cookie_params = cookie_params or []
+        self.body_params = body_params or []
+        self.dependencies = dependencies or []
+        self.security_requirements = security_schemes or []
+        self.request_param_name = request_param_name
+        self.websocket_param_name = websocket_param_name
+        self.http_connection_param_name = http_connection_param_name
+        self.response_param_name = response_param_name
+        self.background_tasks_param_name = background_tasks_param_name
+        self.security_scopes = security_scopes
+        self.security_scopes_param_name = security_scopes_param_name
+        self.name = name
+        self.call = call
+        self.use_cache = use_cache
+        # Store the path to be able to re-generate a dependable from it in overrides
+        self.path = path
+        # Save the cache key at creation to optimize performance
+        self.cache_key = (self.call, tuple(sorted(set(self.security_scopes or []))))

--- a/src/prefect/_vendor/fastapi/dependencies/utils.py
+++ b/src/prefect/_vendor/fastapi/dependencies/utils.py
@@ -1,0 +1,803 @@
+import inspect
+from contextlib import contextmanager
+from copy import deepcopy
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    ForwardRef,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+import anyio
+from prefect._vendor.fastapi import params
+from prefect._vendor.fastapi._compat import (
+    PYDANTIC_V2,
+    ErrorWrapper,
+    ModelField,
+    Required,
+    Undefined,
+    _regenerate_error_with_loc,
+    copy_field_info,
+    create_body_model,
+    evaluate_forwardref,
+    field_annotation_is_scalar,
+    get_annotation_from_field_info,
+    get_missing_field_error,
+    is_bytes_field,
+    is_bytes_sequence_field,
+    is_scalar_field,
+    is_scalar_sequence_field,
+    is_sequence_field,
+    is_uploadfile_or_nonable_uploadfile_annotation,
+    is_uploadfile_sequence_annotation,
+    lenient_issubclass,
+    sequence_types,
+    serialize_sequence_value,
+    value_is_sequence,
+)
+from prefect._vendor.fastapi.concurrency import (
+    AsyncExitStack,
+    asynccontextmanager,
+    contextmanager_in_threadpool,
+)
+from prefect._vendor.fastapi.dependencies.models import Dependant, SecurityRequirement
+from prefect._vendor.fastapi.logger import logger
+from prefect._vendor.fastapi.security.base import SecurityBase
+from prefect._vendor.fastapi.security.oauth2 import OAuth2, SecurityScopes
+from prefect._vendor.fastapi.security.open_id_connect_url import OpenIdConnect
+from prefect._vendor.fastapi.utils import create_response_field, get_path_param_names
+from pydantic.fields import FieldInfo
+from starlette.background import BackgroundTasks
+from starlette.concurrency import run_in_threadpool
+from starlette.datastructures import FormData, Headers, QueryParams, UploadFile
+from starlette.requests import HTTPConnection, Request
+from starlette.responses import Response
+from starlette.websockets import WebSocket
+from typing_extensions import Annotated, get_args, get_origin
+
+multipart_not_installed_error = (
+    'Form data requires "python-multipart" to be installed. \n'
+    'You can install "python-multipart" with: \n\n'
+    "pip install python-multipart\n"
+)
+multipart_incorrect_install_error = (
+    'Form data requires "python-multipart" to be installed. '
+    'It seems you installed "multipart" instead. \n'
+    'You can remove "multipart" with: \n\n'
+    "pip uninstall multipart\n\n"
+    'And then install "python-multipart" with: \n\n'
+    "pip install python-multipart\n"
+)
+
+
+def check_file_field(field: ModelField) -> None:
+    field_info = field.field_info
+    if isinstance(field_info, params.Form):
+        try:
+            # __version__ is available in both multiparts, and can be mocked
+            from multipart import __version__  # type: ignore
+
+            assert __version__
+            try:
+                # parse_options_header is only available in the right multipart
+                from multipart.multipart import parse_options_header  # type: ignore
+
+                assert parse_options_header
+            except ImportError:
+                logger.error(multipart_incorrect_install_error)
+                raise RuntimeError(multipart_incorrect_install_error) from None
+        except ImportError:
+            logger.error(multipart_not_installed_error)
+            raise RuntimeError(multipart_not_installed_error) from None
+
+
+def get_param_sub_dependant(
+    *,
+    param_name: str,
+    depends: params.Depends,
+    path: str,
+    security_scopes: Optional[List[str]] = None,
+) -> Dependant:
+    assert depends.dependency
+    return get_sub_dependant(
+        depends=depends,
+        dependency=depends.dependency,
+        path=path,
+        name=param_name,
+        security_scopes=security_scopes,
+    )
+
+
+def get_parameterless_sub_dependant(*, depends: params.Depends, path: str) -> Dependant:
+    assert callable(
+        depends.dependency
+    ), "A parameter-less dependency must have a callable dependency"
+    return get_sub_dependant(depends=depends, dependency=depends.dependency, path=path)
+
+
+def get_sub_dependant(
+    *,
+    depends: params.Depends,
+    dependency: Callable[..., Any],
+    path: str,
+    name: Optional[str] = None,
+    security_scopes: Optional[List[str]] = None,
+) -> Dependant:
+    security_requirement = None
+    security_scopes = security_scopes or []
+    if isinstance(depends, params.Security):
+        dependency_scopes = depends.scopes
+        security_scopes.extend(dependency_scopes)
+    if isinstance(dependency, SecurityBase):
+        use_scopes: List[str] = []
+        if isinstance(dependency, (OAuth2, OpenIdConnect)):
+            use_scopes = security_scopes
+        security_requirement = SecurityRequirement(
+            security_scheme=dependency, scopes=use_scopes
+        )
+    sub_dependant = get_dependant(
+        path=path,
+        call=dependency,
+        name=name,
+        security_scopes=security_scopes,
+        use_cache=depends.use_cache,
+    )
+    if security_requirement:
+        sub_dependant.security_requirements.append(security_requirement)
+    return sub_dependant
+
+
+CacheKey = Tuple[Optional[Callable[..., Any]], Tuple[str, ...]]
+
+
+def get_flat_dependant(
+    dependant: Dependant,
+    *,
+    skip_repeats: bool = False,
+    visited: Optional[List[CacheKey]] = None,
+) -> Dependant:
+    if visited is None:
+        visited = []
+    visited.append(dependant.cache_key)
+
+    flat_dependant = Dependant(
+        path_params=dependant.path_params.copy(),
+        query_params=dependant.query_params.copy(),
+        header_params=dependant.header_params.copy(),
+        cookie_params=dependant.cookie_params.copy(),
+        body_params=dependant.body_params.copy(),
+        security_schemes=dependant.security_requirements.copy(),
+        use_cache=dependant.use_cache,
+        path=dependant.path,
+    )
+    for sub_dependant in dependant.dependencies:
+        if skip_repeats and sub_dependant.cache_key in visited:
+            continue
+        flat_sub = get_flat_dependant(
+            sub_dependant, skip_repeats=skip_repeats, visited=visited
+        )
+        flat_dependant.path_params.extend(flat_sub.path_params)
+        flat_dependant.query_params.extend(flat_sub.query_params)
+        flat_dependant.header_params.extend(flat_sub.header_params)
+        flat_dependant.cookie_params.extend(flat_sub.cookie_params)
+        flat_dependant.body_params.extend(flat_sub.body_params)
+        flat_dependant.security_requirements.extend(flat_sub.security_requirements)
+    return flat_dependant
+
+
+def get_flat_params(dependant: Dependant) -> List[ModelField]:
+    flat_dependant = get_flat_dependant(dependant, skip_repeats=True)
+    return (
+        flat_dependant.path_params
+        + flat_dependant.query_params
+        + flat_dependant.header_params
+        + flat_dependant.cookie_params
+    )
+
+
+def get_typed_signature(call: Callable[..., Any]) -> inspect.Signature:
+    signature = inspect.signature(call)
+    globalns = getattr(call, "__globals__", {})
+    typed_params = [
+        inspect.Parameter(
+            name=param.name,
+            kind=param.kind,
+            default=param.default,
+            annotation=get_typed_annotation(param.annotation, globalns),
+        )
+        for param in signature.parameters.values()
+    ]
+    typed_signature = inspect.Signature(typed_params)
+    return typed_signature
+
+
+def get_typed_annotation(annotation: Any, globalns: Dict[str, Any]) -> Any:
+    if isinstance(annotation, str):
+        annotation = ForwardRef(annotation)
+        annotation = evaluate_forwardref(annotation, globalns, globalns)
+    return annotation
+
+
+def get_typed_return_annotation(call: Callable[..., Any]) -> Any:
+    signature = inspect.signature(call)
+    annotation = signature.return_annotation
+
+    if annotation is inspect.Signature.empty:
+        return None
+
+    globalns = getattr(call, "__globals__", {})
+    return get_typed_annotation(annotation, globalns)
+
+
+def get_dependant(
+    *,
+    path: str,
+    call: Callable[..., Any],
+    name: Optional[str] = None,
+    security_scopes: Optional[List[str]] = None,
+    use_cache: bool = True,
+) -> Dependant:
+    path_param_names = get_path_param_names(path)
+    endpoint_signature = get_typed_signature(call)
+    signature_params = endpoint_signature.parameters
+    dependant = Dependant(
+        call=call,
+        name=name,
+        path=path,
+        security_scopes=security_scopes,
+        use_cache=use_cache,
+    )
+    for param_name, param in signature_params.items():
+        is_path_param = param_name in path_param_names
+        type_annotation, depends, param_field = analyze_param(
+            param_name=param_name,
+            annotation=param.annotation,
+            value=param.default,
+            is_path_param=is_path_param,
+        )
+        if depends is not None:
+            sub_dependant = get_param_sub_dependant(
+                param_name=param_name,
+                depends=depends,
+                path=path,
+                security_scopes=security_scopes,
+            )
+            dependant.dependencies.append(sub_dependant)
+            continue
+        if add_non_field_param_to_dependency(
+            param_name=param_name,
+            type_annotation=type_annotation,
+            dependant=dependant,
+        ):
+            assert (
+                param_field is None
+            ), f"Cannot specify multiple FastAPI annotations for {param_name!r}"
+            continue
+        assert param_field is not None
+        if is_body_param(param_field=param_field, is_path_param=is_path_param):
+            dependant.body_params.append(param_field)
+        else:
+            add_param_to_fields(field=param_field, dependant=dependant)
+    return dependant
+
+
+def add_non_field_param_to_dependency(
+    *, param_name: str, type_annotation: Any, dependant: Dependant
+) -> Optional[bool]:
+    if lenient_issubclass(type_annotation, Request):
+        dependant.request_param_name = param_name
+        return True
+    elif lenient_issubclass(type_annotation, WebSocket):
+        dependant.websocket_param_name = param_name
+        return True
+    elif lenient_issubclass(type_annotation, HTTPConnection):
+        dependant.http_connection_param_name = param_name
+        return True
+    elif lenient_issubclass(type_annotation, Response):
+        dependant.response_param_name = param_name
+        return True
+    elif lenient_issubclass(type_annotation, BackgroundTasks):
+        dependant.background_tasks_param_name = param_name
+        return True
+    elif lenient_issubclass(type_annotation, SecurityScopes):
+        dependant.security_scopes_param_name = param_name
+        return True
+    return None
+
+
+def analyze_param(
+    *,
+    param_name: str,
+    annotation: Any,
+    value: Any,
+    is_path_param: bool,
+) -> Tuple[Any, Optional[params.Depends], Optional[ModelField]]:
+    field_info = None
+    depends = None
+    type_annotation: Any = Any
+    if (
+        annotation is not inspect.Signature.empty
+        and get_origin(annotation) is Annotated
+    ):
+        annotated_args = get_args(annotation)
+        type_annotation = annotated_args[0]
+        fastapi_annotations = [
+            arg
+            for arg in annotated_args[1:]
+            if isinstance(arg, (FieldInfo, params.Depends))
+        ]
+        assert (
+            len(fastapi_annotations) <= 1
+        ), f"Cannot specify multiple `Annotated` FastAPI arguments for {param_name!r}"
+        fastapi_annotation = next(iter(fastapi_annotations), None)
+        if isinstance(fastapi_annotation, FieldInfo):
+            # Copy `field_info` because we mutate `field_info.default` below.
+            field_info = copy_field_info(
+                field_info=fastapi_annotation, annotation=annotation
+            )
+            assert field_info.default is Undefined or field_info.default is Required, (
+                f"`{field_info.__class__.__name__}` default value cannot be set in"
+                f" `Annotated` for {param_name!r}. Set the default value with `=`"
+                " instead."
+            )
+            if value is not inspect.Signature.empty:
+                assert not is_path_param, "Path parameters cannot have default values"
+                field_info.default = value
+            else:
+                field_info.default = Required
+        elif isinstance(fastapi_annotation, params.Depends):
+            depends = fastapi_annotation
+    elif annotation is not inspect.Signature.empty:
+        type_annotation = annotation
+
+    if isinstance(value, params.Depends):
+        assert depends is None, (
+            "Cannot specify `Depends` in `Annotated` and default value"
+            f" together for {param_name!r}"
+        )
+        assert field_info is None, (
+            "Cannot specify a FastAPI annotation in `Annotated` and `Depends` as a"
+            f" default value together for {param_name!r}"
+        )
+        depends = value
+    elif isinstance(value, FieldInfo):
+        assert field_info is None, (
+            "Cannot specify FastAPI annotations in `Annotated` and default value"
+            f" together for {param_name!r}"
+        )
+        field_info = value
+        if PYDANTIC_V2:
+            field_info.annotation = type_annotation
+
+    if depends is not None and depends.dependency is None:
+        depends.dependency = type_annotation
+
+    if lenient_issubclass(
+        type_annotation,
+        (Request, WebSocket, HTTPConnection, Response, BackgroundTasks, SecurityScopes),
+    ):
+        assert depends is None, f"Cannot specify `Depends` for type {type_annotation!r}"
+        assert (
+            field_info is None
+        ), f"Cannot specify FastAPI annotation for type {type_annotation!r}"
+    elif field_info is None and depends is None:
+        default_value = value if value is not inspect.Signature.empty else Required
+        if is_path_param:
+            # We might check here that `default_value is Required`, but the fact is that the same
+            # parameter might sometimes be a path parameter and sometimes not. See
+            # `tests/test_infer_param_optionality.py` for an example.
+            field_info = params.Path(annotation=type_annotation)
+        elif is_uploadfile_or_nonable_uploadfile_annotation(
+            type_annotation
+        ) or is_uploadfile_sequence_annotation(type_annotation):
+            field_info = params.File(annotation=type_annotation, default=default_value)
+        elif not field_annotation_is_scalar(annotation=type_annotation):
+            field_info = params.Body(annotation=type_annotation, default=default_value)
+        else:
+            field_info = params.Query(annotation=type_annotation, default=default_value)
+
+    field = None
+    if field_info is not None:
+        if is_path_param:
+            assert isinstance(field_info, params.Path), (
+                f"Cannot use `{field_info.__class__.__name__}` for path param"
+                f" {param_name!r}"
+            )
+        elif (
+            isinstance(field_info, params.Param)
+            and getattr(field_info, "in_", None) is None
+        ):
+            field_info.in_ = params.ParamTypes.query
+        use_annotation = get_annotation_from_field_info(
+            type_annotation,
+            field_info,
+            param_name,
+        )
+        if not field_info.alias and getattr(field_info, "convert_underscores", None):
+            alias = param_name.replace("_", "-")
+        else:
+            alias = field_info.alias or param_name
+        field_info.alias = alias
+        field = create_response_field(
+            name=param_name,
+            type_=use_annotation,
+            default=field_info.default,
+            alias=alias,
+            required=field_info.default in (Required, Undefined),
+            field_info=field_info,
+        )
+
+    return type_annotation, depends, field
+
+
+def is_body_param(*, param_field: ModelField, is_path_param: bool) -> bool:
+    if is_path_param:
+        assert is_scalar_field(
+            field=param_field
+        ), "Path params must be of one of the supported types"
+        return False
+    elif is_scalar_field(field=param_field):
+        return False
+    elif isinstance(
+        param_field.field_info, (params.Query, params.Header)
+    ) and is_scalar_sequence_field(param_field):
+        return False
+    else:
+        assert isinstance(
+            param_field.field_info, params.Body
+        ), f"Param: {param_field.name} can only be a request body, using Body()"
+        return True
+
+
+def add_param_to_fields(*, field: ModelField, dependant: Dependant) -> None:
+    field_info = cast(params.Param, field.field_info)
+    if field_info.in_ == params.ParamTypes.path:
+        dependant.path_params.append(field)
+    elif field_info.in_ == params.ParamTypes.query:
+        dependant.query_params.append(field)
+    elif field_info.in_ == params.ParamTypes.header:
+        dependant.header_params.append(field)
+    else:
+        assert (
+            field_info.in_ == params.ParamTypes.cookie
+        ), f"non-body parameters must be in path, query, header or cookie: {field.name}"
+        dependant.cookie_params.append(field)
+
+
+def is_coroutine_callable(call: Callable[..., Any]) -> bool:
+    if inspect.isroutine(call):
+        return inspect.iscoroutinefunction(call)
+    if inspect.isclass(call):
+        return False
+    dunder_call = getattr(call, "__call__", None)  # noqa: B004
+    return inspect.iscoroutinefunction(dunder_call)
+
+
+def is_async_gen_callable(call: Callable[..., Any]) -> bool:
+    if inspect.isasyncgenfunction(call):
+        return True
+    dunder_call = getattr(call, "__call__", None)  # noqa: B004
+    return inspect.isasyncgenfunction(dunder_call)
+
+
+def is_gen_callable(call: Callable[..., Any]) -> bool:
+    if inspect.isgeneratorfunction(call):
+        return True
+    dunder_call = getattr(call, "__call__", None)  # noqa: B004
+    return inspect.isgeneratorfunction(dunder_call)
+
+
+async def solve_generator(
+    *, call: Callable[..., Any], stack: AsyncExitStack, sub_values: Dict[str, Any]
+) -> Any:
+    if is_gen_callable(call):
+        cm = contextmanager_in_threadpool(contextmanager(call)(**sub_values))
+    elif is_async_gen_callable(call):
+        cm = asynccontextmanager(call)(**sub_values)
+    return await stack.enter_async_context(cm)
+
+
+async def solve_dependencies(
+    *,
+    request: Union[Request, WebSocket],
+    dependant: Dependant,
+    body: Optional[Union[Dict[str, Any], FormData]] = None,
+    background_tasks: Optional[BackgroundTasks] = None,
+    response: Optional[Response] = None,
+    dependency_overrides_provider: Optional[Any] = None,
+    dependency_cache: Optional[Dict[Tuple[Callable[..., Any], Tuple[str]], Any]] = None,
+) -> Tuple[
+    Dict[str, Any],
+    List[Any],
+    Optional[BackgroundTasks],
+    Response,
+    Dict[Tuple[Callable[..., Any], Tuple[str]], Any],
+]:
+    values: Dict[str, Any] = {}
+    errors: List[Any] = []
+    if response is None:
+        response = Response()
+        del response.headers["content-length"]
+        response.status_code = None  # type: ignore
+    dependency_cache = dependency_cache or {}
+    sub_dependant: Dependant
+    for sub_dependant in dependant.dependencies:
+        sub_dependant.call = cast(Callable[..., Any], sub_dependant.call)
+        sub_dependant.cache_key = cast(
+            Tuple[Callable[..., Any], Tuple[str]], sub_dependant.cache_key
+        )
+        call = sub_dependant.call
+        use_sub_dependant = sub_dependant
+        if (
+            dependency_overrides_provider
+            and dependency_overrides_provider.dependency_overrides
+        ):
+            original_call = sub_dependant.call
+            call = getattr(
+                dependency_overrides_provider, "dependency_overrides", {}
+            ).get(original_call, original_call)
+            use_path: str = sub_dependant.path  # type: ignore
+            use_sub_dependant = get_dependant(
+                path=use_path,
+                call=call,
+                name=sub_dependant.name,
+                security_scopes=sub_dependant.security_scopes,
+            )
+
+        solved_result = await solve_dependencies(
+            request=request,
+            dependant=use_sub_dependant,
+            body=body,
+            background_tasks=background_tasks,
+            response=response,
+            dependency_overrides_provider=dependency_overrides_provider,
+            dependency_cache=dependency_cache,
+        )
+        (
+            sub_values,
+            sub_errors,
+            background_tasks,
+            _,  # the subdependency returns the same response we have
+            sub_dependency_cache,
+        ) = solved_result
+        dependency_cache.update(sub_dependency_cache)
+        if sub_errors:
+            errors.extend(sub_errors)
+            continue
+        if sub_dependant.use_cache and sub_dependant.cache_key in dependency_cache:
+            solved = dependency_cache[sub_dependant.cache_key]
+        elif is_gen_callable(call) or is_async_gen_callable(call):
+            stack = request.scope.get("fastapi_astack")
+            assert isinstance(stack, AsyncExitStack)
+            solved = await solve_generator(
+                call=call, stack=stack, sub_values=sub_values
+            )
+        elif is_coroutine_callable(call):
+            solved = await call(**sub_values)
+        else:
+            solved = await run_in_threadpool(call, **sub_values)
+        if sub_dependant.name is not None:
+            values[sub_dependant.name] = solved
+        if sub_dependant.cache_key not in dependency_cache:
+            dependency_cache[sub_dependant.cache_key] = solved
+    path_values, path_errors = request_params_to_args(
+        dependant.path_params, request.path_params
+    )
+    query_values, query_errors = request_params_to_args(
+        dependant.query_params, request.query_params
+    )
+    header_values, header_errors = request_params_to_args(
+        dependant.header_params, request.headers
+    )
+    cookie_values, cookie_errors = request_params_to_args(
+        dependant.cookie_params, request.cookies
+    )
+    values.update(path_values)
+    values.update(query_values)
+    values.update(header_values)
+    values.update(cookie_values)
+    errors += path_errors + query_errors + header_errors + cookie_errors
+    if dependant.body_params:
+        (
+            body_values,
+            body_errors,
+        ) = await request_body_to_args(  # body_params checked above
+            required_params=dependant.body_params, received_body=body
+        )
+        values.update(body_values)
+        errors.extend(body_errors)
+    if dependant.http_connection_param_name:
+        values[dependant.http_connection_param_name] = request
+    if dependant.request_param_name and isinstance(request, Request):
+        values[dependant.request_param_name] = request
+    elif dependant.websocket_param_name and isinstance(request, WebSocket):
+        values[dependant.websocket_param_name] = request
+    if dependant.background_tasks_param_name:
+        if background_tasks is None:
+            background_tasks = BackgroundTasks()
+        values[dependant.background_tasks_param_name] = background_tasks
+    if dependant.response_param_name:
+        values[dependant.response_param_name] = response
+    if dependant.security_scopes_param_name:
+        values[dependant.security_scopes_param_name] = SecurityScopes(
+            scopes=dependant.security_scopes
+        )
+    return values, errors, background_tasks, response, dependency_cache
+
+
+def request_params_to_args(
+    required_params: Sequence[ModelField],
+    received_params: Union[Mapping[str, Any], QueryParams, Headers],
+) -> Tuple[Dict[str, Any], List[Any]]:
+    values = {}
+    errors = []
+    for field in required_params:
+        if is_scalar_sequence_field(field) and isinstance(
+            received_params, (QueryParams, Headers)
+        ):
+            value = received_params.getlist(field.alias) or field.default
+        else:
+            value = received_params.get(field.alias)
+        field_info = field.field_info
+        assert isinstance(
+            field_info, params.Param
+        ), "Params must be subclasses of Param"
+        loc = (field_info.in_.value, field.alias)
+        if value is None:
+            if field.required:
+                errors.append(get_missing_field_error(loc=loc))
+            else:
+                values[field.name] = deepcopy(field.default)
+            continue
+        v_, errors_ = field.validate(value, values, loc=loc)
+        if isinstance(errors_, ErrorWrapper):
+            errors.append(errors_)
+        elif isinstance(errors_, list):
+            new_errors = _regenerate_error_with_loc(errors=errors_, loc_prefix=())
+            errors.extend(new_errors)
+        else:
+            values[field.name] = v_
+    return values, errors
+
+
+async def request_body_to_args(
+    required_params: List[ModelField],
+    received_body: Optional[Union[Dict[str, Any], FormData]],
+) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    values = {}
+    errors: List[Dict[str, Any]] = []
+    if required_params:
+        field = required_params[0]
+        field_info = field.field_info
+        embed = getattr(field_info, "embed", None)
+        field_alias_omitted = len(required_params) == 1 and not embed
+        if field_alias_omitted:
+            received_body = {field.alias: received_body}
+
+        for field in required_params:
+            loc: Tuple[str, ...]
+            if field_alias_omitted:
+                loc = ("body",)
+            else:
+                loc = ("body", field.alias)
+
+            value: Optional[Any] = None
+            if received_body is not None:
+                if (is_sequence_field(field)) and isinstance(received_body, FormData):
+                    value = received_body.getlist(field.alias)
+                else:
+                    try:
+                        value = received_body.get(field.alias)
+                    except AttributeError:
+                        errors.append(get_missing_field_error(loc))
+                        continue
+            if (
+                value is None
+                or (isinstance(field_info, params.Form) and value == "")
+                or (
+                    isinstance(field_info, params.Form)
+                    and is_sequence_field(field)
+                    and len(value) == 0
+                )
+            ):
+                if field.required:
+                    errors.append(get_missing_field_error(loc))
+                else:
+                    values[field.name] = deepcopy(field.default)
+                continue
+            if (
+                isinstance(field_info, params.File)
+                and is_bytes_field(field)
+                and isinstance(value, UploadFile)
+            ):
+                value = await value.read()
+            elif (
+                is_bytes_sequence_field(field)
+                and isinstance(field_info, params.File)
+                and value_is_sequence(value)
+            ):
+                # For types
+                assert isinstance(value, sequence_types)  # type: ignore[arg-type]
+                results: List[Union[bytes, str]] = []
+
+                async def process_fn(
+                    fn: Callable[[], Coroutine[Any, Any, Any]]
+                ) -> None:
+                    result = await fn()
+                    results.append(result)  # noqa: B023
+
+                async with anyio.create_task_group() as tg:
+                    for sub_value in value:
+                        tg.start_soon(process_fn, sub_value.read)
+                value = serialize_sequence_value(field=field, value=results)
+
+            v_, errors_ = field.validate(value, values, loc=loc)
+
+            if isinstance(errors_, list):
+                errors.extend(errors_)
+            elif errors_:
+                errors.append(errors_)
+            else:
+                values[field.name] = v_
+    return values, errors
+
+
+def get_body_field(*, dependant: Dependant, name: str) -> Optional[ModelField]:
+    flat_dependant = get_flat_dependant(dependant)
+    if not flat_dependant.body_params:
+        return None
+    first_param = flat_dependant.body_params[0]
+    field_info = first_param.field_info
+    embed = getattr(field_info, "embed", None)
+    body_param_names_set = {param.name for param in flat_dependant.body_params}
+    if len(body_param_names_set) == 1 and not embed:
+        check_file_field(first_param)
+        return first_param
+    # If one field requires to embed, all have to be embedded
+    # in case a sub-dependency is evaluated with a single unique body field
+    # That is combined (embedded) with other body fields
+    for param in flat_dependant.body_params:
+        setattr(param.field_info, "embed", True)  # noqa: B010
+    model_name = "Body_" + name
+    BodyModel = create_body_model(
+        fields=flat_dependant.body_params, model_name=model_name
+    )
+    required = any(True for f in flat_dependant.body_params if f.required)
+    BodyFieldInfo_kwargs: Dict[str, Any] = {
+        "annotation": BodyModel,
+        "alias": "body",
+    }
+    if not required:
+        BodyFieldInfo_kwargs["default"] = None
+    if any(isinstance(f.field_info, params.File) for f in flat_dependant.body_params):
+        BodyFieldInfo: Type[params.Body] = params.File
+    elif any(isinstance(f.field_info, params.Form) for f in flat_dependant.body_params):
+        BodyFieldInfo = params.Form
+    else:
+        BodyFieldInfo = params.Body
+
+        body_param_media_types = [
+            f.field_info.media_type
+            for f in flat_dependant.body_params
+            if isinstance(f.field_info, params.Body)
+        ]
+        if len(set(body_param_media_types)) == 1:
+            BodyFieldInfo_kwargs["media_type"] = body_param_media_types[0]
+    final_field = create_response_field(
+        name="body",
+        type_=BodyModel,
+        required=required,
+        alias="body",
+        field_info=BodyFieldInfo(**BodyFieldInfo_kwargs),
+    )
+    check_file_field(final_field)
+    return final_field

--- a/src/prefect/_vendor/fastapi/encoders.py
+++ b/src/prefect/_vendor/fastapi/encoders.py
@@ -1,0 +1,249 @@
+import dataclasses
+import datetime
+from collections import defaultdict, deque
+from decimal import Decimal
+from enum import Enum
+from ipaddress import (
+    IPv4Address,
+    IPv4Interface,
+    IPv4Network,
+    IPv6Address,
+    IPv6Interface,
+    IPv6Network,
+)
+from pathlib import Path, PurePath
+from re import Pattern
+from types import GeneratorType
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from uuid import UUID
+
+from prefect._vendor.fastapi.types import IncEx
+from pydantic import BaseModel
+from pydantic.color import Color
+from pydantic.networks import AnyUrl, NameEmail
+from pydantic.types import SecretBytes, SecretStr
+
+from ._compat import PYDANTIC_V2, Url, _model_dump
+
+
+# Taken from Pydantic v1 as is
+def isoformat(o: Union[datetime.date, datetime.time]) -> str:
+    return o.isoformat()
+
+
+# Taken from Pydantic v1 as is
+# TODO: pv2 should this return strings instead?
+def decimal_encoder(dec_value: Decimal) -> Union[int, float]:
+    """
+    Encodes a Decimal as int of there's no exponent, otherwise float
+
+    This is useful when we use ConstrainedDecimal to represent Numeric(x,0)
+    where a integer (but not int typed) is used. Encoding this as a float
+    results in failed round-tripping between encode and parse.
+    Our Id type is a prime example of this.
+
+    >>> decimal_encoder(Decimal("1.0"))
+    1.0
+
+    >>> decimal_encoder(Decimal("1"))
+    1
+    """
+    if dec_value.as_tuple().exponent >= 0:  # type: ignore[operator]
+        return int(dec_value)
+    else:
+        return float(dec_value)
+
+
+ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
+    bytes: lambda o: o.decode(),
+    Color: str,
+    datetime.date: isoformat,
+    datetime.datetime: isoformat,
+    datetime.time: isoformat,
+    datetime.timedelta: lambda td: td.total_seconds(),
+    Decimal: decimal_encoder,
+    Enum: lambda o: o.value,
+    frozenset: list,
+    deque: list,
+    GeneratorType: list,
+    IPv4Address: str,
+    IPv4Interface: str,
+    IPv4Network: str,
+    IPv6Address: str,
+    IPv6Interface: str,
+    IPv6Network: str,
+    NameEmail: str,
+    Path: str,
+    Pattern: lambda o: o.pattern,
+    SecretBytes: str,
+    SecretStr: str,
+    set: list,
+    UUID: str,
+    Url: str,
+    AnyUrl: str,
+}
+
+
+def generate_encoders_by_class_tuples(
+    type_encoder_map: Dict[Any, Callable[[Any], Any]]
+) -> Dict[Callable[[Any], Any], Tuple[Any, ...]]:
+    encoders_by_class_tuples: Dict[Callable[[Any], Any], Tuple[Any, ...]] = defaultdict(
+        tuple
+    )
+    for type_, encoder in type_encoder_map.items():
+        encoders_by_class_tuples[encoder] += (type_,)
+    return encoders_by_class_tuples
+
+
+encoders_by_class_tuples = generate_encoders_by_class_tuples(ENCODERS_BY_TYPE)
+
+
+def jsonable_encoder(
+    obj: Any,
+    include: Optional[IncEx] = None,
+    exclude: Optional[IncEx] = None,
+    by_alias: bool = True,
+    exclude_unset: bool = False,
+    exclude_defaults: bool = False,
+    exclude_none: bool = False,
+    custom_encoder: Optional[Dict[Any, Callable[[Any], Any]]] = None,
+    sqlalchemy_safe: bool = True,
+) -> Any:
+    custom_encoder = custom_encoder or {}
+    if custom_encoder:
+        if type(obj) in custom_encoder:
+            return custom_encoder[type(obj)](obj)
+        else:
+            for encoder_type, encoder_instance in custom_encoder.items():
+                if isinstance(obj, encoder_type):
+                    return encoder_instance(obj)
+    if include is not None and not isinstance(include, (set, dict)):
+        include = set(include)
+    if exclude is not None and not isinstance(exclude, (set, dict)):
+        exclude = set(exclude)
+    if isinstance(obj, BaseModel):
+        # TODO: remove when deprecating Pydantic v1
+        encoders: Dict[Any, Any] = {}
+        if not PYDANTIC_V2:
+            encoders = getattr(obj.__config__, "json_encoders", {})  # type: ignore[attr-defined]
+            if custom_encoder:
+                encoders.update(custom_encoder)
+        obj_dict = _model_dump(
+            obj,
+            mode="json",
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_none=exclude_none,
+            exclude_defaults=exclude_defaults,
+        )
+        if "__root__" in obj_dict:
+            obj_dict = obj_dict["__root__"]
+        return jsonable_encoder(
+            obj_dict,
+            exclude_none=exclude_none,
+            exclude_defaults=exclude_defaults,
+            # TODO: remove when deprecating Pydantic v1
+            custom_encoder=encoders,
+            sqlalchemy_safe=sqlalchemy_safe,
+        )
+    if dataclasses.is_dataclass(obj):
+        obj_dict = dataclasses.asdict(obj)
+        return jsonable_encoder(
+            obj_dict,
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+            custom_encoder=custom_encoder,
+            sqlalchemy_safe=sqlalchemy_safe,
+        )
+    if isinstance(obj, Enum):
+        return obj.value
+    if isinstance(obj, PurePath):
+        return str(obj)
+    if isinstance(obj, (str, int, float, type(None))):
+        return obj
+    if isinstance(obj, dict):
+        encoded_dict = {}
+        allowed_keys = set(obj.keys())
+        if include is not None:
+            allowed_keys &= set(include)
+        if exclude is not None:
+            allowed_keys -= set(exclude)
+        for key, value in obj.items():
+            if (
+                (
+                    not sqlalchemy_safe
+                    or (not isinstance(key, str))
+                    or (not key.startswith("_sa"))
+                )
+                and (value is not None or not exclude_none)
+                and key in allowed_keys
+            ):
+                encoded_key = jsonable_encoder(
+                    key,
+                    by_alias=by_alias,
+                    exclude_unset=exclude_unset,
+                    exclude_none=exclude_none,
+                    custom_encoder=custom_encoder,
+                    sqlalchemy_safe=sqlalchemy_safe,
+                )
+                encoded_value = jsonable_encoder(
+                    value,
+                    by_alias=by_alias,
+                    exclude_unset=exclude_unset,
+                    exclude_none=exclude_none,
+                    custom_encoder=custom_encoder,
+                    sqlalchemy_safe=sqlalchemy_safe,
+                )
+                encoded_dict[encoded_key] = encoded_value
+        return encoded_dict
+    if isinstance(obj, (list, set, frozenset, GeneratorType, tuple, deque)):
+        encoded_list = []
+        for item in obj:
+            encoded_list.append(
+                jsonable_encoder(
+                    item,
+                    include=include,
+                    exclude=exclude,
+                    by_alias=by_alias,
+                    exclude_unset=exclude_unset,
+                    exclude_defaults=exclude_defaults,
+                    exclude_none=exclude_none,
+                    custom_encoder=custom_encoder,
+                    sqlalchemy_safe=sqlalchemy_safe,
+                )
+            )
+        return encoded_list
+
+    if type(obj) in ENCODERS_BY_TYPE:
+        return ENCODERS_BY_TYPE[type(obj)](obj)
+    for encoder, classes_tuple in encoders_by_class_tuples.items():
+        if isinstance(obj, classes_tuple):
+            return encoder(obj)
+
+    try:
+        data = dict(obj)
+    except Exception as e:
+        errors: List[Exception] = []
+        errors.append(e)
+        try:
+            data = vars(obj)
+        except Exception as e:
+            errors.append(e)
+            raise ValueError(errors) from e
+    return jsonable_encoder(
+        data,
+        include=include,
+        exclude=exclude,
+        by_alias=by_alias,
+        exclude_unset=exclude_unset,
+        exclude_defaults=exclude_defaults,
+        exclude_none=exclude_none,
+        custom_encoder=custom_encoder,
+        sqlalchemy_safe=sqlalchemy_safe,
+    )

--- a/src/prefect/_vendor/fastapi/exception_handlers.py
+++ b/src/prefect/_vendor/fastapi/exception_handlers.py
@@ -1,0 +1,37 @@
+from prefect._vendor.fastapi.encoders import jsonable_encoder
+from prefect._vendor.fastapi.exceptions import (
+    RequestValidationError,
+    WebSocketRequestValidationError,
+)
+from prefect._vendor.fastapi.utils import is_body_allowed_for_status_code
+from prefect._vendor.fastapi.websockets import WebSocket
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY, WS_1008_POLICY_VIOLATION
+
+
+async def http_exception_handler(request: Request, exc: HTTPException) -> Response:
+    headers = getattr(exc, "headers", None)
+    if not is_body_allowed_for_status_code(exc.status_code):
+        return Response(status_code=exc.status_code, headers=headers)
+    return JSONResponse(
+        {"detail": exc.detail}, status_code=exc.status_code, headers=headers
+    )
+
+
+async def request_validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+        content={"detail": jsonable_encoder(exc.errors())},
+    )
+
+
+async def websocket_request_validation_exception_handler(
+    websocket: WebSocket, exc: WebSocketRequestValidationError
+) -> None:
+    await websocket.close(
+        code=WS_1008_POLICY_VIOLATION, reason=jsonable_encoder(exc.errors())
+    )

--- a/src/prefect/_vendor/fastapi/exceptions.py
+++ b/src/prefect/_vendor/fastapi/exceptions.py
@@ -1,0 +1,55 @@
+from typing import Any, Dict, Optional, Sequence, Type
+
+from pydantic import BaseModel, create_model
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.exceptions import WebSocketException as WebSocketException  # noqa: F401
+
+
+class HTTPException(StarletteHTTPException):
+    def __init__(
+        self,
+        status_code: int,
+        detail: Any = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> None:
+        super().__init__(status_code=status_code, detail=detail, headers=headers)
+
+
+RequestErrorModel: Type[BaseModel] = create_model("Request")
+WebSocketErrorModel: Type[BaseModel] = create_model("WebSocket")
+
+
+class FastAPIError(RuntimeError):
+    """
+    A generic, FastAPI-specific error.
+    """
+
+
+class ValidationException(Exception):
+    def __init__(self, errors: Sequence[Any]) -> None:
+        self._errors = errors
+
+    def errors(self) -> Sequence[Any]:
+        return self._errors
+
+
+class RequestValidationError(ValidationException):
+    def __init__(self, errors: Sequence[Any], *, body: Any = None) -> None:
+        super().__init__(errors)
+        self.body = body
+
+
+class WebSocketRequestValidationError(ValidationException):
+    pass
+
+
+class ResponseValidationError(ValidationException):
+    def __init__(self, errors: Sequence[Any], *, body: Any = None) -> None:
+        super().__init__(errors)
+        self.body = body
+
+    def __str__(self) -> str:
+        message = f"{len(self._errors)} validation errors:\n"
+        for err in self._errors:
+            message += f"  {err}\n"
+        return message

--- a/src/prefect/_vendor/fastapi/logger.py
+++ b/src/prefect/_vendor/fastapi/logger.py
@@ -1,0 +1,3 @@
+import logging
+
+logger = logging.getLogger("fastapi")

--- a/src/prefect/_vendor/fastapi/middleware/__init__.py
+++ b/src/prefect/_vendor/fastapi/middleware/__init__.py
@@ -1,0 +1,1 @@
+from starlette.middleware import Middleware as Middleware

--- a/src/prefect/_vendor/fastapi/middleware/asyncexitstack.py
+++ b/src/prefect/_vendor/fastapi/middleware/asyncexitstack.py
@@ -1,0 +1,25 @@
+from typing import Optional
+
+from prefect._vendor.fastapi.concurrency import AsyncExitStack
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class AsyncExitStackMiddleware:
+    def __init__(self, app: ASGIApp, context_name: str = "fastapi_astack") -> None:
+        self.app = app
+        self.context_name = context_name
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        dependency_exception: Optional[Exception] = None
+        async with AsyncExitStack() as stack:
+            scope[self.context_name] = stack
+            try:
+                await self.app(scope, receive, send)
+            except Exception as e:
+                dependency_exception = e
+                raise e
+        if dependency_exception:
+            # This exception was possibly handled by the dependency but it should
+            # still bubble up so that the ServerErrorMiddleware can return a 500
+            # or the ExceptionMiddleware can catch and handle any other exceptions
+            raise dependency_exception

--- a/src/prefect/_vendor/fastapi/middleware/cors.py
+++ b/src/prefect/_vendor/fastapi/middleware/cors.py
@@ -1,0 +1,1 @@
+from starlette.middleware.cors import CORSMiddleware as CORSMiddleware  # noqa

--- a/src/prefect/_vendor/fastapi/middleware/gzip.py
+++ b/src/prefect/_vendor/fastapi/middleware/gzip.py
@@ -1,0 +1,1 @@
+from starlette.middleware.gzip import GZipMiddleware as GZipMiddleware  # noqa

--- a/src/prefect/_vendor/fastapi/middleware/httpsredirect.py
+++ b/src/prefect/_vendor/fastapi/middleware/httpsredirect.py
@@ -1,0 +1,3 @@
+from starlette.middleware.httpsredirect import (  # noqa
+    HTTPSRedirectMiddleware as HTTPSRedirectMiddleware,
+)

--- a/src/prefect/_vendor/fastapi/middleware/trustedhost.py
+++ b/src/prefect/_vendor/fastapi/middleware/trustedhost.py
@@ -1,0 +1,3 @@
+from starlette.middleware.trustedhost import (  # noqa
+    TrustedHostMiddleware as TrustedHostMiddleware,
+)

--- a/src/prefect/_vendor/fastapi/middleware/wsgi.py
+++ b/src/prefect/_vendor/fastapi/middleware/wsgi.py
@@ -1,0 +1,1 @@
+from starlette.middleware.wsgi import WSGIMiddleware as WSGIMiddleware  # noqa

--- a/src/prefect/_vendor/fastapi/openapi/constants.py
+++ b/src/prefect/_vendor/fastapi/openapi/constants.py
@@ -1,0 +1,3 @@
+METHODS_WITH_BODY = {"GET", "HEAD", "POST", "PUT", "DELETE", "PATCH"}
+REF_PREFIX = "#/components/schemas/"
+REF_TEMPLATE = "#/components/schemas/{model}"

--- a/src/prefect/_vendor/fastapi/openapi/docs.py
+++ b/src/prefect/_vendor/fastapi/openapi/docs.py
@@ -1,0 +1,203 @@
+import json
+from typing import Any, Dict, Optional
+
+from prefect._vendor.fastapi.encoders import jsonable_encoder
+from starlette.responses import HTMLResponse
+
+swagger_ui_default_parameters = {
+    "dom_id": "#swagger-ui",
+    "layout": "BaseLayout",
+    "deepLinking": True,
+    "showExtensions": True,
+    "showCommonExtensions": True,
+}
+
+
+def get_swagger_ui_html(
+    *,
+    openapi_url: str,
+    title: str,
+    swagger_js_url: str = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js",
+    swagger_css_url: str = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css",
+    swagger_favicon_url: str = "https://fastapi.tiangolo.com/img/favicon.png",
+    oauth2_redirect_url: Optional[str] = None,
+    init_oauth: Optional[Dict[str, Any]] = None,
+    swagger_ui_parameters: Optional[Dict[str, Any]] = None,
+) -> HTMLResponse:
+    current_swagger_ui_parameters = swagger_ui_default_parameters.copy()
+    if swagger_ui_parameters:
+        current_swagger_ui_parameters.update(swagger_ui_parameters)
+
+    html = f"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <link type="text/css" rel="stylesheet" href="{swagger_css_url}">
+    <link rel="shortcut icon" href="{swagger_favicon_url}">
+    <title>{title}</title>
+    </head>
+    <body>
+    <div id="swagger-ui">
+    </div>
+    <script src="{swagger_js_url}"></script>
+    <!-- `SwaggerUIBundle` is now available on the page -->
+    <script>
+    const ui = SwaggerUIBundle({{
+        url: '{openapi_url}',
+    """
+
+    for key, value in current_swagger_ui_parameters.items():
+        html += f"{json.dumps(key)}: {json.dumps(jsonable_encoder(value))},\n"
+
+    if oauth2_redirect_url:
+        html += f"oauth2RedirectUrl: window.location.origin + '{oauth2_redirect_url}',"
+
+    html += """
+    presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIBundle.SwaggerUIStandalonePreset
+        ],
+    })"""
+
+    if init_oauth:
+        html += f"""
+        ui.initOAuth({json.dumps(jsonable_encoder(init_oauth))})
+        """
+
+    html += """
+    </script>
+    </body>
+    </html>
+    """
+    return HTMLResponse(html)
+
+
+def get_redoc_html(
+    *,
+    openapi_url: str,
+    title: str,
+    redoc_js_url: str = "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js",
+    redoc_favicon_url: str = "https://fastapi.tiangolo.com/img/favicon.png",
+    with_google_fonts: bool = True,
+) -> HTMLResponse:
+    html = f"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <title>{title}</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    """
+    if with_google_fonts:
+        html += """
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+    """
+    html += f"""
+    <link rel="shortcut icon" href="{redoc_favicon_url}">
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {{
+        margin: 0;
+        padding: 0;
+      }}
+    </style>
+    </head>
+    <body>
+    <noscript>
+        ReDoc requires Javascript to function. Please enable it to browse the documentation.
+    </noscript>
+    <redoc spec-url="{openapi_url}"></redoc>
+    <script src="{redoc_js_url}"> </script>
+    </body>
+    </html>
+    """
+    return HTMLResponse(html)
+
+
+def get_swagger_ui_oauth2_redirect_html() -> HTMLResponse:
+    # copied from https://github.com/swagger-api/swagger-ui/blob/v4.14.0/dist/oauth2-redirect.html
+    html = """
+    <!doctype html>
+    <html lang="en-US">
+    <head>
+        <title>Swagger UI: OAuth2 Redirect</title>
+    </head>
+    <body>
+    <script>
+        'use strict';
+        function run () {
+            var oauth2 = window.opener.swaggerUIRedirectOauth2;
+            var sentState = oauth2.state;
+            var redirectUrl = oauth2.redirectUrl;
+            var isValid, qp, arr;
+
+            if (/code|token|error/.test(window.location.hash)) {
+                qp = window.location.hash.substring(1).replace('?', '&');
+            } else {
+                qp = location.search.substring(1);
+            }
+
+            arr = qp.split("&");
+            arr.forEach(function (v,i,_arr) { _arr[i] = '"' + v.replace('=', '":"') + '"';});
+            qp = qp ? JSON.parse('{' + arr.join() + '}',
+                    function (key, value) {
+                        return key === "" ? value : decodeURIComponent(value);
+                    }
+            ) : {};
+
+            isValid = qp.state === sentState;
+
+            if ((
+              oauth2.auth.schema.get("flow") === "accessCode" ||
+              oauth2.auth.schema.get("flow") === "authorizationCode" ||
+              oauth2.auth.schema.get("flow") === "authorization_code"
+            ) && !oauth2.auth.code) {
+                if (!isValid) {
+                    oauth2.errCb({
+                        authId: oauth2.auth.name,
+                        source: "auth",
+                        level: "warning",
+                        message: "Authorization may be unsafe, passed state was changed in server. The passed state wasn't returned from auth server."
+                    });
+                }
+
+                if (qp.code) {
+                    delete oauth2.state;
+                    oauth2.auth.code = qp.code;
+                    oauth2.callback({auth: oauth2.auth, redirectUrl: redirectUrl});
+                } else {
+                    let oauthErrorMsg;
+                    if (qp.error) {
+                        oauthErrorMsg = "["+qp.error+"]: " +
+                            (qp.error_description ? qp.error_description+ ". " : "no accessCode received from the server. ") +
+                            (qp.error_uri ? "More info: "+qp.error_uri : "");
+                    }
+
+                    oauth2.errCb({
+                        authId: oauth2.auth.name,
+                        source: "auth",
+                        level: "error",
+                        message: oauthErrorMsg || "[Authorization failed]: no accessCode received from the server."
+                    });
+                }
+            } else {
+                oauth2.callback({auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl});
+            }
+            window.close();
+        }
+
+        if (document.readyState !== 'loading') {
+            run();
+        } else {
+            document.addEventListener('DOMContentLoaded', function () {
+                run();
+            });
+        }
+    </script>
+    </body>
+    </html>
+        """
+    return HTMLResponse(content=html)

--- a/src/prefect/_vendor/fastapi/openapi/models.py
+++ b/src/prefect/_vendor/fastapi/openapi/models.py
@@ -1,0 +1,611 @@
+from enum import Enum
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Type, Union
+
+from prefect._vendor.fastapi._compat import (
+    PYDANTIC_V2,
+    CoreSchema,
+    GetJsonSchemaHandler,
+    JsonSchemaValue,
+    _model_rebuild,
+    with_info_plain_validator_function,
+)
+from prefect._vendor.fastapi.logger import logger
+from pydantic import AnyUrl, BaseModel, Field
+from typing_extensions import Annotated, Literal, TypedDict
+from typing_extensions import deprecated as typing_deprecated
+
+try:
+    import email_validator
+
+    assert email_validator  # make autoflake ignore the unused import
+    from pydantic import EmailStr
+except ImportError:  # pragma: no cover
+
+    class EmailStr(str):  # type: ignore
+        @classmethod
+        def __get_validators__(cls) -> Iterable[Callable[..., Any]]:
+            yield cls.validate
+
+        @classmethod
+        def validate(cls, v: Any) -> str:
+            logger.warning(
+                "email-validator not installed, email fields will be treated as str.\n"
+                "To install, run: pip install email-validator"
+            )
+            return str(v)
+
+        @classmethod
+        def _validate(cls, __input_value: Any, _: Any) -> str:
+            logger.warning(
+                "email-validator not installed, email fields will be treated as str.\n"
+                "To install, run: pip install email-validator"
+            )
+            return str(__input_value)
+
+        @classmethod
+        def __get_pydantic_json_schema__(
+            cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler
+        ) -> JsonSchemaValue:
+            return {"type": "string", "format": "email"}
+
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls, source: Type[Any], handler: Callable[[Any], CoreSchema]
+        ) -> CoreSchema:
+            return with_info_plain_validator_function(cls._validate)
+
+
+class Contact(BaseModel):
+    name: Optional[str] = None
+    url: Optional[AnyUrl] = None
+    email: Optional[EmailStr] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class License(BaseModel):
+    name: str
+    identifier: Optional[str] = None
+    url: Optional[AnyUrl] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class Info(BaseModel):
+    title: str
+    summary: Optional[str] = None
+    description: Optional[str] = None
+    termsOfService: Optional[str] = None
+    contact: Optional[Contact] = None
+    license: Optional[License] = None
+    version: str
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class ServerVariable(BaseModel):
+    enum: Annotated[Optional[List[str]], Field(min_length=1)] = None
+    default: str
+    description: Optional[str] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class Server(BaseModel):
+    url: Union[AnyUrl, str]
+    description: Optional[str] = None
+    variables: Optional[Dict[str, ServerVariable]] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class Reference(BaseModel):
+    ref: str = Field(alias="$ref")
+
+
+class Discriminator(BaseModel):
+    propertyName: str
+    mapping: Optional[Dict[str, str]] = None
+
+
+class XML(BaseModel):
+    name: Optional[str] = None
+    namespace: Optional[str] = None
+    prefix: Optional[str] = None
+    attribute: Optional[bool] = None
+    wrapped: Optional[bool] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class ExternalDocumentation(BaseModel):
+    description: Optional[str] = None
+    url: AnyUrl
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class Schema(BaseModel):
+    # Ref: JSON Schema 2020-12: https://json-schema.org/draft/2020-12/json-schema-core.html#name-the-json-schema-core-vocabu
+    # Core Vocabulary
+    schema_: Optional[str] = Field(default=None, alias="$schema")
+    vocabulary: Optional[str] = Field(default=None, alias="$vocabulary")
+    id: Optional[str] = Field(default=None, alias="$id")
+    anchor: Optional[str] = Field(default=None, alias="$anchor")
+    dynamicAnchor: Optional[str] = Field(default=None, alias="$dynamicAnchor")
+    ref: Optional[str] = Field(default=None, alias="$ref")
+    dynamicRef: Optional[str] = Field(default=None, alias="$dynamicRef")
+    defs: Optional[Dict[str, "SchemaOrBool"]] = Field(default=None, alias="$defs")
+    comment: Optional[str] = Field(default=None, alias="$comment")
+    # Ref: JSON Schema 2020-12: https://json-schema.org/draft/2020-12/json-schema-core.html#name-a-vocabulary-for-applying-s
+    # A Vocabulary for Applying Subschemas
+    allOf: Optional[List["SchemaOrBool"]] = None
+    anyOf: Optional[List["SchemaOrBool"]] = None
+    oneOf: Optional[List["SchemaOrBool"]] = None
+    not_: Optional["SchemaOrBool"] = Field(default=None, alias="not")
+    if_: Optional["SchemaOrBool"] = Field(default=None, alias="if")
+    then: Optional["SchemaOrBool"] = None
+    else_: Optional["SchemaOrBool"] = Field(default=None, alias="else")
+    dependentSchemas: Optional[Dict[str, "SchemaOrBool"]] = None
+    prefixItems: Optional[List["SchemaOrBool"]] = None
+    # TODO: uncomment and remove below when deprecating Pydantic v1
+    # It generales a list of schemas for tuples, before prefixItems was available
+    # items: Optional["SchemaOrBool"] = None
+    items: Optional[Union["SchemaOrBool", List["SchemaOrBool"]]] = None
+    contains: Optional["SchemaOrBool"] = None
+    properties: Optional[Dict[str, "SchemaOrBool"]] = None
+    patternProperties: Optional[Dict[str, "SchemaOrBool"]] = None
+    additionalProperties: Optional["SchemaOrBool"] = None
+    propertyNames: Optional["SchemaOrBool"] = None
+    unevaluatedItems: Optional["SchemaOrBool"] = None
+    unevaluatedProperties: Optional["SchemaOrBool"] = None
+    # Ref: JSON Schema Validation 2020-12: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-a-vocabulary-for-structural
+    # A Vocabulary for Structural Validation
+    type: Optional[str] = None
+    enum: Optional[List[Any]] = None
+    const: Optional[Any] = None
+    multipleOf: Optional[float] = Field(default=None, gt=0)
+    maximum: Optional[float] = None
+    exclusiveMaximum: Optional[float] = None
+    minimum: Optional[float] = None
+    exclusiveMinimum: Optional[float] = None
+    maxLength: Optional[int] = Field(default=None, ge=0)
+    minLength: Optional[int] = Field(default=None, ge=0)
+    pattern: Optional[str] = None
+    maxItems: Optional[int] = Field(default=None, ge=0)
+    minItems: Optional[int] = Field(default=None, ge=0)
+    uniqueItems: Optional[bool] = None
+    maxContains: Optional[int] = Field(default=None, ge=0)
+    minContains: Optional[int] = Field(default=None, ge=0)
+    maxProperties: Optional[int] = Field(default=None, ge=0)
+    minProperties: Optional[int] = Field(default=None, ge=0)
+    required: Optional[List[str]] = None
+    dependentRequired: Optional[Dict[str, Set[str]]] = None
+    # Ref: JSON Schema Validation 2020-12: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-vocabularies-for-semantic-c
+    # Vocabularies for Semantic Content With "format"
+    format: Optional[str] = None
+    # Ref: JSON Schema Validation 2020-12: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-a-vocabulary-for-the-conten
+    # A Vocabulary for the Contents of String-Encoded Data
+    contentEncoding: Optional[str] = None
+    contentMediaType: Optional[str] = None
+    contentSchema: Optional["SchemaOrBool"] = None
+    # Ref: JSON Schema Validation 2020-12: https://json-schema.org/draft/2020-12/json-schema-validation.html#name-a-vocabulary-for-basic-meta
+    # A Vocabulary for Basic Meta-Data Annotations
+    title: Optional[str] = None
+    description: Optional[str] = None
+    default: Optional[Any] = None
+    deprecated: Optional[bool] = None
+    readOnly: Optional[bool] = None
+    writeOnly: Optional[bool] = None
+    examples: Optional[List[Any]] = None
+    # Ref: OpenAPI 3.1.0: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object
+    # Schema Object
+    discriminator: Optional[Discriminator] = None
+    xml: Optional[XML] = None
+    externalDocs: Optional[ExternalDocumentation] = None
+    example: Annotated[
+        Optional[Any],
+        typing_deprecated(
+            "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+            "although still supported. Use examples instead."
+        ),
+    ] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+# Ref: https://json-schema.org/draft/2020-12/json-schema-core.html#name-json-schema-documents
+# A JSON Schema MUST be an object or a boolean.
+SchemaOrBool = Union[Schema, bool]
+
+
+class Example(TypedDict, total=False):
+    summary: Optional[str]
+    description: Optional[str]
+    value: Optional[Any]
+    externalValue: Optional[AnyUrl]
+
+    if PYDANTIC_V2:  # type: ignore [misc]
+        __pydantic_config__ = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class ParameterInType(Enum):
+    query = "query"
+    header = "header"
+    path = "path"
+    cookie = "cookie"
+
+
+class Encoding(BaseModel):
+    contentType: Optional[str] = None
+    headers: Optional[Dict[str, Union["Header", Reference]]] = None
+    style: Optional[str] = None
+    explode: Optional[bool] = None
+    allowReserved: Optional[bool] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class MediaType(BaseModel):
+    schema_: Optional[Union[Schema, Reference]] = Field(default=None, alias="schema")
+    example: Optional[Any] = None
+    examples: Optional[Dict[str, Union[Example, Reference]]] = None
+    encoding: Optional[Dict[str, Encoding]] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class ParameterBase(BaseModel):
+    description: Optional[str] = None
+    required: Optional[bool] = None
+    deprecated: Optional[bool] = None
+    # Serialization rules for simple scenarios
+    style: Optional[str] = None
+    explode: Optional[bool] = None
+    allowReserved: Optional[bool] = None
+    schema_: Optional[Union[Schema, Reference]] = Field(default=None, alias="schema")
+    example: Optional[Any] = None
+    examples: Optional[Dict[str, Union[Example, Reference]]] = None
+    # Serialization rules for more complex scenarios
+    content: Optional[Dict[str, MediaType]] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class Parameter(ParameterBase):
+    name: str
+    in_: ParameterInType = Field(alias="in")
+
+
+class Header(ParameterBase):
+    pass
+
+
+class RequestBody(BaseModel):
+    description: Optional[str] = None
+    content: Dict[str, MediaType]
+    required: Optional[bool] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class Link(BaseModel):
+    operationRef: Optional[str] = None
+    operationId: Optional[str] = None
+    parameters: Optional[Dict[str, Union[Any, str]]] = None
+    requestBody: Optional[Union[Any, str]] = None
+    description: Optional[str] = None
+    server: Optional[Server] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class Response(BaseModel):
+    description: str
+    headers: Optional[Dict[str, Union[Header, Reference]]] = None
+    content: Optional[Dict[str, MediaType]] = None
+    links: Optional[Dict[str, Union[Link, Reference]]] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class Operation(BaseModel):
+    tags: Optional[List[str]] = None
+    summary: Optional[str] = None
+    description: Optional[str] = None
+    externalDocs: Optional[ExternalDocumentation] = None
+    operationId: Optional[str] = None
+    parameters: Optional[List[Union[Parameter, Reference]]] = None
+    requestBody: Optional[Union[RequestBody, Reference]] = None
+    # Using Any for Specification Extensions
+    responses: Optional[Dict[str, Union[Response, Any]]] = None
+    callbacks: Optional[Dict[str, Union[Dict[str, "PathItem"], Reference]]] = None
+    deprecated: Optional[bool] = None
+    security: Optional[List[Dict[str, List[str]]]] = None
+    servers: Optional[List[Server]] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class PathItem(BaseModel):
+    ref: Optional[str] = Field(default=None, alias="$ref")
+    summary: Optional[str] = None
+    description: Optional[str] = None
+    get: Optional[Operation] = None
+    put: Optional[Operation] = None
+    post: Optional[Operation] = None
+    delete: Optional[Operation] = None
+    options: Optional[Operation] = None
+    head: Optional[Operation] = None
+    patch: Optional[Operation] = None
+    trace: Optional[Operation] = None
+    servers: Optional[List[Server]] = None
+    parameters: Optional[List[Union[Parameter, Reference]]] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class SecuritySchemeType(Enum):
+    apiKey = "apiKey"
+    http = "http"
+    oauth2 = "oauth2"
+    openIdConnect = "openIdConnect"
+
+
+class SecurityBase(BaseModel):
+    type_: SecuritySchemeType = Field(alias="type")
+    description: Optional[str] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class APIKeyIn(Enum):
+    query = "query"
+    header = "header"
+    cookie = "cookie"
+
+
+class APIKey(SecurityBase):
+    type_: SecuritySchemeType = Field(default=SecuritySchemeType.apiKey, alias="type")
+    in_: APIKeyIn = Field(alias="in")
+    name: str
+
+
+class HTTPBase(SecurityBase):
+    type_: SecuritySchemeType = Field(default=SecuritySchemeType.http, alias="type")
+    scheme: str
+
+
+class HTTPBearer(HTTPBase):
+    scheme: Literal["bearer"] = "bearer"
+    bearerFormat: Optional[str] = None
+
+
+class OAuthFlow(BaseModel):
+    refreshUrl: Optional[str] = None
+    scopes: Dict[str, str] = {}
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class OAuthFlowImplicit(OAuthFlow):
+    authorizationUrl: str
+
+
+class OAuthFlowPassword(OAuthFlow):
+    tokenUrl: str
+
+
+class OAuthFlowClientCredentials(OAuthFlow):
+    tokenUrl: str
+
+
+class OAuthFlowAuthorizationCode(OAuthFlow):
+    authorizationUrl: str
+    tokenUrl: str
+
+
+class OAuthFlows(BaseModel):
+    implicit: Optional[OAuthFlowImplicit] = None
+    password: Optional[OAuthFlowPassword] = None
+    clientCredentials: Optional[OAuthFlowClientCredentials] = None
+    authorizationCode: Optional[OAuthFlowAuthorizationCode] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class OAuth2(SecurityBase):
+    type_: SecuritySchemeType = Field(default=SecuritySchemeType.oauth2, alias="type")
+    flows: OAuthFlows
+
+
+class OpenIdConnect(SecurityBase):
+    type_: SecuritySchemeType = Field(
+        default=SecuritySchemeType.openIdConnect, alias="type"
+    )
+    openIdConnectUrl: str
+
+
+SecurityScheme = Union[APIKey, HTTPBase, OAuth2, OpenIdConnect, HTTPBearer]
+
+
+class Components(BaseModel):
+    schemas: Optional[Dict[str, Union[Schema, Reference]]] = None
+    responses: Optional[Dict[str, Union[Response, Reference]]] = None
+    parameters: Optional[Dict[str, Union[Parameter, Reference]]] = None
+    examples: Optional[Dict[str, Union[Example, Reference]]] = None
+    requestBodies: Optional[Dict[str, Union[RequestBody, Reference]]] = None
+    headers: Optional[Dict[str, Union[Header, Reference]]] = None
+    securitySchemes: Optional[Dict[str, Union[SecurityScheme, Reference]]] = None
+    links: Optional[Dict[str, Union[Link, Reference]]] = None
+    # Using Any for Specification Extensions
+    callbacks: Optional[Dict[str, Union[Dict[str, PathItem], Reference, Any]]] = None
+    pathItems: Optional[Dict[str, Union[PathItem, Reference]]] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class Tag(BaseModel):
+    name: str
+    description: Optional[str] = None
+    externalDocs: Optional[ExternalDocumentation] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+class OpenAPI(BaseModel):
+    openapi: str
+    info: Info
+    jsonSchemaDialect: Optional[str] = None
+    servers: Optional[List[Server]] = None
+    # Using Any for Specification Extensions
+    paths: Optional[Dict[str, Union[PathItem, Any]]] = None
+    webhooks: Optional[Dict[str, Union[PathItem, Reference]]] = None
+    components: Optional[Components] = None
+    security: Optional[List[Dict[str, List[str]]]] = None
+    tags: Optional[List[Tag]] = None
+    externalDocs: Optional[ExternalDocumentation] = None
+
+    if PYDANTIC_V2:
+        model_config = {"extra": "allow"}
+
+    else:
+
+        class Config:
+            extra = "allow"
+
+
+_model_rebuild(Schema)
+_model_rebuild(Operation)
+_model_rebuild(Encoding)

--- a/src/prefect/_vendor/fastapi/openapi/utils.py
+++ b/src/prefect/_vendor/fastapi/openapi/utils.py
@@ -1,0 +1,539 @@
+import http.client
+import inspect
+import warnings
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Type, Union, cast
+
+from prefect._vendor.fastapi import routing
+from prefect._vendor.fastapi._compat import (
+    GenerateJsonSchema,
+    JsonSchemaValue,
+    ModelField,
+    Undefined,
+    get_compat_model_name_map,
+    get_definitions,
+    get_schema_from_model_field,
+    lenient_issubclass,
+)
+from prefect._vendor.fastapi.datastructures import DefaultPlaceholder
+from prefect._vendor.fastapi.dependencies.models import Dependant
+from prefect._vendor.fastapi.dependencies.utils import (
+    get_flat_dependant,
+    get_flat_params,
+)
+from prefect._vendor.fastapi.encoders import jsonable_encoder
+from prefect._vendor.fastapi.openapi.constants import (
+    METHODS_WITH_BODY,
+    REF_PREFIX,
+    REF_TEMPLATE,
+)
+from prefect._vendor.fastapi.openapi.models import OpenAPI
+from prefect._vendor.fastapi.params import Body, Param
+from prefect._vendor.fastapi.responses import Response
+from prefect._vendor.fastapi.types import ModelNameMap
+from prefect._vendor.fastapi.utils import (
+    deep_dict_update,
+    generate_operation_id_for_path,
+    is_body_allowed_for_status_code,
+)
+from starlette.responses import JSONResponse
+from starlette.routing import BaseRoute
+from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
+from typing_extensions import Literal
+
+validation_error_definition = {
+    "title": "ValidationError",
+    "type": "object",
+    "properties": {
+        "loc": {
+            "title": "Location",
+            "type": "array",
+            "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+        },
+        "msg": {"title": "Message", "type": "string"},
+        "type": {"title": "Error Type", "type": "string"},
+    },
+    "required": ["loc", "msg", "type"],
+}
+
+validation_error_response_definition = {
+    "title": "HTTPValidationError",
+    "type": "object",
+    "properties": {
+        "detail": {
+            "title": "Detail",
+            "type": "array",
+            "items": {"$ref": REF_PREFIX + "ValidationError"},
+        }
+    },
+}
+
+status_code_ranges: Dict[str, str] = {
+    "1XX": "Information",
+    "2XX": "Success",
+    "3XX": "Redirection",
+    "4XX": "Client Error",
+    "5XX": "Server Error",
+    "DEFAULT": "Default Response",
+}
+
+
+def get_openapi_security_definitions(
+    flat_dependant: Dependant,
+) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    security_definitions = {}
+    operation_security = []
+    for security_requirement in flat_dependant.security_requirements:
+        security_definition = jsonable_encoder(
+            security_requirement.security_scheme.model,
+            by_alias=True,
+            exclude_none=True,
+        )
+        security_name = security_requirement.security_scheme.scheme_name
+        security_definitions[security_name] = security_definition
+        operation_security.append({security_name: security_requirement.scopes})
+    return security_definitions, operation_security
+
+
+def get_openapi_operation_parameters(
+    *,
+    all_route_params: Sequence[ModelField],
+    schema_generator: GenerateJsonSchema,
+    model_name_map: ModelNameMap,
+    field_mapping: Dict[
+        Tuple[ModelField, Literal["validation", "serialization"]], JsonSchemaValue
+    ],
+    separate_input_output_schemas: bool = True,
+) -> List[Dict[str, Any]]:
+    parameters = []
+    for param in all_route_params:
+        field_info = param.field_info
+        field_info = cast(Param, field_info)
+        if not field_info.include_in_schema:
+            continue
+        param_schema = get_schema_from_model_field(
+            field=param,
+            schema_generator=schema_generator,
+            model_name_map=model_name_map,
+            field_mapping=field_mapping,
+            separate_input_output_schemas=separate_input_output_schemas,
+        )
+        parameter = {
+            "name": param.alias,
+            "in": field_info.in_.value,
+            "required": param.required,
+            "schema": param_schema,
+        }
+        if field_info.description:
+            parameter["description"] = field_info.description
+        if field_info.openapi_examples:
+            parameter["examples"] = jsonable_encoder(field_info.openapi_examples)
+        elif field_info.example != Undefined:
+            parameter["example"] = jsonable_encoder(field_info.example)
+        if field_info.deprecated:
+            parameter["deprecated"] = field_info.deprecated
+        parameters.append(parameter)
+    return parameters
+
+
+def get_openapi_operation_request_body(
+    *,
+    body_field: Optional[ModelField],
+    schema_generator: GenerateJsonSchema,
+    model_name_map: ModelNameMap,
+    field_mapping: Dict[
+        Tuple[ModelField, Literal["validation", "serialization"]], JsonSchemaValue
+    ],
+    separate_input_output_schemas: bool = True,
+) -> Optional[Dict[str, Any]]:
+    if not body_field:
+        return None
+    assert isinstance(body_field, ModelField)
+    body_schema = get_schema_from_model_field(
+        field=body_field,
+        schema_generator=schema_generator,
+        model_name_map=model_name_map,
+        field_mapping=field_mapping,
+        separate_input_output_schemas=separate_input_output_schemas,
+    )
+    field_info = cast(Body, body_field.field_info)
+    request_media_type = field_info.media_type
+    required = body_field.required
+    request_body_oai: Dict[str, Any] = {}
+    if required:
+        request_body_oai["required"] = required
+    request_media_content: Dict[str, Any] = {"schema": body_schema}
+    if field_info.openapi_examples:
+        request_media_content["examples"] = jsonable_encoder(
+            field_info.openapi_examples
+        )
+    elif field_info.example != Undefined:
+        request_media_content["example"] = jsonable_encoder(field_info.example)
+    request_body_oai["content"] = {request_media_type: request_media_content}
+    return request_body_oai
+
+
+def generate_operation_id(
+    *, route: routing.APIRoute, method: str
+) -> str:  # pragma: nocover
+    warnings.warn(
+        (
+            "fastapi.openapi.utils.generate_operation_id() was deprecated, "
+            "it is not used internally, and will be removed soon"
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    if route.operation_id:
+        return route.operation_id
+    path: str = route.path_format
+    return generate_operation_id_for_path(name=route.name, path=path, method=method)
+
+
+def generate_operation_summary(*, route: routing.APIRoute, method: str) -> str:
+    if route.summary:
+        return route.summary
+    return route.name.replace("_", " ").title()
+
+
+def get_openapi_operation_metadata(
+    *, route: routing.APIRoute, method: str, operation_ids: Set[str]
+) -> Dict[str, Any]:
+    operation: Dict[str, Any] = {}
+    if route.tags:
+        operation["tags"] = route.tags
+    operation["summary"] = generate_operation_summary(route=route, method=method)
+    if route.description:
+        operation["description"] = route.description
+    operation_id = route.operation_id or route.unique_id
+    if operation_id in operation_ids:
+        message = (
+            f"Duplicate Operation ID {operation_id} for function "
+            + f"{route.endpoint.__name__}"
+        )
+        file_name = getattr(route.endpoint, "__globals__", {}).get("__file__")
+        if file_name:
+            message += f" at {file_name}"
+        warnings.warn(message, stacklevel=1)
+    operation_ids.add(operation_id)
+    operation["operationId"] = operation_id
+    if route.deprecated:
+        operation["deprecated"] = route.deprecated
+    return operation
+
+
+def get_openapi_path(
+    *,
+    route: routing.APIRoute,
+    operation_ids: Set[str],
+    schema_generator: GenerateJsonSchema,
+    model_name_map: ModelNameMap,
+    field_mapping: Dict[
+        Tuple[ModelField, Literal["validation", "serialization"]], JsonSchemaValue
+    ],
+    separate_input_output_schemas: bool = True,
+) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any]]:
+    path = {}
+    security_schemes: Dict[str, Any] = {}
+    definitions: Dict[str, Any] = {}
+    assert route.methods is not None, "Methods must be a list"
+    if isinstance(route.response_class, DefaultPlaceholder):
+        current_response_class: Type[Response] = route.response_class.value
+    else:
+        current_response_class = route.response_class
+    assert current_response_class, "A response class is needed to generate OpenAPI"
+    route_response_media_type: Optional[str] = current_response_class.media_type
+    if route.include_in_schema:
+        for method in route.methods:
+            operation = get_openapi_operation_metadata(
+                route=route, method=method, operation_ids=operation_ids
+            )
+            parameters: List[Dict[str, Any]] = []
+            flat_dependant = get_flat_dependant(route.dependant, skip_repeats=True)
+            security_definitions, operation_security = get_openapi_security_definitions(
+                flat_dependant=flat_dependant
+            )
+            if operation_security:
+                operation.setdefault("security", []).extend(operation_security)
+            if security_definitions:
+                security_schemes.update(security_definitions)
+            all_route_params = get_flat_params(route.dependant)
+            operation_parameters = get_openapi_operation_parameters(
+                all_route_params=all_route_params,
+                schema_generator=schema_generator,
+                model_name_map=model_name_map,
+                field_mapping=field_mapping,
+                separate_input_output_schemas=separate_input_output_schemas,
+            )
+            parameters.extend(operation_parameters)
+            if parameters:
+                all_parameters = {
+                    (param["in"], param["name"]): param for param in parameters
+                }
+                required_parameters = {
+                    (param["in"], param["name"]): param
+                    for param in parameters
+                    if param.get("required")
+                }
+                # Make sure required definitions of the same parameter take precedence
+                # over non-required definitions
+                all_parameters.update(required_parameters)
+                operation["parameters"] = list(all_parameters.values())
+            if method in METHODS_WITH_BODY:
+                request_body_oai = get_openapi_operation_request_body(
+                    body_field=route.body_field,
+                    schema_generator=schema_generator,
+                    model_name_map=model_name_map,
+                    field_mapping=field_mapping,
+                    separate_input_output_schemas=separate_input_output_schemas,
+                )
+                if request_body_oai:
+                    operation["requestBody"] = request_body_oai
+            if route.callbacks:
+                callbacks = {}
+                for callback in route.callbacks:
+                    if isinstance(callback, routing.APIRoute):
+                        (
+                            cb_path,
+                            cb_security_schemes,
+                            cb_definitions,
+                        ) = get_openapi_path(
+                            route=callback,
+                            operation_ids=operation_ids,
+                            schema_generator=schema_generator,
+                            model_name_map=model_name_map,
+                            field_mapping=field_mapping,
+                            separate_input_output_schemas=separate_input_output_schemas,
+                        )
+                        callbacks[callback.name] = {callback.path: cb_path}
+                operation["callbacks"] = callbacks
+            if route.status_code is not None:
+                status_code = str(route.status_code)
+            else:
+                # It would probably make more sense for all response classes to have an
+                # explicit default status_code, and to extract it from them, instead of
+                # doing this inspection tricks, that would probably be in the future
+                # TODO: probably make status_code a default class attribute for all
+                # responses in Starlette
+                response_signature = inspect.signature(current_response_class.__init__)
+                status_code_param = response_signature.parameters.get("status_code")
+                if status_code_param is not None:
+                    if isinstance(status_code_param.default, int):
+                        status_code = str(status_code_param.default)
+            operation.setdefault("responses", {}).setdefault(status_code, {})[
+                "description"
+            ] = route.response_description
+            if route_response_media_type and is_body_allowed_for_status_code(
+                route.status_code
+            ):
+                response_schema = {"type": "string"}
+                if lenient_issubclass(current_response_class, JSONResponse):
+                    if route.response_field:
+                        response_schema = get_schema_from_model_field(
+                            field=route.response_field,
+                            schema_generator=schema_generator,
+                            model_name_map=model_name_map,
+                            field_mapping=field_mapping,
+                            separate_input_output_schemas=separate_input_output_schemas,
+                        )
+                    else:
+                        response_schema = {}
+                operation.setdefault("responses", {}).setdefault(
+                    status_code, {}
+                ).setdefault("content", {}).setdefault(route_response_media_type, {})[
+                    "schema"
+                ] = response_schema
+            if route.responses:
+                operation_responses = operation.setdefault("responses", {})
+                for (
+                    additional_status_code,
+                    additional_response,
+                ) in route.responses.items():
+                    process_response = additional_response.copy()
+                    process_response.pop("model", None)
+                    status_code_key = str(additional_status_code).upper()
+                    if status_code_key == "DEFAULT":
+                        status_code_key = "default"
+                    openapi_response = operation_responses.setdefault(
+                        status_code_key, {}
+                    )
+                    assert isinstance(
+                        process_response, dict
+                    ), "An additional response must be a dict"
+                    field = route.response_fields.get(additional_status_code)
+                    additional_field_schema: Optional[Dict[str, Any]] = None
+                    if field:
+                        additional_field_schema = get_schema_from_model_field(
+                            field=field,
+                            schema_generator=schema_generator,
+                            model_name_map=model_name_map,
+                            field_mapping=field_mapping,
+                            separate_input_output_schemas=separate_input_output_schemas,
+                        )
+                        media_type = route_response_media_type or "application/json"
+                        additional_schema = (
+                            process_response.setdefault("content", {})
+                            .setdefault(media_type, {})
+                            .setdefault("schema", {})
+                        )
+                        deep_dict_update(additional_schema, additional_field_schema)
+                    status_text: Optional[str] = status_code_ranges.get(
+                        str(additional_status_code).upper()
+                    ) or http.client.responses.get(int(additional_status_code))
+                    description = (
+                        process_response.get("description")
+                        or openapi_response.get("description")
+                        or status_text
+                        or "Additional Response"
+                    )
+                    deep_dict_update(openapi_response, process_response)
+                    openapi_response["description"] = description
+            http422 = str(HTTP_422_UNPROCESSABLE_ENTITY)
+            if (all_route_params or route.body_field) and not any(
+                status in operation["responses"]
+                for status in [http422, "4XX", "default"]
+            ):
+                operation["responses"][http422] = {
+                    "description": "Validation Error",
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": REF_PREFIX + "HTTPValidationError"}
+                        }
+                    },
+                }
+                if "ValidationError" not in definitions:
+                    definitions.update(
+                        {
+                            "ValidationError": validation_error_definition,
+                            "HTTPValidationError": validation_error_response_definition,
+                        }
+                    )
+            if route.openapi_extra:
+                deep_dict_update(operation, route.openapi_extra)
+            path[method.lower()] = operation
+    return path, security_schemes, definitions
+
+
+def get_fields_from_routes(
+    routes: Sequence[BaseRoute],
+) -> List[ModelField]:
+    body_fields_from_routes: List[ModelField] = []
+    responses_from_routes: List[ModelField] = []
+    request_fields_from_routes: List[ModelField] = []
+    callback_flat_models: List[ModelField] = []
+    for route in routes:
+        if getattr(route, "include_in_schema", None) and isinstance(
+            route, routing.APIRoute
+        ):
+            if route.body_field:
+                assert isinstance(
+                    route.body_field, ModelField
+                ), "A request body must be a Pydantic Field"
+                body_fields_from_routes.append(route.body_field)
+            if route.response_field:
+                responses_from_routes.append(route.response_field)
+            if route.response_fields:
+                responses_from_routes.extend(route.response_fields.values())
+            if route.callbacks:
+                callback_flat_models.extend(get_fields_from_routes(route.callbacks))
+            params = get_flat_params(route.dependant)
+            request_fields_from_routes.extend(params)
+
+    flat_models = callback_flat_models + list(
+        body_fields_from_routes + responses_from_routes + request_fields_from_routes
+    )
+    return flat_models
+
+
+def get_openapi(
+    *,
+    title: str,
+    version: str,
+    openapi_version: str = "3.1.0",
+    summary: Optional[str] = None,
+    description: Optional[str] = None,
+    routes: Sequence[BaseRoute],
+    webhooks: Optional[Sequence[BaseRoute]] = None,
+    tags: Optional[List[Dict[str, Any]]] = None,
+    servers: Optional[List[Dict[str, Union[str, Any]]]] = None,
+    terms_of_service: Optional[str] = None,
+    contact: Optional[Dict[str, Union[str, Any]]] = None,
+    license_info: Optional[Dict[str, Union[str, Any]]] = None,
+    separate_input_output_schemas: bool = True,
+) -> Dict[str, Any]:
+    info: Dict[str, Any] = {"title": title, "version": version}
+    if summary:
+        info["summary"] = summary
+    if description:
+        info["description"] = description
+    if terms_of_service:
+        info["termsOfService"] = terms_of_service
+    if contact:
+        info["contact"] = contact
+    if license_info:
+        info["license"] = license_info
+    output: Dict[str, Any] = {"openapi": openapi_version, "info": info}
+    if servers:
+        output["servers"] = servers
+    components: Dict[str, Dict[str, Any]] = {}
+    paths: Dict[str, Dict[str, Any]] = {}
+    webhook_paths: Dict[str, Dict[str, Any]] = {}
+    operation_ids: Set[str] = set()
+    all_fields = get_fields_from_routes(list(routes or []) + list(webhooks or []))
+    model_name_map = get_compat_model_name_map(all_fields)
+    schema_generator = GenerateJsonSchema(ref_template=REF_TEMPLATE)
+    field_mapping, definitions = get_definitions(
+        fields=all_fields,
+        schema_generator=schema_generator,
+        model_name_map=model_name_map,
+        separate_input_output_schemas=separate_input_output_schemas,
+    )
+    for route in routes or []:
+        if isinstance(route, routing.APIRoute):
+            result = get_openapi_path(
+                route=route,
+                operation_ids=operation_ids,
+                schema_generator=schema_generator,
+                model_name_map=model_name_map,
+                field_mapping=field_mapping,
+                separate_input_output_schemas=separate_input_output_schemas,
+            )
+            if result:
+                path, security_schemes, path_definitions = result
+                if path:
+                    paths.setdefault(route.path_format, {}).update(path)
+                if security_schemes:
+                    components.setdefault("securitySchemes", {}).update(
+                        security_schemes
+                    )
+                if path_definitions:
+                    definitions.update(path_definitions)
+    for webhook in webhooks or []:
+        if isinstance(webhook, routing.APIRoute):
+            result = get_openapi_path(
+                route=webhook,
+                operation_ids=operation_ids,
+                schema_generator=schema_generator,
+                model_name_map=model_name_map,
+                field_mapping=field_mapping,
+                separate_input_output_schemas=separate_input_output_schemas,
+            )
+            if result:
+                path, security_schemes, path_definitions = result
+                if path:
+                    webhook_paths.setdefault(webhook.path_format, {}).update(path)
+                if security_schemes:
+                    components.setdefault("securitySchemes", {}).update(
+                        security_schemes
+                    )
+                if path_definitions:
+                    definitions.update(path_definitions)
+    if definitions:
+        components["schemas"] = {k: definitions[k] for k in sorted(definitions)}
+    if components:
+        output["components"] = components
+    output["paths"] = paths
+    if webhook_paths:
+        output["webhooks"] = webhook_paths
+    if tags:
+        output["tags"] = tags
+    return jsonable_encoder(OpenAPI(**output), by_alias=True, exclude_none=True)  # type: ignore

--- a/src/prefect/_vendor/fastapi/param_functions.py
+++ b/src/prefect/_vendor/fastapi/param_functions.py
@@ -1,0 +1,579 @@
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+
+from prefect._vendor.fastapi import params
+from prefect._vendor.fastapi._compat import Undefined
+from prefect._vendor.fastapi.openapi.models import Example
+from typing_extensions import Annotated, deprecated
+
+_Unset: Any = Undefined
+
+
+def Path(  # noqa: N802
+    default: Any = ...,
+    *,
+    default_factory: Union[Callable[[], Any], None] = _Unset,
+    alias: Optional[str] = None,
+    alias_priority: Union[int, None] = _Unset,
+    # TODO: update when deprecating Pydantic v1, import these types
+    # validation_alias: str | AliasPath | AliasChoices | None
+    validation_alias: Union[str, None] = None,
+    serialization_alias: Union[str, None] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    gt: Optional[float] = None,
+    ge: Optional[float] = None,
+    lt: Optional[float] = None,
+    le: Optional[float] = None,
+    min_length: Optional[int] = None,
+    max_length: Optional[int] = None,
+    pattern: Optional[str] = None,
+    regex: Annotated[
+        Optional[str],
+        deprecated(
+            "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
+        ),
+    ] = None,
+    discriminator: Union[str, None] = None,
+    strict: Union[bool, None] = _Unset,
+    multiple_of: Union[float, None] = _Unset,
+    allow_inf_nan: Union[bool, None] = _Unset,
+    max_digits: Union[int, None] = _Unset,
+    decimal_places: Union[int, None] = _Unset,
+    examples: Optional[List[Any]] = None,
+    example: Annotated[
+        Optional[Any],
+        deprecated(
+            "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+            "although still supported. Use examples instead."
+        ),
+    ] = _Unset,
+    openapi_examples: Optional[Dict[str, Example]] = None,
+    deprecated: Optional[bool] = None,
+    include_in_schema: bool = True,
+    json_schema_extra: Union[Dict[str, Any], None] = None,
+    **extra: Any,
+) -> Any:
+    return params.Path(
+        default=default,
+        default_factory=default_factory,
+        alias=alias,
+        alias_priority=alias_priority,
+        validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
+        title=title,
+        description=description,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        min_length=min_length,
+        max_length=max_length,
+        pattern=pattern,
+        regex=regex,
+        discriminator=discriminator,
+        strict=strict,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
+        example=example,
+        examples=examples,
+        openapi_examples=openapi_examples,
+        deprecated=deprecated,
+        include_in_schema=include_in_schema,
+        json_schema_extra=json_schema_extra,
+        **extra,
+    )
+
+
+def Query(  # noqa: N802
+    default: Any = Undefined,
+    *,
+    default_factory: Union[Callable[[], Any], None] = _Unset,
+    alias: Optional[str] = None,
+    alias_priority: Union[int, None] = _Unset,
+    # TODO: update when deprecating Pydantic v1, import these types
+    # validation_alias: str | AliasPath | AliasChoices | None
+    validation_alias: Union[str, None] = None,
+    serialization_alias: Union[str, None] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    gt: Optional[float] = None,
+    ge: Optional[float] = None,
+    lt: Optional[float] = None,
+    le: Optional[float] = None,
+    min_length: Optional[int] = None,
+    max_length: Optional[int] = None,
+    pattern: Optional[str] = None,
+    regex: Annotated[
+        Optional[str],
+        deprecated(
+            "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
+        ),
+    ] = None,
+    discriminator: Union[str, None] = None,
+    strict: Union[bool, None] = _Unset,
+    multiple_of: Union[float, None] = _Unset,
+    allow_inf_nan: Union[bool, None] = _Unset,
+    max_digits: Union[int, None] = _Unset,
+    decimal_places: Union[int, None] = _Unset,
+    examples: Optional[List[Any]] = None,
+    example: Annotated[
+        Optional[Any],
+        deprecated(
+            "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+            "although still supported. Use examples instead."
+        ),
+    ] = _Unset,
+    openapi_examples: Optional[Dict[str, Example]] = None,
+    deprecated: Optional[bool] = None,
+    include_in_schema: bool = True,
+    json_schema_extra: Union[Dict[str, Any], None] = None,
+    **extra: Any,
+) -> Any:
+    return params.Query(
+        default=default,
+        default_factory=default_factory,
+        alias=alias,
+        alias_priority=alias_priority,
+        validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
+        title=title,
+        description=description,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        min_length=min_length,
+        max_length=max_length,
+        pattern=pattern,
+        regex=regex,
+        discriminator=discriminator,
+        strict=strict,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
+        example=example,
+        examples=examples,
+        openapi_examples=openapi_examples,
+        deprecated=deprecated,
+        include_in_schema=include_in_schema,
+        json_schema_extra=json_schema_extra,
+        **extra,
+    )
+
+
+def Header(  # noqa: N802
+    default: Any = Undefined,
+    *,
+    default_factory: Union[Callable[[], Any], None] = _Unset,
+    alias: Optional[str] = None,
+    alias_priority: Union[int, None] = _Unset,
+    # TODO: update when deprecating Pydantic v1, import these types
+    # validation_alias: str | AliasPath | AliasChoices | None
+    validation_alias: Union[str, None] = None,
+    serialization_alias: Union[str, None] = None,
+    convert_underscores: bool = True,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    gt: Optional[float] = None,
+    ge: Optional[float] = None,
+    lt: Optional[float] = None,
+    le: Optional[float] = None,
+    min_length: Optional[int] = None,
+    max_length: Optional[int] = None,
+    pattern: Optional[str] = None,
+    regex: Annotated[
+        Optional[str],
+        deprecated(
+            "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
+        ),
+    ] = None,
+    discriminator: Union[str, None] = None,
+    strict: Union[bool, None] = _Unset,
+    multiple_of: Union[float, None] = _Unset,
+    allow_inf_nan: Union[bool, None] = _Unset,
+    max_digits: Union[int, None] = _Unset,
+    decimal_places: Union[int, None] = _Unset,
+    examples: Optional[List[Any]] = None,
+    example: Annotated[
+        Optional[Any],
+        deprecated(
+            "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+            "although still supported. Use examples instead."
+        ),
+    ] = _Unset,
+    openapi_examples: Optional[Dict[str, Example]] = None,
+    deprecated: Optional[bool] = None,
+    include_in_schema: bool = True,
+    json_schema_extra: Union[Dict[str, Any], None] = None,
+    **extra: Any,
+) -> Any:
+    return params.Header(
+        default=default,
+        default_factory=default_factory,
+        alias=alias,
+        alias_priority=alias_priority,
+        validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
+        convert_underscores=convert_underscores,
+        title=title,
+        description=description,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        min_length=min_length,
+        max_length=max_length,
+        pattern=pattern,
+        regex=regex,
+        discriminator=discriminator,
+        strict=strict,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
+        example=example,
+        examples=examples,
+        openapi_examples=openapi_examples,
+        deprecated=deprecated,
+        include_in_schema=include_in_schema,
+        json_schema_extra=json_schema_extra,
+        **extra,
+    )
+
+
+def Cookie(  # noqa: N802
+    default: Any = Undefined,
+    *,
+    default_factory: Union[Callable[[], Any], None] = _Unset,
+    alias: Optional[str] = None,
+    alias_priority: Union[int, None] = _Unset,
+    # TODO: update when deprecating Pydantic v1, import these types
+    # validation_alias: str | AliasPath | AliasChoices | None
+    validation_alias: Union[str, None] = None,
+    serialization_alias: Union[str, None] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    gt: Optional[float] = None,
+    ge: Optional[float] = None,
+    lt: Optional[float] = None,
+    le: Optional[float] = None,
+    min_length: Optional[int] = None,
+    max_length: Optional[int] = None,
+    pattern: Optional[str] = None,
+    regex: Annotated[
+        Optional[str],
+        deprecated(
+            "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
+        ),
+    ] = None,
+    discriminator: Union[str, None] = None,
+    strict: Union[bool, None] = _Unset,
+    multiple_of: Union[float, None] = _Unset,
+    allow_inf_nan: Union[bool, None] = _Unset,
+    max_digits: Union[int, None] = _Unset,
+    decimal_places: Union[int, None] = _Unset,
+    examples: Optional[List[Any]] = None,
+    example: Annotated[
+        Optional[Any],
+        deprecated(
+            "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+            "although still supported. Use examples instead."
+        ),
+    ] = _Unset,
+    openapi_examples: Optional[Dict[str, Example]] = None,
+    deprecated: Optional[bool] = None,
+    include_in_schema: bool = True,
+    json_schema_extra: Union[Dict[str, Any], None] = None,
+    **extra: Any,
+) -> Any:
+    return params.Cookie(
+        default=default,
+        default_factory=default_factory,
+        alias=alias,
+        alias_priority=alias_priority,
+        validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
+        title=title,
+        description=description,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        min_length=min_length,
+        max_length=max_length,
+        pattern=pattern,
+        regex=regex,
+        discriminator=discriminator,
+        strict=strict,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
+        example=example,
+        examples=examples,
+        openapi_examples=openapi_examples,
+        deprecated=deprecated,
+        include_in_schema=include_in_schema,
+        json_schema_extra=json_schema_extra,
+        **extra,
+    )
+
+
+def Body(  # noqa: N802
+    default: Any = Undefined,
+    *,
+    default_factory: Union[Callable[[], Any], None] = _Unset,
+    embed: bool = False,
+    media_type: str = "application/json",
+    alias: Optional[str] = None,
+    alias_priority: Union[int, None] = _Unset,
+    # TODO: update when deprecating Pydantic v1, import these types
+    # validation_alias: str | AliasPath | AliasChoices | None
+    validation_alias: Union[str, None] = None,
+    serialization_alias: Union[str, None] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    gt: Optional[float] = None,
+    ge: Optional[float] = None,
+    lt: Optional[float] = None,
+    le: Optional[float] = None,
+    min_length: Optional[int] = None,
+    max_length: Optional[int] = None,
+    pattern: Optional[str] = None,
+    regex: Annotated[
+        Optional[str],
+        deprecated(
+            "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
+        ),
+    ] = None,
+    discriminator: Union[str, None] = None,
+    strict: Union[bool, None] = _Unset,
+    multiple_of: Union[float, None] = _Unset,
+    allow_inf_nan: Union[bool, None] = _Unset,
+    max_digits: Union[int, None] = _Unset,
+    decimal_places: Union[int, None] = _Unset,
+    examples: Optional[List[Any]] = None,
+    example: Annotated[
+        Optional[Any],
+        deprecated(
+            "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+            "although still supported. Use examples instead."
+        ),
+    ] = _Unset,
+    openapi_examples: Optional[Dict[str, Example]] = None,
+    deprecated: Optional[bool] = None,
+    include_in_schema: bool = True,
+    json_schema_extra: Union[Dict[str, Any], None] = None,
+    **extra: Any,
+) -> Any:
+    return params.Body(
+        default=default,
+        default_factory=default_factory,
+        embed=embed,
+        media_type=media_type,
+        alias=alias,
+        alias_priority=alias_priority,
+        validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
+        title=title,
+        description=description,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        min_length=min_length,
+        max_length=max_length,
+        pattern=pattern,
+        regex=regex,
+        discriminator=discriminator,
+        strict=strict,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
+        example=example,
+        examples=examples,
+        openapi_examples=openapi_examples,
+        deprecated=deprecated,
+        include_in_schema=include_in_schema,
+        json_schema_extra=json_schema_extra,
+        **extra,
+    )
+
+
+def Form(  # noqa: N802
+    default: Any = Undefined,
+    *,
+    default_factory: Union[Callable[[], Any], None] = _Unset,
+    media_type: str = "application/x-www-form-urlencoded",
+    alias: Optional[str] = None,
+    alias_priority: Union[int, None] = _Unset,
+    # TODO: update when deprecating Pydantic v1, import these types
+    # validation_alias: str | AliasPath | AliasChoices | None
+    validation_alias: Union[str, None] = None,
+    serialization_alias: Union[str, None] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    gt: Optional[float] = None,
+    ge: Optional[float] = None,
+    lt: Optional[float] = None,
+    le: Optional[float] = None,
+    min_length: Optional[int] = None,
+    max_length: Optional[int] = None,
+    pattern: Optional[str] = None,
+    regex: Annotated[
+        Optional[str],
+        deprecated(
+            "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
+        ),
+    ] = None,
+    discriminator: Union[str, None] = None,
+    strict: Union[bool, None] = _Unset,
+    multiple_of: Union[float, None] = _Unset,
+    allow_inf_nan: Union[bool, None] = _Unset,
+    max_digits: Union[int, None] = _Unset,
+    decimal_places: Union[int, None] = _Unset,
+    examples: Optional[List[Any]] = None,
+    example: Annotated[
+        Optional[Any],
+        deprecated(
+            "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+            "although still supported. Use examples instead."
+        ),
+    ] = _Unset,
+    openapi_examples: Optional[Dict[str, Example]] = None,
+    deprecated: Optional[bool] = None,
+    include_in_schema: bool = True,
+    json_schema_extra: Union[Dict[str, Any], None] = None,
+    **extra: Any,
+) -> Any:
+    return params.Form(
+        default=default,
+        default_factory=default_factory,
+        media_type=media_type,
+        alias=alias,
+        alias_priority=alias_priority,
+        validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
+        title=title,
+        description=description,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        min_length=min_length,
+        max_length=max_length,
+        pattern=pattern,
+        regex=regex,
+        discriminator=discriminator,
+        strict=strict,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
+        example=example,
+        examples=examples,
+        openapi_examples=openapi_examples,
+        deprecated=deprecated,
+        include_in_schema=include_in_schema,
+        json_schema_extra=json_schema_extra,
+        **extra,
+    )
+
+
+def File(  # noqa: N802
+    default: Any = Undefined,
+    *,
+    default_factory: Union[Callable[[], Any], None] = _Unset,
+    media_type: str = "multipart/form-data",
+    alias: Optional[str] = None,
+    alias_priority: Union[int, None] = _Unset,
+    # TODO: update when deprecating Pydantic v1, import these types
+    # validation_alias: str | AliasPath | AliasChoices | None
+    validation_alias: Union[str, None] = None,
+    serialization_alias: Union[str, None] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    gt: Optional[float] = None,
+    ge: Optional[float] = None,
+    lt: Optional[float] = None,
+    le: Optional[float] = None,
+    min_length: Optional[int] = None,
+    max_length: Optional[int] = None,
+    pattern: Optional[str] = None,
+    regex: Annotated[
+        Optional[str],
+        deprecated(
+            "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
+        ),
+    ] = None,
+    discriminator: Union[str, None] = None,
+    strict: Union[bool, None] = _Unset,
+    multiple_of: Union[float, None] = _Unset,
+    allow_inf_nan: Union[bool, None] = _Unset,
+    max_digits: Union[int, None] = _Unset,
+    decimal_places: Union[int, None] = _Unset,
+    examples: Optional[List[Any]] = None,
+    example: Annotated[
+        Optional[Any],
+        deprecated(
+            "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+            "although still supported. Use examples instead."
+        ),
+    ] = _Unset,
+    openapi_examples: Optional[Dict[str, Example]] = None,
+    deprecated: Optional[bool] = None,
+    include_in_schema: bool = True,
+    json_schema_extra: Union[Dict[str, Any], None] = None,
+    **extra: Any,
+) -> Any:
+    return params.File(
+        default=default,
+        default_factory=default_factory,
+        media_type=media_type,
+        alias=alias,
+        alias_priority=alias_priority,
+        validation_alias=validation_alias,
+        serialization_alias=serialization_alias,
+        title=title,
+        description=description,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        min_length=min_length,
+        max_length=max_length,
+        pattern=pattern,
+        regex=regex,
+        discriminator=discriminator,
+        strict=strict,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
+        example=example,
+        examples=examples,
+        openapi_examples=openapi_examples,
+        deprecated=deprecated,
+        include_in_schema=include_in_schema,
+        json_schema_extra=json_schema_extra,
+        **extra,
+    )
+
+
+def Depends(  # noqa: N802
+    dependency: Optional[Callable[..., Any]] = None, *, use_cache: bool = True
+) -> Any:
+    return params.Depends(dependency=dependency, use_cache=use_cache)
+
+
+def Security(  # noqa: N802
+    dependency: Optional[Callable[..., Any]] = None,
+    *,
+    scopes: Optional[Sequence[str]] = None,
+    use_cache: bool = True,
+) -> Any:
+    return params.Security(dependency=dependency, scopes=scopes, use_cache=use_cache)

--- a/src/prefect/_vendor/fastapi/params.py
+++ b/src/prefect/_vendor/fastapi/params.py
@@ -1,0 +1,777 @@
+import warnings
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+
+from prefect._vendor.fastapi.openapi.models import Example
+from pydantic.fields import FieldInfo
+from typing_extensions import Annotated, deprecated
+
+from ._compat import PYDANTIC_V2, Undefined
+
+_Unset: Any = Undefined
+
+
+class ParamTypes(Enum):
+    query = "query"
+    header = "header"
+    path = "path"
+    cookie = "cookie"
+
+
+class Param(FieldInfo):
+    in_: ParamTypes
+
+    def __init__(
+        self,
+        default: Any = Undefined,
+        *,
+        default_factory: Union[Callable[[], Any], None] = _Unset,
+        annotation: Optional[Any] = None,
+        alias: Optional[str] = None,
+        alias_priority: Union[int, None] = _Unset,
+        # TODO: update when deprecating Pydantic v1, import these types
+        # validation_alias: str | AliasPath | AliasChoices | None
+        validation_alias: Union[str, None] = None,
+        serialization_alias: Union[str, None] = None,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        gt: Optional[float] = None,
+        ge: Optional[float] = None,
+        lt: Optional[float] = None,
+        le: Optional[float] = None,
+        min_length: Optional[int] = None,
+        max_length: Optional[int] = None,
+        pattern: Optional[str] = None,
+        regex: Annotated[
+            Optional[str],
+            deprecated(
+                "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
+            ),
+        ] = None,
+        discriminator: Union[str, None] = None,
+        strict: Union[bool, None] = _Unset,
+        multiple_of: Union[float, None] = _Unset,
+        allow_inf_nan: Union[bool, None] = _Unset,
+        max_digits: Union[int, None] = _Unset,
+        decimal_places: Union[int, None] = _Unset,
+        examples: Optional[List[Any]] = None,
+        example: Annotated[
+            Optional[Any],
+            deprecated(
+                "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+                "although still supported. Use examples instead."
+            ),
+        ] = _Unset,
+        openapi_examples: Optional[Dict[str, Example]] = None,
+        deprecated: Optional[bool] = None,
+        include_in_schema: bool = True,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
+        **extra: Any,
+    ):
+        self.deprecated = deprecated
+        if example is not _Unset:
+            warnings.warn(
+                "`example` has been deprecated, please use `examples` instead",
+                category=DeprecationWarning,
+                stacklevel=4,
+            )
+        self.example = example
+        self.include_in_schema = include_in_schema
+        self.openapi_examples = openapi_examples
+        kwargs = dict(
+            default=default,
+            default_factory=default_factory,
+            alias=alias,
+            title=title,
+            description=description,
+            gt=gt,
+            ge=ge,
+            lt=lt,
+            le=le,
+            min_length=min_length,
+            max_length=max_length,
+            discriminator=discriminator,
+            multiple_of=multiple_of,
+            allow_nan=allow_inf_nan,
+            max_digits=max_digits,
+            decimal_places=decimal_places,
+            **extra,
+        )
+        if examples is not None:
+            kwargs["examples"] = examples
+        if regex is not None:
+            warnings.warn(
+                "`regex` has been deprecated, please use `pattern` instead",
+                category=DeprecationWarning,
+                stacklevel=4,
+            )
+        current_json_schema_extra = json_schema_extra or extra
+        if PYDANTIC_V2:
+            kwargs.update(
+                {
+                    "annotation": annotation,
+                    "alias_priority": alias_priority,
+                    "validation_alias": validation_alias,
+                    "serialization_alias": serialization_alias,
+                    "strict": strict,
+                    "json_schema_extra": current_json_schema_extra,
+                }
+            )
+            kwargs["pattern"] = pattern or regex
+        else:
+            kwargs["regex"] = pattern or regex
+            kwargs.update(**current_json_schema_extra)
+        use_kwargs = {k: v for k, v in kwargs.items() if v is not _Unset}
+
+        super().__init__(**use_kwargs)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.default})"
+
+
+class Path(Param):
+    in_ = ParamTypes.path
+
+    def __init__(
+        self,
+        default: Any = ...,
+        *,
+        default_factory: Union[Callable[[], Any], None] = _Unset,
+        annotation: Optional[Any] = None,
+        alias: Optional[str] = None,
+        alias_priority: Union[int, None] = _Unset,
+        # TODO: update when deprecating Pydantic v1, import these types
+        # validation_alias: str | AliasPath | AliasChoices | None
+        validation_alias: Union[str, None] = None,
+        serialization_alias: Union[str, None] = None,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        gt: Optional[float] = None,
+        ge: Optional[float] = None,
+        lt: Optional[float] = None,
+        le: Optional[float] = None,
+        min_length: Optional[int] = None,
+        max_length: Optional[int] = None,
+        pattern: Optional[str] = None,
+        regex: Annotated[
+            Optional[str],
+            deprecated(
+                "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
+            ),
+        ] = None,
+        discriminator: Union[str, None] = None,
+        strict: Union[bool, None] = _Unset,
+        multiple_of: Union[float, None] = _Unset,
+        allow_inf_nan: Union[bool, None] = _Unset,
+        max_digits: Union[int, None] = _Unset,
+        decimal_places: Union[int, None] = _Unset,
+        examples: Optional[List[Any]] = None,
+        example: Annotated[
+            Optional[Any],
+            deprecated(
+                "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+                "although still supported. Use examples instead."
+            ),
+        ] = _Unset,
+        openapi_examples: Optional[Dict[str, Example]] = None,
+        deprecated: Optional[bool] = None,
+        include_in_schema: bool = True,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
+        **extra: Any,
+    ):
+        assert default is ..., "Path parameters cannot have a default value"
+        self.in_ = self.in_
+        super().__init__(
+            default=default,
+            default_factory=default_factory,
+            annotation=annotation,
+            alias=alias,
+            alias_priority=alias_priority,
+            validation_alias=validation_alias,
+            serialization_alias=serialization_alias,
+            title=title,
+            description=description,
+            gt=gt,
+            ge=ge,
+            lt=lt,
+            le=le,
+            min_length=min_length,
+            max_length=max_length,
+            pattern=pattern,
+            regex=regex,
+            discriminator=discriminator,
+            strict=strict,
+            multiple_of=multiple_of,
+            allow_inf_nan=allow_inf_nan,
+            max_digits=max_digits,
+            decimal_places=decimal_places,
+            deprecated=deprecated,
+            example=example,
+            examples=examples,
+            openapi_examples=openapi_examples,
+            include_in_schema=include_in_schema,
+            json_schema_extra=json_schema_extra,
+            **extra,
+        )
+
+
+class Query(Param):
+    in_ = ParamTypes.query
+
+    def __init__(
+        self,
+        default: Any = Undefined,
+        *,
+        default_factory: Union[Callable[[], Any], None] = _Unset,
+        annotation: Optional[Any] = None,
+        alias: Optional[str] = None,
+        alias_priority: Union[int, None] = _Unset,
+        # TODO: update when deprecating Pydantic v1, import these types
+        # validation_alias: str | AliasPath | AliasChoices | None
+        validation_alias: Union[str, None] = None,
+        serialization_alias: Union[str, None] = None,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        gt: Optional[float] = None,
+        ge: Optional[float] = None,
+        lt: Optional[float] = None,
+        le: Optional[float] = None,
+        min_length: Optional[int] = None,
+        max_length: Optional[int] = None,
+        pattern: Optional[str] = None,
+        regex: Annotated[
+            Optional[str],
+            deprecated(
+                "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
+            ),
+        ] = None,
+        discriminator: Union[str, None] = None,
+        strict: Union[bool, None] = _Unset,
+        multiple_of: Union[float, None] = _Unset,
+        allow_inf_nan: Union[bool, None] = _Unset,
+        max_digits: Union[int, None] = _Unset,
+        decimal_places: Union[int, None] = _Unset,
+        examples: Optional[List[Any]] = None,
+        example: Annotated[
+            Optional[Any],
+            deprecated(
+                "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+                "although still supported. Use examples instead."
+            ),
+        ] = _Unset,
+        openapi_examples: Optional[Dict[str, Example]] = None,
+        deprecated: Optional[bool] = None,
+        include_in_schema: bool = True,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
+        **extra: Any,
+    ):
+        super().__init__(
+            default=default,
+            default_factory=default_factory,
+            annotation=annotation,
+            alias=alias,
+            alias_priority=alias_priority,
+            validation_alias=validation_alias,
+            serialization_alias=serialization_alias,
+            title=title,
+            description=description,
+            gt=gt,
+            ge=ge,
+            lt=lt,
+            le=le,
+            min_length=min_length,
+            max_length=max_length,
+            pattern=pattern,
+            regex=regex,
+            discriminator=discriminator,
+            strict=strict,
+            multiple_of=multiple_of,
+            allow_inf_nan=allow_inf_nan,
+            max_digits=max_digits,
+            decimal_places=decimal_places,
+            deprecated=deprecated,
+            example=example,
+            examples=examples,
+            openapi_examples=openapi_examples,
+            include_in_schema=include_in_schema,
+            json_schema_extra=json_schema_extra,
+            **extra,
+        )
+
+
+class Header(Param):
+    in_ = ParamTypes.header
+
+    def __init__(
+        self,
+        default: Any = Undefined,
+        *,
+        default_factory: Union[Callable[[], Any], None] = _Unset,
+        annotation: Optional[Any] = None,
+        alias: Optional[str] = None,
+        alias_priority: Union[int, None] = _Unset,
+        # TODO: update when deprecating Pydantic v1, import these types
+        # validation_alias: str | AliasPath | AliasChoices | None
+        validation_alias: Union[str, None] = None,
+        serialization_alias: Union[str, None] = None,
+        convert_underscores: bool = True,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        gt: Optional[float] = None,
+        ge: Optional[float] = None,
+        lt: Optional[float] = None,
+        le: Optional[float] = None,
+        min_length: Optional[int] = None,
+        max_length: Optional[int] = None,
+        pattern: Optional[str] = None,
+        regex: Annotated[
+            Optional[str],
+            deprecated(
+                "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
+            ),
+        ] = None,
+        discriminator: Union[str, None] = None,
+        strict: Union[bool, None] = _Unset,
+        multiple_of: Union[float, None] = _Unset,
+        allow_inf_nan: Union[bool, None] = _Unset,
+        max_digits: Union[int, None] = _Unset,
+        decimal_places: Union[int, None] = _Unset,
+        examples: Optional[List[Any]] = None,
+        example: Annotated[
+            Optional[Any],
+            deprecated(
+                "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+                "although still supported. Use examples instead."
+            ),
+        ] = _Unset,
+        openapi_examples: Optional[Dict[str, Example]] = None,
+        deprecated: Optional[bool] = None,
+        include_in_schema: bool = True,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
+        **extra: Any,
+    ):
+        self.convert_underscores = convert_underscores
+        super().__init__(
+            default=default,
+            default_factory=default_factory,
+            annotation=annotation,
+            alias=alias,
+            alias_priority=alias_priority,
+            validation_alias=validation_alias,
+            serialization_alias=serialization_alias,
+            title=title,
+            description=description,
+            gt=gt,
+            ge=ge,
+            lt=lt,
+            le=le,
+            min_length=min_length,
+            max_length=max_length,
+            pattern=pattern,
+            regex=regex,
+            discriminator=discriminator,
+            strict=strict,
+            multiple_of=multiple_of,
+            allow_inf_nan=allow_inf_nan,
+            max_digits=max_digits,
+            decimal_places=decimal_places,
+            deprecated=deprecated,
+            example=example,
+            examples=examples,
+            openapi_examples=openapi_examples,
+            include_in_schema=include_in_schema,
+            json_schema_extra=json_schema_extra,
+            **extra,
+        )
+
+
+class Cookie(Param):
+    in_ = ParamTypes.cookie
+
+    def __init__(
+        self,
+        default: Any = Undefined,
+        *,
+        default_factory: Union[Callable[[], Any], None] = _Unset,
+        annotation: Optional[Any] = None,
+        alias: Optional[str] = None,
+        alias_priority: Union[int, None] = _Unset,
+        # TODO: update when deprecating Pydantic v1, import these types
+        # validation_alias: str | AliasPath | AliasChoices | None
+        validation_alias: Union[str, None] = None,
+        serialization_alias: Union[str, None] = None,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        gt: Optional[float] = None,
+        ge: Optional[float] = None,
+        lt: Optional[float] = None,
+        le: Optional[float] = None,
+        min_length: Optional[int] = None,
+        max_length: Optional[int] = None,
+        pattern: Optional[str] = None,
+        regex: Annotated[
+            Optional[str],
+            deprecated(
+                "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
+            ),
+        ] = None,
+        discriminator: Union[str, None] = None,
+        strict: Union[bool, None] = _Unset,
+        multiple_of: Union[float, None] = _Unset,
+        allow_inf_nan: Union[bool, None] = _Unset,
+        max_digits: Union[int, None] = _Unset,
+        decimal_places: Union[int, None] = _Unset,
+        examples: Optional[List[Any]] = None,
+        example: Annotated[
+            Optional[Any],
+            deprecated(
+                "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+                "although still supported. Use examples instead."
+            ),
+        ] = _Unset,
+        openapi_examples: Optional[Dict[str, Example]] = None,
+        deprecated: Optional[bool] = None,
+        include_in_schema: bool = True,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
+        **extra: Any,
+    ):
+        super().__init__(
+            default=default,
+            default_factory=default_factory,
+            annotation=annotation,
+            alias=alias,
+            alias_priority=alias_priority,
+            validation_alias=validation_alias,
+            serialization_alias=serialization_alias,
+            title=title,
+            description=description,
+            gt=gt,
+            ge=ge,
+            lt=lt,
+            le=le,
+            min_length=min_length,
+            max_length=max_length,
+            pattern=pattern,
+            regex=regex,
+            discriminator=discriminator,
+            strict=strict,
+            multiple_of=multiple_of,
+            allow_inf_nan=allow_inf_nan,
+            max_digits=max_digits,
+            decimal_places=decimal_places,
+            deprecated=deprecated,
+            example=example,
+            examples=examples,
+            openapi_examples=openapi_examples,
+            include_in_schema=include_in_schema,
+            json_schema_extra=json_schema_extra,
+            **extra,
+        )
+
+
+class Body(FieldInfo):
+    def __init__(
+        self,
+        default: Any = Undefined,
+        *,
+        default_factory: Union[Callable[[], Any], None] = _Unset,
+        annotation: Optional[Any] = None,
+        embed: bool = False,
+        media_type: str = "application/json",
+        alias: Optional[str] = None,
+        alias_priority: Union[int, None] = _Unset,
+        # TODO: update when deprecating Pydantic v1, import these types
+        # validation_alias: str | AliasPath | AliasChoices | None
+        validation_alias: Union[str, None] = None,
+        serialization_alias: Union[str, None] = None,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        gt: Optional[float] = None,
+        ge: Optional[float] = None,
+        lt: Optional[float] = None,
+        le: Optional[float] = None,
+        min_length: Optional[int] = None,
+        max_length: Optional[int] = None,
+        pattern: Optional[str] = None,
+        regex: Annotated[
+            Optional[str],
+            deprecated(
+                "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
+            ),
+        ] = None,
+        discriminator: Union[str, None] = None,
+        strict: Union[bool, None] = _Unset,
+        multiple_of: Union[float, None] = _Unset,
+        allow_inf_nan: Union[bool, None] = _Unset,
+        max_digits: Union[int, None] = _Unset,
+        decimal_places: Union[int, None] = _Unset,
+        examples: Optional[List[Any]] = None,
+        example: Annotated[
+            Optional[Any],
+            deprecated(
+                "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+                "although still supported. Use examples instead."
+            ),
+        ] = _Unset,
+        openapi_examples: Optional[Dict[str, Example]] = None,
+        deprecated: Optional[bool] = None,
+        include_in_schema: bool = True,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
+        **extra: Any,
+    ):
+        self.embed = embed
+        self.media_type = media_type
+        self.deprecated = deprecated
+        if example is not _Unset:
+            warnings.warn(
+                "`example` has been deprecated, please use `examples` instead",
+                category=DeprecationWarning,
+                stacklevel=4,
+            )
+        self.example = example
+        self.include_in_schema = include_in_schema
+        self.openapi_examples = openapi_examples
+        kwargs = dict(
+            default=default,
+            default_factory=default_factory,
+            alias=alias,
+            title=title,
+            description=description,
+            gt=gt,
+            ge=ge,
+            lt=lt,
+            le=le,
+            min_length=min_length,
+            max_length=max_length,
+            discriminator=discriminator,
+            multiple_of=multiple_of,
+            allow_nan=allow_inf_nan,
+            max_digits=max_digits,
+            decimal_places=decimal_places,
+            **extra,
+        )
+        if examples is not None:
+            kwargs["examples"] = examples
+        if regex is not None:
+            warnings.warn(
+                "`regex` has been depreacated, please use `pattern` instead",
+                category=DeprecationWarning,
+                stacklevel=4,
+            )
+        current_json_schema_extra = json_schema_extra or extra
+        if PYDANTIC_V2:
+            kwargs.update(
+                {
+                    "annotation": annotation,
+                    "alias_priority": alias_priority,
+                    "validation_alias": validation_alias,
+                    "serialization_alias": serialization_alias,
+                    "strict": strict,
+                    "json_schema_extra": current_json_schema_extra,
+                }
+            )
+            kwargs["pattern"] = pattern or regex
+        else:
+            kwargs["regex"] = pattern or regex
+            kwargs.update(**current_json_schema_extra)
+
+        use_kwargs = {k: v for k, v in kwargs.items() if v is not _Unset}
+
+        super().__init__(**use_kwargs)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.default})"
+
+
+class Form(Body):
+    def __init__(
+        self,
+        default: Any = Undefined,
+        *,
+        default_factory: Union[Callable[[], Any], None] = _Unset,
+        annotation: Optional[Any] = None,
+        media_type: str = "application/x-www-form-urlencoded",
+        alias: Optional[str] = None,
+        alias_priority: Union[int, None] = _Unset,
+        # TODO: update when deprecating Pydantic v1, import these types
+        # validation_alias: str | AliasPath | AliasChoices | None
+        validation_alias: Union[str, None] = None,
+        serialization_alias: Union[str, None] = None,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        gt: Optional[float] = None,
+        ge: Optional[float] = None,
+        lt: Optional[float] = None,
+        le: Optional[float] = None,
+        min_length: Optional[int] = None,
+        max_length: Optional[int] = None,
+        pattern: Optional[str] = None,
+        regex: Annotated[
+            Optional[str],
+            deprecated(
+                "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
+            ),
+        ] = None,
+        discriminator: Union[str, None] = None,
+        strict: Union[bool, None] = _Unset,
+        multiple_of: Union[float, None] = _Unset,
+        allow_inf_nan: Union[bool, None] = _Unset,
+        max_digits: Union[int, None] = _Unset,
+        decimal_places: Union[int, None] = _Unset,
+        examples: Optional[List[Any]] = None,
+        example: Annotated[
+            Optional[Any],
+            deprecated(
+                "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+                "although still supported. Use examples instead."
+            ),
+        ] = _Unset,
+        openapi_examples: Optional[Dict[str, Example]] = None,
+        deprecated: Optional[bool] = None,
+        include_in_schema: bool = True,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
+        **extra: Any,
+    ):
+        super().__init__(
+            default=default,
+            default_factory=default_factory,
+            annotation=annotation,
+            embed=True,
+            media_type=media_type,
+            alias=alias,
+            alias_priority=alias_priority,
+            validation_alias=validation_alias,
+            serialization_alias=serialization_alias,
+            title=title,
+            description=description,
+            gt=gt,
+            ge=ge,
+            lt=lt,
+            le=le,
+            min_length=min_length,
+            max_length=max_length,
+            pattern=pattern,
+            regex=regex,
+            discriminator=discriminator,
+            strict=strict,
+            multiple_of=multiple_of,
+            allow_inf_nan=allow_inf_nan,
+            max_digits=max_digits,
+            decimal_places=decimal_places,
+            deprecated=deprecated,
+            example=example,
+            examples=examples,
+            openapi_examples=openapi_examples,
+            include_in_schema=include_in_schema,
+            json_schema_extra=json_schema_extra,
+            **extra,
+        )
+
+
+class File(Form):
+    def __init__(
+        self,
+        default: Any = Undefined,
+        *,
+        default_factory: Union[Callable[[], Any], None] = _Unset,
+        annotation: Optional[Any] = None,
+        media_type: str = "multipart/form-data",
+        alias: Optional[str] = None,
+        alias_priority: Union[int, None] = _Unset,
+        # TODO: update when deprecating Pydantic v1, import these types
+        # validation_alias: str | AliasPath | AliasChoices | None
+        validation_alias: Union[str, None] = None,
+        serialization_alias: Union[str, None] = None,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        gt: Optional[float] = None,
+        ge: Optional[float] = None,
+        lt: Optional[float] = None,
+        le: Optional[float] = None,
+        min_length: Optional[int] = None,
+        max_length: Optional[int] = None,
+        pattern: Optional[str] = None,
+        regex: Annotated[
+            Optional[str],
+            deprecated(
+                "Deprecated in FastAPI 0.100.0 and Pydantic v2, use `pattern` instead."
+            ),
+        ] = None,
+        discriminator: Union[str, None] = None,
+        strict: Union[bool, None] = _Unset,
+        multiple_of: Union[float, None] = _Unset,
+        allow_inf_nan: Union[bool, None] = _Unset,
+        max_digits: Union[int, None] = _Unset,
+        decimal_places: Union[int, None] = _Unset,
+        examples: Optional[List[Any]] = None,
+        example: Annotated[
+            Optional[Any],
+            deprecated(
+                "Deprecated in OpenAPI 3.1.0 that now uses JSON Schema 2020-12, "
+                "although still supported. Use examples instead."
+            ),
+        ] = _Unset,
+        openapi_examples: Optional[Dict[str, Example]] = None,
+        deprecated: Optional[bool] = None,
+        include_in_schema: bool = True,
+        json_schema_extra: Union[Dict[str, Any], None] = None,
+        **extra: Any,
+    ):
+        super().__init__(
+            default=default,
+            default_factory=default_factory,
+            annotation=annotation,
+            media_type=media_type,
+            alias=alias,
+            alias_priority=alias_priority,
+            validation_alias=validation_alias,
+            serialization_alias=serialization_alias,
+            title=title,
+            description=description,
+            gt=gt,
+            ge=ge,
+            lt=lt,
+            le=le,
+            min_length=min_length,
+            max_length=max_length,
+            pattern=pattern,
+            regex=regex,
+            discriminator=discriminator,
+            strict=strict,
+            multiple_of=multiple_of,
+            allow_inf_nan=allow_inf_nan,
+            max_digits=max_digits,
+            decimal_places=decimal_places,
+            deprecated=deprecated,
+            example=example,
+            examples=examples,
+            openapi_examples=openapi_examples,
+            include_in_schema=include_in_schema,
+            json_schema_extra=json_schema_extra,
+            **extra,
+        )
+
+
+class Depends:
+    def __init__(
+        self, dependency: Optional[Callable[..., Any]] = None, *, use_cache: bool = True
+    ):
+        self.dependency = dependency
+        self.use_cache = use_cache
+
+    def __repr__(self) -> str:
+        attr = getattr(self.dependency, "__name__", type(self.dependency).__name__)
+        cache = "" if self.use_cache else ", use_cache=False"
+        return f"{self.__class__.__name__}({attr}{cache})"
+
+
+class Security(Depends):
+    def __init__(
+        self,
+        dependency: Optional[Callable[..., Any]] = None,
+        *,
+        scopes: Optional[Sequence[str]] = None,
+        use_cache: bool = True,
+    ):
+        super().__init__(dependency=dependency, use_cache=use_cache)
+        self.scopes = scopes or []

--- a/src/prefect/_vendor/fastapi/requests.py
+++ b/src/prefect/_vendor/fastapi/requests.py
@@ -1,0 +1,2 @@
+from starlette.requests import HTTPConnection as HTTPConnection  # noqa: F401
+from starlette.requests import Request as Request  # noqa: F401

--- a/src/prefect/_vendor/fastapi/responses.py
+++ b/src/prefect/_vendor/fastapi/responses.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+from starlette.responses import FileResponse as FileResponse  # noqa
+from starlette.responses import HTMLResponse as HTMLResponse  # noqa
+from starlette.responses import JSONResponse as JSONResponse  # noqa
+from starlette.responses import PlainTextResponse as PlainTextResponse  # noqa
+from starlette.responses import RedirectResponse as RedirectResponse  # noqa
+from starlette.responses import Response as Response  # noqa
+from starlette.responses import StreamingResponse as StreamingResponse  # noqa
+
+try:
+    import ujson
+except ImportError:  # pragma: nocover
+    ujson = None  # type: ignore
+
+
+try:
+    import orjson
+except ImportError:  # pragma: nocover
+    orjson = None  # type: ignore
+
+
+class UJSONResponse(JSONResponse):
+    def render(self, content: Any) -> bytes:
+        assert ujson is not None, "ujson must be installed to use UJSONResponse"
+        return ujson.dumps(content, ensure_ascii=False).encode("utf-8")
+
+
+class ORJSONResponse(JSONResponse):
+    def render(self, content: Any) -> bytes:
+        assert orjson is not None, "orjson must be installed to use ORJSONResponse"
+        return orjson.dumps(
+            content, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SERIALIZE_NUMPY
+        )

--- a/src/prefect/_vendor/fastapi/routing.py
+++ b/src/prefect/_vendor/fastapi/routing.py
@@ -1,0 +1,1356 @@
+import asyncio
+import dataclasses
+import email.message
+import inspect
+import json
+from contextlib import AsyncExitStack
+from enum import Enum, IntEnum
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
+
+from prefect._vendor.fastapi import params
+from prefect._vendor.fastapi._compat import (
+    ModelField,
+    Undefined,
+    _get_model_config,
+    _model_dump,
+    _normalize_errors,
+    lenient_issubclass,
+)
+from prefect._vendor.fastapi.datastructures import Default, DefaultPlaceholder
+from prefect._vendor.fastapi.dependencies.models import Dependant
+from prefect._vendor.fastapi.dependencies.utils import (
+    get_body_field,
+    get_dependant,
+    get_parameterless_sub_dependant,
+    get_typed_return_annotation,
+    solve_dependencies,
+)
+from prefect._vendor.fastapi.encoders import jsonable_encoder
+from prefect._vendor.fastapi.exceptions import (
+    FastAPIError,
+    RequestValidationError,
+    ResponseValidationError,
+    WebSocketRequestValidationError,
+)
+from prefect._vendor.fastapi.types import DecoratedCallable, IncEx
+from prefect._vendor.fastapi.utils import (
+    create_cloned_field,
+    create_response_field,
+    generate_unique_id,
+    get_value_or_default,
+    is_body_allowed_for_status_code,
+)
+from pydantic import BaseModel
+from starlette import routing
+from starlette.concurrency import run_in_threadpool
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import (
+    BaseRoute,
+    Match,
+    compile_path,
+    get_name,
+    request_response,
+    websocket_session,
+)
+from starlette.routing import Mount as Mount  # noqa
+from starlette.types import ASGIApp, Lifespan, Scope
+from starlette.websockets import WebSocket
+
+
+def _prepare_response_content(
+    res: Any,
+    *,
+    exclude_unset: bool,
+    exclude_defaults: bool = False,
+    exclude_none: bool = False,
+) -> Any:
+    if isinstance(res, BaseModel):
+        read_with_orm_mode = getattr(_get_model_config(res), "read_with_orm_mode", None)
+        if read_with_orm_mode:
+            # Let from_orm extract the data from this model instead of converting
+            # it now to a dict.
+            # Otherwise, there's no way to extract lazy data that requires attribute
+            # access instead of dict iteration, e.g. lazy relationships.
+            return res
+        return _model_dump(
+            res,
+            by_alias=True,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+        )
+    elif isinstance(res, list):
+        return [
+            _prepare_response_content(
+                item,
+                exclude_unset=exclude_unset,
+                exclude_defaults=exclude_defaults,
+                exclude_none=exclude_none,
+            )
+            for item in res
+        ]
+    elif isinstance(res, dict):
+        return {
+            k: _prepare_response_content(
+                v,
+                exclude_unset=exclude_unset,
+                exclude_defaults=exclude_defaults,
+                exclude_none=exclude_none,
+            )
+            for k, v in res.items()
+        }
+    elif dataclasses.is_dataclass(res):
+        return dataclasses.asdict(res)
+    return res
+
+
+async def serialize_response(
+    *,
+    field: Optional[ModelField] = None,
+    response_content: Any,
+    include: Optional[IncEx] = None,
+    exclude: Optional[IncEx] = None,
+    by_alias: bool = True,
+    exclude_unset: bool = False,
+    exclude_defaults: bool = False,
+    exclude_none: bool = False,
+    is_coroutine: bool = True,
+) -> Any:
+    if field:
+        errors = []
+        if not hasattr(field, "serialize"):
+            # pydantic v1
+            response_content = _prepare_response_content(
+                response_content,
+                exclude_unset=exclude_unset,
+                exclude_defaults=exclude_defaults,
+                exclude_none=exclude_none,
+            )
+        if is_coroutine:
+            value, errors_ = field.validate(response_content, {}, loc=("response",))
+        else:
+            value, errors_ = await run_in_threadpool(
+                field.validate, response_content, {}, loc=("response",)
+            )
+        if isinstance(errors_, list):
+            errors.extend(errors_)
+        elif errors_:
+            errors.append(errors_)
+        if errors:
+            raise ResponseValidationError(
+                errors=_normalize_errors(errors), body=response_content
+            )
+
+        if hasattr(field, "serialize"):
+            return field.serialize(
+                value,
+                include=include,
+                exclude=exclude,
+                by_alias=by_alias,
+                exclude_unset=exclude_unset,
+                exclude_defaults=exclude_defaults,
+                exclude_none=exclude_none,
+            )
+
+        return jsonable_encoder(
+            value,
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+        )
+    else:
+        return jsonable_encoder(response_content)
+
+
+async def run_endpoint_function(
+    *, dependant: Dependant, values: Dict[str, Any], is_coroutine: bool
+) -> Any:
+    # Only called by get_request_handler. Has been split into its own function to
+    # facilitate profiling endpoints, since inner functions are harder to profile.
+    assert dependant.call is not None, "dependant.call must be a function"
+
+    if is_coroutine:
+        return await dependant.call(**values)
+    else:
+        return await run_in_threadpool(dependant.call, **values)
+
+
+def get_request_handler(
+    dependant: Dependant,
+    body_field: Optional[ModelField] = None,
+    status_code: Optional[int] = None,
+    response_class: Union[Type[Response], DefaultPlaceholder] = Default(JSONResponse),
+    response_field: Optional[ModelField] = None,
+    response_model_include: Optional[IncEx] = None,
+    response_model_exclude: Optional[IncEx] = None,
+    response_model_by_alias: bool = True,
+    response_model_exclude_unset: bool = False,
+    response_model_exclude_defaults: bool = False,
+    response_model_exclude_none: bool = False,
+    dependency_overrides_provider: Optional[Any] = None,
+) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+    assert dependant.call is not None, "dependant.call must be a function"
+    is_coroutine = asyncio.iscoroutinefunction(dependant.call)
+    is_body_form = body_field and isinstance(body_field.field_info, params.Form)
+    if isinstance(response_class, DefaultPlaceholder):
+        actual_response_class: Type[Response] = response_class.value
+    else:
+        actual_response_class = response_class
+
+    async def app(request: Request) -> Response:
+        try:
+            body: Any = None
+            if body_field:
+                if is_body_form:
+                    body = await request.form()
+                    stack = request.scope.get("fastapi_astack")
+                    assert isinstance(stack, AsyncExitStack)
+                    stack.push_async_callback(body.close)
+                else:
+                    body_bytes = await request.body()
+                    if body_bytes:
+                        json_body: Any = Undefined
+                        content_type_value = request.headers.get("content-type")
+                        if not content_type_value:
+                            json_body = await request.json()
+                        else:
+                            message = email.message.Message()
+                            message["content-type"] = content_type_value
+                            if message.get_content_maintype() == "application":
+                                subtype = message.get_content_subtype()
+                                if subtype == "json" or subtype.endswith("+json"):
+                                    json_body = await request.json()
+                        if json_body != Undefined:
+                            body = json_body
+                        else:
+                            body = body_bytes
+        except json.JSONDecodeError as e:
+            raise RequestValidationError(
+                [
+                    {
+                        "type": "json_invalid",
+                        "loc": ("body", e.pos),
+                        "msg": "JSON decode error",
+                        "input": {},
+                        "ctx": {"error": e.msg},
+                    }
+                ],
+                body=e.doc,
+            ) from e
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(
+                status_code=400, detail="There was an error parsing the body"
+            ) from e
+        solved_result = await solve_dependencies(
+            request=request,
+            dependant=dependant,
+            body=body,
+            dependency_overrides_provider=dependency_overrides_provider,
+        )
+        values, errors, background_tasks, sub_response, _ = solved_result
+        if errors:
+            raise RequestValidationError(_normalize_errors(errors), body=body)
+        else:
+            raw_response = await run_endpoint_function(
+                dependant=dependant, values=values, is_coroutine=is_coroutine
+            )
+
+            if isinstance(raw_response, Response):
+                if raw_response.background is None:
+                    raw_response.background = background_tasks
+                return raw_response
+            response_args: Dict[str, Any] = {"background": background_tasks}
+            # If status_code was set, use it, otherwise use the default from the
+            # response class, in the case of redirect it's 307
+            current_status_code = (
+                status_code if status_code else sub_response.status_code
+            )
+            if current_status_code is not None:
+                response_args["status_code"] = current_status_code
+            if sub_response.status_code:
+                response_args["status_code"] = sub_response.status_code
+            content = await serialize_response(
+                field=response_field,
+                response_content=raw_response,
+                include=response_model_include,
+                exclude=response_model_exclude,
+                by_alias=response_model_by_alias,
+                exclude_unset=response_model_exclude_unset,
+                exclude_defaults=response_model_exclude_defaults,
+                exclude_none=response_model_exclude_none,
+                is_coroutine=is_coroutine,
+            )
+            response = actual_response_class(content, **response_args)
+            if not is_body_allowed_for_status_code(response.status_code):
+                response.body = b""
+            response.headers.raw.extend(sub_response.headers.raw)
+            return response
+
+    return app
+
+
+def get_websocket_app(
+    dependant: Dependant, dependency_overrides_provider: Optional[Any] = None
+) -> Callable[[WebSocket], Coroutine[Any, Any, Any]]:
+    async def app(websocket: WebSocket) -> None:
+        solved_result = await solve_dependencies(
+            request=websocket,
+            dependant=dependant,
+            dependency_overrides_provider=dependency_overrides_provider,
+        )
+        values, errors, _, _2, _3 = solved_result
+        if errors:
+            raise WebSocketRequestValidationError(_normalize_errors(errors))
+        assert dependant.call is not None, "dependant.call must be a function"
+        await dependant.call(**values)
+
+    return app
+
+
+class APIWebSocketRoute(routing.WebSocketRoute):
+    def __init__(
+        self,
+        path: str,
+        endpoint: Callable[..., Any],
+        *,
+        name: Optional[str] = None,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+        dependency_overrides_provider: Optional[Any] = None,
+    ) -> None:
+        self.path = path
+        self.endpoint = endpoint
+        self.name = get_name(endpoint) if name is None else name
+        self.dependencies = list(dependencies or [])
+        self.path_regex, self.path_format, self.param_convertors = compile_path(path)
+        self.dependant = get_dependant(path=self.path_format, call=self.endpoint)
+        for depends in self.dependencies[::-1]:
+            self.dependant.dependencies.insert(
+                0,
+                get_parameterless_sub_dependant(depends=depends, path=self.path_format),
+            )
+
+        self.app = websocket_session(
+            get_websocket_app(
+                dependant=self.dependant,
+                dependency_overrides_provider=dependency_overrides_provider,
+            )
+        )
+
+    def matches(self, scope: Scope) -> Tuple[Match, Scope]:
+        match, child_scope = super().matches(scope)
+        if match != Match.NONE:
+            child_scope["route"] = self
+        return match, child_scope
+
+
+class APIRoute(routing.Route):
+    def __init__(
+        self,
+        path: str,
+        endpoint: Callable[..., Any],
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        name: Optional[str] = None,
+        methods: Optional[Union[Set[str], List[str]]] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Union[Type[Response], DefaultPlaceholder] = Default(
+            JSONResponse
+        ),
+        dependency_overrides_provider: Optional[Any] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Union[
+            Callable[["APIRoute"], str], DefaultPlaceholder
+        ] = Default(generate_unique_id),
+    ) -> None:
+        self.path = path
+        self.endpoint = endpoint
+        if isinstance(response_model, DefaultPlaceholder):
+            return_annotation = get_typed_return_annotation(endpoint)
+            if lenient_issubclass(return_annotation, Response):
+                response_model = None
+            else:
+                response_model = return_annotation
+        self.response_model = response_model
+        self.summary = summary
+        self.response_description = response_description
+        self.deprecated = deprecated
+        self.operation_id = operation_id
+        self.response_model_include = response_model_include
+        self.response_model_exclude = response_model_exclude
+        self.response_model_by_alias = response_model_by_alias
+        self.response_model_exclude_unset = response_model_exclude_unset
+        self.response_model_exclude_defaults = response_model_exclude_defaults
+        self.response_model_exclude_none = response_model_exclude_none
+        self.include_in_schema = include_in_schema
+        self.response_class = response_class
+        self.dependency_overrides_provider = dependency_overrides_provider
+        self.callbacks = callbacks
+        self.openapi_extra = openapi_extra
+        self.generate_unique_id_function = generate_unique_id_function
+        self.tags = tags or []
+        self.responses = responses or {}
+        self.name = get_name(endpoint) if name is None else name
+        self.path_regex, self.path_format, self.param_convertors = compile_path(path)
+        if methods is None:
+            methods = ["GET"]
+        self.methods: Set[str] = {method.upper() for method in methods}
+        if isinstance(generate_unique_id_function, DefaultPlaceholder):
+            current_generate_unique_id: Callable[["APIRoute"], str] = (
+                generate_unique_id_function.value
+            )
+        else:
+            current_generate_unique_id = generate_unique_id_function
+        self.unique_id = self.operation_id or current_generate_unique_id(self)
+        # normalize enums e.g. http.HTTPStatus
+        if isinstance(status_code, IntEnum):
+            status_code = int(status_code)
+        self.status_code = status_code
+        if self.response_model:
+            assert is_body_allowed_for_status_code(
+                status_code
+            ), f"Status code {status_code} must not have a response body"
+            response_name = "Response_" + self.unique_id
+            self.response_field = create_response_field(
+                name=response_name,
+                type_=self.response_model,
+                mode="serialization",
+            )
+            # Create a clone of the field, so that a Pydantic submodel is not returned
+            # as is just because it's an instance of a subclass of a more limited class
+            # e.g. UserInDB (containing hashed_password) could be a subclass of User
+            # that doesn't have the hashed_password. But because it's a subclass, it
+            # would pass the validation and be returned as is.
+            # By being a new field, no inheritance will be passed as is. A new model
+            # will always be created.
+            # TODO: remove when deprecating Pydantic v1
+            self.secure_cloned_response_field: Optional[ModelField] = (
+                create_cloned_field(self.response_field)
+            )
+        else:
+            self.response_field = None  # type: ignore
+            self.secure_cloned_response_field = None
+        self.dependencies = list(dependencies or [])
+        self.description = description or inspect.cleandoc(self.endpoint.__doc__ or "")
+        # if a "form feed" character (page break) is found in the description text,
+        # truncate description text to the content preceding the first "form feed"
+        self.description = self.description.split("\f")[0].strip()
+        response_fields = {}
+        for additional_status_code, response in self.responses.items():
+            assert isinstance(response, dict), "An additional response must be a dict"
+            model = response.get("model")
+            if model:
+                assert is_body_allowed_for_status_code(
+                    additional_status_code
+                ), f"Status code {additional_status_code} must not have a response body"
+                response_name = f"Response_{additional_status_code}_{self.unique_id}"
+                response_field = create_response_field(name=response_name, type_=model)
+                response_fields[additional_status_code] = response_field
+        if response_fields:
+            self.response_fields: Dict[Union[int, str], ModelField] = response_fields
+        else:
+            self.response_fields = {}
+
+        assert callable(endpoint), "An endpoint must be a callable"
+        self.dependant = get_dependant(path=self.path_format, call=self.endpoint)
+        for depends in self.dependencies[::-1]:
+            self.dependant.dependencies.insert(
+                0,
+                get_parameterless_sub_dependant(depends=depends, path=self.path_format),
+            )
+        self.body_field = get_body_field(dependant=self.dependant, name=self.unique_id)
+        self.app = request_response(self.get_route_handler())
+
+    def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+        return get_request_handler(
+            dependant=self.dependant,
+            body_field=self.body_field,
+            status_code=self.status_code,
+            response_class=self.response_class,
+            response_field=self.secure_cloned_response_field,
+            response_model_include=self.response_model_include,
+            response_model_exclude=self.response_model_exclude,
+            response_model_by_alias=self.response_model_by_alias,
+            response_model_exclude_unset=self.response_model_exclude_unset,
+            response_model_exclude_defaults=self.response_model_exclude_defaults,
+            response_model_exclude_none=self.response_model_exclude_none,
+            dependency_overrides_provider=self.dependency_overrides_provider,
+        )
+
+    def matches(self, scope: Scope) -> Tuple[Match, Scope]:
+        match, child_scope = super().matches(scope)
+        if match != Match.NONE:
+            child_scope["route"] = self
+        return match, child_scope
+
+
+class APIRouter(routing.Router):
+    def __init__(
+        self,
+        *,
+        prefix: str = "",
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+        default_response_class: Type[Response] = Default(JSONResponse),
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        routes: Optional[List[routing.BaseRoute]] = None,
+        redirect_slashes: bool = True,
+        default: Optional[ASGIApp] = None,
+        dependency_overrides_provider: Optional[Any] = None,
+        route_class: Type[APIRoute] = APIRoute,
+        on_startup: Optional[Sequence[Callable[[], Any]]] = None,
+        on_shutdown: Optional[Sequence[Callable[[], Any]]] = None,
+        # the generic to Lifespan[AppType] is the type of the top level application
+        # which the router cannot know statically, so we use typing.Any
+        lifespan: Optional[Lifespan[Any]] = None,
+        deprecated: Optional[bool] = None,
+        include_in_schema: bool = True,
+        generate_unique_id_function: Callable[[APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> None:
+        super().__init__(
+            routes=routes,
+            redirect_slashes=redirect_slashes,
+            default=default,
+            on_startup=on_startup,
+            on_shutdown=on_shutdown,
+            lifespan=lifespan,
+        )
+        if prefix:
+            assert prefix.startswith("/"), "A path prefix must start with '/'"
+            assert not prefix.endswith(
+                "/"
+            ), "A path prefix must not end with '/', as the routes will start with '/'"
+        self.prefix = prefix
+        self.tags: List[Union[str, Enum]] = tags or []
+        self.dependencies = list(dependencies or [])
+        self.deprecated = deprecated
+        self.include_in_schema = include_in_schema
+        self.responses = responses or {}
+        self.callbacks = callbacks or []
+        self.dependency_overrides_provider = dependency_overrides_provider
+        self.route_class = route_class
+        self.default_response_class = default_response_class
+        self.generate_unique_id_function = generate_unique_id_function
+
+    def route(
+        self,
+        path: str,
+        methods: Optional[List[str]] = None,
+        name: Optional[str] = None,
+        include_in_schema: bool = True,
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        def decorator(func: DecoratedCallable) -> DecoratedCallable:
+            self.add_route(
+                path,
+                func,
+                methods=methods,
+                name=name,
+                include_in_schema=include_in_schema,
+            )
+            return func
+
+        return decorator
+
+    def add_api_route(
+        self,
+        path: str,
+        endpoint: Callable[..., Any],
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        methods: Optional[Union[Set[str], List[str]]] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Union[Type[Response], DefaultPlaceholder] = Default(
+            JSONResponse
+        ),
+        name: Optional[str] = None,
+        route_class_override: Optional[Type[APIRoute]] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Union[
+            Callable[[APIRoute], str], DefaultPlaceholder
+        ] = Default(generate_unique_id),
+    ) -> None:
+        route_class = route_class_override or self.route_class
+        responses = responses or {}
+        combined_responses = {**self.responses, **responses}
+        current_response_class = get_value_or_default(
+            response_class, self.default_response_class
+        )
+        current_tags = self.tags.copy()
+        if tags:
+            current_tags.extend(tags)
+        current_dependencies = self.dependencies.copy()
+        if dependencies:
+            current_dependencies.extend(dependencies)
+        current_callbacks = self.callbacks.copy()
+        if callbacks:
+            current_callbacks.extend(callbacks)
+        current_generate_unique_id = get_value_or_default(
+            generate_unique_id_function, self.generate_unique_id_function
+        )
+        route = route_class(
+            self.prefix + path,
+            endpoint=endpoint,
+            response_model=response_model,
+            status_code=status_code,
+            tags=current_tags,
+            dependencies=current_dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=combined_responses,
+            deprecated=deprecated or self.deprecated,
+            methods=methods,
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema and self.include_in_schema,
+            response_class=current_response_class,
+            name=name,
+            dependency_overrides_provider=self.dependency_overrides_provider,
+            callbacks=current_callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=current_generate_unique_id,
+        )
+        self.routes.append(route)
+
+    def api_route(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        methods: Optional[List[str]] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        def decorator(func: DecoratedCallable) -> DecoratedCallable:
+            self.add_api_route(
+                path,
+                func,
+                response_model=response_model,
+                status_code=status_code,
+                tags=tags,
+                dependencies=dependencies,
+                summary=summary,
+                description=description,
+                response_description=response_description,
+                responses=responses,
+                deprecated=deprecated,
+                methods=methods,
+                operation_id=operation_id,
+                response_model_include=response_model_include,
+                response_model_exclude=response_model_exclude,
+                response_model_by_alias=response_model_by_alias,
+                response_model_exclude_unset=response_model_exclude_unset,
+                response_model_exclude_defaults=response_model_exclude_defaults,
+                response_model_exclude_none=response_model_exclude_none,
+                include_in_schema=include_in_schema,
+                response_class=response_class,
+                name=name,
+                callbacks=callbacks,
+                openapi_extra=openapi_extra,
+                generate_unique_id_function=generate_unique_id_function,
+            )
+            return func
+
+        return decorator
+
+    def add_api_websocket_route(
+        self,
+        path: str,
+        endpoint: Callable[..., Any],
+        name: Optional[str] = None,
+        *,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+    ) -> None:
+        current_dependencies = self.dependencies.copy()
+        if dependencies:
+            current_dependencies.extend(dependencies)
+
+        route = APIWebSocketRoute(
+            self.prefix + path,
+            endpoint=endpoint,
+            name=name,
+            dependencies=current_dependencies,
+            dependency_overrides_provider=self.dependency_overrides_provider,
+        )
+        self.routes.append(route)
+
+    def websocket(
+        self,
+        path: str,
+        name: Optional[str] = None,
+        *,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        def decorator(func: DecoratedCallable) -> DecoratedCallable:
+            self.add_api_websocket_route(
+                path, func, name=name, dependencies=dependencies
+            )
+            return func
+
+        return decorator
+
+    def websocket_route(
+        self, path: str, name: Union[str, None] = None
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        def decorator(func: DecoratedCallable) -> DecoratedCallable:
+            self.add_websocket_route(path, func, name=name)
+            return func
+
+        return decorator
+
+    def include_router(
+        self,
+        router: "APIRouter",
+        *,
+        prefix: str = "",
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+        default_response_class: Type[Response] = Default(JSONResponse),
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        deprecated: Optional[bool] = None,
+        include_in_schema: bool = True,
+        generate_unique_id_function: Callable[[APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> None:
+        if prefix:
+            assert prefix.startswith("/"), "A path prefix must start with '/'"
+            assert not prefix.endswith(
+                "/"
+            ), "A path prefix must not end with '/', as the routes will start with '/'"
+        else:
+            for r in router.routes:
+                path = getattr(r, "path")  # noqa: B009
+                name = getattr(r, "name", "unknown")
+                if path is not None and not path:
+                    raise FastAPIError(
+                        f"Prefix and path cannot be both empty (path operation: {name})"
+                    )
+        if responses is None:
+            responses = {}
+        for route in router.routes:
+            if isinstance(route, APIRoute):
+                combined_responses = {**responses, **route.responses}
+                use_response_class = get_value_or_default(
+                    route.response_class,
+                    router.default_response_class,
+                    default_response_class,
+                    self.default_response_class,
+                )
+                current_tags = []
+                if tags:
+                    current_tags.extend(tags)
+                if route.tags:
+                    current_tags.extend(route.tags)
+                current_dependencies: List[params.Depends] = []
+                if dependencies:
+                    current_dependencies.extend(dependencies)
+                if route.dependencies:
+                    current_dependencies.extend(route.dependencies)
+                current_callbacks = []
+                if callbacks:
+                    current_callbacks.extend(callbacks)
+                if route.callbacks:
+                    current_callbacks.extend(route.callbacks)
+                current_generate_unique_id = get_value_or_default(
+                    route.generate_unique_id_function,
+                    router.generate_unique_id_function,
+                    generate_unique_id_function,
+                    self.generate_unique_id_function,
+                )
+                self.add_api_route(
+                    prefix + route.path,
+                    route.endpoint,
+                    response_model=route.response_model,
+                    status_code=route.status_code,
+                    tags=current_tags,
+                    dependencies=current_dependencies,
+                    summary=route.summary,
+                    description=route.description,
+                    response_description=route.response_description,
+                    responses=combined_responses,
+                    deprecated=route.deprecated or deprecated or self.deprecated,
+                    methods=route.methods,
+                    operation_id=route.operation_id,
+                    response_model_include=route.response_model_include,
+                    response_model_exclude=route.response_model_exclude,
+                    response_model_by_alias=route.response_model_by_alias,
+                    response_model_exclude_unset=route.response_model_exclude_unset,
+                    response_model_exclude_defaults=route.response_model_exclude_defaults,
+                    response_model_exclude_none=route.response_model_exclude_none,
+                    include_in_schema=route.include_in_schema
+                    and self.include_in_schema
+                    and include_in_schema,
+                    response_class=use_response_class,
+                    name=route.name,
+                    route_class_override=type(route),
+                    callbacks=current_callbacks,
+                    openapi_extra=route.openapi_extra,
+                    generate_unique_id_function=current_generate_unique_id,
+                )
+            elif isinstance(route, routing.Route):
+                methods = list(route.methods or [])
+                self.add_route(
+                    prefix + route.path,
+                    route.endpoint,
+                    methods=methods,
+                    include_in_schema=route.include_in_schema,
+                    name=route.name,
+                )
+            elif isinstance(route, APIWebSocketRoute):
+                current_dependencies = []
+                if dependencies:
+                    current_dependencies.extend(dependencies)
+                if route.dependencies:
+                    current_dependencies.extend(route.dependencies)
+                self.add_api_websocket_route(
+                    prefix + route.path,
+                    route.endpoint,
+                    dependencies=current_dependencies,
+                    name=route.name,
+                )
+            elif isinstance(route, routing.WebSocketRoute):
+                self.add_websocket_route(
+                    prefix + route.path, route.endpoint, name=route.name
+                )
+        for handler in router.on_startup:
+            self.add_event_handler("startup", handler)
+        for handler in router.on_shutdown:
+            self.add_event_handler("shutdown", handler)
+
+    def get(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.api_route(
+            path=path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            methods=["GET"],
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def put(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.api_route(
+            path=path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            methods=["PUT"],
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def post(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.api_route(
+            path=path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            methods=["POST"],
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def delete(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.api_route(
+            path=path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            methods=["DELETE"],
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def options(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.api_route(
+            path=path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            methods=["OPTIONS"],
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def head(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.api_route(
+            path=path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            methods=["HEAD"],
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def patch(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.api_route(
+            path=path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            methods=["PATCH"],
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def trace(
+        self,
+        path: str,
+        *,
+        response_model: Any = Default(None),
+        status_code: Optional[int] = None,
+        tags: Optional[List[Union[str, Enum]]] = None,
+        dependencies: Optional[Sequence[params.Depends]] = None,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        response_description: str = "Successful Response",
+        responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = None,
+        deprecated: Optional[bool] = None,
+        operation_id: Optional[str] = None,
+        response_model_include: Optional[IncEx] = None,
+        response_model_exclude: Optional[IncEx] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        include_in_schema: bool = True,
+        response_class: Type[Response] = Default(JSONResponse),
+        name: Optional[str] = None,
+        callbacks: Optional[List[BaseRoute]] = None,
+        openapi_extra: Optional[Dict[str, Any]] = None,
+        generate_unique_id_function: Callable[[APIRoute], str] = Default(
+            generate_unique_id
+        ),
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        return self.api_route(
+            path=path,
+            response_model=response_model,
+            status_code=status_code,
+            tags=tags,
+            dependencies=dependencies,
+            summary=summary,
+            description=description,
+            response_description=response_description,
+            responses=responses,
+            deprecated=deprecated,
+            methods=["TRACE"],
+            operation_id=operation_id,
+            response_model_include=response_model_include,
+            response_model_exclude=response_model_exclude,
+            response_model_by_alias=response_model_by_alias,
+            response_model_exclude_unset=response_model_exclude_unset,
+            response_model_exclude_defaults=response_model_exclude_defaults,
+            response_model_exclude_none=response_model_exclude_none,
+            include_in_schema=include_in_schema,
+            response_class=response_class,
+            name=name,
+            callbacks=callbacks,
+            openapi_extra=openapi_extra,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    def on_event(
+        self, event_type: str
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        def decorator(func: DecoratedCallable) -> DecoratedCallable:
+            self.add_event_handler(event_type, func)
+            return func
+
+        return decorator

--- a/src/prefect/_vendor/fastapi/security/__init__.py
+++ b/src/prefect/_vendor/fastapi/security/__init__.py
@@ -1,0 +1,15 @@
+from .api_key import APIKeyCookie as APIKeyCookie
+from .api_key import APIKeyHeader as APIKeyHeader
+from .api_key import APIKeyQuery as APIKeyQuery
+from .http import HTTPAuthorizationCredentials as HTTPAuthorizationCredentials
+from .http import HTTPBasic as HTTPBasic
+from .http import HTTPBasicCredentials as HTTPBasicCredentials
+from .http import HTTPBearer as HTTPBearer
+from .http import HTTPDigest as HTTPDigest
+from .oauth2 import OAuth2 as OAuth2
+from .oauth2 import OAuth2AuthorizationCodeBearer as OAuth2AuthorizationCodeBearer
+from .oauth2 import OAuth2PasswordBearer as OAuth2PasswordBearer
+from .oauth2 import OAuth2PasswordRequestForm as OAuth2PasswordRequestForm
+from .oauth2 import OAuth2PasswordRequestFormStrict as OAuth2PasswordRequestFormStrict
+from .oauth2 import SecurityScopes as SecurityScopes
+from .open_id_connect_url import OpenIdConnect as OpenIdConnect

--- a/src/prefect/_vendor/fastapi/security/api_key.py
+++ b/src/prefect/_vendor/fastapi/security/api_key.py
@@ -1,0 +1,98 @@
+from typing import Optional
+
+from prefect._vendor.fastapi.openapi.models import APIKey, APIKeyIn
+from prefect._vendor.fastapi.security.base import SecurityBase
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.status import HTTP_403_FORBIDDEN
+
+
+class APIKeyBase(SecurityBase):
+    pass
+
+
+class APIKeyQuery(APIKeyBase):
+    def __init__(
+        self,
+        *,
+        name: str,
+        scheme_name: Optional[str] = None,
+        description: Optional[str] = None,
+        auto_error: bool = True,
+    ):
+        self.model: APIKey = APIKey(
+            **{"in": APIKeyIn.query},  # type: ignore[arg-type]
+            name=name,
+            description=description,
+        )
+        self.scheme_name = scheme_name or self.__class__.__name__
+        self.auto_error = auto_error
+
+    async def __call__(self, request: Request) -> Optional[str]:
+        api_key = request.query_params.get(self.model.name)
+        if not api_key:
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=HTTP_403_FORBIDDEN, detail="Not authenticated"
+                )
+            else:
+                return None
+        return api_key
+
+
+class APIKeyHeader(APIKeyBase):
+    def __init__(
+        self,
+        *,
+        name: str,
+        scheme_name: Optional[str] = None,
+        description: Optional[str] = None,
+        auto_error: bool = True,
+    ):
+        self.model: APIKey = APIKey(
+            **{"in": APIKeyIn.header},  # type: ignore[arg-type]
+            name=name,
+            description=description,
+        )
+        self.scheme_name = scheme_name or self.__class__.__name__
+        self.auto_error = auto_error
+
+    async def __call__(self, request: Request) -> Optional[str]:
+        api_key = request.headers.get(self.model.name)
+        if not api_key:
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=HTTP_403_FORBIDDEN, detail="Not authenticated"
+                )
+            else:
+                return None
+        return api_key
+
+
+class APIKeyCookie(APIKeyBase):
+    def __init__(
+        self,
+        *,
+        name: str,
+        scheme_name: Optional[str] = None,
+        description: Optional[str] = None,
+        auto_error: bool = True,
+    ):
+        self.model: APIKey = APIKey(
+            **{"in": APIKeyIn.cookie},  # type: ignore[arg-type]
+            name=name,
+            description=description,
+        )
+        self.scheme_name = scheme_name or self.__class__.__name__
+        self.auto_error = auto_error
+
+    async def __call__(self, request: Request) -> Optional[str]:
+        api_key = request.cookies.get(self.model.name)
+        if not api_key:
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=HTTP_403_FORBIDDEN, detail="Not authenticated"
+                )
+            else:
+                return None
+        return api_key

--- a/src/prefect/_vendor/fastapi/security/base.py
+++ b/src/prefect/_vendor/fastapi/security/base.py
@@ -1,0 +1,6 @@
+from prefect._vendor.fastapi.openapi.models import SecurityBase as SecurityBaseModel
+
+
+class SecurityBase:
+    model: SecurityBaseModel
+    scheme_name: str

--- a/src/prefect/_vendor/fastapi/security/http.py
+++ b/src/prefect/_vendor/fastapi/security/http.py
@@ -1,0 +1,165 @@
+import binascii
+from base64 import b64decode
+from typing import Optional
+
+from prefect._vendor.fastapi.exceptions import HTTPException
+from prefect._vendor.fastapi.openapi.models import HTTPBase as HTTPBaseModel
+from prefect._vendor.fastapi.openapi.models import HTTPBearer as HTTPBearerModel
+from prefect._vendor.fastapi.security.base import SecurityBase
+from prefect._vendor.fastapi.security.utils import get_authorization_scheme_param
+from pydantic import BaseModel
+from starlette.requests import Request
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
+
+
+class HTTPBasicCredentials(BaseModel):
+    username: str
+    password: str
+
+
+class HTTPAuthorizationCredentials(BaseModel):
+    scheme: str
+    credentials: str
+
+
+class HTTPBase(SecurityBase):
+    def __init__(
+        self,
+        *,
+        scheme: str,
+        scheme_name: Optional[str] = None,
+        description: Optional[str] = None,
+        auto_error: bool = True,
+    ):
+        self.model = HTTPBaseModel(scheme=scheme, description=description)
+        self.scheme_name = scheme_name or self.__class__.__name__
+        self.auto_error = auto_error
+
+    async def __call__(
+        self, request: Request
+    ) -> Optional[HTTPAuthorizationCredentials]:
+        authorization = request.headers.get("Authorization")
+        scheme, credentials = get_authorization_scheme_param(authorization)
+        if not (authorization and scheme and credentials):
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=HTTP_403_FORBIDDEN, detail="Not authenticated"
+                )
+            else:
+                return None
+        return HTTPAuthorizationCredentials(scheme=scheme, credentials=credentials)
+
+
+class HTTPBasic(HTTPBase):
+    def __init__(
+        self,
+        *,
+        scheme_name: Optional[str] = None,
+        realm: Optional[str] = None,
+        description: Optional[str] = None,
+        auto_error: bool = True,
+    ):
+        self.model = HTTPBaseModel(scheme="basic", description=description)
+        self.scheme_name = scheme_name or self.__class__.__name__
+        self.realm = realm
+        self.auto_error = auto_error
+
+    async def __call__(  # type: ignore
+        self, request: Request
+    ) -> Optional[HTTPBasicCredentials]:
+        authorization = request.headers.get("Authorization")
+        scheme, param = get_authorization_scheme_param(authorization)
+        if self.realm:
+            unauthorized_headers = {"WWW-Authenticate": f'Basic realm="{self.realm}"'}
+        else:
+            unauthorized_headers = {"WWW-Authenticate": "Basic"}
+        if not authorization or scheme.lower() != "basic":
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=HTTP_401_UNAUTHORIZED,
+                    detail="Not authenticated",
+                    headers=unauthorized_headers,
+                )
+            else:
+                return None
+        invalid_user_credentials_exc = HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+            headers=unauthorized_headers,
+        )
+        try:
+            data = b64decode(param).decode("ascii")
+        except (ValueError, UnicodeDecodeError, binascii.Error):
+            raise invalid_user_credentials_exc
+        username, separator, password = data.partition(":")
+        if not separator:
+            raise invalid_user_credentials_exc
+        return HTTPBasicCredentials(username=username, password=password)
+
+
+class HTTPBearer(HTTPBase):
+    def __init__(
+        self,
+        *,
+        bearerFormat: Optional[str] = None,
+        scheme_name: Optional[str] = None,
+        description: Optional[str] = None,
+        auto_error: bool = True,
+    ):
+        self.model = HTTPBearerModel(bearerFormat=bearerFormat, description=description)
+        self.scheme_name = scheme_name or self.__class__.__name__
+        self.auto_error = auto_error
+
+    async def __call__(
+        self, request: Request
+    ) -> Optional[HTTPAuthorizationCredentials]:
+        authorization = request.headers.get("Authorization")
+        scheme, credentials = get_authorization_scheme_param(authorization)
+        if not (authorization and scheme and credentials):
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=HTTP_403_FORBIDDEN, detail="Not authenticated"
+                )
+            else:
+                return None
+        if scheme.lower() != "bearer":
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=HTTP_403_FORBIDDEN,
+                    detail="Invalid authentication credentials",
+                )
+            else:
+                return None
+        return HTTPAuthorizationCredentials(scheme=scheme, credentials=credentials)
+
+
+class HTTPDigest(HTTPBase):
+    def __init__(
+        self,
+        *,
+        scheme_name: Optional[str] = None,
+        description: Optional[str] = None,
+        auto_error: bool = True,
+    ):
+        self.model = HTTPBaseModel(scheme="digest", description=description)
+        self.scheme_name = scheme_name or self.__class__.__name__
+        self.auto_error = auto_error
+
+    async def __call__(
+        self, request: Request
+    ) -> Optional[HTTPAuthorizationCredentials]:
+        authorization = request.headers.get("Authorization")
+        scheme, credentials = get_authorization_scheme_param(authorization)
+        if not (authorization and scheme and credentials):
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=HTTP_403_FORBIDDEN, detail="Not authenticated"
+                )
+            else:
+                return None
+        if scheme.lower() != "digest":
+            raise HTTPException(
+                status_code=HTTP_403_FORBIDDEN,
+                detail="Invalid authentication credentials",
+            )
+        return HTTPAuthorizationCredentials(scheme=scheme, credentials=credentials)

--- a/src/prefect/_vendor/fastapi/security/oauth2.py
+++ b/src/prefect/_vendor/fastapi/security/oauth2.py
@@ -1,0 +1,231 @@
+from typing import Any, Dict, List, Optional, Union, cast
+
+from prefect._vendor.fastapi.exceptions import HTTPException
+from prefect._vendor.fastapi.openapi.models import OAuth2 as OAuth2Model
+from prefect._vendor.fastapi.openapi.models import OAuthFlows as OAuthFlowsModel
+from prefect._vendor.fastapi.param_functions import Form
+from prefect._vendor.fastapi.security.base import SecurityBase
+from prefect._vendor.fastapi.security.utils import get_authorization_scheme_param
+from starlette.requests import Request
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
+
+# TODO: import from typing when deprecating Python 3.9
+from typing_extensions import Annotated
+
+
+class OAuth2PasswordRequestForm:
+    """
+    This is a dependency class, use it like:
+
+        @app.post("/login")
+        def login(form_data: OAuth2PasswordRequestForm = Depends()):
+            data = form_data.parse()
+            print(data.username)
+            print(data.password)
+            for scope in data.scopes:
+                print(scope)
+            if data.client_id:
+                print(data.client_id)
+            if data.client_secret:
+                print(data.client_secret)
+            return data
+
+
+    It creates the following Form request parameters in your endpoint:
+
+    grant_type: the OAuth2 spec says it is required and MUST be the fixed string "password".
+        Nevertheless, this dependency class is permissive and allows not passing it. If you want to enforce it,
+        use instead the OAuth2PasswordRequestFormStrict dependency.
+    username: username string. The OAuth2 spec requires the exact field name "username".
+    password: password string. The OAuth2 spec requires the exact field name "password".
+    scope: Optional string. Several scopes (each one a string) separated by spaces. E.g.
+        "items:read items:write users:read profile openid"
+    client_id: optional string. OAuth2 recommends sending the client_id and client_secret (if any)
+        using HTTP Basic auth, as: client_id:client_secret
+    client_secret: optional string. OAuth2 recommends sending the client_id and client_secret (if any)
+        using HTTP Basic auth, as: client_id:client_secret
+    """
+
+    def __init__(
+        self,
+        *,
+        grant_type: Annotated[Union[str, None], Form(pattern="password")] = None,
+        username: Annotated[str, Form()],
+        password: Annotated[str, Form()],
+        scope: Annotated[str, Form()] = "",
+        client_id: Annotated[Union[str, None], Form()] = None,
+        client_secret: Annotated[Union[str, None], Form()] = None,
+    ):
+        self.grant_type = grant_type
+        self.username = username
+        self.password = password
+        self.scopes = scope.split()
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+
+class OAuth2PasswordRequestFormStrict(OAuth2PasswordRequestForm):
+    """
+    This is a dependency class, use it like:
+
+        @app.post("/login")
+        def login(form_data: OAuth2PasswordRequestFormStrict = Depends()):
+            data = form_data.parse()
+            print(data.username)
+            print(data.password)
+            for scope in data.scopes:
+                print(scope)
+            if data.client_id:
+                print(data.client_id)
+            if data.client_secret:
+                print(data.client_secret)
+            return data
+
+
+    It creates the following Form request parameters in your endpoint:
+
+    grant_type: the OAuth2 spec says it is required and MUST be the fixed string "password".
+        This dependency is strict about it. If you want to be permissive, use instead the
+        OAuth2PasswordRequestForm dependency class.
+    username: username string. The OAuth2 spec requires the exact field name "username".
+    password: password string. The OAuth2 spec requires the exact field name "password".
+    scope: Optional string. Several scopes (each one a string) separated by spaces. E.g.
+        "items:read items:write users:read profile openid"
+    client_id: optional string. OAuth2 recommends sending the client_id and client_secret (if any)
+        using HTTP Basic auth, as: client_id:client_secret
+    client_secret: optional string. OAuth2 recommends sending the client_id and client_secret (if any)
+        using HTTP Basic auth, as: client_id:client_secret
+    """
+
+    def __init__(
+        self,
+        grant_type: Annotated[str, Form(pattern="password")],
+        username: Annotated[str, Form()],
+        password: Annotated[str, Form()],
+        scope: Annotated[str, Form()] = "",
+        client_id: Annotated[Union[str, None], Form()] = None,
+        client_secret: Annotated[Union[str, None], Form()] = None,
+    ):
+        super().__init__(
+            grant_type=grant_type,
+            username=username,
+            password=password,
+            scope=scope,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+
+
+class OAuth2(SecurityBase):
+    def __init__(
+        self,
+        *,
+        flows: Union[OAuthFlowsModel, Dict[str, Dict[str, Any]]] = OAuthFlowsModel(),
+        scheme_name: Optional[str] = None,
+        description: Optional[str] = None,
+        auto_error: bool = True,
+    ):
+        self.model = OAuth2Model(
+            flows=cast(OAuthFlowsModel, flows), description=description
+        )
+        self.scheme_name = scheme_name or self.__class__.__name__
+        self.auto_error = auto_error
+
+    async def __call__(self, request: Request) -> Optional[str]:
+        authorization = request.headers.get("Authorization")
+        if not authorization:
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=HTTP_403_FORBIDDEN, detail="Not authenticated"
+                )
+            else:
+                return None
+        return authorization
+
+
+class OAuth2PasswordBearer(OAuth2):
+    def __init__(
+        self,
+        tokenUrl: str,
+        scheme_name: Optional[str] = None,
+        scopes: Optional[Dict[str, str]] = None,
+        description: Optional[str] = None,
+        auto_error: bool = True,
+    ):
+        if not scopes:
+            scopes = {}
+        flows = OAuthFlowsModel(
+            password=cast(Any, {"tokenUrl": tokenUrl, "scopes": scopes})
+        )
+        super().__init__(
+            flows=flows,
+            scheme_name=scheme_name,
+            description=description,
+            auto_error=auto_error,
+        )
+
+    async def __call__(self, request: Request) -> Optional[str]:
+        authorization = request.headers.get("Authorization")
+        scheme, param = get_authorization_scheme_param(authorization)
+        if not authorization or scheme.lower() != "bearer":
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=HTTP_401_UNAUTHORIZED,
+                    detail="Not authenticated",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            else:
+                return None
+        return param
+
+
+class OAuth2AuthorizationCodeBearer(OAuth2):
+    def __init__(
+        self,
+        authorizationUrl: str,
+        tokenUrl: str,
+        refreshUrl: Optional[str] = None,
+        scheme_name: Optional[str] = None,
+        scopes: Optional[Dict[str, str]] = None,
+        description: Optional[str] = None,
+        auto_error: bool = True,
+    ):
+        if not scopes:
+            scopes = {}
+        flows = OAuthFlowsModel(
+            authorizationCode=cast(
+                Any,
+                {
+                    "authorizationUrl": authorizationUrl,
+                    "tokenUrl": tokenUrl,
+                    "refreshUrl": refreshUrl,
+                    "scopes": scopes,
+                },
+            )
+        )
+        super().__init__(
+            flows=flows,
+            scheme_name=scheme_name,
+            description=description,
+            auto_error=auto_error,
+        )
+
+    async def __call__(self, request: Request) -> Optional[str]:
+        authorization = request.headers.get("Authorization")
+        scheme, param = get_authorization_scheme_param(authorization)
+        if not authorization or scheme.lower() != "bearer":
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=HTTP_401_UNAUTHORIZED,
+                    detail="Not authenticated",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            else:
+                return None  # pragma: nocover
+        return param
+
+
+class SecurityScopes:
+    def __init__(self, scopes: Optional[List[str]] = None):
+        self.scopes = scopes or []
+        self.scope_str = " ".join(self.scopes)

--- a/src/prefect/_vendor/fastapi/security/open_id_connect_url.py
+++ b/src/prefect/_vendor/fastapi/security/open_id_connect_url.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+from prefect._vendor.fastapi.openapi.models import OpenIdConnect as OpenIdConnectModel
+from prefect._vendor.fastapi.security.base import SecurityBase
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.status import HTTP_403_FORBIDDEN
+
+
+class OpenIdConnect(SecurityBase):
+    def __init__(
+        self,
+        *,
+        openIdConnectUrl: str,
+        scheme_name: Optional[str] = None,
+        description: Optional[str] = None,
+        auto_error: bool = True,
+    ):
+        self.model = OpenIdConnectModel(
+            openIdConnectUrl=openIdConnectUrl, description=description
+        )
+        self.scheme_name = scheme_name or self.__class__.__name__
+        self.auto_error = auto_error
+
+    async def __call__(self, request: Request) -> Optional[str]:
+        authorization = request.headers.get("Authorization")
+        if not authorization:
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=HTTP_403_FORBIDDEN, detail="Not authenticated"
+                )
+            else:
+                return None
+        return authorization

--- a/src/prefect/_vendor/fastapi/security/utils.py
+++ b/src/prefect/_vendor/fastapi/security/utils.py
@@ -1,0 +1,10 @@
+from typing import Optional, Tuple
+
+
+def get_authorization_scheme_param(
+    authorization_header_value: Optional[str],
+) -> Tuple[str, str]:
+    if not authorization_header_value:
+        return "", ""
+    scheme, _, param = authorization_header_value.partition(" ")
+    return scheme, param

--- a/src/prefect/_vendor/fastapi/staticfiles.py
+++ b/src/prefect/_vendor/fastapi/staticfiles.py
@@ -1,0 +1,1 @@
+from starlette.staticfiles import StaticFiles as StaticFiles  # noqa

--- a/src/prefect/_vendor/fastapi/templating.py
+++ b/src/prefect/_vendor/fastapi/templating.py
@@ -1,0 +1,1 @@
+from starlette.templating import Jinja2Templates as Jinja2Templates  # noqa

--- a/src/prefect/_vendor/fastapi/testclient.py
+++ b/src/prefect/_vendor/fastapi/testclient.py
@@ -1,0 +1,1 @@
+from starlette.testclient import TestClient as TestClient  # noqa

--- a/src/prefect/_vendor/fastapi/types.py
+++ b/src/prefect/_vendor/fastapi/types.py
@@ -1,0 +1,11 @@
+import types
+from enum import Enum
+from typing import Any, Callable, Dict, Set, Type, TypeVar, Union
+
+from pydantic import BaseModel
+
+DecoratedCallable = TypeVar("DecoratedCallable", bound=Callable[..., Any])
+UnionType = getattr(types, "UnionType", Union)
+NoneType = getattr(types, "UnionType", None)
+ModelNameMap = Dict[Union[Type[BaseModel], Type[Enum]], str]
+IncEx = Union[Set[int], Set[str], Dict[int, Any], Dict[str, Any]]

--- a/src/prefect/_vendor/fastapi/utils.py
+++ b/src/prefect/_vendor/fastapi/utils.py
@@ -1,0 +1,230 @@
+import re
+import warnings
+from dataclasses import is_dataclass
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    MutableMapping,
+    Optional,
+    Set,
+    Type,
+    Union,
+    cast,
+)
+from weakref import WeakKeyDictionary
+
+from prefect._vendor.fastapi._compat import (
+    PYDANTIC_V2,
+    BaseConfig,
+    ModelField,
+    PydanticSchemaGenerationError,
+    Undefined,
+    UndefinedType,
+    Validator,
+    lenient_issubclass,
+)
+from prefect._vendor.fastapi.datastructures import DefaultPlaceholder, DefaultType
+from prefect._vendor.fastapi.exceptions import FastAPIError
+from pydantic import BaseModel, create_model
+from pydantic.fields import FieldInfo
+from typing_extensions import Literal
+
+if TYPE_CHECKING:  # pragma: nocover
+    from .routing import APIRoute
+
+# Cache for `create_cloned_field`
+_CLONED_TYPES_CACHE: MutableMapping[Type[BaseModel], Type[BaseModel]] = (
+    WeakKeyDictionary()
+)
+
+
+def is_body_allowed_for_status_code(status_code: Union[int, str, None]) -> bool:
+    if status_code is None:
+        return True
+    # Ref: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#patterned-fields-1
+    if status_code in {
+        "default",
+        "1XX",
+        "2XX",
+        "3XX",
+        "4XX",
+        "5XX",
+    }:
+        return True
+    current_status_code = int(status_code)
+    return not (current_status_code < 200 or current_status_code in {204, 304})
+
+
+def get_path_param_names(path: str) -> Set[str]:
+    return set(re.findall("{(.*?)}", path))
+
+
+def create_response_field(
+    name: str,
+    type_: Type[Any],
+    class_validators: Optional[Dict[str, Validator]] = None,
+    default: Optional[Any] = Undefined,
+    required: Union[bool, UndefinedType] = Undefined,
+    model_config: Type[BaseConfig] = BaseConfig,
+    field_info: Optional[FieldInfo] = None,
+    alias: Optional[str] = None,
+    mode: Literal["validation", "serialization"] = "validation",
+) -> ModelField:
+    """
+    Create a new response field. Raises if type_ is invalid.
+    """
+    class_validators = class_validators or {}
+    if PYDANTIC_V2:
+        field_info = field_info or FieldInfo(
+            annotation=type_, default=default, alias=alias
+        )
+    else:
+        field_info = field_info or FieldInfo()
+    kwargs = {"name": name, "field_info": field_info}
+    if PYDANTIC_V2:
+        kwargs.update({"mode": mode})
+    else:
+        kwargs.update(
+            {
+                "type_": type_,
+                "class_validators": class_validators,
+                "default": default,
+                "required": required,
+                "model_config": model_config,
+                "alias": alias,
+            }
+        )
+    try:
+        return ModelField(**kwargs)  # type: ignore[arg-type]
+    except (RuntimeError, PydanticSchemaGenerationError):
+        raise FastAPIError(
+            "Invalid args for response field! Hint: "
+            f"check that {type_} is a valid Pydantic field type. "
+            "If you are using a return type annotation that is not a valid Pydantic "
+            "field (e.g. Union[Response, dict, None]) you can disable generating the "
+            "response model from the type annotation with the path operation decorator "
+            "parameter response_model=None. Read more: "
+            "https://fastapi.tiangolo.com/tutorial/response-model/"
+        ) from None
+
+
+def create_cloned_field(
+    field: ModelField,
+    *,
+    cloned_types: Optional[MutableMapping[Type[BaseModel], Type[BaseModel]]] = None,
+) -> ModelField:
+    if PYDANTIC_V2:
+        return field
+    # cloned_types caches already cloned types to support recursive models and improve
+    # performance by avoiding unecessary cloning
+    if cloned_types is None:
+        cloned_types = _CLONED_TYPES_CACHE
+
+    original_type = field.type_
+    if is_dataclass(original_type) and hasattr(original_type, "__pydantic_model__"):
+        original_type = original_type.__pydantic_model__
+    use_type = original_type
+    if lenient_issubclass(original_type, BaseModel):
+        original_type = cast(Type[BaseModel], original_type)
+        use_type = cloned_types.get(original_type)
+        if use_type is None:
+            use_type = create_model(original_type.__name__, __base__=original_type)
+            cloned_types[original_type] = use_type
+            for f in original_type.__fields__.values():
+                use_type.__fields__[f.name] = create_cloned_field(
+                    f, cloned_types=cloned_types
+                )
+    new_field = create_response_field(name=field.name, type_=use_type)
+    new_field.has_alias = field.has_alias  # type: ignore[attr-defined]
+    new_field.alias = field.alias  # type: ignore[misc]
+    new_field.class_validators = field.class_validators  # type: ignore[attr-defined]
+    new_field.default = field.default  # type: ignore[misc]
+    new_field.required = field.required  # type: ignore[misc]
+    new_field.model_config = field.model_config  # type: ignore[attr-defined]
+    new_field.field_info = field.field_info
+    new_field.allow_none = field.allow_none  # type: ignore[attr-defined]
+    new_field.validate_always = field.validate_always  # type: ignore[attr-defined]
+    if field.sub_fields:  # type: ignore[attr-defined]
+        new_field.sub_fields = [  # type: ignore[attr-defined]
+            create_cloned_field(sub_field, cloned_types=cloned_types)
+            for sub_field in field.sub_fields  # type: ignore[attr-defined]
+        ]
+    if field.key_field:  # type: ignore[attr-defined]
+        new_field.key_field = create_cloned_field(  # type: ignore[attr-defined]
+            field.key_field, cloned_types=cloned_types  # type: ignore[attr-defined]
+        )
+    new_field.validators = field.validators  # type: ignore[attr-defined]
+    new_field.pre_validators = field.pre_validators  # type: ignore[attr-defined]
+    new_field.post_validators = field.post_validators  # type: ignore[attr-defined]
+    new_field.parse_json = field.parse_json  # type: ignore[attr-defined]
+    new_field.shape = field.shape  # type: ignore[attr-defined]
+    new_field.populate_validators()  # type: ignore[attr-defined]
+    return new_field
+
+
+def generate_operation_id_for_path(
+    *, name: str, path: str, method: str
+) -> str:  # pragma: nocover
+    warnings.warn(
+        (
+            "fastapi.utils.generate_operation_id_for_path() was deprecated, "
+            "it is not used internally, and will be removed soon"
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    operation_id = name + path
+    operation_id = re.sub(r"\W", "_", operation_id)
+    operation_id = operation_id + "_" + method.lower()
+    return operation_id
+
+
+def generate_unique_id(route: "APIRoute") -> str:
+    operation_id = route.name + route.path_format
+    operation_id = re.sub(r"\W", "_", operation_id)
+    assert route.methods
+    operation_id = operation_id + "_" + list(route.methods)[0].lower()
+    return operation_id
+
+
+def deep_dict_update(main_dict: Dict[Any, Any], update_dict: Dict[Any, Any]) -> None:
+    for key, value in update_dict.items():
+        if (
+            key in main_dict
+            and isinstance(main_dict[key], dict)
+            and isinstance(value, dict)
+        ):
+            deep_dict_update(main_dict[key], value)
+        elif (
+            key in main_dict
+            and isinstance(main_dict[key], list)
+            and isinstance(update_dict[key], list)
+        ):
+            main_dict[key] = main_dict[key] + update_dict[key]
+        else:
+            main_dict[key] = value
+
+
+def get_value_or_default(
+    first_item: Union[DefaultPlaceholder, DefaultType],
+    *extra_items: Union[DefaultPlaceholder, DefaultType],
+) -> Union[DefaultPlaceholder, DefaultType]:
+    """
+    Pass items or `DefaultPlaceholder`s by descending priority.
+
+    The first one to _not_ be a `DefaultPlaceholder` will be returned.
+
+    Otherwise, the first item (a `DefaultPlaceholder`) will be returned.
+    """
+    items = (first_item,) + extra_items
+    for item in items:
+        if not isinstance(item, DefaultPlaceholder):
+            return item
+    return first_item
+
+
+def match_pydantic_error_url(error_type: str) -> Any:
+    from dirty_equals import IsStr
+
+    return IsStr(regex=rf"^https://errors\.pydantic\.dev/.*/v/{error_type}")

--- a/src/prefect/_vendor/fastapi/websockets.py
+++ b/src/prefect/_vendor/fastapi/websockets.py
@@ -1,0 +1,3 @@
+from starlette.websockets import WebSocket as WebSocket  # noqa
+from starlette.websockets import WebSocketDisconnect as WebSocketDisconnect  # noqa
+from starlette.websockets import WebSocketState as WebSocketState  # noqa

--- a/src/prefect/cli/cloud/__init__.py
+++ b/src/prefect/cli/cloud/__init__.py
@@ -13,8 +13,8 @@ import httpx
 import readchar
 import typer
 import uvicorn
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
+from prefect._vendor.fastapi import FastAPI
+from prefect._vendor.fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from rich.live import Live
 from rich.table import Table

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -9,9 +9,9 @@ from uuid import UUID
 import httpx
 import pendulum
 import typer
-from fastapi import status
 from rich.pretty import Pretty
 from rich.table import Table
+from starlette import status
 
 from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error, exit_with_success

--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -7,9 +7,9 @@ from typing import Optional
 
 import httpx
 import typer
-from fastapi import status
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
+from starlette import status
 
 import prefect.context
 import prefect.settings

--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -4,13 +4,25 @@ import threading
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from functools import partial
-from typing import Callable, ContextManager, Dict, Set, Tuple, Type
+from typing import (
+    Any,
+    AsyncGenerator,
+    Awaitable,
+    Callable,
+    Dict,
+    MutableMapping,
+    Protocol,
+    Set,
+    Tuple,
+    Type,
+    runtime_checkable,
+)
 
 import anyio
 import httpx
 from asgi_lifespan import LifespanManager
-from fastapi import FastAPI, status
 from httpx import HTTPStatusError, Response
+from starlette import status
 from typing_extensions import Self
 
 from prefect.exceptions import PrefectHTTPStatusError
@@ -34,8 +46,22 @@ APP_LIFESPANS_LOCKS: Dict[int, anyio.Lock] = defaultdict(anyio.Lock)
 logger = get_logger("client")
 
 
+# Define ASGI application types for type checking
+Scope = MutableMapping[str, Any]
+Message = MutableMapping[str, Any]
+
+Receive = Callable[[], Awaitable[Message]]
+Send = Callable[[Message], Awaitable[None]]
+
+
+@runtime_checkable
+class ASGIApp(Protocol):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        ...
+
+
 @asynccontextmanager
-async def app_lifespan_context(app: FastAPI) -> ContextManager[None]:
+async def app_lifespan_context(app: ASGIApp) -> AsyncGenerator[None, None]:
     """
     A context manager that calls startup/shutdown hooks for the given application.
 

--- a/src/prefect/client/cloud.py
+++ b/src/prefect/client/cloud.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 import anyio
 import httpx
 import pydantic
-from fastapi import status
+from starlette import status
 
 import prefect.context
 import prefect.settings

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2,7 +2,15 @@ import asyncio
 import datetime
 import warnings
 from contextlib import AsyncExitStack
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Union,
+)
 from uuid import UUID
 
 import httpcore
@@ -10,7 +18,7 @@ import httpx
 import pendulum
 import pydantic
 from asgi_lifespan import LifespanManager
-from fastapi import FastAPI, status
+from starlette import status
 
 import prefect
 import prefect.exceptions
@@ -110,7 +118,7 @@ if TYPE_CHECKING:
     from prefect.flows import Flow as FlowObject
     from prefect.tasks import Task as TaskObject
 
-from prefect.client.base import PrefectHttpxClient, app_lifespan_context
+from prefect.client.base import ASGIApp, PrefectHttpxClient, app_lifespan_context
 
 
 class ServerType(AutoEnum):
@@ -174,7 +182,7 @@ class PrefectClient:
 
     def __init__(
         self,
-        api: Union[str, FastAPI],
+        api: Union[str, ASGIApp],
         *,
         api_key: str = None,
         api_version: str = None,
@@ -197,7 +205,7 @@ class PrefectClient:
 
         # Context management
         self._exit_stack = AsyncExitStack()
-        self._ephemeral_app: Optional[FastAPI] = None
+        self._ephemeral_app: Optional[ASGIApp] = None
         self.manage_lifespan = True
         self.server_type: ServerType
 
@@ -245,7 +253,7 @@ class PrefectClient:
             )
 
         # Connect to an in-process application
-        elif isinstance(api, FastAPI):
+        elif isinstance(api, ASGIApp):
             self._ephemeral_app = api
             self.server_type = ServerType.EPHEMERAL
 
@@ -268,7 +276,7 @@ class PrefectClient:
         else:
             raise TypeError(
                 f"Unexpected type {type(api).__name__!r} for argument `api`. Expected"
-                " 'str' or 'FastAPI'"
+                " 'str' or 'ASGIApp/FastAPI'"
             )
 
         # See https://www.python-httpx.org/advanced/#timeout-configuration

--- a/src/prefect/concurrency/services.py
+++ b/src/prefect/concurrency/services.py
@@ -7,7 +7,7 @@ from typing import (
 )
 
 import httpx
-from fastapi import status
+from starlette import status
 
 from prefect import get_client
 from prefect._internal.concurrency import logger

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -31,7 +31,7 @@ from typing import (
 )
 
 import pydantic
-from fastapi.encoders import jsonable_encoder
+from prefect._vendor.fastapi.encoders import jsonable_encoder
 from pydantic.decorator import ValidatedFunction
 from rich.console import Console
 from rich.panel import Panel

--- a/src/prefect/server/api/admin.py
+++ b/src/prefect/server/api/admin.py
@@ -1,7 +1,7 @@
 """
 Routes for admin-level interactions with the Prefect REST API.
 """
-from fastapi import Body, Depends, Response, status
+from prefect._vendor.fastapi import Body, Depends, Response, status
 
 import prefect
 import prefect.settings

--- a/src/prefect/server/api/artifacts.py
+++ b/src/prefect/server/api/artifacts.py
@@ -5,7 +5,7 @@ from typing import List
 from uuid import UUID
 
 import pendulum
-from fastapi import Body, Depends, HTTPException, Path, Response, status
+from prefect._vendor.fastapi import Body, Depends, HTTPException, Path, Response, status
 
 import prefect.server.api.dependencies as dependencies
 from prefect.server import models

--- a/src/prefect/server/api/block_capabilities.py
+++ b/src/prefect/server/api/block_capabilities.py
@@ -3,7 +3,7 @@ Routes for interacting with block capabilities.
 """
 from typing import List
 
-from fastapi import Depends
+from prefect._vendor.fastapi import Depends
 
 from prefect.server import models
 from prefect.server.database.dependencies import (

--- a/src/prefect/server/api/block_documents.py
+++ b/src/prefect/server/api/block_documents.py
@@ -4,7 +4,7 @@ Routes for interacting with block objects.
 from typing import List, Optional
 from uuid import UUID
 
-from fastapi import Body, Depends, HTTPException, Path, Query, status
+from prefect._vendor.fastapi import Body, Depends, HTTPException, Path, Query, status
 
 from prefect.server import models, schemas
 from prefect.server.api import dependencies

--- a/src/prefect/server/api/block_schemas.py
+++ b/src/prefect/server/api/block_schemas.py
@@ -4,7 +4,15 @@ Routes for interacting with block schema objects.
 from typing import List, Optional
 from uuid import UUID
 
-from fastapi import Body, Depends, HTTPException, Path, Query, Response, status
+from prefect._vendor.fastapi import (
+    Body,
+    Depends,
+    HTTPException,
+    Path,
+    Query,
+    Response,
+    status,
+)
 
 from prefect.server import models, schemas
 from prefect.server.api import dependencies

--- a/src/prefect/server/api/block_types.py
+++ b/src/prefect/server/api/block_types.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 from uuid import UUID
 
 import sqlalchemy as sa
-from fastapi import Body, Depends, HTTPException, Path, Query, status
+from prefect._vendor.fastapi import Body, Depends, HTTPException, Path, Query, status
 
 from prefect.blocks.core import _should_update_block_type
 from prefect.server import models, schemas

--- a/src/prefect/server/api/collections.py
+++ b/src/prefect/server/api/collections.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 import httpx
 from cachetools import TTLCache
-from fastapi import HTTPException, status
+from prefect._vendor.fastapi import HTTPException, status
 
 from prefect.server.utilities.server import PrefectRouter
 

--- a/src/prefect/server/api/concurrency_limits.py
+++ b/src/prefect/server/api/concurrency_limits.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from uuid import UUID
 
 import pendulum
-from fastapi import Body, Depends, HTTPException, Path, Response, status
+from prefect._vendor.fastapi import Body, Depends, HTTPException, Path, Response, status
 
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models

--- a/src/prefect/server/api/concurrency_limits_v2.py
+++ b/src/prefect/server/api/concurrency_limits_v2.py
@@ -1,7 +1,7 @@
 from typing import List, Literal, Optional, Union
 from uuid import UUID
 
-from fastapi import Body, Depends, HTTPException, Path, status
+from prefect._vendor.fastapi import Body, Depends, HTTPException, Path, status
 
 import prefect.server.models as models
 import prefect.server.schemas as schemas

--- a/src/prefect/server/api/dependencies.py
+++ b/src/prefect/server/api/dependencies.py
@@ -3,8 +3,8 @@ Utilities for injecting FastAPI dependencies.
 """
 import logging
 
-from fastapi import Body, Depends, Header, HTTPException, status
 from packaging.version import Version
+from prefect._vendor.fastapi import Body, Depends, Header, HTTPException, status
 
 from prefect.settings import PREFECT_API_DEFAULT_LIMIT
 

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 import jsonschema.exceptions
 import pendulum
-from fastapi import Body, Depends, HTTPException, Path, Response, status
+from prefect._vendor.fastapi import Body, Depends, HTTPException, Path, Response, status
 
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models

--- a/src/prefect/server/api/flow_run_notification_policies.py
+++ b/src/prefect/server/api/flow_run_notification_policies.py
@@ -5,7 +5,7 @@ Routes for interacting with flow run notification policy objects.
 from typing import List
 from uuid import UUID
 
-from fastapi import Body, Depends, HTTPException, Path, status
+from prefect._vendor.fastapi import Body, Depends, HTTPException, Path, status
 
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models

--- a/src/prefect/server/api/flow_run_states.py
+++ b/src/prefect/server/api/flow_run_states.py
@@ -5,7 +5,7 @@ Routes for interacting with flow run state objects.
 from typing import List
 from uuid import UUID
 
-from fastapi import Depends, HTTPException, Path, status
+from prefect._vendor.fastapi import Depends, HTTPException, Path, status
 
 import prefect.server.models as models
 import prefect.server.schemas as schemas

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -8,8 +8,8 @@ from uuid import UUID
 
 import pendulum
 import sqlalchemy as sa
-from fastapi import Body, Depends, HTTPException, Path, Response, status
-from fastapi.responses import ORJSONResponse
+from prefect._vendor.fastapi import Body, Depends, HTTPException, Path, Response, status
+from prefect._vendor.fastapi.responses import ORJSONResponse
 
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models

--- a/src/prefect/server/api/flows.py
+++ b/src/prefect/server/api/flows.py
@@ -6,8 +6,8 @@ from typing import List
 from uuid import UUID
 
 import pendulum
-from fastapi import Depends, HTTPException, Path, Response, status
-from fastapi.param_functions import Body
+from prefect._vendor.fastapi import Depends, HTTPException, Path, Response, status
+from prefect._vendor.fastapi.param_functions import Body
 
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models

--- a/src/prefect/server/api/logs.py
+++ b/src/prefect/server/api/logs.py
@@ -4,7 +4,7 @@ Routes for interacting with log objects.
 
 from typing import List
 
-from fastapi import Body, Depends, status
+from prefect._vendor.fastapi import Body, Depends, status
 
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models

--- a/src/prefect/server/api/root.py
+++ b/src/prefect/server/api/root.py
@@ -1,8 +1,8 @@
 """
 Contains the `hello` route for testing and healthcheck purposes.
 """
-from fastapi import Depends, status
-from fastapi.responses import JSONResponse
+from prefect._vendor.fastapi import Depends, status
+from prefect._vendor.fastapi.responses import JSONResponse
 
 from prefect.server.database.dependencies import provide_database_interface
 from prefect.server.database.interface import PrefectDBInterface

--- a/src/prefect/server/api/saved_searches.py
+++ b/src/prefect/server/api/saved_searches.py
@@ -6,7 +6,7 @@ from typing import List
 from uuid import UUID
 
 import pendulum
-from fastapi import Body, Depends, HTTPException, Path, Response, status
+from prefect._vendor.fastapi import Body, Depends, HTTPException, Path, Response, status
 
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -16,14 +16,14 @@ import asyncpg
 import sqlalchemy as sa
 import sqlalchemy.exc
 import sqlalchemy.orm.exc
-from fastapi import APIRouter, Depends, FastAPI, Request, status
-from fastapi.encoders import jsonable_encoder
-from fastapi.exceptions import RequestValidationError
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.middleware.gzip import GZipMiddleware
-from fastapi.openapi.utils import get_openapi
-from fastapi.responses import JSONResponse
-from fastapi.staticfiles import StaticFiles
+from prefect._vendor.fastapi import APIRouter, Depends, FastAPI, Request, status
+from prefect._vendor.fastapi.encoders import jsonable_encoder
+from prefect._vendor.fastapi.exceptions import RequestValidationError
+from prefect._vendor.fastapi.middleware.cors import CORSMiddleware
+from prefect._vendor.fastapi.middleware.gzip import GZipMiddleware
+from prefect._vendor.fastapi.openapi.utils import get_openapi
+from prefect._vendor.fastapi.responses import JSONResponse
+from prefect._vendor.fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException
 
 import prefect

--- a/src/prefect/server/api/task_run_states.py
+++ b/src/prefect/server/api/task_run_states.py
@@ -5,7 +5,7 @@ Routes for interacting with task run state objects.
 from typing import List
 from uuid import UUID
 
-from fastapi import Depends, HTTPException, Path, status
+from prefect._vendor.fastapi import Depends, HTTPException, Path, status
 
 import prefect.server.models as models
 import prefect.server.schemas as schemas

--- a/src/prefect/server/api/task_runs.py
+++ b/src/prefect/server/api/task_runs.py
@@ -7,7 +7,7 @@ from typing import List
 from uuid import UUID
 
 import pendulum
-from fastapi import Body, Depends, HTTPException, Path, Response, status
+from prefect._vendor.fastapi import Body, Depends, HTTPException, Path, Response, status
 
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models

--- a/src/prefect/server/api/ui/flow_runs.py
+++ b/src/prefect/server/api/ui/flow_runs.py
@@ -2,7 +2,7 @@ import datetime
 from typing import List
 from uuid import UUID
 
-from fastapi import Body, Depends
+from prefect._vendor.fastapi import Body, Depends
 from pydantic import Field
 
 import prefect.server.schemas as schemas

--- a/src/prefect/server/api/ui/task_runs.py
+++ b/src/prefect/server/api/ui/task_runs.py
@@ -4,7 +4,7 @@ from typing import List, Optional, cast
 
 import pendulum
 import sqlalchemy as sa
-from fastapi import Depends, HTTPException, status
+from prefect._vendor.fastapi import Depends, HTTPException, status
 from pydantic import Field
 
 import prefect.server.schemas as schemas

--- a/src/prefect/server/api/variables.py
+++ b/src/prefect/server/api/variables.py
@@ -6,7 +6,7 @@ Routes for interacting with variable objects
 from typing import List, Optional
 from uuid import UUID
 
-from fastapi import Body, Depends, HTTPException, Path, status
+from prefect._vendor.fastapi import Body, Depends, HTTPException, Path, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server import models

--- a/src/prefect/server/api/work_queues.py
+++ b/src/prefect/server/api/work_queues.py
@@ -6,7 +6,15 @@ from uuid import UUID
 
 import pendulum
 import sqlalchemy as sa
-from fastapi import BackgroundTasks, Body, Depends, Header, HTTPException, Path, status
+from prefect._vendor.fastapi import (
+    BackgroundTasks,
+    Body,
+    Depends,
+    Header,
+    HTTPException,
+    Path,
+    status,
+)
 
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models

--- a/src/prefect/server/api/workers.py
+++ b/src/prefect/server/api/workers.py
@@ -6,7 +6,14 @@ from typing import List, Optional
 from uuid import UUID
 
 import sqlalchemy as sa
-from fastapi import BackgroundTasks, Body, Depends, HTTPException, Path, status
+from prefect._vendor.fastapi import (
+    BackgroundTasks,
+    Body,
+    Depends,
+    HTTPException,
+    Path,
+    status,
+)
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import prefect.server.api.dependencies as dependencies

--- a/src/prefect/server/utilities/server.py
+++ b/src/prefect/server/utilities/server.py
@@ -6,8 +6,8 @@ import inspect
 from contextlib import AsyncExitStack, asynccontextmanager
 from typing import Any, Callable, Coroutine, Iterable, Set, get_type_hints
 
-from fastapi import APIRouter, Request, Response, status
-from fastapi.routing import APIRoute
+from prefect._vendor.fastapi import APIRouter, Request, Response, status
+from prefect._vendor.fastapi.routing import APIRoute
 
 
 def method_paths_from_routes(routes: Iterable[APIRoute]) -> Set[str]:

--- a/src/prefect/workers/server.py
+++ b/src/prefect/workers/server.py
@@ -1,8 +1,8 @@
 from typing import Union
 
 import uvicorn
-from fastapi import APIRouter, FastAPI, status
-from fastapi.responses import JSONResponse
+from prefect._vendor.fastapi import APIRouter, FastAPI, status
+from prefect._vendor.fastapi.responses import JSONResponse
 
 from prefect.workers.base import BaseWorker
 from prefect.workers.process import ProcessWorker

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 import readchar
-from fastapi import status
+from starlette import status
 from typer import Exit
 
 from prefect.cli.cloud import LoginFailed, LoginSuccess

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -2,8 +2,8 @@ from unittest.mock import call
 
 import httpx
 import pytest
-from fastapi import status
 from httpx import AsyncClient, Request, Response
+from starlette import status
 
 from prefect.client.base import PrefectHttpxClient, PrefectResponse
 from prefect.exceptions import PrefectHTTPStatusError

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -16,8 +16,8 @@ import pendulum
 import pydantic
 import pytest
 import respx
-from fastapi import Depends, FastAPI, status
-from fastapi.security import HTTPBearer
+from prefect._vendor.fastapi import Depends, FastAPI, status
+from prefect._vendor.fastapi.security import HTTPBearer
 
 import prefect.client.schemas as client_schemas
 import prefect.context

--- a/tests/fixtures/storage.py
+++ b/tests/fixtures/storage.py
@@ -8,8 +8,8 @@ from typing import Any, Optional
 import anyio
 import httpx
 import pytest
-from fastapi import Body, FastAPI, status
-from fastapi.exceptions import RequestValidationError
+from prefect._vendor.fastapi import Body, FastAPI, status
+from prefect._vendor.fastapi.exceptions import RequestValidationError
 
 from prefect.filesystems import LocalFileSystem
 from prefect.server.api.server import validation_exception_handler

--- a/tests/server/api/test_admin.py
+++ b/tests/server/api/test_admin.py
@@ -1,4 +1,4 @@
-from fastapi import status
+from starlette import status
 
 import prefect
 from prefect.server import models

--- a/tests/server/api/test_artifacts.py
+++ b/tests/server/api/test_artifacts.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 import pendulum
 import pydantic
 import pytest
-from fastapi import status
+from starlette import status
 
 from prefect.server import models, schemas
 from prefect.server.schemas import actions

--- a/tests/server/api/test_block_capabilites.py
+++ b/tests/server/api/test_block_capabilites.py
@@ -1,5 +1,5 @@
 import pytest
-from fastapi import status
+from starlette import status
 
 from prefect.blocks.core import Block
 from prefect.server import models

--- a/tests/server/api/test_block_documents.py
+++ b/tests/server/api/test_block_documents.py
@@ -4,8 +4,8 @@ from uuid import uuid4
 
 import pydantic
 import pytest
-from fastapi import status
 from pydantic import SecretBytes, SecretStr
+from starlette import status
 
 from prefect.blocks.core import Block
 from prefect.blocks.fields import SecretDict

--- a/tests/server/api/test_block_schemas.py
+++ b/tests/server/api/test_block_schemas.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 import pydantic
 import pytest
-from fastapi import status
+from starlette import status
 
 from prefect.blocks.core import Block
 from prefect.server import models, schemas

--- a/tests/server/api/test_block_types.py
+++ b/tests/server/api/test_block_types.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import pendulum
 import pydantic
 import pytest
-from fastapi import status
+from starlette import status
 
 import prefect
 from prefect.blocks.core import Block

--- a/tests/server/api/test_concurrency_limits.py
+++ b/tests/server/api/test_concurrency_limits.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from fastapi import status
+from starlette import status
 
 from prefect.server import schemas
 from prefect.server.schemas.actions import ConcurrencyLimitCreate

--- a/tests/server/api/test_deployments.py
+++ b/tests/server/api/test_deployments.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 import pendulum
 import pytest
 import sqlalchemy as sa
-from fastapi import status
+from starlette import status
 
 from prefect.server import models, schemas
 from prefect.server.schemas.actions import DeploymentCreate

--- a/tests/server/api/test_flow_run_states.py
+++ b/tests/server/api/test_flow_run_states.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from fastapi import status
+from starlette import status
 
 from prefect.server import models, schemas
 

--- a/tests/server/api/test_flow_runs.py
+++ b/tests/server/api/test_flow_runs.py
@@ -6,7 +6,7 @@ import pendulum
 import pydantic
 import pytest
 import sqlalchemy as sa
-from fastapi import status
+from starlette import status
 
 from prefect.server import models, schemas
 from prefect.server.schemas import actions, core, responses, states

--- a/tests/server/api/test_flows.py
+++ b/tests/server/api/test_flows.py
@@ -4,7 +4,7 @@ from uuid import UUID, uuid4
 import pendulum
 import pydantic
 import pytest
-from fastapi import status
+from starlette import status
 
 from prefect.server import models, schemas
 

--- a/tests/server/api/test_pagination.py
+++ b/tests/server/api/test_pagination.py
@@ -1,6 +1,6 @@
 import pytest
-from fastapi import Body, FastAPI, status
 from httpx import AsyncClient
+from prefect._vendor.fastapi import Body, FastAPI, status
 
 from prefect.server.api.dependencies import LimitBody
 

--- a/tests/server/api/test_root.py
+++ b/tests/server/api/test_root.py
@@ -1,4 +1,4 @@
-from fastapi import status
+from starlette import status
 
 from prefect.testing.utilities import AsyncMock
 

--- a/tests/server/api/test_run_history.py
+++ b/tests/server/api/test_run_history.py
@@ -5,7 +5,7 @@ import pendulum
 import pydantic
 import pytest
 import sqlalchemy as sa
-from fastapi import Response, status
+from prefect._vendor.fastapi import Response, status
 
 from prefect.server import models
 from prefect.server.schemas import actions, core, responses, states

--- a/tests/server/api/test_saved_searches.py
+++ b/tests/server/api/test_saved_searches.py
@@ -2,7 +2,7 @@ from uuid import uuid4
 
 import pendulum
 import pytest
-from fastapi import status
+from starlette import status
 
 from prefect.server import models, schemas
 from prefect.server.schemas.actions import SavedSearchCreate

--- a/tests/server/api/test_server.py
+++ b/tests/server/api/test_server.py
@@ -6,8 +6,8 @@ import asyncpg
 import pytest
 import sqlalchemy as sa
 import toml
-from fastapi import APIRouter, status, testclient
 from httpx import ASGITransport, AsyncClient
+from prefect._vendor.fastapi import APIRouter, status, testclient
 
 from prefect.server.api.server import (
     API_ROUTERS,

--- a/tests/server/api/test_task_run_states.py
+++ b/tests/server/api/test_task_run_states.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from fastapi import status
+from starlette import status
 
 from prefect.server import models, schemas
 

--- a/tests/server/api/test_task_runs.py
+++ b/tests/server/api/test_task_runs.py
@@ -2,7 +2,7 @@ from uuid import uuid4
 
 import pendulum
 import pytest
-from fastapi import status
+from starlette import status
 
 from prefect.server import models, schemas
 from prefect.server.schemas import responses, states

--- a/tests/server/api/test_work_queues.py
+++ b/tests/server/api/test_work_queues.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 import pendulum
 import pydantic
 import pytest
-from fastapi import status
+from starlette import status
 
 from prefect.server import models, schemas
 from prefect.server.schemas.actions import WorkQueueCreate, WorkQueueUpdate

--- a/tests/server/api/test_workers.py
+++ b/tests/server/api/test_workers.py
@@ -3,7 +3,7 @@ from typing import List
 import pendulum
 import pydantic
 import pytest
-from fastapi import status
+from starlette import status
 
 import prefect
 from prefect.client.schemas.actions import WorkPoolCreate

--- a/tests/server/api/ui/test_flow_runs.py
+++ b/tests/server/api/ui/test_flow_runs.py
@@ -2,7 +2,7 @@ from typing import List
 
 import pydantic
 import pytest
-from fastapi import status
+from starlette import status
 
 from prefect.server import models
 from prefect.server.api.ui.flow_runs import SimpleFlowRun

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -1,5 +1,5 @@
 import pytest
-from fastapi.testclient import TestClient
+from prefect._vendor.fastapi.testclient import TestClient
 
 from prefect.server.api.server import create_app
 from prefect.settings import PREFECT_UI_API_URL

--- a/tests/server/utilities/test_server.py
+++ b/tests/server/utilities/test_server.py
@@ -1,12 +1,17 @@
 import urllib.parse
 
 import anyio
-import fastapi
 import httpx
-import packaging.version
 import pytest
-from fastapi import Depends, FastAPI, HTTPException, Path, Request, status
-from fastapi.testclient import TestClient
+from prefect._vendor.fastapi import (
+    Depends,
+    FastAPI,
+    HTTPException,
+    Path,
+    Request,
+    status,
+)
+from prefect._vendor.fastapi.testclient import TestClient
 
 from prefect.server.utilities.server import PrefectRouter, response_scoped_dependency
 
@@ -206,16 +211,11 @@ def test_request_scoped_dependency_cannot_raise_after_yield():
     app.include_router(router)
 
     client = TestClient(app)
-    if packaging.version.parse(fastapi.__version__) < packaging.version.parse("0.74.0"):
-        # The exception is raised in the app (and consequently here) instead of in
-        # the response
-        expected_type = HTTPException
-        match = ".*"
-    else:
-        # In newer FastAPI versions, FastAPI raises a runtime error complaining about
-        # an exception during the response
-        expected_type = RuntimeError
-        match = "Caught handled exception, but response already started"
+
+    # In newer FastAPI versions, FastAPI raises a runtime error complaining about
+    # an exception during the response
+    expected_type = RuntimeError
+    match = "Caught handled exception, but response already started"
 
     with pytest.raises(expected_type, match=match):
         client.get("/")


### PR DESCRIPTION
While we begin to work on `pydantic>2` support, we need to support living in
any of three different "worlds" concurrently:

1. `pydantic<2` is installed (today)
2. `pydantic>2` is installed, `prefect.server.schemas` are pydantic v1 models (intermediate)
3. `pydantic>2` is installed, `prefect.server.schemas` are pydantic v2 models (end state)

FastAPI's compatibility layer only expects (1) or (3), based on the reasonable
assumption that FastAPI users are in control of their `pydantic` version and
schemas.  However, `prefect` will need to exist in world (2) for a prolonged
period of time while we deprecate support for `pydantic<2`.

To this end, we are removing our dependency on the public `fastapi` package, and
vendoring it privately to `prefect` for use exclusively for `prefect.server` and
the short-term login server used for Cloud login.  This means that end users
may have any version of FastAPI they like without conflicting with ours.  We
will make some adjustments to the vendored version's compatibility layer to help
bridge the gap between worlds (1) and (3).

Long-term, we will spin this down and replace it with the public `fastapi`
package again.
