### PR TITLE
allow saving previously saved blocks without passing `name`

### DIFF
--- a/docs/concepts/blocks.md
+++ b/docs/concepts/blocks.md
@@ -145,6 +145,21 @@ If this JSON value needs to be retrieved later to be used within a flow or task,
 json_block.save(name="life-the-universe-everything")
 ```
 
+If you'd like to update the block value stored for a given `name`, you can overwrite the existing block document by setting `overwrite=True`:
+
+```python
+json_block.save(overwrite=True)
+```
+
+!!! Tip
+    in the above example, the name `"life-the-universe-everything"` is inferred from the existing block document
+
+... or save the same block value as a new block document by setting the `name` parameter to a new value:
+
+```python
+json_block.save(name="actually-life-the-universe-everything")
+```
+
 !!! tip "Utilizing the UI"
     Blocks documents can also be created and updated via the [Prefect UI](/ui/blocks/).
 

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -950,11 +950,14 @@ class Block(BaseModel, ABC):
                 `is_anonymous` is `True`.
         """
         if name is None and not is_anonymous:
-            raise ValueError(
-                "You're attempting to save a block document without a name. "
-                "Please either save a block document with a name or set "
-                "is_anonymous to True."
-            )
+            if self._block_document_name is None:
+                raise ValueError(
+                    "You're attempting to save a block document without a name. "
+                    "Please either save a block document with a name or set "
+                    "is_anonymous to True."
+                )
+            else:
+                name = self._block_document_name
 
         self._is_anonymous = is_anonymous
 
@@ -995,7 +998,10 @@ class Block(BaseModel, ABC):
     @sync_compatible
     @instrument_instance_method_call()
     async def save(
-        self, name: str, overwrite: bool = False, client: "PrefectClient" = None
+        self,
+        name: Optional[str] = None,
+        overwrite: bool = False,
+        client: "PrefectClient" = None,
     ):
         """
         Saves the values of a block as a block document.

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -952,9 +952,9 @@ class Block(BaseModel, ABC):
         if name is None and not is_anonymous:
             if self._block_document_name is None:
                 raise ValueError(
-                    "You're attempting to save a block document without a name. "
-                    "Please either save a block document with a name or set "
-                    "is_anonymous to True."
+                    "You're attempting to save a block document without a name."
+                    " Please either call `save` with a `name` or pass"
+                    " `is_anonymous=True` to save an anonymous block."
                 )
             else:
                 name = self._block_document_name

--- a/tests/blocks/test_core.py
+++ b/tests/blocks/test_core.py
@@ -1368,7 +1368,7 @@ class TestSaveBlock:
 
         assert loaded_new_block == new_block
 
-    async def test_save_block_with_inferred_name(self, NewBlock):
+    async def test_save_block_with_name_inferred_from_loaded_document(self, NewBlock):
         new_block = NewBlock(a="foo", b="bar")
 
         with pytest.raises(
@@ -1383,7 +1383,7 @@ class TestSaveBlock:
         new_python_instance.a = "baz"
         await new_python_instance.save(overwrite=True)
 
-        loaded_new_block = await new_block.load("new-block")
+        loaded_new_block = await NewBlock.load("new-block")
         assert loaded_new_block.a == "baz"
         assert loaded_new_block.b == "bar"
 

--- a/tests/blocks/test_core.py
+++ b/tests/blocks/test_core.py
@@ -1368,6 +1368,25 @@ class TestSaveBlock:
 
         assert loaded_new_block == new_block
 
+    async def test_save_block_with_inferred_name(self, NewBlock):
+        new_block = NewBlock(a="foo", b="bar")
+
+        with pytest.raises(
+            ValueError,
+            match="You're attempting to save a block document without a name.",
+        ):
+            await new_block.save()
+
+        await new_block.save("new-block")
+
+        new_python_instance = await NewBlock.load("new-block")
+        new_python_instance.a = "baz"
+        await new_python_instance.save(overwrite=True)
+
+        loaded_new_block = await new_block.load("new-block")
+        assert loaded_new_block.a == "baz"
+        assert loaded_new_block.b == "bar"
+
     async def test_save_anonymous_block(self, NewBlock):
         new_anon_block = NewBlock(a="foo", b="bar")
         await new_anon_block._save(is_anonymous=True)


### PR DESCRIPTION
previously, we forced callers of `save` to pass `name` even if they were trying to save a block that was `.load`ed from the DB

this PR updates `save` to infer `name` from `self._block_document_name` if `name` is not explicitly passed to `save`

### Example
```python
async def test_save_block_with_name_inferred_from_loaded_document(NewBlock):
    new_block = NewBlock(a="foo", b="bar")

    with pytest.raises(
        ValueError,
        match="You're attempting to save a block document without a name.",
    ):
        await new_block.save()

    await new_block.save("new-block")

    new_python_instance = await NewBlock.load("new-block")
    new_python_instance.a = "baz"
    await new_python_instance.save(overwrite=True)

    loaded_new_block = await NewBlock.load("new-block")
    assert loaded_new_block.a == "baz"
    assert loaded_new_block.b == "bar"
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
