### PR TITLE
Exclude schedules from backfill that have a value of `'null'`

### DIFF
--- a/src/prefect/server/database/migrations/versions/postgresql/2024_01_22_120615_8cf4d4933848_create_deployment_schedule_and_add_.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2024_01_22_120615_8cf4d4933848_create_deployment_schedule_and_add_.py
@@ -86,7 +86,8 @@ def upgrade():
         FROM
             deployment d
         WHERE
-            d.schedule IS NOT NULL;
+            d.schedule IS NOT NULL
+            and d.schedule != 'null';
     """
     backfill_paused = """
         UPDATE deployment SET paused = NOT is_schedule_active where paused = is_schedule_active;

--- a/src/prefect/server/database/migrations/versions/sqlite/2024_01_22_120214_265eb1a2da4c_create_deployment_schedule_and_add_.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2024_01_22_120214_265eb1a2da4c_create_deployment_schedule_and_add_.py
@@ -91,7 +91,8 @@ def upgrade():
         FROM
             deployment d
         WHERE
-            d.schedule IS NOT NULL;
+            d.schedule IS NOT NULL
+            and d.schedule != 'null';
     """
     backfill_paused = """
         UPDATE deployment SET paused = NOT is_schedule_active where paused = is_schedule_active;

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -128,7 +128,8 @@ async def create_deployment(
             deployment_id=deployment_id,
             schedules=[
                 schemas.actions.DeploymentScheduleCreate(
-                    schedule=schedule.schedule, active=schedule.active  # type: ignore[call-arg]
+                    schedule=schedule.schedule,
+                    active=schedule.active,  # type: ignore[call-arg]
                 )
                 for schedule in schedules
             ],
@@ -233,7 +234,8 @@ async def update_deployment(
             deployment_id=deployment_id,
             schedules=[
                 schemas.actions.DeploymentScheduleCreate(
-                    schedule=schedule.schedule, active=schedule.active  # type: ignore[call-arg]
+                    schedule=schedule.schedule,
+                    active=schedule.active,  # type: ignore[call-arg]
                 )
                 for schedule in schedules
             ],


### PR DESCRIPTION
In Cloud we noticed issues where the backfilled schedule was `'null'`, we've since removed these cases in Cloud, but need to replicate that change to this feature branch.

Related to https://github.com/PrefectHQ/nebula/issues/6706
