### PR TITLE
docs: fix typo in logs guide

### DIFF
--- a/docs/guides/logs.md
+++ b/docs/guides/logs.md
@@ -360,7 +360,7 @@ def my_flow():
     logger = get_run_logger()
     logger.info("This is [bold red]fancy[/]")
 
-log_email_flow()
+my_flow()
 ```
 
 !!! warning "Inaccurate logs could result"


### PR DESCRIPTION
minor typo