### PR TITLE
Use errors from docker.errors

### DIFF
--- a/tests/fixtures/docker.py
+++ b/tests/fixtures/docker.py
@@ -2,6 +2,7 @@ import sys
 from contextlib import contextmanager
 from typing import Generator
 
+import docker.errors as docker_errors
 import pytest
 from typer.testing import CliRunner
 
@@ -68,7 +69,7 @@ def cleanup_all_new_docker_objects(docker: DockerClient, worker_id: str):
             for image in docker.images.list(filters=filters):
                 for tag in image.tags:
                     docker.images.remove(tag, force=True)
-        except docker.errors.NotFound:
+        except docker_errors.NotFound:
             logger.warning("Failed to clean up Docker objects")
 
 


### PR DESCRIPTION
This PR updates our exception block to handle errors from `docker.errors`, It used to handle exceptions from  `docker.errors`, where `docker` was referring to an instance of a `DockerClient`, **NOT** the docker module. 

Closes #11855 

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.