### PR TITLE
Adds support for `is_schedule_active` to `flow.deploy` and `flow.serve`

### DIFF
--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -361,6 +361,7 @@ class RunnerDeployment(BaseModel):
         cron: Optional[str] = None,
         rrule: Optional[str] = None,
         schedule: Optional[SCHEDULE_TYPES] = None,
+        is_schedule_active: Optional[bool] = None,
         parameters: Optional[dict] = None,
         triggers: Optional[List[DeploymentTrigger]] = None,
         description: Optional[str] = None,
@@ -383,6 +384,9 @@ class RunnerDeployment(BaseModel):
             rrule: An rrule schedule of when to execute runs of this flow.
             schedule: A schedule object of when to execute runs of this flow. Used for
                 advanced scheduling options like timezone.
+            is_schedule_active: Whether or not to set the schedule for this deployment as active. If
+                not provided when creating a deployment, the schedule will be set as active. If not
+                provided when updating a deployment, the schedule's activation will not be changed.
             triggers: A list of triggers that should kick of a run of this flow.
             parameters: A dictionary of default parameter values to pass to runs of this flow.
             description: A description for the created deployment. Defaults to the flow's
@@ -409,6 +413,7 @@ class RunnerDeployment(BaseModel):
             name=Path(name).stem,
             flow_name=flow.name,
             schedule=schedule,
+            is_schedule_active=is_schedule_active,
             tags=tags or [],
             triggers=triggers or [],
             parameters=parameters or {},
@@ -466,6 +471,7 @@ class RunnerDeployment(BaseModel):
         cron: Optional[str] = None,
         rrule: Optional[str] = None,
         schedule: Optional[SCHEDULE_TYPES] = None,
+        is_schedule_active: Optional[bool] = None,
         parameters: Optional[dict] = None,
         triggers: Optional[List[DeploymentTrigger]] = None,
         description: Optional[str] = None,
@@ -489,6 +495,9 @@ class RunnerDeployment(BaseModel):
             rrule: An rrule schedule of when to execute runs of this flow.
             schedule: A schedule object of when to execute runs of this flow. Used for
                 advanced scheduling options like timezone.
+            is_schedule_active: Whether or not to set the schedule for this deployment as active. If
+                not provided when creating a deployment, the schedule will be set as active. If not
+                provided when updating a deployment, the schedule's activation will not be changed.
             triggers: A list of triggers that should kick of a run of this flow.
             parameters: A dictionary of default parameter values to pass to runs of this flow.
             description: A description for the created deployment. Defaults to the flow's
@@ -521,6 +530,7 @@ class RunnerDeployment(BaseModel):
             name=Path(name).stem,
             flow_name=flow.name,
             schedule=schedule,
+            is_schedule_active=is_schedule_active,
             tags=tags or [],
             triggers=triggers or [],
             parameters=parameters or {},
@@ -549,6 +559,7 @@ class RunnerDeployment(BaseModel):
         cron: Optional[str] = None,
         rrule: Optional[str] = None,
         schedule: Optional[SCHEDULE_TYPES] = None,
+        is_schedule_active: Optional[bool] = None,
         parameters: Optional[dict] = None,
         triggers: Optional[List[DeploymentTrigger]] = None,
         description: Optional[str] = None,
@@ -575,6 +586,9 @@ class RunnerDeployment(BaseModel):
             rrule: An rrule schedule of when to execute runs of this flow.
             schedule: A schedule object of when to execute runs of this flow. Used for
                 advanced scheduling options like timezone.
+            is_schedule_active: Whether or not to set the schedule for this deployment as active. If
+                not provided when creating a deployment, the schedule will be set as active. If not
+                provided when updating a deployment, the schedule's activation will not be changed.
             triggers: A list of triggers that should kick of a run of this flow.
             parameters: A dictionary of default parameter values to pass to runs of this flow.
             description: A description for the created deployment. Defaults to the flow's
@@ -611,6 +625,7 @@ class RunnerDeployment(BaseModel):
             name=Path(name).stem,
             flow_name=flow.name,
             schedule=schedule,
+            is_schedule_active=is_schedule_active,
             tags=tags or [],
             triggers=triggers or [],
             parameters=parameters or {},

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -556,6 +556,7 @@ class Flow(Generic[P, R]):
         cron: Optional[str] = None,
         rrule: Optional[str] = None,
         schedule: Optional[SCHEDULE_TYPES] = None,
+        is_schedule_active: Optional[bool] = None,
         parameters: Optional[dict] = None,
         triggers: Optional[List[DeploymentTrigger]] = None,
         description: Optional[str] = None,
@@ -578,6 +579,9 @@ class Flow(Generic[P, R]):
             timezone: A timezone to use for the schedule. Defaults to UTC.
             triggers: A list of triggers that will kick off runs of this deployment.
             schedule: A schedule object defining when to execute runs of this deployment.
