### PR TITLE
Warn if task parameter introspection takes a long time

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -163,9 +163,9 @@ from prefect.results import BaseResult, ResultFactory
 from prefect.settings import (
     PREFECT_DEBUG_MODE,
     PREFECT_LOGGING_LOG_PRINTS,
+    PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD,
     PREFECT_TASKS_REFRESH_CACHE,
     PREFECT_UI_URL,
-    PREFECT_WARN_LONG_TASK_INTROSPECTION,
 )
 from prefect.states import (
     Paused,
@@ -1659,7 +1659,10 @@ async def orchestrate_task_run(
             force=task_run.state.is_pending(),
         )
     end_time = time.time()
-    if PREFECT_WARN_LONG_TASK_INTROSPECTION and (end_time - start_time) > 5:
+    if (
+        PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD.value()
+        and (end_time - start_time) > PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD.value()
+    ):
         logger.warning(
             "Long running task parameter introspection detected."
             "Consider wrapping large task parameters with "

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1667,7 +1667,7 @@ async def orchestrate_task_run(
             "Long running task parameter introspection detected. "
             "Consider wrapping large task parameters with "
             "prefect.utilities.annotations.quote for increased "
-            "performance, e.g. `my_task(quote(param))`."
+            "performance, e.g. `my_task(quote(param))`. "
             "Disable this message with PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD=0."
         )
 

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1665,9 +1665,9 @@ async def orchestrate_task_run(
     ):
         logger.warning(
             "Long running task parameter introspection detected. "
-            "Consider wrapping large task parameters with\n"
+            "Consider wrapping large task parameters with "
             "prefect.utilities.annotations.quote for increased "
-            "performance, e.g. `my_task(quote(param))`.\n"
+            "performance, e.g. `my_task(quote(param))`."
             "Disable this message with PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD=0."
         )
 

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1643,7 +1643,7 @@ async def orchestrate_task_run(
         result_factory=result_factory,
         log_prints=log_prints,
     )
-    start_time = time.time()
+    task_introspection_start_time = time.perf_counter()
     try:
         # Resolve futures in parameters into data
         resolved_parameters = await resolve_inputs(parameters)
@@ -1658,10 +1658,11 @@ async def orchestrate_task_run(
             # update the state name
             force=task_run.state.is_pending(),
         )
-    end_time = time.time()
+    task_introspection_end_time = time.perf_counter()
     if (
         PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD.value()
-        and (end_time - start_time) > PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD.value()
+        and (task_introspection_end_time - task_introspection_start_time)
+        > PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD.value()
     ):
         logger.warning(
             "Long running task parameter introspection detected. "

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1665,8 +1665,8 @@ async def orchestrate_task_run(
     ):
         logger.warning(
             "Long running task parameter introspection detected. "
-            "Consider wrapping large task parameters with "
-            "prefect.utilities.annotations.quote for increased "
+            "Try wrapping large task parameters with "
+            "`prefect.utilities.annotations.quote` for increased "
             "performance, e.g. `my_task(quote(param))`. "
             "Disable this message with PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD=0."
         )

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1659,17 +1659,19 @@ async def orchestrate_task_run(
             force=task_run.state.is_pending(),
         )
     task_introspection_end_time = time.perf_counter()
-    if (
-        PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD.value()
-        and (task_introspection_end_time - task_introspection_start_time)
-        > PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD.value()
-    ):
+
+    introspection_time = round(
+        task_introspection_end_time - task_introspection_start_time, 3
+    )
+    threshold = PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD.value()
+    if threshold and introspection_time > threshold:
         logger.warning(
-            "Long running task parameter introspection detected. "
+            f"Task parameter introspection took {introspection_time} seconds "
+            f", exceeding `PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD` of {threshold}. "
             "Try wrapping large task parameters with "
-            "`prefect.utilities.annotations.quote` for increased "
-            "performance, e.g. `my_task(quote(param))`. "
-            "Disable this message with PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD=0."
+            "`prefect.utilities.annotations.quote` for increased performance, "
+            "e.g. `my_task(quote(param))`. To disable this message set "
+            "`PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD=0`."
         )
 
     # Generate the cache key to attach to proposed states

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1664,11 +1664,11 @@ async def orchestrate_task_run(
         and (end_time - start_time) > PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD.value()
     ):
         logger.warning(
-            "Long running task parameter introspection detected."
-            "Consider wrapping large task parameters with "
-            "prefect.utilities.annotations.quote() for increased "
-            "performance. Disable this waring message by setting"
-            "PREFECT_WARN_LONG_TASK_INTROSPECTION=False."
+            "Long running task parameter introspection detected. "
+            "Consider wrapping large task parameters with\n"
+            "prefect.utilities.annotations.quote for increased "
+            "performance, e.g. `my_task(quote(param))`.\n"
+            "Disable this message with PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD=0."
         )
 
     # Generate the cache key to attach to proposed states

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -142,7 +142,7 @@ async def average_flow_run_lateness(
             # Since we want an _average_ of the lateness we're unable to use
             # the existing FlowRun.expected_start_time_delta property as it
             # returns a timedelta and SQLite is unable to properly deal with it
-            # and always returns 1970.0 as the average. This copies the same
+            # and alwayson3 returns 1970.0 as the average. This copies the same
             # logic but ensures that it returns the number of seconds instead
             # so it's compatible with SQLite.
             base_query = sa.case(

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -142,7 +142,7 @@ async def average_flow_run_lateness(
             # Since we want an _average_ of the lateness we're unable to use
             # the existing FlowRun.expected_start_time_delta property as it
             # returns a timedelta and SQLite is unable to properly deal with it
-            # and alwayson3 returns 1970.0 as the average. This copies the same
+            # and always returns 1970.0 as the average. This copies the same
             # logic but ensures that it returns the number of seconds instead
             # so it's compatible with SQLite.
             base_query = sa.case(

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -928,13 +928,14 @@ interpreted and lead to incomplete output, e.g.
 `DROP TABLE [dbo].[SomeTable];"` outputs `DROP TABLE .[SomeTable];`.
 """
 
-PREFECT_WARN_LONG_TASK_INTROSPECTION = Setting(
-    bool,
-    default=True,
+PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD = Setting(
+    float,
+    default=10.0,
 )
 """
-Whether to disable warnings about long running task parameter introspection.
-Defaults to `True`. Set to `False` to disable.
+Threshold time in seconds for logging a warning if task parameter introspection 
+exceeds this duration. Defaults to `10.0`. Set to `0` to disable logging the
+warning.
 """
 
 PREFECT_AGENT_QUERY_INTERVAL = Setting(

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -928,6 +928,15 @@ interpreted and lead to incomplete output, e.g.
 `DROP TABLE [dbo].[SomeTable];"` outputs `DROP TABLE .[SomeTable];`.
 """
 
+PREFECT_WARN_LONG_TASK_INTROSPECTION = Setting(
+    bool,
+    default=True,
+)
+"""
+Whether to disable warnings about long running task parameter introspection.
+Defaults to `True`. Set to `False` to disable.
+"""
+
 PREFECT_AGENT_QUERY_INTERVAL = Setting(
     float,
     default=15,
@@ -1262,7 +1271,6 @@ PREFECT_API_MAX_FLOW_RUN_GRAPH_NODES = Setting(int, default=10000)
 """
 The maximum size of a flow run graph on the v2 API
 """
-
 
 PREFECT_EXPERIMENTAL_ENABLE_EVENTS_CLIENT = Setting(bool, default=True)
 """

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -934,8 +934,12 @@ PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD = Setting(
 )
 """
 Threshold time in seconds for logging a warning if task parameter introspection 
-exceeds this duration. Defaults to `10.0`. Set to `0` to disable logging the
-warning.
+exceeds this duration. Parameter introspection can be a significant performance hit
+when the parameter is a large collection object, e.g. a large dictionary or DataFrame,
+and each element needs to be inspected. See `prefect.utilities.annotations.quote` 
+for more details.
+Defaults to `10.0`. 
+Set to `0` to disable logging the warning.
 """
 
 PREFECT_AGENT_QUERY_INTERVAL = Setting(

--- a/src/prefect/utilities/annotations.py
+++ b/src/prefect/utilities/annotations.py
@@ -70,6 +70,23 @@ class quote(BaseAnnotation[T]):
     Simple wrapper to mark an expression as a different type so it will not be coerced
     by Prefect. For example, if you want to return a state from a flow without having
     the flow assume that state.
+
+    quote will also instruct prefect to ignore introspection of the wrapped object
+    when passed as flow or task parameter. Parameter introspection can be a
+    significant performance hit when the object is a large collection,
+    e.g. a large dictionary or DataFrame, and each element needs to be visited. This
+    will disable task dependency tracking for the wrapped object, but likely will
+    increase performance.
+
+    ```
+    @task
+    def my_task(df):
+        ...
+
+    @flow
+    def my_flow():
+        my_task(quote(df))
+    ```
     """
 
     def unquote(self) -> T:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2325,7 +2325,7 @@ async def test_long_task_introspection_warning_on(
                 log_prints=False,
             )
 
-    assert "Long running task parameter introspection detected" in caplog.text
+    assert "Task parameter introspection took" in caplog.text
 
 
 async def test_long_task_introspection_warning_off(
@@ -2370,4 +2370,4 @@ async def test_long_task_introspection_warning_off(
                 log_prints=False,
             )
 
-    assert "Long running task parameter introspection detected" not in caplog.text
+    assert "Task parameter introspection took" not in caplog.text


### PR DESCRIPTION
When you apply a `@task` decorator to a function prefect will introspect the parameters you pass so it can track dependencies (like task A's result got passed to task B). This is what we want to show for most cases, but it's a big performance hit when the data you're passing is a really large collection like a `dataframe` or large `dict`, and we try to visit everything inside of it.

`quote()` is an escape utility which tells prefect to ignore introspecting this thing. However this utility is not well known or well documented and this case frequently comes up as there are many data heavy users passing dataframes around.

This pr introduces a helpful warning if task run parameter introspection takes longer than `PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD`, instructing the user to try `quote()`. 
You can disable this warning by setting `PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD=0`

### Example:
```python
import json
from prefect import flow, task
from faker import Faker


def make_a_giant_json(N: int):
    Faker.seed(42)
    fake = Faker()
    out = fake.json(
        data_columns={
            "Spec": "@1.0.1",
            "ID": "pyint",
            "x1": "address",
            "x2": "address",
            "x3": "address",
            "x4": "address",
            "x5": "address",
            "x6": "address",
            "x7": "address",
            "x8": "address",
            "x9": "address",
            "x10": "address",
        },
        num_rows=N,
    )
    x = json.loads(out)
    return x


@task
def my_task(big_json):
    pass


@flow
def my_flow(n: int):
    big_json = make_a_giant_json(n)
    my_task(big_json)


if __name__ == '__main__':
    my_flow(n=35000)
```
### Example Output
```
(demo-flows) ➜  demo-flows git:(main) ✗ python my_flow.py
16:14:39.434 | INFO    | prefect.engine - Created flow run 'prudent-bug' for flow 'my-flow'
16:14:39.438 | INFO    | Flow run 'prudent-bug' - View at https://app.prefect.cloud/account/3cf6b38f-5244-474a-9554-302144506e43/workspace/ce8b1412-01b7-4700-a508-8dbd1f43f623/flow-runs/flow-run/76b8071f-e68d-4ed7-9b0e-da7ab033145a
16:14:59.565 | INFO    | Flow run 'prudent-bug' - Created task run 'my_task-0' for task 'my_task'
16:14:59.567 | INFO    | Flow run 'prudent-bug' - Executing 'my_task-0' immediately...
16:15:02.490 | WARNING | Task run 'my_task-0' - Long running task parameter introspection detected. Consider wrapping large task parameters with prefect.utilities.annotations.quote for increased performance, e.g. `my_task(quote(param))`.Disable this message with PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD=0.
16:15:03.569 | INFO    | Task run 'my_task-0' - Finished in state Completed()
16:15:03.761 | INFO    | Flow run 'prudent-bug' - Finished in state Completed('All states completed.')
```

