### PR TITLE
stop creating `default-agent-pool`

### DIFF
--- a/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
+++ b/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
@@ -122,7 +122,8 @@
           "auto_deregister_task_definition": "{{ auto_deregister_task_definition }}",
           "vpc_id": "{{ vpc_id }}",
           "container_name": "{{ container_name }}",
-          "cluster": "{{ cluster }}"
+          "cluster": "{{ cluster }}",
+          "match_latest_revision_in_family": "{{ match_latest_revision_in_family }}"
         },
         "variables": {
           "description": "Variables for templating an ECS job.",
@@ -263,6 +264,12 @@
             "auto_deregister_task_definition": {
               "title": "Auto Deregister Task Definition",
               "description": "If enabled, any task definitions that are created by this block will be deregistered. Existing task definitions linked by ARN will never be deregistered. Deregistering a task definition does not remove it from your AWS account, instead it will be marked as INACTIVE.",
+              "default": false,
+              "type": "boolean"
+            },
+            "match_latest_revision_in_family": {
+              "title": "Match Latest Revision In Family",
+              "description": "If enabled, the most recent active revision in the task definition family will be compared against the desired ECS task configuration. If they are equal, the existing task definition will be used instead of registering a new one. If no family is specified the default family \"prefect\" will be used.",
               "default": false,
               "type": "boolean"
             }

--- a/src/prefect/server/database/migrations/versions/postgresql/2023_01_31_110543_f98ae6d8e2cc_work_queue_data_migration.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2023_01_31_110543_f98ae6d8e2cc_work_queue_data_migration.py
@@ -35,6 +35,13 @@ def upgrade():
     if default_pool_id_result:
         default_pool_id = default_pool_id_result[0]
 
+        # Update work_queue rows with null work_pool_id to use the default_pool_id
+        connection.execute(
+            sa.text(
+                "UPDATE work_queue SET work_pool_id = :default_pool_id WHERE work_pool_id IS NULL"
+            ).params({"default_pool_id": default_pool_id}),
+        )
+
         # Set priority on all queues and update flow runs and deployments
         queue_rows = connection.execute(
             sa.text(

--- a/src/prefect/server/database/migrations/versions/postgresql/2023_01_31_110543_f98ae6d8e2cc_work_queue_data_migration.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2023_01_31_110543_f98ae6d8e2cc_work_queue_data_migration.py
@@ -26,107 +26,71 @@ def upgrade():
         " deployment (work_queue_id, work_queue_name)"
     )
 
-    # Create default agent work pool and associate all existing queues with it
+    # Get the default pool ID if it exists
     connection = op.get_bind()
-
-    connection.execute(
-        sa.text(
-            "INSERT INTO work_pool (name, type) VALUES ('default-agent-pool',"
-            " 'prefect-agent')"
-        )
-    )
-
-    default_pool_id = connection.execute(
+    default_pool_id_result = connection.execute(
         sa.text("SELECT id FROM work_pool WHERE name = 'default-agent-pool'")
-    ).fetchone()[0]
-
-    default_queue = connection.execute(
-        sa.text("SELECT id FROM work_queue WHERE name = 'default'")
     ).fetchone()
 
-    if not default_queue:
-        connection.execute(
+    if default_pool_id_result:
+        default_pool_id = default_pool_id_result[0]
+
+        # Set priority on all queues and update flow runs and deployments
+        queue_rows = connection.execute(
             sa.text(
-                "INSERT INTO work_queue (name, work_pool_id) VALUES ('default',"
-                " :default_pool_id)"
+                "SELECT id, name FROM work_queue WHERE work_pool_id = :default_pool_id"
             ).params({"default_pool_id": default_pool_id}),
-        )
+        ).fetchall()
 
-    connection.execute(
-        sa.text(
-            "UPDATE work_queue SET work_pool_id = :default_pool_id WHERE work_pool_id"
-            " IS NULL"
-        ).params({"default_pool_id": default_pool_id}),
-    )
-
-    default_queue_id = connection.execute(
-        sa.text(
-            "SELECT id FROM work_queue WHERE name = 'default' and work_pool_id ="
-            " :default_pool_id"
-        ).params({"default_pool_id": default_pool_id}),
-    ).fetchone()[0]
-
-    connection.execute(
-        sa.text(
-            "UPDATE work_pool SET default_queue_id = :default_queue_id WHERE id ="
-            " :default_pool_id"
-        ).params(
-            {"default_pool_id": default_pool_id, "default_queue_id": default_queue_id}
-        ),
-    )
-
-    # Set priority on all queues and update flow runs and deployments
-    queue_rows = connection.execute(
-        sa.text(
-            "SELECT id, name FROM work_queue WHERE work_pool_id = :default_pool_id"
-        ).params({"default_pool_id": default_pool_id}),
-    ).fetchall()
-
-    with op.get_context().autocommit_block():
-        for enumeration, row in enumerate(queue_rows):
-            connection.execute(
-                sa.text(
-                    "UPDATE work_queue SET priority = :priority WHERE id = :id"
-                ).params({"priority": enumeration + 1, "id": row[0]}),
-            )
-
-            batch_size = 250
-
-            while True:
-                result = connection.execute(
+        with op.get_context().autocommit_block():
+            for enumeration, row in enumerate(queue_rows):
+                connection.execute(
                     sa.text(
-                        """
-                        UPDATE flow_run 
-                        SET work_queue_id=:id 
-                        WHERE flow_run.id in (
-                            SELECT id 
-                            FROM flow_run 
-                            WHERE flow_run.work_queue_id IS NULL and flow_run.work_queue_name=:name 
-                            LIMIT :batch_size
-                        )
-                        """
-                    ).params({"id": row[0], "name": row[1], "batch_size": batch_size}),
+                        "UPDATE work_queue SET priority = :priority WHERE id = :id"
+                    ).params({"priority": enumeration + 1, "id": row[0]}),
                 )
-                if result.rowcount <= batch_size:
-                    break
 
-            while True:
-                result = connection.execute(
-                    sa.text(
-                        """
-                        UPDATE deployment 
-                        SET work_queue_id=:id 
-                        WHERE deployment.id in (
-                            SELECT id 
-                            FROM deployment 
-                            WHERE deployment.work_queue_id IS NULL and deployment.work_queue_name=:name 
-                            LIMIT :batch_size
-                        )
-                        """
-                    ).params({"id": row[0], "name": row[1], "batch_size": batch_size}),
-                )
-                if result.rowcount <= batch_size:
-                    break
+                batch_size = 250
+
+                while True:
+                    result = connection.execute(
+                        sa.text(
+                            """
+                            UPDATE flow_run 
+                            SET work_queue_id=:id 
+                            WHERE flow_run.id in (
+                                SELECT id 
+                                FROM flow_run 
+                                WHERE flow_run.work_queue_id IS NULL and flow_run.work_queue_name=:name 
+                                LIMIT :batch_size
+                            )
+                            """
+                        ).params(
+                            {"id": row[0], "name": row[1], "batch_size": batch_size}
+                        ),
+                    )
+                    if result.rowcount <= batch_size:
+                        break
+
+                while True:
+                    result = connection.execute(
+                        sa.text(
+                            """
+                            UPDATE deployment 
+                            SET work_queue_id=:id 
+                            WHERE deployment.id in (
+                                SELECT id 
+                                FROM deployment 
+                                WHERE deployment.work_queue_id IS NULL and deployment.work_queue_name=:name 
+                                LIMIT :batch_size
+                            )
+                            """
+                        ).params(
+                            {"id": row[0], "name": row[1], "batch_size": batch_size}
+                        ),
+                    )
+                    if result.rowcount <= batch_size:
+                        break
 
     with op.batch_alter_table("work_queue", schema=None) as batch_op:
         batch_op.drop_constraint("uq_work_queue__name")
@@ -152,67 +116,6 @@ def downgrade():
 
     with op.batch_alter_table("work_queue", schema=None) as batch_op:
         batch_op.alter_column("work_pool_id", nullable=True)
-
-    connection = op.get_bind()
-
-    # Delete all non-default queues and pools
-    default_pool_id_result = connection.execute(
-        sa.text("SELECT id FROM work_pool WHERE name = 'default-agent-pool'")
-    ).fetchone()
-    if default_pool_id_result:
-        default_pool_id = default_pool_id_result[0]
-        connection.execute(
-            sa.text(
-                "DELETE FROM work_queue WHERE work_pool_id != :default_pool_id"
-            ).params({"default_pool_id": default_pool_id})
-        )
-    queue_rows = connection.execute(
-        sa.text("SELECT id, name FROM work_queue"),
-    ).fetchall()
-
-    with op.get_context().autocommit_block():
-        for row in queue_rows:
-            batch_size = 250
-
-            while True:
-                result = connection.execute(
-                    sa.text(
-                        """
-                        UPDATE flow_run 
-                        SET work_queue_id=NULL 
-                        WHERE flow_run.id in (
-                            SELECT id 
-                            FROM flow_run 
-                            WHERE flow_run.work_queue_id IS NOT NULL and flow_run.work_queue_id=:id 
-                            LIMIT :batch_size
-                        )
-                        """
-                    ).params({"id": row[0], "batch_size": batch_size}),
-                )
-                if result.rowcount <= batch_size:
-                    break
-
-            while True:
-                result = connection.execute(
-                    sa.text(
-                        """
-                        UPDATE deployment 
-                        SET work_queue_id=NULL 
-                        WHERE deployment.id in (
-                            SELECT id 
-                            FROM deployment 
-                            WHERE deployment.work_queue_id IS NOT NULL and deployment.work_queue_id=:id
-                            LIMIT :batch_size
-                        )
-                        """
-                    ).params({"id": row[0], "batch_size": batch_size}),
-                )
-                if result.rowcount <= batch_size:
-                    break
-
-    connection.execute(sa.text("UPDATE work_queue SET work_pool_id = NULL"))
-
-    connection.execute(sa.text("DELETE FROM work_pool"))
 
     with op.batch_alter_table("work_queue", schema=None) as batch_op:
         batch_op.drop_constraint("uq_work_queue__work_pool_id_name")

--- a/src/prefect/server/database/migrations/versions/sqlite/2023_01_31_105442_1678f2fb8b33_work_queue_data_migration.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2023_01_31_105442_1678f2fb8b33_work_queue_data_migration.py
@@ -37,6 +37,13 @@ def upgrade():
     if default_pool_id_result:
         default_pool_id = default_pool_id_result[0]
 
+        # Update work_queue rows with null work_pool_id to use the default_pool_id
+        connection.execute(
+            sa.text(
+                "UPDATE work_queue SET work_pool_id = :default_pool_id WHERE work_pool_id IS NULL"
+            ).params({"default_pool_id": default_pool_id}),
+        )
+
         # Set priority on all queues and update flow runs and deployments
         queue_rows = connection.execute(
             sa.text(

--- a/src/prefect/server/database/migrations/versions/sqlite/2023_01_31_105442_1678f2fb8b33_work_queue_data_migration.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2023_01_31_105442_1678f2fb8b33_work_queue_data_migration.py
@@ -26,107 +26,71 @@ def upgrade():
         " deployment (work_queue_id, work_queue_name)"
     )
 
-    # Create default agent work pool and associate all existing queues with it
+    # Get the default pool ID if it exists
     connection = op.get_bind()
-
-    connection.execute(
-        sa.text(
-            "INSERT INTO work_pool (name, type) VALUES ('default-agent-pool',"
-            " 'prefect-agent')"
-        )
-    )
-
-    default_pool_id = connection.execute(
+    default_pool_id_result = connection.execute(
         sa.text("SELECT id FROM work_pool WHERE name = 'default-agent-pool'")
-    ).fetchone()[0]
-
-    default_queue = connection.execute(
-        sa.text("SELECT id FROM work_queue WHERE name = 'default'")
     ).fetchone()
 
-    if not default_queue:
-        connection.execute(
+    if default_pool_id_result:
+        default_pool_id = default_pool_id_result[0]
+
+        # Set priority on all queues and update flow runs and deployments
+        queue_rows = connection.execute(
             sa.text(
-                "INSERT INTO work_queue (name, work_pool_id) VALUES ('default',"
-                " :default_pool_id)"
+                "SELECT id, name FROM work_queue WHERE work_pool_id = :default_pool_id"
             ).params({"default_pool_id": default_pool_id}),
-        )
+        ).fetchall()
 
-    connection.execute(
-        sa.text(
-            "UPDATE work_queue SET work_pool_id = :default_pool_id WHERE work_pool_id"
-            " IS NULL"
-        ).params({"default_pool_id": default_pool_id}),
-    )
-
-    default_queue_id = connection.execute(
-        sa.text(
-            "SELECT id FROM work_queue WHERE name = 'default' and work_pool_id ="
-            " :default_pool_id"
-        ).params({"default_pool_id": default_pool_id}),
-    ).fetchone()[0]
-
-    connection.execute(
-        sa.text(
-            "UPDATE work_pool SET default_queue_id = :default_queue_id WHERE id ="
-            " :default_pool_id"
-        ).params(
-            {"default_pool_id": default_pool_id, "default_queue_id": default_queue_id}
-        ),
-    )
-
-    # Set priority on all queues and update flow runs and deployments
-    queue_rows = connection.execute(
-        sa.text(
-            "SELECT id, name FROM work_queue WHERE work_pool_id = :default_pool_id"
-        ).params({"default_pool_id": default_pool_id}),
-    ).fetchall()
-
-    with op.get_context().autocommit_block():
-        for enumeration, row in enumerate(queue_rows):
-            connection.execute(
-                sa.text(
-                    "UPDATE work_queue SET priority = :priority WHERE id = :id"
-                ).params({"priority": enumeration + 1, "id": row[0]}),
-            )
-
-            batch_size = 250
-
-            while True:
-                result = connection.execute(
+        with op.get_context().autocommit_block():
+            for enumeration, row in enumerate(queue_rows):
+                connection.execute(
                     sa.text(
-                        """
-                        UPDATE flow_run 
-                        SET work_queue_id=:id 
-                        WHERE flow_run.id in (
-                            SELECT id 
-                            FROM flow_run 
-                            WHERE flow_run.work_queue_id IS NULL and flow_run.work_queue_name=:name 
-                            LIMIT :batch_size
-                        )
-                        """
-                    ).params({"id": row[0], "name": row[1], "batch_size": batch_size}),
+                        "UPDATE work_queue SET priority = :priority WHERE id = :id"
+                    ).params({"priority": enumeration + 1, "id": row[0]}),
                 )
-                if result.rowcount <= batch_size:
-                    break
 
-            while True:
-                result = connection.execute(
-                    sa.text(
-                        """
-                        UPDATE deployment 
-                        SET work_queue_id=:id 
-                        WHERE deployment.id in (
-                            SELECT id 
-                            FROM deployment 
-                            WHERE deployment.work_queue_id IS NULL and deployment.work_queue_name=:name 
-                            LIMIT :batch_size
-                        )
-                        """
-                    ).params({"id": row[0], "name": row[1], "batch_size": batch_size}),
-                )
-                if result.rowcount <= batch_size:
-                    break
+                batch_size = 250
+
+                while True:
+                    result = connection.execute(
+                        sa.text(
+                            """
+                            UPDATE flow_run 
+                            SET work_queue_id=:id 
+                            WHERE flow_run.id in (
+                                SELECT id 
+                                FROM flow_run 
+                                WHERE flow_run.work_queue_id IS NULL and flow_run.work_queue_name=:name 
+                                LIMIT :batch_size
+                            )
+                            """
+                        ).params(
+                            {"id": row[0], "name": row[1], "batch_size": batch_size}
+                        ),
+                    )
+                    if result.rowcount <= batch_size:
+                        break
+
+                while True:
+                    result = connection.execute(
+                        sa.text(
+                            """
+                            UPDATE deployment 
+                            SET work_queue_id=:id 
+                            WHERE deployment.id in (
+                                SELECT id 
+                                FROM deployment 
+                                WHERE deployment.work_queue_id IS NULL and deployment.work_queue_name=:name 
+                                LIMIT :batch_size
+                            )
+                            """
+                        ).params(
+                            {"id": row[0], "name": row[1], "batch_size": batch_size}
+                        ),
+                    )
+                    if result.rowcount <= batch_size:
+                        break
 
     with op.batch_alter_table("work_queue", schema=None) as batch_op:
         batch_op.drop_constraint("uq_work_queue__name")
@@ -140,7 +104,6 @@ def upgrade():
 
 
 def downgrade():
-    connection = op.get_bind()
     # Create temporary indexes for migration
     op.execute(
         "CREATE INDEX IF NOT EXISTS ix_flow_run__work_queue_id_work_queue_name ON"
@@ -153,65 +116,6 @@ def downgrade():
 
     with op.batch_alter_table("work_queue", schema=None) as batch_op:
         batch_op.alter_column("work_pool_id", nullable=True)
-
-    # Delete all non-default queues and pools
-    default_pool_id_result = connection.execute(
-        sa.text("SELECT id FROM work_pool WHERE name = 'default-agent-pool'")
-    ).fetchone()
-    if default_pool_id_result:
-        default_pool_id = default_pool_id_result[0]
-        connection.execute(
-            sa.text(
-                "DELETE FROM work_queue WHERE work_pool_id != :default_pool_id"
-            ).params({"default_pool_id": default_pool_id})
-        )
-    queue_rows = connection.execute(
-        sa.text("SELECT id, name FROM work_queue"),
-    ).fetchall()
-
-    with op.get_context().autocommit_block():
-        for row in queue_rows:
-            batch_size = 250
-
-            while True:
-                result = connection.execute(
-                    sa.text(
-                        """
-                        UPDATE flow_run 
-                        SET work_queue_id=NULL 
-                        WHERE flow_run.id in (
-                            SELECT id 
-                            FROM flow_run 
-                            WHERE flow_run.work_queue_id IS NOT NULL and flow_run.work_queue_id=:id 
-                            LIMIT :batch_size
-                        )
-                        """
-                    ).params({"id": row[0], "batch_size": batch_size}),
-                )
-                if result.rowcount <= batch_size:
-                    break
-
-            while True:
-                result = connection.execute(
-                    sa.text(
-                        """
-                        UPDATE deployment 
-                        SET work_queue_id=NULL 
-                        WHERE deployment.id in (
-                            SELECT id 
-                            FROM deployment 
-                            WHERE deployment.work_queue_id IS NOT NULL and deployment.work_queue_id=:id
-                            LIMIT :batch_size
-                        )
-                        """
-                    ).params({"id": row[0], "batch_size": batch_size}),
-                )
-                if result.rowcount <= batch_size:
-                    break
-
-    connection.execute(sa.text("UPDATE work_queue SET work_pool_id = NULL"))
-
-    connection.execute(sa.text("DELETE FROM work_pool"))
 
     with op.batch_alter_table("work_queue", schema=None) as batch_op:
         batch_op.drop_constraint("uq_work_queue__work_pool_id_name")


### PR DESCRIPTION
closes #11984 

edits an old data migration that was creating a `default-agent-pool` work pool by default, and associating work-queues with this work pool

this has the misleading side-effect of seeming like a recommendation to new users of the open source server

## previously
![image](https://github.com/PrefectHQ/prefect/assets/31014960/745613ff-0831-42fb-94d6-ed12cd73e485)


### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.