### PR TITLE
fix: support Windows paths in load_flow_from_entrypoint

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1458,7 +1458,8 @@ def load_flow_from_entrypoint(entrypoint: str) -> Flow:
         block_code_execution=True,
         capture_failures=True,
     ):
-        path, func_name = entrypoint.split(":")
+        # split by the last colon once to handle Windows paths with drive letters i.e C:\path\to\file.py:do_stuff
+        path, func_name = entrypoint.rsplit(":", maxsplit=1)
         try:
             flow = import_object(entrypoint)
         except AttributeError as exc:

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -2201,9 +2201,10 @@ def test_load_flow_from_entrypoint(tmp_path):
     flow = load_flow_from_entrypoint(f"{fpath}:dog")
     assert flow.fn() == "woof!"
 
+
 def test_load_flow_from_entrypoint_with_absolute_path(tmp_path):
     # test absolute paths to ensure compatibility for all operating systems
-    
+
     flow_code = """
     from prefect import flow
 
@@ -2213,12 +2214,13 @@ def test_load_flow_from_entrypoint_with_absolute_path(tmp_path):
     """
     fpath = tmp_path / "f.py"
     fpath.write_text(dedent(flow_code))
-    
+
     # convert the fpath into an absolute path
     absolute_fpath = str(fpath.resolve())
 
     flow = load_flow_from_entrypoint(f"{absolute_fpath}:dog")
     assert flow.fn() == "woof!"
+
 
 async def test_handling_script_with_unprotected_call_in_flow_script(
     tmp_path,

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -2201,6 +2201,24 @@ def test_load_flow_from_entrypoint(tmp_path):
     flow = load_flow_from_entrypoint(f"{fpath}:dog")
     assert flow.fn() == "woof!"
 
+def test_load_flow_from_entrypoint_with_absolute_path(tmp_path):
+    # test absolute paths to ensure compatibility for all operating systems
+    
+    flow_code = """
+    from prefect import flow
+
+    @flow
+    def dog():
+        return "woof!"
+    """
+    fpath = tmp_path / "f.py"
+    fpath.write_text(dedent(flow_code))
+    
+    # convert the fpath into an absolute path
+    absolute_fpath = str(fpath.resolve())
+
+    flow = load_flow_from_entrypoint(f"{absolute_fpath}:dog")
+    assert flow.fn() == "woof!"
 
 async def test_handling_script_with_unprotected_call_in_flow_script(
     tmp_path,


### PR DESCRIPTION
### Example
load_flow_from_entrypoint("C:\\Users\\maitl\\AppData\\Local\\Temp\\tmp78go90gn\\MAD.Data.SurveyMonkey-main\\mad_data_surveymonkey.dw.surveys_detail.ingest.py:ingest_surveys_detail")

So I can use Flow.from_source during development on my Windows machine.
![image](https://github.com/PrefectHQ/prefect/assets/38200645/17b72520-f43c-4464-839b-74582edfb3fd)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
