### PR TITLE
We should actually fail checks of the DataDog visibility tests fail

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -260,6 +260,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.ENGINEERING_REVIEW_SLACK_WEBHOOK_URL }}
 
   run-tests-for-datadog:
+    name: DataDog CI Visibility
     runs-on:
       group: oss-larger-runners
     strategy:
@@ -370,8 +371,6 @@ jobs:
 
           echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
 
-        # Runs the test with || true to ensure the job does not fail if the tests
-        # fail, because we're sending the results to DataDog
       - name: Run tests
         run: >
           pytest tests
@@ -384,7 +383,6 @@ jobs:
           --durations 26
           --cov
           --cov-config setup.cfg
-          || true
         env:
           DD_CIVISIBILITY_AGENTLESS_ENABLED: true
           DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VISIBILITY }}


### PR DESCRIPTION
I changed my mind on this, because if we don't see the checks fail, it may be
confusing to see a failure in DD that doesn't correspond with a failure on
`main`, and we should have enough confidence that our test suite will pass to
include an additional run of it.
