### PR TITLE
[ci] check tag format in release ci

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -11,6 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check release tag format
+        run: |
+          TAG_REGEX='^[0-9]+\.[0-9]+\.[0-9]+$'
+          if [[ ! "${{ github.ref }}" =~ $TAG_REGEX ]]; then
+            echo "Release tag '${{ github.ref }}' is not in the correct format. It should be a semver tag, e.g. '1.2.3'."
+            exit 1
+          fi
       - uses: actions/checkout@v4
         with:
           # Versioneer only generates correct versions with a full fetch


### PR DESCRIPTION
to avoid future erroneous release tags (like `v2.14.6` instead of `2.14.6`), we should fail the PyPI build/publish CI early