### PR TITLE
fix: Allow logs to handle un-uuid-like `flow_run_id`s

### DIFF
--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -214,7 +214,9 @@ class APILogHandler(logging.Handler):
         # from the standard lib `handleError` method if something goes wrong and
         # prevents malformed logs from entering the queue
         try:
-            is_uuid_like = isinstance(flow_run_id, str) and uuid.UUID(flow_run_id)
+            is_uuid_like = isinstance(flow_run_id, uuid.UUID) or (
+                isinstance(flow_run_id, str) and uuid.UUID(flow_run_id)
+            )
         except ValueError:
             is_uuid_like = False
 

--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -3,6 +3,7 @@ import logging
 import sys
 import time
 import traceback
+import uuid
 import warnings
 from contextlib import asynccontextmanager
 from typing import Any, Dict, List, Type, Union
@@ -212,8 +213,13 @@ class APILogHandler(logging.Handler):
         # Parsing to a `LogCreate` object here gives us nice parsing error messages
         # from the standard lib `handleError` method if something goes wrong and
         # prevents malformed logs from entering the queue
+        try:
+            is_uuid_like = isinstance(flow_run_id, str) and uuid.UUID(flow_run_id)
+        except ValueError:
+            is_uuid_like = False
+
         log = LogCreate(
-            flow_run_id=flow_run_id,
+            flow_run_id=flow_run_id if is_uuid_like else None,
             task_run_id=task_run_id,
             name=record.name,
             level=record.levelno,


### PR DESCRIPTION
This removes an assumption that emitted log records have a uuid-like `flow_run_id` by dropping the value before it creates the log structure. This should give us more flexibility in deciding how to handle missing ids while still shipping logs.  

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
