### PR TITLE
Fix docstring for `flow.deploy` method example

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -902,7 +902,7 @@ class Flow(Generic[P, R]):
             if __name__ == "__main__":
                 my_flow.deploy(
                     "example-deployment",
-                    work_pool="my-work-pool",
+                    work_pool_name="my-work-pool",
                     image="my-repository/my-image:dev",
                 )
             ```
@@ -918,7 +918,7 @@ class Flow(Generic[P, R]):
                     entrypoint="flows.py:my_flow",
                 ).deploy(
                     "example-deployment",
-                    work_pool="my-work-pool",
+                    work_pool_name="my-work-pool",
                     image="my-repository/my-image:dev",
                 )
             ```


### PR DESCRIPTION
`work_pool` in docstring example should be `work_pool_name`

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
