### PR TITLE
Preserve set attribute information in tasks during execution

### DIFF
--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -368,6 +368,8 @@ def visit_collection(
                 # Use `object.__setattr__` to avoid errors on immutable models
                 object.__setattr__(model_instance, attr, getattr(expr, attr))
 
+            # Preserve data about which fields were explicitly set on the original model
+            object.__setattr__(model_instance, "__fields_set__", expr.__fields_set__)
             result = model_instance
         else:
             result = None

--- a/tests/utilities/test_collections.py
+++ b/tests/utilities/test_collections.py
@@ -328,6 +328,19 @@ class TestVisitCollection:
             output_model.val == input_model.val
         ), "The fields value should be used, not the default factory"
 
+    def test_visit_collection_remembers_unset_pydantic_fields(self):
+        class RandomPydantic(pydantic.BaseModel):
+            val: uuid.UUID = pydantic.Field(default_factory=uuid.uuid4)
+
+        input_model = RandomPydantic()
+        output_model = visit_collection(
+            input_model, visit_fn=visit_even_numbers, return_data=True
+        )
+
+        assert output_model.json(exclude_unset=True) == input_model.json(
+            exclude_unset=True
+        ), "Unset fields values should be remembered and preserved"
+
     @pytest.mark.parametrize("immutable", [True, False])
     def test_visit_collection_mutation_with_private_pydantic_attributes(
         self, immutable

--- a/tests/utilities/test_collections.py
+++ b/tests/utilities/test_collections.py
@@ -142,6 +142,12 @@ class ImmutablePrivatePydantic(PrivatePydantic):
         allow_mutation = False
 
 
+class PydanticWithDefaults(pydantic.BaseModel):
+    name: str
+    val: uuid.UUID = pydantic.Field(default_factory=uuid.uuid4)
+    num: int = 0
+
+
 @dataclass
 class Foo:
     x: Any
@@ -328,17 +334,22 @@ class TestVisitCollection:
             output_model.val == input_model.val
         ), "The fields value should be used, not the default factory"
 
-    def test_visit_collection_remembers_unset_pydantic_fields(self):
-        class RandomPydantic(pydantic.BaseModel):
-            val: uuid.UUID = pydantic.Field(default_factory=uuid.uuid4)
-
-        input_model = RandomPydantic()
+    @pytest.mark.parametrize(
+        "input",
+        [
+            {"name": "prefect"},
+            {"name": "prefect", "num": 1},
+            {"name": "prefect", "num": 1, "val": uuid.UUID(int=0)},
+            {"name": "prefect", "val": uuid.UUID(int=0)},
+        ],
+    )
+    def test_visit_collection_remembers_unset_pydantic_fields(self, input: dict):
+        input_model = PydanticWithDefaults(**input)
         output_model = visit_collection(
             input_model, visit_fn=visit_even_numbers, return_data=True
         )
-
-        assert output_model.json(exclude_unset=True) == input_model.json(
-            exclude_unset=True
+        assert (
+            output_model.dict(exclude_unset=True) == input_model
         ), "Unset fields values should be remembered and preserved"
 
     @pytest.mark.parametrize("immutable", [True, False])

--- a/tests/utilities/test_collections.py
+++ b/tests/utilities/test_collections.py
@@ -349,7 +349,7 @@ class TestVisitCollection:
             input_model, visit_fn=visit_even_numbers, return_data=True
         )
         assert (
-            output_model.dict(exclude_unset=True) == input_model
+            output_model.dict(exclude_unset=True) == input
         ), "Unset fields values should be remembered and preserved"
 
     @pytest.mark.parametrize("immutable", [True, False])


### PR DESCRIPTION
When executing a `task` that takes an instance of a `pydantic.BaseModel`, we construct a copy of the input instance and  lose track of which attributes were explicitly set. This is evident when running `.json(exclude_unset=True)` on the instance from inside the task. This change copies information on which fields were explicitly set from the input instance and onto the copy that we create and return. 

### Example

When a model is parsed by a task as input, the value passed is a reconstructed instance that loses some info from the original instance:
```python
from typing import Optional

from pydantic import BaseModel

from prefect import flow, task


class User(BaseModel):
    """Pydantic model for the User."""

    email: Optional[str]
    firstName: Optional[str]
    lastName: Optional[str]


@task()
def t(u: User):
    assert u.dict(exclude_unset=True) == {
        "firstName": "John"
    }, f"Model contains unset fields: {u.dict(exclude_unset=True)}"


@flow()
def fl_create_user():
    user = User(firstName="John")
    assert user.dict(exclude_unset=True) == {"firstName": "John"}
    t(user)


fl_create_user()

```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

