### PR TITLE
specify to run the Python file in the README before starting server (and fix typo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Prefect requires Python 3.8 or later. To [install Prefect](https://docs.prefect.
 pip install prefect
 ```
 
-Then create a Python file the uses Prefect `flow` and `task` decorators to orchestrate and observe your workflow that fetches the number of GitHub stars from a repository.
+Then create and run a Python file that uses Prefect `flow` and `task` decorators to orchestrate and observe your workflow that fetches the number of GitHub stars from a repository.
 
 ```python
 from prefect import flow, task


### PR DESCRIPTION
Maybe obvious and a minor thing, but as a first-time user, I started the server, then realized I needed to run the Python file first

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->