### PR TITLE
Make `server database downgrade` default revision less destructive

### DIFF
--- a/docs/guides/host.md
+++ b/docs/guides/host.md
@@ -222,6 +222,8 @@ prefect server database downgrade -y -r d20618ce678e
 ```
 </div>
 
+To downgrade all migrations, use the `base` revision.
+
 See the [contributing docs](/contributing/overview/#adding-database-migrations) for information on how to create new database migrations.
 
 ## Notifications

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -219,8 +219,8 @@ async def upgrade(
 async def downgrade(
     yes: bool = typer.Option(False, "--yes", "-y"),
     revision: str = typer.Option(
-        "base",
         "-1",
+        "-r",
         help=(
             "The revision to pass to `alembic downgrade`. If not provided, "
             "downgrades to the most recent revision. Use 'base' to run all "

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -220,10 +220,11 @@ async def downgrade(
     yes: bool = typer.Option(False, "--yes", "-y"),
     revision: str = typer.Option(
         "base",
-        "-r",
+        "-1",
         help=(
-            "The revision to pass to `alembic downgrade`. If not provided, runs all"
-            " migrations."
+            "The revision to pass to `alembic downgrade`. If not provided, "
+            "downgrades to the most recent revision. Use 'base' to run all "
+            "migrations."
         ),
     ),
     dry_run: bool = typer.Option(

--- a/src/prefect/server/database/alembic_commands.py
+++ b/src/prefect/server/database/alembic_commands.py
@@ -54,7 +54,7 @@ def alembic_upgrade(revision: str = "head", dry_run: bool = False):
 
 
 @with_alembic_lock
-def alembic_downgrade(revision: str = "base", dry_run: bool = False):
+def alembic_downgrade(revision: str = "-1", dry_run: bool = False):
     """
     Run alembic downgrades on Prefect REST API database
 

--- a/src/prefect/server/database/interface.py
+++ b/src/prefect/server/database/interface.py
@@ -62,7 +62,7 @@ class PrefectDBInterface(metaclass=DBSingleton):
         """Run all upgrade migrations"""
         await run_sync_in_worker_thread(alembic_upgrade)
 
-    async def run_migrations_downgrade(self, revision: str = "base"):
+    async def run_migrations_downgrade(self, revision: str = "-1"):
         """Run all downgrade migrations"""
         await run_sync_in_worker_thread(alembic_downgrade, revision=revision)
 

--- a/src/prefect/server/database/interface.py
+++ b/src/prefect/server/database/interface.py
@@ -56,15 +56,15 @@ class PrefectDBInterface(metaclass=DBSingleton):
 
     async def drop_db(self):
         """Drop the database"""
-        await self.run_migrations_downgrade()
+        await self.run_migrations_downgrade(revision="base")
 
     async def run_migrations_upgrade(self):
         """Run all upgrade migrations"""
         await run_sync_in_worker_thread(alembic_upgrade)
 
-    async def run_migrations_downgrade(self):
+    async def run_migrations_downgrade(self, revision: str = "base"):
         """Run all downgrade migrations"""
-        await run_sync_in_worker_thread(alembic_downgrade)
+        await run_sync_in_worker_thread(alembic_downgrade, revision=revision)
 
     async def is_db_connectable(self):
         """

--- a/tests/server/database/test_alembic_commands.py
+++ b/tests/server/database/test_alembic_commands.py
@@ -38,7 +38,7 @@ class TestAlembicCommands:
         alembic_downgrade()
         args, kwargs = mocked.call_args
         assert mocked.call_count == 1
-        assert args[1] == "base"
+        assert args[1] == "-1"
         # sql == dry_run
         assert kwargs["sql"] is False
 
@@ -89,7 +89,9 @@ class TestAlembicCommands:
         try:
             jobs = []
             for _ in range(0, 2):
-                jobs.append(run_sync_in_worker_thread(alembic_downgrade))
+                jobs.append(
+                    run_sync_in_worker_thread(alembic_downgrade, revision="base")
+                )
                 jobs.append(run_sync_in_worker_thread(alembic_upgrade))
             await asyncio.gather(*jobs)
         finally:

--- a/tests/server/database/test_migrations.py
+++ b/tests/server/database/test_migrations.py
@@ -41,7 +41,7 @@ async def test_orion_full_migration_works_with_data_in_db(sample_db_data):
     Tests that downgrade migrations work when the database has data in it.
     """
     try:
-        await run_sync_in_worker_thread(alembic_downgrade)
+        await run_sync_in_worker_thread(alembic_downgrade, revision="base")
     finally:
         await run_sync_in_worker_thread(alembic_upgrade)
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

Running `prefect server database downgrade` without an explicit target revision defaults to "base" which basically drops the database. While there is a confirmation step here, it'd be nice if the default were less destructive in general as dropping a database is a pretty unfortunate booboo. 

Aside from safety, this new default behavior should be familiar to folks from the flask ecosystem working with tooling like flask-migrate. This default is also just a little more convenient when developing with in-flight migrations. 

### Example
```sh
# this will now downgrade to the current revision - 1. running 0-1 migrations at a time
prefect server database downgrade

# to use the previous default behavior
prefect server database downgrade -r base
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.