### PR TITLE
Skips unsupported Windows tests

### DIFF
--- a/src/prefect/testing/standard_test_suites/task_runners.py
+++ b/src/prefect/testing/standard_test_suites/task_runners.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import sys
 import time
 from abc import ABC, abstractmethod
 from functools import partial
@@ -416,6 +417,10 @@ class TaskRunnerStandardTestSuite(ABC):
         assert bx.type == StateType.PENDING
         assert cx.type == StateType.COMPLETED
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Timeout is unsupported on Windows",
+    )
     def test_sync_task_timeout(self, task_runner):
         @task(timeout_seconds=0.1)
         def my_timeout_task():


### PR DESCRIPTION
This PR is a fix for our downstream collections -- in those collections we subclass the `TaskRunnerStandardTestSuite` and inherit a default suite of tests. One of those inherited tests is `test_sync_task_timeout` which fails consistently on Windows environments because we don't support cancellation due to timeouts on Windows. The marker added here just skips the test on Windows CI runs.

An example of failing tests can be seen [here](https://github.com/PrefectHQ/prefect-dask/actions/runs/6710486682/job/18266164487).
