### PR TITLE
Prevent task args from logging on ParameterBindError

### DIFF
--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -204,7 +204,9 @@ class ParameterBindError(TypeError, PrefectException):
 
         base = f"Error binding parameters for function '{fn.__name__}': {exc}"
         signature = f"Function '{fn.__name__}' has signature '{fn_signature}'"
-        received = f"received args: {call_args} and kwargs: {list(call_kwargs.keys())}"
+        received = (
+            f"received {len(call_args)} args and kwargs: {list(call_kwargs.keys())}"
+        )
         msg = f"{base}.\n{signature} but {received}."
         return cls(msg)
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -85,7 +85,7 @@ class TestParameterBindError:
         type_error = TypeError("Demo TypeError")
         expected_str = (
             "Error binding parameters for function 'fn': Demo TypeError.\nFunction 'fn'"
-            " has signature 'a: int, b: str' but received args: () and kwargs: ['c',"
+            " has signature 'a: int, b: str' but received 0 args and kwargs: ['c',"
             " 'd']."
         )
         pbe = ParameterBindError.from_bind_failure(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

### Description
closes https://github.com/PrefectHQ/prefect/issues/11168

This is a followup to Issue https://github.com/PrefectHQ/prefect/issues/10294 and PR https://github.com/PrefectHQ/prefect/pull/10264. Full context is described in the linked issue above

Change: print number of call args provided to task instead of the args themselves in `ParameterBindError` message. This is to prevent accidental exposure of sensitive plaintext credentials, if those happen to be passed as args to a task

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

```python
from prefect import task, flow


@task
def my_task(arg1):
    pass


@flow
def my_flow():
    my_sensitive_credentials = {"username": "<username>", "password": "<password>"}
    another_arg = None

    # force ParameterBindError -- we know this task only takes one arg, but we 'accidentally' pass a second here
    my_task(my_sensitive_credentials, another_arg)


if __name__ == "__main__":
    my_flow()
```

Upon running the above example, the following error will throw and expose the sensitive credentials:

```
prefect.exceptions.ParameterBindError: Error binding parameters for function 'my_task': too many positional arguments.
Function 'my_task' has signature 'arg1' but received args: ({'username': '<username>', 'password': '<password>'}, None) and kwargs: [].
```

After the change in this PR, the exception will produce the following error message for this example instead:

```
prefect.exceptions.ParameterBindError: Error binding parameters for function 'my_task': too many positional arguments.
Function 'my_task' has signature 'arg1' but received 2 args and kwargs: [].
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
