### PR TITLE
Fix legacy client detection in `update_deployment`

### DIFF
--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -178,7 +178,9 @@ async def update_deployment(
 
         update_data = deployment.dict(exclude_unset=True)
 
-        if "schedule" in update_data or "is_schedule_active" in update_data:
+        if (
+            "schedule" in update_data or "is_schedule_active" in update_data
+        ) and "paused" not in update_data:
             if len(existing_deployment.schedules) > 1:
                 raise _multiple_schedules_error(deployment_id)
 

--- a/tests/server/api/test_deployments.py
+++ b/tests/server/api/test_deployments.py
@@ -1691,6 +1691,65 @@ class TestUpdateDeployment:
         assert deployment.paused is True
         assert deployment.is_schedule_active is False
 
+    async def test_updating_paused_does_not_change_schedule(
+        self,
+        client,
+        deployment,
+        session,
+    ):
+        # This is a regression test for a bug where pausing a deployment would
+        # copy the schedule from the existing deployment to the new one, even
+        # if the schedule was not provided in the request.
+        # https://github.com/PrefectHQ/nebula/issues/6994
+
+        legacy_schedule = schemas.schedules.IntervalSchedule(
+            interval=datetime.timedelta(days=1)
+        )
+        response = await client.patch(
+            f"/deployments/{deployment.id}",
+            json={"schedule": legacy_schedule.dict(json_compatible=True)},
+        )
+        assert response.status_code == 204
+
+        await session.refresh(deployment)
+
+        new_schedule = schemas.schedules.IntervalSchedule(
+            interval=datetime.timedelta(hours=1)
+        )
+
+        assert deployment.paused is False
+        assert deployment.schedule is not None
+        assert deployment.schedule.interval != new_schedule.interval
+
+        await models.deployments.delete_schedules_for_deployment(
+            session=session, deployment_id=deployment.id
+        )
+        await models.deployments.create_deployment_schedules(
+            session=session,
+            deployment_id=deployment.id,
+            schedules=[
+                schemas.actions.DeploymentScheduleCreate(  # type: ignore [call-arg]
+                    active=True, schedule=new_schedule
+                )
+            ],
+        )
+
+        await session.commit()
+
+        response = await client.patch(
+            f"/deployments/{deployment.id}", json={"paused": True}
+        )
+        assert response.status_code == 204
+
+        schedules = await models.deployments.read_deployment_schedules(
+            session=session, deployment_id=deployment.id
+        )
+
+        assert len(schedules) == 1
+        assert isinstance(schedules[0].schedule, schemas.schedules.IntervalSchedule)
+        assert schedules[0].schedule.interval == new_schedule.interval
+        assert schedules[0].active is True
+
 
 class TestGetScheduledFlowRuns:
     @pytest.fixture


### PR DESCRIPTION
This is the OSS side of https://github.com/PrefectHQ/nebula/issues/6994. 

In update_deployment we attempt to detect if a legacy client is altering the schedule, and in those cases we try to backfill the schedule from whatever is provided. Due to https://github.com/PrefectHQ/prefect/pull/12041 the detection was incorrectly detecting a paused update as being from a legacy client asis_schedule_active was being added to the update data by the updated validator.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.