### PR TITLE
Allow `image` passed into `deploy` to be optional if loading flow from storage

### DIFF
--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -749,8 +749,8 @@ async def deploy(
     """
     if not image and not all(d.storage for d in deployments):
         raise ValueError(
-            "An image must be provided when deploying a deployment that does not have"
-            " storage."
+            "Either an image or remote storage location must be provided when deploying"
+            " a deployment."
         )
 
     if image and isinstance(image, str):

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -828,7 +828,7 @@ class Flow(Generic[P, R]):
         self,
         name: str,
         work_pool_name: str,
-        image: Union[str, DeploymentImage],
+        image: Optional[Union[str, DeploymentImage]],
         build: bool = True,
         push: bool = True,
         work_queue_name: Optional[str] = None,

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1337,7 +1337,6 @@ class TestDeploy:
                 work_pool_name=work_pool_with_image_variable.name,
             )
 
-            assert len(deployment_ids) == 1
 
     async def test_deploy_with_image_string_no_tag(
         self,

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1298,7 +1298,6 @@ class TestDeploy:
                 work_pool_name=work_pool_with_image_variable.name,
             )
 
-            assert len(deployment_id) == 1
 
     async def test_deploy_with_image_and_flow_stored_remotely(
         self,

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1327,7 +1327,7 @@ class TestDeploy:
         work_pool_with_image_variable,
     ):
         with pytest.raises(ValueError):
-            deployment_ids = await deploy(
+            await deploy(
                 await dummy_flow_1.to_deployment(__file__),
                 await (
                     await flow.from_source(

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1298,28 +1298,20 @@ class TestDeploy:
                 work_pool_name=work_pool_with_image_variable.name,
             )
 
-    async def test_deploy_with_image_and_flow_stored_remotely(
+    async def test_deploy_with_image_and_flow_stored_remotely_raises(
         self,
         work_pool_with_image_variable,
-        mock_build_image,
     ):
-        deployment_id = await deploy(
-            await (
-                await flow.from_source(
-                    source=MockStorage(), entrypoint="flows.py:test_flow"
-                )
-            ).to_deployment(__file__),
-            work_pool_name=work_pool_with_image_variable.name,
-            image="test-registry/test-image:test-tag",
-        )
-
-        assert len(deployment_id) == 1
-
-        mock_build_image.assert_called_once_with(
-            tag="test-registry/test-image:test-tag",
-            context=Path.cwd(),
-            pull=True,
-        )
+        with pytest.raises(RuntimeError, match="Failed to generate Dockerfile"):
+            await deploy(
+                await (
+                    await flow.from_source(
+                        source=MockStorage(), entrypoint="flows.py:test_flow"
+                    )
+                ).to_deployment(__file__),
+                work_pool_name=work_pool_with_image_variable.name,
+                image="test-registry/test-image:test-tag",
+            )
 
     async def test_deploy_multiple_flows_one_using_storage_one_without_raises_with_no_image(
         self,

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1293,11 +1293,10 @@ class TestDeploy:
         work_pool_with_image_variable,
     ):
         with pytest.raises(ValueError):
-            deployment_id = await deploy(
+            await deploy(
                 await dummy_flow_1.to_deployment(__file__),
                 work_pool_name=work_pool_with_image_variable.name,
             )
-
 
     async def test_deploy_with_image_and_flow_stored_remotely(
         self,
@@ -1336,7 +1335,6 @@ class TestDeploy:
                 ).to_deployment(__file__),
                 work_pool_name=work_pool_with_image_variable.name,
             )
-
 
     async def test_deploy_with_image_string_no_tag(
         self,


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/11096

### Example Usage
```python
from prefect import flow
from prefect import deploy

@flow(log_prints=True)
def local_flow():
    print("I'm a locally defined flow!")


if __name__ == "__main__":
    # use an image (`build` and `push` args default `True`)
    local_flow.deploy(
         name="test-remote-flow-deploy",
         work_pool_name="my-cloud-run-push-work-pool",
         image="serinabeana/dev:latest",
         job_variables={"image_pull_policy": "Never"},
     )

    # use remote storage
    deploy(
        flow.from_source(
            source="https://github.com/desertaxle/demo.git",
            entrypoint="flow.py:my_flow",
        ).to_deployment(
            name="test-deploy-remote-flow",
        ),
        work_pool_name="my-cloud-run-push-work-pool",
    )

    # multiple deployments, one using remote storage
    deploy(
        local_flow.to_deployment("my-deployment"),
        flow.from_source(
            source="https://github.com/desertaxle/demo.git",
            entrypoint="flow.py:my_flow",
        ).to_deployment(
            name="test-deploy-remote-flow",
        ),
        work_pool_name="my-cloud-run-push-work-pool",
        image="serinabeana/dev:latest",  # will raise if image not provided here
    )
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
