### PR TITLE
add settings for worker webserver host and port

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1384,6 +1384,16 @@ The number of seconds into the future a worker should query for scheduled flow r
 Can be used to compensate for infrastructure start up time for a worker.
 """
 
+PREFECT_WORKER_WEBSERVER_HOST = Setting(str, default="0.0.0.0")
+"""
+The host address the worker's webserver should bind to.
+"""
+
+PREFECT_WORKER_WEBSERVER_PORT = Setting(int, default=8080)
+"""
+The port the worker's webserver should bind to.
+"""
+
 PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS = Setting(bool, default=True)
 """
 Whether or not to enable experimental Prefect artifacts.

--- a/src/prefect/workers/server.py
+++ b/src/prefect/workers/server.py
@@ -4,6 +4,10 @@ import uvicorn
 from prefect._vendor.fastapi import APIRouter, FastAPI, status
 from prefect._vendor.fastapi.responses import JSONResponse
 
+from prefect.settings import (
+    PREFECT_WORKER_WEBSERVER_HOST,
+    PREFECT_WORKER_WEBSERVER_PORT,
+)
 from prefect.workers.base import BaseWorker
 from prefect.workers.process import ProcessWorker
 
@@ -39,4 +43,9 @@ def start_healthcheck_server(
 
     webserver.include_router(router)
 
-    uvicorn.run(webserver, host="0.0.0.0", port=8080, log_level=log_level)
+    uvicorn.run(
+        webserver,
+        host=PREFECT_WORKER_WEBSERVER_HOST.value(),
+        port=PREFECT_WORKER_WEBSERVER_PORT.value(),
+        log_level=log_level,
+    )


### PR DESCRIPTION
adds settings to allow configuration of worker webserver:

```python
PREFECT_WORKER_WEBSERVER_HOST = Setting(str, default="0.0.0.0")
"""
The host address the worker's webserver should bind to.
"""

PREFECT_WORKER_WEBSERVER_PORT = Setting(int, default=8080)
"""
The port the worker's webserver should bind to.
"""
```

closes #11158

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
