### PR TITLE
temporarily remove tag check to allow release from 2.14.7 tag

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -17,13 +17,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check release tag format
-        run: |
-          TAG_REGEX='refs/tags/[0-9]+\.[0-9]+\.[0-9]+$'
-          if [[ ! "${{ github.ref }}" =~ $TAG_REGEX ]]; then
-            echo "Release tag '${{ github.ref }}' is not in the correct format. It should be a semver tag, e.g. 'refs/tags/1.2.3'."
-            exit 1
-          fi
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commit }}


### PR DESCRIPTION
the tag check as is checks the `ref`, which must be `main` if supplying a `commit` to build from in the new `workflow_dispatch`

therefore, to get 2.14.7 properly published on PyPI we will **temporarily** remove the tag check and add it back once this is released

cc @zhen0 