### PR TITLE
Enable flow runs to receive typed input from external sources

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -9,6 +9,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Set,
     Union,
 )
 from uuid import UUID
@@ -2712,6 +2713,20 @@ class PrefectClient:
             json={"key": key, "value": value},
         )
         response.raise_for_status()
+
+    async def filter_flow_run_input(
+        self, flow_run_id: UUID, key_prefix: str, limit: int, exclude_keys: Set[str]
+    ) -> List[FlowRunInput]:
+        response = await self._client.post(
+            f"/flow_runs/{flow_run_id}/input/filter",
+            json={
+                "prefix": key_prefix,
+                "limit": limit,
+                "exclude_keys": list(exclude_keys),
+            },
+        )
+        response.raise_for_status()
+        return pydantic.parse_obj_as(List[FlowRunInput], response.json())
 
     async def read_flow_run_input(self, flow_run_id: UUID, key: str) -> str:
         """

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -12,6 +12,7 @@ from typing import (
 )
 from uuid import UUID
 
+import orjson
 import pendulum
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
@@ -1533,6 +1534,16 @@ class FlowRunInput(ObjectBaseModel):
     flow_run_id: UUID = Field(description="The flow run ID associated with the input.")
     key: str = Field(description="The key of the input.")
     value: str = Field(description="The value of the input.")
+
+    @property
+    def decoded_value(self) -> Any:
+        """
+        Decode the value of the input.
+
+        Returns:
+            Any: the decoded value
+        """
+        return orjson.loads(self.value)
 
     @validator("key", check_fields=False)
     def validate_name_characters(cls, v):

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -207,6 +207,7 @@ class RunContext(ContextModel):
     """
 
     start_time: DateTimeTZ = Field(default_factory=lambda: pendulum.now("UTC"))
+    input_keyset: Optional[Dict[str, Dict[str, str]]] = None
     client: PrefectClient
 
 

--- a/src/prefect/input/__init__.py
+++ b/src/prefect/input/__init__.py
@@ -1,11 +1,27 @@
-from .actions import create_flow_run_input, delete_flow_run_input, read_flow_run_input
-from .run_input import RunInput, keyset_from_base_key, keyset_from_paused_state
+from .actions import (
+    create_flow_run_input,
+    delete_flow_run_input,
+    filter_flow_run_input,
+    read_flow_run_input,
+)
+from .get_input import InputWrapper, get_input, send_input
+from .run_input import (
+    Keyset,
+    RunInput,
+    keyset_from_base_key,
+    keyset_from_paused_state,
+)
 
 __all__ = [
+    "InputWrapper",
+    "Keyset",
     "RunInput",
     "create_flow_run_input",
+    "delete_flow_run_input",
+    "filter_flow_run_input",
+    "get_input",
     "keyset_from_base_key",
     "keyset_from_paused_state",
-    "delete_flow_run_input",
     "read_flow_run_input",
+    "send_input",
 ]

--- a/src/prefect/input/actions.py
+++ b/src/prefect/input/actions.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Set
 from uuid import UUID
 
 import orjson
