### PR TITLE
Add PR checkbox for docstrings and Python SDK doc files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,7 +33,7 @@ For documentation changes:
 
 - [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.
 
-For new functions or classes in the Python SDK
+For new functions or classes in the Python SDK:
 
 - [ ] This pull request includes helpful docstrings.
 - [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,4 +31,9 @@ If changing documentation, a link to a preview of the page is great.
 
 For documentation changes:
 
-- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
+- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.
+
+For new functions or classes in the Python SDK
+
+- [ ] This pull request includes helpful docstrings.
+- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.


### PR DESCRIPTION
Python SDK modules are not always updated in the docs because stub files and navigation for mkdocs were often not added. Sometimes docstrings were not added.  Users pointed out that some docs were missing.

This PR adds checkboxes to make folks aware of that expectation with importable Python code.


<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
