### PR TITLE
Update `clear_db` to clear the DB before running a test

### DIFF
--- a/tests/agent/test_agent_run_cancellation.py
+++ b/tests/agent/test_agent_run_cancellation.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Generator
 from unittest.mock import call
 
@@ -133,7 +134,8 @@ async def test_agent_cancel_run_called_for_cancelling_run_with_multiple_work_que
     deployment: ORMDeployment,
     cancelling_constructor,
 ):
-    deployment.work_queue_name = "foo"
+    work_queue = f"foo-{uuid.uuid4()}"
+    deployment.work_queue_name = work_queue
     await prefect_client.update_deployment(deployment)
 
     flow_run = await prefect_client.create_flow_run_from_deployment(
@@ -141,7 +143,11 @@ async def test_agent_cancel_run_called_for_cancelling_run_with_multiple_work_que
         state=cancelling_constructor(),
     )
 
-    async with PrefectAgent(work_queues=["foo", "bar"], prefetch_seconds=10) as agent:
+    async with PrefectAgent(
+        # one existing and one non-existing work queue
+        work_queues=[work_queue, str(uuid.uuid4())],
+        prefetch_seconds=10,
+    ) as agent:
         agent.cancel_run = AsyncMock()
         await agent.check_for_cancelled_flow_runs()
 
@@ -156,11 +162,13 @@ async def test_agent_cancel_run_called_for_each_cancelling_run_in_multiple_work_
     deployment: ORMDeployment,
     cancelling_constructor,
 ):
+    wq1 = f"foo-{uuid.uuid4()}"
+    wq2 = f"bar-{uuid.uuid4()}"
     deployment_foo = await _create_test_deployment_from_orm(
-        prefect_client, deployment, work_queue_name="foo"
+        prefect_client, deployment, work_queue_name=wq1
     )
     deployment_bar = await _create_test_deployment_from_orm(
-        prefect_client, deployment, work_queue_name="bar"
+        prefect_client, deployment, work_queue_name=wq2
     )
 
     flow_run_foo = await prefect_client.create_flow_run_from_deployment(
@@ -172,7 +180,7 @@ async def test_agent_cancel_run_called_for_each_cancelling_run_in_multiple_work_
         state=cancelling_constructor(),
     )
 
-    async with PrefectAgent(work_queues=["foo", "bar"], prefetch_seconds=10) as agent:
+    async with PrefectAgent(work_queues=[wq1, wq2], prefetch_seconds=10) as agent:
         agent.cancel_run = AsyncMock()
         await agent.check_for_cancelled_flow_runs()
 
@@ -599,7 +607,7 @@ async def test_agent_started_in_different_work_pool_with_same_work_queue_name_do
         deployment.id,
         state=cancelling_constructor(),
     )
-    assert flow_run.work_pool_name == "test-work-pool"
+    assert flow_run.work_pool_name == deployment.work_queue.work_pool.name
 
     async with PrefectAgent(
         work_pool_name="another-work-pool",
@@ -626,7 +634,7 @@ async def test_agent_started_in_same_work_pool_with_same_work_queue_name_cancels
         deployment.id,
         state=cancelling_constructor(),
     )
-    assert flow_run.work_pool_name == "test-work-pool"
+    assert flow_run.work_pool_name == deployment.work_queue.work_pool.name
 
     async with PrefectAgent(
         work_pool_name=flow_run.work_pool_name,
@@ -654,7 +662,7 @@ async def test_agent_started_in_same_work_pool_with_different_work_queue_name_do
         deployment.id,
         state=cancelling_constructor(),
     )
-    assert flow_run.work_queue_name == "wq-1"
+    assert flow_run.work_queue_name == deployment.work_queue.name
 
     async with PrefectAgent(
         work_pool_name=flow_run.work_pool_name,
@@ -681,11 +689,11 @@ async def test_agent_started_without_work_pool_does_not_cancel_flow_run_in_nonde
         deployment.id,
         state=cancelling_constructor(),
     )
