### PR TITLE
Remove extraneous trailing quotation marks in concepts/artifacts docs

### DIFF
--- a/docs/concepts/artifacts.md
+++ b/docs/concepts/artifacts.md
@@ -45,7 +45,7 @@ Currently, you can render three artifact types: links, Markdown, and tables.
 
 To create a link artifact, use the `create_link_artifact()` function.
 To create multiple versions of the same artifact and/or view them on the Artifacts page of the Prefect UI, provide a `key` argument to the `create_link_artifact()` function to track an artifact's history over time.
-Without a `key`, the artifact will only be visible in the Artifacts tab of the associated flow run or task run."
+Without a `key`, the artifact will only be visible in the Artifacts tab of the associated flow run or task run.
 
 ```python
 from prefect import flow, task
@@ -112,7 +112,7 @@ An optional `description` could also be added for context.
 
 To create a Markdown artifact, you can use the `create_markdown_artifact()` function.
 To create multiple versions of the same artifact and/or view them on the Artifacts page of the Prefect UI, provide a `key` argument to the `create_markdown_artifact()` function to track an artifact's history over time.
-Without a `key`, the artifact will only be visible in the Artifacts tab of the associated flow run or task run."
+Without a `key`, the artifact will only be visible in the Artifacts tab of the associated flow run or task run.
 
 !!! warning "Don't indent Markdown"
     Markdown in mult-line strings must be unindented to be interpreted correctly.
@@ -178,7 +178,7 @@ As with all artifacts, you'll be able to view the associated flow run or task ru
 
 You can create a table artifact by calling `create_table_artifact()`.
 To create multiple versions of the same artifact and/or view them on the Artifacts page of the Prefect UI, provide a `key` argument to the `create_table_artifact()` function to track an artifact's history over time.
-Without a `key`, the artifact will only be visible in the artifacts tab of the associated flow run or task run."
+Without a `key`, the artifact will only be visible in the artifacts tab of the associated flow run or task run.
 
 !!! note
     The `create_table_artifact()` function accepts a `table` argument, which can be provided as either a list of lists, a list of dictionaries, or a dictionary of lists.


### PR DESCRIPTION
### Description
This PR removes the following extraneous trailing quotation marks from the artifacts documentation page.

| **Section** | **Screenshot** |
| ---- | ---- |
| Creating link artifacts | <img width="1032" alt="image" src="https://github.com/PrefectHQ/prefect/assets/22418768/4384b01b-c379-4853-8133-e5d765cee41c"> |
| Creating Markdown artifacts | <img width="1029" alt="image" src="https://github.com/PrefectHQ/prefect/assets/22418768/93a3e47f-9b6c-4a0b-a4f5-08510c0162f6"> |
| Creating table artifacts | <img width="1042" alt="image" src="https://github.com/PrefectHQ/prefect/assets/22418768/f1cae02e-e134-457c-8eb0-9328c73b1ca9"> |


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [x] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.