### PR TITLE
Suppresses a specific new `pluggy` warning causing flaky tests

### DIFF
--- a/scripts/install-with-latest-dependencies
+++ b/scripts/install-with-latest-dependencies
@@ -1,0 +1,3 @@
+#!/bin/bash
+pip uninstall `pip freeze | grep -v '\-e'` --yes
+pip install -U -e .[dev]

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ filterwarnings =
     # datetime.datetime.utcnow() is deprecated as of Python 3.12, waiting on 3rd party fixes in boto3 https://github.com/boto/boto3/issues/3889
     ignore:datetime\.datetime\.utcnow\(\) is deprecated and scheduled for removal in a future version\..*:DeprecationWarning
     ignore:datetime\.datetime\.utcfromtimestamp\(\) is deprecated and scheduled for removal in a future version\..*:DeprecationWarning
-    # pluggy 1.4.0 has starting showing us a connection leak in the test suite
+    # pluggy 1.4.0 has started showing us a connection leak in the test suite
     # https://github.com/PrefectHQ/prefect/issues/11820
     ignore:hookwrapper:pluggy.PluggyTeardownRaisedWarning
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,9 @@ filterwarnings =
     # datetime.datetime.utcnow() is deprecated as of Python 3.12, waiting on 3rd party fixes in boto3 https://github.com/boto/boto3/issues/3889
     ignore:datetime\.datetime\.utcnow\(\) is deprecated and scheduled for removal in a future version\..*:DeprecationWarning
     ignore:datetime\.datetime\.utcfromtimestamp\(\) is deprecated and scheduled for removal in a future version\..*:DeprecationWarning
+    # pluggy 1.4.0 has starting showing us a connection leak in the test suite
+    # https://github.com/PrefectHQ/prefect/issues/11820
+    ignore:hookwrapper:pluggy.PluggyTeardownRaisedWarning
 
 [mypy]
 # TODO: We will allow definitions to be untyped for now; in the future we will want to


### PR DESCRIPTION
Part of #11820
