### PR TITLE
Use bytes for `value` in `create_flow_run_input` for cloud compatibility

### DIFF
--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -529,7 +529,7 @@ async def set_flow_run_state(
 async def create_flow_run_input(
     flow_run_id: UUID = Path(..., description="The flow run id", alias="id"),
     key: str = Body(..., description="The input key"),
-    value: str = Body(..., description="The value of the input"),
+    value: bytes = Body(..., description="The value of the input"),
     db: PrefectDBInterface = Depends(provide_database_interface),
 ):
     """
@@ -542,7 +542,7 @@ async def create_flow_run_input(
                 flow_run_input=schemas.core.FlowRunInput(
                     flow_run_id=flow_run_id,
                     key=key,
-                    value=value,
+                    value=value.decode(),
                 ),
             )
             await session.commit()


### PR DESCRIPTION
This is the OSS side of https://github.com/PrefectHQ/nebula/pull/6451, we need to make the `value` type `bytes` to maintain compatibility with cloud.

Related to https://github.com/PrefectHQ/nebula/issues/6422