### PR TITLE
Temporarily pin `pytest` to < 8 and `moto` to < 5

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ mypy
 numpy
 pillow
 pre-commit
-pytest > 7
+pytest > 7, < 8
 pytest-asyncio >= 0.18.2, != 0.22.0, < 0.23.0 # Cannot override event loop in 0.23.0. See https://github.com/pytest-dev/pytest-asyncio/issues/706 for more details.
 pytest-cov
 pytest-benchmark

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ mkdocs-material
 mkdocstrings-python
 mike
 mock; python_version < '3.8'
-moto
+moto < 5
 mypy
 numpy
 pillow


### PR DESCRIPTION
New versions of `pytest` and `moto` was just released that break our unit tests, temporarily pinning while we update the suite.

Related to #11750
Related to #11752
