### PR TITLE
Add `aggregate-worker-metadata.json` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,10 @@ dask-worker-space/
 # Prefect files
 prefect.yaml
 
+# Ignore dynamically generated worker metadata
+src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
+
+
 # Deployment recipes
 !src/prefect/deployments/recipes/*/**
 


### PR DESCRIPTION
This PR adds `src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json` to the `.gitignore file`. This change is intended to prevent the dynamically generated worker metadata from affecting the repository's clean state, ensuring that our versioning remains consistent and unmarked by 'dirty' flags.

During our build and deployment process in `python-package.yaml`, `aggregate-worker-metadata.json` is dynamically generated and downloaded (we intend to change this soon). This file's changes caused the build to be marked as 'dirty'.

More details in Slack: https://prefecthq.slack.com/archives/C03PSCZLNKG/p1704406599187539?thread_ts=1704381666.821209&cid=C03PSCZLNKG

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
