### PR TITLE
Adds longer timeout to help prevent flakes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ env =
     PREFECT_TEST_MODE = 1
 
 asyncio_mode = auto
-timeout = 60
+timeout = 90
 
 # Error on unhandled warnings
 filterwarnings =


### PR DESCRIPTION
There are a bunch of different errors that seem to be coming from the case where "a test case is taking longer than our 60 second pytest timeout value". These errors don't seem to be contained to a single test and seem to happen when you cancel a function mid-execution. This PR bumps the timeout from 60 to 90 to see if the extra time helps these tests successfully pass by themselves.

Potential fix for 
- https://github.com/orgs/PrefectHQ/projects/123/views/1?pane=issue&itemId=52401111
- https://github.com/orgs/PrefectHQ/projects/123/views/1?pane=issue&itemId=52262606
- https://github.com/orgs/PrefectHQ/projects/123/views/1?pane=issue&itemId=52263841


<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.