### PR TITLE
Add more info about rate limits and include use cases for global concurrency

### DIFF
--- a/docs/guides/global-concurrency-limits.md
+++ b/docs/guides/global-concurrency-limits.md
@@ -19,7 +19,7 @@ The core difference between a rate limit and a concurrency limit is the way in w
 
 ## Managing Global concurrency limits and rate limits
 
-You can create, read, edit and delete concurrency limits via the Prefect UI. 
+You can create, read, edit, and delete concurrency limits via the Prefect UI. 
 
 When creating a concurrency limit, you can specify the following parameters:
 
@@ -212,11 +212,11 @@ if __name__ == "__main__":
     my_flow()
 ```
 
-### Managing Database Connections
+### Managing database connections
 
 Managing the maximum number of concurrent database connections to avoid exhausting database resources.
 
-In this scenario we've setup a 'database' concurrency limit and given it a maximum concurrency limit that matches the maximum number of database connections we want to allow. We then use the `concurrency` context manager to control the number of database connections that are used at any one time.
+In this scenario we've setup a concurrency limit named `database` and given it a maximum concurrency limit that matches the maximum number of database connections we want to allow. We then use the `concurrency` context manager to control the number of database connections allowed at any one time.
 
 ```python
 from prefect import flow, task, concurrency
@@ -246,11 +246,11 @@ if __name__ == "__main__":
     my_flow()
 ```
 
-### Parallel Data Processing
+### Parallel data processing
 
 Limiting the maximum number of parallel processing tasks.
 
-In this scenario we want to limit the number of `process_data` tasks to 5 at any one time. We do this by using the `concurrency` context manager to request 5 slots on the `data-processing` concurrency limit. This will block until 5 slots are free and then submit 5 more tasks, ensuring that we never exceed the maximum number of parallel processing tasks. 
+In this scenario we want to limit the number of `process_data` tasks to five at any one time. We do this by using the `concurrency` context manager to request five slots on the `data-processing` concurrency limit. This will block until five slots are free and then submit five more tasks, ensuring that we never exceed the maximum number of parallel processing tasks. 
 
 ```python
 import asyncio

--- a/docs/guides/global-concurrency-limits.md
+++ b/docs/guides/global-concurrency-limits.md
@@ -37,11 +37,17 @@ Global concurrency limits can be in either an `active` or `inactive` state.
 
 ### Slot decay
 
-Global concurrency limits can be configured with `slot decay`. This is used when the concurrency limit is used as a rate limit, and it controls the rate at which these slots are released.
+Global concurrency limits can be configured with slot decay. This is used when the concurrency limit is used as a rate limit, and it governs the pace at which slots are released or become available for reuse after being occupied. These slots effectively represent the concurrency capacity within a specific concurrency limit. The concept is best understood as the rate at which these slots "decay" or refresh.
 
-The rate of slot decay is determined by the parameter `slot decay per second`. This parameter defines how quickly slots become available again after being consumed. For example, if you set slot decay per second to 0.5, one slot will become available again every two seconds.
+To configure slot decay, you can set the `slot_decay_per_second` parameter when defining or adjusting a concurrency limit.
 
-Slot decay provides fine-grained control over the availability of slots, enabling you to optimize the concurrency of your workflow based on your specific requirements.
+For practical use, consider the following:
+
+- *Higher values*: Setting `slot_decay_per_second` to a higher value, such as 5.0, results in slots becoming available relatively quickly. In this scenario, a slot that was occupied by a task will free up after just `0.2` (`1.0 / 5.0`) seconds.
+
+- *Lower values*: Conversely, setting `slot_decay_per_second` to a lower value, like 0.1, causes slots to become available more slowly. In this scenario it would take `10` (`1.0 / 0.1`) seconds for a slot to become available again after occupancy
+
+Slot decay provides fine-grained control over the availability of slots, enabling you to optimize the rate of your workflow based on your specific requirements.
 
 ## Using the `concurrency` context manager
 The `concurrency `context manager allows control over the maximum number of concurrent operations. You can select either the synchronous (`sync`) or asynchronous (`async`) version, depending on your use case. Here's how to use it:


### PR DESCRIPTION
This adds a paragraph calling out the primary difference between concurrency and rate limits and adds a section to the end with common use cases for the rate limit and concurrency managers along with code examples.