### PR TITLE
Safely retrieve `flow_run_id` in `EventsWorker`

### DIFF
--- a/src/prefect/events/related.py
+++ b/src/prefect/events/related.py
@@ -68,16 +68,9 @@ async def related_resources_from_run_context(
     if not flow_run_context and not task_run_context:
         return []
 
-    flow_run_id: Optional[UUID] = None
-    if flow_run_context and flow_run_context.flow_run and flow_run_context.flow_run.id:
-        flow_run_id = flow_run_context.flow_run.id
-    elif (
-        task_run_context
-        and task_run_context.task_run
-        and task_run_context.task_run.flow_run_id
-    ):
-        flow_run_id = task_run_context.task_run.flow_run_id
-
+    flow_run_id: Optional[UUID] = getattr(
+        getattr(flow_run_context, "flow_run", None), "id", None
+    ) or getattr(getattr(task_run_context, "task_run", None), "flow_run_id", None)
     if flow_run_id is None:
         return []
 

--- a/src/prefect/events/related.py
+++ b/src/prefect/events/related.py
@@ -68,11 +68,18 @@ async def related_resources_from_run_context(
     if not flow_run_context and not task_run_context:
         return []
 
-    flow_run_id: UUID = (
-        flow_run_context.flow_run.id
-        if flow_run_context
-        else task_run_context.task_run.flow_run_id
-    )
+    flow_run_id: Optional[UUID] = None
+    if flow_run_context and flow_run_context.flow_run and flow_run_context.flow_run.id:
+        flow_run_id = flow_run_context.flow_run.id
+    elif (
+        task_run_context
+        and task_run_context.task_run
+        and task_run_context.task_run.flow_run_id
+    ):
+        flow_run_id = task_run_context.task_run.flow_run_id
+
+    if flow_run_id is None:
+        return []
 
     related_objects: list[ResourceCacheEntry] = []
 


### PR DESCRIPTION
This PR makes the way we're finding the `flow_run_id` more resilient by doing deeper inspection on objects. This removes an assumption that the `{flow_run,task_run}_contexts` are fully populated.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
