### PR TITLE
Documentation for `wait_for_input`

### DIFF
--- a/docs/api-ref/prefect/input/actions.md
+++ b/docs/api-ref/prefect/input/actions.md
@@ -1,0 +1,10 @@
+---
+description: Prefect Python API for creating/reading/deleting flow run inputs.
+tags:
+    - flow run
+    - pause
+    - suspend
+    - input
+---
+
+::: prefect.input.actions

--- a/docs/api-ref/prefect/input/run_input.md
+++ b/docs/api-ref/prefect/input/run_input.md
@@ -1,0 +1,11 @@
+---
+description: Prefect Python API for the `RunInput` class.
+tags:
+    - flow run
+    - pause
+    - suspend
+    - input
+    - run input
+---
+
+::: prefect.input.run_input

--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -974,7 +974,9 @@ async def greet_user():
 
     logger.info(f"Hello, {user_input.name}!")
 ```
-Calling this flow will create a flow run and move it into a paused state. The flow will then block and wait for resumption. When resuming the flow run, users will be prompted to provide a value for the `name` field of the `UserNameInput` model. Upon successful validation, the flow run will resume, and the return value of the `pause_flow_run` will be an instance of the `UserNameInput` model containing the provided data. 
+Running this flow will create a flow run. The flow run will advance until code execution reaches `pause_flow_run`, at which point it will  move it into a `Paused` state. Execution will block and wait for resumption. 
+
+When resuming the flow run, users will be prompted to provide a value for the `name` field of the `UserNameInput` model. Upon successful validation, the flow run will resume, and the return value of the `pause_flow_run` will be an instance of the `UserNameInput` model containing the provided data. 
 
 For more in-depth information on receiving input from users when pausing and suspending flow runs, see the [guide](/guides/receiving-input-when-paused.md).
 

--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -946,7 +946,7 @@ resume_flow_run(FLOW_RUN_ID)
 
 ## Waiting for input when pausing or suspending a flow run
 
-!!! tip "Experimental"
+!!! warning "Experimental"
     The `wait_for_input` parameter used in the `pause_flow_run` or `suspend_flow_run` functions is an experimental feature. The interface or behavior of this feature may change without warning in future releases. 
 
     If you encounter any issues, please let us know in Slack or with a Github issue.
@@ -978,7 +978,7 @@ Running this flow will create a flow run. The flow run will advance until code e
 
 When resuming the flow run, users will be prompted to provide a value for the `name` field of the `UserNameInput` model. Upon successful validation, the flow run will resume, and the return value of the `pause_flow_run` will be an instance of the `UserNameInput` model containing the provided data. 
 
-For more in-depth information on receiving input from users when pausing and suspending flow runs, see the [guide](/guides/receiving-input-when-paused.md).
+For more in-depth information on receiving input from users when pausing and suspending flow runs, see the [guide](/guides/receiving-input-when-paused/).
 
 ## Cancel a flow run
 

--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -978,7 +978,7 @@ Running this flow will create a flow run. The flow run will advance until code e
 
 When resuming the flow run, users will be prompted to provide a value for the `name` field of the `UserNameInput` model. Upon successful validation, the flow run will resume, and the return value of the `pause_flow_run` will be an instance of the `UserNameInput` model containing the provided data. 
 
-For more in-depth information on receiving input from users when pausing and suspending flow runs, see the [guide](/guides/receiving-input-when-paused/).
+For more in-depth information on receiving input from users when pausing and suspending flow runs, see the [Creating human in the loop workflows](/guides/creating-human-in-the-loop-workflows/) guide.
 
 ## Cancel a flow run
 

--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -947,11 +947,11 @@ resume_flow_run(FLOW_RUN_ID)
 ## Waiting for input when pausing or suspending a flow run
 
 !!! tip "Experimental"
-    The `wait_for_input` parameter used in the `pause_flow_run` or `suspend_flow_run` methods is an experimental feature. The interface or behavior of this feature may change without warning in future releases. 
+    The `wait_for_input` parameter used in the `pause_flow_run` or `suspend_flow_run` functions is an experimental feature. The interface or behavior of this feature may change without warning in future releases. 
 
     If you encounter any issues, please let us know in Slack or with a Github issue.
 
-When pausing or suspending a flow run you may want to wait for input from a user. Prefect provides a way to do this by leveraging the `pause_flow_run` and `suspend_flow_run` methods. These methods accept a `wait_for_input` argument, the value of which should be a subclass of `prefect.input.RunInput`, a pydantic model. When resuming the flow run, users are required to provide data for this model. Upon successful validation, the flow run resumes, and the return value of the `pause_flow_run` or `suspend_flow_run` is an instance of the model containing the provided data.
+When pausing or suspending a flow run you may want to wait for input from a user. Prefect provides a way to do this by leveraging the `pause_flow_run` and `suspend_flow_run` functions. These functions accept a `wait_for_input` argument, the value of which should be a subclass of `prefect.input.RunInput`, a pydantic model. When resuming the flow run, users are required to provide data for this model. Upon successful validation, the flow run resumes, and the return value of the `pause_flow_run` or `suspend_flow_run` is an instance of the model containing the provided data.
 
 Here is an example of a flow that pauses and waits for input from a user:
 
@@ -974,8 +974,7 @@ async def greet_user():
 
     logger.info(f"Hello, {user_input.name}!")
 ```
