### PR TITLE
Add experimental enhanced cancellation

### DIFF
--- a/src/prefect/agent.py
+++ b/src/prefect/agent.py
@@ -342,6 +342,13 @@ class PrefectAgent:
 
         try:
             infrastructure = await self.get_infrastructure(flow_run)
+            if infrastructure.is_using_a_runner:
+                self.logger.info(
+                    f"Skipping cancellation because flow run {str(flow_run.id)!r} is"
+                    " using enhanced cancellation. A dedicated runner will handle"
+                    " cancellation."
+                )
+                return
         except Exception:
             self.logger.exception(
                 f"Failed to get infrastructure for flow run '{flow_run.id}'. "

--- a/src/prefect/infrastructure/base.py
+++ b/src/prefect/infrastructure/base.py
@@ -1,8 +1,15 @@
 import abc
+import shlex
+import warnings
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 import anyio.abc
 
+from prefect._internal.compatibility.experimental import (
+    EXPERIMENTAL_WARNING,
+    ExperimentalFeature,
+    experiment_enabled,
+)
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 
 if HAS_PYDANTIC_V2:
@@ -15,7 +22,11 @@ from typing_extensions import Self
 import prefect
 from prefect.blocks.core import Block
 from prefect.logging import get_logger
-from prefect.settings import get_current_settings
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_WARN,
+    PREFECT_EXPERIMENTAL_WARN_ENHANCED_CANCELLATION,
+    get_current_settings,
+)
 
 MIN_COMPAT_PREFECT_VERSION = "2.0b12"
 
@@ -83,6 +94,12 @@ class Infrastructure(Block, abc.ABC):
     def logger(self):
         return get_logger(f"prefect.infrastructure.{self.type}")
 
+    @property
+    def is_using_a_runner(self):
+        return self.command is not None and "prefect flow-run execute" in shlex.join(
+            self.command
+        )
+
     @classmethod
     def _base_environment(cls) -> Dict[str, str]:
         """
@@ -130,6 +147,22 @@ class Infrastructure(Block, abc.ABC):
         """
         Generate a command for a flow run job.
         """
+        if experiment_enabled("enhanced_cancellation"):
+            if (
+                PREFECT_EXPERIMENTAL_WARN
+                and PREFECT_EXPERIMENTAL_WARN_ENHANCED_CANCELLATION
+            ):
+                warnings.warn(
+                    EXPERIMENTAL_WARNING.format(
+                        feature="Enhanced flow run cancellation",
+                        group="enhanced_cancellation",
+                        help="",
+                    ),
+                    ExperimentalFeature,
+                    stacklevel=3,
+                )
+            return ["prefect", "flow-run", "execute"]
+
         return ["python", "-m", "prefect.engine"]
 
     @staticmethod

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -413,6 +413,7 @@ class Runner:
         Execution will wait to monitor for cancellation requests. Exits once
         the flow run process has exited.
         """
+        self.pause_on_shutdown = False
         async with self:
             if not self._acquire_limit_slot(flow_run_id):
                 return

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1287,6 +1287,16 @@ PREFECT_EXPERIMENTAL_WARN_VISUALIZE = Setting(bool, default=False)
 Whether or not to warn when experimental Prefect visualize is used.
 """
 
+PREFECT_EXPERIMENTAL_ENABLE_ENHANCED_CANCELLATION = Setting(bool, default=False)
+"""
+Whether or not to enable experimental enhanced flow run cancellation.
+"""
+
+PREFECT_EXPERIMENTAL_WARN_ENHANCED_CANCELLATION = Setting(bool, default=True)
+"""
+Whether or not to warn when experimental enhanced flow run cancellation is used.
+"""
+
 PREFECT_RUNNER_PROCESS_LIMIT = Setting(int, default=5)
 """
 Maximum number of processes a runner will execute in parallel.

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -633,18 +633,18 @@ class BaseWorker(abc.ABC):
 
         try:
             configuration = await self._get_configuration(flow_run)
+            if configuration.is_using_a_runner:
+                self._logger.info(
+                    f"Skipping cancellation because flow run {str(flow_run.id)!r} is"
+                    " using enhanced cancellation. A dedicated runner will handle"
+                    " cancellation."
+                )
+                return
         except ObjectNotFound:
             self._logger.warning(
                 f"Flow run {flow_run.id!r} cannot be cancelled by this worker:"
                 f" associated deployment {flow_run.deployment_id!r} does not exist."
             )
-
-        if configuration.is_using_a_runner:
-            self._logger.info(
-                f"Skipping cancellation because flow run {str(flow_run.id)!r} is using"
-                " enhanced cancellation. Runner will handle cancellation."
-            )
-            return
 
         if not flow_run.infrastructure_pid:
             run_logger.error(

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -638,7 +638,6 @@ class BaseWorker(abc.ABC):
                 f"Flow run {flow_run.id!r} cannot be cancelled by this worker:"
                 f" associated deployment {flow_run.deployment_id!r} does not exist."
             )
