### PR TITLE
Bugifx: Adjust UI serving to work with a static directory

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -214,12 +214,10 @@ def copy_directory(directory, path):
         destination = os.path.join(path, item)
 
         if os.path.isdir(source):
-            # If the directory already exists at the destination, remove it first
             if os.path.exists(destination):
                 shutil.rmtree(destination)
             shutil.copytree(source, destination, symlinks=True)
         else:
-            # For files, copy2 will overwrite any existing file
             shutil.copy2(source, destination)
 
 

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1456,6 +1456,16 @@ The base URL path to serve the Prefect UI from.
 Defaults to the root path.
 """
 
+PREFECT_UI_STATIC_DIRECTORY = Setting(
+    str,
+    default=None,
+)
+"""
+The directory to serve static files from. This should be used when running into permissions issues
+when attempting to serve the UI from the default directory (for example when running in a Docker container)
+"""
+
+
 # Deprecated settings ------------------------------------------------------------------
 
 


### PR DESCRIPTION
Fixes an issue documented in #11640 where running `prefect server start` with a user that didn't have write permissions to the package subdirectory would cause the command to fail. 

This exposes a setting, `PREFECT_UI_STATIC_DIRECTORY`, that `prefect server start` will attempt to write to instead, allowing the directory to be created/properly permissioned ahead of time. We also no longer remove the root directory when the setting has changed (or on first run) and only overwrite its contents.

Resolves: #11640