### PR TITLE
Run tasks on the main thread

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -6,6 +6,7 @@ coolname >= 1.0.4, < 3.0.0
 croniter >= 1.0.12, < 3.0.0
 fsspec >= 2022.5.0
 graphviz >= 0.20.1
+greenback >= 1.2.0
 griffe >= 0.20.0
 httpcore >=0.15.0, < 2.0.0
 httpx[http2] >= 0.23, != 0.23.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ dateparser >= 1.1.1, < 2.0.0
 docker >= 4.0, < 7.0
 graphviz >= 0.20.1
 griffe >= 0.20.0
+greenback >= 1.2.0
 jinja2 >= 3.0.0, < 4.0.0
 kubernetes >= 24.2.0, < 30.0.0
 pytz >= 2021.1, < 2025

--- a/src/prefect/_internal/concurrency/api.py
+++ b/src/prefect/_internal/concurrency/api.py
@@ -19,6 +19,7 @@ from typing import (
 import greenback
 from typing_extensions import ParamSpec
 
+from prefect._internal.concurrency import logger
 from prefect._internal.concurrency.event_loop import get_running_loop
 from prefect._internal.concurrency.threads import (
     WorkerThread,
@@ -235,21 +236,22 @@ class from_sync(_base):
     ) -> Awaitable[T]:
         # Check for a running event loop to prevent blocking
         if get_running_loop():
-            if not greenback.has_portal():
-                raise RuntimeError(
+            if greenback.has_portal():
+                # Use greenback to avoid blocking the event loop while waiting
+                return greenback.await_(
+                    from_async.wait_for_call_in_loop_thread(
+                        __call,
+                        timeout=timeout,
+                        done_callbacks=done_callbacks,
+                        contexts=contexts,
+                    )
+                )
+            else:
+                logger.error(
                     "Detected unsafe call to `from_sync` from thread with event loop. "
-                    "Call `await greenback.ensure_portal()` to allow functionality."
+                    "Use `await greenback.ensure_portal()` to allow call to run "
+                    "without blocking the event loop."
                 )
-
-            # Use greenback to avoid blocking the event loop while waiting
-            return greenback.await_(
-                from_async.wait_for_call_in_loop_thread(
-                    __call,
-                    timeout=timeout,
-                    done_callbacks=done_callbacks,
-                    contexts=contexts,
-                )
-            )
 
         call = _cast_to_call(__call)
         waiter = SyncWaiter(call)

--- a/src/prefect/_internal/concurrency/api.py
+++ b/src/prefect/_internal/concurrency/api.py
@@ -16,8 +16,10 @@ from typing import (
     Union,
 )
 
+import greenback
 from typing_extensions import ParamSpec
 
+from prefect._internal.concurrency.event_loop import get_running_loop
 from prefect._internal.concurrency.threads import (
     WorkerThread,
     get_global_loop,
@@ -179,7 +181,7 @@ class from_async(_base):
             for context in contexts or []:
                 stack.enter_context(context)
             await waiter.wait()
-            return call.result()
+            return await call.aresult()
 
     @staticmethod
     async def wait_for_call_in_new_thread(
@@ -193,7 +195,7 @@ class from_async(_base):
             waiter.add_done_callback(callback)
         _base.call_soon_in_new_thread(call, timeout=timeout)
         await waiter.wait()
-        return call.result()
+        return await call.aresult()
 
     @staticmethod
     def call_in_waiting_thread(
@@ -231,6 +233,24 @@ class from_sync(_base):
         done_callbacks: Optional[Iterable[Call]] = None,
         contexts: Optional[Iterable[ContextManager]] = None,
     ) -> Awaitable[T]:
+        # Check for a running event loop to prevent blocking
+        if get_running_loop():
+            if not greenback.has_portal():
+                raise RuntimeError(
+                    "Detected unsafe call to `from_sync` from thread with event loop. "
+                    "Call `await greenback.ensure_portal()` to allow functionality."
+                )
+
+            # Use greenback to avoid blocking the event loop while waiting
+            return greenback.await_(
+                from_async.wait_for_call_in_loop_thread(
+                    __call,
+                    timeout=timeout,
+                    done_callbacks=done_callbacks,
+                    contexts=contexts,
+                )
+            )
+
         call = _cast_to_call(__call)
         waiter = SyncWaiter(call)
         _base.call_soon_in_loop_thread(call, timeout=timeout)
@@ -262,6 +282,10 @@ class from_sync(_base):
         thread: threading.Thread,
         timeout: Optional[float] = None,
     ) -> T:
+        if get_running_loop():
+            raise RuntimeError(
+                "Detected unsafe call to `from_sync` from thread with event loop."
+            )
         call = _base.call_soon_in_waiting_thread(__call, thread, timeout=timeout)
         return call.result()
 
@@ -269,6 +293,10 @@ class from_sync(_base):
     def call_in_new_thread(
         __call: Union[Callable[[], T], Call[T]], timeout: Optional[float] = None
     ) -> T:
+        if get_running_loop():
+            raise RuntimeError(
+                "Detected unsafe call to `from_sync` from thread with event loop."
+            )
         call = _base.call_soon_in_new_thread(__call, timeout=timeout)
         return call.result()
 
@@ -282,6 +310,11 @@ class from_sync(_base):
             # blocked waiting for the call
             call = _cast_to_call(__call)
             return call()
+
+        if get_running_loop():
+            raise RuntimeError(
+                "Detected unsafe call to `from_sync` from thread with event loop."
+            )
 
         call = _base.call_soon_in_loop_thread(__call, timeout=timeout)
         return call.result()

--- a/src/prefect/_internal/concurrency/threads.py
+++ b/src/prefect/_internal/concurrency/threads.py
@@ -257,11 +257,12 @@ def in_global_loop() -> bool:
     """
     Check if called from the global loop.
     """
-    if GLOBAL_LOOP is None:
+    loop = get_running_loop()
+    if GLOBAL_LOOP is None or not loop:
         # Avoid creating a global loop if there isn't one
         return False
 
-    return get_global_loop()._loop == get_running_loop()
+    return GLOBAL_LOOP._loop == loop
 
 
 def wait_for_global_loop_exit(timeout: Optional[float] = None) -> None:

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -2142,20 +2142,19 @@ async def orchestrate_task_run(
 
                 flow_run_context = FlowRunContext.get()
 
-                if flow_run_context and (
-                    # Async and sync tasks can get executed on synchronous flows
-                    # if the task runner is sequential.
-                    # If the task is sync and a concurrent task runner is used, we must
-                    # execute it in a worker thread.
+                if flow_run_context and user_thread(
+                    # Async and sync tasks can be executed on synchronous flows
+                    # if the task runner is sequential; if the task is sync and a
+                    # concurrent task runner is used, we must execute it in a worker
+                    # thread instead.
                     (
                         concurrency_type == TaskConcurrencyType.SEQUENTIAL
                         and not flow_run_context.flow.isasync
                     )
-                    # Async tasks can get executed on asynchronous flows if the
-                    # task runner is concurrent
-                    or (flow_run_context.flow.isasync and task.isasync)
-                    # If the flow is async we do not want to block the event loop with
+                    # Async tasks can always be executed on asynchronous flow; if the
+                    # flow is async we do not want to block the event loop with
                     # synchronous tasks
+                    or (flow_run_context.flow.isasync and task.isasync)
                 ):
                     from_async.call_soon_in_waiting_thread(
                         call, thread=user_thread, timeout=task.timeout_seconds

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -852,7 +852,11 @@ async def orchestrate_flow_run(
                     not parent_flow_run_context
                     or (
                         parent_flow_run_context
-                        and parent_flow_run_context.flow.isasync == flow.isasync
+                        and
+                        # Unless the parent is async and the child is sync, run the
+                        # child flow in the parent thread; running a sync child in
+                        # an async parent could be bad for async performance.
+                        not (parent_flow_run_context.flow.isasync and not flow.isasync)
                     )
                 ):
                     from_async.call_soon_in_waiting_thread(

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1940,6 +1940,7 @@ async def orchestrate_task_run(
         flow_run = flow_run_context.flow_run
     else:
         flow_run = await client.read_flow_run(task_run.flow_run_id)
+
     logger = task_run_logger(task_run, task=task, flow_run=flow_run)
 
     partial_task_run_context = PartialModel(
@@ -2140,7 +2141,6 @@ async def orchestrate_task_run(
 
                 call = create_call(task.fn, *args, **kwargs)
 
-                flow_run_context = FlowRunContext.get()
                 if (
                     flow_run_context
                     and user_thread

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,6 +219,7 @@ def event_loop(request):
 
     try:
         yield loop
+
     finally:
         loop.close()
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2057,7 +2057,8 @@ class TestOrchestrateTaskRun:
 
         assert (
             "Received non-final state 'Failed' when proposing final state 'Failed' and"
-            " will not attempt to run again..." not in caplog.text
+            " will not attempt to run again..."
+            not in caplog.text
         )
 
     async def test_retry_condition_fn_retry_handler_returns_notfalse_retries(
@@ -2111,7 +2112,8 @@ class TestOrchestrateTaskRun:
 
         assert (
             "Received non-final state 'AwaitingRetry' when proposing final state"
-            " 'Failed' and will attempt to run again..." in caplog.text
+            " 'Failed' and will attempt to run again..."
+            in caplog.text
         )
 
     async def test_proposes_unknown_result_if_state_is_completed_and_result_data_is_missing(
@@ -2865,7 +2867,8 @@ class TestCreateThenBeginFlowRun:
         assert "Validation of flow parameters failed with error" in state.message
         assert (
             "SignatureMismatchError: Function expects parameters ['dog', 'cat'] but was"
-            " provided with parameters ['puppy', 'kitty']" in state.message
+            " provided with parameters ['puppy', 'kitty']"
+            in state.message
         )
         with pytest.raises(SignatureMismatchError):
             await state.result()
@@ -2959,7 +2962,8 @@ class TestRetrieveFlowThenBeginFlowRun:
         assert "Validation of flow parameters failed with error" in state.message
         assert (
             "SignatureMismatchError: Function expects parameters ['dog', 'cat'] but was"
-            " provided with parameters ['puppy', 'kitty']" in state.message
+            " provided with parameters ['puppy', 'kitty']"
+            in state.message
         )
         with pytest.raises(SignatureMismatchError):
             await state.result()
@@ -3037,7 +3041,8 @@ class TestCreateAndBeginSubflowRun:
         assert "Validation of flow parameters failed with error" in state.message
         assert (
             "SignatureMismatchError: Function expects parameters ['dog', 'cat'] but was"
-            " provided with parameters ['puppy', 'kitty']" in state.message
+            " provided with parameters ['puppy', 'kitty']"
+            in state.message
         )
         with pytest.raises(SignatureMismatchError):
             await state.result()
@@ -3304,7 +3309,8 @@ def test_flow_call_with_task_runner_duplicate_not_implemented(caplog):
     assert (
         "Task runner 'MyTaskRunner' does not implement the"
         " `duplicate` method and will fail if used for concurrent execution of"
-        " the same flow." in caplog.text
+        " the same flow."
+        in caplog.text
     )
 
 
@@ -3333,7 +3339,8 @@ def test_subflow_call_with_task_runner_duplicate_not_implemented(caplog):
     assert (
         "Task runner 'MyTaskRunner' does not implement the"
         " `duplicate` method and will fail if used for concurrent execution of"
-        " the same flow." in caplog.text
+        " the same flow."
+        in caplog.text
     )
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1045,6 +1045,8 @@ class TestOrchestrateTaskRun:
                 interruptible=False,
                 client=prefect_client,
                 log_prints=False,
+                concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                user_thread=threading.current_thread(),
             )
 
     async def test_raises_on_new_pause_state_with_reschedule(
@@ -1101,6 +1103,8 @@ class TestOrchestrateTaskRun:
                 interruptible=False,
                 client=prefect_client,
                 log_prints=False,
+                concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                user_thread=threading.current_thread(),
             )
 
     async def test_abort_breaks_pause_loop(
@@ -1166,6 +1170,8 @@ class TestOrchestrateTaskRun:
                 interruptible=False,
                 client=prefect_client,
                 log_prints=False,
+                concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                user_thread=threading.current_thread(),
             )
 
     async def test_pending_in_pause_loop_submits_running_state(
@@ -1235,6 +1241,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         assert state.is_completed()
@@ -1824,6 +1832,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         # Check that the task failed after two attempts
@@ -1872,6 +1882,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         # Check that the task failed after only one attempt
@@ -1922,6 +1934,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         # Check that the task failed after only one attempt
@@ -1982,6 +1996,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         # Ensure the retry condition function was never called
@@ -2029,6 +2045,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         # Check that the task failed after only one attempt
@@ -2039,8 +2057,7 @@ class TestOrchestrateTaskRun:
 
         assert (
             "Received non-final state 'Failed' when proposing final state 'Failed' and"
-            " will not attempt to run again..."
-            not in caplog.text
+            " will not attempt to run again..." not in caplog.text
         )
 
     async def test_retry_condition_fn_retry_handler_returns_notfalse_retries(
@@ -2084,6 +2101,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         assert state.is_failed()
@@ -2092,8 +2111,7 @@ class TestOrchestrateTaskRun:
 
         assert (
             "Received non-final state 'AwaitingRetry' when proposing final state"
-            " 'Failed' and will attempt to run again..."
-            in caplog.text
+            " 'Failed' and will attempt to run again..." in caplog.text
         )
 
     async def test_proposes_unknown_result_if_state_is_completed_and_result_data_is_missing(
@@ -2133,6 +2151,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         result = await state.result()
@@ -2189,6 +2209,8 @@ class TestBeginTaskRun:
                 wait_for=[],
                 log_prints=False,
                 settings=prefect.context.SettingsContext.get().copy(),
+                concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                user_thread=threading.current_thread(),
             )
 
         assert state
@@ -2843,8 +2865,7 @@ class TestCreateThenBeginFlowRun:
         assert "Validation of flow parameters failed with error" in state.message
         assert (
             "SignatureMismatchError: Function expects parameters ['dog', 'cat'] but was"
-            " provided with parameters ['puppy', 'kitty']"
-            in state.message
+            " provided with parameters ['puppy', 'kitty']" in state.message
         )
         with pytest.raises(SignatureMismatchError):
             await state.result()
@@ -2938,8 +2959,7 @@ class TestRetrieveFlowThenBeginFlowRun:
         assert "Validation of flow parameters failed with error" in state.message
         assert (
             "SignatureMismatchError: Function expects parameters ['dog', 'cat'] but was"
-            " provided with parameters ['puppy', 'kitty']"
-            in state.message
+            " provided with parameters ['puppy', 'kitty']" in state.message
         )
         with pytest.raises(SignatureMismatchError):
             await state.result()
@@ -3017,8 +3037,7 @@ class TestCreateAndBeginSubflowRun:
         assert "Validation of flow parameters failed with error" in state.message
         assert (
             "SignatureMismatchError: Function expects parameters ['dog', 'cat'] but was"
-            " provided with parameters ['puppy', 'kitty']"
-            in state.message
+            " provided with parameters ['puppy', 'kitty']" in state.message
         )
         with pytest.raises(SignatureMismatchError):
             await state.result()
@@ -3285,8 +3304,7 @@ def test_flow_call_with_task_runner_duplicate_not_implemented(caplog):
     assert (
         "Task runner 'MyTaskRunner' does not implement the"
         " `duplicate` method and will fail if used for concurrent execution of"
-        " the same flow."
-        in caplog.text
+        " the same flow." in caplog.text
     )
 
 
@@ -3315,8 +3333,7 @@ def test_subflow_call_with_task_runner_duplicate_not_implemented(caplog):
     assert (
         "Task runner 'MyTaskRunner' does not implement the"
         " `duplicate` method and will fail if used for concurrent execution of"
-        " the same flow."
-        in caplog.text
+        " the same flow." in caplog.text
     )
 
 
@@ -3387,6 +3404,8 @@ async def test_long_task_introspection_warning_on(
                 interruptible=False,
                 client=prefect_client,
                 log_prints=False,
+                concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                user_thread=threading.current_thread(),
             )
 
     assert "Task parameter introspection took" in caplog.text
@@ -3432,6 +3451,8 @@ async def test_long_task_introspection_warning_off(
                 interruptible=False,
                 client=prefect_client,
                 log_prints=False,
+                concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                user_thread=threading.current_thread(),
             )
 
     assert "Task parameter introspection took" not in caplog.text

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1280,6 +1280,8 @@ class TestOrchestrateTaskRun:
                 interruptible=False,
                 client=prefect_client,
                 log_prints=False,
+                concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                user_thread=threading.current_thread(),
             )
 
         assert state.is_completed()
@@ -1324,6 +1326,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         mock_anyio_sleep.assert_not_called()
@@ -1375,6 +1379,8 @@ class TestOrchestrateTaskRun:
                 interruptible=False,
                 client=prefect_client,
                 log_prints=False,
+                concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                user_thread=threading.current_thread(),
             )
 
         # Check for a proper final result
@@ -1437,6 +1443,8 @@ class TestOrchestrateTaskRun:
                 interruptible=False,
                 client=prefect_client,
                 log_prints=False,
+                concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                user_thread=threading.current_thread(),
             )
 
         assert mock_anyio_sleep.await_count == 3
@@ -1489,6 +1497,8 @@ class TestOrchestrateTaskRun:
                 interruptible=False,
                 client=prefect_client,
                 log_prints=False,
+                concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                user_thread=threading.current_thread(),
             )
 
         assert mock_anyio_sleep.await_count == 3
@@ -1542,6 +1552,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         assert mock.call_count == 10 + 1  # 1 run + 10 retries
@@ -1610,6 +1622,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         # The task did not run
@@ -1659,6 +1673,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         # The task ran with the unqoted data
@@ -1709,6 +1725,8 @@ class TestOrchestrateTaskRun:
             interruptible=False,
             client=prefect_client,
             log_prints=False,
+            concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+            user_thread=threading.current_thread(),
         )
 
         # The task ran with the state as its input
@@ -1760,6 +1778,8 @@ class TestOrchestrateTaskRun:
                     interruptible=False,
                     client=prefect_client,
                     log_prints=False,
+                    concurrency_type=TaskConcurrencyType.SEQUENTIAL,
+                    user_thread=threading.current_thread(),
                 )
 
             assert mock_anyio_sleep.await_count == 3

--- a/tests/test_task_server.py
+++ b/tests/test_task_server.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from prefect import task
+from prefect._internal.concurrency.api import create_call, from_async
 from prefect.client.schemas.objects import TaskRun
 from prefect.settings import (
     PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
@@ -102,7 +103,9 @@ async def test_handle_sigterm():
 
         mock_subscribe.assert_called_once()
 
-        task_server.handle_sigterm(signal.SIGTERM, None)
+        await from_async.call_in_new_thread(
+            create_call(task_server.handle_sigterm, signal.SIGTERM, None)
+        )
 
         mock_exit.assert_called_once_with(0)
         mock_stop.assert_called_once()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -528,7 +528,7 @@ class TestTaskSubmit:
             await foo.submit(1)
             # The future is dropped here but the task should finish
 
-        assert foobar() is None
+        assert foobar()[0].is_completed()
         assert task_ran
 
     async def test_sync_task_submitted_inside_async_flow(self):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -193,6 +193,21 @@ class TestTaskCall:
 
         assert await bar() == 1
 
+    def test_async_task_called_inside_async_subflow(self):
+        @flow
+        def foobar():
+            return bar()
+
+        @task
+        async def foo(x):
+            return x
+
+        @flow
+        async def bar():
+            return await foo(1)
+
+        assert foobar() == 1
+
     async def test_sync_task_called_inside_async_flow(self):
         @task
         def foo(x):
@@ -479,6 +494,42 @@ class TestTaskSubmit:
 
         task_state = await bar()
         assert await task_state.result() == 1
+
+    def test_async_task_submitted_inside_async_subflow(self):
+        @flow
+        def foobar():
+            return bar().result()
+
+        @task
+        async def foo(x):
+            return x
+
+        @flow
+        async def bar():
+            return await foo.submit(1)
+
+        assert foobar() == 1
+
+    def test_async_task_submitted_future_dropped_inside_async_subflow(self):
+        task_ran = False
+
+        @flow
+        def foobar():
+            return bar()
+
+        @task
+        async def foo(x):
+            nonlocal task_ran
+            task_ran = True
+            return x
+
+        @flow
+        async def bar():
+            await foo.submit(1)
+            # The future is dropped here but the task should finish
+
+        assert foobar() is None
+        assert task_ran
 
     async def test_sync_task_submitted_inside_async_flow(self):
         @task


### PR DESCRIPTION
This is a new version of #9855 rebased onto [`main`](https://github.com/PrefectHQ/prefect/tree/main) now that the upstream issue in greenback (https://github.com/oremanj/greenback/issues/22) preventing this from working with ephemeral servers is resolved. This no longer requires ugly hacks like https://github.com/PrefectHQ/prefect/pull/9870 to avoid greenlet contamination. The following description is mostly copied from the old pull request. I have no idea if this would interact with or is relevant for new work regarding "autonomous" tasks e.g. https://github.com/PrefectHQ/prefect/pull/11779

-----

When feasible, task runs are now executed on the main thread instead of a worker thread. Previously, all task runs were run in a new worker thread. This should significantly improve performance in asynchronous and sequential use cases. This allows objects to be passed to and from tasks without worrying about thread safety unless you have opted into concurrency. For example, an HTTP client or database connection can be shared between a flow and its tasks now (unless synchronous concurrency is being used).

Tasks are run in the main thread when:
- The task and flow are both asynchronous
- The flow is synchronous and the task run is sequential

Moving task execution should cause _deadlocks_ when asynchronous and synchronous tasks are mixed in an asynchronous flow because if a synchronous task depends on an asynchronous task it will block the event loop waiting for the upstream to finish but the upstream cannot run since it is now on the same event loop. For example:

```python
@flow
async def foo():
    upstream = await async_task.submit(42)  # Running in the background on the main thread event loop
    sync_task(upstream) # Blocks the event loop because there's no `await`
    # If the upstream is not done when `sync_task` is called, we deadlock

await foo()
```

To resolve these deadlocks, `greenback` is added as a dependency. `greenback` inserts a shim that lets us execute the synchronous task without blocking the event loop. This is not necessarily a big deal because we are already using SQLAlchemy which performs a similar hack with gevent to created mixed asynchronous and synchronous interfaces. However, it does add some complexity. With the shim, we no longer block the event loop when synchronous tasks are called from asynchronous flows which resolves this issue _and_ addresses general performance concerns when calling synchronous tasks from asynchronous flows (i.e. the synchronous tasks no longer block the event loop and delay asynchronous tasks). We also improve performance by spawning less threads.

In https://github.com/PrefectHQ/prefect/pull/11930/commits/a25b8b1aab3a169b5d97a6b88986947f9a437399, we also run asynchronous subflows in synchronous flows on the main thread. This was the easiest way to resolve a regression introduced by the prior changes, as well as a sensible way to deal with scheduling this case in the first place. Since an asynchronous subflow in a synchronous flow must always block until completion, it doesn't really make sense to schedule it in a worker thread.

This is a **breaking change** although I'm uncertain what kind of negative impact it would have on practical use cases. It seems likely that the usability benefits and reduction of complexity for users without concurrency should outweigh potential downsides. I think in the majority of cases it should be _more_ permissive. I'm certainly curious to hear opinions though.

Closes https://github.com/PrefectHQ/prefect/issues/9412
Closes https://github.com/PrefectHQ/prefect/issues/10627

## Example

```python
# Where we note that tasks run on the main thread, they previously ran on separate worker threads

import asyncio
import threading

from prefect import flow, task


@task
def sync_task():
    print(threading.current_thread())


@task
async def async_task():
    print(threading.current_thread())


@flow(log_prints=True)
def sync_flow():
    print(threading.current_thread())

    sync_task()  # Runs on main thread
    async_task()  # Runs on main thread
    sync_task.submit()  # Runs on worker thread
    async_task.submit()  # Runs on worker thread


@flow(log_prints=True)
async def async_flow():
    print(threading.current_thread())

    sync_task()  # Runs on worker thread
    sync_task.submit()  # Runs on worker thread
    await async_task()  # Runs on main thread
    await async_task.submit()  # Runs on main thread


sync_flow()
print("---")
asyncio.run(async_flow())
```

```
❯ python example.py
12:34:50.735 | INFO    | prefect.engine - Created flow run 'organic-wallaby' for flow 'sync-flow'
12:34:50.799 | INFO    | Flow run 'organic-wallaby' - <_MainThread(MainThread, started 8725699392)>
12:34:50.814 | INFO    | Flow run 'organic-wallaby' - Created task run 'sync_task-0' for task 'sync_task'
12:34:50.814 | INFO    | Flow run 'organic-wallaby' - Executing 'sync_task-0' immediately...
12:34:50.843 | INFO    | Task run 'sync_task-0' - <_MainThread(MainThread, started 8725699392)>
12:34:50.856 | INFO    | Task run 'sync_task-0' - Finished in state Completed()
12:34:50.870 | INFO    | Flow run 'organic-wallaby' - Created task run 'async_task-0' for task 'async_task'
12:34:50.871 | INFO    | Flow run 'organic-wallaby' - Executing 'async_task-0' immediately...
12:34:50.895 | INFO    | Task run 'async_task-0' - <_MainThread(MainThread, started 8725699392)>
12:34:50.911 | INFO    | Task run 'async_task-0' - Finished in state Completed()
12:34:50.924 | INFO    | Flow run 'organic-wallaby' - Created task run 'sync_task-1' for task 'sync_task'
12:34:50.925 | INFO    | Flow run 'organic-wallaby' - Submitted task run 'sync_task-1' for execution.
12:34:50.935 | INFO    | Flow run 'organic-wallaby' - Created task run 'async_task-1' for task 'async_task'
12:34:50.935 | INFO    | Flow run 'organic-wallaby' - Submitted task run 'async_task-1' for execution.
12:34:50.958 | INFO    | Task run 'sync_task-1' - <Thread(WorkerThread-0, started 6246838272)>
12:34:50.973 | INFO    | Task run 'async_task-1' - <Thread(WorkerThread-1, started 10804703232)>
12:34:50.977 | INFO    | Task run 'sync_task-1' - Finished in state Completed()
12:34:50.988 | INFO    | Task run 'async_task-1' - Finished in state Completed()
12:34:51.003 | INFO    | Flow run 'organic-wallaby' - Finished in state Completed('All states completed.')
---
12:34:51.071 | INFO    | prefect.engine - Created flow run 'melodic-bullfinch' for flow 'async-flow'
12:34:51.115 | INFO    | Flow run 'melodic-bullfinch' - <_MainThread(MainThread, started 8725699392)>
12:34:51.130 | INFO    | Flow run 'melodic-bullfinch' - Created task run 'sync_task-0' for task 'sync_task'
12:34:51.130 | INFO    | Flow run 'melodic-bullfinch' - Executing 'sync_task-0' immediately...
12:34:51.154 | INFO    | Task run 'sync_task-0' - <Thread(WorkerThread-2, started 10771050496)>
12:34:51.174 | INFO    | Task run 'sync_task-0' - Finished in state Completed()
12:34:51.186 | INFO    | Flow run 'melodic-bullfinch' - Created task run 'sync_task-1' for task 'sync_task'
12:34:51.187 | INFO    | Flow run 'melodic-bullfinch' - Submitted task run 'sync_task-1' for execution.
12:34:51.193 | INFO    | Flow run 'melodic-bullfinch' - Created task run 'async_task-0' for task 'async_task'
12:34:51.193 | INFO    | Flow run 'melodic-bullfinch' - Executing 'async_task-0' immediately...
12:34:51.219 | INFO    | Task run 'sync_task-1' - <Thread(WorkerThread-3, started 6263664640)>
12:34:51.231 | INFO    | Task run 'async_task-0' - <_MainThread(MainThread, started 8725699392)>
12:34:51.239 | INFO    | Task run 'sync_task-1' - Finished in state Completed()
12:34:51.248 | INFO    | Task run 'async_task-0' - Finished in state Completed()
12:34:51.259 | INFO    | Flow run 'melodic-bullfinch' - Created task run 'async_task-1' for task 'async_task'
12:34:51.259 | INFO    | Flow run 'melodic-bullfinch' - Submitted task run 'async_task-1' for execution.
12:34:51.282 | INFO    | Task run 'async_task-1' - <_MainThread(MainThread, started 8725699392)>
12:34:51.295 | INFO    | Task run 'async_task-1' - Finished in state Completed()
12:34:51.309 | INFO    | Flow run 'melodic-bullfinch' - Finished in state Completed('All states completed.')
```

Now possible, previously would fail with event loop errors

```python
from prefect import flow, task
import asyncio
import httpx


@task()
async def query_api(client: httpx.AsyncClient):
    resp = await client.get("data")
    return resp


@flow()
async def my_flow():
    async with httpx.AsyncClient(base_url="https://example.com") as client:
        print(await query_api(client))


if __name__ == "__main__":
    asyncio.run(my_flow())
```
