### PR TITLE
Waiting for up to the global pytest timeout for a runner to cancel a flow

### DIFF
--- a/flows.py
+++ b/flows.py
@@ -1,0 +1,16 @@
+import os
+import signal
+
+from prefect import flow
+from prefect.logging.loggers import flow_run_logger
+
+
+def on_crashed(flow, flow_run, state):
+    logger = flow_run_logger(flow_run, flow)
+    logger.info("This flow crashed!")
+
+
+@flow(on_crashed=[on_crashed], log_prints=True)
+def crashing_flow():
+    print("Oh boy, here I go crashing again...")
+    os.kill(os.getpid(), signal.SIGTERM)

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -374,7 +374,7 @@ class TestRunner:
     async def test_runner_can_cancel_flow_runs(
         self, prefect_client: PrefectClient, caplog
     ):
-        runner = Runner(query_seconds=2)
+        runner = Runner(query_seconds=1)
 
         deployment = await cancel_flow_submitted_tasks.to_deployment(__file__)
 
@@ -393,8 +393,8 @@ class TestRunner:
 
             # Need to wait for polling loop to pick up flow run and
             # start execution
-            for _ in range(15):
-                await anyio.sleep(1)
+            while True:
+                await anyio.sleep(0.5)
                 flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
                 if flow_run.state.is_running():
                     break
@@ -408,15 +408,11 @@ class TestRunner:
 
             # Need to wait for polling loop to pick up flow run and then
             # finish cancellation
-            for _ in range(15):
-                await anyio.sleep(1)
+            while True:
+                await anyio.sleep(0.5)
                 flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
                 if flow_run.state.is_cancelled():
                     break
-            else:
-                raise AssertionError(
-                    f"Flow run did not enter cancelled: {flow_run.state.name!r}"
-                )
 
             await runner.stop()
             tg.cancel_scope.cancel()
@@ -462,8 +458,8 @@ class TestRunner:
 
             # Need to wait for polling loop to pick up flow run and
             # start execution
-            for _ in range(15):
-                await anyio.sleep(1)
+            while True:
+                await anyio.sleep(0.5)
                 flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
                 if flow_run.state.is_running():
                     break
@@ -477,8 +473,8 @@ class TestRunner:
 
             # Need to wait for polling loop to pick up flow run and then
             # finish cancellation
-            for _ in range(15):
-                await anyio.sleep(1)
+            while True:
+                await anyio.sleep(0.5)
                 flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
                 if flow_run.state.is_cancelled():
                     break


### PR DESCRIPTION
This removes the in-test timeouts and just lets the two polling loops continue
indefinitely looking for the flow run to transition to the state they are
expecting.  If either loop fails, we'll see these as timeouts from
`pytest-timeout`.
