### PR TITLE
fix work pool banner copy and conditionally hide

### DIFF
--- a/ui/src/pages/WorkPool.vue
+++ b/ui/src/pages/WorkPool.vue
@@ -1,41 +1,48 @@
 <template>
-  <p-layout-default v-if="workPool">
+  <p-layout-well v-if="workPool" class="work-pool">
     <template #header>
       <PageHeadingWorkPool :work-pool="workPool" @update="workPoolSubscription.refresh" />
+      <template v-if="showCodeBanner">
+        <CodeBanner class="work-pool__code-banner" :command="codeBannerCliCommand" title="Your work pool is almost ready!" subtitle="Run this command to start." />
+      </template>
     </template>
-
-    <p-layout-well v-if="workPool" class="work-pool">
-      <template #header>
-        <CodeBanner :command="codeBannerCliCommand" :title="codeBannerTitle" :subtitle="codeBannerSubtitle" />
+    <p-tabs v-model:selected="tab" :tabs="tabs">
+      <template #details>
+        <WorkPoolDetails :work-pool="workPool" />
       </template>
-      <p-tabs v-model:selected="tab" :tabs="tabs">
-        <template #details>
-          <WorkPoolDetails :work-pool="workPool" />
-        </template>
 
-        <template #runs>
-          <FlowRunFilteredList :flow-run-filter="flowRunFilter" />
-        </template>
-
-        <template #work-queues>
-          <WorkPoolQueuesTable :work-pool-name="workPoolName" />
-        </template>
-
-        <template #workers>
-          <WorkersTable :work-pool-name="workPoolName" />
-        </template>
-      </p-tabs>
-
-      <template #well>
-        <WorkPoolDetails alternate :work-pool="workPool" />
+      <template #runs>
+        <FlowRunFilteredList :flow-run-filter="flowRunFilter" />
       </template>
-    </p-layout-well>
-  </p-layout-default>
+
+      <template #work-queues>
+        <WorkPoolQueuesTable :work-pool-name="workPoolName" />
+      </template>
+
+      <template #workers>
+        <WorkersTable :work-pool-name="workPoolName" />
+      </template>
+    </p-tabs>
+
+    <template #well>
+      <WorkPoolDetails alternate :work-pool="workPool" />
+    </template>
+  </p-layout-well>
 </template>
 
 <script lang="ts" setup>
   import { media } from '@prefecthq/prefect-design'
-  import { useWorkspaceApi, PageHeadingWorkPool, WorkPoolDetails, FlowRunFilteredList, WorkPoolQueuesTable, useFlowRunsFilter, useTabs, WorkersTable } from '@prefecthq/prefect-ui-library'
+  import {
+    useWorkspaceApi,
+    PageHeadingWorkPool,
+    WorkPoolDetails,
+    FlowRunFilteredList,
+    WorkPoolQueuesTable,
+    useFlowRunsFilter,
+    useTabs,
+    WorkersTable,
+    CodeBanner
+  } from '@prefecthq/prefect-ui-library'
   import { useRouteParam, useRouteQueryParam, useSubscription } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
   import { usePageTitle } from '@/compositions/usePageTitle'
@@ -60,15 +67,8 @@
   const tab = useRouteQueryParam('tab', 'Details')
   const { tabs } = useTabs(computedTabs, tab)
 
-
-  const codeBannerTitle = computed(() => {
-    if (!workPool.value) {
-      return 'Your work pool is ready to go!'
-    }
-    return `Your work pool ${workPool.value.name} is ready to go!`
-  })
+  const showCodeBanner = computed(() => workPool.value?.status !== 'ready')
   const codeBannerCliCommand = computed(() => `prefect ${isAgentWorkPool.value ? 'agent' : 'worker'} start --pool "${workPool.value?.name}"`)
-  const codeBannerSubtitle = computed(() => `Work pools organize work that ${isAgentWorkPool.value ? 'Prefect agents' : 'Prefect workers'} can pull from.`)
 
   const { filter: flowRunFilter } = useFlowRunsFilter({
     workPools: {
@@ -85,3 +85,9 @@
 
   usePageTitle(title)
 </script>
+
+<style>
+.work-pool__code-banner { @apply
+  mt-4
+}
+</style>


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Previously the banner on the work pool page was inaccurate. It would show "your work pool is ready" and the status below it could say "not ready". Turns out the command it recommends is to get things ready, so we're making that more clear and only showing it if the work pool isn't ready.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
