### PR TITLE
Fix URL formatting in `GitRepository` when using provider-specific git credentials blocks

### DIFF
--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -9,11 +9,17 @@ import fsspec
 from anyio import run_process
 
 from prefect._internal.concurrency.api import create_call, from_async
+from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect.blocks.core import Block, BlockNotSavedError
 from prefect.blocks.system import Secret
 from prefect.filesystems import ReadableDeploymentStorage, WritableDeploymentStorage
 from prefect.logging.loggers import get_logger
 from prefect.utilities.collections import visit_collection
+
+if HAS_PYDANTIC_V2:
+    from pydantic.v1 import SecretStr
+else:
+    from pydantic import SecretStr
 
 
 @runtime_checkable
@@ -156,8 +162,12 @@ class GitRepository:
             if isinstance(self._credentials, Block)
             else deepcopy(self._credentials)
         )
-        if isinstance(credentials.get("access_token"), Secret):
-            credentials["access_token"] = credentials["access_token"].get()
+
+        for k, v in credentials.items():
+            if isinstance(v, Secret):
+                credentials[k] = v.get()
+            elif isinstance(v, SecretStr):
+                credentials[k] = v.get_secret_value()
 
         formatted_credentials = _format_token_from_credentials(
             urlparse(self._url).netloc, credentials

--- a/tests/runner/test_storage.py
+++ b/tests/runner/test_storage.py
@@ -4,8 +4,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Optional
 
-import pytest
-
+from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect.blocks.core import Block, BlockNotSavedError
 from prefect.blocks.system import Secret
 from prefect.deployments.steps.core import run_step
@@ -18,6 +17,12 @@ from prefect.runner.storage import (
     create_storage_from_url,
 )
 from prefect.testing.utilities import AsyncMock, MagicMock
+
+if HAS_PYDANTIC_V2:
+    from pydantic.v1 import SecretStr
+else:
+    from pydantic import SecretStr
+import pytest
 
 
 class TestCreateStorageFromUrl:
@@ -72,9 +77,9 @@ def mock_run_process(monkeypatch):
 
 
 class MockCredentials(Block):
-    token: Optional[str] = None
+    token: Optional[SecretStr] = None
     username: Optional[str] = None
-    password: Optional[str] = None
+    password: Optional[SecretStr] = None
 
 
 class TestGitRepository:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
URL formatting in `GitRepository` is not unwrapping `SecretStr` values from credentials blocks, causing errors. This PR updates the handling to ensure we are unwrapping all `Secret` blocks and `SecretStr` fields.

Closes https://github.com/PrefectHQ/prefect/issues/11279

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
