### PR TITLE
Add typing overloads for pause/suspend methods

### DIFF
--- a/src/prefect/input/run_input.py
+++ b/src/prefect/input/run_input.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Type, TypeVar, Union
 from uuid import UUID
 
 import pydantic
@@ -15,6 +15,7 @@ if HAS_PYDANTIC_V2:
     from prefect._internal.pydantic.v2_schema import create_v2_schema
 
 
+T = TypeVar("T", bound="RunInput")
 KeysetNames = Union[Literal["response"], Literal["schema"]]
 Keyset = Dict[KeysetNames, str]
 
@@ -92,7 +93,7 @@ class RunInput(pydantic.BaseModel):
         return cls(**value)
 
     @classmethod
-    def with_initial_data(cls, **kwargs: Any) -> Type["RunInput"]:
+    def with_initial_data(cls: Type[T], **kwargs: Any) -> Type[T]:
         """
         Create a new `RunInput` subclass with the given initial data as field
         defaults.


### PR DESCRIPTION
This fixes the typing of `pause_flow_run` and `suspend_flow_run` so that it correctly hints that when given `wait_for_input` the return type is an instance of whatever type was passed in as `wait_for_input` and when there is no `wait_for_input` value the return is `None`.

Closes #11402

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
