### PR TITLE
Display work queue status details via CLI

### DIFF
--- a/src/prefect/cli/work_queue.py
+++ b/src/prefect/cli/work_queue.py
@@ -346,9 +346,12 @@ async def inspect(
         name_or_id=name,
         work_pool_name=pool,
     )
+
     async with get_client() as client:
         try:
             result = await client.read_work_queue(id=queue_id)
+            app.console.print(Pretty(result))
+
         except ObjectNotFound:
             if pool:
                 error_message = f"No work queue found: {name!r} in work pool {pool!r}"
@@ -356,7 +359,11 @@ async def inspect(
                 error_message = f"No work queue found: {name!r}"
             exit_with_error(error_message)
 
-    app.console.print(Pretty(result))
+        try:
+            status = await client.read_work_queue_status(id=queue_id)
+            app.console.print(Pretty(status))
+        except ObjectNotFound:
+            pass
 
 
 @work_app.command()

--- a/src/prefect/cli/work_queue.py
+++ b/src/prefect/cli/work_queue.py
@@ -346,12 +346,10 @@ async def inspect(
         name_or_id=name,
         work_pool_name=pool,
     )
-
     async with get_client() as client:
         try:
             result = await client.read_work_queue(id=queue_id)
             app.console.print(Pretty(result))
-
         except ObjectNotFound:
             if pool:
                 error_message = f"No work queue found: {name!r} in work pool {pool!r}"

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -92,6 +92,7 @@ from prefect.client.schemas.objects import (
     Worker,
     WorkPool,
     WorkQueue,
+    WorkQueueStatusDetail,
 )
 from prefect.client.schemas.responses import (
     DeploymentResponse,
@@ -1035,6 +1036,32 @@ class PrefectClient:
             else:
                 raise
         return WorkQueue.parse_obj(response.json())
+
+    async def read_work_queue_status(
+        self,
+        id: UUID,
+    ) -> WorkQueueStatusDetail:
+        """
+        Read a work queue status.
+
+        Args:
+            id: the id of the work queue to load
+
+        Raises:
+            prefect.exceptions.ObjectNotFound: If request returns 404
+            httpx.RequestError: If request fails
+
+        Returns:
+            WorkQueueStatus: an instantiated WorkQueueStatus object
+        """
+        try:
+            response = await self._client.get(f"/work_queues/{id}/status")
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == status.HTTP_404_NOT_FOUND:
+                raise prefect.exceptions.ObjectNotFound(http_exc=e) from e
+            else:
+                raise
+        return WorkQueueStatusDetail.parse_obj(response.json())
 
     async def match_work_queues(
         self,


### PR DESCRIPTION
### Example
```bash
❯ prefect work-queue inspect d9181a64-c098-4e13-ad51-6d63141cd8fc
WorkQueue(
    id='d91...',
    created=DateTime(2023, 2, 2, 17, 39, 58, 692020, tzinfo=Timezone('+00:00')),
    updated=DateTime(2023, 12, 14, 14, 20, 58, 185706, tzinfo=Timezone('+00:00')),
    name='default',
    work_pool_name='default-agent-pool',
    work_pool_id='f8110b4f-f0db-4f10-b615-79081d6afc97',
    last_polled=DateTime(2023, 12, 14, 14, 19, 35, 193143, tzinfo=Timezone('+00:00'))
)
WorkQueueStatusDetail(
    healthy=False,
    last_polled=DateTime(2023, 12, 14, 14, 19, 35, 193143, tzinfo=Timezone('+00:00')),
    health_check_policy=WorkQueueHealthPolicy()
)
```
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
