### PR TITLE
test explicit `result_storage` overrides default setting

### DIFF
--- a/e2f98383525b4b19adc8217c7a2ac30d
+++ b/e2f98383525b4b19adc8217c7a2ac30d
@@ -1,0 +1,1 @@
+{"serializer": {"type": "pickle", "picklelib": "cloudpickle", "picklelib_version": "2.2.1"}, "data": "gAWVEAAAAAAAAAB9lIwDZm9vlIwDYmFylHMu\n", "prefect_version": "2.13.5+17.gd59788df0.dirty"}

--- a/explicit-storage.pkl
+++ b/explicit-storage.pkl
@@ -1,0 +1,1 @@
+{"serializer": {"type": "pickle", "picklelib": "cloudpickle", "picklelib_version": "2.2.1"}, "data": "gAWVEAAAAAAAAAB9lIwDZm9vlIwDYmFylHMu\n", "prefect_version": "2.13.5+17.gd59788df0.dirty"}


### PR DESCRIPTION
a sanity check to prove that explicit `result_storage` settings override the new `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` setting
### Example
```python
await LocalFileSystem(basepath="~/.prefect/results").save("explicit-storage")
await LocalFileSystem(basepath="~/.prefect/other-results").save(
    "default-result-storage"
)

@flow(result_storage=await LocalFileSystem.load("explicit-storage"))
async def foo():
    return get_run_context().result_factory.storage_block

with temporary_settings(
    {
        PREFECT_RESULTS_PERSIST_BY_DEFAULT: True,
        PREFECT_DEFAULT_RESULT_STORAGE_BLOCK: (
            "local-file-system/default-result-storage"
        ),
    }
):
    result = await foo()

assert_blocks_equal(result, await LocalFileSystem.load("explicit-storage"))
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
