### PR TITLE
Add documentation on providing a description when pausing a flow run

### DIFF
--- a/docs/guides/creating-interactive-workflows.md
+++ b/docs/guides/creating-interactive-workflows.md
@@ -135,7 +135,7 @@ async def greet_user():
 
 When a user sees the form for this input, the name field will contain "anonymous" as the default.
 
-### Providing a description and runtime data
+### Providing a description with runtime data
 
 You can provide a dynamic, markdown description that will appear in the Prefect UI when the flow run pauses. This feature enables context-specific prompts, enhancing clarity and user interaction. Building on the example above:
 

--- a/docs/guides/creating-interactive-workflows.md
+++ b/docs/guides/creating-interactive-workflows.md
@@ -135,9 +135,9 @@ async def greet_user():
 
 When a user sees the form for this input, the name field will contain "anonymous" as the default.
 
-### Providing a description with markdown and runtime data
+### Providing a description and runtime data
 
-You can provide a dynamic, markdown, description that will appear in the Prefect UI when the flow run pauses. This feature enables context-specific prompts, enhancing clarity and user interaction. Building on the example above:
+You can provide a dynamic, markdown description that will appear in the Prefect UI when the flow run pauses. This feature enables context-specific prompts, enhancing clarity and user interaction. Building on the example above:
 
 ```python
 from datetime import datetime


### PR DESCRIPTION
Adds documentation for providing a description when pausing a flow run.

Related to #11735 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.