### PR TITLE
Filter available subflows in the generic runner subflow endpoint

### DIFF
--- a/src/prefect/runner/server.py
+++ b/src/prefect/runner/server.py
@@ -13,7 +13,7 @@ import prefect.runtime
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect.client.orchestration import get_client
 from prefect.context import FlowRunContext, TaskRunContext
-from prefect.exceptions import MissingFlowError
+from prefect.exceptions import MissingFlowError, ScriptError
 from prefect.flows import load_flow_from_entrypoint, load_flows_from_script
 from prefect.runner.utils import (
     inject_schemas_into_openapi,
@@ -40,7 +40,6 @@ if HAS_PYDANTIC_V2:
 else:
     from pydantic import BaseModel
 
-logger = prefect.logging.get_logger("runner.server")
 
 RunnableEndpoint = Literal["deployment", "flow", "task"]
 
@@ -178,7 +177,7 @@ def _build_generic_endpoint_for_flows(
     ) -> JSONResponse:
         try:
             flow = load_flow_from_entrypoint(body.entrypoint)
-        except MissingFlowError:
+        except (MissingFlowError, ScriptError):
             return JSONResponse(
                 status_code=status.HTTP_404_NOT_FOUND,
                 content={"message": "Flow not found"},

--- a/src/prefect/runner/server.py
+++ b/src/prefect/runner/server.py
@@ -8,11 +8,13 @@ from prefect._vendor.fastapi import APIRouter, FastAPI, HTTPException, status
 from prefect._vendor.fastapi.responses import JSONResponse
 from typing_extensions import Literal
 
+import prefect.logging
 import prefect.runtime
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect.client.orchestration import get_client
 from prefect.context import FlowRunContext, TaskRunContext
-from prefect.flows import load_flow_from_entrypoint
+from prefect.exceptions import MissingFlowError
+from prefect.flows import load_flow_from_entrypoint, load_flows_from_script
 from prefect.runner.utils import (
     inject_schemas_into_openapi,
 )
@@ -38,6 +40,7 @@ if HAS_PYDANTIC_V2:
 else:
     from pydantic import BaseModel
 
+logger = prefect.logging.get_logger("runner.server")
 
 RunnableEndpoint = Literal["deployment", "flow", "task"]
 
@@ -140,18 +143,61 @@ async def get_deployment_router(
             )
 
             # Used for updating the route schemas later on
-            schemas[f"{deployment.name}-{deployment_id}"] = (
-                deployment.parameter_openapi_schema
-            )
+            schemas[
+                f"{deployment.name}-{deployment_id}"
+            ] = deployment.parameter_openapi_schema
             schemas[deployment_id] = deployment.name
     return router, schemas
 
 
-def _build_generic_endpoint_for_flows(runner: "Runner") -> Callable:
+async def get_subflow_schemas(runner: "Runner") -> Dict[str, Dict]:
+    """
+    Load available subflow schemas by filtering for only those subflows in the
+    deployment entrypoint's import space.
+    """
+    schemas = {}
+    async with get_client() as client:
+        for deployment_id in runner._deployment_ids:
+            deployment = await client.read_deployment(deployment_id)
+            if deployment.entrypoint is None:
+                continue
+
+            script = deployment.entrypoint.split(":")[0]
+            subflows = load_flows_from_script(script)
+            for flow in subflows:
+                schemas[flow.name] = flow.parameters.dict()
+
+    return schemas
+
+
+def _build_generic_endpoint_for_flows(
+    runner: "Runner", schemas: Dict[str, Dict]
+) -> Callable:
     async def _create_flow_run_for_flow_from_fqn(
         body: RunnerGenericFlowRunRequest,
     ) -> JSONResponse:
-        flow = load_flow_from_entrypoint(body.entrypoint)
+        try:
+            flow = load_flow_from_entrypoint(body.entrypoint)
+        except MissingFlowError:
+            return JSONResponse(
+                status_code=status.HTTP_404_NOT_FOUND,
+                content={"message": "Flow not found"},
+            )
+
+        # Verify that the flow we're loading is a subflow this runner is
+        # managing
+        if flow.name not in schemas:
+            runner._logger.warning(
+                f"Flow {flow.name} is not directly managed by the runner. Please "
+                "include it in the runner's served flows' import namespace."
+            )
+        # Verify that the flow we're loading hasn't changed since the webserver
+        # was started
+        if schemas.get(flow.name, {}) != flow.parameters.dict():
+            runner._logger.warning(
+                "A change in flow parameters has been detected. Please "
+                "restart the runner."
+            )
 
         async with get_client() as client:
             flow_run = await client.create_flow_run(
@@ -194,9 +240,11 @@ async def build_server(runner: "Runner") -> FastAPI:
     if PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS.value():
         deployments_router, deployment_schemas = await get_deployment_router(runner)
         webserver.include_router(deployments_router)
+
+        subflow_schemas = await get_subflow_schemas(runner)
         webserver.add_api_route(
             "/flow/run",
-            _build_generic_endpoint_for_flows(runner=runner),
+            _build_generic_endpoint_for_flows(runner=runner, schemas=subflow_schemas),
             methods=["POST"],
             name="Run flow in background",
             description="Trigger any flow run as a background task on the runner.",

--- a/src/prefect/runner/utils.py
+++ b/src/prefect/runner/utils.py
@@ -1,17 +1,10 @@
-import os
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple
+from typing import Any, Dict
 
 from prefect._vendor.fastapi import FastAPI
 from prefect._vendor.fastapi.openapi.utils import get_openapi
 
 from prefect import __version__ as PREFECT_VERSION
-from prefect.deployments.base import _search_for_flow_functions
-from prefect.flows import load_flow_from_entrypoint
-
-if TYPE_CHECKING:
-    from prefect import Flow
-    from prefect.deployments import Deployment
 
 
 def inject_schemas_into_openapi(
@@ -97,31 +90,3 @@ def update_refs_to_components(openapi_schema: Dict[str, Any]) -> Dict[str, Any]:
         update_refs_in_schema(definition, "#/components/schemas/")
 
     return openapi_schema
-
-
-async def _find_subflows_of_deployment(
-    deployment: "Deployment",
-) -> List[Tuple[str, "Flow"]]:
-    """
-    Find all subflows of a deployment.
-
-    Args:
-        deployment: The deployment to find subflows of.
-
-    Returns:
-        A list of flows.
-    """
-
-    entrypoint_dir = os.path.dirname(deployment.entrypoint.split(":")[0])
-
-    flow_entrypoints = [
-        entrypoint
-        for flow in await _search_for_flow_functions(entrypoint_dir)
-        if (entrypoint := f'{flow["filepath"]}:{flow["function_name"]}')
-        != deployment.entrypoint
-    ]
-
-    return [
-        (entrypoint, load_flow_from_entrypoint(entrypoint))
-        for entrypoint in flow_entrypoints
-    ]

--- a/tests/runner/test_webserver.py
+++ b/tests/runner/test_webserver.py
@@ -7,6 +7,7 @@ import pytest
 from prefect._vendor.fastapi.testclient import TestClient
 
 from prefect import flow
+from prefect.client.orchestration import PrefectClient, get_client
 from prefect.runner import Runner
 from prefect.runner.server import build_server
 from prefect.settings import (
@@ -38,19 +39,8 @@ def complex_flow(
     print(x, y, z, a, b)
 
 
-@pytest.fixture(autouse=True)
-def only_flows_from_here(monkeypatch):
-    async def get_flows_in_this_file(directory="."):
-        return [
-            (f"{__file__}:simple_flow", simple_flow),
-            (f"{__file__}:complex_flow", complex_flow),
-        ]
-
-    monkeypatch.setattr(
-        "prefect.runner.server._find_subflows_of_deployment",
-        get_flows_in_this_file,
-    )
-    yield
+def a_non_flow_function():
+    print("This is not a flow!")
 
 
 @pytest.fixture(autouse=True)
@@ -145,29 +135,30 @@ class TestWebserverDeploymentRoutes:
         flow_run_id = response.json()["flow_run_id"]
         assert isinstance(uuid.UUID(flow_run_id), uuid.UUID)
 
-    @mock.patch("prefect.runner.server.get_client")
-    async def test_runners_deployment_run_route_execs_flow_run(
-        self, mock_get_client: mock.Mock, runner: Runner
-    ):
+    async def test_runners_deployment_run_route_execs_flow_run(self, runner: Runner):
         mock_flow_run_id = str(uuid.uuid4())
-        mock_client = mock.AsyncMock()
-        mock_get_client.return_value.__aenter__.return_value = mock_client
+
+        mock_client = mock.create_autospec(PrefectClient, spec_set=True)
         mock_client.create_flow_run_from_deployment.return_value.id = mock_flow_run_id
+        mock_get_client = mock.create_autospec(get_client, spec_set=True)
+        mock_get_client.return_value.__aenter__.return_value = mock_client
+        mock_get_client.return_value.__aexit__.return_value = None
 
         deployment_id = await create_deployment(runner, simple_flow)
         webserver = await build_server(runner)
-
         client = TestClient(webserver)
-        response = client.post(f"/deployment/{deployment_id}/run")
 
-        assert response.status_code == 201, response.json()
-        flow_run_id = response.json()["flow_run_id"]
-        assert flow_run_id == mock_flow_run_id
-        assert isinstance(uuid.UUID(flow_run_id), uuid.UUID)
-
-        mock_client.create_flow_run_from_deployment.assert_called_once_with(
-            deployment_id=uuid.UUID(deployment_id), parameters={}
-        )
+        with mock.patch(
+            "prefect.runner.server.get_client", new=mock_get_client
+        ), mock.patch.object(runner, "execute_in_background"):
+            response = client.post(f"/deployment/{deployment_id}/run")
+            assert response.status_code == 201, response.json()
+            flow_run_id = response.json()["flow_run_id"]
+            assert flow_run_id == mock_flow_run_id
+            assert isinstance(uuid.UUID(flow_run_id), uuid.UUID)
+            mock_client.create_flow_run_from_deployment.assert_called_once_with(
+                deployment_id=uuid.UUID(deployment_id), parameters={}
+            )
 
 
 class TestWebserverFlowRoutes:
@@ -181,3 +172,103 @@ class TestWebserverFlowRoutes:
             webserver = await build_server(runner)
             flow_routes = [r for r in webserver.routes if r.path == "/flow/run"]
             assert len(flow_routes) == 0
+
+    async def test_flow_router_runs_managed_flow(self, runner: Runner):
+        await create_deployment(runner, simple_flow)
+        webserver = await build_server(runner)
+        client = TestClient(webserver)
+
+        with mock.patch.object(
+            runner, "execute_flow_run", new_callable=mock.AsyncMock
+        ) as mock_run:
+            response = client.post(
+                "/flow/run",
+                json={"entrypoint": f"{__file__}:simple_flow", "parameters": {}},
+            )
+            assert response.status_code == 201, response.status_code
+            assert "flow_run_id" in response.json()
+            mock_run.assert_called()
+
+    @pytest.mark.parametrize("flow_name", ["a_missing_flow", "a_non_flow_function"])
+    @pytest.mark.parametrize(
+        "flow_file", [__file__, "/not/a/path.py", "not/a/python/file.txt"]
+    )
+    async def test_non_flow_raises_a_404(
+        self,
+        runner: Runner,
+        flow_file: str,
+        flow_name: str,
+    ):
+        await create_deployment(runner, simple_flow)
+        webserver = await build_server(runner)
+        client = TestClient(webserver)
+
+        response = client.post(
+            "/flow/run",
+            json={"entrypoint": f"{flow_file}:{flow_name}", "parameters": {}},
+        )
+        assert response.status_code == 404, response.status_code
+
+    @mock.patch("prefect.runner.server.load_flow_from_entrypoint")
+    async def test_flow_router_complains_about_running_unmanaged_flow(
+        self, mocked_load: mock.MagicMock, runner: Runner, caplog
+    ):
+        await create_deployment(runner, simple_flow)
+        webserver = await build_server(runner)
+        client = TestClient(webserver)
+
+        @flow
+        def new_flow():
+            pass
+
+        # force load_flow_from_entrypoint to return a different flow
+        mocked_load.return_value = new_flow
+        with mock.patch.object(
+            runner, "execute_flow_run", new_callable=mock.AsyncMock
+        ) as mock_run:
+            response = client.post(
+                "/flow/run", json={"entrypoint": "doesnt_matter", "parameters": {}}
+            )
+            # the flow should still be run even though it's not managed
+            assert response.status_code == 201, response.status_code
+            assert "flow_run_id" in response.json()
+            mock_run.assert_called()
+
+        # we should have logged a warning
+        assert (
+            "Flow new-flow is not directly managed by the runner. Please "
+            "include it in the runner's served flows' import namespace."
+            in caplog.text
+        )
+
+    @mock.patch("prefect.runner.server.load_flow_from_entrypoint")
+    async def test_flow_router_complains_about_flow_with_different_schema(
+        self, mocked_load: mock.MagicMock, runner: Runner, caplog
+    ):
+        await create_deployment(runner, simple_flow)
+        webserver = await build_server(runner)
+        client = TestClient(webserver)
+
+        @flow
+        def simple_flow2(age: int = 99):
+            pass
+
+        # force load_flow_from_entrypoint to return the updated flow
+        simple_flow2.name = "simple_flow"
+        mocked_load.return_value = simple_flow2
+        with mock.patch.object(
+            runner, "execute_flow_run", new_callable=mock.AsyncMock
+        ) as mock_run:
+            response = client.post(
+                "/flow/run", json={"entrypoint": "doesnt_matter", "parameters": {}}
+            )
+            # we'll still attempt to run the changed flow
+            assert response.status_code == 201, response.status_code
+            assert "flow_run_id" in response.json()
+            mock_run.assert_called()
+
+        # we should have logged a warning
+        assert (
+            "A change in flow parameters has been detected. Please restart the runner."
+            in caplog.text
+        )


### PR DESCRIPTION
This PR adds filtering to limit the flows the runner is aware of to only those flows available in the deployment's import namespace. This PR also includes logging on flow schema changes -- this is useful to detect when a runner has pulled new code that is different than the code available when the webserver was built.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
