### PR TITLE
Bump prefect-ui-library to 2.4.25.

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.8.0",
       "dependencies": {
         "@prefecthq/prefect-design": "2.2.9",
-        "@prefecthq/prefect-ui-library": "2.4.21",
+        "@prefecthq/prefect-ui-library": "2.4.25",
         "@prefecthq/vue-charts": "2.0.3",
         "@prefecthq/vue-compositions": "1.6.7",
         "@types/lodash.debounce": "4.0.9",
@@ -1239,9 +1239,9 @@
       }
     },
     "node_modules/@prefecthq/prefect-ui-library": {
-      "version": "2.4.21",
-      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.4.21.tgz",
-      "integrity": "sha512-GJR39n8Q004gMUlEj+K0SZa+mgaM1TfjnSUGA3P56amavXIm202MH9EqgqhX48kwNfSUfM9KiUEsjvnS8utwDw==",
+      "version": "2.4.25",
+      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.4.25.tgz",
+      "integrity": "sha512-3i1YkMpfED7kda+tSbB8XJs+eXlI9AIFe0q56vzQmm433AvXB920etFcyyr4XFaV1Hvb9tBG4IAi0tf2V5pmjQ==",
       "dependencies": {
         "@prefecthq/graphs": "2.1.9",
         "@types/lodash.isequal": "4.5.8",
@@ -1259,7 +1259,7 @@
         "@prefecthq/vue-charts": "^2.0.3",
         "@prefecthq/vue-compositions": "^1.6.6",
         "vee-validate": "^4.7.0",
-        "vue": "^3.3.4",
+        "vue": "^3.4.4",
         "vue-router": "^4.0.12"
       }
     },
@@ -7276,9 +7276,9 @@
       }
     },
     "@prefecthq/prefect-ui-library": {
-      "version": "2.4.21",
-      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.4.21.tgz",
-      "integrity": "sha512-GJR39n8Q004gMUlEj+K0SZa+mgaM1TfjnSUGA3P56amavXIm202MH9EqgqhX48kwNfSUfM9KiUEsjvnS8utwDw==",
+      "version": "2.4.25",
+      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.4.25.tgz",
+      "integrity": "sha512-3i1YkMpfED7kda+tSbB8XJs+eXlI9AIFe0q56vzQmm433AvXB920etFcyyr4XFaV1Hvb9tBG4IAi0tf2V5pmjQ==",
       "requires": {
         "@prefecthq/graphs": "2.1.9",
         "@types/lodash.isequal": "4.5.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@prefecthq/prefect-design": "2.2.9",
-    "@prefecthq/prefect-ui-library": "2.4.21",
+    "@prefecthq/prefect-ui-library": "2.4.25",
     "@prefecthq/vue-charts": "2.0.3",
     "@prefecthq/vue-compositions": "1.6.7",
     "@types/lodash.debounce": "4.0.9",


### PR DESCRIPTION
Prepping for a release - bumping prefect-ui-library from 2.4.21 -> 2.4.25 🤖 