### PR TITLE
fix IDE support for `PrefectObjectRegistry.register_instances` decorated classes

### DIFF
--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -11,6 +11,7 @@ import warnings
 from collections import defaultdict
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
+from functools import update_wrapper
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -172,17 +173,17 @@ class PrefectObjectRegistry(ContextModel):
         )
 
     @classmethod
-    def register_instances(cls, type_: Type):
+    def register_instances(cls, type_: Type[T]) -> Type[T]:
         """
         Decorator for a class that adds registration to the `PrefectObjectRegistry`
         on initialization of instances.
         """
-        __init__ = type_.__init__
+        original_init = type_.__init__
 
-        def __register_init__(__self__, *args, **kwargs):
+        def __register_init__(__self__: T, *args: Any, **kwargs: Any) -> None:
             registry = cls.get()
             try:
-                __init__(__self__, *args, **kwargs)
+                original_init(__self__, *args, **kwargs)
             except Exception as exc:
                 if not registry or not registry.capture_failures:
                     raise
@@ -191,6 +192,8 @@ class PrefectObjectRegistry(ContextModel):
             else:
                 if registry:
                     registry.register_instance(__self__)
+
+        update_wrapper(__register_init__, original_init)
 
         type_.__init__ = __register_init__
         return type_


### PR DESCRIPTION
classes decorated with`PrefectObjectRegistry`'s `register_instances` (like `Flow`) had obfuscated methods / typing, which is most relevant with `my_flow.deploy`, `my_flow.from_source`, `my_flow.to_deployment` etc, but also `flow`/`task` `with_options` and similar methods

this should make it easier to grok what is needed to deploy a flow minimally without being reliant on docs

<img width="612" alt="image" src="https://github.com/PrefectHQ/prefect/assets/31014960/f5491a61-177b-4503-ac16-5f476b373613">

<img width="725" alt="image" src="https://github.com/PrefectHQ/prefect/assets/31014960/7874a001-bdc8-4911-bd75-afb422c1a2da">

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
