### PR TITLE
failover setting and init test coverage

### DIFF
--- a/src/prefect/runner/__init__.py
+++ b/src/prefect/runner/__init__.py
@@ -1,2 +1,2 @@
 from .runner import Runner, serve
-from .submit import submit_many_to_runner, submit_to_runner, wait_for_submitted_runs
+from .submit import submit_to_runner, wait_for_submitted_runs

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -83,9 +83,9 @@ from prefect.runner.server import start_webserver
 from prefect.runner.storage import RunnerStorage
 from prefect.settings import (
     PREFECT_API_URL,
-    PREFECT_RUNNER_ENABLE_SERVER,
     PREFECT_RUNNER_POLL_FREQUENCY,
     PREFECT_RUNNER_PROCESS_LIMIT,
+    PREFECT_RUNNER_SERVER_ENABLE,
     PREFECT_UI_URL,
     get_current_settings,
 )
@@ -351,7 +351,7 @@ class Runner:
 
         webserver = webserver if webserver is not None else self.webserver
 
-        if webserver or PREFECT_RUNNER_ENABLE_SERVER.value():
+        if webserver or PREFECT_RUNNER_SERVER_ENABLE.value():
             # we'll start the ASGI server in a separate thread so that
             # uvicorn does not block the main thread
             server_thread = threading.Thread(

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -409,7 +409,7 @@ class Runner:
         runs_to_cancel = []
 
         # done to avoid dictionary size changing during iteration
-        for _, info in self._flow_run_process_map.items():
+        for info in self._flow_run_process_map.values():
             runs_to_cancel.append(info["flow_run"])
         if runs_to_cancel:
             for run in runs_to_cancel:
@@ -821,6 +821,15 @@ class Runner:
         )
         self._logger.debug(f"Discovered {len(scheduled_flow_runs)} scheduled_flow_runs")
         return scheduled_flow_runs
+
+    def has_slots_available(self) -> bool:
+        """
+        Determine if the flow run limit has been reached.
+
+        Returns:
+            - bool: True if the limit has not been reached, False otherwise.
+        """
+        return self._limiter.available_tokens > 0
 
     def _acquire_limit_slot(self, flow_run_id: str) -> bool:
         """

--- a/src/prefect/runner/server.py
+++ b/src/prefect/runner/server.py
@@ -194,6 +194,12 @@ def _build_generic_endpoint_for_flows(
     async def _create_flow_run_for_flow_from_fqn(
         body: RunnerGenericFlowRunRequest,
     ) -> JSONResponse:
+        if not runner.has_slots_available():
+            return JSONResponse(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                content={"message": "Runner has no available slots"},
+            )
+
         try:
             flow = load_flow_from_entrypoint(body.entrypoint)
         except (MissingFlowError, ScriptError, ModuleNotFoundError):

--- a/src/prefect/runner/submit.py
+++ b/src/prefect/runner/submit.py
@@ -181,13 +181,12 @@ async def submit_to_runner(
                 ) from exc
 
     if unsubmitted_parameters:
-        flow_run_ids = await asyncio.gather(
+        await asyncio.gather(
             *[
                 run_prefect_callable_and_retrieve_run_id(prefect_callable, p)
                 for p in unsubmitted_parameters
             ]
         )
-        submitted_run_ids.extend(flow_run_ids)
 
     if (diff := len(parameters) - len(submitted_run_ids)) > 0:
         logger.warning(

--- a/src/prefect/runner/submit.py
+++ b/src/prefect/runner/submit.py
@@ -42,7 +42,7 @@ async def run_prefect_callable_and_retrieve_run_id(
 ) -> uuid.UUID:
     flow_run_id: Optional[uuid.UUID] = None
 
-    def store_run_id(flow, flow_run, state):
+    async def store_run_id(flow, flow_run, state):
         nonlocal flow_run_id
         flow_run_id = flow_run.id
 
@@ -128,7 +128,7 @@ async def _submit_flow_to_runner(
 @sync_compatible
 async def submit_to_runner(
     prefect_callable: Union[Flow, Task],
-    parameters: Union[Dict[str, Any], List[Dict[str, Any]]],
+    parameters: Optional[Union[Dict[str, Any], List[Dict[str, Any]]]] = None,
     retry_failed_submissions: bool = True,
 ) -> Union[uuid.UUID, List[uuid.UUID]]:
     """
