### PR TITLE
Always use the larger `oss-test-runner`

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -37,36 +37,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  isinternal:
-    runs-on: ubuntu-latest
-    outputs:
-      status: ${{ steps.isinternal.outputs.status }}
-    steps:
-      - name: Is internal team?
-        id: isinternal
-        run: |
-          # Treat dependabot as an internal user
-          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
-            echo "status=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          echo "actor: ${{ github.actor }}"
-          curl -iL \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.ORG_MEMBER_RO }}"\
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/prefecthq/members/${{ github.actor }}
-
-          if [[ $? -eq 0 ]]; then
-            echo "status=true" >> $GITHUB_OUTPUT
-          else
-            echo "status=false" >> $GITHUB_OUTPUT
-          fi
-
   run-tests:
     name: python:${{ matrix.python-version }}, ${{ matrix.database }}, ${{ matrix.pytest-options }}
-    needs: isinternal
     strategy:
       matrix:
         database:
@@ -74,7 +46,7 @@ jobs:
           - "postgres:14"
           - "sqlite"
         os:
-          - ${{ needs.isinternal.outputs.status == 'true' && github.event_name == 'pull_request' && 'oss-test-runner' || 'ubuntu-latest' }}
+          - "oss-test-runner"
         python-version:
           - "3.8"
           - "3.9"
@@ -254,14 +226,13 @@ jobs:
   # Python versions we support, and only on sqlite + postgres 14
   run-tests-pydantic-v2:
     name: pydantic v2, python:${{ matrix.python-version }}, ${{ matrix.database }}, ${{ matrix.pytest-options }}
-    needs: isinternal
     strategy:
       matrix:
         database:
           - "postgres:14"
           - "sqlite"
         os:
-          - ${{ needs.isinternal.outputs.status == 'true' && github.event_name == 'pull_request' && 'oss-test-runner' || 'ubuntu-latest' }}
+          - "oss-test-runner"
         python-version:
           - "3.8"
           - "3.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ packaging >= 21.3, < 24.3
 pathspec >= 0.8.0
 pendulum >= 2.1.2, < 3.0.0
 # the version constraints for pydantic are merged with those from fastapi 0.103.2
-pydantic>=1.10.0,< 2.0.0,>=1.7.4,!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0
+pydantic>=1.10.0,<2.0.0,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0
 python-slugify >= 5.0, < 9.0
 pytz >= 2021.1, < 2024
 pyyaml >= 5.4.1, < 7.0.0


### PR DESCRIPTION
We're discovering that our test suite requires the larger test runner to
complete in a reasonable time, and that we are starting to see widespread
failures when running on the default runner.  This is due to an unclosed
connection, which is likely due to internal timeouts in the test suite.

This removes the internal user constraint entirely, because it appears that the
suite won't complete successfully on the default runner anymore.  This will give
a better experience for external contributors.  If we see signs of abuse, we can
require approvals for new contributors.

Note: I'm also adjusting the `pydantic` requirement due to how the
`generate-lower-bounds.py` script works.  We had a redundant `>=1.10.0,>=1.7.4`
line (from recent compatibility work) so the lower bound was generating as
`1.7.4` (which we don't support).

Closes #10896