### PR TITLE
ft: add docs clarifying where to run prefect-deploy and entrypoint format

### DIFF
--- a/docs/guides/deployment/storage-guide.md
+++ b/docs/guides/deployment/storage-guide.md
@@ -71,7 +71,7 @@ Prefect supports each of these platforms.
 
 ### Creating a deployment with git-based storage
 
-Run `prefect deploy` from within a git repository and create a new deployment. You will see a series of prompts. Select that you want to create a new deployment, select the flow code entrypoint, and name your deployment.
+Run `prefect deploy` from the root directory of the git repository and create a new deployment. You will see a series of prompts. Select that you want to create a new deployment, select the flow code entrypoint, and name your deployment.
 
 Prefect detects that you are in a git repository and asks if you want to store your flow code in a git repository. Select "y" and you will be prompted to confirm the URL of your git repository and the branch name, as in the example below:
 
@@ -202,7 +202,7 @@ Another popular way to store your flow code is to include it in a Docker image. 
     - Google Cloud Run - Push
 
 1. Run `prefect init` in the root of your repository and choose `docker` for the project name and answer the prompts to create a `prefect.yaml` file with a build step that will create a Docker image with the flow code built in. See the [Workers and Work Pools page of the tutorial](/tutorial/workers/) for more info.
-1. Run `prefect deploy` to create a deployment. 
+1. Run `prefect deploy` from the root of your repository to create a deployment. 
 1. Upon deployment run the worker will pull the Docker image and spin up a container. 
 1. The flow code baked into the image will run inside the container. 
 

--- a/docs/guides/prefect-deploy.md
+++ b/docs/guides/prefect-deploy.md
@@ -464,6 +464,13 @@ Use the tabs below to explore these two deployment creation options.
 
     Any deployment configuration can be overridden via options available on the `prefect deploy` CLI command when creating a deployment.
 
+    !!! tip "New `prefect.yaml` file flexibility"
+        Traditionally, this file had to be in the root of your repository or project directory and named `prefect.yaml`.
+        Now this file can be located elsewhere and be named differently. To use a custom prefect.yaml file, run the new 
+        form of the deploy CLI command from the root of your project directory: 
+        
+        `prefect deploy --prefect-file path/to/my_file.yaml`
+
     The base structure for `prefect.yaml` is as follows:
 
     ```yaml
@@ -883,6 +890,10 @@ These deployments can be managed independently of one another, allowing you to d
     Prefect supports multiple deployment declarations within the `prefect.yaml` file. This method of declaring multiple deployments allows the configuration for all deployments to be version controlled and deployed with a single command.
 
     New deployment declarations can be added to the `prefect.yaml` file by adding a new entry to the `deployments` list. Each deployment declaration must have a unique `name` field which is used to select deployment declarations when using the `prefect deploy` command.
+    
+    !!! warning
+        When using a custom `prefect.yaml` file, remember that the value for deployment `entrypoints` must be relative to 
+        the root directory of the project.  
 
     For example, consider the following `prefect.yaml` file:
 


### PR DESCRIPTION
Closes #11613

Elaborates in relevant doc sections that

- the `prefect deploy` command must be run from the root of the project directory / repository
- the `deployments` section of the `prefect.yaml` file must have entrypoints that are relative to the root of the project directory/repository.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
- [X] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

