### PR TITLE
[task scheduling] add intermediate `Pending` state and update policy

### DIFF
--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -83,7 +83,7 @@ class AutonomousTaskPolicy(BaseOrchestrationPolicy):
 
     def priority():
         return [
-            PreventRunningToRunningTransitions,
+            PreventPendingTransitions,
             CacheRetrieval,
             HandleTaskTerminalStateTransitions,
             SecureTaskConcurrencySlots,  # retrieve cached states even if slots are full
@@ -1004,20 +1004,3 @@ class PreventDuplicateTransitions(BaseOrchestrationRule):
                 state=None,
                 reason="This run has already made this state transition.",
             )
-
-
-class PreventRunningToRunningTransitions(BaseOrchestrationRule):
-    """Prevents transitions from Running to Running states."""
-
-    FROM_STATES = [StateType.RUNNING]
-    TO_STATES = [StateType.RUNNING]
-
-    async def before_transition(
-        self,
-        initial_state: Optional[states.State],
-        proposed_state: Optional[states.State],
-        context: OrchestrationContext,
-    ) -> None:
-        await self.abort_transition(
-            reason="Cannot transition from Running to Running.",
-        )

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -9,6 +9,7 @@ from typing import (
 )
 
 import anyio
+import greenback
 from typing_extensions import Literal
 
 from prefect._internal.concurrency.api import create_call, from_async, from_sync
@@ -68,4 +69,5 @@ async def submit_autonomous_task_to_engine(
             if task.isasync:
                 return await from_async.wait_for_call_in_loop_thread(begin_run)
             else:
+                await greenback.ensure_portal()
                 return from_sync.wait_for_call_in_loop_thread(begin_run)

--- a/src/prefect/task_server.py
+++ b/src/prefect/task_server.py
@@ -163,7 +163,7 @@ class TaskServer:
         if not state.is_pending():
             logger.warning(
                 f"Aborted task run {task_run.id!r} -"
-                f" Server returned a non-pending state {state.type.value!r}."
+                f" server returned a non-pending state {state.type.value!r}."
                 " Task run may have already begun execution."
             )
 

--- a/tests/server/api/test_task_runs.py
+++ b/tests/server/api/test_task_runs.py
@@ -526,8 +526,11 @@ class TestSetTaskRunState:
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    async def test_autonomous_task_run_aborts_if_transitions_to_running_twice(
-        self, client, session
+    @pytest.mark.parametrize(
+        "incoming_state_type", ["PENDING", "RUNNING", "CANCELLED", "CANCELLING"]
+    )
+    async def test_autonomous_task_run_aborts_if_enters_pending_from_disallowed_state(
+        self, client, session, incoming_state_type
     ):
         autonomous_task_run = await models.task_runs.create_task_run(
             session=session,
@@ -543,7 +546,7 @@ class TestSetTaskRunState:
 
         response_1 = await client.post(
             f"/task_runs/{autonomous_task_run.id}/set_state",
-            json=dict(state=dict(type="RUNNING")),
+            json=dict(state=dict(type=incoming_state_type)),
         )
 
         api_response_1 = OrchestrationResult.parse_obj(response_1.json())
@@ -552,7 +555,7 @@ class TestSetTaskRunState:
 
         response_2 = await client.post(
             f"/task_runs/{autonomous_task_run.id}/set_state",
-            json=dict(state=dict(type="RUNNING")),
+            json=dict(state=dict(type="PENDING")),
         )
 
         api_response_2 = OrchestrationResult.parse_obj(response_2.json())

--- a/tests/server/orchestration/test_core_policy.py
+++ b/tests/server/orchestration/test_core_policy.py
@@ -31,7 +31,6 @@ from prefect.server.orchestration.core_policy import (
     PreventDuplicateTransitions,
     PreventPendingTransitions,
     PreventRunningTasksFromStoppedFlows,
-    PreventRunningToRunningTransitions,
     ReleaseTaskConcurrencySlots,
     RenameReruns,
     RetryFailedFlows,
@@ -3134,20 +3133,3 @@ class TestPreventDuplicateTransitions:
 
         # states have the same transition id so the transition should be rejected
         assert ctx.response_status == SetStateStatus.REJECT
-
-
-class TestPreventRunningToRunningTransitions:
-    async def test_prevents_running_to_running_transitions(
-        self,
-        session,
-        initialize_orchestration,
-    ):
-        transition = (StateType.RUNNING, StateType.RUNNING)
-        context = await initialize_orchestration(
-            session, "flow", *transition, initial_details=None, proposed_details=None
-        )
-
-        async with PreventRunningToRunningTransitions(context, *transition) as ctx:
-            await ctx.validate_proposed_state()
-
-        assert ctx.response_status == SetStateStatus.ABORT


### PR DESCRIPTION
based on discussion, we should:
- have autonomous task runs go from `SCHEDULED` -> `PENDING` -> `RUNNING`
- prevent `PENDING` -> `PENDING` (using the existing `PreventPendingTransitions` rule) instead of `RUNNING` -> `RUNNING`