### PR TITLE
Remove worker metadata download from build/publish workflow, fix typos in worker metadata

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -45,10 +45,6 @@ jobs:
         run: |
           prefect dev build-ui
 
-      - name: Download current worker metadata
-        run: |
-          curl -o src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json https://raw.githubusercontent.com/PrefectHQ/prefect-collection-registry/main/views/aggregate-worker-metadata.json
-
       - name: Build a binary wheel and a source tarball
         run: |
           python setup.py sdist bdist_wheel

--- a/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
+++ b/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
@@ -7,7 +7,7 @@
       "logo_url": "https://cdn.sanity.io/images/3ugk85nk/production/c771bb53894c877e169c8db158c5598558b8f175-24x24.svg",
       "install_command": "pip install prefect",
       "default_base_job_configuration": {},
-      "description": "Execute flow runs on heterogenous infrastructure using infrastructure blocks."
+      "description": "Execute flow runs on heterogeneous infrastructure using infrastructure blocks."
     },
     "process": {
       "default_base_job_configuration": {
@@ -180,7 +180,7 @@
             },
             "launch_type": {
               "title": "Launch Type",
-              "description": "The type of ECS task run infrastructure that should be used. Note that 'FARGATE_SPOT' is not a formal ECS launch type, but we will configure the proper capacity provider stategy if set here.",
+              "description": "The type of ECS task run infrastructure that should be used. Note that 'FARGATE_SPOT' is not a formal ECS launch type, but we will configure the proper capacity provider strategy if set here.",
               "default": "FARGATE",
               "enum": [
                 "FARGATE",


### PR DESCRIPTION
This PR is the first step to change the way we incorporate the latest worker metadata into each release. Here we remove it from being downloaded prior to building the package. We fix typos in the json. Prior to the next `prefect` release (2.14.14), @zzstoatzz plans to write a script to generate a PR to the `prefect` repo whenever the metadata changes.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
