### PR TITLE
Fix bug where check for required packages fails incorrectly

### DIFF
--- a/src/prefect/deployments/steps/core.py
+++ b/src/prefect/deployments/steps/core.py
@@ -16,7 +16,7 @@ import subprocess
 import warnings
 from copy import deepcopy
 from importlib import import_module
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
 from prefect._internal.concurrency.api import Call, from_async
@@ -60,7 +60,9 @@ def _strip_version(requirement: str) -> str:
     return re.split(r"[<>=!~]", requirement)[0].strip()
 
 
-def _get_function_for_step(fully_qualified_name: str, requires: Optional[str] = None):
+def _get_function_for_step(
+    fully_qualified_name: str, requires: Union[str, List[str], None] = None
+):
     if not isinstance(requires, list):
         packages = [requires] if requires else []
     else:
@@ -68,7 +70,7 @@ def _get_function_for_step(fully_qualified_name: str, requires: Optional[str] = 
 
     try:
         for package in packages:
-            import_module(_strip_version(package))
+            import_module(_strip_version(package).replace("-", "_"))
         step_func = import_object(fully_qualified_name)
         return step_func
     except ImportError:
@@ -80,9 +82,14 @@ def _get_function_for_step(fully_qualified_name: str, requires: Optional[str] = 
         else:
             raise
 
-    subprocess.check_call(
-        [get_sys_executable(), "-m", "pip", "install", ",".join(packages)]
-    )
+    try:
+        subprocess.check_call(
+            [get_sys_executable(), "-m", "pip", "install", ",".join(packages)]
+        )
+    except subprocess.CalledProcessError:
+        get_logger("deployments.steps.core").warning(
+            "Unable to install required packages for %s", fully_qualified_name
+        )
     step_func = import_object(fully_qualified_name)
     return step_func
 

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -802,7 +802,8 @@ class TestPipInstallRequirements:
         assert (
             "pip_install_requirements failed with error code 1: ERROR: Could not open "
             "requirements file: [Errno 2] No such file or directory: "
-            "'doesnt-exist.txt'" in str(exc.value)
+            "'doesnt-exist.txt'"
+            in str(exc.value)
         )
 
 

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -1,4 +1,5 @@
 import shutil
+import subprocess
 import sys
 import warnings
 from pathlib import Path
@@ -120,6 +121,72 @@ class TestRunStep:
         )
         assert output.returncode == 0
         assert output.stdout.decode().strip() == "hello world"
+
+    async def test_requirement_installation_successful(self, monkeypatch):
+        """
+        Test that the function attempts to install the package and succeeds.
+        """
+        import_module_mock = MagicMock()
+        monkeypatch.setattr(
+            "prefect.deployments.steps.core.import_module", import_module_mock
+        )
+
+        monkeypatch.setattr(subprocess, "check_call", MagicMock())
+
+        import_object_mock = MagicMock(side_effect=[ImportError, lambda x: x])
+        monkeypatch.setattr(
+            "prefect.deployments.steps.core.import_object", import_object_mock
+        )
+
+        await run_step(
+            {"test_module.test_function": {"requires": "test-package>=1.0.0", "x": 1}}
+        )
+
+        import_module_mock.assert_called_once_with("test_package")
+        assert (
+            import_object_mock.call_count == 2
+        )  # once before and once after installation
+        subprocess.check_call.assert_called_once_with(
+            [sys.executable, "-m", "pip", "install", "test-package>=1.0.0"]
+        )
+
+    async def test_requirement_installation_failure(self, monkeypatch, caplog):
+        """
+        Test that the function logs a warning if it fails to install the package.
+        """
+        # Mocking the import_module function to always raise ImportError
+        monkeypatch.setattr(
+            "prefect.deployments.steps.core.import_module",
+            MagicMock(side_effect=ImportError),
+        )
+
+        # Mock subprocess.check_call to simulate failed package installation
+        monkeypatch.setattr(
+            subprocess,
+            "check_call",
+            MagicMock(side_effect=subprocess.CalledProcessError(1, ["pip"])),
+        )
+
+        with pytest.raises(ImportError):
+            await run_step(
+                {
+                    "test_module.test_function": {
+                        "requires": "nonexistent-package>=1.0.0"
+                    }
+                }
+            )
+
+        assert subprocess.check_call.called
+        record = next(
+            (
+                record
+                for record in caplog.records
+                if "Unable to install required packages" in record.message
+            ),
+            None,
+        )
+        assert record is not None, "No warning was logged"
+        assert record.levelname == "WARNING"
 
 
 class TestRunSteps:
@@ -705,8 +772,7 @@ class TestPipInstallRequirements:
         assert (
             "pip_install_requirements failed with error code 1: ERROR: Could not open "
             "requirements file: [Errno 2] No such file or directory: "
-            "'doesnt-exist.txt'"
-            in str(exc.value)
+            "'doesnt-exist.txt'" in str(exc.value)
         )
 
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
- Adds formatting to handle libraries with `-` in the name, but the corresponding module uses a `_` (e.g. `prefect-aws`)
- Raises warning, but doesn't fail when requirements installation fails. Steps can succeed if the necessary requirements are available, but installation fails. The warning can help with debugging if a step run fails.

Closes https://github.com/PrefectHQ/prefect/issues/11091

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
