### PR TITLE
Ft/runner runs flows parent waits

### DIFF
--- a/src/prefect/runner/__init__.py
+++ b/src/prefect/runner/__init__.py
@@ -1,2 +1,2 @@
 from .runner import Runner, serve
-from .server import submit_to_runner, wait_for_background_processes
+from .submit import submit_many_to_runner, submit_to_runner, wait_for_submitted_runs

--- a/src/prefect/runner/__init__.py
+++ b/src/prefect/runner/__init__.py
@@ -1,2 +1,2 @@
 from .runner import Runner, serve
-from .server import submit_to_runner
+from .server import submit_to_runner, wait_for_background_processes

--- a/src/prefect/runner/server.py
+++ b/src/prefect/runner/server.py
@@ -1,3 +1,5 @@
+import asyncio
+import inspect
 import uuid
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple
 
@@ -8,11 +10,10 @@ from prefect._vendor.fastapi import APIRouter, FastAPI, HTTPException, status
 from prefect._vendor.fastapi.responses import JSONResponse
 from typing_extensions import Literal
 
-import prefect.runtime
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect.client.orchestration import get_client
-from prefect.context import FlowRunContext, TaskRunContext
-from prefect.flows import load_flow_from_entrypoint
+from prefect.context import FlowRunContext
+from prefect.flows import Flow, load_flow_from_entrypoint
 from prefect.runner.utils import (
     inject_schemas_into_openapi,
 )
@@ -24,9 +25,9 @@ from prefect.settings import (
     PREFECT_RUNNER_SERVER_MISSED_POLLS_TOLERANCE,
     PREFECT_RUNNER_SERVER_PORT,
 )
-from prefect.tasks import Task, task
+from prefect.states import Pending
+from prefect.tasks import Task
 from prefect.utilities.asyncutils import sync_compatible
-from prefect.utilities.slugify import slugify
 from prefect.utilities.validation import validate_values_conform_to_schema
 
 if TYPE_CHECKING:
@@ -40,6 +41,18 @@ else:
 
 
 RunnableEndpoint = Literal["deployment", "flow", "task"]
+WEBSERVER_RESPONSE_LOG: asyncio.Queue = asyncio.Queue(maxsize=100)
+
+
+def get_responses():
+    responses = []
+    while True:
+        try:
+            response = WEBSERVER_RESPONSE_LOG.get_nowait()
+            responses.append(response)
+        except asyncio.QueueEmpty:
+            break  # Break out of the loop if the queue is empty
+    return responses
 
 
 class RunnerGenericFlowRunRequest(BaseModel):
@@ -108,7 +121,6 @@ async def _build_endpoint_for_deployment(
                 deployment_id=deployment.id, parameters=body
             )
         runner.execute_in_background(runner.execute_flow_run, flow_run.id)
