### PR TITLE
model from deployment OpenAPI schema

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -494,12 +494,12 @@ class Flow(Generic[P, R]):
                     "Cannot mix Pydantic v1 and v2 models as arguments to a flow."
                 )
 
-            if has_v1_models:
-                validated_fn = V1ValidatedFunction(
+            if has_v2_models:
+                validated_fn = V2ValidatedFunction(
                     self.fn, config={"arbitrary_types_allowed": True}
                 )
             else:
-                validated_fn = V2ValidatedFunction(
+                validated_fn = V1ValidatedFunction(
                     self.fn, config={"arbitrary_types_allowed": True}
                 )
 

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -892,6 +892,9 @@ class Runner:
         run_logger = self._get_flow_run_logger(flow_run)
 
         try:
+            import json
+
+            print(json.dumps(flow_run.dict(json_compatible=True), indent=4))
             status_code = await self._run_process(
                 flow_run=flow_run,
                 task_status=task_status,

--- a/src/prefect/runner/server.py
+++ b/src/prefect/runner/server.py
@@ -128,12 +128,15 @@ async def _make_run_deployment_endpoint(
 
     Model.__config__.arbitrary_types_allowed = True
 
-    async def _create_flow_run_for_deployment(m: Model):  # type: ignore
+    async def _create_flow_run_for_deployment(m: Model) -> JSONResponse:
         async with get_client() as client:
             await client.create_flow_run_from_deployment(
                 deployment_id=deployment.id,
                 parameters=m.dict(),
             )
+        return JSONResponse(
+            status_code=status.HTTP_201_CREATED, content={"message": "OK"}
+        )
 
     return _create_flow_run_for_deployment
 

--- a/src/prefect/runner/server.py
+++ b/src/prefect/runner/server.py
@@ -59,7 +59,7 @@ def shutdown(runner) -> int:
 
 
 def create_model_from_openapi(
-    schema: dict[str, t.Any], title: str
+    schema: t.Dict[str, t.Any], title: str
 ) -> t.Type[BaseModel]:
     definitions = schema.get("definitions", {})
 
@@ -79,7 +79,9 @@ def create_model_from_openapi(
         else:
             raise ValueError(f"Unknown type '{type_name}'.")
 
-    def resolve_reference(ref: str, definitions: dict[str, t.Any]) -> t.Type[BaseModel]:
+    def resolve_reference(
+        ref: str, definitions: t.Dict[str, t.Any]
+    ) -> t.Type[BaseModel]:
         ref_name = ref.lstrip("#/definitions/")
         ref_schema = definitions.get(ref_name)
         if ref_schema is None:
@@ -87,7 +89,7 @@ def create_model_from_openapi(
         return create_model_from_schema(ref_schema, ref_name, definitions)
 
     def create_model_from_schema(
-        schema: dict[str, t.Any], model_name: str, definitions: dict[str, t.Any]
+        schema: t.Dict[str, t.Any], model_name: str, definitions: t.Dict[str, t.Any]
     ) -> t.Type[BaseModel]:
         model_fields = {}
 


### PR DESCRIPTION
exploration branch off of `ft/runner-runs-deployments`

attempts to build the endpoint model directly from the OpenAPI schema via `create_model_from_openapi`