### PR TITLE
[deploy ux] fix install when `requires` more than one package

### DIFF
--- a/src/prefect/deployments/steps/core.py
+++ b/src/prefect/deployments/steps/core.py
@@ -84,7 +84,7 @@ def _get_function_for_step(
 
     try:
         subprocess.check_call(
-            [get_sys_executable(), "-m", "pip", "install", ",".join(packages)]
+            [get_sys_executable(), "-m", "pip", "install", *packages],
         )
     except subprocess.CalledProcessError:
         get_logger("deployments.steps.core").warning(

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -177,7 +177,7 @@ class TestRunStep:
 
         import_module_mock.assert_has_calls([call("test_package"), call("another")])
         subprocess.check_call.assert_called_once_with(
-            [sys.executable, "-m", "pip", "install", "test-package>=1.0.0,another"]
+            [sys.executable, "-m", "pip", "install", "test-package>=1.0.0", "another"]
         )
 
     async def test_requirement_installation_failure(self, monkeypatch, caplog):


### PR DESCRIPTION
closes #11243

spreads `packages` into `check_call` to avoid this error
```python
subprocess.CalledProcessError: Command '['/bin/python', '-m', 'pip', 'install', 'prefect-aws==0.4.2,mysecondpackage==0.0.1']' returned non-zero exit status 1.
```

cc @desertaxle - just making sure I'm not misunderstanding the intent of #11111 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
