### PR TITLE
fix: handle v2 models in func signatures

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ filterwarnings =
     ignore:The `__fields_set__` attribute is deprecated, use `model_fields_set` instead
     ignore:`__get_validators__` is deprecated and will be removed, use `__get_pydantic_core_schema__`
     ignore:The `dict` method is deprecated; use `model_dump` instead
+    ignore:The `schema` method is deprecated; use `model_json_schema` instead
+    ignore:Default value default=
     # Temporary directories are cleaned up implicitly on Windows
     # It is unclear if this comes from an external tool or our own usage
     # Here the start of the path is included to only filter warnings on Windows

--- a/src/prefect/_internal/pydantic/annotations/pendulum.py
+++ b/src/prefect/_internal/pydantic/annotations/pendulum.py
@@ -1,0 +1,57 @@
+"""
+This file contains compat code to handle pendulum.DateTime objects during jsonschema 
+generation and validation. 
+"""
+
+import typing as t
+
+import pendulum
+from pydantic import (
+    GetCoreSchemaHandler,
+    GetJsonSchemaHandler,
+)
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import core_schema
+from typing_extensions import Annotated
+
+
+class _PendulumAnnotation:
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        _source_type: t.Any,
+        _handler: GetCoreSchemaHandler,
+    ) -> core_schema.CoreSchema:
+        def validate_from_str(value: str) -> pendulum.DateTime:
+            return pendulum.parse(value)
+
+        def to_str(value: pendulum.DateTime) -> str:
+            return value.isoformat()
+
+        from_str_schema = core_schema.chain_schema(
+            [
+                core_schema.datetime_schema(),
+                core_schema.no_info_plain_validator_function(validate_from_str),
+            ]
+        )
+
+        return core_schema.json_or_python_schema(
+            json_schema=from_str_schema,
+            python_schema=core_schema.union_schema(
+                [
+                    # check if it's an instance first before doing any further work
+                    core_schema.is_instance_schema(pendulum.DateTime),
+                    from_str_schema,
+                ]
+            ),
+            serialization=core_schema.plain_serializer_function_ser_schema(to_str),
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, _core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        return handler(core_schema.datetime_schema())
+
+
+PydanticPendulumType = Annotated[pendulum.DateTime, _PendulumAnnotation]

--- a/src/prefect/_internal/pydantic/schemas.py
+++ b/src/prefect/_internal/pydantic/schemas.py
@@ -1,0 +1,14 @@
+from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
+from pydantic_core import core_schema
+
+
+class GenerateEmptySchemaForUserClasses(GenerateJsonSchema):
+    """
+    This custom schema overrides the default pydantic is-instance schema
+    behavior to simply return an empty dict for user-defined classes
+    """
+
+    def is_instance_schema(
+        self, schema: core_schema.IsInstanceSchema
+    ) -> JsonSchemaValue:
+        return {}

--- a/src/prefect/_internal/pydantic/v2_schema.py
+++ b/src/prefect/_internal/pydantic/v2_schema.py
@@ -5,6 +5,7 @@ import typing as t
 
 import pendulum
 import pydantic
+from pydantic import BaseModel as V2BaseModel
 from pydantic import ConfigDict, create_model
 from pydantic.type_adapter import TypeAdapter
 
@@ -16,10 +17,19 @@ from prefect._internal.pydantic.annotations.pendulum import (
 from prefect._internal.pydantic.schemas import GenerateEmptySchemaForUserClasses
 
 
+def has_v2_model_as_param(signature: inspect.Signature) -> bool:
+    parameters = signature.parameters.values()
+    return any(
+        isinstance(p, V2BaseModel)
+        or (inspect.isclass(p.annotation) and issubclass(p.annotation, V2BaseModel))
+        for p in parameters
+    )
+
+
 def process_v2_params(
-    position: int,
     param: inspect.Parameter,
     *,
+    position: int,
     docstrings: t.Dict[str, str],
     aliases: t.Dict
 ) -> t.Tuple[str, t.Any, "pydantic.Field"]:

--- a/src/prefect/_internal/pydantic/v2_schema.py
+++ b/src/prefect/_internal/pydantic/v2_schema.py
@@ -8,7 +8,11 @@ import pydantic
 from pydantic import ConfigDict, create_model
 from pydantic.type_adapter import TypeAdapter
 
-from prefect._internal.pydantic.annotations.pendulum import PydanticPendulumType
+from prefect._internal.pydantic.annotations.pendulum import (
+    PydanticPendulumDateTimeType,
+    PydanticPendulumDateType,
+    PydanticPendulumDurationType,
+)
 from prefect._internal.pydantic.schemas import GenerateEmptySchemaForUserClasses
 
 
@@ -33,9 +37,14 @@ def process_v2_params(
         name = param.name
 
     type_ = t.Any if param.annotation is inspect._empty else param.annotation
+
+    # Replace pendulum type annotations with our own so that they are pydantic compatible
     if type_ == pendulum.DateTime:
-        # Replace pendulum type annoations with our own so that they are pydantic compatible
-        type_ = PydanticPendulumType
+        type_ = PydanticPendulumDateTimeType
+    if type_ == pendulum.Date:
+        type_ = PydanticPendulumDateType
+    if type_ == pendulum.Duration:
+        type_ = PydanticPendulumDurationType
 
     field = pydantic.Field(
         default=... if param.default is param.empty else param.default,

--- a/src/prefect/_internal/pydantic/v2_schema.py
+++ b/src/prefect/_internal/pydantic/v2_schema.py
@@ -39,11 +39,11 @@ def process_v2_params(
     return name, type_, field
 
 
-def create_v2_schema(name: str, model_cfg: ConfigDict, **model_fields):
+def create_v2_schema(name_: str, model_cfg: ConfigDict, **model_fields):
     """
     Create a pydantic v2 model and craft a v1 compatible schema from it.
     """
-    model = create_model(name, __config__=model_cfg, **model_fields)
+    model = create_model(name_, __config__=model_cfg, **model_fields)
     adapter = TypeAdapter(model)
 
     # root model references under #definitions

--- a/src/prefect/_internal/pydantic/v2_schema.py
+++ b/src/prefect/_internal/pydantic/v2_schema.py
@@ -1,0 +1,54 @@
+# Note: This file should only be imported under a HAS_PYDANTIC_V2 flag
+
+import inspect
+import typing as t
+
+import pydantic
+from pydantic import ConfigDict, create_model
+from pydantic.type_adapter import TypeAdapter
+
+
+def process_v2_params(
+    position: int,
+    param: inspect.Parameter,
+    *,
+    docstrings: t.Dict[str, str],
+    aliases: t.Dict
+) -> t.Tuple[str, t.Any, "pydantic.Field"]:
+    """
+    Generate a sanitized name, type, and pydantic.Field for a given parameter.
+
+    This implementation is exactly the same as the v1 implementation except
+    that it uses pydantic v2 constructs.
+    """
+    # Pydantic model creation will fail if names collide with the BaseModel type
+    if hasattr(pydantic.BaseModel, param.name):
+        name = param.name + "__"
+        aliases[name] = param.name
+    else:
+        name = param.name
+
+    type_ = t.Any if param.annotation is inspect._empty else param.annotation
+    field = pydantic.Field(
+        default=... if param.default is param.empty else param.default,
+        title=param.name,
+        description=docstrings.get(param.name, None),
+        alias=aliases.get(name),
+        json_schema_extra={"position": position},
+    )
+    return name, type_, field
+
+
+def create_v2_schema(name: str, model_cfg: ConfigDict, **model_fields):
+    """
+    Create a pydantic v2 model and craft a v1 compatible schema from it.
+    """
+    model = create_model(name, __config__=model_cfg, **model_fields)
+    adapter = TypeAdapter(model)
+
+    # root model references under #definitions
+    schema = adapter.json_schema(by_alias=True, ref_template="#/definitions/{model}")
+    # ensure backwards compatability by copying $defs into definitions
+    if "$defs" in schema:
+        schema["definitions"] = schema["$defs"]
+    return schema

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -559,7 +559,9 @@ async def run(
                         "TO_TIMEZONE": "UTC",
                         "RETURN_AS_TIMEZONE_AWARE": False,
                         "PREFER_DATES_FROM": "future",
-                        "RELATIVE_BASE": datetime.fromtimestamp(now.timestamp()),
+                        "RELATIVE_BASE": datetime.fromtimestamp(
+                            now.timestamp(), tz=pendulum.tz.UTC
+                        ),
                     },
                 )
 
@@ -601,6 +603,7 @@ async def run(
         )
 
         try:
+            print(Scheduled(scheduled_time=scheduled_start_time).state_details)
             flow_run = await client.create_flow_run_from_deployment(
                 deployment.id,
                 parameters=parameters,
@@ -621,6 +624,7 @@ async def run(
         run_url = "<no dashboard available>"
 
     datetime_local_tz = scheduled_start_time.in_tz(pendulum.tz.local_timezone())
+    print(datetime_local_tz)
     scheduled_display = (
         datetime_local_tz.to_datetime_string()
         + " "

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -603,7 +603,6 @@ async def run(
         )
 
         try:
-            print(Scheduled(scheduled_time=scheduled_start_time).state_details)
             flow_run = await client.create_flow_run_from_deployment(
                 deployment.id,
                 parameters=parameters,
@@ -624,7 +623,6 @@ async def run(
         run_url = "<no dashboard available>"
 
     datetime_local_tz = scheduled_start_time.in_tz(pendulum.tz.local_timezone())
-    print(datetime_local_tz)
     scheduled_display = (
         datetime_local_tz.to_datetime_string()
         + " "

--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -294,16 +294,16 @@ def _process_param(
     return name, type_, field
 
 
-def _generate_schema_for_model(name: str, **model_fields) -> Dict:
+def _generate_schema_for_model(name_: str, **model_fields) -> Dict:
     class ModelConfig:
         arbitrary_types_allowed = True
 
     if HAS_PYDANTIC_V2:
         # if we're processing v2 fields, we need to create a v2 schema
-        return create_v2_schema(name_=name, model_cfg=ModelConfig, **model_fields)
+        return create_v2_schema(name_, model_cfg=ModelConfig, **model_fields)
 
     model: "pydantic.BaseModel" = pydantic.create_model(
-        name, __config__=ModelConfig, **model_fields
+        name_, __config__=ModelConfig, **model_fields
     )
     return model.schema(by_alias=True)
 
@@ -335,14 +335,14 @@ def parameter_schema(fn: Callable) -> ParameterSchema:
         # Generate a Pydantic model at each step so we can check if this parameter
         # type supports schema generation
         try:
-            _generate_schema_for_model(name="CheckParameter", **{name: (type_, field)})
+            _generate_schema_for_model("CheckParameter", **{name: (type_, field)})
         except ValueError:
             # This field's type is not valid for schema creation, update it to `Any`
             type_ = Any
         model_fields[name] = (type_, field)
 
     # Generate the final model and schema
-    schema = _generate_schema_for_model(name="Parameters", **model_fields)
+    schema = _generate_schema_for_model("Parameters", **model_fields)
     return ParameterSchema(**schema)
 
 

--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -300,7 +300,7 @@ def _generate_schema_for_model(name: str, **model_fields) -> Dict:
 
     if HAS_PYDANTIC_V2:
         # if we're processing v2 fields, we need to create a v2 schema
-        return create_v2_schema(name=name, model_cfg=ModelConfig, **model_fields)
+        return create_v2_schema(name_=name, model_cfg=ModelConfig, **model_fields)
 
     model: "pydantic.BaseModel" = pydantic.create_model(
         name, __config__=ModelConfig, **model_fields

--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -340,6 +340,7 @@ def parameter_schema(fn: Callable) -> ParameterSchema:
                 "Parameters", __config__=ModelConfig, **model_fields
             )
             schema = model.schema(by_alias=True)
+            schema["definitions"] = schema["$defs"]
         else:
             raise
     return ParameterSchema(**schema)

--- a/tests/utilities/test_callables.py
+++ b/tests/utilities/test_callables.py
@@ -297,6 +297,22 @@ class TestFunctionToSchema:
             "type": "object",
         }
 
+    def test_function_with_pydantic_model_default(self):
+        """
+        The serialization results for a v1 and v2 schema are different so
+        this test does not attempt to compare the results. Instead it just verifies
+        that the schema is generated without error.
+        """
+        import pydantic
+
+        class Foo(pydantic.BaseModel):
+            bar: str
+
+        def f(foo: Foo = Foo(bar="baz")):
+            ...
+
+        callables.parameter_schema(f)
+
 
 class TestMethodToSchema:
     def test_methods_with_no_arguments(self):

--- a/tests/utilities/test_callables.py
+++ b/tests/utilities/test_callables.py
@@ -380,7 +380,6 @@ class TestFunctionToSchema:
             duration_schema["format"] = "duration"
 
         schema = callables.parameter_schema(f)
-        print(schema.dict())
         assert schema.dict() == {
             "title": "Parameters",
             "type": "object",


### PR DESCRIPTION
Closes #10965

This is an addition to our pydantic v2 parameter schema generation logic. When we parse a flow function we attempt to generate a schema for it. Our schema generation logic is entirely pydantic v1 based. Now that we've lifted our restriction on pydantic v2, it's possible for flow function signatures to make use of pydantic v2-based models. The error was coming from using v1-schema generation on a v2 model. 

~Note that with this fix the schema that is generated will drop the default with a warning:~ This is no longer an issue with the new implementation!


<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
