### PR TITLE
revert deprecation of worker webserver setting

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,12 +13,12 @@ mkdocs-material
 mkdocstrings-python
 mike
 mock; python_version < '3.8'
-moto
+moto < 5
 mypy
 numpy
 pillow
 pre-commit
-pytest > 7
+pytest > 7, < 8
 pytest-asyncio >= 0.18.2, != 0.22.0, < 0.23.0 # Cannot override event loop in 0.23.0. See https://github.com/pytest-dev/pytest-asyncio/issues/706 for more details.
 pytest-cov
 pytest-benchmark

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -389,42 +389,6 @@ def check_for_deprecated_cloud_url(settings, value):
     return deprecated_value or value
 
 
-def check_for_deprecated_runner_server_host(settings, value):
-    deprecated_value = PREFECT_WORKER_WEBSERVER_HOST.value_from(
-        settings, bypass_callback=True
-    )
-    if deprecated_value is not None:
-        warnings.warn(
-            (
-                "`PREFECT_WORKER_WEBSERVER_HOST` is set and will be used instead of"
-                " `PREFECT_RUNNER_SERVER_HOST` for backwards compatibility."
-                " `PREFECT_WORKER_WEBSERVER_HOST` is deprecated, set"
-                " `PREFECT_RUNNER_SERVER_HOST` instead."
-            ),
-            DeprecationWarning,
-        )
-
-    return deprecated_value or value
-
-
-def check_for_deprecated_runner_server_port(settings, value):
-    deprecated_value = PREFECT_WORKER_WEBSERVER_PORT.value_from(
-        settings, bypass_callback=True
-    )
-    if deprecated_value is not None:
-        warnings.warn(
-            (
-                "`PREFECT_WORKER_WEBSERVER_PORT` is set and will be used instead of"
-                " `PREFECT_RUNNER_SERVER_PORT` for backwards compatibility."
-                " `PREFECT_WORKER_WEBSERVER_PORT` is deprecated, set"
-                " `PREFECT_RUNNER_SERVER_PORT` instead."
-            ),
-            DeprecationWarning,
-        )
-
-    return deprecated_value or value
-
-
 def warn_on_misconfigured_api_url(values):
     """
     Validator for settings warning if the API URL is misconfigured.
@@ -1393,20 +1357,12 @@ PREFECT_RUNNER_SERVER_MISSED_POLLS_TOLERANCE = Setting(int, default=2)
 Number of missed polls before a runner is considered unhealthy by its webserver.
 """
 
-PREFECT_RUNNER_SERVER_HOST = Setting(
-    str,
-    default="localhost",
-    value_callback=check_for_deprecated_runner_server_host,
-)
+PREFECT_RUNNER_SERVER_HOST = Setting(str, default="localhost")
 """
 The host address the runner's webserver should bind to.
 """
 
-PREFECT_RUNNER_SERVER_PORT = Setting(
-    int,
-    default=8080,
-    value_callback=check_for_deprecated_runner_server_port,
-)
+PREFECT_RUNNER_SERVER_PORT = Setting(int, default=8081)
 """
 The port the runner's webserver should bind to.
 """
@@ -1439,10 +1395,7 @@ Can be used to compensate for infrastructure start up time for a worker.
 
 PREFECT_WORKER_WEBSERVER_HOST = Setting(
     str,
-    default=None,
-    deprecated=True,
-    deprecated_start_date="Jan 2024",
-    deprecated_help="Use `PREFECT_RUNNER_SERVER_HOST` instead",
+    default="localhost",
 )
 """
 The host address the worker's webserver should bind to.
@@ -1450,10 +1403,7 @@ The host address the worker's webserver should bind to.
 
 PREFECT_WORKER_WEBSERVER_PORT = Setting(
     int,
-    default=None,
-    deprecated=True,
-    deprecated_start_date="Jan 2024",
-    deprecated_help="Use `PREFECT_RUNNER_SERVER_PORT` instead",
+    default=8080,
 )
 """
 The port the worker's webserver should bind to.

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1395,7 +1395,7 @@ Can be used to compensate for infrastructure start up time for a worker.
 
 PREFECT_WORKER_WEBSERVER_HOST = Setting(
     str,
-    default="localhost",
+    default="0.0.0.0",
 )
 """
 The host address the worker's webserver should bind to.

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1362,7 +1362,7 @@ PREFECT_RUNNER_SERVER_HOST = Setting(str, default="localhost")
 The host address the runner's webserver should bind to.
 """
 
-PREFECT_RUNNER_SERVER_PORT = Setting(int, default=8081)
+PREFECT_RUNNER_SERVER_PORT = Setting(int, default=8080)
 """
 The port the runner's webserver should bind to.
 """

--- a/src/prefect/workers/server.py
+++ b/src/prefect/workers/server.py
@@ -5,8 +5,8 @@ from prefect._vendor.fastapi import APIRouter, FastAPI, status
 from prefect._vendor.fastapi.responses import JSONResponse
 
 from prefect.settings import (
-    PREFECT_RUNNER_SERVER_HOST,
-    PREFECT_RUNNER_SERVER_PORT,
+    PREFECT_WORKER_WEBSERVER_HOST,
+    PREFECT_WORKER_WEBSERVER_PORT,
 )
 from prefect.workers.base import BaseWorker
 from prefect.workers.process import ProcessWorker
@@ -45,7 +45,7 @@ def start_healthcheck_server(
 
     uvicorn.run(
         webserver,
-        host=PREFECT_RUNNER_SERVER_HOST.value(),
-        port=PREFECT_RUNNER_SERVER_PORT.value(),
+        host=PREFECT_WORKER_WEBSERVER_HOST.value(),
+        port=PREFECT_WORKER_WEBSERVER_PORT.value(),
         log_level=log_level,
     )

--- a/tests/runner/test_webserver.py
+++ b/tests/runner/test_webserver.py
@@ -15,8 +15,6 @@ from prefect.settings import (
     PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS,
     PREFECT_RUNNER_SERVER_HOST,
     PREFECT_RUNNER_SERVER_PORT,
-    PREFECT_WORKER_WEBSERVER_HOST,
-    PREFECT_WORKER_WEBSERVER_PORT,
     temporary_settings,
 )
 
@@ -81,19 +79,6 @@ class TestWebserverSettings:
         ):
             assert PREFECT_RUNNER_SERVER_HOST.value() == "127.0.0.1"
             assert PREFECT_RUNNER_SERVER_PORT.value() == 4200
-
-    async def test_deprecated_webserver_settings_are_respected(self, runner: Runner):
-        with pytest.warns(
-            DeprecationWarning, match=r".*PREFECT_WORKER_WEBSERVER_.*deprecated.*"
-        ):
-            with temporary_settings(
-                updates={
-                    PREFECT_WORKER_WEBSERVER_HOST: "127.0.0.1",
-                    PREFECT_WORKER_WEBSERVER_PORT: 4200,
-                }
-            ):
-                assert PREFECT_RUNNER_SERVER_HOST.value() == "127.0.0.1"
-                assert PREFECT_RUNNER_SERVER_PORT.value() == 4200
 
 
 class TestWebserverDeploymentRoutes:


### PR DESCRIPTION
the `PREFECT_WORKER_WEBSERVER_HOST` and `...PORT` settings were erroneously deprecated in this [PR](https://github.com/PrefectHQ/prefect/pull/11476/files#diff-eb8a03a8ac41aec52fe38a471a96a468ffba04db74fb97149c65f9ee1efd2266R49) such the default host for the worker's webserver went from `0.0.0.0` to `localhost`