### PR TITLE
Update default pause/suspend timeout to be 1 hour

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -952,7 +952,7 @@ async def orchestrate_flow_run(
 async def pause_flow_run(
     wait_for_input: None = None,
     flow_run_id: UUID = None,
-    timeout: int = 300,
+    timeout: int = 3600,
     poll_interval: int = 10,
     reschedule: bool = False,
     key: str = None,
@@ -964,7 +964,7 @@ async def pause_flow_run(
 async def pause_flow_run(
     wait_for_input: Type[T],
     flow_run_id: UUID = None,
-    timeout: int = 300,
+    timeout: int = 3600,
     poll_interval: int = 10,
     reschedule: bool = False,
     key: str = None,
@@ -988,7 +988,7 @@ async def pause_flow_run(
 async def pause_flow_run(
     wait_for_input: Optional[Type[T]] = None,
     flow_run_id: UUID = None,
-    timeout: int = 300,
+    timeout: int = 3600,
     poll_interval: int = 10,
     reschedule: bool = False,
     key: str = None,
@@ -1011,7 +1011,7 @@ async def pause_flow_run(
             have an associated deployment and results need to be configured with the
             `persist_results` option.
         timeout: the number of seconds to wait for the flow to be resumed before
-            failing. Defaults to 5 minutes (300 seconds). If the pause timeout exceeds
+            failing. Defaults to 1 hour (3600 seconds). If the pause timeout exceeds
             any configured flow-level timeout, the flow might fail even after resuming.
         poll_interval: The number of seconds between checking whether the flow has been
             resumed. Defaults to 10 seconds.
@@ -1050,11 +1050,8 @@ async def pause_flow_run(
 
 
 @inject_client
-@experimental_parameter(
-    "wait_for_input", group="flow_run_input", when=lambda y: y is not None
-)
 async def _in_process_pause(
-    timeout: int = 300,
+    timeout: int = 3600,
     poll_interval: int = 10,
     reschedule=False,
     key: str = None,
@@ -1149,7 +1146,7 @@ async def _in_process_pause(
 @inject_client
 async def _out_of_process_pause(
     flow_run_id: UUID,
-    timeout: int = 300,
+    timeout: int = 3600,
     reschedule: bool = True,
     key: str = None,
     client=None,
@@ -1172,7 +1169,7 @@ async def _out_of_process_pause(
 async def suspend_flow_run(
     wait_for_input: None = None,
     flow_run_id: Optional[UUID] = None,
-    timeout: Optional[int] = 300,
+    timeout: Optional[int] = 3600,
     key: Optional[str] = None,
     client: PrefectClient = None,
 ) -> None:
@@ -1183,7 +1180,7 @@ async def suspend_flow_run(
 async def suspend_flow_run(
     wait_for_input: Type[T],
     flow_run_id: Optional[UUID] = None,
-    timeout: Optional[int] = 300,
+    timeout: Optional[int] = 3600,
     key: Optional[str] = None,
     client: PrefectClient = None,
 ) -> T:
@@ -1192,10 +1189,13 @@ async def suspend_flow_run(
 
 @sync_compatible
 @inject_client
+@experimental_parameter(
+    "wait_for_input", group="flow_run_input", when=lambda y: y is not None
+)
 async def suspend_flow_run(
     wait_for_input: Optional[Type[T]] = None,
     flow_run_id: Optional[UUID] = None,
-    timeout: Optional[int] = 300,
+    timeout: Optional[int] = 3600,
     key: Optional[str] = None,
     client: PrefectClient = None,
 ):
@@ -1214,7 +1214,7 @@ async def suspend_flow_run(
             suspend the specified flow run. If not supplied will attempt to
             suspend the current flow run.
         timeout: the number of seconds to wait for the flow to be resumed before
-            failing. Defaults to 5 minutes (300 seconds). If the pause timeout
+            failing. Defaults to 1 hour (3600 seconds). If the pause timeout
             exceeds any configured flow-level timeout, the flow might fail even
             after resuming.
         key: An optional key to prevent calling suspend more than once. This

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -652,6 +652,12 @@ class TestOutOfProcessPause:
 
 
 class TestSuspendFlowRun:
+    @pytest.fixture(autouse=True)
+    def ignore_experimental_warnings(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=ExperimentalFeature)
+            yield
+
     async def test_suspended_flow_runs_do_not_block_execution(
         self, prefect_client, deployment, session
     ):


### PR DESCRIPTION
Updates the default `pause_flow_run` and `suspend_flow_run` from 5m (300s) to 1 hour (3600s). 

Closes #11413 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
