### PR TITLE
Add CLI command to read runs in WQ

### DIFF
--- a/src/prefect/cli/work_queue.py
+++ b/src/prefect/cli/work_queue.py
@@ -1,6 +1,7 @@
 """
 Command line interface for working with work queues.
 """
+
 from textwrap import dedent
 from typing import List, Optional, Union
 from uuid import UUID
@@ -625,4 +626,39 @@ async def delete(
         )
     else:
         success_message = f"Successfully deleted work queue {name!r}"
+    exit_with_success(success_message)
+
+
+@work_app.command("read-runs")
+@experimental_parameter("pool", group="work_pools", when=lambda y: y is not None)
+async def read_wq_runs(
+    name: str = typer.Argument(..., help="The name or ID of the work queue to poll"),
+    pool: Optional[str] = typer.Option(
+        None,
+        "-p",
+        "--pool",
+        help="The name of the work pool containing the work queue to poll.",
+    ),
+):
+    """
+    Get runs in a work queue. Note that this will trigger an artificial poll of
+    the work queue.
+    """
+
+    queue_id = await _get_work_queue_id_from_name_or_id(
+        name_or_id=name,
+        work_pool_name=pool,
+    )
+    async with get_client() as client:
+        try:
+            runs = await client.get_runs_in_work_queue(id=queue_id)
+        except ObjectNotFound:
+            if pool:
+                error_message = f"No work queue found: {name!r} in work pool {pool!r}"
+            else:
+                error_message = f"No work queue found: {name!r}"
+            exit_with_error(error_message)
+    success_message = (
+        f"Read {len(runs)} runs for work queue {name!r} in work pool {pool}: {runs}"
+    )
     exit_with_success(success_message)

--- a/tests/cli/test_work_queues.py
+++ b/tests/cli/test_work_queues.py
@@ -1,6 +1,9 @@
+import uuid
+
 import pytest
 
 import prefect.exceptions
+from prefect import flow
 from prefect.testing.cli import invoke_and_assert
 from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
 
@@ -586,3 +589,49 @@ class TestLS:
             expected_code=1,
         )
         assert f"No work pool found: '{work_queue_1.work_pool.name}-bad'" in res.output
+
+
+class TestReadRuns:
+    @sync_compatible
+    async def create_runs_in_queue(self, prefect_client, queue, count: int):
+        foo = flow(lambda: None, name="foo")
+        flow_id = await prefect_client.create_flow(foo)
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name="test-deployment",
+            manifest_path="file.json",
+            work_queue_name=queue.name,
+        )
+        for _ in range(count):
+            await prefect_client.create_flow_run_from_deployment(deployment_id)
+
+    def test_read_wq(self, prefect_client, work_queue):
+        n_runs = 3
+        self.create_runs_in_queue(prefect_client, work_queue, n_runs)
+        cmd = f"work-queue read-runs {work_queue.name}"
+        result = invoke_and_assert(command=cmd, expected_code=0)
+        assert f"Read {n_runs} runs for work queue" in result.output
+
+    def test_read_wq_with_pool(self, prefect_client, work_queue):
+        n_runs = 3
+        self.create_runs_in_queue(prefect_client, work_queue, n_runs)
+        cmd = (
+            f"work-queue read-runs --pool {work_queue.work_pool.name} {work_queue.name}"
+        )
+        result = invoke_and_assert(command=cmd, expected_code=0)
+        assert f"Read {n_runs} runs for work queue" in result.output
+
+    def test_read_missing_wq(self, work_queue):
+        bad_name = str(uuid.uuid4())
+        cmd = f"work-queue read-runs --pool {work_queue.work_pool.name} {bad_name}"
+        result = invoke_and_assert(command=cmd, expected_code=1)
+        assert f"No work queue found: '{bad_name}'" in result.output
+
+    def test_read_wq_with_missing_pool(self, work_queue):
+        bad_name = str(uuid.uuid4())
+        cmd = f"work-queue read-runs --pool {bad_name} {work_queue.name}"
+        result = invoke_and_assert(command=cmd, expected_code=1)
+        assert (
+            f"No work queue named '{work_queue.name}' found in work pool '{bad_name}'"
+            in result.output
+        )


### PR DESCRIPTION
This PR adds a CLI command to make it easy to read the runs off of a work queue:

```
❯ prefect work-queue read-runs --pool local-process-wp local-wq-2
Read 0 runs for work queue 'local-wq-2' in work pool local-process-wp: []
```

My main use case was simulating a worker/agent poll to a work queue to simulate work queue status events. The command was useful during testing and I can image it being useful to test other work queue status related things (i.e. automations, events). Note that running this command is equivalent to a worker polling a work queue and may lead to a temporary false positive where it looks like "something is polling for work" but it was just a one time command. 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.