### PR TITLE
don't get an instance if we don't need one

### DIFF
--- a/src/prefect/events/utilities.py
+++ b/src/prefect/events/utilities.py
@@ -8,7 +8,7 @@ from prefect._internal.schemas.fields import DateTimeTZ
 
 from .clients import AssertingEventsClient, PrefectCloudEventsClient
 from .schemas import Event, RelatedResource
-from .worker import EventsWorker
+from .worker import EventsWorker, emit_events_to_cloud
 
 TIGHT_TIMING = timedelta(minutes=5)
 
@@ -42,6 +42,9 @@ def emit_event(
         The event that was emitted if worker is using a client that emit
         events, otherwise None.
     """
+    if not emit_events_to_cloud():
+        return None
+
     operational_clients = [AssertingEventsClient, PrefectCloudEventsClient]
     worker_instance = EventsWorker.instance()
 

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -302,6 +302,11 @@ def events_api_url(events_server: WebSocketServer, unused_tcp_port: int) -> str:
 
 
 @pytest.fixture
+def mock_emit_events_to_cloud(monkeypatch):
+    monkeypatch.setattr("prefect.events.utilities.emit_events_to_cloud", lambda: True)
+
+
+@pytest.fixture
 def asserting_events_worker(monkeypatch) -> Generator[EventsWorker, None, None]:
     worker = EventsWorker.instance(AssertingEventsClient)
     # Always yield the asserting worker when new instances are retrieved

--- a/tests/concurrency/test_concurrency_asyncio.py
+++ b/tests/concurrency/test_concurrency_asyncio.py
@@ -94,6 +94,7 @@ async def test_concurrency_emits_events(
     concurrency_limit: ConcurrencyLimitV2,
     other_concurrency_limit: ConcurrencyLimitV2,
     asserting_events_worker: EventsWorker,
+    mock_emit_events_to_cloud,
     reset_worker_events,
 ):
     executed = False
@@ -247,6 +248,7 @@ async def test_rate_limit_emits_events(
     concurrency_limit_with_decay: ConcurrencyLimitV2,
     other_concurrency_limit_with_decay: ConcurrencyLimitV2,
     asserting_events_worker: EventsWorker,
+    mock_emit_events_to_cloud,
     reset_worker_events,
 ):
     async def resource_heavy():

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -49,6 +49,7 @@ def test_concurrency_emits_events(
     concurrency_limit: ConcurrencyLimitV2,
     other_concurrency_limit: ConcurrencyLimitV2,
     asserting_events_worker: EventsWorker,
+    mock_emit_events_to_cloud,
     reset_worker_events,
 ):
     def resource_heavy():
@@ -240,6 +241,7 @@ def test_rate_limit_emits_events(
     concurrency_limit_with_decay: ConcurrencyLimitV2,
     other_concurrency_limit_with_decay: ConcurrencyLimitV2,
     asserting_events_worker: EventsWorker,
+    mock_emit_events_to_cloud,
     reset_worker_events,
 ):
     def resource_heavy():

--- a/tests/events/conftest.py
+++ b/tests/events/conftest.py
@@ -10,8 +10,7 @@ def reset_asserting_events_client():
 
 
 @pytest.fixture(autouse=True)
-def mock_emit_events_to_cloud(monkeypatch):
-    monkeypatch.setattr("prefect.events.utilities.emit_events_to_cloud", lambda: True)
+def mock_emit_events_to_cloud(mock_emit_events_to_cloud):
     yield
 
 

--- a/tests/events/conftest.py
+++ b/tests/events/conftest.py
@@ -9,6 +9,12 @@ def reset_asserting_events_client():
     AssertingEventsClient.reset()
 
 
+@pytest.fixture(autouse=True)
+def mock_emit_events_to_cloud(monkeypatch):
+    monkeypatch.setattr("prefect.events.utilities.emit_events_to_cloud", lambda: True)
+    yield
+
+
 @pytest.fixture
 def example_event_1() -> Event:
     return Event(


### PR DESCRIPTION
We observed instances of tests timing out with `Failed: Timeout >90.0s` trying to get an instance of `EventsWorker` and starting it in the global loop thread. Before this pr, calling fixtures that had blocks in them (with `.save()`) would try and instantiate a null client.

There is definitely something up with calling `QueueService.instance` and it timing out, however it is very difficult to debug. For now we can at least cut down on places we're calling `.instance` in tests by short circuiting if we're not hooked up to cloud or not testing events explicitly. 

```
/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/asyncio/base_events.py:653: in run_until_complete
    return future.result()
/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/pytest_asyncio/plugin.py:323: in setup
    res = await func(**_add_kwargs(func, kwargs, event_loop, request))
tests/fixtures/database.py:342: in storage_document_id
    return await LocalFileSystem(basepath=str(tmpdir)).save(
src/prefect/events/instrument.py:60: in inner
    emit_instance_method_called_event(
src/prefect/events/instrument.py:36: in emit_instance_method_called_event
    emit_event(
src/prefect/events/utilities.py:46: in emit_event
    worker_instance = EventsWorker.instance()
src/prefect/events/worker.py:72: in instance
    return super().instance(client_type, tuple(client_kwargs.items()))
src/prefect/_internal/concurrency/services.py:243: in instance
    cls._instances[key] = cls._new_instance(*args)
src/prefect/_internal/concurrency/services.py:263: in _new_instance
    from_sync.call_soon_in_loop_thread(create_call(instance.start)).result()
src/prefect/_internal/concurrency/api.py:104: in call_soon_in_loop_thread
    runner.submit(call)
src/prefect/_internal/concurrency/threads.py:153: in submit
    self.start()
src/prefect/_internal/concurrency/threads.py:149: in start
    self._ready_future.result()
/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/concurrent/futures/_base.py:451: in result
    self._condition.wait(timeout)
```
e.x. https://github.com/PrefectHQ/prefect/actions/runs/7833314748/job/21374039903?pr=11927
