### PR TITLE
Surface work pool not found error

### DIFF
--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -285,10 +285,9 @@ async def inspect(
     async with get_client() as client:
         try:
             pool = await client.read_work_pool(work_pool_name=name)
-        except ObjectNotFound as exc:
-            exit_with_error(exc)
-
-        app.console.print(Pretty(pool))
+            app.console.print(Pretty(pool))
+        except ObjectNotFound:
+            exit_with_error(f"Work pool {name!r} not found!")
 
 
 @work_pool_app.command()


### PR DESCRIPTION
While looking into work pool CLI, I realized I was trying to inspect a work pool in the wrong prefect profile. It would be nice to surface an error.

### Example

Current:
```bash
❯ prefect work-pool inspect <nonexistent-wp>

```
(no output)

With fix:
```bash
❯ prefect work-pool inspect <nonexistent-wp>
Work pool 'local-work' not found!
```



- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.