### PR TITLE
Give `test_generate_work_pool_base_job_template` up to 4 runs to pass

### DIFF
--- a/tests/infrastructure/test_docker_container.py
+++ b/tests/infrastructure/test_docker_container.py
@@ -933,7 +933,7 @@ def base_job_template_with_defaults(docker_default_base_job_template):
     return base_job_template_with_defaults
 
 
-@pytest.mark.flaky
+@pytest.mark.flaky(max_runs=4)
 @pytest.mark.usefixtures("mock_collection_registry")
 @pytest.mark.parametrize(
     "container_config",


### PR DESCRIPTION
This test is failing quite a bit even with the `flaky` decorator, this gives it 4 runs to pass.