### PR TITLE
fix `truncate_to` bug that results in the original string being returned

### DIFF
--- a/src/prefect/utilities/text.py
+++ b/src/prefect/utilities/text.py
@@ -8,12 +8,8 @@ def truncated_to(length: int, value: Optional[str]) -> str:
     if len(value) <= length:
         return value
 
-    half = length // 2
+    help_text = "...[truncated]..."
 
-    beginning = value[:half]
-    end = value[-half:]
-    omitted = len(value) - (len(beginning) + len(end))
+    truncated = value[: length - len(help_text)]
 
-    proposed = f"{beginning}...{omitted} additional characters...{end}"
-
-    return proposed if len(proposed) < len(value) else value
+    return truncated + help_text if len(truncated) < len(help_text) else value[:length]

--- a/src/prefect/utilities/text.py
+++ b/src/prefect/utilities/text.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+HELP_TEXT = "...[truncated]..."
+
 
 def truncated_to(length: int, value: Optional[str]) -> str:
     if not value:
@@ -8,8 +10,8 @@ def truncated_to(length: int, value: Optional[str]) -> str:
     if len(value) <= length:
         return value
 
-    help_text = "...[truncated]..."
-
-    truncated = value[: length - len(help_text)]
-
-    return truncated + help_text if len(truncated) < len(help_text) else value[:length]
+    return (
+        value[: length - len(HELP_TEXT)] + HELP_TEXT
+        if len(HELP_TEXT) < length
+        else value[:length]
+    )

--- a/tests/utilities/test_text.py
+++ b/tests/utilities/test_text.py
@@ -1,0 +1,29 @@
+from prefect.utilities.text import HELP_TEXT, truncated_to
+
+
+class TestTruncatedTo:
+    def test_empty_value(self):
+        value = None
+        length = 100
+        trunc = truncated_to(length, value)
+        assert trunc == ""
+
+    def test_length_exceeds_value(self):
+        value = "a" * 50
+        length = 51
+        trunc = truncated_to(length, value)
+        assert trunc == value
+
+    def test_normal_truncation(self):
+        value = "a" * 100
+        length = 50
+        trunc = truncated_to(length, value)
+        assert len(trunc) == length
+        assert trunc.endswith(HELP_TEXT)
+
+    def test_truncation_help_text_too_long(self):
+        value = "a" * 100
+        length = 10
+        trunc = truncated_to(length, value)
+        assert len(trunc) == length
+        assert trunc == "a" * length


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

This closes #11045 , wherein the `truncated_to` function returns the original, un-truncated string. For simplicity sake, I made the decision to have this function truncate text from the end of the string, rather than pulling it from the middle.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Calling the new function in a python REPL

```python
In [10] original_string = 'something that is too long and needs to be shorted'

In [11] len(original_string)
Out [11] 50

In  [12] new_string = truncated_to(40, original_string)

In  [13] new_string
Out [13] 'something that is too l...[truncated]...'
```

here are the test results as well:

```
% pytest tests/utilities/test_text.py 
======================================================================= test session starts =======================================================================
platform darwin -- Python 3.10.10, pytest-7.4.2, pluggy-1.3.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/brianreid/jellyfish-source/prefect
configfile: setup.cfg
plugins: hypothesis-6.88.1, timeout-2.2.0, respx-0.20.2, flaky-3.7.0, env-1.0.1, flakefinder-1.1.0, cov-4.1.0, Faker-19.11.0, asyncio-0.21.1, anyio-3.7.1, requests-mock-1.11.0, xdist-3.3.1, benchmark-4.0.0
timeout: 60.0s
timeout method: signal
timeout func_only: False
asyncio: mode=auto
collected 4 items                                                                                                                                                 

tests/utilities/test_text.py ....                                                                                                                           [100%]

======================================================================= 4 passed in 21.97s ========================================================================
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
