### PR TITLE
fix requirements.txt : renamed ruamel-yaml to ruamel.yaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ pytz >= 2021.1, < 2024
 pyyaml >= 5.4.1, < 7.0.0
 readchar >= 4.0.0, < 5.0.0
 rich >= 11.0, < 14.0
-ruamel-yaml >= 0.17.0
+ruamel.yaml >= 0.17.0
 sqlalchemy[asyncio] >= 1.4.22, != 1.4.33, < 3.0.0
 starlette >= 0.27.0, < 0.28.0
 toml >= 0.10.0


### PR DESCRIPTION
Closes #10954 

It fixes an issue with rez package manager when installing prefect dependencies as 
a package need to declare its requirements with the same name as the pip package https://pypi.org/project/ruamel.yaml/


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