-            return
 
         if configuration.is_using_a_runner:
             self._logger.info(

--- a/src/prefect/workers/process.py
+++ b/src/prefect/workers/process.py
@@ -109,6 +109,13 @@ class ProcessJobConfiguration(BaseJobConfiguration):
             else self.command
         )
 
+    def _base_flow_run_command(self) -> str:
+        """
+        Override the base flow run command because enhanced cancellation doesn't
+        work with the process worker.
+        """
+        return "python -m prefect.engine"
+
 
 class ProcessVariables(BaseVariables):
     stream_output: bool = Field(

--- a/tests/agent/test_agent_run_cancellation.py
+++ b/tests/agent/test_agent_run_cancellation.py
@@ -11,6 +11,11 @@ from prefect.exceptions import InfrastructureNotAvailable, InfrastructureNotFoun
 from prefect.infrastructure.base import Infrastructure
 from prefect.server.database.orm_models import ORMDeployment
 from prefect.server.schemas.core import Deployment
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_ENHANCED_CANCELLATION,
+    PREFECT_EXPERIMENTAL_WARN_ENHANCED_CANCELLATION,
+    temporary_settings,
+)
 from prefect.states import (
     Cancelled,
     Cancelling,
@@ -22,6 +27,17 @@ from prefect.states import (
 )
 from prefect.testing.utilities import AsyncMock
 from prefect.utilities.dispatch import get_registry_for_type
+
+
+@pytest.fixture
+def enable_enhanced_cancellation():
+    with temporary_settings(
+        updates={
+            PREFECT_EXPERIMENTAL_ENABLE_ENHANCED_CANCELLATION: True,
+            PREFECT_EXPERIMENTAL_WARN_ENHANCED_CANCELLATION: False,
+        }
+    ):
+        yield
 
 
 def legacy_named_cancelling_state(**kwargs):
@@ -707,3 +723,35 @@ async def test_agent_started_with_nondefault_work_pool_does_not_cancel_flow_run_
     assert "Found 1 flow runs awaiting cancellation" not in caplog.text
     post_flow_run = await prefect_client.read_flow_run(flow_run.id)
     assert post_flow_run.state.name == "Cancelling"
+
+
+@pytest.mark.parametrize(
+    "cancelling_constructor", [legacy_named_cancelling_state, Cancelling]
+)
+async def test_agent_skips_cancellation_when_enhanced_cancellation_is_enabled(
+    prefect_client: PrefectClient,
+    deployment_2: ORMDeployment,
+    cancelling_constructor,
+    enable_enhanced_cancellation,
+    caplog,
+):
+    flow_run = await prefect_client.create_flow_run_from_deployment(
+        deployment_2.id,
+        state=cancelling_constructor(),
+    )
+
+    await prefect_client.update_flow_run(flow_run.id, infrastructure_pid="test")
+
+    async with PrefectAgent(
+        work_queues=[deployment_2.work_queue_name],
+        work_pool_name=flow_run.work_pool_name,
+        prefetch_seconds=10,
+    ) as agent:
+        await agent.check_for_cancelled_flow_runs()
+
+    post_flow_run = await prefect_client.read_flow_run(flow_run.id)
+    # state type shouldn't change
+    assert post_flow_run.state.type == cancelling_constructor().type
+
+    assert "Skipping cancellation because flow run" in caplog.text
+    assert "is using enhanced cancellation" in caplog.text

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -363,6 +363,41 @@ async def deployment(
 
 
 @pytest.fixture
+async def deployment_2(
+    session,
+    flow,
+    flow_function,
+    infrastructure_document_id_2,
+    storage_document_id,
+    work_queue_1,  # attached to a work pool called the work_pool fixture named "test-work-pool"
+):
+    def hello(name: str):
+        pass
+
+    deployment = await models.deployments.create_deployment(
+        session=session,
+        deployment=schemas.core.Deployment(
+            name="My Deployment",
+            tags=["test"],
+            flow_id=flow.id,
+            schedule=schemas.schedules.IntervalSchedule(
+                interval=datetime.timedelta(days=1),
+                anchor_date=pendulum.datetime(2020, 1, 1),
+            ),
+            storage_document_id=storage_document_id,
+            path="./subdir",
+            entrypoint="/file.py:flow",
+            infrastructure_document_id=infrastructure_document_id_2,
+            work_queue_name=work_queue_1.name,
+            parameter_openapi_schema=parameter_schema(hello),
+            work_queue_id=work_queue_1.id,
+        ),
+    )
+    await session.commit()
+    return deployment
+
+
+@pytest.fixture
 async def deployment_in_default_work_pool(
     session,
     flow,

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -32,7 +32,12 @@ from prefect.server import models
 from prefect.server.schemas.core import Flow
 from prefect.server.schemas.responses import DeploymentResponse
 from prefect.server.schemas.states import StateType
-from prefect.settings import PREFECT_WORKER_PREFETCH_SECONDS, get_current_settings
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_ENHANCED_CANCELLATION,
+    PREFECT_WORKER_PREFETCH_SECONDS,
+    get_current_settings,
+    temporary_settings,
+)
 from prefect.states import Cancelled, Cancelling, Completed, Pending, Running, Scheduled
 from prefect.testing.utilities import AsyncMock
 from prefect.workers.base import BaseJobConfiguration, BaseVariables, BaseWorker
@@ -80,6 +85,14 @@ async def variables(prefect_client: PrefectClient):
     await prefect_client._client.post(
         "/variables/", json={"name": "test_variable_2", "value": "test_value_2"}
     )
+
+
+@pytest.fixture
+def enable_enhanced_cancellation():
+    with temporary_settings(
+        updates={PREFECT_EXPERIMENTAL_ENABLE_ENHANCED_CANCELLATION: True}
+    ):
+        yield
 
 
 async def test_worker_creates_work_pool_by_default_during_sync(
@@ -1336,6 +1349,26 @@ class TestPrepareForFlowRun:
         assert job_config.name == "my-job-name"
         assert job_config.command == "python -m prefect.engine"
 
+    def test_prepare_for_flow_run_with_enhanced_cancellation(
+        self, job_config, flow_run, enable_enhanced_cancellation
+    ):
+        job_config.prepare_for_flow_run(flow_run)
+
+        assert job_config.env == {
+            **get_current_settings().to_environment_variables(exclude_unset=True),
+            "MY_VAR": "foo",
+            "PREFECT__FLOW_RUN_ID": str(flow_run.id),
+        }
+        assert job_config.labels == {
+            "my-label": "foo",
+            "prefect.io/flow-run-id": str(flow_run.id),
+            "prefect.io/flow-run-name": flow_run.name,
+            "prefect.io/version": prefect.__version__,
+        }
+        assert job_config.name == "my-job-name"
+        # only thing that changes is the command
+        assert job_config.command == "prefect flow-run execute"
+
     def test_prepare_for_flow_run_with_deployment_and_flow(
         self, job_config, flow_run, deployment, flow
     ):
@@ -1829,6 +1862,35 @@ class TestCancellation:
             in caplog.text
         )
         assert "Cancellation cannot be guaranteed." in caplog.text
+
+    @pytest.mark.parametrize(
+        "cancelling_constructor", [legacy_named_cancelling_state, Cancelling]
+    )
+    async def test_worker_cancel_run_skips_with_runner(
+        self,
+        prefect_client: PrefectClient,
+        worker_deployment_wq1,
+        caplog,
+        cancelling_constructor,
+        enable_enhanced_cancellation,
+        work_pool,
+    ):
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            worker_deployment_wq1.id,
+            state=cancelling_constructor(),
+        )
+
+        async with WorkerTestImpl(work_pool_name=work_pool.name) as worker:
+            await worker.sync_with_backend()
+            worker.cancel_run = AsyncMock()
+            await worker.check_for_cancelled_flow_runs()
+
+        post_flow_run = await prefect_client.read_flow_run(flow_run.id)
+        # shouldn't change state
+        assert post_flow_run.state.type == cancelling_constructor()
+
+        assert "Skipping cancellation because flow run" in caplog.text
+        assert "is using  enhanced cancellation" in caplog.text
 
 
 async def test_get_flow_run_logger(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Adds the ability to use a one-off runner to provide more consistent and reliable flow run cancellations. Enabling the `PREFECT_EXPERIMENTAL_ENABLE_ENHANCED_CANCELLATION` setting on a worker will change the default command the worker provided to infrastructure when starting a flow run from `python -m prefect.engine` to `prefect flow-run execute`. 

The new(ish) `prefect flow-run execute` command will spin up a runner to handle the execution of a flow run, and the runner will listen for cancellation requests for that flow run only. Cancellation will be more consistent with a runner because the runner only needs to kill a single process to ensure cancellation. Once that single process completes or is killed, the runner will stop, and the infrastructure will terminate. Also, the flow run can still be canceled if the worker disappears before cancellation.

Note: if users are providing a value for `command` in a work pool base job template or via `job_variables`, the `PREFECT_EXPERIMENTAL_ENABLE_ENHANCED_CANCELLATION` setting will have no effect. Enhanced cancellation also does not apply to the process worker.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Here are some example logs from a cancellation for a flow run in a Kubernetes pod with a runner:

![Screenshot 2023-10-11 at 4 40 42 PM](https://github.com/PrefectHQ/prefect/assets/12350579/73b05144-6d07-4734-b72e-e11270b79d29)

Note the last two log entries regarding cancellation come from the runner.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
