### PR TITLE
Fix sqlite block type name backfill

### DIFF
--- a/src/prefect/server/database/migrations/versions/sqlite/2023_10_30_103720_22ef3915ccd8_index_and_backfill_block_type_name.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2023_10_30_103720_22ef3915ccd8_index_and_backfill_block_type_name.py
@@ -24,12 +24,9 @@ def upgrade():
         )
 
     backfill_query = """
-        WITH null_block_type_name_cte AS (SELECT id from block_document where block_type_name is null limit 500)
         UPDATE block_document
-        SET block_type_name = block_type.name
-        FROM block_type, null_block_type_name_cte
-        WHERE block_document.block_type_id = block_type.id
-        AND block_document.id = null_block_type_name_cte.id;
+        SET block_type_name = (SELECT name from block_type where block_type.id = block_document.block_type_id)
+        WHERE block_document.id in (SELECT id from block_document where block_type_name is null limit 500);
     """
 
     with op.get_context().autocommit_block():


### PR DESCRIPTION
This PR fixes a SQLite migration for backfilling `block_document.block_type_name`. The previous migration required SQLite functionality not supported by our minimum version.

Closes https://github.com/PrefectHQ/prefect/issues/11104

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [x] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
