### PR TITLE
[task scheduling] send up client id if cloud

### DIFF
--- a/src/prefect/task_server.py
+++ b/src/prefect/task_server.py
@@ -86,16 +86,8 @@ class TaskServer:
         self._runs_task_group: anyio.abc.TaskGroup = anyio.create_task_group()
 
     @property
-    def _client_id(self) -> Optional[str]:
-        is_cloud = any(
-            str(self._client.api_url).startswith(url)
-            for url in ("https://api.prefect.cloud", "https://api.prefect.dev")
-        )
-
-        if is_cloud:
-            return f"{socket.gethostname()}-{os.getpid()}"
-        else:
-            return None
+    def _client_id(self) -> str:
+        return f"{socket.gethostname()}-{os.getpid()}"
 
     def handle_sigterm(self, signum, frame):
         """

--- a/src/prefect/task_server.py
+++ b/src/prefect/task_server.py
@@ -1,6 +1,8 @@
 import asyncio
 import inspect
+import os
 import signal
+import socket
 import sys
 from contextlib import AsyncExitStack
 from functools import partial
@@ -83,6 +85,18 @@ class TaskServer:
 
         self._runs_task_group: anyio.abc.TaskGroup = anyio.create_task_group()
 
+    @property
+    def _client_id(self) -> Optional[str]:
+        is_cloud = any(
+            str(self._client.api_url).startswith(url)
+            for url in ("https://api.prefect.cloud", "https://api.prefect.dev")
+        )
+
+        if is_cloud:
+            return f"{socket.gethostname()}-{os.getpid()}"
+        else:
+            return None
+
     def handle_sigterm(self, signum, frame):
         """
         Shuts down the task server when a SIGTERM is received.
@@ -118,9 +132,10 @@ class TaskServer:
 
     async def _subscribe_to_task_scheduling(self):
         async for task_run in Subscription(
-            TaskRun,
-            "/task_runs/subscriptions/scheduled",
-            [task.task_key for task in self.tasks],
+            model=TaskRun,
+            path="/task_runs/subscriptions/scheduled",
+            keys=[task.task_key for task in self.tasks],
+            client_id=self._client_id,
         ):
             logger.info(f"Received task run: {task_run.id} - {task_run.name}")
             await self._submit_scheduled_task_run(task_run)

--- a/tests/test_task_server.py
+++ b/tests/test_task_server.py
@@ -127,6 +127,25 @@ async def test_handle_sigterm(mock_create_subscription):
         mock_stop.assert_called_once()
 
 
+async def test_client_id_not_set_for_open_source():
+    with patch("socket.gethostname", return_value="foo"), patch(
+        "os.getpid", return_value=42
+    ):
+        task_server = TaskServer(...)
+
+        assert task_server._client_id is None
+
+
+async def test_client_id_set_for_cloud():
+    with patch("socket.gethostname", return_value="foo"), patch(
+        "os.getpid", return_value=42
+    ):
+        task_server = TaskServer(...)
+        task_server._client = MagicMock(api_url="https://api.prefect.cloud")
+
+        assert task_server._client_id == "foo-42"
+
+
 @pytest.mark.usefixtures("mock_task_server_start")
 class TestServe:
     async def test_serve_raises_if_task_scheduling_not_enabled(self, foo_task):

--- a/tests/test_task_server.py
+++ b/tests/test_task_server.py
@@ -127,21 +127,12 @@ async def test_handle_sigterm(mock_create_subscription):
         mock_stop.assert_called_once()
 
 
-async def test_client_id_not_set_for_open_source():
+async def test_task_server_client_id_is_set():
     with patch("socket.gethostname", return_value="foo"), patch(
         "os.getpid", return_value=42
     ):
         task_server = TaskServer(...)
-
-        assert task_server._client_id is None
-
-
-async def test_client_id_set_for_cloud():
-    with patch("socket.gethostname", return_value="foo"), patch(
-        "os.getpid", return_value=42
-    ):
-        task_server = TaskServer(...)
-        task_server._client = MagicMock(api_url="https://api.prefect.cloud")
+        task_server._client = MagicMock(api_url="http://localhost:4200")
 
         assert task_server._client_id == "foo-42"
 


### PR DESCRIPTION
for task scheduling in cloud, it'd be helpful if we have a unique websocket client id to refer to a given `TaskServer` / consumer

so we add a client id property to `TaskServer` like `{socket.gethostname()}-{os.getpid()}` that reads settings from its `_client`

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.