### PR TITLE
Removes pin locking `pydantic` <2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ packaging >= 21.3, < 24.3
 pathspec >= 0.8.0
 pendulum >= 2.1.2, < 3.0.0
 # the version constraints for pydantic are merged with those from fastapi 0.103.2
-pydantic>=1.10.0,<2.0.0,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0
+pydantic>=1.10.0,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0
 python-slugify >= 5.0, < 9.0
 pytz >= 2021.1, < 2024
 pyyaml >= 5.4.1, < 7.0.0


### PR DESCRIPTION
This updates our `requirements.txt` to remove the pin keeping users from updating to `pydantic>2`. This will let users install newer versions of `pydantic` without error from their dependency tracking tools.

<!-- Include an overview here -->

### Example
```console
❯ pip install -e . 
....
❯ pip show pydantic
Name: pydantic
Version: 2.4.2
Summary: Data validation using Python type hints
Home-page:
Author:
Author-email: Samuel Colvin <s@muelcolvin.com>, Eric Jolibois <em.jolibois@gmail.com>, Hasan Ramezani <hasan.r67@gmail.com>, Adrian Garcia Badaracco <1755071+adriangb@users.noreply.github.com>, Terrence Dorsey <terry@pydantic.dev>, David Montague <david@pydantic.dev>
License:
Location: /Users/uriel/.pyenv/versions/3.8.17/envs/prefect-38/lib/python3.8/site-packages
Requires: annotated-types, pydantic-core, typing-extensions
Required-by: prefect
```


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
