### PR TITLE
Add client-side setting for default work pool

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -55,7 +55,11 @@ from prefect.deployments.steps.core import run_steps
 from prefect.events.schemas import DeploymentTrigger
 from prefect.exceptions import ObjectNotFound
 from prefect.flows import load_flow_from_entrypoint
-from prefect.settings import PREFECT_DEBUG_MODE, PREFECT_UI_URL
+from prefect.settings import (
+    PREFECT_DEBUG_MODE,
+    PREFECT_DEFAULT_WORK_POOL_NAME,
+    PREFECT_UI_URL,
+)
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.callables import parameter_schema
@@ -435,7 +439,11 @@ async def _run_single_deploy(
     deploy_config["schedule"] = _construct_schedule(deploy_config, ci=ci)
 
     # determine work pool
-    if get_from_dict(deploy_config, "work_pool.name"):
+    work_pool_name = (
+        get_from_dict(deploy_config, "work_pool.name")
+        or PREFECT_DEFAULT_WORK_POOL_NAME.value()
+    )
+    if work_pool_name:
         try:
             work_pool = await client.read_work_pool(deploy_config["work_pool"]["name"])
 

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -31,6 +31,7 @@ from prefect.cli._prompts import (
     prompt_select_remote_flow_storage,
     prompt_select_work_pool,
 )
+from prefect.cli._types import SettingsOption
 from prefect.cli._utilities import (
     exit_with_error,
 )
@@ -118,8 +119,8 @@ async def deploy(
             " --work-queue flag."
         ),
     ),
