### PR TITLE
return flow run and update tests

### DIFF
--- a/src/prefect/runner/server.py
+++ b/src/prefect/runner/server.py
@@ -236,7 +236,7 @@ def _build_generic_endpoint_for_flows(
 
         return JSONResponse(
             status_code=status.HTTP_201_CREATED,
-            content={"flow_run_id": str(flow_run.id)},
+            content=flow_run.dict(json_compatible=True),
         )
 
     return _create_flow_run_for_flow_from_fqn

--- a/tests/runner/test_webserver.py
+++ b/tests/runner/test_webserver.py
@@ -8,6 +8,7 @@ from prefect._vendor.fastapi.testclient import TestClient
 
 from prefect import flow
 from prefect.client.orchestration import PrefectClient, get_client
+from prefect.client.schemas.objects import FlowRun
 from prefect.runner import Runner
 from prefect.runner.server import build_server
 from prefect.settings import (
@@ -213,7 +214,7 @@ class TestWebserverFlowRoutes:
                 json={"entrypoint": f"{__file__}:simple_flow", "parameters": {}},
             )
             assert response.status_code == 201, response.status_code
-            assert "flow_run_id" in response.json()
+            assert isinstance(FlowRun.parse_obj(response.json()), FlowRun)
             mock_run.assert_called()
 
     @pytest.mark.parametrize("flow_name", ["a_missing_flow", "a_non_flow_function"])
@@ -258,7 +259,7 @@ class TestWebserverFlowRoutes:
             )
             # the flow should still be run even though it's not managed
             assert response.status_code == 201, response.status_code
-            assert "flow_run_id" in response.json()
+            assert isinstance(FlowRun.parse_obj(response.json()), FlowRun)
             mock_run.assert_called()
 
         # we should have logged a warning
@@ -291,7 +292,7 @@ class TestWebserverFlowRoutes:
             )
             # we'll still attempt to run the changed flow
             assert response.status_code == 201, response.status_code
-            assert "flow_run_id" in response.json()
+            assert isinstance(FlowRun.parse_obj(response.json()), FlowRun)
             mock_run.assert_called()
 
         # we should have logged a warning


### PR DESCRIPTION
returning `flow_run` from `submit_to_runner` makes better use of the fact that the webserver endpoint already asks the API for a `FlowRun` when we create it and hand it off to the `Runner`