-    assert flow_run.work_queue_name == "wq-1"
-    assert flow_run.work_pool_name == "test-work-pool"
+    assert flow_run.work_queue_name == deployment.work_queue.name
+    assert flow_run.work_pool_name == deployment.work_queue.work_pool.name
 
     async with PrefectAgent(
-        work_queues=["wq-1"],
+        work_queues=[deployment.work_queue.name],
         prefetch_seconds=10,
     ) as agent:
         assert agent.work_pool_name is None
@@ -709,12 +717,12 @@ async def test_agent_started_with_nondefault_work_pool_does_not_cancel_flow_run_
         deployment_in_default_work_pool.id,
         state=cancelling_constructor(),
     )
-    assert flow_run.work_queue_name == "wq-1"
+    assert flow_run.work_queue_name == deployment_in_default_work_pool.work_queue.name
     assert flow_run.work_pool_name == "default-agent-pool"
 
     async with PrefectAgent(
-        work_pool_name="test-work-pool",
-        work_queues=["wq-1"],
+        work_pool_name=f"non-default-{uuid.uuid4()}",
+        work_queues=[deployment_in_default_work_pool.work_queue.name],
         prefetch_seconds=10,
     ) as agent:
         await agent.check_for_cancelled_flow_runs()

--- a/tests/agent/test_agent_run_submission.py
+++ b/tests/agent/test_agent_run_submission.py
@@ -1,5 +1,6 @@
 import datetime
 import inspect
+import uuid
 from typing import Generator
 from unittest.mock import MagicMock
 
@@ -87,11 +88,8 @@ async def test_agent_with_work_queue(prefect_client, deployment):
     flow_run_ids = [run.id for run in flow_runs]
 
     # Pull runs from the work queue to get expected runs
-    work_queue = await prefect_client.read_work_queue_by_name(
-        deployment.work_queue_name
-    )
     work_queue_runs = await prefect_client.get_runs_in_work_queue(
-        work_queue.id, scheduled_before=pendulum.now("UTC").add(seconds=10)
+        deployment.work_queue.id, scheduled_before=pendulum.now("UTC").add(seconds=10)
     )
     work_queue_flow_run_ids = {run.id for run in work_queue_runs}
 
@@ -99,7 +97,7 @@ async def test_agent_with_work_queue(prefect_client, deployment):
     # Should not include runs without deployments
     assert work_queue_flow_run_ids == set(flow_run_ids[1:4])
 
-    agent = PrefectAgent(work_queues=[work_queue.name], prefetch_seconds=10)
+    agent = PrefectAgent(work_queues=[deployment.work_queue.name], prefetch_seconds=10)
 
     async with agent:
         agent.submit_run = AsyncMock()  # do not actually run anything
@@ -140,11 +138,8 @@ async def test_agent_with_work_queue_and_limit(prefect_client, deployment):
     flow_run_ids = [run.id for run in flow_runs]
 
     # Pull runs from the work queue to get expected runs
-    work_queue = await prefect_client.read_work_queue_by_name(
-        deployment.work_queue_name
-    )
     work_queue_runs = await prefect_client.get_runs_in_work_queue(
-        work_queue.id, scheduled_before=pendulum.now("UTC").add(seconds=10)
+        deployment.work_queue.id, scheduled_before=pendulum.now("UTC").add(seconds=10)
     )
     work_queue_runs.sort(key=lambda run: run.next_scheduled_start_time)
     work_queue_flow_run_ids = [run.id for run in work_queue_runs]
@@ -153,7 +148,9 @@ async def test_agent_with_work_queue_and_limit(prefect_client, deployment):
     # Should not include runs without deployments
     assert set(work_queue_flow_run_ids) == set(flow_run_ids[1:4])
 
