### PR TITLE
Remove flaky marker from `Process` stderr stream test

### DIFF
--- a/tests/infrastructure/test_process.py
+++ b/tests/infrastructure/test_process.py
@@ -52,7 +52,6 @@ def test_process_stream_output(capsys, stream_output):
         assert "hello world" in out
 
 
-@pytest.mark.flaky(max_runs=2 if sys.version_info > (3, 10) else 1)
 @pytest.mark.skipif(
     sys.platform == "win32", reason="stderr redirect does not work on Windows"
 )


### PR DESCRIPTION
Unfortunately, we don't have access to the GitHub Actions logs for why this test was flaky in the first place (nor was it available in the original PR). However, being that this test was deemed flaky one year ago:
1. that may no longer be the case
2. if it is so, we will try to handle the test failure in other ways than marking as flaky