### PR TITLE
Add LIKE filtering for block document names

### DIFF
--- a/src/prefect/client/schemas/filters.py
+++ b/src/prefect/client/schemas/filters.py
@@ -723,6 +723,14 @@ class BlockDocumentFilterName(PrefectBaseModel):
     any_: Optional[List[str]] = Field(
         default=None, description="A list of block names to include"
     )
+    like_: Optional[str] = Field(
+        default=None,
+        description=(
+            "A string to match block names against. This can include "
+            "SQL wildcard characters like `%` and `_`."
+        ),
+        example="my-block%",
+    )
 
 
 class BlockDocumentFilter(PrefectBaseModel, OperatorMixin):

--- a/src/prefect/server/database/migrations/versions/postgresql/2023_11_20_084708_9c493c02ca6d_add_trgm_index_to_block_document_name.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2023_11_20_084708_9c493c02ca6d_add_trgm_index_to_block_document_name.py
@@ -1,0 +1,35 @@
+"""Add trgm index to block_document.name
+
+Revision ID: 9c493c02ca6d
+Revises: cef24af2ec34
+Create Date: 2023-11-20 08:47:08.929487
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9c493c02ca6d"
+down_revision = "cef24af2ec34"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS
+            trgm_ix_block_document_name
+            ON block_document USING gin (name gin_trgm_ops);
+            """
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            DROP INDEX CONCURRENTLY IF EXISTS
+            trgm_ix_block_document_name;
+            """
+        )

--- a/src/prefect/server/database/migrations/versions/sqlite/2023_11_20_084708_9c493c02ca6d_add_trgm_index_to_block_document_name.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2023_11_20_084708_9c493c02ca6d_add_trgm_index_to_block_document_name.py
@@ -1,0 +1,26 @@
+"""Add trgm index to block_document.name
+
+Revision ID: 9c493c02ca6d
+Revises: 22ef3915ccd8
+Create Date: 2023-11-20 08:47:08.929487
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9c493c02ca6d"
+down_revision = "22ef3915ccd8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        CREATE INDEX ix_block_document_name_case_insensitive on block_document (name COLLATE NOCASE);
+        """
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX ix_block_document_name_case_insensitive;")

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -1311,11 +1311,21 @@ class BlockDocumentFilterName(PrefectFilterBaseModel):
     any_: Optional[List[str]] = Field(
         default=None, description="A list of block names to include"
     )
+    like_: Optional[str] = Field(
+        default=None,
+        description=(
+            "A string to match block names against. This can include "
+            "SQL wildcard characters like `%` and `_`."
+        ),
+        example="my-block%",
+    )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
         filters = []
         if self.any_ is not None:
             filters.append(db.BlockDocument.name.in_(self.any_))
+        if self.like_ is not None:
+            filters.append(db.BlockDocument.name.ilike(f"%{self.like_}%"))
         return filters
 
 

--- a/tests/server/api/test_block_documents.py
+++ b/tests/server/api/test_block_documents.py
@@ -586,6 +586,18 @@ class TestReadBlockDocuments:
             block_documents[4].id,
         ]
 
+    async def test_read_block_documents_filter_name_like(self, client, block_documents):
+        response = await client.post(
+            "/block_documents/filter",
+            json=dict(block_documents=dict(name=dict(like_="nested"))),
+        )
+        assert response.status_code == 200
+        docs = pydantic.parse_obj_as(List[schemas.core.BlockDocument], response.json())
+        assert [b.id for b in docs] == [
+            block_documents[6].id,
+            block_documents[7].id,
+        ]
+
     async def test_read_block_documents_filter_multiple(self, client, block_documents):
         response = await client.post(
             "/block_documents/filter",


### PR DESCRIPTION
This PR adds fuzzy name matching for block documents as part of pagination work @pleek91 is doing.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
