### PR TITLE
Avoid yanked `pytest-asyncio==0.22.0`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ numpy
 pillow
 pre-commit
 pytest > 7
-pytest-asyncio >= 0.18.2
+pytest-asyncio >= 0.18.2, != 0.22.0
 pytest-cov
 pytest-benchmark
 pytest-env


### PR DESCRIPTION
This version of `pytest-asyncio` started emitting a new warning (which fails
our tests because we treat warnings as errors).  It looks like this may have
been premature on the maintainer's part:

    This release deprecated event loop overrides, but didn't provide adequate
    replacement functionality for all relevant use cases. As such, the release
    was yanked from PyPI.

https://github.com/pytest-dev/pytest-asyncio/releases/tag/v0.22.0

I'm going to avoid that particular release and we can revisit once they have
given clearer guidance on how to update your test suite.
