### PR TITLE
Mark `test_import_object_from_script_with_relative_imports` as flaky

### DIFF
--- a/tests/utilities/test_importtools.py
+++ b/tests/utilities/test_importtools.py
@@ -141,6 +141,7 @@ def test_lazy_import_includes_help_message_in_deferred_failure():
         module.foo
 
 
+@pytest.mark.flaky
 @pytest.mark.usefixtures("reset_sys_modules")
 @pytest.mark.parametrize(
     "working_directory,script_path",


### PR DESCRIPTION
This has been failing a lot recently, marking it as flaky for now.