### PR TITLE
Add `last_polled` to deployment

### DIFF
--- a/src/prefect/server/database/migrations/versions/postgresql/2023_10_12_224511_bfe653bbf62e_add_last_polled_to_deployment.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2023_10_12_224511_bfe653bbf62e_add_last_polled_to_deployment.py
@@ -1,0 +1,33 @@
+"""Add `last_polled` to deployment
+
+Revision ID: bfe653bbf62e
+Revises: 05ea6f882b1d
+Create Date: 2023-10-12 22:45:11.024191
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+import prefect
+
+# revision identifiers, used by Alembic.
+revision = "bfe653bbf62e"
+down_revision = "05ea6f882b1d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "last_polled",
+                prefect.server.utilities.database.Timestamp(timezone=True),
+                nullable=True,
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.drop_column("last_polled")

--- a/src/prefect/server/database/migrations/versions/sqlite/2023_10_12_175815_f3165ae0a213_add_last_polled_to_deployment.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2023_10_12_175815_f3165ae0a213_add_last_polled_to_deployment.py
@@ -1,0 +1,41 @@
+"""Add `last_polled` to deployment
+
+Revision ID: f3165ae0a213
+Revises: 05ea6f882b1d
+Create Date: 2023-10-12 17:58:15.326385
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+import prefect
+
+# revision identifiers, used by Alembic.
+revision = "f3165ae0a213"
+down_revision = "05ea6f882b1d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("PRAGMA foreign_keys=OFF")
+
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "last_polled",
+                prefect.server.utilities.database.Timestamp(timezone=True),
+                nullable=True,
+            )
+        )
+
+    op.execute("PRAGMA foreign_keys=ON")
+
+
+def downgrade():
+    op.execute("PRAGMA foreign_keys=OFF")
+
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.drop_column("last_polled")
+
+    op.execute("PRAGMA foreign_keys=ON")

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -566,6 +566,9 @@ class Deployment(ORMBaseModel):
             " be scheduled."
         ),
     )
+    last_polled: Optional[DateTimeTZ] = Field(
+        default=None, description="The last time the deployment was polled."
+    )
     parameter_openapi_schema: Optional[Dict[str, Any]] = Field(
         default=None,
         description="The parameter schema of the flow, including defaults.",


### PR DESCRIPTION
This PR adds a `last_polled` column to the deployment table so that we can use it at query time to determine deployment status.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
