### PR TITLE
more unique failure flag names

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -400,14 +400,18 @@ jobs:
           # Do not run Kubernetes service tests, we do not have a cluster available
           pytest tests -vvv --numprocesses auto --dist loadscope --disable-docker-image-builds --exclude-service kubernetes --durations=25 --cov=src/ --cov=tests/ --no-cov-on-fail --cov-report=term --cov-config=setup.cfg ${{ matrix.pytest-options }}
 
-      - name: Create and Upload failure flag
+      - name: Create failure flag
         if: ${{ failure() }}
         id: create_failure_flag
         run: |
           sanitized_name="${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}"
           sanitized_name="${sanitized_name//:/-}"
-          echo "Failure in $sanitized_name" > "${sanitized_name}-failure.txt"
-          echo "artifact_name=${sanitized_name}-failure" >> $GITHUB_OUTPUT
+          
+          timestamp=$(date -u +"%Y%m%dT%H%M%SZ")
+          unique_artifact_name="${sanitized_name}-failure-${timestamp}"
+          
+          echo "Failure in $sanitized_name" > "${unique_artifact_name}.txt"
+          echo "artifact_name=${unique_artifact_name}" >> $GITHUB_OUTPUT
 
       - name: Upload failure flag
         if: ${{ failure() }}


### PR DESCRIPTION
to avoid these variety of errors uploading failure flags

```
With the provided path, there will be 1 file uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```