### PR TITLE
Dont print worker start command for managed pool

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -709,7 +709,7 @@ async def _run_single_deploy(
                         " prefect.yaml file."
                     ),
                 )
-    if not work_pool.is_push_pool:
+    if not work_pool.is_push_pool and not work_pool.is_managed_pool:
         app.console.print(
             "\nTo execute flow runs from this deployment, start a worker in a"
             " separate terminal that pulls work from the"

--- a/src/prefect/cli/worker.py
+++ b/src/prefect/cli/worker.py
@@ -229,7 +229,7 @@ async def _retrieve_worker_type_from_pool(work_pool_name: Optional[str] = None) 
             f"Discovered type {worker_type!r} for work pool {work_pool.name!r}."
         )
 
-        if work_pool.is_push_pool:
+        if work_pool.is_push_pool or work_pool.is_managed_pool:
             exit_with_error(
                 "Workers are not required for push work pools. "
                 "See https://docs.prefect.io/latest/guides/deployment/push-work-pools/ "

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -863,7 +863,7 @@ async def deploy(
     console.print(table)
 
     if print_next_steps_message and not complete_failure:
-        if not work_pool.is_push_pool:
+        if not work_pool.is_push_pool and not work_pool.is_managed_pool:
             console.print(
                 "\nTo execute flow runs from these deployments, start a worker in a"
                 " separate terminal that pulls work from the"

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -959,7 +959,7 @@ class Flow(Generic[P, R]):
 
         if print_next_steps:
             console = Console()
-            if not work_pool.is_push_pool:
+            if not work_pool.is_push_pool and not work_pool.is_managed_pool:
                 console.print(
                     "\nTo execute flow runs from this deployment, start a worker in a"
                     " separate terminal that pulls work from the"


### PR DESCRIPTION
Similar to push work pools, for managed pools we want to avoid printing any help text suggesting users can/should start their own worker for the pool.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
