### PR TITLE
Fix intermittent integrations test failure when testing compatibility with 2.11

### DIFF
--- a/flows/concurrent_subflows.py
+++ b/flows/concurrent_subflows.py
@@ -6,7 +6,7 @@ from packaging.version import Version
 import prefect
 from prefect import flow, task
 
-# Support for the subflows with the same name was added in 2.10.6
+# Support for subflows with the same name was added in 2.10.6
 # Support for the concurrent subflow fix in #10533 was released in 2.12.0
 MINIMUM_VERSION = "2.12.0"
 

--- a/flows/concurrent_subflows.py
+++ b/flows/concurrent_subflows.py
@@ -6,9 +6,9 @@ from packaging.version import Version
 import prefect
 from prefect import flow, task
 
-# Support for this pattern was added in 2.10.6
-# to support subflows with the same name
-MINIMUM_VERSION = "2.10.6"
+# Support for the subflows with the same name was added in 2.10.6
+# Support for the concurrent subflow fix in #10533 was released in 2.12.0
+MINIMUM_VERSION = "2.12.0"
 
 
 @task


### PR DESCRIPTION
 Currently, testing the `concurrent_subflow.py` flow in integrations tests will fail against client version `2.11.5`. The [fix for concurrent subflows](https://github.com/PrefectHQ/prefect/pull/10533) that added the concurrent subflow flow in the first place was not released until `2.12.0`; so we should test only again versions at equivalent or greater.

I think the reason why we haven't had more regular failures on `main` due to this is because the issue itself (the one the fix is based on) did not always occur and also I'm guessing because there is an element of randomness in our concurrent subflow test. We began to see this failure more regularly in December.

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
