### PR TITLE
ft: support reading and writing  custom prefect.yaml files

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -211,6 +211,11 @@ async def deploy(
             " provided, this flag will be ignored."
         ),
     ),
+    prefect_file: Path = typer.Option(
+        Path("prefect.yaml"),
+        "--prefect-file",
+        help="Specify a custom path to a prefect.yaml file",
+    ),
     ci: bool = typer.Option(
         False,
         "--ci",
@@ -260,8 +265,9 @@ async def deploy(
         "enforce_parameter_schema": enforce_parameter_schema,
     }
     try:
-        deploy_configs, actions = _load_deploy_configs_and_actions(ci=ci)
-
+        deploy_configs, actions = _load_deploy_configs_and_actions(
+            prefect_file=prefect_file, ci=ci
+        )
         parsed_names = []
         for name in names:
             if "*" in name:
@@ -287,6 +293,7 @@ async def deploy(
                 actions=actions,
                 deploy_all=deploy_all,
                 ci=ci,
+                prefect_file=prefect_file,
             )
         else:
             # Accommodate passing in -n flow-name/deployment-name as well as -n deployment-name
@@ -299,6 +306,7 @@ async def deploy(
                 actions=actions,
                 options=options,
                 ci=ci,
+                prefect_file=prefect_file,
             )
     except ValueError as exc:
         exit_with_error(str(exc))
@@ -311,6 +319,7 @@ async def _run_single_deploy(
     options: Optional[Dict] = None,
     ci: bool = False,
     client: PrefectClient = None,
+    prefect_file: Path = Path("prefect.yaml"),
 ):
     deploy_config = deepcopy(deploy_config) if deploy_config else {}
     actions = deepcopy(actions) if actions else {}
@@ -359,8 +368,7 @@ async def _run_single_deploy(
             raise ValueError(
                 "An entrypoint must be provided:\n\n"
                 " \t[yellow]prefect deploy path/to/file.py:flow_function\n\n"
-                "You can also provide an entrypoint in a prefect.yaml"
-                " file located in the current working directory."
+                "You can also provide an entrypoint in a prefect.yaml file."
             )
         deploy_config["entrypoint"] = await prompt_entrypoint(app.console)
     if deploy_config.get("flow_name") and deploy_config.get("entrypoint"):
@@ -670,7 +678,9 @@ async def _run_single_deploy(
         )
 
     identical_deployment_exists_in_prefect_file = (
-        _check_if_identical_deployment_in_prefect_file(deploy_config_before_templating)
+        _check_if_identical_deployment_in_prefect_file(
+            deploy_config_before_templating, prefect_file
+        )
     )
     if should_prompt_for_save and not identical_deployment_exists_in_prefect_file:
         if confirm(
@@ -682,7 +692,8 @@ async def _run_single_deploy(
         ):
             matching_deployment_exists = (
                 _check_for_matching_deployment_name_and_entrypoint_in_prefect_file(
-                    deploy_config=deploy_config_before_templating
+                    deploy_config=deploy_config_before_templating,
+                    prefect_file=prefect_file,
                 )
             )
             if matching_deployment_exists and not confirm(
@@ -691,14 +702,14 @@ async def _run_single_deploy(
                     f" [yellow]{deploy_config_before_templating.get('name')}[/yellow]"
                     " and entrypoint:"
                     f" [yellow]{deploy_config_before_templating.get('entrypoint')}[/yellow]"
-                    " in the [yellow]prefect.yaml[/yellow] file. Would you like to"
-                    " overwrite that entry?"
+                    f" in the [yellow]prefect.yaml[/yellow] file at {prefect_file}."
+                    " Would you like to overwrite that entry?"
                 ),
             ):
                 app.console.print(
                     "[red]Cancelled saving deployment configuration"
                     f" '{deploy_config_before_templating.get('name')}' to the"
-                    " prefect.yaml file.[/red]"
+                    f" prefect.yaml file.[/red] at {prefect_file}"
                 )
             else:
                 _save_deployment_to_prefect_file(
@@ -707,15 +718,16 @@ async def _run_single_deploy(
                     push_steps=push_steps or None,
                     pull_steps=pull_steps or None,
                     triggers=trigger_specs or None,
+                    prefect_file=prefect_file,
                 )
                 app.console.print(
                     (
-                        "\n[green]Deployment configuration saved to prefect.yaml![/]"
+                        f"\n[green]Deployment configuration saved to {prefect_file}![/]"
                         " You can now deploy using this deployment configuration"
                         " with:\n\n\t[blue]$ prefect deploy -n"
                         f" {deploy_config['name']}[/]\n\nYou can also make changes to"
                         " this deployment configuration by making changes to the"
-                        " prefect.yaml file."
+                        " file."
                     ),
                 )
     if not work_pool.is_push_pool and not work_pool.is_managed_pool:
@@ -746,6 +758,7 @@ async def _run_multi_deploy(
     names: Optional[List[str]] = None,
     deploy_all: bool = False,
     ci: bool = False,
+    prefect_file: Path = Path("prefect.yaml"),
 ):
     deploy_configs = deepcopy(deploy_configs) if deploy_configs else []
     actions = deepcopy(actions) if actions else {}
@@ -776,7 +789,9 @@ async def _run_multi_deploy(
                 app.console.print("Skipping unnamed deployment.", style="yellow")
                 continue
         app.console.print(Panel(f"Deploying {deploy_config['name']}", style="blue"))
-        await _run_single_deploy(deploy_config, actions, ci=ci)
+        await _run_single_deploy(
+            deploy_config, actions, ci=ci, prefect_file=prefect_file
+        )
 
 
 def _construct_schedule(
@@ -1157,9 +1172,11 @@ def _handle_deployment_yaml_copy(prefect_yaml_contents, ci):
         )
 
 
-def _load_deploy_configs_and_actions(ci=False) -> Tuple[List[Dict], Dict]:
+def _load_deploy_configs_and_actions(
+    prefect_file: Path, ci: bool = False
+) -> Tuple[List[Dict], Dict]:
     """
-    Load deploy configs and actions from the prefect.yaml file.
+    Load deploy configs and actions from a prefect.yaml file.
 
     Handles the deprecation of the deployment.yaml file.
 
@@ -1170,9 +1187,19 @@ def _load_deploy_configs_and_actions(ci=False) -> Tuple[List[Dict], Dict]:
         Tuple[List[Dict], Dict]: a tuple of deployment configurations and actions
     """
     try:
-        with open("prefect.yaml", "r") as f:
+        with prefect_file.open("r") as f:
             prefect_yaml_contents = yaml.safe_load(f)
-    except FileNotFoundError:
+    except (FileNotFoundError, IsADirectoryError) as exc:
+        app.console.print(
+            f"Unable to read the specified config file. Reason: {exc}. Skipping.",
+            style="yellow",
+        )
+        prefect_yaml_contents = {}
+    if not isinstance(prefect_yaml_contents, dict):
+        app.console.print(
+            "Unable to parse the specified config file. Skipping.",
+            style="yellow",
+        )
         prefect_yaml_contents = {}
 
     actions = {
@@ -1518,9 +1545,8 @@ def _apply_cli_options_to_deploy_config(deploy_config, cli_options):
 
 
 def _check_for_matching_deployment_name_and_entrypoint_in_prefect_file(
-    deploy_config,
+    deploy_config, prefect_file: Path = Path("prefect.yaml")
 ) -> bool:
-    prefect_file = Path("prefect.yaml")
     if prefect_file.exists():
         with prefect_file.open(mode="r") as f:
             parsed_prefect_file_contents = yaml.safe_load(f)
@@ -1538,7 +1564,7 @@ def _check_for_matching_deployment_name_and_entrypoint_in_prefect_file(
 
 
 def _check_if_identical_deployment_in_prefect_file(
-    untemplated_deploy_config: Dict,
+    untemplated_deploy_config: Dict, prefect_file: Path = Path("prefect.yaml")
 ) -> bool:
     """
     Check if the given deploy config is identical to an existing deploy config in the
@@ -1551,8 +1577,6 @@ def _check_if_identical_deployment_in_prefect_file(
     user_specified_deploy_config = _format_deployment_for_saving_to_prefect_file(
         untemplated_deploy_config
     )
-
-    prefect_file = Path("prefect.yaml")
     if prefect_file.exists():
         with prefect_file.open(mode="r") as f:
             parsed_prefect_file_contents = yaml.safe_load(f)

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -727,7 +727,7 @@ async def _run_single_deploy(
                         " with:\n\n\t[blue]$ prefect deploy -n"
                         f" {deploy_config['name']}[/]\n\nYou can also make changes to"
                         " this deployment configuration by making changes to the"
-                        " file."
+                        " YAML file."
                     ),
                 )
     if not work_pool.is_push_pool and not work_pool.is_managed_pool:

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -14,6 +14,7 @@ import typer.core
 import yaml
 from rich.console import Console
 from rich.panel import Panel
+from yaml.error import YAMLError
 
 from prefect._internal.compatibility.deprecated import (
     generate_deprecation_message,
@@ -1189,7 +1190,7 @@ def _load_deploy_configs_and_actions(
     try:
         with prefect_file.open("r") as f:
             prefect_yaml_contents = yaml.safe_load(f)
-    except (FileNotFoundError, IsADirectoryError) as exc:
+    except (FileNotFoundError, IsADirectoryError, YAMLError) as exc:
         app.console.print(
             f"Unable to read the specified config file. Reason: {exc}. Skipping.",
             style="yellow",

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -1176,7 +1176,7 @@ def _load_deploy_configs_and_actions(
     prefect_file: Path, ci: bool = False
 ) -> Tuple[List[Dict], Dict]:
     """
-    Load deploy configs and actions from a prefect.yaml file.
+    Load deploy configs and actions from a deployment configuration YAML file.
 
     Handles the deprecation of the deployment.yaml file.
 

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -709,7 +709,7 @@ async def _run_single_deploy(
                 app.console.print(
                     "[red]Cancelled saving deployment configuration"
                     f" '{deploy_config_before_templating.get('name')}' to the"
-                    f" prefect.yaml file.[/red] at {prefect_file}"
+                    f" deployment configuration file[/red] at {prefect_file}"
                 )
             else:
                 _save_deployment_to_prefect_file(

--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -425,6 +425,7 @@ def _save_deployment_to_prefect_file(
     push_steps: Optional[List[Dict]] = None,
     pull_steps: Optional[List[Dict]] = None,
     triggers: Optional[List[Dict]] = None,
+    prefect_file: Path = Path("prefect.yaml"),
 ):
     """
     Save a deployment configuration to the `prefect.yaml` file in the
@@ -438,7 +439,6 @@ def _save_deployment_to_prefect_file(
     deployment = _format_deployment_for_saving_to_prefect_file(deployment)
 
     current_directory_name = os.path.basename(os.getcwd())
-    prefect_file = Path("prefect.yaml")
     if not prefect_file.exists():
         create_default_prefect_yaml(
             ".",

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -5135,7 +5135,8 @@ class TestSaveUserInputs:
                     "Would you like to save configuration for this deployment for"
                     " faster deployments in the future?"
                 ),
-                "Would you like to overwrite",
+                "Would you like",
+                "to overwrite that entry?",
                 "Deployment configuration saved to prefect.yaml!",
             ],
         )

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -7093,7 +7093,7 @@ class TestDeployingUsingCustomPrefectFile:
                 command=f"deploy --all --prefect-file {fp.name}",
                 expected_code=1,
                 expected_output_contains=[
-                    "Unable to parse the specified config file. Skipping....."
+                    "Unable to parse the specified config file. Skipping."
                 ],
             )
 

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -7081,16 +7081,19 @@ class TestDeployingUsingCustomPrefectFile:
         )
 
     @pytest.mark.usefixtures("project_dir")
-    async def test_deploying_using_malformed_prefect_file(self):
+    @pytest.mark.parametrize(
+        "content", ["{this isn't valid YAML!}", "unbalanced blackets: ]["]
+    )
+    async def test_deploying_using_malformed_prefect_file(self, content: str):
         with tempfile.NamedTemporaryFile("w+") as fp:
-            fp.write("{this isn't valid YAML!}")
+            fp.write(content)
 
             await run_sync_in_worker_thread(
                 invoke_and_assert,
                 command=f"deploy --all --prefect-file {fp.name}",
                 expected_code=1,
                 expected_output_contains=[
-                    "Unable to parse the specified config file. Skipping."
+                    "Unable to parse the specified config file. Skipping....."
                 ],
             )
 


### PR DESCRIPTION
Closes #10618 

This PR adds a new flag `--prefect-file` to the `prefect deploy` command to support custom prefect file names and locations during deployment. Note that while the file can now be located anywhere, the `prefect deploy` command **must** be run from the project root and the contents of the file (e.g. entrypoints) **must** be relative to the project root.  

In addition to supporting loading configuration from a custom prefect file, these changes also allow a user to save their changes to the target file when they're prompted to do so during deployment.

### Example

```shell
❯ prefect deploy --prefect-file ../prefect2.yaml --all
╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Deploying out-of-this-dir-prefect                                                                                 │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Deployment 'pause-test/out-of-this-dir-prefect' successfully created with id                                      │
│ '35dd4dd7-8a84-4acf-94e8-bbb07ce7bba3'.                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
? Would you like to save configuration for this deployment for faster deployments in the future? [y/n]: y
? Found existing deployment configuration with name: out-of-this-dir-prefect and entrypoint:
flows/flow_pauses.py:pause_test in the prefect.yaml file at ../prefect2.yaml. Would you like to overwrite that entry?
[y/n]: y

Deployment configuration saved to ../prefect2.yaml! You can now deploy using this deployment configuration with:

        $ prefect deploy -n out-of-this-dir-prefect
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
