### PR TITLE
Store description when saving a RunInput schema

### DIFF
--- a/src/prefect/input/run_input.py
+++ b/src/prefect/input/run_input.py
@@ -94,7 +94,9 @@ if HAS_PYDANTIC_V2:
     from prefect._internal.pydantic.v2_schema import create_v2_schema
 
 T = TypeVar("T", bound="RunInput")
-Keyset = Dict[Union[Literal["response"], Literal["schema"]], str]
+Keyset = Dict[
+    Union[Literal["description"], Literal["response"], Literal["schema"]], str
+]
 
 
 def keyset_from_paused_state(state: "State") -> Keyset:
@@ -123,6 +125,7 @@ def keyset_from_base_key(base_key: str) -> Keyset:
         - Dict[str, str]: the keyset
     """
     return {
+        "description": f"{base_key}-description",
         "response": f"{base_key}-response",
         "schema": f"{base_key}-schema",
     }
@@ -138,6 +141,7 @@ class RunInput(pydantic.BaseModel):
     class Config:
         extra = "forbid"
 
+    _description: Optional[str] = pydantic.PrivateAttr(default=None)
     _metadata: RunInputMetadata = pydantic.PrivateAttr()
 
     @property
@@ -167,6 +171,14 @@ class RunInput(pydantic.BaseModel):
         await create_flow_run_input(
             key=keyset["schema"], value=schema, flow_run_id=flow_run_id
         )
+
+        description = cls._description if isinstance(cls._description, str) else None
+        if description:
+            await create_flow_run_input(
+                key=keyset["description"],
+                value=description,
+                flow_run_id=flow_run_id,
+            )
 
     @classmethod
     @sync_compatible
@@ -206,18 +218,27 @@ class RunInput(pydantic.BaseModel):
         return instance
 
     @classmethod
-    def with_initial_data(cls: Type[T], **kwargs: Any) -> Type[T]:
+    def with_initial_data(
+        cls: Type[T], description: Optional[str] = None, **kwargs: Any
+    ) -> Type[T]:
         """
         Create a new `RunInput` subclass with the given initial data as field
         defaults.
 
         Args:
-            - kwargs (Any): the initial data
+            - description (str, optional): a description to show when resuming
+                a flow run that requires input
+            - kwargs (Any): the initial data to populate the subclass
         """
         fields = {}
         for key, value in kwargs.items():
             fields[key] = (type(value), value)
-        return pydantic.create_model(cls.__name__, **fields, __base__=cls)
+        model = pydantic.create_model(cls.__name__, **fields, __base__=cls)
+
+        if description is not None:
+            model._description = description
+
+        return model
 
     @sync_compatible
     async def respond(

--- a/tests/input/test_run_input.py
+++ b/tests/input/test_run_input.py
@@ -69,7 +69,7 @@ def test_keyset_from_paused_state_non_paused_state_raises_exception():
         keyset_from_paused_state(Running())
 
 
-async def test_save_schema(flow_run_context):
+async def test_save_stores_schema(flow_run_context):
     keyset = keyset_from_base_key("person")
     await Person.save(keyset)
     schema = await read_flow_run_input(key=keyset["schema"])
@@ -78,6 +78,13 @@ async def test_save_schema(flow_run_context):
         "email",
         "human",
     }
+
+
+async def test_save_stores_provided_description(flow_run_context):
+    keyset = keyset_from_base_key("person")
+    await Person.with_initial_data(description="Testing").save(keyset)
+    description = await read_flow_run_input(key=keyset["description"])
+    assert description == "Testing"
 
 
 def test_save_works_sync(flow_run_context):


### PR DESCRIPTION
This adds a private `_description` field to `RunInput` and stores a provided description when saving the schema so the UI can grab it and display it in the resume modal.

Related to #11735

### Example
```
from prefect import flow, pause_flow_run
from prefect.input import RunInput


class TreeInput(RunInput):
    kind: str


@flow
async def tree_flow():
    await pause_flow_run(
        wait_for_input=TreeInput.with_initial_data(
            description="What kind of tree do you want to plant?"
        )
    )
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.