-    work_pool_name: str = typer.Option(
-        None,
+    work_pool_name: str = SettingsOption(
+        PREFECT_DEFAULT_WORK_POOL_NAME,
         "-p",
         "--pool",
         help="The work pool that will handle this deployment's runs.",
@@ -439,10 +440,7 @@ async def _run_single_deploy(
     deploy_config["schedule"] = _construct_schedule(deploy_config, ci=ci)
 
     # determine work pool
-    work_pool_name = (
-        get_from_dict(deploy_config, "work_pool.name")
-        or PREFECT_DEFAULT_WORK_POOL_NAME.value()
-    )
+    work_pool_name = get_from_dict(deploy_config, "work_pool.name")
     if work_pool_name:
         try:
             work_pool = await client.read_work_pool(deploy_config["work_pool"]["name"])

--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -2,7 +2,6 @@
 Command line interface for working with work queues.
 """
 import json
-import subprocess
 
 import pendulum
 import typer
@@ -20,6 +19,7 @@ from prefect.cli.root import app, is_interactive
 from prefect.client.collections import get_collections_metadata_client
 from prefect.client.schemas.actions import WorkPoolCreate, WorkPoolUpdate
 from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
+from prefect.settings import update_current_profile
 from prefect.workers.utilities import (
     get_available_work_pool_types,
     get_default_base_job_template_for_infrastructure_type,
@@ -29,6 +29,20 @@ work_pool_app = PrefectTyper(
     name="work-pool", help="Commands for working with work pools."
 )
 app.add_typer(work_pool_app, aliases=["work-pool"])
+
+
+def set_work_pool_as_default(name: str):
+    profile = update_current_profile({"PREFECT_DEFAULT_WORK_POOL_NAME": name})
+    app.console.print(
+        f"Set {name!r} as default work pool for profile {profile.name!r}\n",
+        style="green",
+    )
+    app.console.print(
+        (
+            "To change your default work pool, run:\n\n\t[blue]prefect config set"
+            " PREFECT_DEFAULT_WORK_POOL_NAME=<work-pool-name>[/]\n"
+        ),
+    )
 
 
 @work_pool_app.command()
@@ -51,11 +65,12 @@ async def create(
     type: str = typer.Option(
         None, "-t", "--type", help="The type of work pool to create."
     ),
-    use_as_default: bool = typer.Option(
+    set_as_default: bool = typer.Option(
         False,
-        "--use-as-default",
+        "--set-as-default",
         help=(
-            "Whether or not to use the created work pool as the default for deployment."
+            "Whether or not to use the created work pool as the local default for"
+            " deployment."
         ),
     ),
 ):
@@ -117,16 +132,15 @@ async def create(
                 is_paused=paused,
             )
             work_pool = await client.create_work_pool(work_pool=wp)
-            if use_as_default:
-                subprocess.check_call(
-                    [
-                        "prefect",
-                        "config",
-                        "set",
-                        f"PREFECT_DEFAULT_WORK_POOL_NAME={work_pool.name}",
-                    ]
+            app.console.print(f"Created work pool {work_pool.name!r}!\n", style="green")
+            if not work_pool.is_paused and not work_pool.is_managed_pool:
+                app.console.print("To start a worker for this work pool, run:\n")
+                app.console.print(
+                    f"\t[blue]prefect worker start --pool {work_pool.name}[/]\n"
                 )
-            exit_with_success(f"Created work pool {work_pool.name!r}.")
+            if set_as_default:
+                set_work_pool_as_default(work_pool.name)
+            exit_with_success("")
         except ObjectAlreadyExists:
             exit_with_error(
                 f"Work pool named {name!r} already exists. Please try creating your"

--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -2,6 +2,7 @@
 Command line interface for working with work queues.
 """
 import json
+import subprocess
 
 import pendulum
 import typer
@@ -49,6 +50,13 @@ async def create(
     ),
     type: str = typer.Option(
         None, "-t", "--type", help="The type of work pool to create."
+    ),
+    use_as_default: bool = typer.Option(
+        False,
+        "--use-as-default",
+        help=(
+            "Whether or not to use the created work pool as the default for deployment."
+        ),
     ),
 ):
     """
@@ -109,6 +117,15 @@ async def create(
                 is_paused=paused,
             )
             work_pool = await client.create_work_pool(work_pool=wp)
+            if use_as_default:
+                subprocess.check_call(
+                    [
+                        "prefect",
+                        "config",
+                        "set",
+                        f"PREFECT_DEFAULT_WORK_POOL_NAME={work_pool.name}",
+                    ]
+                )
             exit_with_success(f"Created work pool {work_pool.name!r}.")
         except ObjectAlreadyExists:
             exit_with_error(

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -708,7 +708,8 @@ async def deploy(
 
     Args:
         *deployments: A list of deployments to deploy.
-        work_pool_name: The name of the work pool to use for these deployments.
+        work_pool_name: The name of the work pool to use for these deployments. Defaults to
+            the value of `PREFECT_DEFAULT_WORK_POOL_NAME`.
         image: The name of the Docker image to build, including the registry and
             repository. Pass a DeploymentImage instance to customize the Dockerfile used
             and build arguments.
@@ -751,6 +752,13 @@ async def deploy(
         raise ValueError(
             "Either an image or remote storage location must be provided when deploying"
             " a deployment."
+        )
+
+    if not work_pool_name:
+        raise ValueError(
+            "A work pool name must be provided when deploying a deployment. Either"
+            " provide a work pool name when calling `deploy` or set"
+            " `PREFECT_DEFAULT_WORK_POOL_NAME` in your profile."
         )
 
     if image and isinstance(image, str):

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -44,7 +44,7 @@ from rich.table import Table
 from prefect._internal.concurrency.api import create_call, from_async
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect.runner.storage import RunnerStorage
-from prefect.settings import PREFECT_UI_URL
+from prefect.settings import PREFECT_DEFAULT_WORK_POOL_NAME, PREFECT_UI_URL
 from prefect.utilities.collections import get_from_dict
 
 if HAS_PYDANTIC_V2:
@@ -689,7 +689,7 @@ class DeploymentImage:
 @sync_compatible
 async def deploy(
     *deployments: RunnerDeployment,
-    work_pool_name: str,
+    work_pool_name: Optional[str] = None,
     image: Optional[Union[str, DeploymentImage]] = None,
     build: bool = True,
     push: bool = True,
@@ -745,6 +745,8 @@ async def deploy(
             )
         ```
     """
+    work_pool_name = work_pool_name or PREFECT_DEFAULT_WORK_POOL_NAME.value()
+
     if not image and not all(d.storage for d in deployments):
         raise ValueError(
             "Either an image or remote storage location must be provided when deploying"

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -871,7 +871,8 @@ class Flow(Generic[P, R]):
 
         Args:
             name: The name to give the created deployment.
-            work_pool_name: The name of the work pool to use for this deployment.
+            work_pool_name: The name of the work pool to use for this deployment. Defaults to
+                the value of `PREFECT_DEFAULT_WORK_POOL_NAME`.
             image: The name of the Docker image to build, including the registry and
                 repository. Pass a DeploymentImage instance to customize the Dockerfile used
                 and build arguments.

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -83,6 +83,7 @@ from prefect.futures import PrefectFuture
 from prefect.logging import get_logger
 from prefect.results import ResultSerializer, ResultStorage
 from prefect.settings import (
+    PREFECT_DEFAULT_WORK_POOL_NAME,
     PREFECT_FLOW_DEFAULT_RETRIES,
     PREFECT_FLOW_DEFAULT_RETRY_DELAY_SECONDS,
     PREFECT_UI_URL,
@@ -841,7 +842,7 @@ class Flow(Generic[P, R]):
     async def deploy(
         self,
         name: str,
-        work_pool_name: str,
+        work_pool_name: Optional[str] = None,
         image: Optional[Union[str, DeploymentImage]] = None,
         build: bool = True,
         push: bool = True,
@@ -937,6 +938,8 @@ class Flow(Generic[P, R]):
                 )
             ```
         """
+        work_pool_name = work_pool_name or PREFECT_DEFAULT_WORK_POOL_NAME.value()
+
         try:
             async with get_client() as client:
                 work_pool = await client.read_work_pool(work_pool_name)

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1414,6 +1414,13 @@ PREFECT_EXPERIMENTAL_WARN_WORKSPACE_DASHBOARD = Setting(bool, default=False)
 Whether or not to warn when the experimental workspace dashboard is enabled.
 """
 
+# Defaults -----------------------------------------------------------------------------
+
+PREFECT_DEFAULT_WORK_POOL_NAME = Setting(str, default=None)
+"""
+The default work pool to deploy to.
+"""
+
 # Deprecated settings ------------------------------------------------------------------
 
 

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -115,7 +115,7 @@ class TestCreate:
                 Path(__file__).parent / "base-job-templates" / "process-worker.json",
             ],
             expected_code=0,
-            expected_output="Created work pool 'my-olympic-pool'.",
+            expected_output="Created work pool 'my-olympic-pool'",
         )
 
         client_res = await prefect_client.read_work_pool(pool_name)

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -115,7 +115,7 @@ class TestCreate:
                 Path(__file__).parent / "base-job-templates" / "process-worker.json",
             ],
             expected_code=0,
-            expected_output="Created work pool 'my-olympic-pool'",
+            expected_output_contains="Created work pool 'my-olympic-pool'",
         )
 
         client_res = await prefect_client.read_work_pool(pool_name)

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -8,7 +8,9 @@ from typer import Exit
 
 from prefect.client.schemas.actions import WorkPoolUpdate
 from prefect.client.schemas.objects import WorkPool
+from prefect.context import get_settings_context
 from prefect.exceptions import ObjectNotFound
+from prefect.settings import PREFECT_DEFAULT_WORK_POOL_NAME, load_profile
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.workers.base import BaseWorker
@@ -283,6 +285,34 @@ class TestCreate:
         assert client_res.name == work_pool_name
         assert client_res.type == "fake"
         assert isinstance(client_res, WorkPool)
+
+    async def test_create_set_as_default(self, prefect_client):
+        settings_context = get_settings_context()
+        assert (
+            settings_context.profile.settings.get(PREFECT_DEFAULT_WORK_POOL_NAME)
+            is None
+        )
+        pool_name = "my-pool"
+        res = await run_sync_in_worker_thread(
+            invoke_and_assert,
+            f"work-pool create {pool_name} -t process --set-as-default",
+            expected_output_contains=[
+                f"Created work pool {pool_name!r}",
+                (
+                    f"Set {pool_name!r} as default work pool for profile"
+                    f" {settings_context.profile.name!r}\n"
+                ),
+            ],
+        )
+        assert res.exit_code == 0
+        assert f"Created work pool {pool_name!r}" in res.output
+        client_res = await prefect_client.read_work_pool(pool_name)
+        assert client_res.name == pool_name
+        assert isinstance(client_res, WorkPool)
+
+        # reload the profile to pick up change
+        profile = load_profile(settings_context.profile.name)
+        assert profile.settings.get(PREFECT_DEFAULT_WORK_POOL_NAME) == pool_name
 
 
 class TestInspect:

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -32,6 +32,7 @@ from prefect.logging.loggers import flow_run_logger
 from prefect.runner.runner import Runner
 from prefect.runner.server import perform_health_check
 from prefect.settings import (
+    PREFECT_DEFAULT_WORK_POOL_NAME,
     PREFECT_RUNNER_POLL_FREQUENCY,
     PREFECT_RUNNER_PROCESS_LIMIT,
     temporary_settings,
@@ -1085,6 +1086,60 @@ class TestDeploy:
             in console_output
         )
         assert "prefect deployment run [DEPLOYMENT_NAME]" in console_output
+
+    async def test_deploy_to_default_work_pool(
+        self,
+        mock_build_image,
+        mock_docker_client,
+        mock_generate_default_dockerfile,
+        work_pool_with_image_variable,
+        prefect_client: PrefectClient,
+        capsys,
+    ):
+        with temporary_settings(
+            updates={PREFECT_DEFAULT_WORK_POOL_NAME: work_pool_with_image_variable.name}
+        ):
+            deployment_ids = await deploy(
+                await dummy_flow_1.to_deployment(__file__),
+                await (
+                    await flow.from_source(
+                        source=MockStorage(), entrypoint="flows.py:test_flow"
+                    )
+                ).to_deployment(__file__),
+                image=DeploymentImage(
+                    name="test-registry/test-image",
+                    tag="test-tag",
+                ),
+            )
+            assert len(deployment_ids) == 2
+            mock_generate_default_dockerfile.assert_called_once()
+            mock_build_image.assert_called_once_with(
+                tag="test-registry/test-image:test-tag", context=Path.cwd(), pull=True
+            )
+            mock_docker_client.api.push.assert_called_once_with(
+                repository="test-registry/test-image",
+                tag="test-tag",
+                stream=True,
+                decode=True,
+            )
+
+            deployment_1 = await prefect_client.read_deployment_by_name(
+                f"{dummy_flow_1.name}/test_runner"
+            )
+            assert deployment_1.id == deployment_ids[0]
+
+            deployment_2 = await prefect_client.read_deployment_by_name(
+                "test-flow/test_runner"
+            )
+            assert deployment_2.id == deployment_ids[1]
+            assert deployment_2.pull_steps == [{"prefect.fake.module": {}}]
+
+            console_output = capsys.readouterr().out
+            assert (
+                f"prefect worker start --pool {work_pool_with_image_variable.name!r}"
+                in console_output
+            )
+            assert "prefect deployment run [DEPLOYMENT_NAME]" in console_output
 
     async def test_deploy_non_existent_work_pool(self):
         with pytest.raises(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Adds a new setting `PREFECT_DEFAULT_WORK_POOL_NAME` which controls the work pool that a flow will be deployed to if a work pool name is not explicitly given. This change is only client-side and will not persist between different machines.

When creating a work pool, users can add a `--set-as-default` flag to automatically update their current profile to point to the new work pool as the default.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Create a work pool and set it as the default:

```bash
prefect work-pool create --type process --set-as-default inflatable
```

Deploy a flow to the default work pool:

```python
from prefect import flow

if __name__ == "__main__":
    flow.from_source(
       source="https://github.com/desertaxle/demo.git",
       entrypoint="flow.py:my_flow",
    ).deploy(
        name="to-default-work-pool",
    )
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