-    agent = PrefectAgent(work_queues=[work_queue.name], prefetch_seconds=10, limit=2)
+    agent = PrefectAgent(
+        work_queues=[deployment.work_queue.name], prefetch_seconds=10, limit=2
+    )
 
     async with agent:
         agent.submit_run = AsyncMock()  # do not actually run anything
@@ -176,23 +173,23 @@ async def test_agent_with_work_queue_and_limit(prefect_client, deployment):
 async def test_agent_matches_work_queues_dynamically(
     session, work_queue, prefect_caplog
 ):
-    name = "wq-1"
-    assert await models.work_queues.read_work_queue_by_name(session=session, name=name)
+    assert await models.work_queues.read_work_queue_by_name(
+        session=session, name=work_queue.name
+    )
     async with PrefectAgent(work_queue_prefix=["wq-"]) as agent:
-        assert name not in agent.work_queues
+        assert work_queue.name not in agent.work_queues
         await agent.get_and_submit_flow_runs()
-        assert name in agent.work_queues
+        assert work_queue.name in agent.work_queues
 
-    assert f"Matched new work queues: {name}" in prefect_caplog.text
+    assert "Matched new work queues:" in prefect_caplog.text
+    assert work_queue.name in prefect_caplog.text
 
 
-async def test_agent_matches_multiple_work_queues_dynamically(
-    session, prefect_client, prefect_caplog
-):
+async def test_agent_matches_multiple_work_queues_dynamically(prefect_client):
     prod1 = "prod-deployment-1"
     prod2 = "prod-deployment-2"
     prod3 = "prod-deployment-3"
-    dev1 = "dev-data-producer"
+    dev1 = "dev-data-producer-1"
     await prefect_client.create_work_queue(name=prod1)
     await prefect_client.create_work_queue(name=prod2)
 
@@ -215,11 +212,9 @@ async def test_agent_matches_multiple_work_queues_dynamically(
         ), "work queue matcher should not match partial names"
 
 
-async def test_agent_matches_multiple_work_queue_prefixes(
-    session, prefect_client, prefect_caplog
-):
-    prod = "prod-deployment"
-    dev = "dev-data-producer"
+async def test_agent_matches_multiple_work_queue_prefixes(prefect_client):
+    prod = "prod-deployment-4"
+    dev = "dev-data-producer-2"
     await prefect_client.create_work_queue(name=prod)
     await prefect_client.create_work_queue(name=dev)
 
