### PR TITLE
Improve flaky import tests

### DIFF
--- a/tests/test-projects/nested-project/explicit_relative.py
+++ b/tests/test-projects/nested-project/explicit_relative.py
@@ -1,9 +1,11 @@
 from prefect import flow
 
-from .shared_libs.bar import bar
-from .shared_libs.foo import foo
+from .shared_libs.bar import get_bar
+from .shared_libs.foo import get_foo
 
 
 @flow
 def foobar():
-    return foo() + bar()
+    assert callable(get_foo), f"Expected callable, got {get_foo!r}"
+    assert callable(get_bar), f"Expected callable, got {get_bar!r}"
+    return get_foo() + get_bar()

--- a/tests/test-projects/nested-project/implicit_relative.py
+++ b/tests/test-projects/nested-project/implicit_relative.py
@@ -1,9 +1,11 @@
-from shared_libs.bar import bar
-from shared_libs.foo import foo
+from shared_libs.bar import get_bar
+from shared_libs.foo import get_foo
 
 import prefect
 
 
 @prefect.flow
 def foobar():
-    return foo() + bar()
+    assert callable(get_foo), f"Expected callable, got {get_foo!r}"
+    assert callable(get_bar), f"Expected callable, got {get_bar!r}"
+    return get_foo() + get_bar()

--- a/tests/test-projects/nested-project/shared_libs/bar.py
+++ b/tests/test-projects/nested-project/shared_libs/bar.py
@@ -1,2 +1,2 @@
-def bar():
+def get_bar():
     return "bar"

--- a/tests/test-projects/nested-project/shared_libs/foo.py
+++ b/tests/test-projects/nested-project/shared_libs/foo.py
@@ -1,2 +1,2 @@
-def foo():
+def get_foo():
     return "foo"

--- a/tests/test-projects/tree-project/imports/explicit_relative.py
+++ b/tests/test-projects/tree-project/imports/explicit_relative.py
@@ -1,6 +1,8 @@
-from ..shared_libs.bar import bar
-from ..shared_libs.foo import foo
+from ..shared_libs.bar import get_bar
+from ..shared_libs.foo import get_foo
 
 
 def foobar():
-    return foo() + bar()
+    assert callable(get_foo), f"Expected callable, got {get_foo!r}"
+    assert callable(get_bar), f"Expected callable, got {get_bar!r}"
+    return get_foo() + get_bar()

--- a/tests/test-projects/tree-project/imports/implicit_relative.py
+++ b/tests/test-projects/tree-project/imports/implicit_relative.py
@@ -1,6 +1,8 @@
-from shared_libs.bar import bar
-from shared_libs.foo import foo
+from shared_libs.bar import get_bar
+from shared_libs.foo import get_foo
 
 
 def foobar():
-    return foo() + bar()
+    assert callable(get_foo), f"Expected callable, got {get_foo!r}"
+    assert callable(get_bar), f"Expected callable, got {get_bar!r}"
+    return get_foo() + get_bar()

--- a/tests/test-projects/tree-project/shared_libs/bar.py
+++ b/tests/test-projects/tree-project/shared_libs/bar.py
@@ -1,2 +1,2 @@
-def bar():
+def get_bar():
     return "bar"

--- a/tests/test-projects/tree-project/shared_libs/foo.py
+++ b/tests/test-projects/tree-project/shared_libs/foo.py
@@ -1,6 +1,2 @@
-def foo():
+def get_foo():
     return "foo"
-
-
-def bar():
-    return "bar"

--- a/tests/utilities/test_importtools.py
+++ b/tests/utilities/test_importtools.py
@@ -141,7 +141,6 @@ def test_lazy_import_includes_help_message_in_deferred_failure():
         module.foo
 
 
-@pytest.mark.skip("Too flaky")
 @pytest.mark.usefixtures("reset_sys_modules")
 @pytest.mark.parametrize(
     "working_directory,script_path",
@@ -178,6 +177,7 @@ def test_import_object_from_script_with_relative_imports(
     with tmpchdir(working_directory):
         foobar = import_object(f"{script_path}:foobar")
 
+    assert callable(foobar), f"Expected callable, got {foobar!r}"
     assert foobar() == "foobar"
 
 

--- a/tests/utilities/test_importtools.py
+++ b/tests/utilities/test_importtools.py
@@ -226,7 +226,6 @@ def test_import_object_from_module_with_relative_imports(
         assert foobar() == "foobar"
 
 
-@pytest.mark.flaky(max_runs=3)
 @pytest.mark.usefixtures("reset_sys_modules")
 @pytest.mark.parametrize(
     "working_directory,import_path",


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Our `load_script_as_module` utility modifies the sys path to handle relative imports when loading scripts. This can cause issues when used concurrently. Some of the import tests flake because a relative import that should be a function instead is loaded as a module. This PR changes the names of those functions to avoid naming conflicts with other tests. This PR also adds additional assertions so we can get better information about where the conflict is coming from in the unlikely event it happens again.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.