@@ -45,6 +45,28 @@ async def create_flow_run_input(
 
     await client.create_flow_run_input(
         flow_run_id=flow_run_id, key=key, value=orjson.dumps(value).decode()
+    )
+
+
+@sync_compatible
+@inject_client
+async def filter_flow_run_input(
+    key_prefix: str,
+    limit: int = 1,
+    exclude_keys: Optional[Set[str]] = None,
+    flow_run_id: Optional[UUID] = None,
+    client: "PrefectClient" = None,
+):
+    if exclude_keys is None:
+        exclude_keys = set()
+
+    flow_run_id = _ensure_flow_run_id(flow_run_id)
+
+    return await client.filter_flow_run_input(
+        flow_run_id=flow_run_id,
+        key_prefix=key_prefix,
+        limit=limit,
+        exclude_keys=exclude_keys,
     )
 
 

--- a/src/prefect/input/get_input.py
+++ b/src/prefect/input/get_input.py
@@ -1,0 +1,245 @@
+from typing import (
+    TYPE_CHECKING,
+    Generic,
+    Literal,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
+from uuid import UUID, uuid4
+
+import anyio
+import orjson
+import pydantic
+
+from prefect.context import FlowRunContext
+from prefect.input.actions import (
+    create_flow_run_input,
+    filter_flow_run_input,
+)
+from prefect.input.run_input import RunInput
+from prefect.utilities.asyncutils import sync_compatible
+
+if TYPE_CHECKING:
+    from prefect.client.schemas.objects import FlowRunInput
+
+
+T = TypeVar("T", bound="RunInput")
+
+
+@sync_compatible
+async def send_input(
+    input: "RunInput", flow_run_id: UUID, sender: Optional[Union[str, UUID]] = None
+):
+    """
+    Send `input` to the given flow run.
+
+    Args:
+        - input (RunInput): the input to send
+        - flow_run_id (UUID): the flow run ID to send the input to
+        - sender (Optional[Union[str, UUID]]): the sender of the input,
+          defaults to the current flow run ID if one exists.
+    """
+
+    if sender is None:
+        context = FlowRunContext.get()
+        if context is not None and context.flow_run is not None:
+            sender = context.flow_run.id
+
+    keyset = input.__class__.keyset_from_type()
+    key = f"{keyset['response']}-{uuid4()}"
+
+    wrapper = InputWrapper(value=input, key=key, sender=str(sender))
+
+    await create_flow_run_input(
+        key=key, value=orjson.loads(wrapper.json()), flow_run_id=flow_run_id
+    )
+
+
+class GetInput(Generic[T]):
+    def __init__(
+        self,
+        run_input_cls: Type[T],
+        timeout: Optional[float] = 3600,
+        poll_interval: float = 10,
+        raise_timeout_error: bool = False,
+        exclude_keys: Optional[set[str]] = None,
+    ):
+        self.run_input_cls = run_input_cls
+        self.timeout = timeout
+        self.poll_interval = poll_interval
+        self.exclude_keys = set()
+        self.raise_timeout_error = raise_timeout_error
+
+        if exclude_keys is not None:
+            self.exclude_keys.update(exclude_keys)
+
+        self.keyset = self.run_input_cls.keyset_from_type()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> "InputWrapper[T]":
+        try:
+            return self.next()
+        except TimeoutError:
+            if self.raise_timeout_error:
+                raise
+            raise StopIteration
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> "InputWrapper[T]":
+        try:
+            return await self.next()
+        except TimeoutError:
+            if self.raise_timeout_error:
+                raise
+            raise StopAsyncIteration
+
+    async def filter_for_inputs(self):
+        flow_run_inputs = await filter_flow_run_input(
+            key_prefix=self.keyset["response"],
+            limit=1,
+            exclude_keys=self.exclude_keys,
+        )
+
+        if flow_run_inputs:
+            self.exclude_keys.add(*[i.key for i in flow_run_inputs])
+
+        return flow_run_inputs
+
+    def to_input_wrapper(self, flow_run_input: "FlowRunInput") -> "InputWrapper[T]":
+        decoded = flow_run_input.decoded_value
+        value = decoded.pop("value")
+        return InputWrapper(value=self.run_input_cls(**value), **decoded)
+
+    @sync_compatible
+    async def next(self) -> "InputWrapper[T]":
+        flow_run_inputs = await self.filter_for_inputs()
+        if flow_run_inputs:
+            return self.to_input_wrapper(flow_run_inputs[0])
+
+        with anyio.fail_after(self.timeout):
+            while True:
+                await anyio.sleep(self.poll_interval)
+                flow_run_inputs = await self.filter_for_inputs()
+                if flow_run_inputs:
+                    return self.to_input_wrapper(flow_run_inputs[0])
+
+
+class GetInputUnwrapped(GetInput[T]):
+    def __next__(self) -> T:
+        try:
+            return self.next()
+        except TimeoutError:
+            if self.raise_timeout_error:
+                raise
+            raise StopIteration
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> T:
+        try:
+            return await self.next()
+        except TimeoutError:
+            if self.raise_timeout_error:
+                raise
+            raise StopAsyncIteration
+
+    @sync_compatible
+    async def next(self) -> T:
+        wrapper = await super().next()
+        return wrapper.unwrap()
+
+
+@overload
+def get_input(
+    run_input_cls: Type[T],
+    wrapped: Literal[True],
+    timeout: Optional[float] = 3600.0,
+    poll_interval: float = 10.0,
+    raise_timeout_error: bool = False,
+    exclude_keys: Optional[set[str]] = None,
+) -> GetInput[T]:
+    ...
+
+
+@overload
+def get_input(
+    run_input_cls: Type[T],
+    wrapped: Literal[False],
+    timeout: Optional[float] = 3600.0,
+    poll_interval: float = 10.0,
+    raise_timeout_error: bool = False,
+    exclude_keys: Optional[set[str]] = None,
+) -> GetInputUnwrapped[T]:
+    ...
+
+
+@overload
+def get_input(
+    run_input_cls: Type[T],
+    wrapped: bool = False,
+    timeout: Optional[float] = 3600.0,
+    poll_interval: float = 10.0,
+    raise_timeout_error: bool = False,
+    exclude_keys: Optional[set[str]] = None,
+) -> GetInputUnwrapped[T]:
+    ...
+
+
+def get_input(
+    run_input_cls: Type[T],
+    wrapped: bool = False,
+    timeout: Optional[float] = 3600.0,
+    poll_interval: float = 10.0,
+    raise_timeout_error: bool = False,
+    exclude_keys: Optional[set[str]] = None,
+):
+    """
+    Get input for the given run input class.
+
+    Args:
+        run_input_cls (Type[T]): the run input class to get input for
+        wrapped (bool, optional): whether or not to return the input wrapped in
+            an `InputWrapper`, defaults to `False`
+        timeout (float, optional): the timeout in seconds to wait for input,
+            defaults to 3600
+        poll_interval (float, optional): the interval in seconds to poll for
+            input, defaults to 10
+        raise_timeout_error (bool, optional): when used as a generator whether
+            or not to raise a `TimeoutError` if the timeout is reached,
+            defaults to `False`
+        exclude_keys (Optional[set[str]], optional): keys to exclude from the
+            input
+    """
+
+    kwargs = {
+        "run_input_cls": run_input_cls,
+        "timeout": timeout,
+        "poll_interval": poll_interval,
+        "raise_timeout_error": raise_timeout_error,
+        "exclude_keys": exclude_keys,
+    }
+
+    if wrapped:
+        return GetInput(**kwargs)
+    else:
+        return GetInputUnwrapped(**kwargs)
+
+
+class InputWrapper(Generic[T], pydantic.BaseModel):
+    value: T
+    key: str
+    sender: Optional[str] = None
+
+    def unwrap(self) -> T:
+        return self.value
+
+
+InputWrapper.update_forward_refs()

--- a/src/prefect/input/get_input.py
+++ b/src/prefect/input/get_input.py
@@ -15,6 +15,7 @@ import anyio
 import orjson
 import pydantic
 
+from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect.context import FlowRunContext
 from prefect.input.actions import (
     create_flow_run_input,
@@ -243,4 +244,7 @@ class InputWrapper(pydantic.BaseModel, Generic[T]):
         return self.value
 
 
-InputWrapper.update_forward_refs()
+if HAS_PYDANTIC_V2:
+    InputWrapper.model_rebuild()
+else:
+    InputWrapper.update_forward_refs()

--- a/src/prefect/input/get_input.py
+++ b/src/prefect/input/get_input.py
@@ -55,9 +55,12 @@ async def send_input(
 
     wrapper = InputWrapper(value=input, key=key, sender=str(sender))
 
-    await create_flow_run_input(
-        key=key, value=orjson.loads(wrapper.json()), flow_run_id=flow_run_id
-    )
+    if HAS_PYDANTIC_V2:
+        json_safe = orjson.loads(wrapper.model_dump_json())
+    else:
+        json_safe = orjson.loads(wrapper.json())
+
+    await create_flow_run_input(key=key, value=json_safe, flow_run_id=flow_run_id)
 
 
 class GetInput(Generic[T]):

--- a/src/prefect/input/get_input.py
+++ b/src/prefect/input/get_input.py
@@ -3,6 +3,7 @@ from typing import (
     Generic,
     Literal,
     Optional,
+    Set,
     Type,
     TypeVar,
     Union,
@@ -65,7 +66,7 @@ class GetInput(Generic[T]):
         timeout: Optional[float] = 3600,
         poll_interval: float = 10,
         raise_timeout_error: bool = False,
-        exclude_keys: Optional[set[str]] = None,
+        exclude_keys: Optional[Set[str]] = None,
     ):
         self.run_input_cls = run_input_cls
         self.timeout = timeout
@@ -164,7 +165,7 @@ def get_input(
     timeout: Optional[float] = 3600.0,
     poll_interval: float = 10.0,
     raise_timeout_error: bool = False,
-    exclude_keys: Optional[set[str]] = None,
+    exclude_keys: Optional[Set[str]] = None,
 ) -> GetInput[T]:
     ...
 
@@ -176,7 +177,7 @@ def get_input(
     timeout: Optional[float] = 3600.0,
     poll_interval: float = 10.0,
     raise_timeout_error: bool = False,
-    exclude_keys: Optional[set[str]] = None,
+    exclude_keys: Optional[Set[str]] = None,
 ) -> GetInputUnwrapped[T]:
     ...
 
@@ -188,7 +189,7 @@ def get_input(
     timeout: Optional[float] = 3600.0,
     poll_interval: float = 10.0,
     raise_timeout_error: bool = False,
-    exclude_keys: Optional[set[str]] = None,
+    exclude_keys: Optional[Set[str]] = None,
 ) -> GetInputUnwrapped[T]:
     ...
 
@@ -199,7 +200,7 @@ def get_input(
     timeout: Optional[float] = 3600.0,
     poll_interval: float = 10.0,
     raise_timeout_error: bool = False,
-    exclude_keys: Optional[set[str]] = None,
+    exclude_keys: Optional[Set[str]] = None,
 ):
     """
     Get input for the given run input class.
@@ -215,7 +216,7 @@ def get_input(
         raise_timeout_error (bool, optional): when used as a generator whether
             or not to raise a `TimeoutError` if the timeout is reached,
             defaults to `False`
-        exclude_keys (Optional[set[str]], optional): keys to exclude from the
+        exclude_keys (Optional[Set[str]], optional): keys to exclude from the
             input
     """
 
@@ -233,7 +234,7 @@ def get_input(
         return GetInputUnwrapped(**kwargs)
 
 
-class InputWrapper(Generic[T], pydantic.BaseModel):
+class InputWrapper(pydantic.BaseModel, Generic[T]):
     value: T
     key: str
     sender: Optional[str] = None

--- a/src/prefect/input/run_input.py
+++ b/src/prefect/input/run_input.py
@@ -1,10 +1,22 @@
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Type, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Literal,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+)
 from uuid import UUID
 
 import pydantic
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
-from prefect.input.actions import create_flow_run_input, read_flow_run_input
+from prefect.input.actions import (
+    create_flow_run_input,
+    read_flow_run_input,
+)
 from prefect.utilities.asyncutils import sync_compatible
 
 if TYPE_CHECKING:
@@ -16,8 +28,7 @@ if HAS_PYDANTIC_V2:
 
 
 T = TypeVar("T", bound="RunInput")
-KeysetNames = Union[Literal["response"], Literal["schema"]]
-Keyset = Dict[KeysetNames, str]
+Keyset = Dict[Union[Literal["response"], Literal["schema"]], str]
 
 
 def keyset_from_paused_state(state: "State") -> Keyset:
@@ -31,9 +42,8 @@ def keyset_from_paused_state(state: "State") -> Keyset:
     if not state.is_paused():
         raise RuntimeError(f"{state.type.value!r} is unsupported.")
 
-    return keyset_from_base_key(
-        f"{state.name.lower()}-{str(state.state_details.pause_key)}"
-    )
+    base_key = f"{state.name.lower()}-{str(state.state_details.pause_key)}"
+    return keyset_from_base_key(base_key)
 
 
 def keyset_from_base_key(base_key: str) -> Keyset:
@@ -55,6 +65,10 @@ def keyset_from_base_key(base_key: str) -> Keyset:
 class RunInput(pydantic.BaseModel):
     class Config:
         extra = "forbid"
+
+    @classmethod
+    def keyset_from_type(cls) -> Keyset:
+        return keyset_from_base_key(cls.__name__.lower())
 
     @classmethod
     @sync_compatible

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -559,6 +559,31 @@ async def create_flow_run_input(
                 )
 
 
+@router.post("/{id}/input/filter")
+async def filter_flow_run_input(
+    flow_run_id: UUID = Path(..., description="The flow run id", alias="id"),
+    prefix: str = Body(..., description="The input key prefix", embed=True),
+    limit: int = Body(
+        1, description="The maximum number of results to return", embed=True
+    ),
+    exclude_keys: List[str] = Body(
+        [], description="Exclude inputs with these keys", embed=True
+    ),
+    db: PrefectDBInterface = Depends(provide_database_interface),
+) -> List[schemas.core.FlowRunInput]:
+    """
+    Filter flow run inputs by key prefix
+    """
+    async with db.session_context() as session:
+        return await models.flow_run_input.filter_flow_run_input(
+            session=session,
+            flow_run_id=flow_run_id,
+            prefix=prefix,
+            limit=limit,
+            exclude_keys=exclude_keys,
+        )
+
+
 @router.get("/{id}/input/{key}")
 async def read_flow_run_input(
     flow_run_id: UUID = Path(..., description="The flow run id", alias="id"),

--- a/tests/input/test_actions.py
+++ b/tests/input/test_actions.py
@@ -95,9 +95,7 @@ class TestFilterFlowRunInput:
 
         return keys
 
-    async def test_implicit_flow_run(
-        self, flow_run_context, flow_run_input_keys: list[str]
-    ):
+    async def test_implicit_flow_run(self, flow_run_context, flow_run_input_keys):
         filtered = await filter_flow_run_input(
             key_prefix="key", limit=len(flow_run_input_keys) + 1
         )
@@ -105,7 +103,7 @@ class TestFilterFlowRunInput:
         assert {"key-1", "key-2"} != flow_run_input_keys
         assert {"key-1", "key-2"} == {item.key for item in filtered}
 
-    async def test_explicit_flow_run(self, flow_run, flow_run_input_keys: list[str]):
+    async def test_explicit_flow_run(self, flow_run, flow_run_input_keys):
         filtered = await filter_flow_run_input(
             key_prefix="key",
             limit=len(flow_run_input_keys) + 1,
@@ -121,7 +119,7 @@ class TestFilterFlowRunInput:
         ):
             await filter_flow_run_input(key_prefix="key")
 
-    async def test_exclude_keys(self, flow_run_context, flow_run_input_keys: list[str]):
+    async def test_exclude_keys(self, flow_run_context, flow_run_input_keys):
         filtered = await filter_flow_run_input(
             key_prefix="key", limit=len(flow_run_input_keys) + 1, exclude_keys={"key-2"}
         )

--- a/tests/input/test_get_input.py
+++ b/tests/input/test_get_input.py
@@ -1,0 +1,293 @@
+import asyncio
+
+import pytest
+
+from prefect.context import FlowRunContext
+from prefect.input import (
+    InputWrapper,
+    RunInput,
+    filter_flow_run_input,
+    get_input,
+    send_input,
+)
+
+
+@pytest.fixture
+def flow_run_context(flow_run, prefect_client):
+    with FlowRunContext.construct(flow_run=flow_run, client=prefect_client) as context:
+        yield context
+
+
+class Person(RunInput):
+    name: str
+    email: str
+    human: bool
+
+
+async def test_send_input_stores_input(flow_run):
+    person = Person(name="Bob", email="bob@bob.bob", human=True)
+    await send_input(input=person, flow_run_id=flow_run.id)
+
+    inputs = await filter_flow_run_input(
+        key_prefix=person.keyset_from_type()["response"], flow_run_id=flow_run.id
+    )
+
+    assert len(inputs) == 1
+
+    decoded = inputs[0].decoded_value
+    value = decoded.pop("value")
+    wrapper = InputWrapper(value=Person(**value), **decoded)
+
+    assert wrapper.value == person
+
+
+def test_send_input_stores_input_sync(flow_run):
+    person = Person(name="Bob", email="bob@bob.bob", human=True)
+    send_input(input=person, flow_run_id=flow_run.id)
+
+    inputs = filter_flow_run_input(
+        key_prefix=person.keyset_from_type()["response"], flow_run_id=flow_run.id
+    )
+
+    assert len(inputs) == 1
+
+    decoded = inputs[0].decoded_value
+    value = decoded.pop("value")
+    wrapper = InputWrapper(value=Person(**value), **decoded)
+
+    assert wrapper.value == person
+
+
+async def test_send_input_infers_sender(flow_run_context):
+    person = Person(name="Bob", email="bob@bob.bob", human=True)
+    await send_input(input=person, flow_run_id=flow_run_context.flow_run.id)
+
+    inputs = await filter_flow_run_input(
+        key_prefix=person.keyset_from_type()["response"]
+    )
+
+    decoded = inputs[0].decoded_value
+    value = decoded.pop("value")
+    wrapper = InputWrapper(value=Person(**value), **decoded)
+
+    # Since we're in a flow run context, the sender should be the flow run ID.
+    # But since we're only dealing with a single flow run context here the
+    # sender and receiver are the same.
+
+    assert wrapper.sender == str(flow_run_context.flow_run.id)
+
+
+async def test_send_input_can_set_sender(flow_run):
+    person = Person(name="Bob", email="bob@bob.bob", human=True)
+    await send_input(
+        input=person,
+        flow_run_id=flow_run.id,
+        sender="sally",
+    )
+
+    inputs = await filter_flow_run_input(
+        key_prefix=person.keyset_from_type()["response"], flow_run_id=flow_run.id
+    )
+
+    decoded = inputs[0].decoded_value
+    value = decoded.pop("value")
+    wrapper = InputWrapper(value=Person(**value), **decoded)
+
+    assert wrapper.sender == "sally"
+
+
+def test_get_input_works_sync(flow_run_context):
+    person = Person(name="Bob", email="bob@example.com", human=True)
+    send_input(
+        input=person,
+        flow_run_id=flow_run_context.flow_run.id,
+    )
+
+    received = get_input(Person).next()
+    assert person == received
+
+
+def test_get_input_wrapped_works_sync(flow_run_context):
+    person = Person(name="Bob", email="bob@example.com", human=True)
+    send_input(
+        input=person,
+        flow_run_id=flow_run_context.flow_run.id,
+    )
+
+    received = get_input(Person, wrapped=True).next()
+    assert person == received.value
+
+
+async def test_get_input_single_value(flow_run_context):
+    person = Person(name="Bob", email="bob@example.com", human=True)
+    await send_input(
+        input=person,
+        flow_run_id=flow_run_context.flow_run.id,
+    )
+
+    received = await get_input(Person).next()
+    assert person == received
+
+
+async def test_get_input_as_generator(flow_run_context):
+    for name, email, human in [
+        ("Bob", "bob@example.com", True),
+        ("Sally", "sally@example.com", True),
+        ("Bot", "bot@example.com", False),
+    ]:
+        person = Person(name=name, email=email, human=human)
+        await send_input(
+            input=person,
+            flow_run_id=flow_run_context.flow_run.id,
+        )
+
+    received = []
+    async for person in get_input(Person, timeout=0):
+        received.append(person)
+
+    assert len(received) == 3
+    assert all(isinstance(person, Person) for person in received)
+    assert {person.name for person in received} == {"Bob", "Sally", "Bot"}
+
+
+async def test_get_input_single_wrapped_value(flow_run_context):
+    person = Person(name="Bob", email="bob@example.com", human=True)
+    await send_input(
+        input=person,
+        flow_run_id=flow_run_context.flow_run.id,
+    )
+
+    wrapper = await get_input(Person, wrapped=True).next()
+    assert wrapper == InputWrapper(
+        value=person, key=wrapper.key, sender=str(flow_run_context.flow_run.id)
+    )
+
+
+async def test_get_input_wrapped_as_generator(flow_run_context):
+    for name, email, human in [
+        ("Bob", "bob@example.com", True),
+        ("Sally", "sally@example.com", True),
+        ("Bot", "bot@example.com", False),
+    ]:
+        person = Person(name=name, email=email, human=human)
+        await send_input(
+            input=person,
+            flow_run_id=flow_run_context.flow_run.id,
+        )
+
+    received = []
+    async for wrapper in get_input(Person, timeout=0, wrapped=True):
+        received.append(wrapper)
+
+    assert len(received) == 3
+    assert all(isinstance(wrapper, InputWrapper) for wrapper in received)
+    assert {wrapper.value.name for wrapper in received} == {"Bob", "Sally", "Bot"}
+
+
+async def test_get_input_waits_for_input(flow_run_context):
+    async def send():
+        # Sleep a bit to make sure that `receive` has started and failed to
+        # find a matching input.
+        await asyncio.sleep(0.5)
+        await send_input(
+            input=Person(name="Bob", email="bob@example.com", human=True),
+            flow_run_id=flow_run_context.flow_run.id,
+        )
+
+    async def receive():
+        person = await get_input(Person, timeout=1, poll_interval=0.1).next()
+        return person
+
+    _, received = await asyncio.gather(send(), receive())
+
+    assert isinstance(received, Person)
+    assert received.name == "Bob"
+
+
+async def test_get_input_exclude_keys(flow_run_context):
+    for name, email, human in [
+        ("Bob", "bob@example.com", True),
+        ("Sally", "sally@example.com", True),
+        ("Bot", "bot@example.com", False),
+    ]:
+        person = Person(name=name, email=email, human=human)
+        await send_input(
+            input=person,
+            flow_run_id=flow_run_context.flow_run.id,
+        )
+
+    # This is a bit contrived, but we want to make sure that we can exclude
+    # certain keys from being returned by `get_input`. In this case, we're
+    # going to get the first input, and then use get_input as a generator.
+    # Without `exclude_keys` we would get the same input twice.
+    excluded = await get_input(Person, wrapped=True).next()
+
+    received = []
+    async for person in get_input(Person, timeout=0, exclude_keys={excluded.key}):
+        received.append(person)
+
+    assert excluded not in received
+
+
+async def test_get_input_generator_raise_timeout(flow_run_context):
+    with pytest.raises(TimeoutError):
+        async for item in get_input(
+            Person, timeout=0.2, poll_interval=0.1, raise_timeout_error=True
+        ):
+            pass
+
+
+def test_get_input_generator_raise_timeout_sync(flow_run_context):
+    with pytest.raises(TimeoutError):
+        for item in get_input(
+            Person, timeout=0.2, poll_interval=0.1, raise_timeout_error=True
+        ):
+            pass
+
+
+async def test_get_input_generator_no_raise_exits_gracefully(flow_run_context):
+    async for item in get_input(Person, timeout=0.1):
+        pass
+    assert True
+
+
+def test_get_input_generator_no_raise_exits_gracefully_sync(flow_run_context):
+    for item in get_input(Person, timeout=0.1):
+        pass
+    assert True
+
+
+async def test_get_input_generator_wrapped_raise_timeout(flow_run_context):
+    with pytest.raises(TimeoutError):
+        async for item in get_input(
+            Person,
+            timeout=0.2,
+            poll_interval=0.1,
+            raise_timeout_error=True,
+            wrapped=True,
+        ):
+            pass
+
+
+def test_get_input_generator_wrapped_raise_timeout_sync(flow_run_context):
+    with pytest.raises(TimeoutError):
+        for item in get_input(
+            Person,
+            timeout=0.1,
+            poll_interval=0.2,
+            raise_timeout_error=True,
+            wrapped=True,
+        ):
+            pass
+
+
+async def test_get_input_generator_wrapped_no_raise_exits_gracefully(flow_run_context):
+    async for item in get_input(Person, timeout=0.1, wrapped=True):
+        pass
+    assert True
+
+
+def test_get_input_generator_wrapped_no_raise_exits_gracefully_sync(flow_run_context):
+    for item in get_input(Person, timeout=0.1, wrapped=True):
+        pass
+    assert True

--- a/tests/input/test_run_input.py
+++ b/tests/input/test_run_input.py
@@ -30,6 +30,12 @@ def test_keyset_from_base_key():
     assert keyset["schema"] == "person-schema"
 
 
+def test_keyset_from_type():
+    keyset = Person.keyset_from_type()
+    assert keyset["response"] == "person-response"
+    assert keyset["schema"] == "person-schema"
+
+
 @pytest.mark.parametrize(
     "state,expected",
     [

--- a/tests/server/api/test_flow_runs.py
+++ b/tests/server/api/test_flow_runs.py
@@ -1532,6 +1532,15 @@ class TestFlowRunInput:
 
         assert response.status_code == 409
 
+    async def test_filter_flow_run_input(self, client: AsyncClient, flow_run_input):
+        response = await client.post(
+            f"/flow_runs/{flow_run_input.flow_run_id}/input/filter",
+            json={"prefix": "structured"},
+        )
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+        assert schemas.core.FlowRunInput.parse_obj(response.json()[0]) == flow_run_input
+
     async def test_read_flow_run_input(self, client: AsyncClient, flow_run_input):
         response = await client.get(
             f"/flow_runs/{flow_run_input.flow_run_id}/input/{flow_run_input.key}",

--- a/tests/server/models/test_flow_run_input.py
+++ b/tests/server/models/test_flow_run_input.py
@@ -63,6 +63,61 @@ class TestCreateFlowRunInput:
             )
 
 
+class TestFilterFlowRunInput:
+    async def test_reads_flow_run_input(self, session: AsyncSession, flow_run):
+        for key in ["my-key", "my-key2", "other-key"]:
+            await models.flow_run_input.create_flow_run_input(
+                session=session,
+                flow_run_input=schemas.core.FlowRunInput(
+                    flow_run_id=flow_run.id, key=key, value="my-value"
+                ),
+            )
+
+        flow_run_inputs = await models.flow_run_input.filter_flow_run_input(
+            session=session,
+            flow_run_id=flow_run.id,
+            prefix="my-key",
+            limit=10,
+            exclude_keys=[],
+        )
+
+        assert len(flow_run_inputs) == 2
+        assert all(
+            isinstance(flow_run_input, schemas.core.FlowRunInput)
+            for flow_run_input in flow_run_inputs
+        )
+        assert {flow_run_input.key for flow_run_input in flow_run_inputs} == {
+            "my-key",
+            "my-key2",
+        }
+
+    async def test_reads_flow_run_input_exclude_keys(
+        self, session: AsyncSession, flow_run
+    ):
+        for key in ["my-key", "my-key2", "other-key"]:
+            await models.flow_run_input.create_flow_run_input(
+                session=session,
+                flow_run_input=schemas.core.FlowRunInput(
+                    flow_run_id=flow_run.id, key=key, value="my-value"
+                ),
+            )
+
+        flow_run_inputs = await models.flow_run_input.filter_flow_run_input(
+            session=session,
+            flow_run_id=flow_run.id,
+            prefix="my-key",
+            limit=10,
+            exclude_keys=["my-key2"],
+        )
+
+        assert len(flow_run_inputs) == 1
+        assert all(
+            isinstance(flow_run_input, schemas.core.FlowRunInput)
+            for flow_run_input in flow_run_inputs
+        )
+        assert {flow_run_input.key for flow_run_input in flow_run_inputs} == {"my-key"}
+
+
 class TestReadFlowRunInput:
     async def test_reads_flow_run_input(self, session: AsyncSession, flow_run):
         await models.flow_run_input.create_flow_run_input(


### PR DESCRIPTION
This enables flow runs to receive typed input from external sources via the `get_input` and `send_input` methods.

Related to https://github.com/PrefectHQ/nebula/issues/6425

### Example
This is an example of a map/reduce flow that comprises three separate flows communicating with one another:

`map` flow:

```python
from prefect import flow
from prefect.input import get_input, send_input

from common import Values


@flow()
def mapit():
    for wrapper in get_input(Values, poll_interval=1, wrapped=True):
        incoming = wrapper.value.values
        mapped = [value * 2 for value in incoming]

        send_input(Values(values=mapped), flow_run_id=wrapper.sender)


if __name__ == "__main__":
    mapit.serve(name="mapit")
```

`reduce` flow:
```python
from prefect import flow
from prefect.input import get_input, send_input

from common import Summed, Values


@flow()
async def reduce():
    async for wrapper in get_input(Values, poll_interval=1, wrapped=True):
        incoming = wrapper.value.values

        await send_input(
            Summed(value=sum(incoming)), flow_run_id=wrapper.sender
        )


if __name__ == "__main__":
    reduce.serve(name="reduce")
```

And the `mapreduce` flow:
```python
from uuid import UUID

from prefect import flow, get_run_logger
from prefect.input import get_input, send_input

from common import Values, Summed


@flow()
async def mapreduce(
    map_flow_run_id: UUID, reduce_flow_run_id: UUID, incoming: list[int]
):
    logger = get_run_logger()

    await send_input(Values(values=incoming), flow_run_id=map_flow_run_id)

    mapped = await get_input(Values, poll_interval=1).next()
    await send_input(Values(values=mapped.values), flow_run_id=reduce_flow_run_id)

    summed = await get_input(Summed, poll_interval=1).next()
    logger.info(f"Summed value: {summed.value}")


if __name__ == "__main__":
    mapreduce.serve(name="mapreduce")
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
