### PR TITLE
Handle Cached tasks on graph-v2

### DIFF
--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -730,7 +730,15 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
                             task_run.start_time,
                             task_run.expected_start_time
                         ) as start_time,
-                        COALESCE(subflow.end_time, task_run.end_time) as end_time,
+                        COALESCE(
+                            subflow.end_time,
+                            task_run.end_time,
+                            CASE
+                                WHEN task_run.state_type = 'COMPLETED'
+                                    THEN task_run.expected_start_time
+                                ELSE NULL
+                            END
+                        ) as end_time,
                         (argument->>'id')::uuid as parent
                 FROM    task_run
                         LEFT JOIN jsonb_each(task_run.task_inputs) as input ON true
@@ -1124,7 +1132,15 @@ class AioSqliteQueryComponents(BaseQueryComponents):
                             task_run.start_time,
                             task_run.expected_start_time
                         ) as start_time,
-                        COALESCE(subflow.end_time, task_run.end_time) as end_time,
+                        COALESCE(
+                            subflow.end_time,
+                            task_run.end_time,
+                            CASE
+                                WHEN task_run.state_type = 'COMPLETED'
+                                    THEN task_run.expected_start_time
+                                ELSE NULL
+                            END
+                        ) as end_time,
                         json_extract(argument.value, '$.id') as parent
                 FROM    task_run
                         LEFT JOIN json_each(task_run.task_inputs) as input ON true

--- a/tests/server/api/test_flow_run_graph_v2.py
+++ b/tests/server/api/test_flow_run_graph_v2.py
@@ -139,6 +139,7 @@ async def flat_tasks(
             dynamic_key=f"task-{i}",
             state_type=StateType.COMPLETED,
             state_name="Irrelevant",
+            expected_start_time=base_time.add(seconds=i).subtract(microseconds=1),
             start_time=base_time.add(seconds=i),
             end_time=base_time.add(minutes=1, seconds=i),
         )
@@ -161,6 +162,14 @@ async def flat_tasks(
             end_time=base_time.add(minutes=1, seconds=3),
         )
     )
+
+    # turn the 3rd task into a Cached task, which needs to be treated specially
+    # because Cached tasks are COMPLETED, but don't have start/end times, only
+    # an expected_start_time
+    task_runs[2].start_time = None
+    task_runs[2].end_time = None
+    task_runs[2].state_type = StateType.COMPLETED
+    task_runs[2].state_name = "Cached"
 
     await session.commit()
     return task_runs
@@ -188,8 +197,22 @@ async def test_reading_graph_for_flow_run_with_flat_tasks(
                 id=task_run.id,
                 label=task_run.name,
                 state_type=task_run.state_type,
-                start_time=task_run.start_time,
-                end_time=task_run.end_time,
+                start_time=(
+                    task_run.expected_start_time
+                    if (
+                        task_run.state_type == StateType.COMPLETED
+                        and not task_run.start_time
+                    )
+                    else task_run.start_time
+                ),
+                end_time=(
+                    task_run.expected_start_time
+                    if (
+                        task_run.state_type == StateType.COMPLETED
+                        and not task_run.end_time
+                    )
+                    else task_run.end_time
+                ),
                 parents=[],
                 children=[],
             ),


### PR DESCRIPTION
Cached tasks have an `expected_start_time`, but because they aren't actually run, they
have `NULL` `start_time` and `end_time`.  Cached tasks appear as `COMPLETED`, so we can
detect those and use their `expected_start_time` in place of both times, reflecting that
they are "zero duration" tasks.  The UI will correctly hold those to a minimum width and
drop them in the right spot on the layout.
