### PR TITLE
Add ability to provision infrastructure for an existing work pool

### DIFF
--- a/src/prefect/cli/_types.py
+++ b/src/prefect/cli/_types.py
@@ -108,8 +108,8 @@ class PrefectTyper(typer.Typer):
 
     def command(
         self,
-        aliases: List[str] = None,
         *args,
+        aliases: List[str] = None,
         **kwargs,
     ):
         """

--- a/src/prefect/cli/_types.py
+++ b/src/prefect/cli/_types.py
@@ -106,8 +106,16 @@ class PrefectTyper(typer.Typer):
             typer_instance, *args, no_args_is_help=no_args_is_help, **kwargs
         )
 
-    def command(self, *args, **kwargs):
-        command_decorator = super().command(*args, **kwargs)
+    def command(
+        self,
+        aliases: List[str] = None,
+        *args,
+        **kwargs,
+    ):
+        """
+        Create a new command. If aliases are provided, the same command function
+        will be registered with multiple names.
+        """
 
         def wrapper(fn):
             if is_async_fn(fn):
@@ -115,6 +123,20 @@ class PrefectTyper(typer.Typer):
             fn = with_cli_exception_handling(fn)
             if self.deprecated:
                 fn = with_deprecated_message(self.deprecated_message)(fn)
-            return command_decorator(fn)
+
+            # register fn with its original name
+            command_decorator = super(PrefectTyper, self).command(*args, **kwargs)
+            original_command = command_decorator(fn)
+
+            # register fn for each alias, e.g. @marvin_app.command(aliases=["r"])
+            if aliases:
+                for alias in aliases:
+                    super(PrefectTyper, self).command(
+                        name=alias,
+                        *args,
+                        **{k: v for k, v in kwargs.items() if k != "aliases"},
+                    )(fn)
+
+            return original_command
 
         return wrapper

--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -393,6 +393,8 @@ async def provision_infrastructure(
     Examples:
         $ prefect work-pool provision-infrastructure "my-pool"
 
+        $ prefect work-pool provision-infra "my-pool"
+
     """
     async with get_client() as client:
         try:

