### PR TITLE
Switching to the astral-sh pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.2.1"
     hooks:
-      - id: ruff-format
       - id: ruff
         language_version: python3
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
+      - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 ruff
 cairosvg
-codespell
+codespell>=2.2.6
 ddtrace
 # Pin IPython to 8.12 when building on Python 3.8
 # https://github.com/ipython/ipython/blob/main/README.rst


### PR DESCRIPTION
In their README, they recommend putting putting the linter with `--fix` first,
before the formatter.