@@ -190,7 +190,7 @@ async def submit_to_runner(
 
     if (diff := len(parameters) - len(submitted_run_ids)) > 0:
         logger.warning(
-            f"Failed to submit {diff} to the runner, as all of the available "
+            f"Failed to submit {diff} runs to the runner, as all of the available "
             f"{PREFECT_RUNNER_PROCESS_LIMIT.value()} slots were occupied. To "
             "increase the number of available slots, configure the"
             "`PREFECT_RUNNER_PROCESS_LIMIT` setting."

--- a/src/prefect/runner/submit.py
+++ b/src/prefect/runner/submit.py
@@ -123,7 +123,7 @@ async def submit_to_runner(
     parameters = parameters or {}
     try:
         flow_run = await _submit_flow_to_runner(prefect_callable, parameters)
-    except (httpx.ConnectError, httpx.HTTPStatusError):
+    except (httpx.ConnectError, httpx.HTTPStatusError) as exc:
         if PREFECT_RUNNER_SERVER_ENABLE_BLOCKING_FAILOVER.value():
             logger.warning(
                 "The `submit_to_runner` utility failed to connect to the `Runner`"
@@ -137,7 +137,11 @@ async def submit_to_runner(
                 result = await result
             return result
         else:
-            raise
+            raise RuntimeError(
+                "The `submit_to_runner` utility failed to connect to the `Runner`"
+                " webserver. To enable blocking failover, set the"
+                " `PREFECT_RUNNER_SERVER_ENABLE_BLOCKING_FAILOVER` setting to `True`."
+            ) from exc
 
     if inspect.isawaitable(flow_run):
         return await flow_run

--- a/src/prefect/runner/submit.py
+++ b/src/prefect/runner/submit.py
@@ -154,6 +154,9 @@ async def submit_to_runner(
     if isinstance(parameters, dict):
         parameters = [parameters]
 
+    if not parameters:
+        parameters = [{}]
+
     submitted_run_ids = []
     unsubmitted_parameters = []
 

--- a/src/prefect/runner/submit.py
+++ b/src/prefect/runner/submit.py
@@ -40,6 +40,12 @@ async def run_prefect_callable_and_retrieve_run_id(
     prefect_callable: Union[Flow, Task],
     parameters: Dict[str, Any],
 ) -> uuid.UUID:
+    """
+    This function exists only to capture the flow_run_id that is created 
+    while directly executing a flow. It does so by injecting its own 
+    on_completion callback. This should only be called if flow run 
+    submission to the Runner's webserver failed.
+    """
     flow_run_id: Optional[uuid.UUID] = None
 
     async def store_run_id(flow, flow_run, state):

--- a/src/prefect/runner/submit.py
+++ b/src/prefect/runner/submit.py
@@ -126,9 +126,7 @@ async def _submit_flow_to_runner(
         )
         response.raise_for_status()
 
-        flow_run_id = uuid.UUID(response.json()["flow_run_id"])
-
-        return await client.read_flow_run(flow_run_id)
+        return uuid.UUID(response.json()["flow_run_id"])
 
 
 @sync_compatible

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1416,9 +1416,15 @@ PREFECT_RUNNER_SERVER_LOG_LEVEL = Setting(str, default="error")
 The log level of the runner's webserver.
 """
 
-PREFECT_RUNNER_ENABLE_SERVER = Setting(bool, default=False)
+PREFECT_RUNNER_SERVER_ENABLE = Setting(bool, default=False)
 """
 Whether or not to enable the runner's webserver.
+"""
+
+PREFECT_RUNNER_SERVER_ENABLE_BLOCKING_FAILOVER = Setting(bool, default=True)
+"""
+Whether or not to execute runs in a blocking fashion (on the main thread) if
+the runner's webserver is unavailable to accept submissions to the runner.
 """
 
 PREFECT_WORKER_HEARTBEAT_SECONDS = Setting(float, default=30)

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -35,9 +35,9 @@ from prefect.runner.server import perform_health_check
 from prefect.settings import (
     PREFECT_DEFAULT_DOCKER_BUILD_NAMESPACE,
     PREFECT_DEFAULT_WORK_POOL_NAME,
-    PREFECT_RUNNER_ENABLE_SERVER,
     PREFECT_RUNNER_POLL_FREQUENCY,
     PREFECT_RUNNER_PROCESS_LIMIT,
+    PREFECT_RUNNER_SERVER_ENABLE,
     temporary_settings,
 )
 from prefect.testing.utilities import AsyncMock
@@ -1085,7 +1085,7 @@ class TestServer:
 
     @pytest.mark.parametrize("enabled", [True, False])
     async def test_webserver_start_flag(self, enabled: bool):
-        with temporary_settings(updates={PREFECT_RUNNER_ENABLE_SERVER: enabled}):
+        with temporary_settings(updates={PREFECT_RUNNER_SERVER_ENABLE: enabled}):
             with mock.patch("prefect.runner.runner.threading.Thread") as mocked_thread:
                 runner = Runner()
                 await runner.start(run_once=True)

--- a/tests/runner/test_submit.py
+++ b/tests/runner/test_submit.py
@@ -1,0 +1,51 @@
+import pytest
+
+from prefect import flow
+from prefect.runner import (
+    submit_to_runner,
+)
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS,
+    PREFECT_RUNNER_SERVER_ENABLE,
+    temporary_settings,
+)
+
+
+@flow
+def schleeb() -> int:
+    return 42
+
+
+@pytest.fixture(autouse=True)
+def runner_settings():
+    with temporary_settings(
+        {
+            PREFECT_RUNNER_SERVER_ENABLE: True,
+            PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS: True,
+        }
+    ):
+        yield
+
+
+def test_submission_raises_if_extra_endpoints_not_enabled():
+    with temporary_settings(
+        {PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS: False}
+    ):
+        with pytest.raises(
+            ValueError,
+            match="`submit_to_runner` utility requires the `Runner` webserver",
+        ):
+            submit_to_runner(lambda: None)
+
+
+def test_submission_fails_over_if_webserver_is_not_running(caplog):
+    expected_text = "The `submit_to_runner` utility failed to connect to the `Runner` webserver, but blocking failover is enabled."  # noqa
+    with caplog.at_level("WARNING", logger="prefect.webserver"), temporary_settings(
+        {
+            PREFECT_RUNNER_SERVER_ENABLE: False,
+        }
+    ):
+        result = submit_to_runner(schleeb)
+
+        assert result == 42
+        assert expected_text in caplog.text

--- a/tests/runner/test_submit.py
+++ b/tests/runner/test_submit.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 
 from prefect import flow
@@ -7,6 +8,7 @@ from prefect.runner import (
 from prefect.settings import (
     PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS,
     PREFECT_RUNNER_SERVER_ENABLE,
+    PREFECT_RUNNER_SERVER_ENABLE_BLOCKING_FAILOVER,
     temporary_settings,
 )
 
@@ -49,3 +51,14 @@ def test_submission_fails_over_if_webserver_is_not_running(caplog):
 
         assert result == 42
         assert expected_text in caplog.text
+
+
+def test_submission_raises_if_webserver_not_running_and_no_failover():
+    with temporary_settings(
+        {
+            PREFECT_RUNNER_SERVER_ENABLE: False,
+            PREFECT_RUNNER_SERVER_ENABLE_BLOCKING_FAILOVER: False,
+        }
+    ):
+        with pytest.raises((httpx.HTTPStatusError, RuntimeError)):
+            submit_to_runner(schleeb)


### PR DESCRIPTION
adds `PREFECT_RUNNER_SERVER_ENABLE_BLOCKING_FAILOVER` and corresponding handling in `submit_to_runner`