### PR TITLE
Resolve `work_pool` env vars during `prefect deploy`

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -329,6 +329,14 @@ async def _run_single_deploy(
 
     deploy_config = await resolve_variables(deploy_config)
 
+    env_vars = dict(os.environ)
+    deploy_config["work_pool"]["name"] = apply_values(
+        deploy_config["work_pool"]["name"], env_vars
+    )
+    deploy_config["work_pool"]["work_queue_name"] = apply_values(
+        deploy_config["work_pool"]["work_queue_name"], env_vars
+    )
+
     if get_from_dict(deploy_config, "schedule.anchor_date") and not get_from_dict(
         deploy_config, "schedule.interval"
     ):

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -330,12 +330,7 @@ async def _run_single_deploy(
     deploy_config = await resolve_variables(deploy_config)
 
     env_vars = dict(os.environ)
-    deploy_config["work_pool"]["name"] = apply_values(
-        deploy_config["work_pool"]["name"], env_vars
-    )
-    deploy_config["work_pool"]["work_queue_name"] = apply_values(
-        deploy_config["work_pool"]["work_queue_name"], env_vars
-    )
+    deploy_config = apply_values(deploy_config, env_vars, remove_notset=False)
 
     if get_from_dict(deploy_config, "schedule.anchor_date") and not get_from_dict(
         deploy_config, "schedule.interval"

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -329,8 +329,8 @@ async def _run_single_deploy(
 
     deploy_config = await resolve_variables(deploy_config)
 
-    env_vars = dict(os.environ)
-    deploy_config = apply_values(deploy_config, env_vars, remove_notset=False)
+    # check for env var placeholders early so users can pass work pool names, etc.
+    deploy_config = apply_values(deploy_config, os.environ, remove_notset=False)
 
     if get_from_dict(deploy_config, "schedule.anchor_date") and not get_from_dict(
         deploy_config, "schedule.interval"

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -6515,7 +6515,7 @@ class TestDeployInfraOverrides:
             command=(
                 "deploy ./flows/hello.py:my_flow -n test-name -p test-pool --version"
                 " 1.0.0 -v env=prod -t foo-bar --variable "
-                ' \'{"resources":{"limits":{"cpu": 1}}}\''
+                ' \'{"resources":{"limits":{"cpu"}\''
             ),
             expected_code=1,
             expected_output_contains=[


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/11189, where the `work_pool_name` in `prefect.yaml` was being used during `prefect deploy` prior to when we read the value from the environment variable.

This PR modifies the `deploy_config` resolution process to apply environment variables parsing to all configuration elements earlier, including `work_pool_name`.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->