### PR TITLE
Exclude any flow/task run with a `NULL` `start_time` from Graph v2

### DIFF
--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -748,7 +748,13 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
                         LEFT JOIN flow
                                 ON flow.id = subflow.flow_id
                 WHERE   task_run.flow_run_id = :flow_run_id AND
-                        task_run.state_type <> 'PENDING'
+                        task_run.state_type <> 'PENDING' AND
+                        COALESCE(
+                            subflow.start_time,
+                            subflow.expected_start_time,
+                            task_run.start_time,
+                            task_run.expected_start_time
+                        ) IS NOT NULL
 
                 -- the order here is important to speed up building the two sets of
                 -- edges in the with_parents and with_children CTEs below
@@ -1150,7 +1156,13 @@ class AioSqliteQueryComponents(BaseQueryComponents):
                         LEFT JOIN flow
                                 ON flow.id = subflow.flow_id
                 WHERE   task_run.flow_run_id = :flow_run_id AND
-                        task_run.state_type <> 'PENDING'
+                        task_run.state_type <> 'PENDING' AND
+                        COALESCE(
+                            subflow.start_time,
+                            subflow.expected_start_time,
+                            task_run.start_time,
+                            task_run.expected_start_time
+                        ) IS NOT NULL
 
                 -- the order here is important to speed up building the two sets of
                 -- edges in the with_parents and with_children CTEs below

--- a/tests/server/api/test_flow_run_graph_v2.py
+++ b/tests/server/api/test_flow_run_graph_v2.py
@@ -163,6 +163,22 @@ async def flat_tasks(
         )
     )
 
+    # mix in a RUNNING task with no start_time to show that it is excluded
+    session.add(
+        db.TaskRun(
+            id=uuid4(),
+            flow_run_id=flow_run.id,
+            name="task-running",
+            task_key="task-running",
+            dynamic_key="task-running",
+            state_type=StateType.RUNNING,
+            state_name="Irrelevant",
+            expected_start_time=None,
+            start_time=None,
+            end_time=None,
+        )
+    )
+
     # turn the 3rd task into a Cached task, which needs to be treated specially
     # because Cached tasks are COMPLETED, but don't have start/end times, only
     # an expected_start_time


### PR DESCRIPTION
There can be a brief period of time when a flow/task run has been created but does not
yet have a `start_time` or even an `expected_start_time`.  This is causing a pydantic
`ValidationError` when trying to read the graph.  We can safely ignore these
cases, as they can't be plotted on the graph visualization anyway, and the runs they
represent will "pop in" as soon as they have a valid time.
