### PR TITLE
Updates env var parsing to use pendulum

### DIFF
--- a/src/prefect/runtime/flow_run.py
+++ b/src/prefect/runtime/flow_run.py
@@ -41,16 +41,29 @@ __all__ = [
 ]
 
 
+def _dateparser_parse(dt: str) -> pendulum.DateTime:
+    """
+    Use dateparser to cast different format date strings to pendulum.DateTime --
+    tzinfo is ignored (UTC forced)
+    """
+    datetime = dateparser.parse(dt).replace(tzinfo=None)
+    return pendulum.instance(datetime, "UTC")
+
+
+def _pendulum_parse(dt: str) -> pendulum.DateTime:
+    """
+    Use pendulum to cast different format date strings to pendulum.DateTime --
+    tzinfo is ignored (UTC forced)
+    """
+    return pendulum.parse(dt, tz=None, strict=False).set(tz="UTC")
+
+
 type_cast = {
     bool: lambda x: x.lower() == "true",
     int: int,
     float: float,
     str: str,
-    # use dateparser to cast different formats of date in string, and then instance to pendulum.DateTime
-    # tzinfo is ignored (UTC forced)
-    pendulum.DateTime: lambda x: pendulum.instance(
-        dateparser.parse(x).replace(tzinfo=None), "UTC"
-    ),
+    pendulum.DateTime: _pendulum_parse,
     # for optional defined attributes, when real value is NoneType, use str
     type(None): str,
 }

--- a/tests/runtime/test_flow_run.py
+++ b/tests/runtime/test_flow_run.py
@@ -61,6 +61,24 @@ class TestAttributeAccessPatterns:
         assert flow_run_attr == expected_value
 
     @pytest.mark.parametrize(
+        "value",
+        [
+            "1996-12-19T16:39:57-08:00",  # RFC 3339
+            "2012-05-03",  # Date
+            "12:04:23.45",  # Time
+            "00:00",  # Time
+        ],
+    )
+    async def test_dateparser_and_pendulum_parse_equivalency(self, value):
+        """
+        Note that this is a temporary test to verify that pendulum's and dateparser's
+        parse results are the same. Once we remove dateparser, this test will be removed.
+        """
+        from prefect.runtime.flow_run import _dateparser_parse, _pendulum_parse
+
+        assert _pendulum_parse(value) == _dateparser_parse(value)
+
+    @pytest.mark.parametrize(
         "attribute_name, attribute_value",
         [
             # complex types (list and dict) not allowed to be mocked using environment variables


### PR DESCRIPTION
This PR is a stop-gap PR to help ensure that date string parsing using `pendulum` == parsing using `dateparser`. This will allow us to make a follow up PR removing the `dateparser` dependency entirely and removing a lot of the code introduced here.

<!-- Include an overview here -->
Kinda of relates to https://github.com/PrefectHQ/prefect/issues/10096


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