-
-Calling this flow will block code execution and wait for resumption. When resuming the flow run, users will be prompted to provide a value for the `name` field of the `UserNameInput` model. Upon successful validation, the flow run will resume, and the return value of the `pause_flow_run` will be an instance of the `UserNameInput` model containing the provided data. 
+Calling this flow will create a flow run and move it into a paused state. The flow will then block and wait for resumption. When resuming the flow run, users will be prompted to provide a value for the `name` field of the `UserNameInput` model. Upon successful validation, the flow run will resume, and the return value of the `pause_flow_run` will be an instance of the `UserNameInput` model containing the provided data. 
 
 For more in-depth information on receiving input from users when pausing and suspending flow runs, see the [guide](/guides/receiving-input-when-paused.md).
 

--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -1026,7 +1026,7 @@ While the cancellation process is robust, there are a few issues than can occur:
     ```
     </div>
 
-    If you encounter any issues, please let us know in Slack or with a Github issue.
+    If you encounter any issues, please let us know in [Slack](https://www.prefect.io/slack/)Slack or with a [Github](https://github.com/PrefectHQ/prefect) issue.
 ### Cancel via the CLI
 
 From the command line in your execution environment, you can cancel a flow run by using the `prefect flow-run cancel` CLI command, passing the ID of the flow run.

--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -944,6 +944,40 @@ Suspended flow runs can be resumed by clicking the **Resume** button in the Pref
 resume_flow_run(FLOW_RUN_ID)
 ```
 
+## Waiting for input when pausing or suspending a flow run
+
+!!! tip "Experimental"
+    The `wait_for_input` parameter used in the `pause_flow_run` or `suspend_flow_run` methods is an experimental feature. The interface or behavior of this feature may change without warning in future releases. 
+
+    If you encounter any issues, please let us know in Slack or with a Github issue.
+
+When pausing or suspending a flow run you may want to wait for input from a user. Prefect provides a way to do this by leveraging the `pause_flow_run` and `suspend_flow_run` methods. These methods accept a `wait_for_input` argument, the value of which should be a subclass of `prefect.input.RunInput`, a pydantic model. When resuming the flow run, users are required to provide data for this model. Upon successful validation, the flow run resumes, and the return value of the `pause_flow_run` or `suspend_flow_run` is an instance of the model containing the provided data.
+
+Here is an example of a flow that pauses and waits for input from a user:
+
+```python
+from prefect import flow, get_run_logger, pause_flow_run
+from prefect.input import RunInput
+
+
+class UserNameInput(RunInput):
+    name: str
+
+
+@flow
+async def greet_user():
+    logger = get_run_logger()
+
+    user_input = await pause_flow_run(
+        wait_for_input=UserNameInput
+    )
+
+    logger.info(f"Hello, {user_input.name}!")
+```
+
+Calling this flow will block code execution and wait for resumption. When resuming the flow run, users will be prompted to provide a value for the `name` field of the `UserNameInput` model. Upon successful validation, the flow run will resume, and the return value of the `pause_flow_run` will be an instance of the `UserNameInput` model containing the provided data. 
+
+For more in-depth information on receiving input from users when pausing and suspending flow runs, see the [guide](/guides/receiving-input-when-paused.md).
 
 ## Cancel a flow run
 

--- a/docs/guides/creating-human-in-the-loop-workflows.md
+++ b/docs/guides/creating-human-in-the-loop-workflows.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how to receive input when a flow run is paused or suspended.
+description: Learn how to create human-in-the-loop workflows with Prefect.
 tags:
     - flow run
     - pause
