### PR TITLE
Make subflows optional with run_deployment

### DIFF
--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -118,7 +118,7 @@ These can be overwritten through a trigger or when manually creating a custom ru
     Because deployments are nothing more than metadata, runs can be created at anytime.
     Note that pausing a schedule, updating your deployment, and other actions reset your auto-scheduled runs.
 
-#### Scheduling deployments from within Python flow code
+#### Running a deployed flow from within Python flow code
 
 Prefect provides a [`run_deployment` function](/api-ref/prefect/deployments/deployments/#prefect.deployments.deployments.run_deployment) that can be used to schedule the run of an existing deployment when your Python code executes.
 

--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -135,7 +135,7 @@ def main():
     
 If you call `run_deployment` from within a flow or task, the scheduled flow
 run will be linked to the calling flow run (or the calling task's flow run)
-by default.
+as a subflow run by default.
 
 Subflow runs have different behavior than regular flow runs. For example, a 
 subflow run can't be suspended independently of its parent flow. If you'd

--- a/docs/concepts/deployments.md
+++ b/docs/concepts/deployments.md
@@ -118,19 +118,65 @@ These can be overwritten through a trigger or when manually creating a custom ru
     Because deployments are nothing more than metadata, runs can be created at anytime.
     Note that pausing a schedule, updating your deployment, and other actions reset your auto-scheduled runs.
 
-!!! tip "Scheduling deployments from within Python flow code"
-    Note that Prefect provides a [`run_deployment` function](/api-ref/prefect/deployments/deployments/#prefect.deployments.deployments.run_deployment) that can be used to schedule the run of an existing deployment when your Python code executes.
+#### Scheduling deployments from within Python flow code
 
-    ```python
-    from prefect.deployments import run_deployment
+Prefect provides a [`run_deployment` function](/api-ref/prefect/deployments/deployments/#prefect.deployments.deployments.run_deployment) that can be used to schedule the run of an existing deployment when your Python code executes.
 
-    def main():
-        run_deployment(name="my_flow_name/my_deployment_name")
-    ```
+```python
+from prefect.deployments import run_deployment
 
-    Pass `timeout=0` to return immediately and not block.
+def main():
+    run_deployment(name="my_flow_name/my_deployment_name")
+```
 
-### Versioning and bookkeeping
+!!! tip "Run a deployment without blocking"
+    By default, `run_deployment` blocks until the scheduled flow run finishes
+    executing. Pass `timeout=0` to return immediately and not block.
+    
+If you call `run_deployment` from within a flow or task, the scheduled flow
+run will be linked to the calling flow run (or the calling task's flow run)
+by default.
+
+Subflow runs have different behavior than regular flow runs. For example, a 
+subflow run can't be suspended independently of its parent flow. If you'd
+rather not link the scheduled flow run to the calling flow or task run, you
+can disable this behavior by passing `as_subflow=False`:
+
+```python
+from prefect import flow
+from prefect.deployments import run_deployment
+
+
+@flow
+def my_flow():
+    # The scheduled flow run will not be linked to this flow as a subflow.
+    run_deployment(name="my_other_flow/my_deployment_name", as_subflow=False)
+```
+
+The return value of `run_deployment` is a [FlowRun](/api-ref/prefect/client/schemas/#prefect.client.schemas.objects.FlowRun) object containing metadata about the scheduled run. You
+can use this object to retrieve information about the run after calling
+`run_deployment`:
+
+```python
+from prefect import get_client
+from prefect.deployments import run_deployment
+
+def main():
+    flow_run = run_deployment(name="my_flow_name/my_deployment_name")
+    flow_run_id = flow_run.id
+
+    # If you save the flow run's ID, you can use it later to retrieve
+    # flow run metadata again, e.g. to check if it's completed.
+    async with get_client() as client:
+        flow_run = client.read_flow_run(flow_run_id)
+        print(f"Current state of the flow run: {flow_run.state}")
+```
+
+!!! tip "Using the Prefect client"
+    For more information on using the Prefect client to interact with Prefect's
+    REST API, see [our guide](/guides/using-the-client/).
+
+## Versioning and bookkeeping
 
 Versions, descriptions and tags are omnipresent fields throughout Prefect that can be easy to overlook. However, putting some extra thought into how you use these fields can pay dividends down the road.
 

--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -1037,6 +1037,16 @@ Suspended flow runs can be resumed by clicking the **Resume** button in the Pref
 resume_flow_run(FLOW_RUN_ID)
 ```
 
+!!! note "Subflows cannot be suspended independently of their parent run"
+    You can't suspend a subflow run independently of its parent flow run.
+
+    If you are using a flow to schedule a flow run with `run_deployment`, the
+    scheduled flow run will be linked to the calling flow by default. This means
+    you won't be able to suspend the scheduled flow run independently of the
+    calling flow. Call `run_deployment` with `as_subflow=False` to disable this
+    linking if you need to be able to suspend the scheduled flow run
+    independently of the calling flow.
+    
 ## Waiting for input when pausing or suspending a flow run
 
 !!! warning "Experimental"

--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -1041,11 +1041,11 @@ resume_flow_run(FLOW_RUN_ID)
     You can't suspend a subflow run independently of its parent flow run.
 
     If you use a flow to schedule a flow run with `run_deployment`, the
-    scheduled flow run will be linked to the calling flow by default. This means
-    you won't be able to suspend the scheduled flow run independently of the
-    calling flow. Call `run_deployment` with `as_subflow=False` to disable this
-    linking if you need to be able to suspend the scheduled flow run
-    independently of the calling flow.
+    scheduled flow run will be linked to the calling flow as a subflow run by
+    default. This means you won't be able to suspend the scheduled flow run
+    independently of the calling flow. Call `run_deployment` with
+    `as_subflow=False` to disable this linking if you need to be able to suspend
+    the scheduled flow run independently of the calling flow.
     
 ## Waiting for input when pausing or suspending a flow run
 

--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -1037,7 +1037,7 @@ Suspended flow runs can be resumed by clicking the **Resume** button in the Pref
 resume_flow_run(FLOW_RUN_ID)
 ```
 
-!!! note "Subflows cannot be suspended independently of their parent run"
+!!! note "Subflows can't be suspended independently of their parent run"
     You can't suspend a subflow run independently of its parent flow run.
 
     If you use a flow to schedule a flow run with `run_deployment`, the

--- a/src/prefect/deployments/deployments.py
+++ b/src/prefect/deployments/deployments.py
@@ -63,6 +63,7 @@ async def run_deployment(
     tags: Optional[Iterable[str]] = None,
     idempotency_key: Optional[str] = None,
     work_queue_name: Optional[str] = None,
+    as_subflow: Optional[bool] = True,
 ):
     """
     Create a flow run for a deployment and return it after completion or a timeout.
@@ -117,7 +118,7 @@ async def run_deployment(
 
     flow_run_ctx = FlowRunContext.get()
     task_run_ctx = TaskRunContext.get()
-    if flow_run_ctx or task_run_ctx:
+    if as_subflow and (flow_run_ctx or task_run_ctx):
         # This was called from a flow. Link the flow run as a subflow.
         from prefect.engine import (
             Pending,

--- a/src/prefect/deployments/deployments.py
+++ b/src/prefect/deployments/deployments.py
@@ -92,6 +92,8 @@ async def run_deployment(
             prevent creating multiple flow runs.
         work_queue_name: The name of a work queue to use for this run. Defaults to
             the default work queue for the deployment.
+        as_subflow: Whether or not to link the flow run as a subflow of the current
+            flow or task run.
     """
     if timeout is not None and timeout < 0:
         raise ValueError("`timeout` cannot be negative")

--- a/src/prefect/deployments/deployments.py
+++ b/src/prefect/deployments/deployments.py
@@ -66,7 +66,7 @@ async def run_deployment(
     as_subflow: Optional[bool] = True,
 ) -> FlowRun:
     """
-    Create a flow run for a deployment and return its metadata.
+    Create a flow run for a deployment and return it after completion or a timeout.
 
     By default, this function blocks until the flow run finishes executing.
     Specify a timeout (in seconds) to wait for the flow run to execute before

--- a/src/prefect/deployments/deployments.py
+++ b/src/prefect/deployments/deployments.py
@@ -64,14 +64,21 @@ async def run_deployment(
     idempotency_key: Optional[str] = None,
     work_queue_name: Optional[str] = None,
     as_subflow: Optional[bool] = True,
-):
+) -> FlowRun:
     """
-    Create a flow run for a deployment and return it after completion or a timeout.
+    Create a flow run for a deployment and return its metadata.
 
-    This function will return when the created flow run enters any terminal state or
-    the timeout is reached. If the timeout is reached and the flow run has not reached
-    a terminal state, it will still be returned. When using a timeout, we suggest
-    checking the state of the flow run if completion is important moving forward.
+    By default, this function blocks until the flow run finishes executing.
+    Specify a timeout (in seconds) to wait for the flow run to execute before
+    returning flow run metadata. To return immediately, without waiting for the
+    flow run to execute, set `timeout=0`.
+
+    Note that if you specify a timeout, this function will return the flow run
+    metadata whether or not the flow run finished executing.
+
+    If called within a flow or task, the flow run this function creates will
+    be linked to the current flow run as a subflow. Disable this behavior by
+    passing `as_subflow=False`.
 
     Args:
         name: The deployment id or deployment name in the form:
@@ -81,10 +88,10 @@ async def run_deployment(
         scheduled_time: The time to schedule the flow run for, defaults to scheduling
             the flow run to start now.
         flow_run_name: A name for the created flow run
-        timeout: The amount of time to wait for the flow run to complete before
-            returning. Setting `timeout` to 0 will return the flow run immediately.
-            Setting `timeout` to None will allow this function to poll indefinitely.
-            Defaults to None
+        timeout: The amount of time to wait (in seconds) for the flow run to
+            complete before returning. Setting `timeout` to 0 will return the flow
+            run metadata immediately. Setting `timeout` to None will allow this
+            function to poll indefinitely. Defaults to None.
         poll_interval: The number of seconds between polls
         tags: A list of tags to associate with this flow run; note that tags are used
             only for organizational purposes.

--- a/tests/_internal/concurrency/test_cancellation.py
+++ b/tests/_internal/concurrency/test_cancellation.py
@@ -24,6 +24,9 @@ from prefect._internal.concurrency.cancellation import (
 
 @pytest.fixture
 def mock_alarm_signal_handler():
+    if threading.current_thread() != threading.main_thread():
+        pytest.skip("Can't test signal handlers from a thread")
+
     mock = MagicMock()
     _previous_alarm_handler = signal.signal(signal.SIGALRM, mock)
     try:


### PR DESCRIPTION
Allow the user to specify when calling `run_deployment` whether or not they want the flow run to run as a subflow.

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [x] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.