### PR TITLE
Enable flow runs to receive typed input from external sources

### DIFF
--- a/src/prefect/_internal/pydantic/v2_schema.py
+++ b/src/prefect/_internal/pydantic/v2_schema.py
@@ -18,7 +18,7 @@ from prefect._internal.pydantic.annotations.pendulum import (
 from prefect._internal.pydantic.schemas import GenerateEmptySchemaForUserClasses
 
 
-def _is_v2_model(v) -> bool:
+def is_v2_model(v) -> bool:
     if isinstance(v, V2BaseModel):
         return True
     try:
@@ -27,17 +27,19 @@ def _is_v2_model(v) -> bool:
     except TypeError:
         pass
 
+    return False
+
 
 def has_v2_model_as_param(signature: inspect.Signature) -> bool:
     parameters = signature.parameters.values()
     for p in parameters:
         # check if this parameter is a v2 model
-        if _is_v2_model(p.annotation):
+        if is_v2_model(p.annotation):
             return True
 
         # check if this parameter is a collection of types
         for v in typing.get_args(p.annotation):
-            if _is_v2_model(v):
+            if is_v2_model(v):
                 return True
     return False
 

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -12,6 +12,7 @@ from typing import (
 )
 from uuid import UUID
 
+import orjson
 import pendulum
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
@@ -1544,6 +1545,17 @@ class FlowRunInput(ObjectBaseModel):
     flow_run_id: UUID = Field(description="The flow run ID associated with the input.")
     key: str = Field(description="The key of the input.")
     value: str = Field(description="The value of the input.")
+    sender: Optional[str] = Field(description="The sender of the input.")
+
+    @property
+    def decoded_value(self) -> Any:
+        """
+        Decode the value of the input.
+
+        Returns:
+            Any: the decoded value
+        """
+        return orjson.loads(self.value)
 
     @validator("key", check_fields=False)
     def validate_name_characters(cls, v):

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -207,6 +207,7 @@ class RunContext(ContextModel):
     """
 
     start_time: DateTimeTZ = Field(default_factory=lambda: pendulum.now("UTC"))
+    input_keyset: Optional[Dict[str, Dict[str, str]]] = None
     client: PrefectClient
 
 

--- a/src/prefect/input/__init__.py
+++ b/src/prefect/input/__init__.py
@@ -1,11 +1,29 @@
-from .actions import create_flow_run_input, delete_flow_run_input, read_flow_run_input
-from .run_input import RunInput, keyset_from_base_key, keyset_from_paused_state
+from .actions import (
+    create_flow_run_input,
+    create_flow_run_input_from_model,
+    delete_flow_run_input,
+    filter_flow_run_input,
+    read_flow_run_input,
+)
+from .run_input import (
+    GetInputHandler,
+    Keyset,
+    RunInput,
+    RunInputMetadata,
+    keyset_from_base_key,
+    keyset_from_paused_state,
+)
 
 __all__ = [
+    "GetInputHandler",
+    "Keyset",
     "RunInput",
+    "RunInputMetadata",
     "create_flow_run_input",
+    "create_flow_run_input_from_model",
+    "delete_flow_run_input",
+    "filter_flow_run_input",
     "keyset_from_base_key",
     "keyset_from_paused_state",
-    "delete_flow_run_input",
     "read_flow_run_input",
 ]

--- a/src/prefect/input/run_input.py
+++ b/src/prefect/input/run_input.py
@@ -1,23 +1,39 @@
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Type, TypeVar, Union
-from uuid import UUID
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generic,
+    Literal,
+    Optional,
+    Set,
+    Type,
+    TypeVar,
+    Union,
+)
+from uuid import UUID, uuid4
 
+import anyio
 import pydantic
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
-from prefect.input.actions import create_flow_run_input, read_flow_run_input
+from prefect.input.actions import (
+    create_flow_run_input,
+    create_flow_run_input_from_model,
+    ensure_flow_run_id,
+    filter_flow_run_input,
+    read_flow_run_input,
+)
 from prefect.utilities.asyncutils import sync_compatible
 
 if TYPE_CHECKING:
+    from prefect.client.schemas.objects import FlowRunInput
     from prefect.states import State
-
 
 if HAS_PYDANTIC_V2:
     from prefect._internal.pydantic.v2_schema import create_v2_schema
 
-
 T = TypeVar("T", bound="RunInput")
-KeysetNames = Union[Literal["response"], Literal["schema"]]
-Keyset = Dict[KeysetNames, str]
+Keyset = Dict[Union[Literal["response"], Literal["schema"]], str]
 
 
 def keyset_from_paused_state(state: "State") -> Keyset:
@@ -31,9 +47,8 @@ def keyset_from_paused_state(state: "State") -> Keyset:
     if not state.is_paused():
         raise RuntimeError(f"{state.type.value!r} is unsupported.")
 
-    return keyset_from_base_key(
-        f"{state.name.lower()}-{str(state.state_details.pause_key)}"
-    )
+    base_key = f"{state.name.lower()}-{str(state.state_details.pause_key)}"
+    return keyset_from_base_key(base_key)
 
 
 def keyset_from_base_key(base_key: str) -> Keyset:
@@ -52,9 +67,25 @@ def keyset_from_base_key(base_key: str) -> Keyset:
     }
 
 
+class RunInputMetadata(pydantic.BaseModel):
+    key: str
+    sender: Optional[str]
+    receiver: UUID
+
+
 class RunInput(pydantic.BaseModel):
     class Config:
         extra = "forbid"
+
+    _metadata: RunInputMetadata = pydantic.PrivateAttr()
+
+    @property
+    def metadata(self) -> RunInputMetadata:
+        return self._metadata
+
+    @classmethod
+    def keyset_from_type(cls) -> Keyset:
+        return keyset_from_base_key(cls.__name__.lower())
 
     @classmethod
     @sync_compatible
@@ -86,8 +117,29 @@ class RunInput(pydantic.BaseModel):
             - keyset (Keyset): the keyset to load the input for
             - flow_run_id (UUID, optional): the flow run ID to load the input for
         """
+        flow_run_id = ensure_flow_run_id(flow_run_id)
         value = await read_flow_run_input(keyset["response"], flow_run_id=flow_run_id)
-        return cls(**value)
+        instance = cls(**value)
+        instance._metadata = RunInputMetadata(
+            key=keyset["response"], sender=None, receiver=flow_run_id
+        )
+        return instance
+
+    @classmethod
+    def load_from_flow_run_input(cls, flow_run_input: "FlowRunInput"):
+        """
+        Load the run input from a FlowRunInput object.
+
+        Args:
+            - flow_run_input (FlowRunInput): the flow run input to load the input for
+        """
+        instance = cls(**flow_run_input.decoded_value)
+        instance._metadata = RunInputMetadata(
+            key=flow_run_input.key,
+            sender=flow_run_input.sender,
+            receiver=flow_run_input.flow_run_id,
+        )
+        return instance
 
     @classmethod
     def with_initial_data(cls: Type[T], **kwargs: Any) -> Type[T]:
@@ -102,3 +154,154 @@ class RunInput(pydantic.BaseModel):
         for key, value in kwargs.items():
             fields[key] = (type(value), value)
         return pydantic.create_model(cls.__name__, **fields, __base__=cls)
+
+    @sync_compatible
+    async def respond(
+        self,
+        run_input: "RunInput",
+        sender: Optional[str] = None,
+        key_prefix: Optional[str] = None,
+    ):
+        flow_run_id = None
+        if self.metadata.sender and self.metadata.sender.startswith("prefect.flow-run"):
+            _, _, id = self.metadata.sender.rpartition(".")
+            flow_run_id = UUID(id)
+
+        if not flow_run_id:
+            raise RuntimeError(
+                "Cannot respond to an input that was not sent by a flow run."
+            )
+
+        await _send_input(
+            flow_run_id=flow_run_id,
+            run_input=run_input,
+            sender=sender,
+            key_prefix=key_prefix,
+        )
+
+    @sync_compatible
+    async def send_to(
+        self,
+        flow_run_id: UUID,
+        sender: Optional[str] = None,
+        key_prefix: Optional[str] = None,
+    ):
+        await _send_input(
+            flow_run_id=flow_run_id,
+            run_input=self,
+            sender=sender,
+            key_prefix=key_prefix,
+        )
+
+    @classmethod
+    def receive(
+        cls,
+        timeout: Optional[float] = 3600,
+        poll_interval: float = 10,
+        raise_timeout_error: bool = False,
+        exclude_keys: Optional[Set[str]] = None,
+        key_prefix: Optional[str] = None,
+        flow_run_id: Optional[UUID] = None,
+    ):
+        if key_prefix is None:
+            key_prefix = f"{cls.__name__.lower()}-auto"
+
+        return GetInputHandler(
+            run_input_cls=cls,
+            key_prefix=key_prefix,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            raise_timeout_error=raise_timeout_error,
+            exclude_keys=exclude_keys,
+            flow_run_id=flow_run_id,
+        )
+
+
+class GetInputHandler(Generic[T]):
+    def __init__(
+        self,
+        run_input_cls: Type[T],
+        key_prefix: str,
+        timeout: Optional[float] = 3600,
+        poll_interval: float = 10,
+        raise_timeout_error: bool = False,
+        exclude_keys: Optional[Set[str]] = None,
+        flow_run_id: Optional[UUID] = None,
+    ):
+        self.run_input_cls = run_input_cls
+        self.key_prefix = key_prefix
+        self.timeout = timeout
+        self.poll_interval = poll_interval
+        self.exclude_keys = set()
+        self.raise_timeout_error = raise_timeout_error
+        self.flow_run_id = ensure_flow_run_id(flow_run_id)
+
+        if exclude_keys is not None:
+            self.exclude_keys.update(exclude_keys)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> T:
+        try:
+            return self.next()
+        except TimeoutError:
+            if self.raise_timeout_error:
+                raise
+            raise StopIteration
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> T:
+        try:
+            return await self.next()
+        except TimeoutError:
+            if self.raise_timeout_error:
+                raise
+            raise StopAsyncIteration
+
+    async def filter_for_inputs(self):
+        flow_run_inputs = await filter_flow_run_input(
+            key_prefix=self.key_prefix,
+            limit=1,
+            exclude_keys=self.exclude_keys,
+            flow_run_id=self.flow_run_id,
+        )
+
+        if flow_run_inputs:
+            self.exclude_keys.add(*[i.key for i in flow_run_inputs])
+
+        return flow_run_inputs
+
+    def to_instance(self, flow_run_input: "FlowRunInput") -> T:
+        return self.run_input_cls.load_from_flow_run_input(flow_run_input)
+
+    @sync_compatible
+    async def next(self) -> T:
+        flow_run_inputs = await self.filter_for_inputs()
+        if flow_run_inputs:
+            return self.to_instance(flow_run_inputs[0])
+
+        with anyio.fail_after(self.timeout):
+            while True:
+                await anyio.sleep(self.poll_interval)
+                flow_run_inputs = await self.filter_for_inputs()
+                if flow_run_inputs:
+                    return self.to_instance(flow_run_inputs[0])
+
+
+async def _send_input(
+    flow_run_id: UUID,
+    run_input: "RunInput",
+    sender: Optional[str] = None,
+    key_prefix: Optional[str] = None,
+):
+    if key_prefix is None:
+        key_prefix = f"{run_input.__class__.__name__.lower()}-auto"
+
+    key = f"{key_prefix}-{uuid4()}"
+
+    await create_flow_run_input_from_model(
+        key=key, flow_run_id=flow_run_id, model_instance=run_input, sender=sender
+    )

--- a/src/prefect/server/database/migrations/MIGRATION-NOTES.md
+++ b/src/prefect/server/database/migrations/MIGRATION-NOTES.md
@@ -8,6 +8,10 @@ Each time a database migration is written, an entry is included here with:
 
 This gives us a history of changes and will create merge conflicts if two migrations are made at once, flagging situations where a branch needs to be updated before merging.
 
+# Add `sender` to `FlowRunInput`
+SQLite: `c63a0a6dc787`
+Postgres: `6b63c51c31b4`
+
 # Make `FlowRunInput.flow_run_id` a foreign key to `flow_run.id`
 SQLite: `a299308852a7`
 Postgres: `7c453555d3a5`

--- a/src/prefect/server/database/migrations/versions/postgresql/2024_01_05_101034_6b63c51c31b4_add_sender_to_flowruninput.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2024_01_05_101034_6b63c51c31b4_add_sender_to_flowruninput.py
@@ -1,0 +1,23 @@
+"""Add `sender` to `FlowRunInput`
+
+Revision ID: 6b63c51c31b4
+Revises: 7c453555d3a5
+Create Date: 2024-01-05 10:10:34.201651
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "6b63c51c31b4"
+down_revision = "7c453555d3a5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("flow_run_input", sa.Column("sender", sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("flow_run_input", "sender")

--- a/src/prefect/server/database/migrations/versions/sqlite/2024_01_05_101041_c63a0a6dc787_add_sender_to_flowruninput.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2024_01_05_101041_c63a0a6dc787_add_sender_to_flowruninput.py
@@ -1,0 +1,25 @@
+"""Add `sender` to `FlowRunInput`
+
+Revision ID: c63a0a6dc787
+Revises: 35659cc49969
+Create Date: 2024-01-05 10:10:41.226754
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c63a0a6dc787"
+down_revision = "35659cc49969"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("flow_run_input", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("sender", sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("flow_run_input", schema=None) as batch_op:
+        batch_op.drop_column("sender")

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -1349,6 +1349,7 @@ class ORMFlowRunInput:
 
     key = sa.Column(sa.String, nullable=False)
     value = sa.Column(sa.Text(), nullable=False)
+    sender = sa.Column(sa.String, nullable=True)
 
     __table_args__ = (sa.UniqueConstraint("flow_run_id", "key"),)
 

--- a/src/prefect/server/models/flow_run_input.py
+++ b/src/prefect/server/models/flow_run_input.py
@@ -40,6 +40,7 @@ async def filter_flow_run_input(
                 db.FlowRunInput.key.not_in(exclude_keys),
             )
         )
+        .order_by(db.FlowRunInput.created)
         .limit(limit)
     )
 

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -1283,6 +1283,7 @@ class FlowRunInput(ORMBaseModel):
     flow_run_id: UUID = Field(description="The flow run ID associated with the input.")
     key: str = Field(description="The key of the input.")
     value: str = Field(description="The value of the input.")
+    sender: Optional[str] = Field(description="The sender of the input.")
 
     @validator("key", check_fields=False)
     def validate_name_characters(cls, v):

--- a/tests/input/test_actions.py
+++ b/tests/input/test_actions.py
@@ -1,3 +1,4 @@
+import pydantic
 import pytest
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
@@ -10,15 +11,74 @@ else:
 from prefect.context import FlowRunContext
 from prefect.input import (
     create_flow_run_input,
+    create_flow_run_input_from_model,
     delete_flow_run_input,
+    filter_flow_run_input,
     read_flow_run_input,
 )
+
+
+class DemoModel(pydantic.BaseModel):
+    name: str
+    age: int
 
 
 @pytest.fixture
 def flow_run_context(flow_run, prefect_client):
     with FlowRunContext.construct(flow_run=flow_run, client=prefect_client) as context:
         yield context
+
+
+class TestCreateFlowRunInputFromModel:
+    async def test_creates_flow_run_input(self, flow_run_context):
+        demo = DemoModel(name="Bob", age=100)
+        await create_flow_run_input_from_model(key="key", model_instance=demo)
+
+        value = await read_flow_run_input(
+            key="key", flow_run_id=flow_run_context.flow_run.id
+        )
+
+        assert DemoModel(**value) == demo
+
+    async def test_sets_sender_to_flow_run_in_context(self, flow_run_context):
+        demo = DemoModel(name="Bob", age=100)
+        await create_flow_run_input_from_model(key="key", model_instance=demo)
+
+        flow_run_inputs = await filter_flow_run_input(
+            key_prefix="key", flow_run_id=flow_run_context.flow_run.id
+        )
+
+        assert len(flow_run_inputs) == 1
+        assert (
+            flow_run_inputs[0].sender
+            == f"prefect.flow-run.{flow_run_context.flow_run.id}"
+        )
+
+    async def test_can_set_sender(self, flow_run_context):
+        demo = DemoModel(name="Bob", age=100)
+        await create_flow_run_input_from_model(
+            key="key", model_instance=demo, sender="somebody"
+        )
+
+        flow_run_inputs = await filter_flow_run_input(
+            key_prefix="key", flow_run_id=flow_run_context.flow_run.id
+        )
+
+        assert len(flow_run_inputs) == 1
+        assert flow_run_inputs[0].sender == "somebody"
+
+    async def test_no_sender_no_flow_run_context(self, flow_run):
+        demo = DemoModel(name="Bob", age=100)
+        await create_flow_run_input_from_model(
+            key="key", model_instance=demo, flow_run_id=flow_run.id
+        )
+
+        flow_run_inputs = await filter_flow_run_input(
+            key_prefix="key", flow_run_id=flow_run.id
+        )
+
+        assert len(flow_run_inputs) == 1
+        assert flow_run_inputs[0].sender is None
 
 
 class TestCreateFlowRunInput:
@@ -83,3 +143,45 @@ class TestReadFlowRunInput:
 
     async def test_missing_key_returns_none(self, flow_run):
         assert await read_flow_run_input(key="missing", flow_run_id=flow_run.id) is None
+
+
+class TestFilterFlowRunInput:
+    @pytest.fixture
+    async def flow_run_input_keys(self, flow_run):
+        keys = {"key-1", "key-2", "different-1"}
+        for key in keys:
+            await create_flow_run_input(key=key, value="value", flow_run_id=flow_run.id)
+
+        return keys
+
+    async def test_implicit_flow_run(self, flow_run_context, flow_run_input_keys):
+        filtered = await filter_flow_run_input(
+            key_prefix="key", limit=len(flow_run_input_keys) + 1
+        )
+        assert len(filtered) == 2
+        assert {"key-1", "key-2"} != flow_run_input_keys
+        assert {"key-1", "key-2"} == {item.key for item in filtered}
+
+    async def test_explicit_flow_run(self, flow_run, flow_run_input_keys):
+        filtered = await filter_flow_run_input(
+            key_prefix="key",
+            limit=len(flow_run_input_keys) + 1,
+            flow_run_id=flow_run.id,
+        )
+        assert len(filtered) == 2
+        assert {"key-1", "key-2"} != flow_run_input_keys
+        assert {"key-1", "key-2"} == {item.key for item in filtered}
+
+    async def test_no_flow_run_raises(self):
+        with pytest.raises(
+            RuntimeError, match="provide a flow run ID or be within a flow run"
+        ):
+            await filter_flow_run_input(key_prefix="key")
+
+    async def test_exclude_keys(self, flow_run_context, flow_run_input_keys):
+        filtered = await filter_flow_run_input(
+            key_prefix="key", limit=len(flow_run_input_keys) + 1, exclude_keys={"key-2"}
+        )
+        assert len(filtered) == 1
+        assert {"key-1"} == {item.key for item in filtered}
+        assert "key-2" in flow_run_input_keys

--- a/tests/input/test_run_input.py
+++ b/tests/input/test_run_input.py
@@ -208,7 +208,9 @@ async def test_respond(flow_run):
     await person.respond(Place(city="New York", state="NY"))
 
     place = await Place.receive(flow_run_id=flow_run.id, timeout=0.1).next()
-    assert place == Place(city="New York", state="NY")
+    assert isinstance(place, Place)
+    assert place.city == "New York"
+    assert place.state == "NY"
 
 
 def test_respond_functions_sync(flow_run):
@@ -225,7 +227,9 @@ def test_respond_functions_sync(flow_run):
     person.respond(Place(city="New York", state="NY"))
 
     place = Place.receive(flow_run_id=flow_run.id, timeout=0.1).next()
-    assert place == Place(city="New York", state="NY")
+    assert isinstance(place, Place)
+    assert place.city == "New York"
+    assert place.state == "NY"
 
 
 async def test_respond_can_set_sender(flow_run):
@@ -261,7 +265,9 @@ async def test_respond_can_set_key_prefix(flow_run):
     place = await Place.receive(
         flow_run_id=flow_run.id, timeout=0.1, key_prefix="heythere"
     ).next()
-    assert place == Place(city="New York", state="NY")
+    assert isinstance(place, Place)
+    assert place.city == "New York"
+    assert place.state == "NY"
 
 
 async def test_respond_raises_exception_no_sender_in_input():
@@ -293,7 +299,10 @@ async def test_send_to(flow_run):
     await person.send_to(flow_run_id=flow_run.id)
 
     received = await Person.receive(flow_run_id=flow_run.id, timeout=0.1).next()
-    assert received == person
+    assert isinstance(received, Person)
+    assert person.name == "Bob"
+    assert person.email == "bob@example.com"
+    assert person.human is True
 
 
 def test_send_to_works_sync(flow_run):
@@ -309,7 +318,10 @@ def test_send_to_works_sync(flow_run):
     person.send_to(flow_run_id=flow_run.id)
 
     received = Person.receive(flow_run_id=flow_run.id, timeout=0.1).next()
-    assert received == person
+    assert isinstance(received, Person)
+    assert person.name == "Bob"
+    assert person.email == "bob@example.com"
+    assert person.human is True
 
 
 async def test_send_to_can_set_sender(flow_run):
@@ -343,7 +355,10 @@ async def test_send_to_can_set_key_prefix(flow_run):
     received = await Person.receive(
         flow_run_id=flow_run.id, timeout=0.1, key_prefix="heythere"
     ).next()
-    assert received == person
+    assert isinstance(received, Person)
+    assert person.name == "Bob"
+    assert person.email == "bob@example.com"
+    assert person.human is True
 
 
 async def test_receive(flow_run):
@@ -417,8 +432,11 @@ async def test_receive_with_exclude_keys(flow_run):
         flow_run_id=flow_run.id, timeout=0, exclude_keys=exclude_keys
     ):
         received.append(place)
+
     assert len(received) == 1
-    assert received[0] == Place(city="Portland", state="OR")
+    place = received[0]
+    assert place.city == "Portland"
+    assert place.state == "OR"
 
 
 async def test_receive_can_raise_timeout_errors_as_generator(flow_run):

--- a/tests/input/test_run_input.py
+++ b/tests/input/test_run_input.py
@@ -1,9 +1,15 @@
+import asyncio
+from uuid import uuid4
+
+import orjson
 import pydantic
 import pytest
 
+from prefect.client.schemas.objects import FlowRunInput
 from prefect.context import FlowRunContext
 from prefect.input import (
     RunInput,
+    RunInputMetadata,
     create_flow_run_input,
     keyset_from_base_key,
     keyset_from_paused_state,
@@ -24,8 +30,19 @@ class Person(RunInput):
     human: bool
 
 
+class Place(RunInput):
+    city: str
+    state: str
+
+
 def test_keyset_from_base_key():
     keyset = keyset_from_base_key("person")
+    assert keyset["response"] == "person-response"
+    assert keyset["schema"] == "person-schema"
+
+
+def test_keyset_from_type():
+    keyset = Person.keyset_from_type()
     assert keyset["response"] == "person-response"
     assert keyset["schema"] == "person-schema"
 
@@ -89,6 +106,19 @@ async def test_load(flow_run_context):
     assert person.human is True
 
 
+async def test_load_populates_metadata(flow_run_context):
+    keyset = keyset_from_base_key("person")
+    await create_flow_run_input(
+        keyset["response"],
+        value={"name": "Bob", "email": "bob@bob.bob", "human": True},
+    )
+
+    person = await Person.load(keyset)
+    assert person.metadata == RunInputMetadata(
+        key=keyset["response"], receiver=flow_run_context.flow_run.id, sender=None
+    )
+
+
 def test_load_works_sync(flow_run_context):
     keyset = keyset_from_base_key("person")
     create_flow_run_input(
@@ -131,6 +161,28 @@ async def test_load_fails_validation_raises_exception(flow_run_context):
         assert isinstance(person, Person)
 
 
+async def test_load_from_flow_run_input(flow_run_context):
+    flow_run_input = FlowRunInput(
+        flow_run_id=flow_run_context.flow_run.id,
+        key="person-response",
+        value=orjson.dumps(
+            {"name": "Bob", "email": "bob@example.com", "human": True}
+        ).decode(),
+        sender=f"prefect.flow-run.{uuid4()}",
+    )
+
+    person = Person.load_from_flow_run_input(flow_run_input)
+
+    assert person.name == "Bob"
+    assert person.email == "bob@example.com"
+    assert person.human is True
+    assert person.metadata == RunInputMetadata(
+        key=flow_run_input.key,
+        receiver=flow_run_context.flow_run.id,
+        sender=flow_run_input.sender,
+    )
+
+
 async def test_with_initial_data(flow_run_context):
     keyset = keyset_from_base_key("bob")
 
@@ -140,3 +192,256 @@ async def test_with_initial_data(flow_run_context):
     await new_cls.save(keyset)
     schema = await read_flow_run_input(key=keyset["schema"])
     assert schema["properties"]["name"]["default"] == "Bob"
+
+
+async def test_respond(flow_run):
+    flow_run_input = FlowRunInput(
+        flow_run_id=uuid4(),
+        key="person-response",
+        value=orjson.dumps(
+            {"name": "Bob", "email": "bob@example.com", "human": True}
+        ).decode(),
+        sender=f"prefect.flow-run.{flow_run.id}",
+    )
+
+    person = Person.load_from_flow_run_input(flow_run_input)
+    await person.respond(Place(city="New York", state="NY"))
+
+    place = await Place.receive(flow_run_id=flow_run.id, timeout=0.1).next()
+    assert place == Place(city="New York", state="NY")
+
+
+def test_respond_functions_sync(flow_run):
+    flow_run_input = FlowRunInput(
+        flow_run_id=uuid4(),
+        key="person-response",
+        value=orjson.dumps(
+            {"name": "Bob", "email": "bob@example.com", "human": True}
+        ).decode(),
+        sender=f"prefect.flow-run.{flow_run.id}",
+    )
+
+    person = Person.load_from_flow_run_input(flow_run_input)
+    person.respond(Place(city="New York", state="NY"))
+
+    place = Place.receive(flow_run_id=flow_run.id, timeout=0.1).next()
+    assert place == Place(city="New York", state="NY")
+
+
+async def test_respond_can_set_sender(flow_run):
+    flow_run_input = FlowRunInput(
+        flow_run_id=uuid4(),
+        key="person-response",
+        value=orjson.dumps(
+            {"name": "Bob", "email": "bob@example.com", "human": True}
+        ).decode(),
+        sender=f"prefect.flow-run.{flow_run.id}",
+    )
+
+    person = Person.load_from_flow_run_input(flow_run_input)
+    await person.respond(Place(city="New York", state="NY"), sender="sally")
+
+    place = await Place.receive(flow_run_id=flow_run.id, timeout=0.1).next()
+    assert place.metadata.sender == "sally"
+
+
+async def test_respond_can_set_key_prefix(flow_run):
+    flow_run_input = FlowRunInput(
+        flow_run_id=uuid4(),
+        key="person-response",
+        value=orjson.dumps(
+            {"name": "Bob", "email": "bob@example.com", "human": True}
+        ).decode(),
+        sender=f"prefect.flow-run.{flow_run.id}",
+    )
+
+    person = Person.load_from_flow_run_input(flow_run_input)
+    await person.respond(Place(city="New York", state="NY"), key_prefix="heythere")
+
+    place = await Place.receive(
+        flow_run_id=flow_run.id, timeout=0.1, key_prefix="heythere"
+    ).next()
+    assert place == Place(city="New York", state="NY")
+
+
+async def test_respond_raises_exception_no_sender_in_input():
+    flow_run_input = FlowRunInput(
+        flow_run_id=uuid4(),
+        key="person-response",
+        value=orjson.dumps(
+            {"name": "Bob", "email": "bob@example.com", "human": True}
+        ).decode(),
+        sender=None,
+    )
+
+    person = Person.load_from_flow_run_input(flow_run_input)
+
+    with pytest.raises(RuntimeError, match="Cannot respond"):
+        await person.respond(Place(city="New York", state="NY"))
+
+
+async def test_send_to(flow_run):
+    flow_run_input = FlowRunInput(
+        flow_run_id=uuid4(),
+        key="person-response",
+        value=orjson.dumps(
+            {"name": "Bob", "email": "bob@example.com", "human": True}
+        ).decode(),
+    )
+
+    person = Person.load_from_flow_run_input(flow_run_input)
+    await person.send_to(flow_run_id=flow_run.id)
+
+    received = await Person.receive(flow_run_id=flow_run.id, timeout=0.1).next()
+    assert received == person
+
+
+def test_send_to_works_sync(flow_run):
+    flow_run_input = FlowRunInput(
+        flow_run_id=uuid4(),
+        key="person-response",
+        value=orjson.dumps(
+            {"name": "Bob", "email": "bob@example.com", "human": True}
+        ).decode(),
+    )
+
+    person = Person.load_from_flow_run_input(flow_run_input)
+    person.send_to(flow_run_id=flow_run.id)
+
+    received = Person.receive(flow_run_id=flow_run.id, timeout=0.1).next()
+    assert received == person
+
+
+async def test_send_to_can_set_sender(flow_run):
+    flow_run_input = FlowRunInput(
+        flow_run_id=uuid4(),
+        key="person-response",
+        value=orjson.dumps(
+            {"name": "Bob", "email": "bob@example.com", "human": True}
+        ).decode(),
+    )
+
+    person = Person.load_from_flow_run_input(flow_run_input)
+    await person.send_to(flow_run_id=flow_run.id, sender="sally")
+
+    received = await Person.receive(flow_run_id=flow_run.id, timeout=0.1).next()
+    assert received.metadata.sender == "sally"
+
+
+async def test_send_to_can_set_key_prefix(flow_run):
+    flow_run_input = FlowRunInput(
+        flow_run_id=uuid4(),
+        key="person-response",
+        value=orjson.dumps(
+            {"name": "Bob", "email": "bob@example.com", "human": True}
+        ).decode(),
+    )
+
+    person = Person.load_from_flow_run_input(flow_run_input)
+    await person.send_to(flow_run_id=flow_run.id, key_prefix="heythere")
+
+    received = await Person.receive(
+        flow_run_id=flow_run.id, timeout=0.1, key_prefix="heythere"
+    ).next()
+    assert received == person
+
+
+async def test_receive(flow_run):
+    async def send():
+        for city, state in [("New York", "NY"), ("Boston", "MA"), ("Chicago", "IL")]:
+            await Place(city=city, state=state).send_to(flow_run_id=flow_run.id)
+            await asyncio.sleep(0.2)
+
+    async def receive():
+        received = []
+        async for place in Place.receive(
+            flow_run_id=flow_run.id, timeout=0.5, poll_interval=0.1
+        ):
+            received.append(place)
+        return received
+
+    _, received = await asyncio.gather(send(), receive())
+
+    assert len(received) == 3
+    assert all(isinstance(place, Place) for place in received)
+    assert {(place.city, place.state) for place in received} == {
+        ("New York", "NY"),
+        ("Boston", "MA"),
+        ("Chicago", "IL"),
+    }
+
+
+def test_receive_works_sync(flow_run):
+    for city, state in [("New York", "NY"), ("Boston", "MA"), ("Chicago", "IL")]:
+        Place(city=city, state=state).send_to(flow_run_id=flow_run.id)
+
+    received = []
+    for place in Place.receive(flow_run_id=flow_run.id, timeout=0, poll_interval=0.1):
+        received.append(place)
+
+    assert len(received) == 3
+    assert all(isinstance(place, Place) for place in received)
+    assert {(place.city, place.state) for place in received} == {
+        ("New York", "NY"),
+        ("Boston", "MA"),
+        ("Chicago", "IL"),
+    }
+
+
+async def test_receive_with_exclude_keys(flow_run):
+    for city, state in [("New York", "NY"), ("Boston", "MA"), ("Chicago", "IL")]:
+        await Place(city=city, state=state).send_to(flow_run_id=flow_run.id)
+
+    # Receive the places that were sent.
+    received = []
+    async for place in Place.receive(flow_run_id=flow_run.id, timeout=0):
+        received.append(place)
+    assert len(received) == 3
+
+    # Send a new place
+    await Place(city="Los Angeles", state="CA").send_to(flow_run_id=flow_run.id)
+
+    # Since this receive is being called without exclude_keys, it will receive
+    # all of the places that have been sent.
+    received = []
+    async for place in Place.receive(flow_run_id=flow_run.id, timeout=0):
+        received.append(place)
+    assert len(received) == 4
+
+    # Lets send another new place, and receive excluding the keys that have
+    # been previously received and we should only receive the new place.
+    exclude_keys = {place.metadata.key for place in received}
+    await Place(city="Portland", state="OR").send_to(flow_run_id=flow_run.id)
+    received = []
+    async for place in Place.receive(
+        flow_run_id=flow_run.id, timeout=0, exclude_keys=exclude_keys
+    ):
+        received.append(place)
+    assert len(received) == 1
+    assert received[0] == Place(city="Portland", state="OR")
+
+
+async def test_receive_can_raise_timeout_errors_as_generator(flow_run):
+    with pytest.raises(TimeoutError):
+        async for _ in Place.receive(
+            flow_run_id=flow_run.id,
+            timeout=0,
+            poll_interval=0.1,
+            # Normally the loop would just exit, but this causes it to raise
+            # when it doesn't receive a value for `timeout` seconds.
+            raise_timeout_error=True,
+        ):
+            pass
+
+
+def test_receive_can_raise_timeout_errors_as_generator_sync(flow_run):
+    with pytest.raises(TimeoutError):
+        for _ in Place.receive(
+            flow_run_id=flow_run.id,
+            timeout=0,
+            poll_interval=0.1,
+            # Normally the loop would just exit, but this causes it to raise
+            # when it doesn't receive a value for `timeout` seconds.
+            raise_timeout_error=True,
+        ):
+            pass

--- a/tests/input/test_run_input.py
+++ b/tests/input/test_run_input.py
@@ -370,7 +370,7 @@ async def test_receive(flow_run):
     async def receive():
         received = []
         async for place in Place.receive(
-            flow_run_id=flow_run.id, timeout=0.5, poll_interval=0.1
+            flow_run_id=flow_run.id, timeout=1, poll_interval=0.1
         ):
             received.append(place)
         return received

--- a/tests/server/api/test_flow_runs.py
+++ b/tests/server/api/test_flow_runs.py
@@ -1553,6 +1553,7 @@ class TestFlowRunInput:
                     value="really important stuff",
                 ),
             )
