### PR TITLE
Don't attempt to register signals in non-main thread

### DIFF
--- a/src/prefect/server/services/loop_service.py
+++ b/src/prefect/server/services/loop_service.py
@@ -11,6 +11,7 @@ import pendulum
 from prefect.logging import get_logger
 from prefect.server.database.dependencies import inject_db
 from prefect.server.database.interface import PrefectDBInterface
+from prefect.utilities.processutils import _register_signal
 
 
 class LoopService:
@@ -39,8 +40,8 @@ class LoopService:
         self.logger = get_logger(f"server.services.{self.name.lower()}")
 
         if handle_signals:
-            signal.signal(signal.SIGINT, self._stop)
-            signal.signal(signal.SIGTERM, self._stop)
+            _register_signal(signal.SIGINT, self._stop)
+            _register_signal(signal.SIGTERM, self._stop)
 
     @inject_db
     async def _on_start(self, db: PrefectDBInterface) -> None:


### PR DESCRIPTION
This helps address #10895
The flaky tests on main leading to: `ValueError: signal only works in main thread of the main interpreter` are getting out of hand. This PR attempts to fix that by only attempting to registering signal on main thread.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
