### PR TITLE
Fix tasks.md -> retry handler

### DIFF
--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -285,9 +285,9 @@ def retry_handler(task, task_run, state) -> bool:
     except httpx.ConnectError:
         # Do not retry
         return False
-
-    # For any other exception, retry
-    return True
+    except:
+        # For any other exception, retry
+        return True
 
 @task(retries=1, retry_condition_fn=retry_handler)
 def my_api_call_task(url):


### PR DESCRIPTION
I think this documentation may not work. As in, for any other exception it just gets raised after the last except. `return True`, which is what the documentation says should happen in that case, never gets called. 

Here's some example code to show it:
```python
try:
    raise NotImplementedError()
except KeyError:
    print("Got caught")
    quit()

print("Did get through")
```
Output: `NotImplementedError`

but the documentation here makes it seem like `Did get through` should be printed. 

I think this fixes it!
