### PR TITLE
ft: add more tests for submissions

### DIFF
--- a/src/prefect/runner/submit.py
+++ b/src/prefect/runner/submit.py
@@ -174,11 +174,12 @@ async def submit_to_runner(
             " `PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS` setting to `True`."
         )
 
+    parameters = parameters or {}
+    if isinstance(parameters, List):
+        return_single = False
     if isinstance(parameters, dict):
         parameters = [parameters]
-
-    if not parameters:
-        parameters = [{}]
+        return_single = True
 
     submitted_run_ids = []
     unsubmitted_parameters = []
@@ -229,7 +230,7 @@ async def submit_to_runner(
         )
 
     # If one run was submitted, return the run_id directly
-    if len(parameters) == 1:
+    if return_single:
         return submitted_run_ids[0]
     return submitted_run_ids
 

--- a/tests/runner/test_submit.py
+++ b/tests/runner/test_submit.py
@@ -36,7 +36,7 @@ async def async_identity(whatever):
 
 
 @flow
-def super_schleeb(*args, **kwargs):
+def super_identity(*args, **kwargs):
     return args, kwargs
 
 
@@ -267,7 +267,7 @@ def test_return_for_submissions_matches_input(input_: Union[List[Dict], Dict]):
     ],
 )
 def test_types_in_submission(input_: Union[List[Dict], Dict]):
-    results = submit_to_runner(super_schleeb, input_)
+    results = submit_to_runner(super_identity, input_)
 
     if isinstance(input_, List):
         assert len(results) == len(input_)

--- a/tests/runner/test_submit.py
+++ b/tests/runner/test_submit.py
@@ -1,5 +1,7 @@
 import asyncio
 import uuid
+from typing import Dict, List, Union
+from unittest import mock
 
 import httpx
 import pytest
@@ -31,6 +33,11 @@ def identity(whatever):
 @flow
 async def async_identity(whatever):
     return whatever
+
+
+@flow
+def super_schleeb(*args, **kwargs):
+    return args, kwargs
 
 
 @flow(log_prints=True)
@@ -135,3 +142,136 @@ def test_submission_raises_if_webserver_not_running_and_no_failover():
     ):
         with pytest.raises((httpx.HTTPStatusError, RuntimeError)):
             submit_to_runner(identity, {"d": {"schleeb": 9001}})
+
+
+@mock.patch(
+    "prefect.runner.submit._run_prefect_callable_and_retrieve_run_id",
+)
+def test_failed_submission_gets_run_sync(run_callable_mock: mock.Mock, caplog):
+    with mock.patch(
+        "prefect.runner.submit._submit_flow_to_runner",
+        side_effect=httpx.ConnectError(""),
+    ):
+        inputs = [{"schleeb": 1}, {"schleeb": 2}, {"schleeb": 3}]
+        results = submit_to_runner(schleeb, inputs)
+
+        assert run_callable_mock.call_count == len(inputs)
+        assert run_callable_mock.call_args_list == [
+            mock.call(schleeb, d) for d in inputs
+        ]
+        assert len(results) == len(inputs)
+        assert (
+            "The `submit_to_runner` utility failed to connect to the `Runner` webserver"
+            in caplog.text
+        )
+
+
+@mock.patch(
+    "prefect.runner.submit._run_prefect_callable_and_retrieve_run_id",
+)
+def test_intermittent_failed_submission_gets_run_sync(
+    run_callable_mock: mock.Mock, caplog
+):
+    """
+    Verify that failures interspersed between successful submissions are run sync
+    """
+    with mock.patch(
+        "prefect.runner.submit._submit_flow_to_runner",
+        side_effect=[uuid.uuid4(), httpx.ConnectError(""), uuid.uuid4()],
+    ):
+        inputs = [{"schleeb": 1}, {"schleeb": 2}, {"schleeb": 3}]
+        results = submit_to_runner(schleeb, inputs)
+
+        assert run_callable_mock.call_count == 1
+        assert run_callable_mock.call_args_list == [mock.call(schleeb, {"schleeb": 2})]
+        assert len(results) == len(inputs)
+        assert (
+            "The `submit_to_runner` utility failed to connect to the `Runner` webserver"
+            in caplog.text
+        )
+
+
+def test_failed_submission_are_not_run_sync_if_configured(caplog):
+    with temporary_settings(
+        {
+            PREFECT_RUNNER_SERVER_ENABLE: True,
+            PREFECT_RUNNER_SERVER_ENABLE_BLOCKING_FAILOVER: False,
+        }
+    ), mock.patch(
+        "prefect.runner.submit._submit_flow_to_runner",
+        side_effect=httpx.ConnectError(""),
+    ) as sub_flow_mock:
+        with pytest.raises(RuntimeError):
+            submit_to_runner(schleeb, {"schleeb": 1})
+
+        assert sub_flow_mock.call_count == 1
+        assert sub_flow_mock.call_args_list == [
+            mock.call(schleeb, {"schleeb": 1}, True)
+        ], sub_flow_mock.call_args_list
+        assert (
+            "The `submit_to_runner` utility failed to connect to the `Runner`"
+            in caplog.text
+        )
+
+
+@pytest.mark.parametrize("input_", [[{"schleeb": 1}, {"schleeb": 2}], {"schleeb": 3}])
+def test_return_for_submissions_matches_input(input_: Union[List[Dict], Dict]):
+    def _uuid_generator(*_, **__):
+        return uuid.uuid4()
+
+    with mock.patch(
+        "prefect.runner.submit._submit_flow_to_runner",
+        side_effect=_uuid_generator,
+    ):
+        results = submit_to_runner(schleeb, input_)
+
+        if isinstance(input_, dict):
+            assert isinstance(results, uuid.UUID)
+        else:
+            assert len(results) == len(input_)
+            assert all(isinstance(r, uuid.UUID) for r in results)
+
+
+@pytest.mark.parametrize(
+    "input_",
+    [
+        {
+            "name": "Schleeb",
+            "age": 99,
+            "young": True,
+            "metadata": [{"nested": "info"}],
+            "data": [True, False, True],
+            "info": {"nested": "info"},
+        },
+        [
+            {
+                "name": "Schleeb",
+                "age": 99,
+                "young": True,
+                "metadata": [{"nested": "info"}],
+                "data": [True, False, True],
+                "info": {"nested": "info"},
+            }
+        ],
+        [
+            {
+                "name": "Schleeb",
+                "age": 99,
+                "young": True,
+                "metadata": [{"nested": "info"}],
+                "data": [True, False, True],
+                "info": {"nested": "info"},
+            }
+        ],
+        [{"1": {2: {3: {4: None}}}}],
+    ],
+)
+def test_types_in_submission(input_: Union[List[Dict], Dict]):
+    results = submit_to_runner(super_schleeb, input_)
+
+    if isinstance(input_, List):
+        assert len(results) == len(input_)
+        for r in results:
+            assert isinstance(r, uuid.UUID)
+    else:
+        assert isinstance(results, uuid.UUID)


### PR DESCRIPTION
Added a bunch of tests to verify behavior for `_submit_flow_to_runner` running flows in a sync fashion (not in the webserver). Along the way I found a small bug in how we were detecting whether to return a list of UUIDs or a single UUID - so I updated the logic to make it clearer how we make that decision.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

