### PR TITLE
Fix flaky test_engine.py::TestBlockingPause tests

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2019,7 +2019,8 @@ class TestOrchestrateTaskRun:
 
         assert (
             "Received non-final state 'Failed' when proposing final state 'Failed' and"
-            " will not attempt to run again..." not in caplog.text
+            " will not attempt to run again..."
+            not in caplog.text
         )
 
     async def test_retry_condition_fn_retry_handler_returns_notfalse_retries(
@@ -2071,7 +2072,8 @@ class TestOrchestrateTaskRun:
 
         assert (
             "Received non-final state 'AwaitingRetry' when proposing final state"
-            " 'Failed' and will attempt to run again..." in caplog.text
+            " 'Failed' and will attempt to run again..."
+            in caplog.text
         )
 
     async def test_proposes_unknown_result_if_state_is_completed_and_result_data_is_missing(
@@ -2821,7 +2823,8 @@ class TestCreateThenBeginFlowRun:
         assert "Validation of flow parameters failed with error" in state.message
         assert (
             "SignatureMismatchError: Function expects parameters ['dog', 'cat'] but was"
-            " provided with parameters ['puppy', 'kitty']" in state.message
+            " provided with parameters ['puppy', 'kitty']"
+            in state.message
         )
         with pytest.raises(SignatureMismatchError):
             await state.result()
@@ -2915,7 +2918,8 @@ class TestRetrieveFlowThenBeginFlowRun:
         assert "Validation of flow parameters failed with error" in state.message
         assert (
             "SignatureMismatchError: Function expects parameters ['dog', 'cat'] but was"
-            " provided with parameters ['puppy', 'kitty']" in state.message
+            " provided with parameters ['puppy', 'kitty']"
+            in state.message
         )
         with pytest.raises(SignatureMismatchError):
             await state.result()
@@ -2993,7 +2997,8 @@ class TestCreateAndBeginSubflowRun:
         assert "Validation of flow parameters failed with error" in state.message
         assert (
             "SignatureMismatchError: Function expects parameters ['dog', 'cat'] but was"
-            " provided with parameters ['puppy', 'kitty']" in state.message
+            " provided with parameters ['puppy', 'kitty']"
+            in state.message
         )
         with pytest.raises(SignatureMismatchError):
             await state.result()
@@ -3216,9 +3221,9 @@ class TestAPIHealthcheck:
     async def test_healthcheck_reset_after_expiration(self):
         async with get_client() as client:
             await check_api_reachable(client, fail_message="test")
-            value = API_HEALTHCHECKS["http://ephemeral-prefect/api/"] = (
-                time.monotonic()
-            )  # set it to expire now
+            value = API_HEALTHCHECKS[
+                "http://ephemeral-prefect/api/"
+            ] = time.monotonic()  # set it to expire now
             await check_api_reachable(client, fail_message="test")
             assert API_HEALTHCHECKS["http://ephemeral-prefect/api/"] != value
             assert API_HEALTHCHECKS["http://ephemeral-prefect/api/"] == pytest.approx(
@@ -3260,7 +3265,8 @@ def test_flow_call_with_task_runner_duplicate_not_implemented(caplog):
     assert (
         "Task runner 'MyTaskRunner' does not implement the"
         " `duplicate` method and will fail if used for concurrent execution of"
-        " the same flow." in caplog.text
+        " the same flow."
+        in caplog.text
     )
 
 
@@ -3289,7 +3295,8 @@ def test_subflow_call_with_task_runner_duplicate_not_implemented(caplog):
     assert (
         "Task runner 'MyTaskRunner' does not implement the"
         " `duplicate` method and will fail if used for concurrent execution of"
-        " the same flow." in caplog.text
+        " the same flow."
+        in caplog.text
     )
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -327,6 +327,10 @@ class TestBlockingPause:
             keyset = flow_run.state.state_details.run_input_keyset
             assert keyset
 
+            # Wait for the flow run input schema to be saved
+            while not (await read_flow_run_input(keyset["schema"], flow_run_id)):
+                await asyncio.sleep(0.1)
+
             await resume_flow_run(flow_run_id, run_input={"x": 42})
 
         flow_run_state, the_answer = await asyncio.gather(
@@ -343,7 +347,9 @@ class TestBlockingPause:
         )
         assert schema is not None
 
-    async def test_paused_flows_can_receive_automatic_input(self, prefect_client):
+    async def test_paused_flows_can_receive_automatic_input(
+        self, prefect_client: PrefectClient
+    ):
         flow_run_id = None
 
         @flow(task_runner=SequentialTaskRunner())
@@ -368,6 +374,10 @@ class TestBlockingPause:
 
             keyset = flow_run.state.state_details.run_input_keyset
             assert keyset
+
+            # Wait for the flow run input schema to be saved
+            while not (await read_flow_run_input(keyset["schema"], flow_run_id)):
+                await asyncio.sleep(0.1)
 
             await resume_flow_run(flow_run_id, run_input={"value": 42})
 
@@ -2009,8 +2019,7 @@ class TestOrchestrateTaskRun:
 
         assert (
             "Received non-final state 'Failed' when proposing final state 'Failed' and"
-            " will not attempt to run again..."
-            not in caplog.text
+            " will not attempt to run again..." not in caplog.text
         )
 
     async def test_retry_condition_fn_retry_handler_returns_notfalse_retries(
@@ -2062,8 +2071,7 @@ class TestOrchestrateTaskRun:
 
         assert (
             "Received non-final state 'AwaitingRetry' when proposing final state"
-            " 'Failed' and will attempt to run again..."
-            in caplog.text
+            " 'Failed' and will attempt to run again..." in caplog.text
         )
 
     async def test_proposes_unknown_result_if_state_is_completed_and_result_data_is_missing(
@@ -2813,8 +2821,7 @@ class TestCreateThenBeginFlowRun:
         assert "Validation of flow parameters failed with error" in state.message
         assert (
             "SignatureMismatchError: Function expects parameters ['dog', 'cat'] but was"
-            " provided with parameters ['puppy', 'kitty']"
-            in state.message
+            " provided with parameters ['puppy', 'kitty']" in state.message
         )
         with pytest.raises(SignatureMismatchError):
             await state.result()
@@ -2908,8 +2915,7 @@ class TestRetrieveFlowThenBeginFlowRun:
         assert "Validation of flow parameters failed with error" in state.message
         assert (
             "SignatureMismatchError: Function expects parameters ['dog', 'cat'] but was"
-            " provided with parameters ['puppy', 'kitty']"
-            in state.message
+            " provided with parameters ['puppy', 'kitty']" in state.message
         )
         with pytest.raises(SignatureMismatchError):
             await state.result()
@@ -2987,8 +2993,7 @@ class TestCreateAndBeginSubflowRun:
         assert "Validation of flow parameters failed with error" in state.message
         assert (
             "SignatureMismatchError: Function expects parameters ['dog', 'cat'] but was"
-            " provided with parameters ['puppy', 'kitty']"
-            in state.message
+            " provided with parameters ['puppy', 'kitty']" in state.message
         )
         with pytest.raises(SignatureMismatchError):
             await state.result()
@@ -3211,9 +3216,9 @@ class TestAPIHealthcheck:
     async def test_healthcheck_reset_after_expiration(self):
         async with get_client() as client:
             await check_api_reachable(client, fail_message="test")
-            value = API_HEALTHCHECKS[
-                "http://ephemeral-prefect/api/"
-            ] = time.monotonic()  # set it to expire now
+            value = API_HEALTHCHECKS["http://ephemeral-prefect/api/"] = (
+                time.monotonic()
+            )  # set it to expire now
             await check_api_reachable(client, fail_message="test")
             assert API_HEALTHCHECKS["http://ephemeral-prefect/api/"] != value
             assert API_HEALTHCHECKS["http://ephemeral-prefect/api/"] == pytest.approx(
@@ -3255,8 +3260,7 @@ def test_flow_call_with_task_runner_duplicate_not_implemented(caplog):
     assert (
         "Task runner 'MyTaskRunner' does not implement the"
         " `duplicate` method and will fail if used for concurrent execution of"
-        " the same flow."
-        in caplog.text
+        " the same flow." in caplog.text
     )
 
 
@@ -3285,8 +3289,7 @@ def test_subflow_call_with_task_runner_duplicate_not_implemented(caplog):
     assert (
         "Task runner 'MyTaskRunner' does not implement the"
         " `duplicate` method and will fail if used for concurrent execution of"
-        " the same flow."
-        in caplog.text
+        " the same flow." in caplog.text
     )
 
 


### PR DESCRIPTION
Fixes a race condition in the tests where flow resume runs too quickly - after the pausing flow is paused but before the input schema is saved.

When a flow is paused, the client updates the status and _then_ the run input schema is saved. If the test's flow resumer picks up that the flow run is now paused _before_ the run input schema saves, then the test flakes and fails. This PR is to resolve that issue by having the flow resumer wait for the input schema to exist before resuming the flow run.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.