+            is_schedule_active: Whether or not to set the schedule for this deployment as active. If
+                not provided when creating a deployment, the schedule will be set as active. If not
+                provided when updating a deployment, the schedule's activation will not be changed.
             parameters: A dictionary of default parameter values to pass to runs of this deployment.
             description: A description for the created deployment. Defaults to the flow's
                 description if not provided.
@@ -623,6 +627,7 @@ class Flow(Generic[P, R]):
                 cron=cron,
                 rrule=rrule,
                 schedule=schedule,
+                is_schedule_active=is_schedule_active,
                 tags=tags,
                 triggers=triggers,
                 parameters=parameters or {},
@@ -641,6 +646,7 @@ class Flow(Generic[P, R]):
                 cron=cron,
                 rrule=rrule,
                 schedule=schedule,
+                is_schedule_active=is_schedule_active,
                 tags=tags,
                 triggers=triggers,
                 parameters=parameters or {},
@@ -660,6 +666,7 @@ class Flow(Generic[P, R]):
         cron: Optional[str] = None,
         rrule: Optional[str] = None,
         schedule: Optional[SCHEDULE_TYPES] = None,
+        is_schedule_active: Optional[bool] = None,
         triggers: Optional[List[DeploymentTrigger]] = None,
         parameters: Optional[dict] = None,
         description: Optional[str] = None,
@@ -682,6 +689,9 @@ class Flow(Generic[P, R]):
             triggers: A list of triggers that will kick off runs of this deployment.
             schedule: A schedule object defining when to execute runs of this deployment. Used to
                 define additional scheduling options like `timezone`.
+            is_schedule_active: Whether or not to set the schedule for this deployment as active. If
+                not provided when creating a deployment, the schedule will be set as active. If not
+                provided when updating a deployment, the schedule's activation will not be changed.
             parameters: A dictionary of default parameter values to pass to runs of this deployment.
             description: A description for the created deployment. Defaults to the flow's
                 description if not provided.
@@ -738,6 +748,7 @@ class Flow(Generic[P, R]):
             cron=cron,
             rrule=rrule,
             schedule=schedule,
+            is_schedule_active=is_schedule_active,
             parameters=parameters,
             description=description,
             tags=tags,
@@ -852,6 +863,7 @@ class Flow(Generic[P, R]):
         cron: Optional[str] = None,
         rrule: Optional[str] = None,
         schedule: Optional[SCHEDULE_TYPES] = None,
+        is_schedule_active: Optional[bool] = None,
         triggers: Optional[List[DeploymentTrigger]] = None,
         parameters: Optional[dict] = None,
         description: Optional[str] = None,
@@ -891,6 +903,9 @@ class Flow(Generic[P, R]):
             triggers: A list of triggers that will kick off runs of this deployment.
             schedule: A schedule object defining when to execute runs of this deployment. Used to
                 define additional scheduling options like `timezone`.
+            is_schedule_active: Whether or not to set the schedule for this deployment as active. If
+                not provided when creating a deployment, the schedule will be set as active. If not
+                provided when updating a deployment, the schedule's activation will not be changed.
             parameters: A dictionary of default parameter values to pass to runs of this deployment.
             description: A description for the created deployment. Defaults to the flow's
                 description if not provided.
@@ -956,6 +971,7 @@ class Flow(Generic[P, R]):
             cron=cron,
             rrule=rrule,
             schedule=schedule,
+            is_schedule_active=is_schedule_active,
             triggers=triggers,
             parameters=parameters,
             description=description,

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -204,6 +204,7 @@ class Runner:
         cron: Optional[str] = None,
         rrule: Optional[str] = None,
         schedule: Optional[SCHEDULE_TYPES] = None,
+        is_schedule_active: Optional[bool] = None,
         parameters: Optional[dict] = None,
         triggers: Optional[List[DeploymentTrigger]] = None,
         description: Optional[str] = None,
@@ -227,6 +228,9 @@ class Runner:
             rrule: An rrule schedule of when to execute runs of this flow.
             schedule: A schedule object of when to execute runs of this flow. Used for
                 advanced scheduling options like timezone.
+            is_schedule_active: Whether or not to set the schedule for this deployment as active. If
+                not provided when creating a deployment, the schedule will be set as active. If not
+                provided when updating a deployment, the schedule's activation will not be changed.
             triggers: A list of triggers that should kick of a run of this flow.
             parameters: A dictionary of default parameter values to pass to runs of this flow.
             description: A description for the created deployment. Defaults to the flow's
@@ -249,6 +253,7 @@ class Runner:
             cron=cron,
             rrule=rrule,
             schedule=schedule,
+            is_schedule_active=is_schedule_active,
             triggers=triggers,
             parameters=parameters,
             description=description,

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -895,7 +895,6 @@ class TestRunnerDeployment:
         )
 
         assert deployment.is_schedule_active is expected
