### PR TITLE
Being explicit that we need `pluggy>=1.4.0`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,7 @@ mypy
 numpy
 pillow
 pre-commit
+pluggy >= 1.4.0
 pytest >= 8
 pytest-asyncio >= 0.18.2, != 0.22.0, < 0.23.0 # Cannot override event loop in 0.23.0. See https://github.com/pytest-dev/pytest-asyncio/issues/706 for more details.
 pytest-cov


### PR DESCRIPTION
Fixes #11836
Related to #11820
