### PR TITLE
docs: add clarifying comment on use of `task`

### DIFF
--- a/docs/guides/global-concurrency-limits.md
+++ b/docs/guides/global-concurrency-limits.md
@@ -11,6 +11,9 @@ search:
 
 Global concurrency limits allow you to manage task execution efficiently, controlling how many tasks can run simultaneously. They are ideal when optimizing resource usage, preventing bottlenecks, and customizing task execution are priorities.
 
+!!! tip "Clarification on 'Tasks'"
+In the context of global concurrency and rate limits, "tasks" refers not specifically to Prefect tasks, but to concurrent units of work in general, such as those managed by an event loop or `TaskGroup` in asynchronous programming. These general "tasks" could include Prefect tasks when they are part of an asynchronous execution environment.
+
 Rate Limits ensure system stability by governing the frequency of requests or operations. They are suitable for preventing overuse, ensuring fairness, and handling errors gracefully.
 
 When selecting between Concurrency and Rate Limits, consider your primary goal. Choose Concurrency Limits for resource optimization and task management. Choose Rate Limits to maintain system stability and fair access to services.

--- a/docs/guides/global-concurrency-limits.md
+++ b/docs/guides/global-concurrency-limits.md
@@ -11,8 +11,8 @@ search:
 
 Global concurrency limits allow you to manage task execution efficiently, controlling how many tasks can run simultaneously. They are ideal when optimizing resource usage, preventing bottlenecks, and customizing task execution are priorities.
 
-!!! tip "Clarification on 'Tasks'"
-In the context of global concurrency and rate limits, "tasks" refers not specifically to Prefect tasks, but to concurrent units of work in general, such as those managed by an event loop or `TaskGroup` in asynchronous programming. These general "tasks" could include Prefect tasks when they are part of an asynchronous execution environment.
+!!! tip "Clarification on use of the term 'tasks'"
+    In the context of global concurrency and rate limits, "tasks" refers not specifically to Prefect tasks, but to concurrent units of work in general, such as those managed by an event loop or `TaskGroup` in asynchronous programming. These general "tasks" could include Prefect tasks when they are part of an asynchronous execution environment.
 
 Rate Limits ensure system stability by governing the frequency of requests or operations. They are suitable for preventing overuse, ensuring fairness, and handling errors gracefully.
 


### PR DESCRIPTION
addressing #11081

(if im understanding the existing doc correctly) This PR adds a `!!!tip` to mitigate conflation of general "tasks" in common concurrency lingo with Prefect proper noun "Task".
