### PR TITLE
Tracking connections process-wide for test assertions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   test-db:
-    image: postgres:13
+    image: postgres:14
     ports:
       - 15432:5432
     environment:

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ filterwarnings =
     # of the tests.
     ignore:garbage collector:sqlalchemy.exc.SAWarning
     ignore:5432:ResourceWarning
+    ignore::pluggy.PluggyTeardownRaisedWarning
 
 
 [mypy]

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,7 @@ filterwarnings =
     # the test suite before they can be cleaned up properly, but this is not a failure
     # of the tests.
     ignore:garbage collector:sqlalchemy.exc.SAWarning
+    ignore:5432:ResourceWarning
 
 
 [mypy]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ filterwarnings =
     # Temporary directories are cleaned up implicitly on Windows
     # It is unclear if this comes from an external tool or our own usage
     # Here the start of the path is included to only filter warnings on Windows
-    ignore:Implicitly cleaning up <TemporaryDirectory 'C:ResourceWarning
+    ignore:Implicitly cleaning up:ResourceWarning
     # Dask leaves files open when using file locks
     # See https://github.com/dask/distributed/pull/6122
     ignore::ResourceWarning:distributed.diskutils
@@ -75,8 +75,8 @@ filterwarnings =
     # the test suite before they can be cleaned up properly, but this is not a failure
     # of the tests.
     ignore:garbage collector:sqlalchemy.exc.SAWarning
-    ignore:5432:ResourceWarning
-    ignore:_ConnectionRecord:pytest.PytestUnraisableExceptionWarning
+    ignore:unclosed:ResourceWarning
+    ignore:Connection:pytest.PytestUnraisableExceptionWarning
     ignore::pluggy.PluggyTeardownRaisedWarning
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,9 +74,9 @@ filterwarnings =
     # We know that under certain constraints, SQLAlchemy connections may leak during
     # the test suite before they can be cleaned up properly, but this is not a failure
     # of the tests.
-    ignore:garbage collector:sqlalchemy.exc.SAWarning
-    ignore:unclosed:ResourceWarning
-    ignore:Connection:pytest.PytestUnraisableExceptionWarning
+    ignore::sqlalchemy.exc.SAWarning
+    ignore::ResourceWarning
+    ignore::pytest.PytestUnraisableExceptionWarning
     ignore::pluggy.PluggyTeardownRaisedWarning
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ filterwarnings =
     # of the tests.
     ignore:garbage collector:sqlalchemy.exc.SAWarning
     ignore:5432:ResourceWarning
+    ignore:_ConnectionRecord:pytest.PytestUnraisableExceptionWarning:
     ignore::pluggy.PluggyTeardownRaisedWarning
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,11 +71,7 @@ filterwarnings =
     # datetime.datetime.utcnow() is deprecated as of Python 3.12, waiting on 3rd party fixes in boto3 https://github.com/boto/boto3/issues/3889
     ignore:datetime\.datetime\.utcnow\(\) is deprecated and scheduled for removal in a future version\..*:DeprecationWarning
     ignore:datetime\.datetime\.utcfromtimestamp\(\) is deprecated and scheduled for removal in a future version\..*:DeprecationWarning
-    # pluggy 1.4.0 has started showing us a connection leak in the test suite
-    # https://github.com/PrefectHQ/prefect/issues/11820
-    ignore::sqlalchemy.exc.SAWarning
-    ignore::ResourceWarning:asyncpg.connection
-    ignore::pluggy.PluggyTeardownRaisedWarning
+
 
 
 [mypy]

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,10 @@ filterwarnings =
     # datetime.datetime.utcnow() is deprecated as of Python 3.12, waiting on 3rd party fixes in boto3 https://github.com/boto/boto3/issues/3889
     ignore:datetime\.datetime\.utcnow\(\) is deprecated and scheduled for removal in a future version\..*:DeprecationWarning
     ignore:datetime\.datetime\.utcfromtimestamp\(\) is deprecated and scheduled for removal in a future version\..*:DeprecationWarning
-
+    # We know that under certain constraints, SQLAlchemy connections may leak during
+    # the test suite before they can be cleaned up properly, but this is not a failure
+    # of the tests.
+    ignore:garbage collector:sqlalchemy.exc.SAWarning
 
 
 [mypy]

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ filterwarnings =
     # of the tests.
     ignore:garbage collector:sqlalchemy.exc.SAWarning
     ignore:5432:ResourceWarning
