### PR TITLE
Remove line from `Pausing a flow` docs saying you can `pause` from the UI

### DIFF
--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -922,7 +922,7 @@ When a flow run is suspended, code execution is stopped and so is the process.
 ### Pausing a flow run
 
 Prefect enables pausing an in-progress flow run for manual approval. 
-Prefect exposes this functionality via the [`pause_flow_run`](/api-ref/prefect/engine/#prefect.engine.pause_flow_run) and [`resume_flow_run`](/api-ref/prefect/engine/#prefect.engine.resume_flow_run) functions, as well as the Prefect UI.
+Prefect exposes this functionality via the [`pause_flow_run`](/api-ref/prefect/engine/#prefect.engine.pause_flow_run) and [`resume_flow_run`](/api-ref/prefect/engine/#prefect.engine.resume_flow_run) functions.
 
 !!! note "Timeouts"
     Paused flow runs time out after one hour by default. 


### PR DESCRIPTION
This removes line from `Pausing a flow` docs saying you can `pause` from the UI, you're only able to _suspend_ from the UI, not pause.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.