### PR TITLE
Remove scheduled flow runs when updating/removing schedules

### DIFF
--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -738,6 +738,14 @@ async def update_deployment_schedule(
         if not updated:
             raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Schedule not found.")
 
+        if not bool(deployment.paused):
+            await models.deployments._delete_scheduled_runs(
+                session=session,
+                deployment_id=deployment_id,
+                db=db,
+                auto_scheduled_only=True,
+            )
+
 
 @router.delete("/{id}/schedules/{schedule_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_deployment_schedule(
@@ -763,3 +771,11 @@ async def delete_deployment_schedule(
 
         if not deleted:
             raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Schedule not found.")
+
+        if not bool(deployment.paused):
+            await models.deployments._delete_scheduled_runs(
+                session=session,
+                deployment_id=deployment_id,
+                db=db,
+                auto_scheduled_only=True,
+            )


### PR DESCRIPTION
OSS side of https://github.com/PrefectHQ/nebula/pull/6982

Ensures that when we update schedules we also clear out any runs created by those schedules.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.