### PR TITLE
Run tests with Pydantic V2 installed for all Python versions we support

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -236,6 +236,8 @@ jobs:
           - "oss-test-runner"
         python-version:
           - "3.8"
+          - "3.9"
+          - "3.10"
           - "3.11"
         pytest-options:
           - "--exclude-services"

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -223,7 +223,7 @@ jobs:
           || echo "Ignoring bad exit code"
 
 
-  # Run a smaller subset of tests with pydantic v2 installed, only the oldest and newest
+  # Run a smaller subset of tests with pydantic v2 installed, the
   # Python versions we support, and only on sqlite + postgres 14
   run-tests-pydantic-v2:
     name: pydantic v2, python:${{ matrix.python-version }}, ${{ matrix.database }}, ${{ matrix.pytest-options }}


### PR DESCRIPTION
Originates from #11149 

As we've had issues opened lately related to Pydantic V2, I would advocate for testing against all our Python versions (3.8, 3.9, 3.10, 3.11) instead of just (3.8 and 3.11).

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
