### PR TITLE
Allow users to select relative and fixed date ranges to filter the dashboard

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.8.0",
       "dependencies": {
         "@prefecthq/prefect-design": "2.2.1",
-        "@prefecthq/prefect-ui-library": "2.4.8",
+        "@prefecthq/prefect-ui-library": "2.4.10",
         "@prefecthq/vue-charts": "2.0.3",
         "@prefecthq/vue-compositions": "1.6.7",
         "@types/lodash.debounce": "4.0.9",
@@ -1237,9 +1237,9 @@
       }
     },
     "node_modules/@prefecthq/prefect-ui-library": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.4.8.tgz",
-      "integrity": "sha512-KdE/gUGNnqRqyRlfbKm2i/phxM67f6vGNKyqA+ArMtqYLaZdtLviNCaXxcgJL+3JXeel4PhVaNK+hjwwI7L7nA==",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.4.10.tgz",
+      "integrity": "sha512-zl9utRR4MMNKBAcZFH2wBPxBuwOlBM4KxhhLIN7v26OT/sm5134REmX0cksGpo4InY86nePsbDdYvguRlz7whw==",
       "dependencies": {
         "@prefecthq/graphs": "2.1.9",
         "@types/lodash.isequal": "4.5.8",
@@ -1253,7 +1253,7 @@
         "prismjs": "1.29.0"
       },
       "peerDependencies": {
-        "@prefecthq/prefect-design": "^2.1.3",
+        "@prefecthq/prefect-design": "^2.2.1",
         "@prefecthq/vue-charts": "^2.0.3",
         "@prefecthq/vue-compositions": "^1.6.6",
         "vee-validate": "^4.7.0",
@@ -7277,9 +7277,9 @@
       }
     },
     "@prefecthq/prefect-ui-library": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.4.8.tgz",
-      "integrity": "sha512-KdE/gUGNnqRqyRlfbKm2i/phxM67f6vGNKyqA+ArMtqYLaZdtLviNCaXxcgJL+3JXeel4PhVaNK+hjwwI7L7nA==",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.4.10.tgz",
+      "integrity": "sha512-zl9utRR4MMNKBAcZFH2wBPxBuwOlBM4KxhhLIN7v26OT/sm5134REmX0cksGpo4InY86nePsbDdYvguRlz7whw==",
       "requires": {
         "@prefecthq/graphs": "2.1.9",
         "@types/lodash.isequal": "4.5.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@prefecthq/prefect-design": "2.2.1",
-    "@prefecthq/prefect-ui-library": "2.4.8",
+    "@prefecthq/prefect-ui-library": "2.4.10",
     "@prefecthq/vue-charts": "2.0.3",
     "@prefecthq/vue-compositions": "1.6.7",
     "@types/lodash.debounce": "4.0.9",

--- a/ui/src/pages/Dashboard.vue
+++ b/ui/src/pages/Dashboard.vue
@@ -54,7 +54,7 @@
     useWorkspaceDashboardFilterFromRoute
   } from '@prefecthq/prefect-ui-library'
   import { useSubscription } from '@prefecthq/vue-compositions'
-  import { secondsInWeek, secondsToMilliseconds } from 'date-fns'
+  import { secondsInDay, secondsToMilliseconds } from 'date-fns'
   import { computed, provide } from 'vue'
 
   provide(subscriptionIntervalKey, {
@@ -68,7 +68,7 @@
   const crumbs: Crumb[] = [{ text: 'Dashboard' }]
 
   const filter = useWorkspaceDashboardFilterFromRoute({
-    range: { type: 'span', seconds: -secondsInWeek },
+    range: { type: 'span', seconds: -secondsInDay },
     tags: [],
   })
 


### PR DESCRIPTION
# Description
Implements a new date range select on the dashboard. Now users can select both past and future relative date ranges like "Past 1 week" or "Next 1 hour" but users can also select specific date and time ranges. Previously the dashboard was limited to viewing the last 8 hours, 24 hours, or 1 week. 

| Before | After |
|--------|--------|
| <img width="1054" alt="image" src="https://github.com/PrefectHQ/prefect/assets/6200442/db88c7c3-eaea-4d85-a6ed-83f9218bda1f"> | <img width="1048" alt="image" src="https://github.com/PrefectHQ/prefect/assets/6200442/94c99646-de24-434f-85ca-b672cdfb4299"> | 