### PR TITLE
Fix deployment instruction in documentation

### DIFF
--- a/docs/tutorial/deployments.md
+++ b/docs/tutorial/deployments.md
@@ -76,7 +76,7 @@ Because this deployment has no schedule or triggering automation, you will need 
 Let's use the CLI (in a separate terminal window) to see what happens:
 <div class="terminal">
 ```bash
-prefect deployment run 'get_repo_info/my-first-deployment'
+prefect deployment run 'get-repo-info/my-first-deployment'
 ```
 </div>
 


### PR DESCRIPTION

Fixed a typo in the deployment instructions in the documentation. 
The correct command should be `prefect deployment run 'get-repo-info/my-first-deployment'`.

### Example
The typo was fixed in the deployment instructions of the tutorial documentation. 
You can view the corrected line [here](https://github.com/Omni-d0t/prefect/blob/fix-deployment-instruction/docs/tutorial/deployments.md).

Closes #10929


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `#10929`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
