### PR TITLE
Fixing test flake in Docker container naming

### DIFF
--- a/tests/infrastructure/test_docker_container.py
+++ b/tests/infrastructure/test_docker_container.py
@@ -774,15 +774,16 @@ def test_container_auto_remove(docker: "DockerClient"):
 
 @pytest.mark.service("docker")
 def test_container_metadata(docker: "DockerClient"):
+    name = f"test-name-{uuid.uuid4()}"
     result = DockerContainer(
         command=["echo", "hello"],
-        name="test-name",
+        name=name,
         labels={"test.foo": "a", "test.bar": "b"},
     ).run()
 
     _, container_id = DockerContainer()._parse_infrastructure_pid(result.identifier)
     container: "Container" = docker.containers.get(container_id)
-    assert container.name == "test-name"
+    assert container.name == name
     assert container.labels["test.foo"] == "a"
     assert container.labels["test.bar"] == "b"
     assert container.image.tags[0] == get_prefect_image_name()


### PR DESCRIPTION
When running in parallel, it's possible that more than one test is trying to
create the `test-name` container (in the other test trying to test for name
collisions) and we'll end up with `test-name-1` here.  Giving it a fully unique
name sorts this out.
