### PR TITLE
Improves reliability of import tests

### DIFF
--- a/tests/deployment/test_base.py
+++ b/tests/deployment/test_base.py
@@ -1,5 +1,4 @@
 import json
-import os
 import shutil
 import sys
 from pathlib import Path
@@ -18,24 +17,22 @@ from prefect.deployments.base import (
 )
 from prefect.settings import PREFECT_DEBUG_MODE, temporary_settings
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
+from prefect.utilities.filesystem import tmpchdir
 
 TEST_PROJECTS_DIR = prefect.__development_base_path__ / "tests" / "test-projects"
 
 
 @pytest.fixture(autouse=True)
 def project_dir(tmp_path):
-    original_dir = os.getcwd()
-    if sys.version_info >= (3, 8):
-        shutil.copytree(TEST_PROJECTS_DIR, tmp_path, dirs_exist_ok=True)
-        (tmp_path / ".prefect").mkdir(exist_ok=True, mode=0o0700)
-        os.chdir(tmp_path)
-        yield tmp_path
-    else:
-        shutil.copytree(TEST_PROJECTS_DIR, tmp_path / "three-seven")
-        (tmp_path / "three-seven" / ".prefect").mkdir(exist_ok=True, mode=0o0700)
-        os.chdir(tmp_path / "three-seven")
-        yield tmp_path / "three-seven"
-    os.chdir(original_dir)
+    with tmpchdir(tmp_path):
+        if sys.version_info >= (3, 8):
+            shutil.copytree(TEST_PROJECTS_DIR, tmp_path, dirs_exist_ok=True)
+            (tmp_path / ".prefect").mkdir(exist_ok=True, mode=0o0700)
+            yield tmp_path
+        else:
+            shutil.copytree(TEST_PROJECTS_DIR, tmp_path / "three-seven")
+            (tmp_path / "three-seven" / ".prefect").mkdir(exist_ok=True, mode=0o0700)
+            yield tmp_path / "three-seven"
 
 
 class TestFindProject:

--- a/tests/test-projects/flat-project/explicit_relative.py
+++ b/tests/test-projects/flat-project/explicit_relative.py
@@ -1,5 +1,7 @@
-from .shared_libs import bar, foo
+from .shared_libs import get_bar, get_foo
 
 
 def foobar():
-    return foo() + bar()
+    assert callable(get_foo), f"Expected callable, got {get_foo!r}"
+    assert callable(get_bar), f"Expected callable, got {get_bar!r}"
+    return get_foo() + get_bar()

--- a/tests/test-projects/flat-project/implicit_relative.py
+++ b/tests/test-projects/flat-project/implicit_relative.py
@@ -1,5 +1,7 @@
-from shared_libs import bar, foo
+from shared_libs import get_bar, get_foo
 
 
 def foobar():
-    return foo() + bar()
+    assert callable(get_foo), f"Expected callable, got {get_foo!r}"
+    assert callable(get_bar), f"Expected callable, got {get_bar!r}"
+    return get_foo() + get_bar()

--- a/tests/test-projects/flat-project/shared_libs.py
+++ b/tests/test-projects/flat-project/shared_libs.py
@@ -1,6 +1,6 @@
-def foo():
+def get_foo():
     return "foo"
 
 
-def bar():
+def get_bar():
     return "bar"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Further addresses flakiness in import tests. The `deploy` CLI tests change the working directory during the test setup. This PR updates those tests to use `tmpchdir` to ensure the working directory is changed back reliability to avoid interfering with the import object tests.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.