### PR TITLE
Allow minimal prefect-client CI validation on external PRs

### DIFF
--- a/client/client_flow.py
+++ b/client/client_flow.py
@@ -1,6 +1,21 @@
 from prefect import flow, task
 
 
+def skip_remote_run():
+    """
+    Github Actions will not populate secrets if the workflow is triggered by
+    external collaborators (including dependabot). This function checks if
+    we're in a CI environment AND if the secret was not populated -- if
+    those conditions are true, we won't try to run the flow against the remote
+    API
+    """
+    import os
+
+    in_gha = os.environ.get("CI", False)
+    secret_not_set = os.environ.get("PREFECT_API_KEY", "") == ""
+    return in_gha and secret_not_set
+
+
 @task
 def smoke_test_task(*args, **kwargs):
     print(args, kwargs)
@@ -11,4 +26,6 @@ def smoke_test_flow():
     smoke_test_task("foo", "bar", baz="qux")
 
 
-smoke_test_flow()
+if __name__ == "__main__":
+    if not skip_remote_run():
+        smoke_test_flow()


### PR DESCRIPTION
When we run CI on external PRs (such as dependabot automatic updates), the workflow does not have access to the repository secrets and fails while running an integration test workflow. It's still helpful to run as much of the build as possible without failing on integration flows that require secrets to work against a remote API. This PR changes the integration flow to detect when it should not run (in GHA and no secret availabl). In these cases, the integration test step will just verify `prefect-client`'s imports work correctly.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
