### PR TITLE
Fix method name typo in Tasks tutorial

### DIFF
--- a/docs/tutorial/tasks.md
+++ b/docs/tutorial/tasks.md
@@ -54,7 +54,7 @@ def get_repo_info(repo_name: str = "PrefectHQ/prefect"):
     print(f"Forks 🍴 : {repo_stats['forks_count']}")
 
 if __name__ == "__main__":
-    repo_info()
+    get_repo_info()
 ```
 
 Running the flow in your terminal will result in something like this:


### PR DESCRIPTION
Documentation fix: On the Tasks page of the tutorial, the defined method is named `get_repo_info()`, but the call from the main function was incorrectly spelled `repo_info()`.

### Example
N/A

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.

For documentation changes:

- [x] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed