### PR TITLE
`prefect deploy`: don't prompt remote storage if global pull step

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -542,7 +542,7 @@ async def _run_single_deploy(
     if (
         is_interactive()
         and not ci
-        and not deploy_config.get("pull")
+        and not (deploy_config.get("pull") or actions.get("pull"))
         and not docker_push_step_exists
         and confirm(
             (

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -734,7 +734,7 @@ class TestProjectDeploy:
         )
 
     async def test_deploy_does_not_prompt_storage_when_pull_step_exists(
-        self, project_dir, work_pool
+        self, project_dir, work_pool, interactive_console
     ):
         # write a pull step to the prefect.yaml
         with open("prefect.yaml", "r") as f:
@@ -753,6 +753,11 @@ class TestProjectDeploy:
                 "deploy ./flows/hello.py:my_flow -n test-name -p"
                 f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
                 " --interval 60"
+            ),
+            user_input=(
+                # don't save the deployment configuration
+                "n"
+                + readchar.key.ENTER
             ),
             expected_code=0,
             expected_output_does_not_contain=[

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -733,6 +733,34 @@ class TestProjectDeploy:
             ],
         )
 
+    async def test_deploy_does_not_prompt_storage_when_pull_step_exists(
+        self, project_dir, work_pool
+    ):
+        # write a pull step to the prefect.yaml
+        with open("prefect.yaml", "r") as f:
+            config = yaml.safe_load(f)
+
+        config["pull"] = [
+            {"prefect.deployments.steps.set_working_directory": {"directory": "."}}
+        ]
+
+        with open("prefect.yaml", "w") as f:
+            yaml.safe_dump(config, f)
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=(
+                "deploy ./flows/hello.py:my_flow -n test-name -p"
+                f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
+                " --interval 60"
+            ),
+            expected_code=0,
+            expected_output_does_not_contain=[
+                "Would you like your workers to pull your flow code from a remote"
+                " storage location when running this flow?"
+            ],
+        )
+
     class TestGeneratedPullAction:
         async def test_project_deploy_generates_pull_action(
             self, work_pool, prefect_client, uninitialized_project_dir
@@ -3141,11 +3169,8 @@ class TestMultiDeploy:
             command="deploy --all",
             expected_code=0,
             user_input=(
-                # decline remote storage
-                "n"
-                + readchar.key.ENTER
                 # reject saving configuration
-                + "n"
+                "n"
                 + readchar.key.ENTER
                 # accept naming deployment
                 + "y"
@@ -4248,9 +4273,6 @@ class TestSaveUserInputs:
                 # enter work pool name
                 "inflatable"
                 + readchar.key.ENTER
-                # Decline remote storage
-                + "n"
-                + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
                 + readchar.key.ENTER
@@ -4299,9 +4321,6 @@ class TestSaveUserInputs:
                 +
                 # enter work pool name
                 "inflatable"
-                + readchar.key.ENTER
-                # Decline remote storage
-                + "n"
                 + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
@@ -4358,9 +4377,6 @@ class TestSaveUserInputs:
                 # enter work pool name
                 "inflatable"
                 + readchar.key.ENTER
-                # Decline remote storage
-                + "n"
-                + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
                 + readchar.key.ENTER
@@ -4414,9 +4430,6 @@ class TestSaveUserInputs:
                 +
                 # enter work pool name
                 "inflatable"
-                + readchar.key.ENTER
-                # decline remote storage
-                + "n"
                 + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
@@ -4506,9 +4519,6 @@ class TestSaveUserInputs:
                 # enter work pool name
                 "inflatable"
                 + readchar.key.ENTER
-                # decline remote storage
-                + "n"
-                + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
                 + readchar.key.ENTER
@@ -4537,11 +4547,8 @@ class TestSaveUserInputs:
         invoke_and_assert(
             command="deploy -n existing-deployment --cron '* * * * *'",
             user_input=(
-                # decline remote storage
-                "n"
-                + readchar.key.ENTER
                 # accept create work pool
-                + readchar.key.ENTER
+                readchar.key.ENTER
                 # choose process work pool
                 + readchar.key.ENTER
                 +
@@ -4605,9 +4612,6 @@ class TestSaveUserInputs:
                 +
                 # enter work pool name
                 "inflatable"
-                + readchar.key.ENTER
-                # Decline remote storage
-                + "n"
                 + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
@@ -4763,9 +4767,6 @@ class TestSaveUserInputs:
                 # enter work pool name
                 + "inflatable"
                 + readchar.key.ENTER
-                # Decline remote storage
-                + "n"
-                + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
                 + readchar.key.ENTER
@@ -4808,9 +4809,6 @@ class TestSaveUserInputs:
                 +
                 # accept create work pool
                 readchar.key.ENTER
-                # Decline remote storage
-                + "n"
-                + readchar.key.ENTER
                 +
                 # choose process work pool
                 readchar.key.ENTER
@@ -4861,9 +4859,6 @@ class TestSaveUserInputs:
                 # enter work pool name
                 "inflatable"
                 + readchar.key.ENTER
-                # Decline remote storage
-                + "n"
-                + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
                 + readchar.key.ENTER
@@ -4901,9 +4896,6 @@ class TestSaveUserInputs:
                 + "3600"
                 + readchar.key.ENTER
                 # accept create work pool
-                + readchar.key.ENTER
-                # Decline remote storage
-                + "n"
                 + readchar.key.ENTER
                 # choose process work pool
                 + readchar.key.ENTER
@@ -4976,9 +4968,6 @@ class TestSaveUserInputs:
             user_input=(
                 # reject schedule
                 "n"
-                + readchar.key.ENTER
-                # decline remote storage
-                + "n"
                 + readchar.key.ENTER
                 # accept saving configuration
                 + "y"
@@ -5786,9 +5775,6 @@ class TestDeploymentTrigger:
                         # Decline docker build
                         + "n"
                         + readchar.key.ENTER
-                        # Decline remote storage
-                        + "n"
-                        + readchar.key.ENTER
                         # Accept save configuration
                         + "y"
                         + readchar.key.ENTER
@@ -5893,9 +5879,6 @@ class TestDeployDockerBuildSteps:
                 # Reject build custom docker image
                 "n"
                 + readchar.key.ENTER
-                # Decline remote storage
-                + "n"
-                + readchar.key.ENTER
                 # Accept save configuration
                 + "y"
                 + readchar.key.ENTER
@@ -5929,9 +5912,6 @@ class TestDeployDockerBuildSteps:
             user_input=(
                 # Reject build custom docker image
                 "n"
-                + readchar.key.ENTER
-                # Decline remote storage
-                + "n"
                 + readchar.key.ENTER
                 # Accept save configuration
                 + "y"
@@ -5985,9 +5965,6 @@ class TestDeployDockerBuildSteps:
                 +
                 # Reject push to registry
                 "n"
-                + readchar.key.ENTER
-                # Decline remote storage
-                + "n"
                 + readchar.key.ENTER
                 # Accept save configuration
                 + "y"
@@ -6060,9 +6037,6 @@ class TestDeployDockerBuildSteps:
                 +
                 # Reject push to registry
                 "n"
-                + readchar.key.ENTER
-                # Decline remote storage
-                + "n"
                 + readchar.key.ENTER
                 # Accept save configuration
                 + "y"
@@ -6157,9 +6131,6 @@ class TestDeployDockerBuildSteps:
                 # Default tag
                 + readchar.key.ENTER
                 # Reject push to registry
-                + "n"
-                + readchar.key.ENTER
-                # Decline remote storage
                 + "n"
                 + readchar.key.ENTER
                 # Accept save configuration
@@ -6428,9 +6399,6 @@ class TestDeployDockerPushSteps:
                 # Default tag
                 + readchar.key.ENTER
                 # Reject push to registry
-                + "n"
-                + readchar.key.ENTER
-                # Decline remote storage
                 + "n"
                 + readchar.key.ENTER
                 # Accept save configuration

--- a/tests/workers/test_process_worker.py
+++ b/tests/workers/test_process_worker.py
@@ -477,6 +477,7 @@ async def test_process_kill_mismatching_hostname(monkeypatch, work_pool):
     os_kill.assert_not_called()
 
 
+@pytest.mark.flaky(max_runs=3)
 async def test_process_kill_no_matching_pid(monkeypatch, work_pool):
     patch_client(monkeypatch)
     infrastructure_pid = f"{socket.gethostname()}:12345"


### PR DESCRIPTION
closes #10939

This PR adds a condition to check for a global pull step (instead of just an explicit `pull` step on the specific deployment config) before prompting the user to select remote storage for the flow

the tests are updated to remove responses to the cases where the prompt is no longer present
### Example
see example on [issue](https://github.com/PrefectHQ/prefect/issues/10939) 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
