### PR TITLE
Safer handling of class-based type hints with `from __future__ import annotations`

### DIFF
--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -311,8 +311,10 @@ def parameter_schema(fn: Callable) -> ParameterSchema:
     Returns:
         ParameterSchema: the argument schema
     """
-
-    signature = inspect.signature(fn)
+    try:
+        signature = inspect.signature(fn, eval_str=True)
+    except (NameError, TypeError):
+        signature = inspect.signature(fn)
 
     model_fields = {}
     aliases = {}

--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -2,7 +2,6 @@
 Utilities for working with Python callables.
 """
 import inspect
-import sys
 from functools import partial
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
@@ -312,10 +311,8 @@ def parameter_schema(fn: Callable) -> ParameterSchema:
     Returns:
         ParameterSchema: the argument schema
     """
-    if (3, 10) <= sys.version_info < (3, 13):
-        signature = inspect.signature(fn, eval_str=True)
-    else:
-        signature = inspect.signature(fn)
+
+    signature = inspect.signature(fn)
 
     model_fields = {}
     aliases = {}
@@ -341,7 +338,7 @@ def parameter_schema(fn: Callable) -> ParameterSchema:
             create_schema(
                 "CheckParameter", model_cfg=ModelConfig, **{name: (type_, field)}
             )
-        except ValueError:
+        except (ValueError, TypeError):
             # This field's type is not valid for schema creation, update it to `Any`
             type_ = Any
         model_fields[name] = (type_, field)

--- a/tests/test_flows_compat.py
+++ b/tests/test_flows_compat.py
@@ -1,20 +1,30 @@
 from __future__ import annotations
 
-import sys
-
-import pytest
+from typing import TYPE_CHECKING
 
 from prefect import flow
+
+if TYPE_CHECKING:
+
+    class Test2:
+        pass
 
 
 class Test:
     pass
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python 3.10 or higher")
-def test_class_destringify():
+def test_class_arg():
     @flow
     def foo(x: Test):
+        return
+
+    assert foo
+
+
+def test_class_arg2():
+    @flow
+    def foo(x: Test2):
         return
 
     assert foo

--- a/tests/test_flows_compat.py
+++ b/tests/test_flows_compat.py
@@ -23,7 +23,7 @@ def test_class_arg():
 
 
 def test_class_arg2():
-    @flow
+    @flow(validate_parameters=False)
     def foo(x: Test2) -> Test2:
         return x
 

--- a/tests/test_flows_compat.py
+++ b/tests/test_flows_compat.py
@@ -16,15 +16,15 @@ class Test:
 
 def test_class_arg():
     @flow
-    def foo(x: Test):
-        return
+    def foo(x: Test) -> Test:
+        return x
 
     assert foo
 
 
 def test_class_arg2():
     @flow
-    def foo(x: Test2):
-        return
+    def foo(x: Test2) -> Test2:
+        return x
 
     assert foo


### PR DESCRIPTION
This is a direct follow-up to PR #11578, which closed issue #7502. This PR closes #11605. CC @chrisguidry.

When a class is behind an `if TYPE_CHECKING` block, as noted in #7502, the string cannot be evaluated, and the `Flow` can no longer be instantiated.

```python
from __future__ import annotations
from prefect import flow
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    class Test2:
        pass

@flow
def foo(x: Test2):
    return

assert foo
```

This is because there is no way for `inspection.signature(fn, eval_str=True)` to evaluate the parameter in such a case because `TYPE_CHECKING` is `False` in most real-world cases.

In hindsight, I realized it is probably just simpler to catch the exception and have the parameter be `Any`. Prefect can't find it, and Prefect won't care (at least until Python 3.13 prevents this issue altogether). I argue that this is the more sane option. 

This PR allows the above to work, provided `validate_parameters=False` is in the `@flow` decorator.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.