+        await session.commit()
 
         response = await client.post(
             f"/flow_runs/{flow_run.id}/input/filter",

--- a/tests/server/api/test_flow_runs.py
+++ b/tests/server/api/test_flow_runs.py
@@ -1532,6 +1532,15 @@ class TestFlowRunInput:
 
         assert response.status_code == 409
 
+    async def test_filter_flow_run_input(self, client: AsyncClient, flow_run_input):
+        response = await client.post(
+            f"/flow_runs/{flow_run_input.flow_run_id}/input/filter",
+            json={"prefix": "structured"},
+        )
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+        assert schemas.core.FlowRunInput.parse_obj(response.json()[0]) == flow_run_input
+
     async def test_read_flow_run_input(self, client: AsyncClient, flow_run_input):
         response = await client.get(
             f"/flow_runs/{flow_run_input.flow_run_id}/input/{flow_run_input.key}",

--- a/tests/server/api/test_flow_runs.py
+++ b/tests/server/api/test_flow_runs.py
@@ -1546,7 +1546,7 @@ class TestFlowRunInput:
     ):
         for i in range(100):
             await models.flow_run_input.create_flow_run_input(
-                session,
+                session=session,
                 flow_run_input=schemas.core.FlowRunInput(
                     flow_run_id=flow_run.id,
                     key=f"structured-key-{i}",

--- a/tests/server/models/test_flow_run_input.py
+++ b/tests/server/models/test_flow_run_input.py
@@ -63,6 +63,61 @@ class TestCreateFlowRunInput:
             )
 
 
+class TestFilterFlowRunInput:
+    async def test_reads_flow_run_input(self, session: AsyncSession, flow_run):
+        for key in ["my-key", "my-key2", "other-key"]:
+            await models.flow_run_input.create_flow_run_input(
+                session=session,
+                flow_run_input=schemas.core.FlowRunInput(
+                    flow_run_id=flow_run.id, key=key, value="my-value"
+                ),
+            )
+
+        flow_run_inputs = await models.flow_run_input.filter_flow_run_input(
+            session=session,
+            flow_run_id=flow_run.id,
+            prefix="my-key",
+            limit=10,
+            exclude_keys=[],
+        )
+
+        assert len(flow_run_inputs) == 2
+        assert all(
+            isinstance(flow_run_input, schemas.core.FlowRunInput)
+            for flow_run_input in flow_run_inputs
+        )
+        assert {flow_run_input.key for flow_run_input in flow_run_inputs} == {
+            "my-key",
+            "my-key2",
+        }
+
+    async def test_reads_flow_run_input_exclude_keys(
+        self, session: AsyncSession, flow_run
+    ):
+        for key in ["my-key", "my-key2", "other-key"]:
+            await models.flow_run_input.create_flow_run_input(
+                session=session,
+                flow_run_input=schemas.core.FlowRunInput(
+                    flow_run_id=flow_run.id, key=key, value="my-value"
+                ),
+            )
+
+        flow_run_inputs = await models.flow_run_input.filter_flow_run_input(
+            session=session,
+            flow_run_id=flow_run.id,
+            prefix="my-key",
+            limit=10,
+            exclude_keys=["my-key2"],
+        )
+
+        assert len(flow_run_inputs) == 1
+        assert all(
+            isinstance(flow_run_input, schemas.core.FlowRunInput)
+            for flow_run_input in flow_run_inputs
+        )
+        assert {flow_run_input.key for flow_run_input in flow_run_inputs} == {"my-key"}
+
+
 class TestReadFlowRunInput:
     async def test_reads_flow_run_input(self, session: AsyncSession, flow_run):
         await models.flow_run_input.create_flow_run_input(


### PR DESCRIPTION
This enables flow runs to receive and send input from/to external sources.

Closes https://github.com/PrefectHQ/nebula/issues/6425

### Example
This example implements a simple `mapreduce` set of flows. A main `mapreduce` flow delegates the mapping/reducing logic to other long-running flows. These flows wait to receive input, process it, and then respond to that input with their computed values.

First there is a `common` set of `RunInput` classes, referenced from `common.py`:

```python
from prefect.input import RunInput


class Values(RunInput):
    values: list[int]


class Summed(RunInput):
    value: int
```

Then a flow that receives `Values` inputs and transforms the provided list of ints by multiplying each by 2. It then responds to the incoming `Values` input with the newly mapped `Values`:

```python
from prefect import flow

from common import Values


@flow()
def mapit():
    for values in Values.receive(poll_interval=1):
        mapped = [value * 2 for value in values.values]
        values.respond(Values(values=mapped))


if __name__ == "__main__":
    mapit.serve(name="mapit")
```

This flow is written in sync python just to show support, but you can also write async python.

The flow below is written in async python. It receives `Values` inputs and responds with a `Summed` `RunInput` that is the sum of the list of ints in the `Values` input.

```python
from prefect import flow

from common import Summed, Values


@flow()
async def reduce():
    async for input in Values.receive(poll_interval=1):
        await input.respond(Summed(value=sum(input.values)))


if __name__ == "__main__":
    reduce.serve(name="reduce")
```

And finally the main `mapreduce` flow that will send an incoming list of ints to the `map` flow, receive the value back, then pass that value to the `reduce` flow and finally log the sum:

```python
from uuid import UUID

from prefect import flow, get_run_logger

from common import Values, Summed


@flow()
async def mapreduce(
    map_flow_run_id: UUID, reduce_flow_run_id: UUID, incoming: list[int]
):
    logger = get_run_logger()

    await Values(values=incoming).send_to(map_flow_run_id)

    mapped = await Values.receive(poll_interval=1).next()
    await mapped.send_to(reduce_flow_run_id)

    summed = await Summed.receive(poll_interval=1).next()
    logger.info(f"Summed value: {summed.value}")

if __name__ == "__main__":
    mapreduce.serve(name="mapreduce")
``` 


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
