### PR TITLE
fix context tests

### DIFF
--- a/flows/client_context_lifespan.py
+++ b/flows/client_context_lifespan.py
@@ -17,7 +17,6 @@ from unittest.mock import MagicMock
 import anyio
 from prefect._vendor.fastapi import FastAPI
 
-import prefect
 import prefect.context
 import prefect.exceptions
 from prefect.client.orchestration import PrefectClient

--- a/flows/client_context_lifespan.py
+++ b/flows/client_context_lifespan.py
@@ -1,3 +1,13 @@
+import sys
+
+from packaging.version import Version
+
+import prefect
+
+# Only run these tests if the version is at least 2.13.0
+if Version(prefect.__version__) < Version("2.13.0"):
+    sys.exit(0)
+
 import asyncio
 import random
 import threading
@@ -5,17 +15,12 @@ from contextlib import asynccontextmanager
 from unittest.mock import MagicMock
 
 import anyio
-from packaging.version import Version
+from prefect._vendor.fastapi import FastAPI
 
 import prefect
 import prefect.context
 import prefect.exceptions
 from prefect.client.orchestration import PrefectClient
-
-if Version(prefect.__version__) >= Version("2.13.0"):
-    from prefect._vendor.fastapi import FastAPI
-else:
-    from fastapi import FastAPI
 
 
 def make_lifespan(startup, shutdown) -> callable:

--- a/flows/client_context_lifespan.py
+++ b/flows/client_context_lifespan.py
@@ -5,11 +5,17 @@ from contextlib import asynccontextmanager
 from unittest.mock import MagicMock
 
 import anyio
-from prefect._vendor.fastapi import FastAPI
+from packaging.version import Version
 
+import prefect
 import prefect.context
 import prefect.exceptions
 from prefect.client.orchestration import PrefectClient
+
+if Version(prefect.__version__) >= Version("2.13.0"):
+    from prefect._vendor.fastapi import FastAPI
+else:
+    from fastapi import FastAPI
 
 
 def make_lifespan(startup, shutdown) -> callable:


### PR DESCRIPTION
we run these for every major version of prefect, so we only want our vendored fastapi after 2.13.0