### PR TITLE
Task subscription api retry queue

### DIFF
--- a/src/prefect/server/api/task_runs.py
+++ b/src/prefect/server/api/task_runs.py
@@ -37,14 +37,20 @@ logger = get_logger("server.api")
 router = PrefectRouter(prefix="/task_runs", tags=["Task Runs"])
 
 
-_scheduled_task_runs_queues: Dict[asyncio.AbstractEventLoop, asyncio.Queue[schemas.core.TaskRun]] = {}
-_retry_task_runs_queues: Dict[asyncio.AbstractEventLoop, asyncio.Queue[schemas.core.TaskRun]] = {}
+_scheduled_task_runs_queues: Dict[
+    asyncio.AbstractEventLoop, asyncio.Queue[schemas.core.TaskRun]
+] = {}
+_retry_task_runs_queues: Dict[
+    asyncio.AbstractEventLoop, asyncio.Queue[schemas.core.TaskRun]
+] = {}
+
 
 def scheduled_task_runs_queue() -> asyncio.Queue[schemas.core.TaskRun]:
     loop = asyncio.get_event_loop()
     if loop not in _scheduled_task_runs_queues:
         _scheduled_task_runs_queues[loop] = asyncio.Queue()
     return _scheduled_task_runs_queues[loop]
+
 
 def retry_task_runs_queue() -> asyncio.Queue[schemas.core.TaskRun]:
     loop = asyncio.get_event_loop()
@@ -316,7 +322,6 @@ async def scheduled_task_subscription(
                 # If sending fails, put the task back into the retry queue
                 await retry_queue.put(task_run)
                 break  # Exit the loop to handle the disconnection
-
 
     except subscriptions.NORMAL_DISCONNECT_EXCEPTIONS:
         pass  # Handle normal disconnections

--- a/src/prefect/server/utilities/subscriptions.py
+++ b/src/prefect/server/utilities/subscriptions.py
@@ -9,6 +9,19 @@ from websockets.exceptions import ConnectionClosed
 NORMAL_DISCONNECT_EXCEPTIONS = (IOError, ConnectionClosed)
 
 
+async def ping_pong(websocket: WebSocket):
+    try:
+        await websocket.send_json({"type": "ping"})
+
+        response = await websocket.receive_json()
+        if response.get("type") == "pong":
+            return True
+        else:
+            return False
+    except Exception:
+        return False
+
+
 async def accept_prefect_socket(websocket: WebSocket) -> Optional[WebSocket]:
     subprotocols = websocket.headers.get("Sec-WebSocket-Protocol", "").split(",")
     if "prefect" not in subprotocols:


### PR DESCRIPTION
adds a retry queue for when tasks are submitted and there is no running `TaskServer`
<img width="1298" alt="image" src="https://github.com/PrefectHQ/prefect/assets/31014960/14106dd0-6a3a-48ff-978b-a08915d83e04">

empirically this solves the problem I described earlier:
- prefect server start
- run a TaskServer
- submit a task -> runs great :white-check-mark2:
- stop the TaskServer
- submit a task while no task server running
- start the TaskServer -> subscription created
- nothing gets picked up