### PR TITLE
Isolate alarm based thread test

### DIFF
--- a/tests/_internal/concurrency/test_cancellation.py
+++ b/tests/_internal/concurrency/test_cancellation.py
@@ -35,9 +35,40 @@ def mock_alarm_signal_handler():
         signal.signal(signal.SIGALRM, _previous_alarm_handler)
 
 
-@pytest.mark.parametrize(
-    "cls", [AlarmCancelScope, WatcherThreadCancelScope, AsyncCancelScope]
-)
+@pytest.mark.timeout(method="thread")  # alarm-based pytest-timeout will interfere
+async def test_alarm_cancel_scope_repr(cls=AlarmCancelScope):
+    scope = cls()
+    assert "PENDING" in repr(scope)
+    assert "runtime" not in repr(scope)
+    assert hex(id(scope)) in repr(scope)
+
+    if threading.current_thread() is threading.main_thread():
+        with scope:
+            assert "RUNNING" in repr(scope)
+            assert "runtime" in repr(scope)
+
+        assert "COMPLETED" in repr(scope)
+        assert "runtime" in repr(scope)
+
+    if threading.current_thread() is threading.main_thread():
+        scope = cls()
+        try:
+            with scope:
+                scope.cancel()
+        except CancelledError:
+            pass
+
+        assert "CANCELLED" in repr(scope)
+
+    scope = cls(name="test")
+    assert hex(id(scope)) not in repr(scope)
+    assert "name='test'" in repr(scope)
+
+    scope = cls(timeout=0.1)
+    assert "timeout=0.1" in repr(scope)
+
+
+@pytest.mark.parametrize("cls", [WatcherThreadCancelScope, AsyncCancelScope])
 async def test_cancel_scope_repr(cls):
     scope = cls()
     assert "PENDING" in repr(scope)

--- a/tests/_internal/concurrency/test_cancellation.py
+++ b/tests/_internal/concurrency/test_cancellation.py
@@ -35,9 +35,8 @@ def mock_alarm_signal_handler():
         signal.signal(signal.SIGALRM, _previous_alarm_handler)
 
 
-@pytest.mark.timeout(method="thread")  # alarm-based pytest-timeout will interfere
-async def test_alarm_cancel_scope_repr(cls=AlarmCancelScope):
-    scope = cls()
+async def test_alarm_cancel_scope_repr():
+    scope = AlarmCancelScope()
     assert "PENDING" in repr(scope)
     assert "runtime" not in repr(scope)
     assert hex(id(scope)) in repr(scope)
@@ -51,7 +50,7 @@ async def test_alarm_cancel_scope_repr(cls=AlarmCancelScope):
         assert "runtime" in repr(scope)
 
     if threading.current_thread() is threading.main_thread():
-        scope = cls()
+        scope = AlarmCancelScope()
         try:
             with scope:
                 scope.cancel()
@@ -60,11 +59,11 @@ async def test_alarm_cancel_scope_repr(cls=AlarmCancelScope):
 
         assert "CANCELLED" in repr(scope)
 
-    scope = cls(name="test")
+    scope = AlarmCancelScope(name="test")
     assert hex(id(scope)) not in repr(scope)
     assert "name='test'" in repr(scope)
 
-    scope = cls(timeout=0.1)
+    scope = AlarmCancelScope(timeout=0.1)
     assert "timeout=0.1" in repr(scope)
 
 


### PR DESCRIPTION
Closes #11890 

For some reason, this test will sometimes get scheduled not on the `MainThread`. When that happens, the parameterization with `AlarmCancelScope` fails. This fix isolates the `AlarmCancelScope` test case to only enter its context if it is on the main thread. The parts of the test that don't depend on entering the context will still run.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.