### PR TITLE
Check if we're on the main thread when using mock sigterm handler in tests

### DIFF
--- a/tests/public/flows/test_flow_crashes.py
+++ b/tests/public/flows/test_flow_crashes.py
@@ -9,6 +9,7 @@ interrupts.
 import asyncio
 import os
 import signal
+import threading
 from unittest.mock import ANY, MagicMock
 
 import anyio
@@ -211,6 +212,8 @@ async def test_interrupt_in_child_crashes_parent_and_child_flow(
 
 @pytest.fixture
 def mock_sigterm_handler():
+    if threading.current_thread() != threading.main_thread():
+        pytest.skip("Can't test signal handlers from a thread")
     mock = MagicMock()
 
     def handler(*args, **kwargs):

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -5,6 +5,7 @@ import inspect
 import os
 import signal
 import sys
+import threading
 import time
 from functools import partial
 from itertools import combinations
@@ -82,6 +83,8 @@ def test_flow():
 
 @pytest.fixture
 def mock_sigterm_handler():
+    if threading.current_thread() != threading.main_thread():
+        pytest.skip("Can't test signal handlers from a thread")
     mock = MagicMock()
 
     def handler(*args, **kwargs):


### PR DESCRIPTION
Should close #10895 

We missed a spot where we're using the `mock_sigterm_handler` fixture in our tests and we sometimes face intermittent failures resulting in the `ValueError: signal only works in main thread of the main interpreter` we've been seeing lately. 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
