### PR TITLE
init: add target_directory to git_clone

### DIFF
--- a/src/prefect/deployments/steps/pull.py
+++ b/src/prefect/deployments/steps/pull.py
@@ -36,6 +36,7 @@ async def git_clone(
     include_submodules: bool = False,
     access_token: Optional[str] = None,
     credentials: Optional[Block] = None,
+    target_directory: Optional[str] = None,
 ) -> dict:
     """
     Clones a git repository into the current working directory.
@@ -114,6 +115,7 @@ async def git_clone(
     credentials = {"access_token": access_token} if access_token else credentials
 
     storage = GitRepository(
+        name=target_directory,
         url=repository,
         credentials=credentials,
         branch=branch,

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -477,6 +477,56 @@ class TestGitCloneStep:
         )
         git_repository_mock.return_value.pull_code.assert_awaited_once()
 
+    async def test_git_clone_with_template_name(self, git_repository_mock):
+        template_name = "{{ repository }}-{{ branch }}-foo"
+        expected_name = "repo-main-foo"
+
+        output = await run_step(
+            {
+                "prefect.deployments.steps.git_clone": {
+                    "repository": "https://github.com/org/repo.git",
+                    "target_directory": template_name,
+                }
+            }
+        )
+
+        assert output["directory"] == expected_name
+
+        git_repository_mock.assert_called_once_with(
+            url="https://github.com/org/repo.git",
+            credentials=None,
+            branch=None,
+            include_submodules=False,
+            name=expected_name,
+        )
+        git_repository_mock.return_value.pull_code.assert_awaited_once()
+
+    async def test_git_clone_with_bad_template_name_falls_back_to_default(
+        self, git_repository_mock
+    ):
+        template_name = "🎶 It's the end of the world as we know it 🎶"
+        expected_name = "repo-main"
+
+        output = await run_step(
+            {
+                "prefect.deployments.steps.git_clone": {
+                    "repository": "https://github.com/org/repo.git",
+                    "target_directory": template_name,
+                }
+            }
+        )
+
+        assert output["directory"] == expected_name
+
+        git_repository_mock.assert_called_once_with(
+            url="https://github.com/org/repo.git",
+            credentials=None,
+            branch=None,
+            include_submodules=False,
+            name=expected_name,
+        )
+        git_repository_mock.return_value.pull_code.assert_awaited_once()
+
 
 class TestPullFromRemoteStorage:
     @pytest.fixture


### PR DESCRIPTION
## Example
```yaml
- name: custom-clone-dir
  entrypoint: src/demo_project/test.py:random_flow
  work_pool:
    name: local
  schedule: null
  pull:
  - prefect.deployments.steps.git_clone:
      repository: https://github.com/zzstoatzz/prefect-monorepo
      target_directory: "{{ repository }}"
  - prefect.deployments.steps.run_shell_script:
      script: ls prefect-monorepo
```

<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
