### PR TITLE
Enable work queue status in the UI by default

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -39,6 +39,7 @@ settings to be dynamically modified on retrieval. This allows us to make setting
 dependent on the value of other settings or perform other dynamic effects.
 
 """
+
 import logging
 import os
 import string
@@ -1461,7 +1462,7 @@ PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING = Setting(bool, default=False)
 Whether or not to enable experimental task scheduling.
 """
 
-PREFECT_EXPERIMENTAL_ENABLE_WORK_QUEUE_STATUS = Setting(bool, default=False)
+PREFECT_EXPERIMENTAL_ENABLE_WORK_QUEUE_STATUS = Setting(bool, default=True)
 """
 Whether or not to enable experimental work queue status in-place of work queue health.
 """

--- a/tests/_internal/compatibility/test_experimental.py
+++ b/tests/_internal/compatibility/test_experimental.py
@@ -474,6 +474,7 @@ def test_enabled_experiments_with_opt_in():
         "workspace_dashboard",
         "deployment_status",
         "enhanced_cancellation",
+        "work_queue_status",
     }
 
 
@@ -486,4 +487,5 @@ def test_enabled_experiments_without_opt_in():
         "workspace_dashboard",
         "deployment_status",
         "enhanced_cancellation",
+        "work_queue_status",
     }

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -37,6 +37,7 @@ def test_app_exposes_ui_settings():
         "workspace_dashboard",
         "deployment_status",
         "enhanced_cancellation",
+        "work_queue_status",
     }
 
 
@@ -57,4 +58,5 @@ def test_app_exposes_ui_settings_with_experiments_enabled():
         "workspace_dashboard",
         "deployment_status",
         "enhanced_cancellation",
+        "work_queue_status",
     }


### PR DESCRIPTION
This PR changes the default value for our feature flag enabling `WorkQueue` status indicators in the UI. 

<!-- Include an overview here -->

### Example
There is no need to enable work queue status via environment variables, just start the server:

```
❯ prefect server start

 ___ ___ ___ ___ ___ ___ _____
| _ \ _ \ __| __| __/ __|_   _|
|  _/   / _|| _|| _| (__  | |
|_| |_|_\___|_| |___\___| |_|

Configure Prefect to communicate with the server with:

    prefect config set PREFECT_API_URL=http://127.0.0.1:4200/api

View the API reference documentation at http://127.0.0.1:4200/docs

Check out the dashboard at http://127.0.0.1:4200
```
And enjoy the new status indicators:
<img width="970" alt="image" src="https://github.com/PrefectHQ/prefect/assets/62311618/69720a80-8aa8-4b3d-ba4c-be4dcd06cf17">

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.