### PR TITLE
Use new route to read work pool types when connected to Prefect Cloud

### DIFF
--- a/src/prefect/client/cloud.py
+++ b/src/prefect/client/cloud.py
@@ -24,7 +24,7 @@ from prefect.settings import (
     PREFECT_UNIT_TEST_MODE,
 )
 
-PARSE_API_URL_REGEX = re.compile(r"accounts/(.{36})/workspaces/(.{36})\Z")
+PARSE_API_URL_REGEX = re.compile(r"accounts/(.{36})/workspaces/(.{36})")
 
 
 def get_cloud_client(

--- a/src/prefect/client/cloud.py
+++ b/src/prefect/client/cloud.py
@@ -24,6 +24,8 @@ from prefect.settings import (
     PREFECT_UNIT_TEST_MODE,
 )
 
+PARSE_API_URL_REGEX = re.compile(r"accounts/(.{36})/workspaces/(.{36})\Z")
+
 
 def get_cloud_client(
     host: Optional[str] = None,
@@ -41,7 +43,7 @@ def get_cloud_client(
         host = host or PREFECT_CLOUD_API_URL.value()
     else:
         configured_url = prefect.settings.PREFECT_API_URL.value()
-        host = re.sub(r"accounts/.{36}/workspaces/.{36}\Z", "", configured_url)
+        host = re.sub(PARSE_API_URL_REGEX, "", configured_url)
 
     return CloudClient(
         host=host,
@@ -86,7 +88,11 @@ class CloudClient:
         return pydantic.parse_obj_as(List[Workspace], await self.get("/me/workspaces"))
 
     async def read_worker_metadata(self) -> Dict[str, Any]:
-        return await self.get("collections/views/aggregate-worker-metadata")
+        configured_url = prefect.settings.PREFECT_API_URL.value()
+        account_id, workspace_id = re.findall(PARSE_API_URL_REGEX, configured_url)[0]
+        return await self.get(
+            f"accounts/{account_id}/workspaces/{workspace_id}/collections/work_pool_types"
+        )
 
     async def __aenter__(self):
         await self._client.__aenter__()

--- a/tests/client/test_cloud_client.py
+++ b/tests/client/test_cloud_client.py
@@ -1,5 +1,49 @@
+import uuid
+
+import httpx
+import pytest
+import respx
+from respx.patterns import M
+
 from prefect.client.cloud import get_cloud_client
-from prefect.settings import PREFECT_UNIT_TEST_MODE, temporary_settings
+from prefect.settings import PREFECT_API_URL, PREFECT_UNIT_TEST_MODE, temporary_settings
+
+mock_work_pool_types_response = (
+    {
+        "prefect": {
+            "prefect-agent": {
+                "type": "prefect-agent",
+                "default_base_job_configuration": {},
+            }
+        },
+        "prefect-kubernetes": {
+            "kubernetes": {
+                "type": "kubernetes",
+                "default_base_job_configuration": {},
+            }
+        },
+    },
+)
+
+
+@pytest.fixture
+async def mock_work_pool_types():
+    with respx.mock(
+        assert_all_mocked=False, base_url=PREFECT_API_URL.value()
+    ) as respx_mock:
+        respx_mock.route(
+            M(
+                path__regex=(
+                    r"accounts/(.{36})/workspaces/(.{36})/collections/work_pool_types"
+                )
+            ),
+            method="GET",
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json=mock_work_pool_types_response,
+            )
+        )
 
 
 async def test_cloud_client_follow_redirects():
@@ -19,3 +63,15 @@ async def test_cloud_client_follow_redirects():
     # do not follow redirects by default during unit tests
     async with get_cloud_client() as client:
         assert client._client.follow_redirects is False
+
+
+async def test_get_cloud_work_pool_types(mock_work_pool_types):
+    account_id = uuid.uuid4()
+    workspace_id = uuid.uuid4()
+    with temporary_settings(
+        updates={
+            PREFECT_API_URL: f"https://api.prefect.cloud/api/accounts/{account_id}/workspaces/{workspace_id}/"
+        }
+    ):
+        async with get_cloud_client() as client:
+            assert await client.read_worker_metadata() == mock_work_pool_types_response

--- a/tests/client/test_cloud_client.py
+++ b/tests/client/test_cloud_client.py
@@ -8,22 +8,20 @@ from respx.patterns import M
 from prefect.client.cloud import get_cloud_client
 from prefect.settings import PREFECT_API_URL, PREFECT_UNIT_TEST_MODE, temporary_settings
 
-mock_work_pool_types_response = (
-    {
-        "prefect": {
-            "prefect-agent": {
-                "type": "prefect-agent",
-                "default_base_job_configuration": {},
-            }
-        },
-        "prefect-kubernetes": {
-            "kubernetes": {
-                "type": "kubernetes",
-                "default_base_job_configuration": {},
-            }
-        },
+mock_work_pool_types_response = {
+    "prefect": {
+        "prefect-agent": {
+            "type": "prefect-agent",
+            "default_base_job_configuration": {},
+        }
     },
-)
+    "prefect-kubernetes": {
+        "kubernetes": {
+            "type": "kubernetes",
+            "default_base_job_configuration": {},
+        }
+    },
+}
 
 
 @pytest.fixture
@@ -44,6 +42,7 @@ async def mock_work_pool_types():
                 json=mock_work_pool_types_response,
             )
         )
+        yield
 
 
 async def test_cloud_client_follow_redirects():
@@ -74,4 +73,5 @@ async def test_get_cloud_work_pool_types(mock_work_pool_types):
         }
     ):
         async with get_cloud_client() as client:
-            assert await client.read_worker_metadata() == mock_work_pool_types_response
+            response = await client.read_worker_metadata()
+            assert response == mock_work_pool_types_response


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Updates `read_worker_metadata` method on `CloudClient` to use new workspace scoped route to read available work pool types and their metadata.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
