### PR TITLE
Remove `flaky_on_windows` helper

### DIFF
--- a/src/prefect/testing/utilities.py
+++ b/src/prefect/testing/utilities.py
@@ -9,8 +9,6 @@ from pprint import pprint
 from tempfile import TemporaryDirectory
 from typing import Dict, List, Union
 
-import pytest
-
 import prefect.context
 import prefect.settings
 from prefect.blocks.core import Block
@@ -22,16 +20,6 @@ from prefect.results import PersistedResult
 from prefect.serializers import Serializer
 from prefect.server.database.dependencies import temporary_database_interface
 from prefect.states import State
-
-
-def flaky_on_windows(fn, **kwargs):
-    """
-    Mark a test as flaky for repeated test runs if on Windows.
-    """
-    if sys.platform == "win32":
-        return pytest.mark.flaky(**kwargs)(fn)
-    else:
-        return fn
 
 
 def exceptions_equal(a, b):

--- a/tests/server/services/test_loop_service.py
+++ b/tests/server/services/test_loop_service.py
@@ -6,7 +6,6 @@ import pendulum
 import pytest
 
 from prefect.server.services.loop_service import LoopService
-from prefect.testing.utilities import flaky_on_windows
 
 
 async def test_asyncio_sleep_accepts_negative_numbers():
@@ -105,7 +104,6 @@ async def test_loop_service_calls_on_start_on_stop_once():
     assert service.state == ["_on_start", "_on_stop"]
 
 
-@flaky_on_windows
 async def test_early_stop():
     """Test that stop criterion is evaluated without waiting for loop_seconds"""
 
@@ -132,7 +130,6 @@ async def test_early_stop():
     assert dt2 - dt < pendulum.duration(seconds=1)
 
 
-@flaky_on_windows
 async def test_stop_block_escapes_deadlock(caplog):
     """Test that calling a blocking stop inside the service eventually returns"""
 

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -67,7 +67,6 @@ from prefect.task_runners import ConcurrentTaskRunner, SequentialTaskRunner
 from prefect.testing.utilities import (
     AsyncMock,
     exceptions_equal,
-    flaky_on_windows,
     get_most_recent_flow_run,
 )
 from prefect.utilities.annotations import allow_failure, quote
@@ -1182,7 +1181,6 @@ class TestFlowTimeouts:
         assert not canary_file.exists()
         assert not task_canary_file.exists()
 
-    @flaky_on_windows
     async def test_timeout_stops_execution_after_await_for_async_flows(self, tmp_path):
         """
         Async flow runs can be cancelled after a timeout

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -35,7 +35,7 @@ from prefect.settings import (
 from prefect.states import State
 from prefect.task_runners import SequentialTaskRunner
 from prefect.tasks import Task, task, task_input_hash
-from prefect.testing.utilities import exceptions_equal, flaky_on_windows
+from prefect.testing.utilities import exceptions_equal
 from prefect.utilities.annotations import allow_failure, unmapped
 from prefect.utilities.collections import quote
 
@@ -1152,7 +1152,6 @@ class TestTaskCaching:
         assert second_state.result() == 6
         assert third_state.result() == 6
 
-    @flaky_on_windows
     def test_cache_key_hits_with_future_expiration_are_cached(self):
         @task(
             cache_key_fn=lambda *_: "cache hit",


### PR DESCRIPTION
The windows test suite doesn't even run anymore, no reason to explicitly mark things there as flaky.