-        assert deployment.is_schedule_active is False
 
     @pytest.mark.parametrize(
         "kwargs",

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -770,12 +770,16 @@ class TestRunnerDeployment:
 
         assert deployment.schedule.rrule == "FREQ=MINUTELY"
 
-    def test_from_flow_accepts_is_schedule_active(self):
+    @pytest.mark.parametrize(
+        "value,expected",
+        [(True, True), (False, False), (None, None)],
+    )
+    def test_from_flow_accepts_is_schedule_active(self, value, expected):
         deployment = RunnerDeployment.from_flow(
-            dummy_flow_1, __file__, is_schedule_active=False
+            dummy_flow_1, __file__, is_schedule_active=value
         )
 
-        assert deployment.is_schedule_active is False
+        assert deployment.is_schedule_active is expected
 
     @pytest.mark.parametrize(
         "kwargs",
@@ -879,11 +883,18 @@ class TestRunnerDeployment:
 
         assert deployment.schedule.rrule == "FREQ=MINUTELY"
 
-    def test_from_entrypoint_accepts_is_schedule_active(self, dummy_flow_1_entrypoint):
+    @pytest.mark.parametrize(
+        "value,expected",
+        [(True, True), (False, False), (None, None)],
+    )
+    def test_from_entrypoint_accepts_is_schedule_active(
+        self, dummy_flow_1_entrypoint, value, expected
+    ):
         deployment = RunnerDeployment.from_entrypoint(
-            dummy_flow_1_entrypoint, __file__, is_schedule_active=False
+            dummy_flow_1_entrypoint, __file__, is_schedule_active=value
         )
 
+        assert deployment.is_schedule_active is expected
         assert deployment.is_schedule_active is False
 
     @pytest.mark.parametrize(

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -3562,13 +3562,13 @@ class TestFlowDeploy:
                 work_queue_name="line",
                 job_variables={"foo": "bar"},
                 enforce_parameter_schema=True,
+                is_schedule_active=False,
             ),
             work_pool_name=work_pool.name,
             image=image,
             build=False,
             push=False,
             print_next_steps_message=False,
-            is_schedule_active=False,
         )
 
         console_output = capsys.readouterr().out
@@ -3609,13 +3609,13 @@ class TestFlowDeploy:
                 work_queue_name="line",
                 job_variables={"foo": "bar"},
                 enforce_parameter_schema=True,
+                is_schedule_active=False,
             ),
             work_pool_name=work_pool.name,
             image=image,
             build=True,
             push=False,
             print_next_steps_message=False,
-            is_schedule_active=False,
         )
 
     async def test_deploy_non_existent_work_pool(

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -3304,6 +3304,7 @@ class TestFlowServe:
             description="This is a test",
             version="alpha",
             enforce_parameter_schema=True,
+            is_schedule_active=False,
         )
 
         deployment = await prefect_client.read_deployment_by_name(name="test-flow/test")
@@ -3318,6 +3319,7 @@ class TestFlowServe:
         assert deployment.description == "This is a test"
         assert deployment.version == "alpha"
         assert deployment.enforce_parameter_schema
+        assert not deployment.is_schedule_active
 
     async def test_serve_handles__file__(self, prefect_client: PrefectClient):
         await test_flow.serve(__file__)
@@ -3547,6 +3549,7 @@ class TestFlowDeploy:
             build=False,
             push=False,
             enforce_parameter_schema=True,
+            is_schedule_active=False,
         )
 
         mock_deploy.assert_called_once_with(
@@ -3565,6 +3568,7 @@ class TestFlowDeploy:
             build=False,
             push=False,
             print_next_steps_message=False,
+            is_schedule_active=False,
         )
 
         console_output = capsys.readouterr().out
@@ -3592,6 +3596,7 @@ class TestFlowDeploy:
             image=image,
             push=False,
             enforce_parameter_schema=True,
+            is_schedule_active=False,
         )
 
         mock_deploy.assert_called_once_with(
@@ -3610,6 +3615,7 @@ class TestFlowDeploy:
             build=True,
             push=False,
             print_next_steps_message=False,
+            is_schedule_active=False,
         )
 
     async def test_deploy_non_existent_work_pool(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

Adds `is_schedule_active` arg to allow users to create a deployment with the schedule paused or pause/resume the schedule of an existing deployment. The `RunnerDeployment` class already supported `is_schedule_active`, but it was not exposed in the user-facing API.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Create a deployment with a paused schedule:

```python
from prefect import flow


@flow(log_prints=True)
def local_flow():
    print("I'm a locally defined flow!")


if __name__ == "__main__":
    local_flow.deploy(
        name="test-flow-deploy",
        work_pool_name="olympic",
        image="desertaxle/test-local-flow-deploy:dev",
        interval=3600,
        is_schedule_active=False,
    )
```



### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
