### PR TITLE
Pydanticv2 compat

### DIFF
--- a/src/prefect/_internal/pydantic/__init__.py
+++ b/src/prefect/_internal/pydantic/__init__.py
@@ -8,4 +8,4 @@
 
 from pydantic.version import VERSION as PYDANTIC_VERSION
 
-PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
+HAS_PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")


### PR DESCRIPTION
adds a pydantic submodule to _internal for a common compatibility flag