### PR TITLE
Add plumbing for toggling work queue status experimental flag.

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -39,7 +39,6 @@ settings to be dynamically modified on retrieval. This allows us to make setting
 dependent on the value of other settings or perform other dynamic effects.
 
 """
-
 import logging
 import os
 import string
@@ -421,7 +420,9 @@ def warn_on_misconfigured_api_url(values):
             )
 
         if warnings_list:
-            example = 'e.g. PREFECT_API_URL="https://api.prefect.cloud/api/accounts/[ACCOUNT-ID]/workspaces/[WORKSPACE-ID]"'
+            example = (
+                'e.g. PREFECT_API_URL="https://api.prefect.cloud/api/accounts/[ACCOUNT-ID]/workspaces/[WORKSPACE-ID]"'
+            )
             warnings_list.append(example)
 
             warnings.warn("\n".join(warnings_list), stacklevel=2)

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1463,6 +1463,8 @@ PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING = Setting(bool, default=False)
 Whether or not to enable experimental task scheduling.
 """
 
+PREFECT_EXPERIMENTAL_ENABLE_WORK_QUEUE_STATUS = Setting(bool, default=False)
+
 # Defaults -----------------------------------------------------------------------------
 
 PREFECT_DEFAULT_RESULT_STORAGE_BLOCK = Setting(

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -39,6 +39,7 @@ settings to be dynamically modified on retrieval. This allows us to make setting
 dependent on the value of other settings or perform other dynamic effects.
 
 """
+
 import logging
 import os
 import string
@@ -420,9 +421,7 @@ def warn_on_misconfigured_api_url(values):
             )
 
         if warnings_list:
-            example = (
-                'e.g. PREFECT_API_URL="https://api.prefect.cloud/api/accounts/[ACCOUNT-ID]/workspaces/[WORKSPACE-ID]"'
-            )
+            example = 'e.g. PREFECT_API_URL="https://api.prefect.cloud/api/accounts/[ACCOUNT-ID]/workspaces/[WORKSPACE-ID]"'
             warnings_list.append(example)
 
             warnings.warn("\n".join(warnings_list), stacklevel=2)
@@ -1464,6 +1463,9 @@ Whether or not to enable experimental task scheduling.
 """
 
 PREFECT_EXPERIMENTAL_ENABLE_WORK_QUEUE_STATUS = Setting(bool, default=False)
+"""
+Whether or not to enable experimental work queue status in-place of work queue health.
+"""
 
 # Defaults -----------------------------------------------------------------------------
 

--- a/ui/src/maps/featureFlag.ts
+++ b/ui/src/maps/featureFlag.ts
@@ -13,7 +13,10 @@ export const mapFlagResponseToFeatureFlag: MapFunction<FlagResponse, FeatureFlag
       return "access:artifacts"
     case "deployment_status":
       return "access:deploymentStatus"
+    case "work_queue_status":
+      return "access:workQueueStatus"
     default:
+      const exhaustiveCheck: never = source
       return null
   }
 }

--- a/ui/src/types/flagResponse.ts
+++ b/ui/src/types/flagResponse.ts
@@ -3,3 +3,4 @@ export type FlagResponse =
 | "work_pools"
 | "artifacts"
 | "deployment_status"
+| "work_queue_status"

--- a/ui/src/utilities/permissions.ts
+++ b/ui/src/utilities/permissions.ts
@@ -6,6 +6,7 @@ const featureFlags = [
   "access:work_pools",
   "access:artifacts",
   "access:deploymentStatus",
+  "access:workQueueStatus",
 ] as const
 
 export type FeatureFlag = typeof featureFlags[number] | WorkspaceFeatureFlag


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

Adds a new setting to toggle on experimental work queue status flag. Toggling this flag on will enable a new incoming feature which will replace Work Queue Health metrics with a new Work Queue _Status_ similar to the recently introduced deployment statuses. More info to come soon 🙃 .

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.