### PR TITLE
remove push work pool concurrency warning in docs

### DIFF
--- a/docs/guides/deployment/push-work-pools.md
+++ b/docs/guides/deployment/push-work-pools.md
@@ -77,7 +77,7 @@ Our push work pool will store information about what type of infrastructure our 
 
     Navigate to the blocks page, click create new block, and select AWS Credentials for the type.
     
-    For use in a push work pool, this block must have the region and cluster name filled out, in addition to access key and access key secret.
+    For use in a push work pool, this block must have the region filled out, in addition to access key and access key secret.
 
     Provide any other optional information and create your block.
 
@@ -116,10 +116,6 @@ Now navigate to the work pools page. Click create to start configuring your push
     Each step has several optional fields that are detailed in the [work pools](/concepts/work-pools/) documentation. For our purposes, select the block you created under the GCP Credentials field. This will allow Prefect Cloud to securely interact with your GCP project.
 
 Create your pool and you are ready to deploy flows to your Push work pool.
-
-!!! note "Push work pool concurrency"
-
-    Push work pools do not have a concurrency setting. If you would like to control concurrency at the flow level, you can use [global concurrency limits](/guides/global-concurrency-limits/).
 
 ## Deployment
 


### PR DESCRIPTION
Some push work pools docs updates:
- push work pools can now have concurrency limits
- the cluster name doesn't go in an AWS Credentials block

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
