### PR TITLE
Ensure paused and is_schedule_active stay in sync through updates/upserts

### DIFF
--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -132,9 +132,11 @@ class DeploymentCreate(ActionBaseModel):
 
         return values
 
-    @root_validator()
-    def populate_paused(cls, values):
-        if "is_schedule_active" in values:
+    @root_validator(pre=True)
+    def sync_paused_and_is_schedule_active(cls, values):
+        if "paused" in values:
+            values["is_schedule_active"] = not values["paused"]
+        elif "is_schedule_active" in values:
             values["paused"] = not values["is_schedule_active"]
         return values
 
@@ -250,9 +252,11 @@ class DeploymentCreate(ActionBaseModel):
 class DeploymentUpdate(ActionBaseModel):
     """Data used by the Prefect REST API to update a deployment."""
 
-    @root_validator()
-    def populate_paused(cls, values):
-        if "is_schedule_active" in values:
+    @root_validator(pre=True)
+    def sync_paused_and_is_schedule_active(cls, values):
+        if "paused" in values:
+            values["is_schedule_active"] = not values["paused"]
+        elif "is_schedule_active" in values:
             values["paused"] = not values["is_schedule_active"]
         return values
 


### PR DESCRIPTION
This is the OSS side of https://github.com/PrefectHQ/nebula/pull/6979. It ensures that when older clients upsert/update the deployment we keep `paused` in sync and vice-versa.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.