### PR TITLE
[ci] allow adhoc release from certain commit

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -3,6 +3,13 @@ name: Publish Python package
 on:
   release:
     types: [released, prereleased]
+  # ADDED this bit
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit to build from"
+        required: true
+        default: "main"
 
 jobs:
   build-pypi-dists:
@@ -20,6 +27,7 @@ jobs:
           fi
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.inputs.commit }}
           # Versioneer only generates correct versions with a full fetch
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -3,7 +3,6 @@ name: Publish Python package
 on:
   release:
     types: [released, prereleased]
-  # ADDED this bit
   workflow_dispatch:
     inputs:
       commit:

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - name: Check release tag format
         run: |
-          TAG_REGEX='^[0-9]+\.[0-9]+\.[0-9]+$'
+          TAG_REGEX='refs/tags/[0-9]+\.[0-9]+\.[0-9]+$'
           if [[ ! "${{ github.ref }}" =~ $TAG_REGEX ]]; then
-            echo "Release tag '${{ github.ref }}' is not in the correct format. It should be a semver tag, e.g. '1.2.3'."
+            echo "Release tag '${{ github.ref }}' is not in the correct format. It should be a semver tag, e.g. 'refs/tags/1.2.3'."
             exit 1
           fi
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds an escape hatch to allow the `Publish Python package` workflow to run in isolation from a specific commit SHA (or generally, any valid `ref` as accepted by `actions/checkout@v4`)

In particular, this is motivated by a [failure in the `Publish Python package` workflow upon creation of the `2.14.7`](https://github.com/PrefectHQ/prefect/actions/runs/7023267856) where all other release-triggered CI completed successfully (docker images, docs etc) but the publish to PyPI did not.

Note: we've verified that the docker images do in fact contain the correct version of the code, which is correctly versioned as `2.14.7`, its just PyPI that doesn't have 2.14.7

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
