### PR TITLE
Ignore "schedule" in `Deployment.build_from_flow` if it's out of date

### DIFF
--- a/src/prefect/deployments/deployments.py
+++ b/src/prefect/deployments/deployments.py
@@ -20,9 +20,9 @@ from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect.client.schemas.actions import DeploymentScheduleCreate
 
 if HAS_PYDANTIC_V2:
-    from pydantic.v1 import BaseModel, Field, parse_obj_as, validator
+    from pydantic.v1 import BaseModel, Field, parse_obj_as, root_validator, validator
 else:
-    from pydantic import BaseModel, Field, parse_obj_as, validator
+    from pydantic import BaseModel, Field, parse_obj_as, root_validator, validator
 
 from prefect._internal.compatibility.experimental import experimental_field
 from prefect.blocks.core import Block
@@ -470,6 +470,7 @@ class Deployment(BaseModel):
 
     @classmethod
     def _validate_schedule(cls, value):
+        """We do not support COUNT-based (# of occurrences) RRule schedules for deployments."""
         if value:
             rrule_value = getattr(value, "rrule", None)
             if rrule_value and "COUNT" in rrule_value.upper():
@@ -491,7 +492,7 @@ class Deployment(BaseModel):
         default_factory=list,
         description="One of more tags to apply to this deployment.",
     )
-    schedule: SCHEDULE_TYPES = None
+    schedule: Optional[SCHEDULE_TYPES] = Field(default=None)
     schedules: List[MinimalDeploymentSchedule] = Field(
         default_factory=list,
         description="The schedules to run this deployment on.",
@@ -609,31 +610,30 @@ class Deployment(BaseModel):
 
         return field_value
 
+    @root_validator(pre=True)
+    def validate_deprecated_schedule_fields(cls, values):
+        if values.get("schedule") and not values.get("schedules"):
+            logger.warning(
+                "The field 'schedule' in 'Deployment' has been deprecated. It will not be "
+                "available after Sep 2024. Define schedules in the `schedules` list instead."
+            )
+        elif values.get("is_schedule_active") and not values.get("schedules"):
+            logger.warning(
+                "The field 'is_schedule_active' in 'Deployment' has been deprecated. It will "
+                "not be available after Sep 2024. Use the `active` flag within a schedule in "
+                "the `schedules` list instead and the `pause` flag in 'Deployment' to pause "
+                "all schedules."
+            )
+        return values
+
     @validator("schedule")
     def validate_schedule(cls, value):
-        """We do not support COUNT-based (# of occurrences) RRule schedules for deployments."""
         if value:
             cls._validate_schedule(value)
-
-        logger.warning(
-            "The field 'schedule' in 'Deployment' has been deprecated. It will not be "
-            "available after Sep 2024. Define schedules in the `schedules` list instead."
-        )
-        return value
-
-    @validator("is_schedule_active")
-    def validate_is_schedule_active(cls, value):
-        logger.warning(
-            "The field 'is_schedule_active' in 'Deployment' has been deprecated. It will "
-            " not be available after Sep 2024. Use the `active` flag within a schedule in "
-            "the `schedules` list instead and the `pause` flag in 'Deployment' to pause "
-            "all schedules."
-        )
         return value
 
     @validator("schedules")
     def validate_schedules(cls, value):
-        """We do not support COUNT-based (# of occurrences) RRule schedules for deployments."""
         for schedule in value:
             cls._validate_schedule(schedule.schedule)
         return value
@@ -692,6 +692,8 @@ class Deployment(BaseModel):
                         "triggers",
                         "enforce_parameter_schema",
                         "schedules",
+                        "schedule",
+                        "is_schedule_active",
                     }
                 )
                 for field in set(self.__fields__.keys()) - excluded_fields:
@@ -705,6 +707,23 @@ class Deployment(BaseModel):
                         )
                         for schedule in deployment.schedules
                     ]
+
+                # The API server generates the "schedule" field from the
+                # current list of schedules, so if the user has locally set
+                # "schedules" to anything, we should avoid sending "schedule"
+                # and let the API server generate a new value if necessary.
+                if "schedules" in self.__fields_set__:
+                    self.schedule = None
+                    self.is_schedule_active = None
+                else:
+                    # The user isn't using "schedules," so we should
+                    # populate "schedule" and "is_schedule_active" from the
+                    # API's version of the deployment, unless the user gave
+                    # us this fields in __init__().
+                    if "schedule" not in self.__fields_set__:
+                        self.schedule = deployment.schedule
+                    if "is_schedule_active" not in self.__fields_set__:
+                        self.is_schedule_active = deployment.is_schedule_active
 
                 if "infrastructure" not in self.__fields_set__:
                     if deployment.infrastructure_document_id:

--- a/src/prefect/deployments/deployments.py
+++ b/src/prefect/deployments/deployments.py
@@ -719,7 +719,7 @@ class Deployment(BaseModel):
                     # The user isn't using "schedules," so we should
                     # populate "schedule" and "is_schedule_active" from the
                     # API's version of the deployment, unless the user gave
-                    # us this fields in __init__().
+                    # us these fields in __init__().
                     if "schedule" not in self.__fields_set__:
                         self.schedule = deployment.schedule
                     if "is_schedule_active" not in self.__fields_set__:

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -742,7 +742,7 @@ class TestDeploymentApply:
         )
         assert dep.schedules[0].active is True
 
-    async def test_deployment_apply_clears_multiple_schedules(
+    async def test_deployment_build_from_flow_clears_multiple_schedules(
         self,
         patch_import,
         flow_function,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

If we know that a Deployment has been initialized with `schedules=[]`, ignore any generated `schedule` field the API returns from `Deployment.load` because we know it's out of date.

This PR also makes our deprecation warnings for `schedule` and `is_schedule_paused` less aggressive, only setting them if a user initializes `Deployment` with one of those fields and not `schedules`.

fixes #12099 

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.