### PR TITLE
Improved tag handling on DeploymentImage

### DIFF
--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -649,9 +649,9 @@ class DeploymentImage:
     def __init__(self, name, tag=None, dockerfile="auto", **build_kwargs):
         split_name = name.split(":")
         self.name = split_name[0]
-        if split_name[1] and tag:
+        if len(split_name) > 1 and tag:
             raise ValueError(f"Both {split_name[1]} and {tag} were provided as tags.")
-        elif split_name[1]:
+        elif len(split_name) > 1:
             tag = split_name[1]
         self.tag = tag or slugify(pendulum.now("utc").isoformat())
         self.dockerfile = dockerfile

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -650,7 +650,10 @@ class DeploymentImage:
         split_name = name.split(":")
         self.name = split_name[0]
         if len(split_name) > 1 and tag:
-            raise ValueError(f"Both {split_name[1]} and {tag} were provided as tags.")
+            raise ValueError(
+                f"Only one tag can be provided - both {split_name[1]!r} and"
+                f" {tag!r} were provided as tags."
+            )
         elif len(split_name) > 1:
             tag = split_name[1]
         self.tag = tag or slugify(pendulum.now("utc").isoformat())

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -647,7 +647,12 @@ class DeploymentImage:
     """
 
     def __init__(self, name, tag=None, dockerfile="auto", **build_kwargs):
-        self.name = name
+        split_name = name.split(":")
+        self.name = split_name[0]
+        if split_name[1] and tag:
+            raise ValueError(f"Both {split_name[1]} and {tag} were provided as tags.")
+        elif split_name[1]:
+            tag = split_name[1]
         self.tag = tag or slugify(pendulum.now("utc").isoformat())
         self.dockerfile = dockerfile
         self.build_kwargs = build_kwargs

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1100,6 +1100,12 @@ class TestDeploy:
         assert image.tag == "test-tag"
         assert image.reference == "test-registry/test-image:test-tag"
 
+        # test both can't be provided
+        with pytest.raises(
+            ValueError, match="both 'test-tag' and 'bad-tag' were provided"
+        ):
+            DeploymentImage(name="test-registry/test-image:test-tag", tag="bad-tag")
+
     async def test_deploy_custom_dockerfile(
         self,
         mock_build_image,

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1078,6 +1078,28 @@ class TestDeploy:
                 image="test-registry/test-image",
             )
 
+    async def test_deployment_image_tag_handling(self):
+        # test image tag has default
+        image = DeploymentImage(
+            name="test-registry/test-image",
+        )
+        assert image.name == "test-registry/test-image"
+        assert image.tag.startswith(str(pendulum.now("utc").year))
+
+        # test image tag can be inferred
+        image = DeploymentImage(
+            name="test-registry/test-image:test-tag",
+        )
+        assert image.name == "test-registry/test-image"
+        assert image.tag == "test-tag"
+        assert image.reference == "test-registry/test-image:test-tag"
+
+        # test image tag can be provided
+        image = DeploymentImage(name="test-registry/test-image", tag="test-tag")
+        assert image.name == "test-registry/test-image"
+        assert image.tag == "test-tag"
+        assert image.reference == "test-registry/test-image:test-tag"
+
     async def test_deploy_custom_dockerfile(
         self,
         mock_build_image,


### PR DESCRIPTION
The `DeploymentImage` class currently appends tags even if one is provided implicitly through the name; this PR adds the convenience of providing a `name:tag` formatted name and we "do the right thing".

### Example
```python
image = DeploymentImage(name="my-repo/my-image:my-tag") # works
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->