### PR TITLE
Raise `StepExecutionError` on non-zero `run_shell_script` return code during `prefect deploy`

### DIFF
--- a/src/prefect/deployments/steps/utility.py
+++ b/src/prefect/deployments/steps/utility.py
@@ -190,7 +190,7 @@ async def run_shell_script(
 
             if process.returncode != 0:
                 raise RuntimeError(
-                    f"run_shell_script failed with error code {process.returncode}:"
+                    f"`run_shell_script` failed with error code {process.returncode}:"
                     f" {stderr_sink.getvalue()}"
                 )
 

--- a/src/prefect/deployments/steps/utility.py
+++ b/src/prefect/deployments/steps/utility.py
@@ -188,6 +188,12 @@ async def run_shell_script(
 
             await process.wait()
 
+            if process.returncode != 0:
+                raise RuntimeError(
+                    f"run_shell_script failed with error code {process.returncode}:"
+                    f" {stderr_sink.getvalue()}"
+                )
+
     return {
         "stdout": stdout_sink.getvalue().strip(),
         "stderr": stderr_sink.getvalue().strip(),

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -2402,7 +2402,7 @@ class TestProjectDeploy:
         self, project_dir, work_pool
     ):
         """
-        Regression test for a bug where deployment steps woould continue even when
+        Regression test for a bug where deployment steps would continue even when
         a `run_shell_script` step failed.
         """
         prefect_file = Path("prefect.yaml")

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -29,6 +29,7 @@ from prefect.deployments.base import (
     create_default_prefect_yaml,
     initialize_project,
 )
+from prefect.deployments.steps.core import StepExecutionError
 from prefect.events.schemas import Posture
 from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
 from prefect.infrastructure.container import DockerRegistry
@@ -2396,6 +2397,39 @@ class TestProjectDeploy:
         assert await prefect_client.read_deployment_by_name(
             "An important name/test-name"
         )
+
+    async def test_deploy_with_bad_run_shell_script_raises(
+        self, project_dir, work_pool
+    ):
+        """
+        Regression test for a bug where deployment steps woould continue even when
+        a `run_shell_script` step failed.
+        """
+        prefect_file = Path("prefect.yaml")
+        with prefect_file.open(mode="r") as f:
+            config = yaml.safe_load(f)
+
+        config["build"] = [
+            {
+                "prefect.deployments.steps.run_shell_script": {
+                    "id": "test",
+                    "script": "cat nothing",
+                    "stream_output": True,
+                }
+            }
+        ]
+
+        with prefect_file.open(mode="w") as f:
+            yaml.safe_dump(config, f)
+
+        with pytest.raises(StepExecutionError):
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=(
+                    "deploy ./flows/hello.py:my_flow -n test-name --pool"
+                    f" {work_pool.name}"
+                ),
+            )
 
     @pytest.mark.usefixtures("project_dir")
     async def test_deploy_templates_env_vars(
@@ -6006,8 +6040,8 @@ class TestDeployDockerBuildSteps:
         prefect_config["build"] = [
             {
                 "prefect.deployments.steps.run_shell_script": {
-                    "id": "get-commit-hash",
-                    "script": "git rev-parse --short HEAD",
+                    "id": "sample-bash-cmd",
+                    "script": "echo 'Hello, World!'",
                     "stream_output": False,
                 }
             }


### PR DESCRIPTION
This PR focuses on handling errors more effectively during the execution of `run_shell_script` in deployment steps. Instead of silently allowing deployment steps to continue during `prefect deploy`, we raise on error here. 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed
