### PR TITLE
Adding a more readable error in case Docker not running 

### DIFF
--- a/src/prefect/utilities/dockerutils.py
+++ b/src/prefect/utilities/dockerutils.py
@@ -112,7 +112,7 @@ def docker_client() -> Generator["DockerClient", None, None]:
             yield client
     except docker.errors.DockerException as exc:
         raise RuntimeError(
-            "This error is likely caused because Docker is not running. Please start Docker and rerun your code."
+            "This error is often thrown because Docker is not running. Please ensure Docker is running."
         ) from exc
     finally:
         client is not None and client.close()

--- a/src/prefect/utilities/dockerutils.py
+++ b/src/prefect/utilities/dockerutils.py
@@ -111,7 +111,9 @@ def docker_client() -> Generator["DockerClient", None, None]:
 
             yield client
     except docker.errors.DockerException as exc:
-        raise RuntimeError("Docker is not running. please run docker and try again") from exc
+        raise RuntimeError(
+            "This error is likely caused because Docker is not running. Please start Docker and rerun your code."
+        ) from exc
     finally:
         client is not None and client.close()
 

--- a/src/prefect/utilities/dockerutils.py
+++ b/src/prefect/utilities/dockerutils.py
@@ -104,13 +104,16 @@ with silence_docker_warnings():
 @contextmanager
 def docker_client() -> Generator["DockerClient", None, None]:
     """Get the environmentally-configured Docker client"""
-    with silence_docker_warnings():
-        client = docker.DockerClient.from_env()
-
+    client = None
     try:
-        yield client
+        with silence_docker_warnings():
+            client = docker.DockerClient.from_env()
+
+            yield client
+    except docker.errors.DockerException as exc:
+        raise RuntimeError("Docker is not running. please run docker and try again") from exc
     finally:
-        client.close()
+        client is not None and client.close()
 
 
 class BuildError(Exception):


### PR DESCRIPTION

When deploying using a Docker image we get an unclear error in case Docker is not running on the local machine.
Added a more readable error Runtime Exception: `Docker is not running. please run docker and try again`

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes #11802"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.