### PR TITLE
Add pagination to blocks in the ui

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.8.0",
       "dependencies": {
         "@prefecthq/prefect-design": "2.0.14",
-        "@prefecthq/prefect-ui-library": "2.2.7",
+        "@prefecthq/prefect-ui-library": "2.3.0",
         "@prefecthq/vue-charts": "2.0.3",
         "@prefecthq/vue-compositions": "1.6.7",
         "@types/lodash.debounce": "4.0.9",
@@ -1282,9 +1282,9 @@
       }
     },
     "node_modules/@prefecthq/prefect-ui-library": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.2.7.tgz",
-      "integrity": "sha512-Tdyu/6HUOGXwgBu9GEc3R+xmuOL/72TZUKlHl6COoYrmRF/WvYHHlIyk3GMQWZPFR89NBqRGC2TkjyXdWoVf9w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.3.0.tgz",
+      "integrity": "sha512-2v4P5PGdBQOippNgueb7Jx5sT/5UEhIet8i8DAuvZkZleeqDIbuK+wDJcqDqu2Hm71Yaylqf1eBWwg068AvFNg==",
       "dependencies": {
         "@prefecthq/graphs": "2.1.7",
         "@types/lodash.isequal": "4.5.8",
@@ -7203,9 +7203,9 @@
       }
     },
     "@prefecthq/prefect-ui-library": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.2.7.tgz",
-      "integrity": "sha512-Tdyu/6HUOGXwgBu9GEc3R+xmuOL/72TZUKlHl6COoYrmRF/WvYHHlIyk3GMQWZPFR89NBqRGC2TkjyXdWoVf9w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.3.0.tgz",
+      "integrity": "sha512-2v4P5PGdBQOippNgueb7Jx5sT/5UEhIet8i8DAuvZkZleeqDIbuK+wDJcqDqu2Hm71Yaylqf1eBWwg068AvFNg==",
       "requires": {
         "@prefecthq/graphs": "2.1.7",
         "@types/lodash.isequal": "4.5.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@prefecthq/prefect-design": "2.0.14",
-    "@prefecthq/prefect-ui-library": "2.2.7",
+    "@prefecthq/prefect-ui-library": "2.3.0",
     "@prefecthq/vue-charts": "2.0.3",
     "@prefecthq/vue-compositions": "1.6.7",
     "@types/lodash.debounce": "4.0.9",

--- a/ui/src/pages/Blocks.vue
+++ b/ui/src/pages/Blocks.vue
@@ -8,7 +8,7 @@
         <BlocksPageEmptyState />
       </template>
       <template v-else>
-        <BlockDocumentsTable :block-documents="blockDocuments" @delete="blockDocumentsSubscription.refresh" />
+        <BlockDocumentsTable @delete="subscription.refresh" />
       </template>
     </template>
   </p-layout-default>
@@ -21,10 +21,9 @@
   import { usePageTitle } from '@/compositions/usePageTitle'
 
   const api = useWorkspaceApi()
-  const blockDocumentsSubscription = useSubscription(api.blockDocuments.getBlockDocuments)
-  const blockDocuments = computed(() => blockDocumentsSubscription.response ?? [])
-  const empty = computed(() => blockDocumentsSubscription.executed && blockDocuments.value.length == 0)
-  const loaded = computed(() => blockDocumentsSubscription.executed)
+  const subscription = useSubscription(api.blockDocuments.getBlockDocumentsCount)
+  const empty = computed(() => subscription.executed && subscription.response == 0)
+  const loaded = computed(() => subscription.executed)
 
   usePageTitle('Blocks')
 </script>


### PR DESCRIPTION
# Description
Adds pagination to the block documents page in the ui and replaces the browser side filtering and sorting with api filtering and sorting.

Needs: https://github.com/PrefectHQ/prefect-ui-library/pull/1876