### PR TITLE
docs: add hint for disabling logger in unit testing

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -27,7 +27,7 @@ def my_favorite_flow():
 def test_my_favorite_flow():
   with prefect_test_harness():
       # run the flow against a temporary testing database
-      assert my_favorite_flow() == 42 
+      assert my_favorite_flow() == 42
 ```
 
 For more extensive testing, you can leverage `prefect_test_harness` as a fixture in your unit testing framework. For example, when using `pytest`:
@@ -72,3 +72,13 @@ def my_favorite_flow():
 def test_my_favorite_task():
     assert my_favorite_task.fn() == 42
 ```
+
+!!! tip "Disable logger"
+    If your task makes use of a logger, you can disable the logger in order to avoid the `RuntimeError` raised from a missing flow context.
+    ```python
+    from prefect.logging import disable_run_logger
+
+    def test_my_favorite_task():
+        with disable_run_logger():
+            assert my_favorite_task.fn() == 42
+    ```

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -74,7 +74,7 @@ def test_my_favorite_task():
 ```
 
 !!! tip "Disable logger"
-    If your task makes use of a logger, you can disable the logger in order to avoid the `RuntimeError` raised from a missing flow context.
+    If your task makes uses a logger, you can disable the logger in order to avoid the `RuntimeError` raised from a missing flow context.
     ```python
     from prefect.logging import disable_run_logger
 


### PR DESCRIPTION
I've begun unit testing my flows, and used the [current guide](https://docs.prefect.io/latest/guides/testing/#unit-testing-tasks) to help me on my way. I use logging in my task and was unable to properly test it as I was running into:
```
RuntimeError: There is no active flow or task run context.
```

I then ran across [this solution](https://discourse.prefect.io/t/unit-testing-best-practices-for-prefect-flows-subflows-and-tasks/1070/10) - so I'm adding it to the docs to help the next person.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
