### PR TITLE
prep `2.14.18`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,7 +3,7 @@
 ## Release 2.14.18
 
 ### Fixes
-- Fix environment variable not accepting lists — https://github.com/PrefectHQ/prefect/pull/11722
+- Allow prefect settings to accept lists — https://github.com/PrefectHQ/prefect/pull/11722
 - Revert deprecation of worker webserver setting — https://github.com/PrefectHQ/prefect/pull/11758
 
 ### Documentation

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,7 +7,7 @@
 - Revert deprecation of worker webserver setting — https://github.com/PrefectHQ/prefect/pull/11758
 
 ### Documentation
-- Detail `send_input` and `receive_input` — https://github.com/PrefectHQ/prefect/pull/11724
+- Expand docs on interactive flows, detailing `send_input` and `receive_input` — https://github.com/PrefectHQ/prefect/pull/11724
 - Clarify that interval schedules use an anchor not start date — https://github.com/PrefectHQ/prefect/pull/11767
 
 ## New Contributors

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,11 +14,6 @@
 
 ## New Contributors
 * @clefelhocz2 made their first contribution in https://github.com/PrefectHQ/prefect/pull/11722
-### Contributors
-- @abrookins
-- @clefelhocz2
-- @zhen0
-- @zzstoatzz
 
 **All changes**: https://github.com/PrefectHQ/prefect/compare/2.14.17...2.14.18
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,7 +20,7 @@
 - @zhen0
 - @zzstoatzz
 
-**All changes**: https://github.com/PrefectHQ/prefect/compare/2.14.17...preview
+**All changes**: https://github.com/PrefectHQ/prefect/compare/2.14.17...2.14.18
 
 ## Release 2.14.17
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,27 @@
 # Prefect Release Notes
 
+## Release 2.14.18
+
+### Fixes
+- Fix environment variable not accepting lists — https://github.com/PrefectHQ/prefect/pull/11722
+- Revert deprecation of worker webserver setting — https://github.com/PrefectHQ/prefect/pull/11758
+
+### Documentation
+- Detail `send_input` and `receive_input` — https://github.com/PrefectHQ/prefect/pull/11724
+
+### Uncategorized
+- Clarify that interval schedules use an anchor not start date — https://github.com/PrefectHQ/prefect/pull/11767
+
+## New Contributors
+* @clefelhocz2 made their first contribution in https://github.com/PrefectHQ/prefect/pull/11722
+### Contributors
+- @abrookins
+- @clefelhocz2
+- @zhen0
+- @zzstoatzz
+
+**All changes**: https://github.com/PrefectHQ/prefect/compare/2.14.17...preview
+
 ## Release 2.14.17
 
 ### **Experimental**: Non-blocking submission of flow runs to the `Runner` web server

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,8 +8,6 @@
 
 ### Documentation
 - Detail `send_input` and `receive_input` — https://github.com/PrefectHQ/prefect/pull/11724
-
-### Uncategorized
 - Clarify that interval schedules use an anchor not start date — https://github.com/PrefectHQ/prefect/pull/11767
 
 ## New Contributors


### PR DESCRIPTION
cutting an early patch release to get [this](https://github.com/PrefectHQ/prefect/pull/11758) fix out asap