### PR TITLE
feature flag and deprecate dupe webserver settings

### DIFF
--- a/src/prefect/runner/submit.py
+++ b/src/prefect/runner/submit.py
@@ -13,6 +13,7 @@ from prefect.context import FlowRunContext
 from prefect.flows import Flow
 from prefect.logging import get_logger
 from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS,
     PREFECT_RUNNER_PROCESS_LIMIT,
     PREFECT_RUNNER_SERVER_HOST,
     PREFECT_RUNNER_SERVER_PORT,
@@ -48,6 +49,13 @@ async def _submit_flow_to_runner(
         timeout: the maximum time to wait for the callable to finish
         poll_interval: the interval (in seconds) to wait between polling the callable
     """
+    if not PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS.value():
+        raise ValueError(
+            "The `submit_to_runner` utility requires the `Runner` webserver to be"
+            " built with extra endpoints enabled. To enable this, set the"
+            " `PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS` setting to `True`."
+        )
+
     from prefect.engine import (
         _dynamic_key_for_task_run,
         collect_task_run_inputs,

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1434,7 +1434,7 @@ Can be used to compensate for infrastructure start up time for a worker.
 
 PREFECT_WORKER_WEBSERVER_HOST = Setting(
     str,
-    default="0.0.0.0",
+    default=None,
     deprecated=True,
     deprecated_start_date="Jan 2024",
     deprecated_help="Use `PREFECT_RUNNER_SERVER_HOST` instead",
@@ -1445,7 +1445,7 @@ The host address the worker's webserver should bind to.
 
 PREFECT_WORKER_WEBSERVER_PORT = Setting(
     int,
-    default=8080,
+    default=None,
     deprecated=True,
     deprecated_start_date="Jan 2024",
     deprecated_help="Use `PREFECT_RUNNER_SERVER_PORT` instead",

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -389,6 +389,42 @@ def check_for_deprecated_cloud_url(settings, value):
     return deprecated_value or value
 
 
+def check_for_deprecated_runner_server_host(settings, value):
+    deprecated_value = PREFECT_WORKER_WEBSERVER_HOST.value_from(
+        settings, bypass_callback=True
+    )
+    if deprecated_value is not None:
+        warnings.warn(
+            (
+                "`PREFECT_WORKER_WEBSERVER_HOST` is set and will be used instead of"
+                " `PREFECT_RUNNER_SERVER_HOST` for backwards compatibility."
+                " `PREFECT_WORKER_WEBSERVER_HOST` is deprecated, set"
+                " `PREFECT_RUNNER_SERVER_HOST` instead."
+            ),
+            DeprecationWarning,
+        )
+
+    return deprecated_value or value
+
+
+def check_for_deprecated_runner_server_port(settings, value):
+    deprecated_value = PREFECT_WORKER_WEBSERVER_PORT.value_from(
+        settings, bypass_callback=True
+    )
+    if deprecated_value is not None:
+        warnings.warn(
+            (
+                "`PREFECT_WORKER_WEBSERVER_PORT` is set and will be used instead of"
+                " `PREFECT_RUNNER_SERVER_PORT` for backwards compatibility."
+                " `PREFECT_WORKER_WEBSERVER_PORT` is deprecated, set"
+                " `PREFECT_RUNNER_SERVER_PORT` instead."
+            ),
+            DeprecationWarning,
+        )
+
+    return deprecated_value or value
+
+
 def warn_on_misconfigured_api_url(values):
     """
     Validator for settings warning if the API URL is misconfigured.
@@ -1357,12 +1393,20 @@ PREFECT_RUNNER_SERVER_MISSED_POLLS_TOLERANCE = Setting(int, default=2)
 Number of missed polls before a runner is considered unhealthy by its webserver.
 """
 
-PREFECT_RUNNER_SERVER_HOST = Setting(str, default="0.0.0.0")
+PREFECT_RUNNER_SERVER_HOST = Setting(
+    str,
+    default="0.0.0.0",
+    value_callback=check_for_deprecated_runner_server_host,
+)
 """
 The host address the runner's webserver should bind to.
 """
 
-PREFECT_RUNNER_SERVER_PORT = Setting(int, default=8080)
+PREFECT_RUNNER_SERVER_PORT = Setting(
+    int,
+    default=8080,
+    value_callback=check_for_deprecated_runner_server_port,
+)
 """
 The port the runner's webserver should bind to.
 """
@@ -1388,12 +1432,24 @@ The number of seconds into the future a worker should query for scheduled flow r
 Can be used to compensate for infrastructure start up time for a worker.
 """
 
-PREFECT_WORKER_WEBSERVER_HOST = Setting(str, default="0.0.0.0")
+PREFECT_WORKER_WEBSERVER_HOST = Setting(
+    str,
+    default="0.0.0.0",
+    deprecated=True,
+    deprecated_start_date="Jan 2024",
+    deprecated_help="Use `PREFECT_RUNNER_SERVER_HOST` instead",
+)
 """
 The host address the worker's webserver should bind to.
 """
 
-PREFECT_WORKER_WEBSERVER_PORT = Setting(int, default=8080)
+PREFECT_WORKER_WEBSERVER_PORT = Setting(
+    int,
+    default=8080,
+    deprecated=True,
+    deprecated_start_date="Jan 2024",
+    deprecated_help="Use `PREFECT_RUNNER_SERVER_PORT` instead",
+)
 """
 The port the worker's webserver should bind to.
 """

--- a/src/prefect/workers/server.py
+++ b/src/prefect/workers/server.py
@@ -5,8 +5,8 @@ from prefect._vendor.fastapi import APIRouter, FastAPI, status
 from prefect._vendor.fastapi.responses import JSONResponse
 
 from prefect.settings import (
-    PREFECT_WORKER_WEBSERVER_HOST,
-    PREFECT_WORKER_WEBSERVER_PORT,
+    PREFECT_RUNNER_SERVER_HOST,
+    PREFECT_RUNNER_SERVER_PORT,
 )
 from prefect.workers.base import BaseWorker
 from prefect.workers.process import ProcessWorker
@@ -45,7 +45,7 @@ def start_healthcheck_server(
 
     uvicorn.run(
         webserver,
-        host=PREFECT_WORKER_WEBSERVER_HOST.value(),
-        port=PREFECT_WORKER_WEBSERVER_PORT.value(),
+        host=PREFECT_RUNNER_SERVER_HOST.value(),
+        port=PREFECT_RUNNER_SERVER_PORT.value(),
         log_level=log_level,
     )

--- a/tests/runner/test_webserver.py
+++ b/tests/runner/test_webserver.py
@@ -14,6 +14,8 @@ from prefect.settings import (
     PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS,
     PREFECT_RUNNER_SERVER_HOST,
     PREFECT_RUNNER_SERVER_PORT,
+    PREFECT_WORKER_WEBSERVER_HOST,
+    PREFECT_WORKER_WEBSERVER_PORT,
     temporary_settings,
 )
 
@@ -66,6 +68,31 @@ async def create_deployment(runner: Runner, func: Callable):
         func, f"{uuid.uuid4()}", enforce_parameter_schema=True
     )
     return str(deployment_id)
+
+
+class TestWebserverSettings:
+    async def test_webserver_settings_are_respected(self, runner: Runner):
+        with temporary_settings(
+            updates={
+                PREFECT_RUNNER_SERVER_HOST: "127.0.0.1",
+                PREFECT_RUNNER_SERVER_PORT: 4200,
+            }
+        ):
+            assert PREFECT_RUNNER_SERVER_HOST.value() == "127.0.0.1"
+            assert PREFECT_RUNNER_SERVER_PORT.value() == 4200
+
+    async def test_deprecated_webserver_settings_are_respected(self, runner: Runner):
+        with pytest.warns(
+            DeprecationWarning, match=r".*PREFECT_WORKER_WEBSERVER_.*deprecated.*"
+        ):
+            with temporary_settings(
+                updates={
+                    PREFECT_WORKER_WEBSERVER_HOST: "127.0.0.1",
+                    PREFECT_WORKER_WEBSERVER_PORT: 4200,
+                }
+            ):
+                assert PREFECT_RUNNER_SERVER_HOST.value() == "127.0.0.1"
+                assert PREFECT_RUNNER_SERVER_PORT.value() == 4200
 
 
 class TestWebserverDeploymentRoutes:


### PR DESCRIPTION
```console
(bleeding-prefect) pad-2 :: github.com/PrefectHQ/prefect ‹ft/runner-runs-flows*›
» prefect config set PREFECT_WORKER_WEBSERVER_HOST=localhost
Set 'PREFECT_WORKER_WEBSERVER_HOST' to 'localhost'.
Setting 'PREFECT_WORKER_WEBSERVER_HOST' has been deprecated. It will not be available after Jul 2024. Use `PREFECT_RUNNER_SERVER_HOST` instead.
Updated profile 'pong'.

» prefect config set PREFECT_WORKER_WEBSERVER_PORT=8080
Set 'PREFECT_WORKER_WEBSERVER_PORT' to '8080'.
Setting 'PREFECT_WORKER_WEBSERVER_PORT' has been deprecated. It will not be available after Jul 2024. Use `PREFECT_RUNNER_SERVER_PORT` instead.
Updated profile 'pong'.
```