### PR TITLE
fix docstring example for `from_source`

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -814,7 +814,7 @@ class Flow(Generic[P, R]):
             my_flow()
             ```
 
-            Load a flow from a private git repository:
+            Load a flow from a private git repository using an access token stored in a `Secret` block:
 
             ```python
             from prefect import flow
@@ -824,7 +824,7 @@ class Flow(Generic[P, R]):
             my_flow = flow.from_source(
                 source=GitRepository(
                     url="https://github.com/org/repo.git",
-                    access_token=Secret.load("github-access-token").get(),
+                    credentials={"access_token": Secret.load("github-access-token")}
                 ),
                 entrypoint="flows.py:my_flow",
             )

--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -111,7 +111,7 @@ class GitRepository:
     def __init__(
         self,
         url: str,
-        credentials: Union[GitCredentials, Block, None] = None,
+        credentials: Union[GitCredentials, Block, Dict[str, Any], None] = None,
         name: Optional[str] = None,
         branch: Optional[str] = None,
         include_submodules: bool = False,


### PR DESCRIPTION
`GitRepository` does not accept an `access_token` kwarg, rather it seems to accept `credentials: GitCredentials | Block | dict | None`

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
