### PR TITLE
Remove `prefect.yaml` tag from page where unmentioned

### DIFF
--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -6,7 +6,6 @@ tags:
     - deployments
     - schedules
     - triggers
-    - prefect.yaml
     - infrastructure
     - storage
     - work pool


### PR DESCRIPTION
There's no reference to `prefect.yaml` so ideally it wouldn't come up when searching for `prefect.yaml` in the docs.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
