### PR TITLE
Use an unstarted flow run's expected start time for the Graph start time

### DIFF
--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -704,7 +704,10 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
         """Returns the query that selects all of the nodes and edges for a flow run
         graph (version 2)."""
         result = await session.execute(
-            sa.select(db.FlowRun.start_time, db.FlowRun.end_time).where(
+            sa.select(
+                sa.func.coalesce(db.FlowRun.start_time, db.FlowRun.expected_start_time),
+                db.FlowRun.end_time,
+            ).where(
                 db.FlowRun.id == flow_run_id,
             )
         )
@@ -1112,7 +1115,10 @@ class AioSqliteQueryComponents(BaseQueryComponents):
         """Returns the query that selects all of the nodes and edges for a flow run
         graph (version 2)."""
         result = await session.execute(
-            sa.select(db.FlowRun.start_time, db.FlowRun.end_time).where(
+            sa.select(
+                sa.func.coalesce(db.FlowRun.start_time, db.FlowRun.expected_start_time),
+                db.FlowRun.end_time,
+            ).where(
                 db.FlowRun.id == flow_run_id,
             )
         )


### PR DESCRIPTION
We're seeing a very small error rate of trying to set `Graph.start_time` to
`None` when reading a flow run graph, and it is due to unstarted flow runs
briefly having no `start_time` (just like we fixed with task runs).  This
affects the whole `Graph`, not the `Node`s, but the idea is the same: use the
`expected_start_time` if there's no `start_time`.