-
         return JSONResponse(
             status_code=status.HTTP_201_CREATED,
             content={"flow_run_id": str(flow_run.id)},
@@ -163,6 +175,7 @@ def _build_generic_endpoint_for_flows(runner: "Runner") -> Callable:
         runner.execute_in_background(
             runner.execute_flow_run, flow_run.id, body.entrypoint
         )
+        WEBSERVER_RESPONSE_LOG.put_nowait(flow_run.id)
 
         return JSONResponse(
             status_code=status.HTTP_201_CREATED,
@@ -202,6 +215,14 @@ async def build_server(runner: "Runner") -> FastAPI:
             description="Trigger any flow run as a background task on the runner.",
             summary="Run flow",
         )
+        webserver.add_api_route(
+            "/responses",
+            get_responses,
+            methods=["GET"],
+            name="Get response log",
+            description="Get a log of all responses from to the webserver.",
+            summary="Get response log",
+        )
 
         def customize_openapi():
             if webserver.openapi_schema:
@@ -231,13 +252,11 @@ def start_webserver(runner: "Runner", log_level: Optional[str] = None) -> None:
     uvicorn.run(webserver, host=host, port=port, log_level=log_level)
 
 
-async def _submit_to_runner(
-    prefect_callable: Callable,
+async def _submit_flow_to_runner(
+    flow: Flow,
     parameters: Dict[str, Any],
-    timeout: Optional[float] = None,
-    poll_interval: Optional[float] = 5,
     # capture_errors: bool = SETTING.value()?
-) -> None:
+) -> uuid.UUID:
     """
     Run a callable in the background via the runner webserver.
 
@@ -247,94 +266,53 @@ async def _submit_to_runner(
         timeout: the maximum time to wait for the callable to finish
         poll_interval: the interval (in seconds) to wait between polling the callable
     """
+    from prefect.engine import (
+        _dynamic_key_for_task_run,
+        collect_task_run_inputs,
+        resolve_inputs,
+    )
+
     async with get_client() as client:
-        object_type = prefect_callable.__class__.__name__.lower()
+        parent_flow_run_context = FlowRunContext.get()
 
-        if object_type not in ["flow", "task"]:
-            raise ValueError(
-                f"Object type {object_type!r} cannot be submitted to the runner."
-            )
+        task_inputs = {
+            k: await collect_task_run_inputs(v) for k, v in parameters.items()
+        }
 
-        flow_run_ctx = FlowRunContext.get()
-        task_run_ctx = TaskRunContext.get()
+        dummy_task = Task(name=flow.name, fn=flow.fn, version=flow.version)
+        parent_task_run = await client.create_task_run(
+            task=dummy_task,
+            flow_run_id=parent_flow_run_context.flow_run.id,
+            dynamic_key=_dynamic_key_for_task_run(parent_flow_run_context, dummy_task),
+            task_inputs=task_inputs,
+            state=Pending(),
+        )
 
-        if flow_run_ctx or task_run_ctx:
-            from prefect.engine import (
-                Pending,
-                _dynamic_key_for_task_run,
-                collect_task_run_inputs,
-            )
-
-            task_inputs = {
-                k: await collect_task_run_inputs(v) for k, v in parameters.items()
-            }
-
-            flow_run_id = (
-                flow_run_ctx.flow_run.id
-                if flow_run_ctx
-                else task_run_ctx.task_run.flow_run_id
-            )
-
-            deployment_id = prefect.runtime.deployment.id or "local"
-
-            dummy_task = Task(
-                name=prefect_callable.name,
-                fn=lambda: None,
-            )
-
-            dummy_task.task_key = f"{__name__}.run_{object_type}.{slugify(prefect_callable.name)}_{deployment_id}"
-
-            dynamic_key = (
-                _dynamic_key_for_task_run(flow_run_ctx, dummy_task)
-                if flow_run_ctx
-                else task_run_ctx.task_run.dynamic_key
-            )
-            parent_task_run = await client.create_task_run(
-                task=dummy_task,
-                flow_run_id=flow_run_id,
-                dynamic_key=dynamic_key,
-                task_inputs=task_inputs,
-                state=Pending(),
-            )
-            parent_task_run_id = parent_task_run.id
-        else:
-            parent_task_run_id = None
+        parameters = await resolve_inputs(parameters)
 
         response = await client._client.post(
             (
                 f"http://{PREFECT_RUNNER_SERVER_HOST.value()}"
                 f":{PREFECT_RUNNER_SERVER_PORT.value()}"
-                f"/{object_type}/run"
+                "/flow/run"
             ),
             json={
-                "entrypoint": prefect_callable._entrypoint,
+                "entrypoint": flow._entrypoint,
                 "parameters": parameters,
-                "parent_task_run_id": str(parent_task_run_id),
+                "parent_task_run_id": str(parent_task_run.id),
             },
         )
         response.raise_for_status()
 
-        if timeout == 0:
-            return
+        flow_run_id = response.json()["flow_run_id"]
 
-        new_flow_run_id = response.json()["flow_run_id"]
-
-        with anyio.move_on_after(timeout):
-            while True:
-                flow_run = await client.read_flow_run(new_flow_run_id)
-                flow_state = flow_run.state
-                if flow_state and flow_state.is_final():
-                    return flow_run
-                await anyio.sleep(poll_interval)
+        return uuid.UUID(flow_run_id)
 
 
 @sync_compatible
 async def submit_to_runner(
     prefect_callable: Callable,
     parameters: Dict[str, Any],
-    timeout: Optional[float] = None,
-    poll_interval: Optional[float] = 5,
-    # capture_errors: bool = SETTING.value()?
 ) -> None:
     """
     Run a callable in the background via the runner webserver.
@@ -346,9 +324,48 @@ async def submit_to_runner(
         poll_interval: the interval (in seconds) to wait between polling the callable
     """
 
-    task(_submit_to_runner).submit(
-        prefect_callable,
-        parameters,
-        timeout,
-        poll_interval,
-    )
+    flow_run_id = await _submit_flow_to_runner(prefect_callable, parameters)
+
+    if inspect.isawaitable(flow_run_id):
+        return await flow_run_id
+    else:
+        return flow_run_id
+
+
+@sync_compatible
+async def wait_for_background_processes(
+    timeout: float = None, poll_interval: float = 3.0
+):
+    """
+    Wait for all background processes to finish.
+
+    Args:
+        timeout (float): the maximum time to wait for the callable to finish
+    """
+    async with anyio.move_on_after(timeout):
+        try:
+            async with get_client() as client:
+                response = await client._client.get(
+                    f"http://{PREFECT_RUNNER_SERVER_HOST.value()}"
+                    f":{PREFECT_RUNNER_SERVER_PORT.value()}/responses"
+                )
+                response.raise_for_status()
+
+                flow_run_ids = response.json()  # Assuming this is a list of UUIDs
+
+                incomplete_runs = set(flow_run_ids)
+                while incomplete_runs:
+                    for flow_run_id in list(incomplete_runs):
+                        flow_run = await client.read_flow_run(flow_run_id)
+                        flow_state = flow_run.state
+                        if flow_state and flow_state.is_final():
+                            incomplete_runs.remove(flow_run_id)
+
+                    await anyio.sleep(poll_interval)
+
+        except Exception as exc:
+            raise ValueError(
+                "An error occurred while waiting for background processes to finish."
+            ) from exc
+
+        return {flow_run_id: "completed" for flow_run_id in flow_run_ids}

--- a/src/prefect/runner/submit.py
+++ b/src/prefect/runner/submit.py
@@ -1,0 +1,196 @@
+import asyncio
+import inspect
+import uuid
+from typing import Any, Dict, List, Optional, Union
+
+import anyio
+import httpx
+from typing_extensions import Literal
+
+from prefect.client.orchestration import get_client
+from prefect.context import FlowRunContext
+from prefect.flows import Flow
+from prefect.logging import get_logger
+from prefect.settings import (
+    PREFECT_RUNNER_PROCESS_LIMIT,
+    PREFECT_RUNNER_SERVER_HOST,
+    PREFECT_RUNNER_SERVER_PORT,
+)
+from prefect.states import Pending
+from prefect.tasks import Task
+from prefect.utilities.asyncutils import sync_compatible
+
+logger = get_logger("webserver")
+
+
+async def get_current_run_count() -> int:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"http://{PREFECT_RUNNER_SERVER_HOST.value()}"
+            f":{PREFECT_RUNNER_SERVER_PORT.value()}/run_count"
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+async def _submit_flow_to_runner(
+    flow: Flow,
+    parameters: Dict[str, Any],
+    # capture_errors: bool = SETTING.value()?
+) -> uuid.UUID:
+    """
+    Run a callable in the background via the runner webserver.
+
+    Args:
+        prefect_callable: the callable to run, e.g. a flow or task
+        parameters: the keyword arguments to pass to the callable
+        timeout: the maximum time to wait for the callable to finish
+        poll_interval: the interval (in seconds) to wait between polling the callable
+    """
+    from prefect.engine import (
+        _dynamic_key_for_task_run,
+        collect_task_run_inputs,
+        resolve_inputs,
+    )
+
+    async with get_client() as client:
+        parent_flow_run_context = FlowRunContext.get()
+
+        task_inputs = {
+            k: await collect_task_run_inputs(v) for k, v in parameters.items()
+        }
+
+        dummy_task = Task(name=flow.name, fn=flow.fn, version=flow.version)
+        parent_task_run = await client.create_task_run(
+            task=dummy_task,
+            flow_run_id=parent_flow_run_context.flow_run.id,
+            dynamic_key=_dynamic_key_for_task_run(parent_flow_run_context, dummy_task),
+            task_inputs=task_inputs,
+            state=Pending(),
+        )
+
+        parameters = await resolve_inputs(parameters)
+
+        response = await client._client.post(
+            (
+                f"http://{PREFECT_RUNNER_SERVER_HOST.value()}"
+                f":{PREFECT_RUNNER_SERVER_PORT.value()}"
+                "/flow/run"
+            ),
+            json={
+                "entrypoint": flow._entrypoint,
+                "parameters": flow.serialize_parameters(parameters),
+                "parent_task_run_id": str(parent_task_run.id),
+            },
+        )
+        response.raise_for_status()
+
+        flow_run_id = response.json()["flow_run_id"]
+
+        return uuid.UUID(flow_run_id)
+
+
+@sync_compatible
+async def submit_to_runner(
+    prefect_callable: Union[Flow, Task],
+    parameters: Dict[str, Any],
+) -> uuid.UUID:
+    """
+    Run a callable in the background via the runner webserver.
+
+    Args:
+        prefect_callable: the callable to run (only flows are supported for now, but eventually tasks)
+        parameters: the keyword arguments to pass to the callable,
+    """
+
+    flow_run_id = await _submit_flow_to_runner(prefect_callable, parameters)
+
+    if inspect.isawaitable(flow_run_id):
+        return await flow_run_id
+    else:
+        return flow_run_id
+
+
+@sync_compatible
+async def submit_many_to_runner(
+    prefect_callable: Union[Flow, Task], parameters_list: List[Dict[str, Any]]
+) -> List[uuid.UUID]:
+    """
+    Run multiple callables in the background via the runner webserver, respecting the run limit.
+
+    Args:
+        prefect_callable: the callable to run (flows or tasks)
+        parameters_list: a list of dictionaries, each representing keyword arguments to pass to the callable.
+    """
+
+    n_current_runs = await get_current_run_count()
+    available_slots = max(0, PREFECT_RUNNER_PROCESS_LIMIT.value() - n_current_runs)
+
+    submitted_run_ids = []
+    for parameters in parameters_list[:available_slots]:
+        flow_run_id = await submit_to_runner(prefect_callable, parameters)
+        if inspect.isawaitable(flow_run_id):
+            flow_run_id = await flow_run_id
+        submitted_run_ids.append(flow_run_id)
+
+    if (diff := len(parameters_list) - available_slots) > 0:
+        logger.warning(
+            f"The last {diff} runs were not submitted to the runner,"
+            f" as all of the available {PREFECT_RUNNER_PROCESS_LIMIT.value()}"
+            " slots were occupied. To increase the number of available slots,"
+            " configure the `PREFECT_RUNNER_PROCESS_LIMIT` setting."
+        )
+
+    return submitted_run_ids
+
+
+@sync_compatible
+async def wait_for_submitted_runs(
+    flow_run_ids: Optional[set[uuid.UUID]] = None,
+    task_run_ids: Optional[set[uuid.UUID]] = None,
+    timeout: Optional[float] = None,
+    poll_interval: float = 3.0,
+):
+    """
+    Wait for completion of any provided flow and task runs, as well as runs submitted to the
+    current runner webserver, within a timeout.
+
+    Args:
+        flow_run_ids: Additional flow run IDs to wait for.
+        task_run_ids: Additional task run IDs to wait for. # TODO: /task/run endpoint
+        timeout: How long to wait for completion of all runs (seconds).
+        poll_interval: How long to wait between polling each run's state (seconds).
+    """
+    flow_run_ids = flow_run_ids or set()
+    if task_run_ids:
+        raise NotImplementedError("Waiting for task runs is not yet supported.")
+
+    async def wait_for_final_state(
+        run_type: Literal["flow", "task"], run_id: uuid.UUID
+    ):
+        read_run_method = getattr(client, f"read_{run_type}_run")
+        while True:
+            run = await read_run_method(run_id)
+            if run.state and run.state.is_final():
+                return run_id
+            await anyio.sleep(poll_interval)
+
+    async with anyio.move_on_after(timeout), get_client() as client:
+        response = await client._client.get(
+            f"http://{PREFECT_RUNNER_SERVER_HOST.value()}"
+            f":{PREFECT_RUNNER_SERVER_PORT.value()}/run_response_details"
+        )
+        response.raise_for_status()
+        fetched_ids = response.json()
+
+        fetched_flow_run_ids: set[uuid.UUID] = {
+            flow_run_id
+            for run_details in fetched_ids
+            if (flow_run_id := run_details.get("flow_run_id"))
+        }
+
+        flow_run_ids.update(fetched_flow_run_ids)
+
+        await asyncio.gather(
+            *(wait_for_final_state("flow", run_id) for run_id in flow_run_ids)
+        )

--- a/src/prefect/runner/submit.py
+++ b/src/prefect/runner/submit.py
@@ -1,7 +1,7 @@
 import asyncio
 import inspect
 import uuid
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 import anyio
 import httpx
@@ -146,8 +146,8 @@ async def submit_many_to_runner(
 
 @sync_compatible
 async def wait_for_submitted_runs(
-    flow_run_ids: Optional[set[uuid.UUID]] = None,
-    task_run_ids: Optional[set[uuid.UUID]] = None,
+    flow_run_ids: Optional[Set[uuid.UUID]] = None,
+    task_run_ids: Optional[Set[uuid.UUID]] = None,
     timeout: Optional[float] = None,
     poll_interval: float = 3.0,
 ):

--- a/src/prefect/runner/submit.py
+++ b/src/prefect/runner/submit.py
@@ -183,7 +183,7 @@ async def wait_for_submitted_runs(
         response.raise_for_status()
         fetched_ids = response.json()
 
-        fetched_flow_run_ids: set[uuid.UUID] = {
+        fetched_flow_run_ids: Set[uuid.UUID] = {
             flow_run_id
             for run_details in fetched_ids
             if (flow_run_id := run_details.get("flow_run_id"))

--- a/tests/runner/test_webserver.py
+++ b/tests/runner/test_webserver.py
@@ -39,21 +39,6 @@ def complex_flow(
 
 
 @pytest.fixture(autouse=True)
-def only_flows_from_here(monkeypatch):
-    async def get_flows_in_this_file(directory="."):
-        return [
-            (f"{__file__}:simple_flow", simple_flow),
-            (f"{__file__}:complex_flow", complex_flow),
-        ]
-
-    monkeypatch.setattr(
-        "prefect.runner.server._find_subflows_of_deployment",
-        get_flows_in_this_file,
-    )
-    yield
-
-
-@pytest.fixture(autouse=True)
 def tmp_runner_settings():
     with temporary_settings(
         updates={


### PR DESCRIPTION
<img width="1159" alt="image" src="https://github.com/PrefectHQ/prefect/assets/31014960/9c2787bb-fb00-49d9-8611-80ad7584bda0">


this PR:
- refactors `submit_to_runner` to better handle parameter serialization / resolution and better track invoked runs in the API
- adds a `submit_many_to_runner` util that calls `submit_to_runner` many times and enforces the `PREFECT_RUNNER_PROCESS_LIMIT` according to the webserver's `/run_count` endpoint
- adds `wait_for_submitted_runs` to block until a set of provided run ids + runs submitted via webserver reach a final state, to be called at the end of the flow if you want the calling parent flow run to block before entering a terminal state

### the outcomes we wanted
the only direct way I could think of to accomplish all of the following:
- allow non-blocking submission of flows from the user thread to the runner via the webserver
- represent submitted flow runs as subflows in the API, with the actual duration/details of the invoked flow run
- allow the calling flow to wait for these subflows before entering a `Completed` state


... was to somehow track the run ids (only flows for now) _and then_ call a new blocking util `wait_for_submitted_runs` at the end of a flow

### things i tried before running with this solution (with some reservations)
- repurposing `run_deployment` directly, but `run_deployment` blocks with `timeout!=0`, which is the part that prevents the calling parent from entering `Completed` before its submissions finish (my prior is that this is not viable here)
- repurposing `create_and_begin_flow_run` from the engine, but ran into the same problem of not being able to stop the calling parent from entering `Completed` without making the submission blocking
- wrapping the blocking submission in a `task` and submitting it, but even though this got the outcome, it never really seemed viable since it creates this random looking task in the API / timeline that wraps the one you actually care about / want to see and so this generally just didnt seem like a viable thing to do 

### things that feel like problems:
- its a bit annoying to have to call this `wait_for_submitted_runs` thing when it has no arguments anyways, like it seems to me there might be a better place to conditionally call something like this on the user's behalf

### things that are okay about it:
- without calling `wait_for_submitted_runs`, the behavior more or less mimics calling `run_deployment` with `timeout=0`, as in the calling parent happily exits regardless of the state(s) of the thing(s) it kicked off
- the experience of `submit_many_to_runner` and `wait_for_submitted_runs` is not terrible since you get what I would say is the intuitive outcome and as a user you don't have to pass anything to `wait_for_submitted_runs` since we can get the run ids from the client (and `wait_for_submitted_runs` could be used outside of a flow run context as a general util)

<details>
   <summary> solved problems </summary>
   
   - solved by using the client instead: the `Queue` to used by `/run_response_details` could fill up if you call `submit_to_runner` a bunch without dequeuing via `wait_for_submitted_runs` on the same webserver. I think this would be solved by using something like the event subscriber, which feels possible in webserver land somehow. Overall the queue here just feels not ideal to me
   
</details>

## Example

```python
import time

from pydantic import BaseModel

from prefect import flow, serve, task
from prefect.runner import submit_many_to_runner, wait_for_submitted_runs
from prefect.settings import PREFECT_RUNNER_PROCESS_LIMIT, temporary_settings


class Foo(BaseModel):
    bar: str
    baz: int


class ParentFoo(BaseModel):
    foo: Foo
    x: int = 42

@task
def noop():
    pass

@flow(log_prints=True)
def child(foo: Foo = Foo(bar="hello", baz=42)):
    print(f"received {foo.bar} and {foo.baz}")
    print("going to sleep")
    noop()
    time.sleep(20)


@task
def foo():
    time.sleep(2)

@flow(log_prints=True)
def parent(parent_foo: ParentFoo = ParentFoo(foo=Foo(bar="hello", baz=42))):
    print(f"I'm a parent and I received {parent_foo=}")

    submit_many_to_runner(
        child, [{"foo": Foo(bar="hello", baz=i)} for i in range(9)]
    )
    
    foo.submit()
    
    wait_for_submitted_runs()

if __name__ == "__main__":
    with temporary_settings({PREFECT_RUNNER_PROCESS_LIMIT: 10}):  # 9 children + 1 parent
        serve(parent.to_deployment(__file__), webserver=True)
```