-    ignore:_ConnectionRecord:pytest.PytestUnraisableExceptionWarning:
+    ignore:_ConnectionRecord:pytest.PytestUnraisableExceptionWarning
     ignore::pluggy.PluggyTeardownRaisedWarning
 
 

--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -264,7 +264,7 @@ class TestUpdatingDeployments:
                 "inspect",
                 "rence-griffith/test-deployment",
             ],
-            expected_output_contains=["10.76"],  # 100 m record
+            expected_output_contains=["'interval': 10.76,"],  # 100 m record
             expected_code=0,
         )
 
@@ -285,7 +285,9 @@ class TestUpdatingDeployments:
                 "inspect",
                 "rence-griffith/test-deployment",
             ],
-            expected_output_contains=["10.49"],  # flo-jo breaks the world record
+            expected_output_contains=[
+                "'interval': 10.49,"
+            ],  # flo-jo breaks the world record
             expected_code=0,
         )
 
@@ -296,7 +298,7 @@ class TestUpdatingDeployments:
                 "inspect",
                 "rence-griffith/test-deployment",
             ],
-            expected_output_contains=["10.76"],  # 100 m record
+            expected_output_contains=["'interval': 10.76,"],  # 100 m record
             expected_code=0,
         )
 
@@ -317,7 +319,7 @@ class TestUpdatingDeployments:
                 "inspect",
                 "rence-griffith/test-deployment",
             ],
-            expected_output_does_not_contain=["10.76"],
+            expected_output_does_not_contain=["'interval': 10.76,"],
             expected_output_contains=["'schedule': None"],
             expected_code=0,
         )

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -66,7 +66,10 @@ async def database_engine(db: PrefectDBInterface):
     # post-test-session ResourceWarning errors about unclosed connections.
 
     TRACKER.clear()
-    gc.collect()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=ResourceWarning)
+        gc.collect()
 
 
 @pytest.fixture

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -1,7 +1,10 @@
 import asyncio
 import datetime
+import gc
 import warnings
 
+import aiosqlite
+import asyncpg
 import pendulum
 import pytest
 from sqlalchemy.exc import InterfaceError
@@ -11,7 +14,7 @@ from prefect.blocks.notifications import NotificationBlock
 from prefect.filesystems import LocalFileSystem
 from prefect.infrastructure import DockerContainer, Process
 from prefect.server import models, schemas
-from prefect.server.database.configurations import ENGINES
+from prefect.server.database.configurations import ENGINES, TRACKER
 from prefect.server.database.dependencies import (
     PrefectDBInterface,
     provide_database_interface,
@@ -33,6 +36,8 @@ def db(test_database_connection_url, safety_check_settings):
 @pytest.fixture(scope="session", autouse=True)
 async def database_engine(db: PrefectDBInterface):
     """Produce a database engine"""
+    TRACKER.active = True
+
     engine = await db.engine()
 
     yield engine
@@ -46,6 +51,22 @@ async def database_engine(db: PrefectDBInterface):
 
     for engine in engines:
         await engine.dispose()
+
+    # Now confirm that after disposing all engines, all connections are closed
+
+    for connection in TRACKER.all_connections:
+        driver_connection = connection.driver_connection
+        if isinstance(driver_connection, asyncpg.Connection):
+            assert driver_connection.is_closed()
+        elif isinstance(driver_connection, aiosqlite.Connection):
+            assert not driver_connection._connection
+
+    # Finally, free up all references to connections and clean up proactively so that
+    # we don't have any lingering connections after this.  This should prevent
+    # post-test-session ResourceWarning errors about unclosed connections.
+
+    TRACKER.clear()
+    gc.collect()
 
 
 @pytest.fixture

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -66,10 +66,7 @@ async def database_engine(db: PrefectDBInterface):
     # post-test-session ResourceWarning errors about unclosed connections.
 
     TRACKER.clear()
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=ResourceWarning)
-        gc.collect()
+    gc.collect()
 
 
 @pytest.fixture


### PR DESCRIPTION
This adds a tracking utility that observes all connections produced by our
engine's pools, allowing us to make assertions and clean them up at the end of
a test session.  This utility helps to avoid a `ResourceWarning` about
connections being cleaned up with `__del__` instead of being deliberately
closed, because it keeps a reference to all connections (open or closed) until
we can dispose of the engines and all the pooled connections deliberately.

The utility is only active during unit tests, when `TRACKER.active` is set, so
we shouldn't have concerns about memory use in long-running servers.

Fixes #11820
