### PR TITLE
Invalidate `sys.modules` cache after each test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -537,3 +537,26 @@ def disable_enhanced_cancellation():
 @pytest.fixture
 def start_of_test() -> pendulum.DateTime:
     return pendulum.now("UTC")
+
+
+@pytest.fixture(autouse=True)
+def reset_sys_modules():
+    import importlib
+
+    original_modules = sys.modules.copy()
+
+    # Workaround for weird behavior on Linux where some of our "expected
+    # failure" tests succeed because '.' is in the path.
+    if sys.platform == "linux" and "." in sys.path:
+        sys.path.remove(".")
+
+    yield
+
+    # Delete all of the module objects that were introduced so they are not
+    # cached.
+    for module in set(sys.modules.keys()):
+        if module not in original_modules:
+            del sys.modules[module]
+
+    importlib.invalidate_caches()
+    sys.modules = original_modules

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -559,4 +559,3 @@ def reset_sys_modules():
             del sys.modules[module]
 
     importlib.invalidate_caches()
-    sys.modules = original_modules

--- a/tests/utilities/test_importtools.py
+++ b/tests/utilities/test_importtools.py
@@ -34,26 +34,6 @@ class Foo:
 pytest.mark.usefixtures("hosted_orion")
 
 
-@pytest.fixture
-def reset_sys_modules():
-    original_modules = sys.modules.copy()
-
-    # Workaround for weird behavior on Linux where some of our "expected failure" tests
-    # succeed because '.' is in the path.
-    if sys.platform == "linux" and "." in sys.path:
-        sys.path.remove(".")
-
-    yield
-
-    # Delete all of the module objects that were introduced so they are not cached
-    for module in set(sys.modules.keys()):
-        if module not in original_modules:
-            del sys.modules[module]
-
-    importlib.invalidate_caches()
-    sys.modules = original_modules
-
-
 @pytest.mark.parametrize(
     "obj,expected",
     [
@@ -141,7 +121,6 @@ def test_lazy_import_includes_help_message_in_deferred_failure():
         module.foo
 
 
-@pytest.mark.usefixtures("reset_sys_modules")
 @pytest.mark.parametrize(
     "working_directory,script_path",
     [
@@ -181,7 +160,6 @@ def test_import_object_from_script_with_relative_imports(
     assert foobar() == "foobar"
 
 
-@pytest.mark.usefixtures("reset_sys_modules")
 @pytest.mark.parametrize(
     "working_directory,script_path",
     [
@@ -208,7 +186,6 @@ def test_import_object_from_script_with_relative_imports_expected_failures(
             runpy.run_path(str(script_path))
 
 
-@pytest.mark.usefixtures("reset_sys_modules")
 @pytest.mark.parametrize(
     "working_directory,import_path",
     [
@@ -226,7 +203,6 @@ def test_import_object_from_module_with_relative_imports(
         assert foobar() == "foobar"
 
 
-@pytest.mark.usefixtures("reset_sys_modules")
 @pytest.mark.parametrize(
     "working_directory,import_path",
     [


### PR DESCRIPTION
The issue here was that the `cli/test_deploy.py` tests were also importing these `shared_lib` functions which got cached in `sys.modules`, but we weren't invalidating the cache during those tests. This makes the invalidation fixture a global autouse.