### PR TITLE
Flow run graph v2 polish

### DIFF
--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -724,7 +724,6 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
                         COALESCE(subflow.id, task_run.id) as id,
                         COALESCE(flow.name || ' / ' || subflow.name, task_run.name) as label,
                         COALESCE(subflow.state_type, task_run.state_type) as state_type,
-                        COALESCE(subflow.state_name, task_run.state_name) as state_name,
                         COALESCE(
                             subflow.start_time,
                             subflow.expected_start_time,
@@ -740,7 +739,8 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
                                 ON subflow.parent_task_run_id = task_run.id
                         LEFT JOIN flow
                                 ON flow.id = subflow.flow_id
-                WHERE   task_run.flow_run_id = :flow_run_id
+                WHERE   task_run.flow_run_id = :flow_run_id AND
+                        task_run.state_type <> 'PENDING'
 
                 -- the order here is important to speed up building the two sets of
                 -- edges in the with_parents and with_children CTEs below
@@ -768,7 +768,6 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
                         edges.id,
                         edges.label,
                         edges.state_type,
-                        edges.state_name,
                         edges.start_time,
                         edges.end_time,
                         with_parents.parent_ids,
@@ -783,7 +782,6 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
                     id,
                     label,
                     state_type,
-                    state_name,
                     start_time,
                     end_time,
                     parent_ids,
@@ -819,7 +817,6 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
                         id=row.id,
                         label=row.label,
                         state_type=row.state_type,
-                        state_name=row.state_name,
                         start_time=row.start_time,
                         end_time=row.end_time,
                         parents=[Edge(id=id) for id in row.parent_ids or []],
@@ -1121,7 +1118,6 @@ class AioSqliteQueryComponents(BaseQueryComponents):
                         COALESCE(subflow.id, task_run.id) as id,
                         COALESCE(flow.name || ' / ' || subflow.name, task_run.name) as label,
                         COALESCE(subflow.state_type, task_run.state_type) as state_type,
-                        COALESCE(subflow.state_name, task_run.state_name) as state_name,
                         COALESCE(
                             subflow.start_time,
                             subflow.expected_start_time,
@@ -1137,7 +1133,8 @@ class AioSqliteQueryComponents(BaseQueryComponents):
                                 ON subflow.parent_task_run_id = task_run.id
                         LEFT JOIN flow
                                 ON flow.id = subflow.flow_id
-                WHERE   task_run.flow_run_id = :flow_run_id
+                WHERE   task_run.flow_run_id = :flow_run_id AND
+                        task_run.state_type <> 'PENDING'
 
                 -- the order here is important to speed up building the two sets of
                 -- edges in the with_parents and with_children CTEs below
@@ -1166,7 +1163,6 @@ class AioSqliteQueryComponents(BaseQueryComponents):
                         edges.id,
                         edges.label,
                         edges.state_type,
-                        edges.state_name,
                         edges.start_time,
                         edges.end_time,
                         with_parents.parent_ids,
@@ -1181,7 +1177,6 @@ class AioSqliteQueryComponents(BaseQueryComponents):
                     id,
                     label,
                     state_type,
-                    state_name,
                     start_time,
                     end_time,
                     parent_ids,
@@ -1251,7 +1246,6 @@ class AioSqliteQueryComponents(BaseQueryComponents):
                         id=row.id,
                         label=row.label,
                         state_type=row.state_type,
-                        state_name=row.state_name,
                         start_time=time(row.start_time),
                         end_time=time(row.end_time),
                         parents=edges(row.parent_ids),

--- a/src/prefect/server/schemas/graph.py
+++ b/src/prefect/server/schemas/graph.py
@@ -15,7 +15,6 @@ class Node(PrefectBaseModel):
     id: UUID
     label: str
     state_type: StateType
-    state_name: str
     start_time: datetime
     end_time: Optional[datetime]
     parents: List[Edge]

--- a/tests/server/api/test_flow_run_graph_v2.py
+++ b/tests/server/api/test_flow_run_graph_v2.py
@@ -97,7 +97,7 @@ async def flow_run(
         id=uuid4(),
         flow_id=flow.id,
         state_type=StateType.COMPLETED,
-        state_name="Completed",
+        state_name="Irrelevant",
         start_time=base_time,
         end_time=base_time.add(minutes=5),
     )
@@ -138,13 +138,30 @@ async def flat_tasks(
             task_key=f"task-{i}",
             dynamic_key=f"task-{i}",
             state_type=StateType.COMPLETED,
-            state_name="Completed",
+            state_name="Irrelevant",
             start_time=base_time.add(seconds=i),
             end_time=base_time.add(minutes=1, seconds=i),
         )
         for i in range(5)
     ]
     session.add_all(task_runs)
+
+    # mix in a PENDING task to show that it is excluded
+    session.add(
+        db.TaskRun(
+            id=uuid4(),
+            flow_run_id=flow_run.id,
+            name="task-pending",
+            task_key="task-pending",
+            dynamic_key="task-pending",
+            state_type=StateType.PENDING,
+            state_name="Irrelevant",
+            expected_start_time=base_time.add(seconds=3).subtract(microseconds=1),
+            start_time=base_time.add(seconds=3),
+            end_time=base_time.add(minutes=1, seconds=3),
+        )
+    )
+
     await session.commit()
     return task_runs
 
@@ -171,7 +188,6 @@ async def test_reading_graph_for_flow_run_with_flat_tasks(
                 id=task_run.id,
                 label=task_run.name,
                 state_type=task_run.state_type,
-                state_name=task_run.state_name,
                 start_time=task_run.start_time,
                 end_time=task_run.end_time,
                 parents=[],
@@ -209,7 +225,7 @@ async def linked_tasks(
             task_key=f"task-{i}",
             dynamic_key=f"task-{i}",
             state_type=StateType.COMPLETED,
-            state_name="Completed",
+            state_name="Irrelevant",
             expected_start_time=base_time.add(seconds=i).subtract(microseconds=1),
             start_time=base_time.add(seconds=i),
             end_time=base_time.add(minutes=1, seconds=i),
@@ -227,7 +243,7 @@ async def linked_tasks(
                 task_key=f"task-{index + j}",
                 dynamic_key=f"task-{index + j}",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
+                state_name="Irrelevant",
                 expected_start_time=base_time.add(seconds=index + j).subtract(
                     microseconds=1
                 ),
@@ -247,6 +263,23 @@ async def linked_tasks(
     )
 
     session.add_all(task_runs)
+
+    # mix in a PENDING task to show that it is excluded
+    session.add(
+        db.TaskRun(
+            id=uuid4(),
+            flow_run_id=flow_run.id,
+            name="task-pending",
+            task_key="task-pending",
+            dynamic_key="task-pending",
+            state_type=StateType.PENDING,
+            state_name="Irrelevant",
+            expected_start_time=base_time.add(seconds=3).subtract(microseconds=1),
+            start_time=base_time.add(seconds=3),
+            end_time=base_time.add(minutes=1, seconds=3),
+        )
+    )
+
     await session.commit()
     return task_runs
 
@@ -285,7 +318,6 @@ async def test_reading_graph_for_flow_run_with_linked_tasks(
                 id=linked_tasks[0].id,
                 label="task-0",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=0),
                 end_time=base_time.add(minutes=1, seconds=0),
                 parents=[],
@@ -301,7 +333,6 @@ async def test_reading_graph_for_flow_run_with_linked_tasks(
                 id=linked_tasks[1].id,
                 label="task-1",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=1),
                 end_time=base_time.add(minutes=1, seconds=1),
                 parents=[],
@@ -317,7 +348,6 @@ async def test_reading_graph_for_flow_run_with_linked_tasks(
                 id=linked_tasks[2].id,
                 label="task-2",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=2),
                 end_time=base_time.add(minutes=1, seconds=2),
                 parents=[],
@@ -333,7 +363,6 @@ async def test_reading_graph_for_flow_run_with_linked_tasks(
                 id=linked_tasks[3].id,
                 label="task-3",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=3),
                 end_time=base_time.add(minutes=1, seconds=3),
                 parents=[],
@@ -349,7 +378,6 @@ async def test_reading_graph_for_flow_run_with_linked_tasks(
                 id=linked_tasks[4].id,
                 label="task-4",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=4),
                 end_time=base_time.add(minutes=1, seconds=4),
                 parents=[
@@ -366,7 +394,6 @@ async def test_reading_graph_for_flow_run_with_linked_tasks(
                 id=linked_tasks[5].id,
                 label="task-5",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=5),
                 end_time=base_time.add(minutes=1, seconds=5),
                 parents=[
@@ -420,7 +447,6 @@ async def test_reading_graph_for_flow_run_with_linked_unstarted_tasks(
                 id=linked_tasks[0].id,
                 label="task-0",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=0).subtract(microseconds=1),
                 end_time=base_time.add(minutes=1, seconds=0),
                 parents=[],
@@ -436,7 +462,6 @@ async def test_reading_graph_for_flow_run_with_linked_unstarted_tasks(
                 id=linked_tasks[1].id,
                 label="task-1",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=1).subtract(microseconds=1),
                 end_time=base_time.add(minutes=1, seconds=1),
                 parents=[],
@@ -452,7 +477,6 @@ async def test_reading_graph_for_flow_run_with_linked_unstarted_tasks(
                 id=linked_tasks[2].id,
                 label="task-2",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=2).subtract(microseconds=1),
                 end_time=base_time.add(minutes=1, seconds=2),
                 parents=[],
@@ -468,7 +492,6 @@ async def test_reading_graph_for_flow_run_with_linked_unstarted_tasks(
                 id=linked_tasks[3].id,
                 label="task-3",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=3).subtract(microseconds=1),
                 end_time=base_time.add(minutes=1, seconds=3),
                 parents=[],
@@ -484,7 +507,6 @@ async def test_reading_graph_for_flow_run_with_linked_unstarted_tasks(
                 id=linked_tasks[4].id,
                 label="task-4",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=4).subtract(microseconds=1),
                 end_time=base_time.add(minutes=1, seconds=4),
                 parents=[
@@ -501,7 +523,6 @@ async def test_reading_graph_for_flow_run_with_linked_unstarted_tasks(
                 id=linked_tasks[5].id,
                 label="task-5",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=5).subtract(microseconds=1),
                 end_time=base_time.add(minutes=1, seconds=5),
                 parents=[
@@ -558,7 +579,6 @@ async def test_reading_graph_for_flow_run_with_linked_tasks_incrementally(
                 id=linked_tasks[2].id,
                 label="task-2",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=2),
                 end_time=base_time.add(minutes=1, seconds=2),
                 parents=[],
@@ -574,7 +594,6 @@ async def test_reading_graph_for_flow_run_with_linked_tasks_incrementally(
                 id=linked_tasks[3].id,
                 label="task-3",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=3),
                 end_time=base_time.add(minutes=1, seconds=3),
                 parents=[],
@@ -590,7 +609,6 @@ async def test_reading_graph_for_flow_run_with_linked_tasks_incrementally(
                 id=linked_tasks[4].id,
                 label="task-4",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=4),
                 end_time=base_time.add(minutes=1, seconds=4),
                 parents=[
@@ -609,7 +627,6 @@ async def test_reading_graph_for_flow_run_with_linked_tasks_incrementally(
                 id=linked_tasks[5].id,
                 label="task-5",
                 state_type=StateType.COMPLETED,
-                state_name="Completed",
                 start_time=base_time.add(seconds=5),
                 end_time=base_time.add(minutes=1, seconds=5),
                 parents=[
@@ -636,7 +653,7 @@ async def subflow_run(
         task_key="task-0",
         dynamic_key="task-0",
         state_type=StateType.COMPLETED,
-        state_name="Completed",
+        state_name="Irrelevant",
         expected_start_time=base_time.subtract(microseconds=1),
         start_time=base_time.add(seconds=1),
         end_time=base_time.add(minutes=1),
@@ -648,7 +665,7 @@ async def subflow_run(
         id=uuid4(),
         flow_id=flow_run.flow_id,
         state_type=StateType.COMPLETED,
-        state_name="Completed",
+        state_name="Irrelevant",
         expected_start_time=base_time.subtract(microseconds=1),
         start_time=base_time,
         end_time=base_time.add(minutes=5),
@@ -685,7 +702,6 @@ async def test_reading_graph_with_subflow_run(
                 id=subflow_run.id,
                 label=f"{flow.name} / {subflow_run.name}",
                 state_type=subflow_run.state_type,
-                state_name=subflow_run.state_name,
                 start_time=subflow_run.start_time,
                 end_time=subflow_run.end_time,
                 parents=[],
@@ -727,7 +743,6 @@ async def test_reading_graph_with_unstarted_subflow_run(
                 id=subflow_run.id,
                 label=f"{flow.name} / {subflow_run.name}",
                 state_type=subflow_run.state_type,
-                state_name=subflow_run.state_name,
                 start_time=subflow_run.expected_start_time,
                 end_time=subflow_run.end_time,
                 parents=[],


### PR DESCRIPTION
* Excludes `PENDING` tasks, as it is ambiguous whether they will be subflow runs
* Removes `state_name` from the API, as it isn't needed by the UI
