### PR TITLE
Retry on responses with a 408 status code

### DIFF
--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -285,6 +285,7 @@ class PrefectHttpxClient(httpx.AsyncClient):
                 status.HTTP_429_TOO_MANY_REQUESTS,
                 status.HTTP_503_SERVICE_UNAVAILABLE,
                 status.HTTP_502_BAD_GATEWAY,
+                status.HTTP_408_REQUEST_TIMEOUT,
                 *PREFECT_CLIENT_RETRY_EXTRA_CODES.value(),
             },
             retry_exceptions=(

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -47,6 +47,7 @@ class TestPrefectHttpxClient:
             status.HTTP_429_TOO_MANY_REQUESTS,
             status.HTTP_503_SERVICE_UNAVAILABLE,
             status.HTTP_502_BAD_GATEWAY,
+            status.HTTP_408_REQUEST_TIMEOUT,
         ],
     )
     async def test_prefect_httpx_client_retries_on_designated_error_codes(


### PR DESCRIPTION
In most cases, a 408 response indicates a temporary situation, and
retrying will work. We should be resilient to this and retry by default.

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
