### PR TITLE
Bugfix: Missing `UI_SERVE_BASE_URL` lead to incorrect asset urls

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -370,7 +370,7 @@ def create_ui_app(ephemeral: bool) -> FastAPI:
         replace_placeholder_string_in_files(
             prefect.__ui_static_subpath__,
             "/PREFECT_UI_SERVE_BASE_REPLACE_PLACEHOLDER",
-            base_url if base_url != "/" else "",
+            base_url.rstrip("/"),
         )
 
         # Create a file to indicate that the static files have been copied

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -370,7 +370,7 @@ def create_ui_app(ephemeral: bool) -> FastAPI:
         replace_placeholder_string_in_files(
             prefect.__ui_static_subpath__,
             "/PREFECT_UI_SERVE_BASE_REPLACE_PLACEHOLDER",
-            base_url,
+            base_url if base_url != "/" else "",
         )
 
         # Create a file to indicate that the static files have been copied


### PR DESCRIPTION
Fixes an issue where setting `UI_SERVE_BASE` to an empty string or `/` lead to incorrectly replaced asset urls like `//asset.js` instead of `/asset.js`