--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -380,8 +380,8 @@ async def update(
         exit_with_success(f"Updated work pool {name!r}")
 
 
-@work_pool_app.command()
-async def provision_infra(
+@work_pool_app.command(aliases=["provision-infra"])
+async def provision_infrastructure(
     name: str = typer.Argument(
         ..., help="The name of the work pool to provision infrastructure for."
     ),
@@ -394,8 +394,6 @@ async def provision_infra(
         $ prefect work-pool provision-infrastructure "my-pool"
 
     """
-    if not name:
-        exit_with_error("Work pool name cannot be empty.")
     async with get_client() as client:
         try:
             work_pool = await client.read_work_pool(work_pool_name=name)

--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -420,8 +420,11 @@ async def provision_infra(
         except ValueError as exc:
             app.console.print(f"Error: {exc}")
             app.console.print(
-                "Automatic infrastructure provisioning is not supported for"
-                f" {work_pool.type!r} work pools."
+                (
+                    "Automatic infrastructure provisioning is not supported for"
+                    f" {work_pool.type!r} work pools."
+                ),
+                style="yellow",
             )
         except RuntimeError as exc:
             exit_with_error(

--- a/src/prefect/infrastructure/provisioners/cloud_run.py
+++ b/src/prefect/infrastructure/provisioners/cloud_run.py
@@ -259,6 +259,12 @@ class CloudRunPushProvisioner:
             ] = {"$ref": {"block_document_id": str(block_doc_id)}}
             progress.advance(task)
 
-        self._console.print("Infrastructure successfully provisioned!", style="green")
+        self._console.print(
+            (
+                f"Infrastructure successfully provisioned for '{work_pool_name}' work"
+                " pool!"
+            ),
+            style="green",
+        )
 
         return base_job_template_copy

--- a/src/prefect/infrastructure/provisioners/container_instance.py
+++ b/src/prefect/infrastructure/provisioners/container_instance.py
@@ -787,5 +787,11 @@ class ContainerInstancePushProvisioner:
             "default"
         ] = self._subscription_id
 
-        self._console.print("Infrastructure successfully provisioned!", style="green")
+        self._console.print(
+            (
+                f"Infrastructure successfully provisioned for '{work_pool_name}' work"
+                " pool!"
+            ),
+            style="green",
+        )
         return base_job_template_copy

--- a/tests/cli/test_typer_utils.py
+++ b/tests/cli/test_typer_utils.py
@@ -35,3 +35,23 @@ class TestPrefectTyper:
             expected_output_contains="hello",
             expected_code=0,
         )
+
+    def test_command_with_alias(self):
+        # Add a command with an alias
+        @self.pluralized_subcommand.command(aliases=["test-cmd-alias"])
+        def test_cmd():
+            print("Test Command Executed")
+
+        # Test invoking with the original command name
+        invoke_and_assert(
+            ["pluralized-subcommand", "test-cmd"],
+            expected_output_contains="Test Command Executed",
+            expected_code=0,
+        )
+
+        # Test invoking with the alias
+        invoke_and_assert(
+            ["pluralized-subcommands", "test-cmd-alias"],
+            expected_output_contains="Test Command Executed",
+            expected_code=0,
+        )

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -746,10 +746,6 @@ class TestProvisionInfrastructure:
 
         assert mock_provision.await_count == 1
 
-        # assert that the base job template was updated
-        client_res = await prefect_client.read_work_pool(push_work_pool.name)
-        assert client_res.base_job_template == FAKE_DEFAULT_BASE_JOB_TEMPLATE
-
     async def test_provision_infra_unsupported(self, push_work_pool):
         res = await run_sync_in_worker_thread(
             invoke_and_assert,

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -711,3 +711,53 @@ class TestGetDefaultBaseJobTemplate:
         contents = file.read_text()
         assert "job_configuration" in contents
         assert len(contents) == 211
+
+
+class TestProvisionInfrastructure:
+    async def test_provision_infra(self, monkeypatch, push_work_pool, prefect_client):
+        mock_provision = AsyncMock()
+
+        class MockProvisioner:
+            def __init__(self):
+                self._console = None
+
+            @property
+            def console(self):
+                return self._console
+
+            @console.setter
+            def console(self, value):
+                self._console = value
+
+            async def provision(self, *args, **kwargs):
+                await mock_provision(*args, **kwargs)
+                return FAKE_DEFAULT_BASE_JOB_TEMPLATE
+
+        monkeypatch.setattr(
+            "prefect.cli.work_pool.get_infrastructure_provisioner_for_work_pool_type",
+            lambda *args: MockProvisioner(),
+        )
+
+        res = await run_sync_in_worker_thread(
+            invoke_and_assert,
+            f"work-pool provision-infra {push_work_pool.name}",
+        )
+        assert res.exit_code == 0
+
+        assert mock_provision.await_count == 1
+
+        # assert that the base job template was updated
+        client_res = await prefect_client.read_work_pool(push_work_pool.name)
+        assert client_res.base_job_template == FAKE_DEFAULT_BASE_JOB_TEMPLATE
+
+    async def test_provision_infra_unsupported(self, push_work_pool):
+        res = await run_sync_in_worker_thread(
+            invoke_and_assert,
+            f"work-pool provision-infrastructure {push_work_pool.name}",
+        )
+        assert res.exit_code == 0
+        assert (
+            "Automatic infrastructure provisioning is not supported for"
+            " 'push-work-pool:push' work pools."
+            in res.output
+        )


### PR DESCRIPTION
This PR introduces the functionality to provision infrastructure for an existing work pool through a `prefect work-pool provision-infra` subcommand in the Prefect CLI. 

### Example output
```bash
❯ prefect work-pool provision-infra my-work-pool
13:22:32.560 | DEBUG   | prefect.profiles - Using profile 'cloud'
13:22:32.640 | DEBUG   | prefect.client - Connecting to API at https://api.prefect.cloud/api/accounts/abc/workspaces/xyz/
13:22:32.851 | DEBUG   | prefect.client - Connecting to API at https://api.prefect.cloud/api/accounts/abc/workspaces/xyz/
? Please select which Azure subscription to use: [Use arrows to move; enter to select]
┏━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃    ┃ Name                 ┃ Subscription ID                      ┃
┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│    │ Engineering          │ 13d │
│ >  │ Azure subscription 1 │ 6h4 │
│    │ Azure subscription 1 │ 293 │
└────┴──────────────────────┴──────────────────────────────────────┘
╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Provisioning infrastructure for your work pool my-work-pool will require:                                               │
│                                                                                                                │
│     Updates in subscription Azure subscription 1                                                               │
│                                                                                                                │
│         - Create a resource group in location eastus                                                           │
│         - Create an app registration in Azure AD prefect-aci-push-pool-app                                     │
│         - Create/use a service principal for app registration                                                  │
│         - Generate a secret for app registration                                                               │
│         - Assign Contributor role to service account                                                           │
│         - Create Azure Container Instance 'aci-push-pool-container' in resource group prefect-aci-push-pool-rg │
│                                                                                                                │
│     Updates in Prefect workspace                                                                               │
│                                                                                                                │
│         - Create Azure Container Instance credentials block aci-push-pool-credentials                          │
│                                                                                                                │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Proceed with infrastructure provisioning? [y/n]: y
...
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
