### PR TITLE
Construct a pause state without reusing the state ID

### DIFF
--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -817,8 +817,10 @@ class PreventRunningTasksFromStoppedFlows(BaseOrchestrationRule):
             elif flow_run.state.type == StateType.PAUSED:
                 # Use the flow run's Paused state details to preserve data like
                 # timeouts.
-                paused_state = flow_run.state.as_state().copy(
-                    update={"name": "NotReady"}
+                paused_state = states.Paused(
+                    name="NotReady",
+                    pause_expiration_time=flow_run.state.state_details.pause_timeout,
+                    reschedule=flow_run.state.state_details.pause_reschedule,
                 )
                 await self.reject_transition(
                     state=paused_state,

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -855,9 +855,12 @@ def initialize_orchestration(flow):
         flow_retries: int = None,
         flow_run_count: int = None,
         resuming: bool = None,
+        initial_flow_run_state_details=None,
     ):
         flow_create_kwargs = {}
         empirical_policy = {}
+        if initial_flow_run_state_details is None:
+            initial_flow_run_state_details = {}
         if flow_retries:
             empirical_policy.update({"retries": flow_retries})
         if resuming:
@@ -888,10 +891,11 @@ def initialize_orchestration(flow):
         elif run_type == "task":
             if initial_flow_run_state_type:
                 flow_state_constructor = commit_flow_run_state
+                kwargs = {}
+                if initial_flow_run_state_details:
+                    kwargs["state_details"] = initial_flow_run_state_details
                 await flow_state_constructor(
-                    session,
-                    flow_run,
-                    initial_flow_run_state_type,
+                    session, flow_run, initial_flow_run_state_type, **kwargs
                 )
             task_run = await models.task_runs.create_task_run(
                 session=session,

--- a/tests/server/orchestration/test_core_policy.py
+++ b/tests/server/orchestration/test_core_policy.py
@@ -11,7 +11,7 @@ import pytest
 from prefect.results import LiteralResult, PersistedResult, UnpersistedResult
 from prefect.server import schemas
 from prefect.server.exceptions import ObjectNotFoundError
-from prefect.server.models import concurrency_limits
+from prefect.server.models import concurrency_limits, flow_runs
 from prefect.server.orchestration.core_policy import (
     BypassCancellingScheduledFlowRuns,
     CacheInsertion,
@@ -2719,6 +2719,44 @@ class TestPreventRunningTasksFromStoppedFlows:
         else:
             assert ctx.response_status == SetStateStatus.ABORT
             assert ctx.validated_state.is_pending()
+
+    async def test_does_not_reuse_state_pk_from_paused_flow_run(
+        self, session, initialize_orchestration
+    ):
+        """
+        A regression test: fix a bug in version 2.14.10 where we inadvertently
+        reused the state ID from the flow run's paused state for task runs when
+        we paused them, leading to PK conflicts in some cases.
+        """
+        initial_state_type = states.StateType.PENDING
+        proposed_state_type = states.StateType.RUNNING
+        intended_transition = (initial_state_type, proposed_state_type)
+        pause_timeout = pendulum.now("UTC").add(minutes=5)
+        ctx = await initialize_orchestration(
+            session,
+            "task",
+            *intended_transition,
+            initial_flow_run_state_type=states.StateType.PAUSED,
+            initial_flow_run_state_details={
+                "pause_timeout": pause_timeout,
+                "pause_reschedule": True,
+            },
+        )
+
+        flow_run = await flow_runs.read_flow_run(session, ctx.run.flow_run_id)
+        run_preventer = PreventRunningTasksFromStoppedFlows(ctx, *intended_transition)
+
+        async with run_preventer as ctx:
+            await ctx.validate_proposed_state()
+
+        assert ctx.response_status == SetStateStatus.REJECT
+        assert ctx.validated_state.is_paused()
+        assert flow_run.state.type == states.StateType.PAUSED
+        assert ctx.validated_state.id != flow_run.state.id
+
+        # Check that other values carried over from the state data
+        assert ctx.validated_state.state_details.pause_timeout == pause_timeout
+        assert ctx.validated_state.state_details.pause_reschedule is True
 
 
 class TestHandleCancellingStateTransitions:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

Recent work on fixing a pause/resume bug with tasks introduced a new bug in which we reused the ID of an existing state while constructing a new state record. Oops.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
