### PR TITLE
Allow `password` to be provided in `credentials` for `GitRespository`

### DIFF
--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -110,10 +110,11 @@ class GitRepository:
         if (
             isinstance(credentials, dict)
             and credentials.get("username")
-            and not credentials.get("access_token")
+            and not (credentials.get("access_token") or credentials.get("password"))
         ):
             raise ValueError(
-                "If a username is provided, an access token must also be provided."
+                "If a username is provided, an access token or password must also be"
+                " provided."
             )
         self._url = url
         self._branch = branch

--- a/tests/runner/test_storage.py
+++ b/tests/runner/test_storage.py
@@ -91,7 +91,10 @@ class TestGitRepository:
     def test_init_with_username_no_token(self):
         with pytest.raises(
             ValueError,
-            match="If a username is provided, an access token must also be provided.",
+            match=(
+                "If a username is provided, an access token or password must also be"
+                " provided."
+            ),
         ):
             GitRepository(
                 url="https://github.com/org/repo.git",


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Fixes bug introduced when unifying `git_clone` and `GitRepository` implementations where `password` would not be accepted in the `credentials` dictionary provided to `git_clone`. Added a regression with description for future reference.

Closes https://github.com/PrefectHQ/prefect/issues/11051

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
