### PR TITLE
Create `suspend_flow_run` method to suspend a flow run.

### DIFF
--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -44,7 +44,7 @@ from prefect.context import tags
 from prefect.manifests import Manifest
 from prefect.utilities.annotations import unmapped, allow_failure
 from prefect.results import BaseResult
-from prefect.engine import pause_flow_run, resume_flow_run
+from prefect.engine import pause_flow_run, resume_flow_run, suspend_flow_run
 from prefect.client.orchestration import get_client, PrefectClient
 from prefect.client.cloud import get_cloud_client, CloudClient
 import prefect.variables
@@ -172,4 +172,7 @@ __all__ = [
     "Runner",
     "serve",
     "deploy",
+    "pause_flow_run",
+    "resume_flow_run",
+    "suspend_flow_run",
 ]

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -172,6 +172,7 @@ from prefect.states import (
     Pending,
     Running,
     State,
+    Suspended,
     exception_to_crashed_state,
     exception_to_failed_state,
     get_state_exception,
@@ -949,7 +950,7 @@ async def pause_flow_run(
     key: str = None,
 ):
     """
-    Pauses the current flow run by stopping execution until resumed.
+    Pauses the current flow run by blocking execution until resumed.
 
     When called within a flow run, execution will block and no downstream tasks will
     run until the flow is resumed. Task runs that have already started will continue
@@ -1086,6 +1087,90 @@ async def _out_of_process_pause(
     )
     if response.status != SetStateStatus.ACCEPT:
         raise RuntimeError(response.details.reason)
+
+
+@sync_compatible
+@inject_client
+async def suspend_flow_run(
+    flow_run_id: Optional[UUID] = None,
+    timeout: Optional[int] = 300,
+    key: Optional[str] = None,
+    client: PrefectClient = None,
+):
+    """
+    Suspends a flow run by stopping code execution until resumed.
+
+    When suspended, the flow run will continue execution until the NEXT task is
+    orchestrated, at which point the flow will exit. Any tasks that have
+    already started will run until completion. When resumed, the flow run will
+    be rescheduled to finish execution. In order suspend a flow run in this
+    way, the flow needs to have an associated deployment and results need to be
+    configured with the `persist_results` option.
+
+    Args:
+        flow_run_id: a flow run id. If supplied, this function will attempt to
+            suspend the specified flow run. If not supplied will attempt to
+            suspend the current flow run.
+        timeout: the number of seconds to wait for the flow to be resumed before
+            failing. Defaults to 5 minutes (300 seconds). If the pause timeout
+            exceeds any configured flow-level timeout, the flow might fail even
+            after resuming.
+        key: An optional key to prevent calling suspend more than once. This
+            defaults to a random string and prevents suspends from running the
+            same suspend twice. A custom key can be supplied for custom
+            suspending behavior.
+    """
+    context = FlowRunContext.get()
+
+    if flow_run_id is None:
+        if TaskRunContext.get():
+            raise RuntimeError("Cannot suspend task runs.")
+
+        if context is None or context.flow_run is None:
+            raise RuntimeError(
+                "Flow runs can only be suspended from within a flow run."
+            )
+
+        logger = get_run_logger(context=context)
+        logger.info(
+            "Suspending flow run, execution will be rescheduled when this flow run is"
+            " resumed."
+        )
+        flow_run_id = context.flow_run.id
+        suspending_current_flow_run = True
+        pause_counter = _observed_flow_pauses(context)
+        pause_key = key or str(pause_counter)
+    else:
+        # Since we're suspending another flow run we need to generate a pause
+        # key that won't conflict with whatever suspends/pauses that flow may
+        # have. Since this method won't be called during that flow run it's
+        # okay that this is non-deterministic.
+        suspending_current_flow_run = False
+        pause_key = key or str(uuid4())
+
+    try:
+        state = await propose_state(
+            client=client,
+            state=Suspended(timeout_seconds=timeout, pause_key=pause_key),
+            flow_run_id=flow_run_id,
+        )
+    except Abort as exc:
+        # Aborted requests mean the suspension is not allowed
+        raise RuntimeError(f"Flow run cannot be suspended: {exc}")
+
+    if state.is_running():
+        # The orchestrator requests that this suspend be ignored
+        return
+
+    if not state.is_paused():
+        # If we receive anything but a PAUSED state, we are unable to continue
+        raise RuntimeError(
+            f"Flow run cannot be suspended. Received unexpected state from API: {state}"
+        )
+
+    if suspending_current_flow_run:
+        # Exit this process so the run can be resubmitted later
+        raise Pause()
 
 
 @sync_compatible

--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -1,7 +1,7 @@
 """
 Orchestration logic that fires on state transitions.
 
-`CoreFlowPolicy` and `CoreTaskPolicy` contain all default orchestration rules that 
+`CoreFlowPolicy` and `CoreTaskPolicy` contain all default orchestration rules that
 Prefect enforces on a state transition.
 """
 
@@ -467,7 +467,7 @@ class WaitForScheduledTime(BaseOrchestrationRule):
 
 class HandlePausingFlows(BaseOrchestrationRule):
     """
-    Governs runs attempting to enter a Paused state
+    Governs runs attempting to enter a Paused/Suspended state
     """
 
     FROM_STATES = ALL_ORCHESTRATION_STATES
@@ -479,13 +479,16 @@ class HandlePausingFlows(BaseOrchestrationRule):
         proposed_state: Optional[states.State],
         context: TaskOrchestrationContext,
     ) -> None:
+        verb = "suspend" if proposed_state.name == "Suspended" else "pause"
+
         if initial_state is None:
-            await self.abort_transition("Cannot pause flows with no state.")
+            await self.abort_transition(f"Cannot {verb} flows with no state.")
             return
 
         if not initial_state.is_running():
             await self.reject_transition(
-                state=None, reason="Cannot pause flows that are not currently running."
+                state=None,
+                reason=f"Cannot {verb} flows that are not currently running.",
             )
             return
 
@@ -496,23 +499,20 @@ class HandlePausingFlows(BaseOrchestrationRule):
 
         if self.key in context.run.empirical_policy.pause_keys:
             await self.reject_transition(
-                state=None, reason="This pause has already fired."
+                state=None, reason=f"This {verb} has already fired."
             )
             return
 
         if proposed_state.state_details.pause_reschedule:
             if context.run.parent_task_run_id:
                 await self.abort_transition(
-                    reason="Cannot pause subflows with the reschedule option.",
+                    reason=f"Cannot {verb} subflows.",
                 )
                 return
 
             if context.run.deployment_id is None:
                 await self.abort_transition(
-                    reason=(
-                        "Cannot pause flows without a deployment with the reschedule"
-                        " option."
-                    ),
+                    reason=f"Cannot {verb} flows without a deployment.",
                 )
                 return
 
@@ -555,21 +555,28 @@ class HandleResumingPausedFlows(BaseOrchestrationRule):
             )
             return
 
+        verb = "suspend" if proposed_state.name == "Suspended" else "pause"
+
         if initial_state.state_details.pause_reschedule:
             if not context.run.deployment_id:
                 await self.reject_transition(
                     state=None,
-                    reason="Cannot reschedule a paused flow run without a deployment.",
+                    reason=(
+                        f"Cannot reschedule a {proposed_state.name.lower()} flow run"
+                        " without a deployment."
+                    ),
                 )
                 return
         pause_timeout = initial_state.state_details.pause_timeout
         if pause_timeout and pause_timeout < pendulum.now("UTC"):
             pause_timeout_failure = states.Failed(
-                message="The flow was paused and never resumed.",
+                message=(
+                    f"The flow was {proposed_state.name.lower()} and never resumed."
+                ),
             )
             await self.reject_transition(
                 state=pause_timeout_failure,
-                reason="The flow run pause has timed out and can no longer resume.",
+                reason=f"The flow run {verb} has timed out and can no longer resume.",
             )
             return
 

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -568,10 +568,10 @@ def Pending(cls: Type[State] = State, **kwargs) -> State:
 
 def Paused(
     cls: Type[State] = State,
-    timeout_seconds: int = None,
-    pause_expiration_time: datetime.datetime = None,
+    timeout_seconds: Optional[int] = None,
+    pause_expiration_time: Optional[datetime.datetime] = None,
     reschedule: bool = False,
-    pause_key: str = None,
+    pause_key: Optional[str] = None,
     **kwargs,
 ) -> State:
     """Convenience function for creating `Paused` states.
@@ -600,6 +600,29 @@ def Paused(
     state_details.pause_key = pause_key
 
     return cls(type=StateType.PAUSED, state_details=state_details, **kwargs)
+
+
+def Suspended(
+    cls: Type[State] = State,
+    timeout_seconds: Optional[int] = None,
+    pause_expiration_time: Optional[datetime.datetime] = None,
+    pause_key: Optional[str] = None,
+    **kwargs,
+):
+    """Convenience function for creating `Suspended` states.
+
+    Returns:
+        State: a Suspended state
+    """
+    return Paused(
+        cls=cls,
+        name="Suspended",
+        reschedule=True,
+        timeout_seconds=timeout_seconds,
+        pause_expiration_time=pause_expiration_time,
+        pause_key=pause_key,
+        **kwargs,
+    )
 
 
 def AwaitingRetry(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -38,6 +38,7 @@ from prefect.engine import (
     propose_state,
     resume_flow_run,
     retrieve_flow_then_begin_flow_run,
+    suspend_flow_run,
 )
 from prefect.exceptions import (
     Abort,
@@ -551,6 +552,143 @@ class TestOutOfProcessPause:
         assert state.state_details.pause_timeout == date
         assert state.state_details.pause_reschedule is False
         assert state.state_details.pause_key == "foo"
+
+
+class TestSuspendFlowRun:
+    async def test_suspended_flow_runs_do_not_block_execution(
+        self, prefect_client, deployment, session
+    ):
+        flow_run_id = None
+
+        @flow()
+        async def suspending_flow():
+            nonlocal flow_run_id
+            context = get_run_context()
+            assert context.flow_run
+            flow_run_id = context.flow_run.id
+
+            from prefect.server.models.flow_runs import update_flow_run
+
+            await update_flow_run(
+                session,
+                flow_run_id,
+                FlowRun.construct(deployment_id=deployment.id),
+            )
+            await session.commit()
+
+            await suspend_flow_run()
+            await asyncio.sleep(20)
+
+        start = time.time()
+        with pytest.raises(Pause):
+            await suspending_flow()
+        end = time.time()
+        assert end - start < 20
+
+    async def test_suspended_flow_run_has_correct_state(
+        self, prefect_client, deployment, session
+    ):
+        flow_run_id = None
+
+        @flow()
+        async def suspending_flow():
+            nonlocal flow_run_id
+            context = get_run_context()
+            assert context.flow_run
+            flow_run_id = context.flow_run.id
+
+            from prefect.server.models.flow_runs import update_flow_run
+
+            await update_flow_run(
+                session,
+                flow_run_id,
+                FlowRun.construct(deployment_id=deployment.id),
+            )
+            await session.commit()
+
+            await suspend_flow_run()
+
+        with pytest.raises(Pause):
+            await suspending_flow()
+
+        flow_run = await prefect_client.read_flow_run(flow_run_id)
+        state = flow_run.state
+        assert state.is_paused()
+        assert state.name == "Suspended"
+
+    async def test_suspending_flow_run_without_deployment_fails(self):
+        @flow()
+        async def suspending_flow():
+            await suspend_flow_run()
+
+        with pytest.raises(
+            RuntimeError, match="Cannot suspend flows without a deployment."
+        ):
+            await suspending_flow()
+
+    async def test_suspending_sub_flow_run_fails(self):
+        @flow()
+        async def suspending_flow():
+            await suspend_flow_run()
+
+        @flow
+        async def main_flow():
+            await suspending_flow()
+
+        with pytest.raises(RuntimeError, match="Cannot suspend subflows."):
+            await main_flow()
+
+    async def test_suspend_flow_run_by_id(self, deployment, session):
+        flow_run_id = None
+        task_completions = 0
+
+        @task
+        async def increment_completions():
+            nonlocal task_completions
+            task_completions += 1
+            await asyncio.sleep(0.1)
+
+        @flow()
+        async def suspendable_flow():
+            nonlocal flow_run_id
+            context = get_run_context()
+            assert context.flow_run
+
+            from prefect.server.models.flow_runs import update_flow_run
+
+            await update_flow_run(
+                session,
+                context.flow_run.id,
+                FlowRun.construct(deployment_id=deployment.id),
+            )
+            await session.commit()
+
+            flow_run_id = context.flow_run.id
+
+            for i in range(20):
+                await increment_completions()
+
+        @flow()
+        async def suspending_flow():
+            nonlocal flow_run_id
+
+            while flow_run_id is None:
+                await asyncio.sleep(0.1)
+
+            # Sleep for a bit to let some of `suspendable_flow`s tasks complete
+            await asyncio.sleep(0.3)
+
+            await suspend_flow_run(flow_run_id=flow_run_id)
+
+        with pytest.raises(asyncio.exceptions.CancelledError):
+            await asyncio.gather(suspendable_flow(), suspending_flow())
+
+        # When suspending a flow run by id, that flow run must use tasks for
+        # the suspension to take place. This setup allows for `suspendable_flow`
+        # to complete some tasks before `suspending_flow` suspends the flow run.
+        # Here then we check to ensure that some tasks completed but not _all_
+        # of the tasks.
+        assert task_completions > 0 and task_completions < 20
 
 
 class TestOrchestrateTaskRun:


### PR DESCRIPTION
This creates the `suspend_flow_run` method. This method similar to calling `pause_flow_run` with `reschedule=True`, but disambiguates the concept of pause vs suspend. When a flow run is paused code execution is blocked and the process continues to run, when a flow run is suspended, code execution is stopped as is the process.

Closes #11271 

### Example
```python
from prefect import flow, task, suspend_flow_run


@task
async def get_tree(n) -> str:
    return ["🌲", "🌳", "🌴"][n]


@task
async def display_tree(tree: str) -> None:
    print(tree)


@flow
async def happy(num_trees: int = 3):
    trees = []
    for i in range(num_trees):
        # tree_n = random.randint(0, 2)
        state = await get_tree.submit(i)
        trees.append(await state.result())

    await suspend_flow_run()

    for tree in trees:
        await display_tree(tree)


if __name__ == "__main__":
    happy.serve(name="happy-trees")
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