@@ -233,26 +228,29 @@ async def test_agent_matches_multiple_work_queue_prefixes(
 async def test_matching_work_queues_handes_work_queue_deletion(
     session, work_queue, prefect_client, prefect_caplog
 ):
-    name = "wq-1"
-    assert await models.work_queues.read_work_queue_by_name(session=session, name=name)
+    assert await models.work_queues.read_work_queue_by_name(
+        session=session, name=work_queue.name
+    )
     async with PrefectAgent(work_queue_prefix=["wq-"]) as agent:
         await agent.get_and_submit_flow_runs()
-        assert name in agent.work_queues
+        assert work_queue.name in agent.work_queues
 
         # bypass work_queue caching
         agent._work_queue_cache_expiration = pendulum.now("UTC") - pendulum.duration(
             minutes=1
         )
+        assert "Matched new work queues:" in prefect_caplog.text
+        assert work_queue.name in prefect_caplog.text
         await prefect_client.delete_work_queue_by_id(work_queue.id)
         await agent.get_and_submit_flow_runs()
-        assert name not in agent.work_queues
-
-    assert f"Matched new work queues: {name}" in prefect_caplog.text
-    assert f"Work queues no longer matched: {name}" in prefect_caplog.text
+        assert work_queue.name not in agent.work_queues
+        assert (
+            f"Work queues no longer matched: {work_queue.name}" in prefect_caplog.text
+        )
 
 
 async def test_agent_creates_work_queue_if_doesnt_exist(session, prefect_caplog):
-    name = "hello-there"
+    name = f"hello-there-{uuid.uuid4()}"
     assert not await models.work_queues.read_work_queue_by_name(
         session=session, name=name
     )
@@ -268,7 +266,7 @@ async def test_agent_creates_work_queue_if_doesnt_exist_in_work_pool(
     work_pool,
     prefect_caplog,
 ):
-    name = "hello-there"
+    name = f"hello-there-{uuid.uuid4()}"
     assert not await models.workers.read_work_queue_by_name(
         session=session, work_pool_name=work_pool.name, work_queue_name=name
     )
@@ -286,11 +284,15 @@ async def test_agent_creates_work_queue_if_doesnt_exist_in_work_pool(
 async def test_agent_does_not_create_work_queues_if_matching_with_prefix(
     session, prefect_caplog, prefect_client: PrefectClient
 ):
-    await prefect_client.create_work_pool(
-        WorkPoolCreate(name=DEFAULT_AGENT_WORK_POOL_NAME, type="prefect-agent")
+    default_work_pool = await prefect_client.read_work_pool(
+        DEFAULT_AGENT_WORK_POOL_NAME
     )
+    if not default_work_pool:
+        await prefect_client.create_work_pool(
+            WorkPoolCreate(name=DEFAULT_AGENT_WORK_POOL_NAME, type="prefect-agent")
+        )
 
-    name = "hello-there"
+    name = f"hello-there-{uuid.uuid4()}"
     assert not await models.work_queues.read_work_queue_by_name(
         session=session, name=name
     )
@@ -315,7 +317,7 @@ async def test_agent_gracefully_handles_error_when_creating_work_queue(
     would attempt to create it, but only one would create it successfully; the
     others would get an error because it already exists. In that case, we want to handle the error gracefully.
     """
-    name = "hello-there"
+    name = f"hello-there-{uuid.uuid4()}"
     assert not await models.workers.read_work_queue_by_name(
         session=session, work_queue_name=name, work_pool_name=work_pool.name
     )
@@ -338,9 +340,7 @@ async def test_agent_gracefully_handles_error_when_creating_work_queue(
 
 
 async def test_agent_caches_work_queues(prefect_client, deployment, monkeypatch):
-    work_queue = await prefect_client.read_work_queue_by_name(
-        deployment.work_queue_name
-    )
+    work_queue = await prefect_client.read_work_queue(deployment.work_queue.id)
 
     async def read_queue(name, work_pool_name=None):
         return work_queue
@@ -365,9 +365,7 @@ async def test_agent_with_work_queue_name_survives_queue_deletion(
     prefect_client, deployment
 ):
     """Ensure that cached work queues don't create errors if deleted"""
-    work_queue = await prefect_client.read_work_queue_by_name(
-        deployment.work_queue_name
-    )
+    work_queue = await prefect_client.read_work_queue(deployment.work_queue.id)
 
     async with PrefectAgent(
         work_queues=[work_queue.name], prefetch_seconds=10
@@ -905,34 +903,32 @@ class TestInfrastructureIntegration:
 
 
 async def test_agent_displays_message_on_work_queue_pause(
-    prefect_client, prefect_caplog, deployment
+    prefect_client, prefect_caplog, deployment_in_default_work_pool
 ):
-    work_queue = await prefect_client.read_work_queue_by_name(
-        deployment.work_queue_name
-    )
-
     async with PrefectAgent(
-        work_queues=[deployment.work_queue_name], prefetch_seconds=10
+        work_queues=[deployment_in_default_work_pool.work_queue.name],
+        prefetch_seconds=10,
     ) as agent:
         agent.submit_run = AsyncMock()  # do not actually run
 
         await agent.get_and_submit_flow_runs()
 
         assert (
-            f"Work queue {work_queue.name!r} ({work_queue.id}) is paused."
+            f"Work queue {deployment_in_default_work_pool.work_queue.name!r} ({deployment_in_default_work_pool.work_queue.id}) is paused."
             not in prefect_caplog.text
         ), "Message should not be displayed before pausing"
 
-        await prefect_client.update_work_queue(work_queue.id, is_paused=True)
+        await prefect_client.update_work_queue(
+            deployment_in_default_work_pool.work_queue.id, is_paused=True
+        )
 
         # clear agent cache
         agent._work_queue_cache_expiration = pendulum.now("UTC")
 
         # Should emit the paused message
         await agent.get_and_submit_flow_runs()
-
         assert (
-            f"Work queue {work_queue.name!r} ({work_queue.id}) is paused."
+            f"Work queue {deployment_in_default_work_pool.work_queue.name!r} ({deployment_in_default_work_pool.work_queue.id}) is paused."
             in prefect_caplog.text
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,7 +121,7 @@ def pytest_addoption(parser):
     )
 
 
-EXCLUDE_FROM_CLEAR_DB_AUTO_MARK = ["tests/utilities/"]
+EXCLUDE_FROM_CLEAR_DB_AUTO_MARK = ["tests/utilities", "tests/agent"]
 
 
 def pytest_collection_modifyitems(session, config, items):
@@ -195,7 +195,7 @@ def pytest_collection_modifyitems(session, config, items):
         if not any(
             excluded in item.nodeid for excluded in EXCLUDE_FROM_CLEAR_DB_AUTO_MARK
         ):
-            # Apply the custom mark
+            # Apply the custom mark to clear the database prior to the test
             item.add_marker(pytest.mark.clear_db)
 
 

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -107,11 +107,9 @@ async def setup_db(database_engine, db):
 @pytest.fixture(autouse=True)
 async def clear_db(db, request):
     """
-    Delete all data from all tables after running each test, attempting to handle
+    Delete all data from all tables before running each test, attempting to handle
     connection errors.
     """
-
-    yield
 
     if "clear_db" in request.keywords:
         max_retries = 3
@@ -135,6 +133,8 @@ async def clear_db(db, request):
                     await asyncio.sleep(retry_delay)
                 else:
                     raise
+
+    yield
 
 
 @pytest.fixture

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import gc
+import uuid
 import warnings
 
 import aiosqlite
@@ -373,14 +374,7 @@ async def task_run_states(session, task_run, task_run_state):
 @pytest.fixture
 async def storage_document_id(prefect_client, tmpdir):
     return await LocalFileSystem(basepath=str(tmpdir)).save(
-        name="local-test", client=prefect_client
-    )
-
-
-@pytest.fixture
-async def storage_document_id_2(prefect_client):
-    return await LocalFileSystem().save(
-        name="distinct-local-test", client=prefect_client
+        name=f"local-test-{uuid.uuid4()}", client=prefect_client
     )
 
 
@@ -413,7 +407,7 @@ async def deployment(
     deployment = await models.deployments.create_deployment(
         session=session,
         deployment=schemas.core.Deployment(
-            name="My Deployment",
+            name=f"my-deployment-{uuid.uuid4()}",
             tags=["test"],
             flow_id=flow.id,
             schedule=schemas.schedules.IntervalSchedule(
@@ -448,7 +442,7 @@ async def deployment_2(
     deployment = await models.deployments.create_deployment(
         session=session,
         deployment=schemas.core.Deployment(
-            name="My Deployment",
+            name=f"my-deployment-{uuid.uuid4()}",
             tags=["test"],
             flow_id=flow.id,
             schedule=schemas.schedules.IntervalSchedule(
@@ -485,7 +479,7 @@ async def deployment_in_default_work_pool(
     deployment = await models.deployments.create_deployment(
         session=session,
         deployment=schemas.core.Deployment(
-            name="My Deployment",
+            name=f"my-deployment-{uuid.uuid4()}",
             tags=["test"],
             flow_id=flow.id,
             schedule=schemas.schedules.IntervalSchedule(
@@ -520,7 +514,7 @@ async def deployment_in_non_default_work_pool(
     deployment = await models.deployments.create_deployment(
         session=session,
         deployment=schemas.core.Deployment(
-            name="My Deployment",
+            name=f"my-deployment-{uuid.uuid4()}",
             tags=["test"],
             flow_id=flow.id,
             schedule=schemas.schedules.IntervalSchedule(
@@ -548,7 +542,7 @@ async def deployment_with_parameter_schema(
     deployment = await models.deployments.create_deployment(
         session=session,
         deployment=schemas.core.Deployment(
-            name="My Deployment X",
+            name=f"my-deployment-with-parameter-schema{uuid.uuid4()}",
             flow_id=flow.id,
             parameter_openapi_schema={
                 "type": "object",
@@ -567,7 +561,9 @@ async def work_queue(session):
     work_queue = await models.work_queues.create_work_queue(
         session=session,
         work_queue=schemas.actions.WorkQueueCreate(
-            name="wq-1", description="All about my work queue", priority=1
+            name=f"wq-1-{uuid.uuid4()}",
+            description="All about my work queue",
+            priority=1,
         ),
     )
     await session.commit()
@@ -579,7 +575,7 @@ async def work_pool(session):
     model = await models.workers.create_work_pool(
         session=session,
         work_pool=schemas.actions.WorkPoolCreate(
-            name="test-work-pool",
+            name=f"test-work-pool-{uuid.uuid4()}",
             type="test-type",
             base_job_template={
                 "job_configuration": {
@@ -736,7 +732,7 @@ async def work_queue_1(session, work_pool):
     model = await models.workers.create_work_queue(
         session=session,
         work_pool_id=work_pool.id,
-        work_queue=schemas.actions.WorkQueueCreate(name="wq-1"),
+        work_queue=schemas.actions.WorkQueueCreate(name=f"wq-1-{uuid.uuid4()}"),
     )
     await session.commit()
     return model

--- a/tests/server/api/test_work_queues.py
+++ b/tests/server/api/test_work_queues.py
@@ -160,7 +160,7 @@ class TestReadWorkQueue:
         response = await client.get(f"/work_queues/{work_queue.id}")
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["id"] == str(work_queue.id)
-        assert response.json()["name"] == "wq-1"
+        assert response.json()["name"] == work_queue.name
         assert response.json()["work_pool_name"] == "default-agent-pool"
 
     async def test_read_work_queue_returns_404_if_does_not_exist(self, client):

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -3570,7 +3570,8 @@ class TestFlowDeploy:
         )
 
         console_output = capsys.readouterr().out
-        assert f"prefect worker start --pool {work_pool.name!r}" in console_output
+        assert "prefect worker start --pool" in console_output
+        assert work_pool.name in console_output
         assert "prefect deployment run 'local-flow-deploy/test'" in console_output
 
     async def test_calls_deploy_with_expected_args_remote_flow(

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -1911,7 +1911,7 @@ async def test_get_flow_run_logger(
     )
 
     async with WorkerTestImpl(
-        name="test", work_pool_name="test-work-pool", create_pool_if_not_found=False
+        name="test", work_pool_name=work_pool.name, create_pool_if_not_found=False
     ) as worker:
         await worker.sync_with_backend()
         logger = worker.get_flow_run_logger(flow_run)
@@ -1922,7 +1922,7 @@ async def test_get_flow_run_logger(
             "flow_run_id": str(flow_run.id),
             "flow_name": "<unknown>",
             "worker_name": "test",
-            "work_pool_name": "test-work-pool",
+            "work_pool_name": work_pool.name,
             "work_pool_id": str(work_pool.id),
         }
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

Updates the `clear_db` fixture to clear the test DB **before** running a test to make it more intuitive for individual tests.

Excludes `test/agents` from DB clearing to slightly decrease the test running time and makes the changes necessary to get the tests to pass.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.