@@ -9,7 +9,7 @@ search:
   boost: 2
 ---
 
-# Receiving input when pausing or suspending a flow run
+# Creating human in the loop workflows
 !!! warning "Experimental"
 
     The `wait_for_input` parameter used in the `pause_flow_run` or `suspend_flow_run` functions is an experimental feature. The interface or behavior of this feature may change without warning in future releases. 

--- a/docs/guides/creating-human-in-the-loop-workflows.md
+++ b/docs/guides/creating-human-in-the-loop-workflows.md
@@ -9,7 +9,7 @@ search:
   boost: 2
 ---
 
-# Creating human in the loop workflows
+# Creating Human-in-the-Loop Workflows
 !!! warning "Experimental"
 
     The `wait_for_input` parameter used in the `pause_flow_run` or `suspend_flow_run` functions is an experimental feature. The interface or behavior of this feature may change without warning in future releases. 

--- a/docs/guides/creating-human-in-the-loop-workflows.md
+++ b/docs/guides/creating-human-in-the-loop-workflows.md
@@ -14,7 +14,7 @@ search:
 
     The `wait_for_input` parameter used in the `pause_flow_run` or `suspend_flow_run` functions is an experimental feature. The interface or behavior of this feature may change without warning in future releases. 
 
-    If you encounter any issues, please let us know in Slack or with a Github issue.
+    If you encounter any issues, please let us know in [Slack](https://www.prefect.io/slack/)Slack or with a [Github](https://github.com/PrefectHQ/prefect) issue.
 
 
 When a flow run is paused or suspended, you can receive input from the user. This is useful when you need to ask the user for additional information or feedback before resuming the flow run.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -23,7 +23,7 @@ This section of the documentation contains how-to guides for common workflows an
 | [Runtime Context](/guides/runtime-context/) | Enable a flow to access metadata about itself and its context when it runs.  |
 | [Variables](/guides/variables/) | Store and retrieve configuration data. |
 | [Prefect Client](/guides/using-the-client/) | Use `PrefectClient` to interact with the API server. |
-| [Receiving Input When Paused](/guides/creating-human-in-the-loop-workflows/) | Creating human in the loop workflows. |
+| [Human-in-the-Loop Workflows:](/guides/creating-human-in-the-loop-workflows/) | Create human-in-the-loop workflows by pausing flow runs for input. |
 | [Webhooks](/guides/webhooks/) | Receive, observe, and react to events from other systems. |
 | [Terraform Provider](https://registry.terraform.io/providers/PrefectHQ/prefect/latest/docs/guides/getting-started) | Use the Terraform Provider for Prefect Cloud for infrastructure as code. |
 | [Prefect Recipes](/recipes/recipes/) |  Common, extensible examples for setting up Prefect. |

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -23,7 +23,7 @@ This section of the documentation contains how-to guides for common workflows an
 | [Runtime Context](/guides/runtime-context/) | Enable a flow to access metadata about itself and its context when it runs.  |
 | [Variables](/guides/variables/) | Store and retrieve configuration data. |
 | [Prefect Client](/guides/using-the-client/) | Use `PrefectClient` to interact with the API server. |
-| [Receiving Input When Paused](/guides/receiving-input-when-paused/) | Use `PrefectClient` to interact with the API server. |
+| [Receiving Input When Paused](/guides/creating-human-in-the-loop-workflows/) | Creating human in the loop workflows. |
 | [Webhooks](/guides/webhooks/) | Receive, observe, and react to events from other systems. |
 | [Terraform Provider](https://registry.terraform.io/providers/PrefectHQ/prefect/latest/docs/guides/getting-started) | Use the Terraform Provider for Prefect Cloud for infrastructure as code. |
 | [Prefect Recipes](/recipes/recipes/) |  Common, extensible examples for setting up Prefect. |

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -23,6 +23,7 @@ This section of the documentation contains how-to guides for common workflows an
 | [Runtime Context](/guides/runtime-context/) | Enable a flow to access metadata about itself and its context when it runs.  |
 | [Variables](/guides/variables/) | Store and retrieve configuration data. |
 | [Prefect Client](/guides/using-the-client/) | Use `PrefectClient` to interact with the API server. |
+| [Receiving Input When Paused](/guides/receiving-input-when-paused/) | Use `PrefectClient` to interact with the API server. |
 | [Webhooks](/guides/webhooks/) | Receive, observe, and react to events from other systems. |
 | [Terraform Provider](https://registry.terraform.io/providers/PrefectHQ/prefect/latest/docs/guides/getting-started) | Use the Terraform Provider for Prefect Cloud for infrastructure as code. |
 | [Prefect Recipes](/recipes/recipes/) |  Common, extensible examples for setting up Prefect. |

--- a/docs/guides/receiving-input-when-paused.md
+++ b/docs/guides/receiving-input-when-paused.md
@@ -1,0 +1,150 @@
+---
+description: Learn how to receive input when a flow run is paused or suspended.
+tags:
+    - flow run
+    - pause
+    - suspend
+    - input
+search:
+  boost: 2
+---
+
+# Receiving input when pausing or suspending a flow run
+!!! tip "Experimental"
+
+    The `wait_for_input` parameter used in the `pause_flow_run` or `suspend_flow_run` methods is an experimental feature. The interface or behavior of this feature may change without warning in future releases. 
+
+    If you encounter any issues, please let us know in Slack or with a Github issue.
+
+
+When a flow run is paused or suspended, you can receive input from the user. This is useful when you need to ask the user for additional information or feedback before resuming the flow run.
+
+## Waiting for input
+
+To receive input you must use the `wait_for_input` parameter in the `pause_flow_run` or `suspend_flow_run` methods. This parameter accepts a subclass of `prefect.input.RunInput`. `RunInput` is a subclass of `pydantic.BaseModel` and can be used to define the input that you want to receive:
+
+```python
+class UserNameInput(RunInput):
+    name: str
+```
+
+In this case we are defining a `UserNameInput` class that will receive a `name` string from the user. You can then use this class in the `wait_for_input` parameter:
+
+```python
+@flow
+async def greet_user():
+    logger = get_run_logger()
+
+    user_input = await pause_flow_run(
+        wait_for_input=UserNameInput
+    )
+
+    logger.info(f"Hello, {user_input.name}!")
+```
+
+When the flow run is paused, the user will be prompted to enter a name. If the user does not enter a name, the flow run will not resume. If the user enters a name, the flow run will resume and the `user_input` variable will contain the name that the user entered.
+
+## Providing initial data
+
+You can set default values for fields in your model by using the `with_initial_data` method. This is particularly useful when you want to provide default values for fields such as `title` and `description` that are part of the base `RunInput` class and are displayed in the UI when resuming a flow run.
+
+Expanding on the example above, you could default the `name` field to something anonymous.
+
+```python
+@flow
+async def greet_user():
+    logger = get_run_logger()
+
+    user_input = await pause_flow_run(
+        wait_for_input=UserNameInput.with_initial_data(name="anonymous")
+    )
+
+    if user_input.name == "anonymous":
+        logger.info("Hello, stranger!")
+    else:
+        logger.info(f"Hello, {user_input.name}!")
+```
+
+## Handling custom validation
+
+While Prefect does validate the input that the user provides it can only validate the general structure of the input. If you need to perform more complex validation you can use pydantic's validation methods.
+
+```python
+import pydantic
+from prefect.input import RunInput
+
+class UserAgeInput(RunInput):
+    age: int
+
+    @pydantic.validator("age")
+    def validate_age(cls, value):
+        min_age = 18
+        max_age = 99
+
+        if not min_age <= value <= max_age:
+            raise ValueError(f"Age must be between {min_age} and {max_age}")
+        
+        return value
+```
+
+In this case we are using pydantic's `validator` decorator to define a custom validation method for the `age` field. We can use it in a flow like this:
+
+```python
+import pydantic
+from prefect import flow, pause_flow_run
+
+class UserAgeInput(pydantic.BaseModel):
+    age: int
+
+    @pydantic.validator("age")
+    def validate_age(cls, value):
+        min_age = 18
+        max_age = 99
+
+        if not min_age <= value <= max_age:
+            raise ValueError(f"Age must be between {min_age} and {max_age}")
+
+        return value
+
+@flow
+def get_user_age():
+    user_age_input = pause_flow_run(wait_for_input=UserAgeInput)
+```
+
+If a user entered an invalid age of `hello` the flow run would not resume and the user would be given a validation error. However if the user enters a valid integer, but one that is not between 18 and 99, the flow run will resume and `pause_flow_run` will raise a `ValidationError` exception.
+
+One way to handle this and ensure that the user enters valid input is to use a `while` loop and pause again if the `ValidationError` exception is raised:
+
+```python
+import pydantic
+from prefect import flow, pause_flow_run
+
+class UserAgeInput(pydantic.BaseModel):
+    age: int
+
+    @pydantic.validator("age")
+    def validate_age(cls, value):
+        min_age = 18
+        max_age = 99
+
+        if not min_age <= value <= max_age:
+            raise ValueError(f"Age must be between {min_age} and {max_age}")
+
+        return value
+
+@flow
+def get_user_age():
+    logger = get_run_logger()
+
+    user_age = None
+
+    while user_age is None:
+        try:
+            user_age_data = pause_flow_run(wait_for_input=UserAgeInput)
+        except pydantic.ValidationError as exc:
+            logger.error(f"Invalid age: {exc}")
+        else:
+            user_age = user_age_data.age
+```
+
+This will cause the flow run to continually pause until the user enters a valid age.

--- a/docs/guides/receiving-input-when-paused.md
+++ b/docs/guides/receiving-input-when-paused.md
@@ -48,7 +48,7 @@ When the flow run is paused, the user will be prompted to enter a name. If the u
 
 ## Providing initial data
 
-You can set default values for fields in your model by using the `with_initial_data` method. This is particularly useful when you want to provide default values for fields such as `title` and `description` that are part of the base `RunInput` class and are displayed in the UI when resuming a flow run. You can also specify defaults for fields that you define in your own `RunInput` subclasses.
+You can set default values for fields in your model by using the `with_initial_data` method. This is useful when you want to provide default values for the fields in your own `RunInput` subclasses.
 
 Expanding on the example above, you could default the `name` field to something anonymous.
 
@@ -58,11 +58,7 @@ async def greet_user():
     logger = get_run_logger()
 
     user_input = await pause_flow_run(
-        wait_for_input=UserNameInput.with_initial_data(
-            title="Enter your name",
-            description="If you'd prefer not to enter your name, you can enter 'anonymous' instead.",
-            name="anonymous"
-        )
+        wait_for_input=UserNameInput.with_initial_data(name="anonymous")
     )
 
     if user_input.name == "anonymous":

--- a/docs/guides/receiving-input-when-paused.md
+++ b/docs/guides/receiving-input-when-paused.md
@@ -10,7 +10,7 @@ search:
 ---
 
 # Receiving input when pausing or suspending a flow run
-!!! tip "Experimental"
+!!! warning "Experimental"
 
     The `wait_for_input` parameter used in the `pause_flow_run` or `suspend_flow_run` functions is an experimental feature. The interface or behavior of this feature may change without warning in future releases. 
 

--- a/docs/guides/receiving-input-when-paused.md
+++ b/docs/guides/receiving-input-when-paused.md
@@ -67,7 +67,7 @@ async def greet_user():
 
 ## Handling custom validation
 
-While Prefect does validate the input that the user provides it can only validate the general structure of the input. If you need to perform more complex validation you can use pydantic's validation methods.
+Prefect uses the fields and type hints on your `RunInput` subclass to validate the general structure of input your flow run receives, but you might require more complex validation. If you do, you can use Pydantic's validation methods.
 
 ```python
 import pydantic
@@ -87,7 +87,7 @@ class UserAgeInput(RunInput):
         return value
 ```
 
-In this case we are using pydantic's `validator` decorator to define a custom validation method for the `age` field. We can use it in a flow like this:
+In this case, we are using Pydantic's `validator` decorator to define a custom validation method for the `age` field. We can use it in a flow like this:
 
 ```python
 import pydantic
@@ -111,7 +111,7 @@ def get_user_age():
     user_age_input = pause_flow_run(wait_for_input=UserAgeInput)
 ```
 
-If a user entered an invalid age of `hello` the flow run would not resume and the user would be given a validation error. However if the user enters a valid integer, but one that is not between 18 and 99, the flow run will resume and `pause_flow_run` will raise a `ValidationError` exception.
+If a user enters an invalid age of `hello`, the flow run will not resume and the user will receive a validation error. However, if the user enters a number that is a valid integer but that is not between 18 and 99, the flow run will resume, and `pause_flow_run` will raise a `ValidationError` exception.
 
 One way to handle this and ensure that the user enters valid input is to use a `while` loop and pause again if the `ValidationError` exception is raised:
 

--- a/docs/guides/receiving-input-when-paused.md
+++ b/docs/guides/receiving-input-when-paused.md
@@ -120,8 +120,9 @@ One way to handle this and ensure that the user enters valid input is to use a `
 
 ```python
 import pydantic
-from prefect import flow, pause_flow_run, get_run_logger
+from prefect import flow, suspend_flow_run, get_run_logger
 from prefect.input import RunInput
+
 
 class UserAgeInput(RunInput):
     age: int
@@ -136,19 +137,20 @@ class UserAgeInput(RunInput):
 
         return value
 
+
 @flow
 def get_user_age():
     logger = get_run_logger()
 
-    user_age = None
+    user_age_data = None
 
-    while user_age is None:
+    while user_age_data is None:
         try:
             user_age_data = pause_flow_run(wait_for_input=UserAgeInput)
         except pydantic.ValidationError as exc:
             logger.error(f"Invalid age: {exc}")
-        else:
-            user_age = user_age_data.age
+
+    logger.info(f"User age: {user_age_data.age}")
 ```
 
 This code will cause the flow run to continually pause until the user enters a valid age.

--- a/docs/guides/receiving-input-when-paused.md
+++ b/docs/guides/receiving-input-when-paused.md
@@ -48,7 +48,7 @@ When the flow run is paused, the user will be prompted to enter a name. If the u
 
 ## Providing initial data
 
-You can set default values for fields in your model by using the `with_initial_data` method. This is particularly useful when you want to provide default values for fields such as `title` and `description` that are part of the base `RunInput` class and are displayed in the UI when resuming a flow run. But you can also specify defaults for fields that you define in your own `RunInput` subclasses.
+You can set default values for fields in your model by using the `with_initial_data` method. This is particularly useful when you want to provide default values for fields such as `title` and `description` that are part of the base `RunInput` class and are displayed in the UI when resuming a flow run. You can also specify defaults for fields that you define in your own `RunInput` subclasses.
 
 Expanding on the example above, you could default the `name` field to something anonymous.
 
@@ -155,4 +155,4 @@ def get_user_age():
             user_age = user_age_data.age
 ```
 
-This will cause the flow run to continually pause until the user enters a valid age.
+This code will cause the flow run to continually pause until the user enters a valid age.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,7 @@ nav:
                 - Runtime Context: guides/runtime-context.md
                 - Variables: guides/variables.md
                 - Prefect Client: guides/using-the-client.md
+                - Receiving Input When Paused: guides/receiving-input-when-paused.md
                 - Webhooks: guides/webhooks.md
                 - Terraform Provider: https://registry.terraform.io/providers/PrefectHQ/prefect/latest/docs/guides/getting-started
                 - Recipes: recipes/recipes.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,7 +152,7 @@ nav:
                 - Runtime Context: guides/runtime-context.md
                 - Variables: guides/variables.md
                 - Prefect Client: guides/using-the-client.md
-                - Receiving Input When Paused: guides/receiving-input-when-paused.md
+                - Creating human in the loop workflows: guides/creating-human-in-the-loop-workflows.md
                 - Webhooks: guides/webhooks.md
                 - Terraform Provider: https://registry.terraform.io/providers/PrefectHQ/prefect/latest/docs/guides/getting-started
                 - Recipes: recipes/recipes.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,7 +152,7 @@ nav:
                 - Runtime Context: guides/runtime-context.md
                 - Variables: guides/variables.md
                 - Prefect Client: guides/using-the-client.md
-                - Creating human in the loop workflows: guides/creating-human-in-the-loop-workflows.md
+                - Human-in-the-Loop Workflows: guides/creating-human-in-the-loop-workflows.md
                 - Webhooks: guides/webhooks.md
                 - Terraform Provider: https://registry.terraform.io/providers/PrefectHQ/prefect/latest/docs/guides/getting-started
                 - Recipes: recipes/recipes.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -274,6 +274,9 @@ nav:
                       - "work_pool": api-ref/prefect/cli/work_pool.md
                       - "work_queue": api-ref/prefect/cli/work_queue.md
                       - "worker": api-ref/prefect/cli/worker.md
+                - "prefect.input":
+                      - "actions": api-ref/prefect/input/actions.md
+                      - "run_input": api-ref/prefect/input/run_input.md
                 - "prefect.utilities":
                       - "annotations": api-ref/prefect/utilities/annotations.md
                       - "asyncutils": api-ref/prefect/utilities/asyncutils.md


### PR DESCRIPTION
This adds `wait_for_input` documentation to the existing pause/resume documentation and creates a guide that goes more in-depth.

Closes #11401 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
