### PR TITLE
Add logging filter to prevent logging the current Prefect API key

### DIFF
--- a/src/prefect/logging/filters.py
+++ b/src/prefect/logging/filters.py
@@ -1,0 +1,19 @@
+import logging
+
+from prefect.utilities.names import obfuscate
+
+
+class ObfuscateApiKeyFilter(logging.Filter):
+    """
+    A logging filter that obfuscates any string that matches the obfuscate_string function.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        # Need to import here to avoid circular imports
+        from prefect.settings import PREFECT_API_KEY
+
+        if PREFECT_API_KEY:
+            record.msg = record.msg.replace(
+                PREFECT_API_KEY.value(), obfuscate(PREFECT_API_KEY.value())
+            )
+        return True

--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Union
 
 import prefect
 from prefect.exceptions import MissingContextError
+from prefect.logging.filters import ObfuscateApiKeyFilter
 
 if TYPE_CHECKING:
     from prefect.client.schemas import FlowRun as ClientFlowRun
@@ -73,7 +74,6 @@ def get_logger(name: str = None) -> logging.Logger:
     See `get_run_logger` for retrieving loggers for use within task or flow runs.
     By default, only run-related loggers are connected to the `APILogHandler`.
     """
-
     parent_logger = logging.getLogger("prefect")
 
     if name:
@@ -85,6 +85,10 @@ def get_logger(name: str = None) -> logging.Logger:
             logger = logging.getLogger(name)
     else:
         logger = parent_logger
+
+    # Prevent the current API key from being logged in plain text
+    obfuscate_api_key_filter = ObfuscateApiKeyFilter()
+    logger.addFilter(obfuscate_api_key_filter)
 
     return logger
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1241,63 +1241,68 @@ class TestJsonFormatter:
 
 class TestObfuscateApiKeyFilter:
     def test_filters_current_api_key(self):
-        with temporary_settings({PREFECT_API_KEY: "hi-hello-im-an-api-key"}):
+        test_api_key = "hi-hello-im-an-api-key"
+        with temporary_settings({PREFECT_API_KEY: test_api_key}):
             filter = ObfuscateApiKeyFilter()
             record = logging.LogRecord(
                 name="Test Log",
                 level=1,
                 pathname="/path/file.py",
                 lineno=1,
-                msg="hi-hello-im-an-api-key",
+                msg=test_api_key,
                 args=None,
                 exc_info=None,
             )
 
             filter.filter(record)
 
-            assert "hi-hello-im-an-api-key" not in record.getMessage()
-            assert obfuscate("hi-hello-im-an-api-key") in record.getMessage()
+        assert test_api_key not in record.getMessage()
+        assert obfuscate(test_api_key) in record.getMessage()
 
     def test_current_api_key_is_not_logged(self, caplog):
-        with temporary_settings({PREFECT_API_KEY: "hi-hello-im-an-api-key"}):
+        test_api_key = "hot-dog-theres-a-logger-this-is-my-big-chance-for-stardom"
+        with temporary_settings({PREFECT_API_KEY: test_api_key}):
             logger = get_logger("test")
-            logger.info("hi-hello-im-an-api-key")
+            logger.info(test_api_key)
 
-        assert "hi-hello-im-an-api-key" not in caplog.text
-        assert obfuscate("hi-hello-im-an-api-key") in caplog.text
+        assert test_api_key not in caplog.text
+        assert obfuscate(test_api_key) in caplog.text
 
     def test_current_api_key_is_not_logged_from_flow(self, caplog):
-        with temporary_settings({PREFECT_API_KEY: "i-am-a-sneaky-little-api-key"}):
+        test_api_key = "i-am-a-plaintext-api-key-and-i-dream-of-being-logged-one-day"
+        with temporary_settings({PREFECT_API_KEY: test_api_key}):
 
             @flow
             def test_flow():
                 logger = get_run_logger()
-                logger.info("i-am-a-sneaky-little-api-key")
+                logger.info(test_api_key)
 
             test_flow()
 
-        assert "i-am-a-sneaky-little-api-key" not in caplog.text
-        assert obfuscate("i-am-a-sneaky-little-api-key") in caplog.text
+        assert test_api_key not in caplog.text
+        assert obfuscate(test_api_key) in caplog.text
 
     def test_current_api_key_is_not_logged_from_flow_log_prints(self, caplog):
-        with temporary_settings({PREFECT_API_KEY: "i-am-a-sneaky-little-api-key"}):
+        test_api_key = "i-am-a-sneaky-little-api-key"
+        with temporary_settings({PREFECT_API_KEY: test_api_key}):
 
             @flow(log_prints=True)
             def test_flow():
-                print("i-am-a-sneaky-little-api-key")
+                print(test_api_key)
 
             test_flow()
 
-        assert "i-am-a-sneaky-little-api-key" not in caplog.text
-        assert obfuscate("i-am-a-sneaky-little-api-key") in caplog.text
+        assert test_api_key not in caplog.text
+        assert obfuscate(test_api_key) in caplog.text
 
     def test_current_api_key_is_not_logged_from_task(self, caplog):
-        with temporary_settings({PREFECT_API_KEY: "i-am-jacks-security-risk"}):
+        test_api_key = "i-am-jacks-security-risk"
+        with temporary_settings({PREFECT_API_KEY: test_api_key}):
 
             @task
             def test_task():
                 logger = get_run_logger()
-                logger.info("i-am-bobs-security-risk")
+                logger.info(test_api_key)
 
             @flow
             def test_flow():
@@ -1305,8 +1310,8 @@ class TestObfuscateApiKeyFilter:
 
             test_flow()
 
-        assert "i-am-bobs-security-risk" not in caplog.text
-        assert obfuscate("i-am-bobs-security-risk") in caplog.text
+        assert test_api_key not in caplog.text
+        assert obfuscate(test_api_key) in caplog.text
 
 
 def test_log_in_flow(caplog):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
On rare occasions, unexpected crashes in task runners can sometimes lead to log dumps that include all configurations, including the current API key. This PR adds a logging filter to prevent inadvertently logging the current Prefect API key.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Running this flow:

```python
from prefect import flow
from prefect.settings import PREFECT_API_KEY


@flow(log_prints=True)
def my_treacherous_flow():
    print(PREFECT_API_KEY.value())

if __name__ == "__main__":
    my_treacherous_flow()
```

will log this in the console:
![Screenshot 2024-02-23 at 11 13 37 AM](https://github.com/PrefectHQ/prefect/assets/12350579/270de7a9-89d9-4933-a0a8-588e70d1793d)

and log this in the UI:
![Screenshot 2024-02-23 at 11 14 10 AM](https://github.com/PrefectHQ/prefect/assets/12350579/659af8dc-ca2f-4c5e-8a9c-76e0e8bc38ad)


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.