### PR TITLE
Add artifact data to flow run graph API

### DIFF
--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -22,6 +22,7 @@ from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from prefect._internal.compatibility.experimental import experiment_enabled
 from prefect.server import schemas
 from prefect.server.exceptions import FlowRunGraphTooLarge, ObjectNotFoundError
 from prefect.server.schemas.graph import Edge, Graph, GraphArtifact, Node
@@ -552,6 +553,9 @@ class BaseQueryComponents(ABC):
         Does not recurse into subflows.
         Artifacts for the flow run without a task run id are grouped under None.
         """
+        if not experiment_enabled("artifacts_on_flow_run_graph"):
+            return defaultdict(list)
+
         query = (
             sa.select(
                 db.Artifact, db.ArtifactCollection.id.label("latest_in_collection_id")

--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -539,6 +539,17 @@ class BaseQueryComponents(ABC):
         """Returns the query that selects all of the nodes and edges for a flow run graph (version 2)."""
         ...
 
+    # async def _get_flow_run_graph_artifacts(
+    #     self,
+    #     session: AsyncSession,
+    #     flow_run_id: UUID,
+    # ) -> :
+    #     """Get the artifacts for a flow run grouped by task run id.
+
+    #     Does not recurse into subflows.
+    #     Artifacts for the flow run without a task run id are grouped under None.
+    #     """
+
 
 class AsyncPostgresQueryComponents(BaseQueryComponents):
     # --- Postgres-specific SqlAlchemy bindings
@@ -839,6 +850,7 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
                         end_time=row.end_time,
                         parents=[Edge(id=id) for id in row.parent_ids or []],
                         children=[Edge(id=id) for id in row.child_ids or []],
+                        artifacts=[],
                     ),
                 )
             )
@@ -854,6 +866,7 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
             end_time=end_time,
             root_node_ids=root_node_ids,
             nodes=nodes,
+            artifacts=[],
         )
 
 
@@ -1285,6 +1298,7 @@ class AioSqliteQueryComponents(BaseQueryComponents):
                         end_time=time(row.end_time),
                         parents=edges(row.parent_ids),
                         children=edges(row.child_ids),
+                        artifacts=[],
                     ),
                 )
             )
@@ -1300,4 +1314,5 @@ class AioSqliteQueryComponents(BaseQueryComponents):
             end_time=end_time,
             root_node_ids=root_node_ids,
             nodes=nodes,
+            artifacts=[],
         )

--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -537,6 +537,7 @@ class BaseQueryComponents(ABC):
         flow_run_id: UUID,
         since: datetime.datetime,
         max_nodes: int,
+        max_artifacts: int,
     ) -> Graph:
         """Returns the query that selects all of the nodes and edges for a flow run graph (version 2)."""
         ...
@@ -752,6 +753,7 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
         flow_run_id: UUID,
         since: datetime.datetime,
         max_nodes: int,
+        max_artifacts: int,
     ) -> Graph:
         """Returns the query that selects all of the nodes and edges for a flow run
         graph (version 2)."""
@@ -872,7 +874,7 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
         results = await session.execute(query)
 
         graph_artifacts = await self._get_flow_run_graph_artifacts(
-            db, session, flow_run_id, max_artifacts=10000
+            db, session, flow_run_id, max_artifacts
         )
 
         nodes: List[Tuple[UUID, Node]] = []
@@ -1169,6 +1171,7 @@ class AioSqliteQueryComponents(BaseQueryComponents):
         flow_run_id: UUID,
         since: datetime.datetime,
         max_nodes: int,
+        max_artifacts: int,
     ) -> Graph:
         """Returns the query that selects all of the nodes and edges for a flow run
         graph (version 2)."""
@@ -1302,7 +1305,7 @@ class AioSqliteQueryComponents(BaseQueryComponents):
         results = await session.execute(query)
 
         graph_artifacts = await self._get_flow_run_graph_artifacts(
-            db, session, flow_run_id, max_artifacts=10000
+            db, session, flow_run_id, max_artifacts
         )
 
         nodes: List[Tuple[UUID, Node]] = []

--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -1,5 +1,6 @@
 import datetime
 from abc import ABC, abstractmethod, abstractproperty
+from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
     Dict,
@@ -23,7 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server import schemas
 from prefect.server.exceptions import FlowRunGraphTooLarge, ObjectNotFoundError
-from prefect.server.schemas.graph import Edge, Graph, Node
+from prefect.server.schemas.graph import Edge, Graph, GraphArtifact, Node
 from prefect.server.utilities.database import UUID as UUIDTypeDecorator
 from prefect.server.utilities.database import Timestamp, json_has_any_key
 
@@ -539,16 +540,51 @@ class BaseQueryComponents(ABC):
         """Returns the query that selects all of the nodes and edges for a flow run graph (version 2)."""
         ...
 
-    # async def _get_flow_run_graph_artifacts(
-    #     self,
-    #     session: AsyncSession,
-    #     flow_run_id: UUID,
-    # ) -> :
-    #     """Get the artifacts for a flow run grouped by task run id.
+    async def _get_flow_run_graph_artifacts(
+        self,
+        db: "PrefectDBInterface",
+        session: AsyncSession,
+        flow_run_id: UUID,
+        max_artifacts: int,
+    ):
+        """Get the artifacts for a flow run grouped by task run id.
 
-    #     Does not recurse into subflows.
-    #     Artifacts for the flow run without a task run id are grouped under None.
-    #     """
+        Does not recurse into subflows.
+        Artifacts for the flow run without a task run id are grouped under None.
+        """
+        query = (
+            sa.select(
+                db.Artifact, db.ArtifactCollection.id.label("latest_in_collection_id")
+            )
+            .where(
+                db.Artifact.flow_run_id == flow_run_id,
+                db.Artifact.type != "result",
+            )
+            .join(
+                db.ArtifactCollection,
+                (db.ArtifactCollection.key == db.Artifact.key)
+                & (db.ArtifactCollection.latest_id == db.Artifact.id),
+                isouter=True,
+            )
+            .limit(max_artifacts)
+        )
+
+        results = await session.execute(query)
+
+        artifacts_by_task = defaultdict(list)
+        for artifact, latest_in_collection_id in results:
+            artifacts_by_task[artifact.task_run_id].append(
+                GraphArtifact(
+                    id=artifact.id,
+                    created=artifact.created,
+                    key=artifact.key,
+                    type=artifact.type,
+                    is_latest=artifact.key is None
+                    or latest_in_collection_id is not None,
+                )
+            )
+
+        return artifacts_by_task
 
 
 class AsyncPostgresQueryComponents(BaseQueryComponents):
@@ -831,6 +867,10 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
 
         results = await session.execute(query)
 
+        graph_artifacts = await self._get_flow_run_graph_artifacts(
+            db, session, flow_run_id, max_artifacts=10000
+        )
+
         nodes: List[Tuple[UUID, Node]] = []
         root_node_ids: List[UUID] = []
 
@@ -850,7 +890,7 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
                         end_time=row.end_time,
                         parents=[Edge(id=id) for id in row.parent_ids or []],
                         children=[Edge(id=id) for id in row.child_ids or []],
-                        artifacts=[],
+                        artifacts=graph_artifacts.get(row.id, []),
                     ),
                 )
             )
@@ -866,7 +906,7 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
             end_time=end_time,
             root_node_ids=root_node_ids,
             nodes=nodes,
-            artifacts=[],
+            artifacts=graph_artifacts.get(None, []),
         )
 
 
@@ -1257,6 +1297,10 @@ class AioSqliteQueryComponents(BaseQueryComponents):
 
         results = await session.execute(query)
 
+        graph_artifacts = await self._get_flow_run_graph_artifacts(
+            db, session, flow_run_id, max_artifacts=10000
+        )
+
         nodes: List[Tuple[UUID, Node]] = []
         root_node_ids: List[UUID] = []
 
@@ -1298,7 +1342,7 @@ class AioSqliteQueryComponents(BaseQueryComponents):
                         end_time=time(row.end_time),
                         parents=edges(row.parent_ids),
                         children=edges(row.child_ids),
-                        artifacts=[],
+                        artifacts=graph_artifacts.get(UUID(row.id), []),
                     ),
                 )
             )
@@ -1314,5 +1358,5 @@ class AioSqliteQueryComponents(BaseQueryComponents):
             end_time=end_time,
             root_node_ids=root_node_ids,
             nodes=nodes,
-            artifacts=[],
+            artifacts=graph_artifacts.get(None, []),
         )

--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -571,6 +571,7 @@ class BaseQueryComponents(ABC):
                 & (db.ArtifactCollection.latest_id == db.Artifact.id),
                 isouter=True,
             )
+            .order_by(db.Artifact.created.asc())
             .limit(max_artifacts)
         )
 

--- a/src/prefect/server/models/flow_runs.py
+++ b/src/prefect/server/models/flow_runs.py
@@ -29,7 +29,10 @@ from prefect.server.schemas.graph import Graph
 from prefect.server.schemas.responses import OrchestrationResult, SetStateStatus
 from prefect.server.schemas.states import State
 from prefect.server.utilities.schemas import PrefectBaseModel
-from prefect.settings import PREFECT_API_MAX_FLOW_RUN_GRAPH_NODES
+from prefect.settings import (
+    PREFECT_API_MAX_FLOW_RUN_GRAPH_ARTIFACTS,
+    PREFECT_API_MAX_FLOW_RUN_GRAPH_NODES,
+)
 
 
 @inject_db
@@ -539,4 +542,5 @@ async def read_flow_run_graph(
         flow_run_id=flow_run_id,
         since=since,
         max_nodes=PREFECT_API_MAX_FLOW_RUN_GRAPH_NODES.value(),
+        max_artifacts=PREFECT_API_MAX_FLOW_RUN_GRAPH_ARTIFACTS.value(),
     )

--- a/src/prefect/server/schemas/graph.py
+++ b/src/prefect/server/schemas/graph.py
@@ -2,8 +2,18 @@ from datetime import datetime
 from typing import List, Literal, Optional, Tuple
 from uuid import UUID
 
+from pydantic import Field
+
 from prefect.server.schemas.states import StateType
 from prefect.server.utilities.schemas import PrefectBaseModel
+
+
+class GraphArtifact(PrefectBaseModel):
+    id: UUID
+    created: datetime
+    key: Optional[str]
+    type: str
+    is_latest: bool = Field(default=False)
 
 
 class Edge(PrefectBaseModel):
@@ -19,6 +29,7 @@ class Node(PrefectBaseModel):
     end_time: Optional[datetime]
     parents: List[Edge]
     children: List[Edge]
+    artifacts: List[GraphArtifact] = Field(default_factory=list)
 
 
 class Graph(PrefectBaseModel):
@@ -26,3 +37,4 @@ class Graph(PrefectBaseModel):
     end_time: Optional[datetime]
     root_node_ids: List[UUID]
     nodes: List[Tuple[UUID, Node]]
+    artifacts: List[GraphArtifact] = Field(default_factory=list)

--- a/src/prefect/server/schemas/graph.py
+++ b/src/prefect/server/schemas/graph.py
@@ -2,8 +2,6 @@ from datetime import datetime
 from typing import List, Literal, Optional, Tuple
 from uuid import UUID
 
-from pydantic import Field
-
 from prefect.server.schemas.states import StateType
 from prefect.server.utilities.schemas import PrefectBaseModel
 
@@ -13,7 +11,7 @@ class GraphArtifact(PrefectBaseModel):
     created: datetime
     key: Optional[str]
     type: str
-    is_latest: bool = Field(default=False)
+    is_latest: bool
 
 
 class Edge(PrefectBaseModel):
@@ -29,7 +27,7 @@ class Node(PrefectBaseModel):
     end_time: Optional[datetime]
     parents: List[Edge]
     children: List[Edge]
-    artifacts: List[GraphArtifact] = Field(default_factory=list)
+    artifacts: List[GraphArtifact]
 
 
 class Graph(PrefectBaseModel):
@@ -37,4 +35,4 @@ class Graph(PrefectBaseModel):
     end_time: Optional[datetime]
     root_node_ids: List[UUID]
     nodes: List[Tuple[UUID, Node]]
-    artifacts: List[GraphArtifact] = Field(default_factory=list)
+    artifacts: List[GraphArtifact]

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1276,6 +1276,11 @@ PREFECT_API_MAX_FLOW_RUN_GRAPH_NODES = Setting(int, default=10000)
 The maximum size of a flow run graph on the v2 API
 """
 
+PREFECT_API_MAX_FLOW_RUN_GRAPH_ARTIFACTS = Setting(int, default=10000)
+"""
+The maximum number of artifacts to show on a flow run graph on the v2 API
+"""
+
 PREFECT_EXPERIMENTAL_ENABLE_EVENTS_CLIENT = Setting(bool, default=True)
 """
 Whether or not to enable experimental Prefect work pools.
@@ -1482,6 +1487,9 @@ Whether or not to enable the enhanced scheduling UI.
 """
 
 PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS_ON_FLOW_RUN_GRAPH = Setting(bool, default=True)
+"""
+Whether or not to enable artifacts on the flow run graph.
+"""
 
 # Defaults -----------------------------------------------------------------------------
 

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1481,6 +1481,8 @@ PREFECT_EXPERIMENTAL_ENABLE_ENHANCED_SCHEDULING_UI = Setting(bool, default=True)
 Whether or not to enable the enhanced scheduling UI.
 """
 
+PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS_ON_FLOW_RUN_GRAPH = Setting(bool, default=True)
+
 # Defaults -----------------------------------------------------------------------------
 
 PREFECT_DEFAULT_RESULT_STORAGE_BLOCK = Setting(

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1281,6 +1281,11 @@ PREFECT_API_MAX_FLOW_RUN_GRAPH_ARTIFACTS = Setting(int, default=10000)
 The maximum number of artifacts to show on a flow run graph on the v2 API
 """
 
+PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS_ON_FLOW_RUN_GRAPH = Setting(bool, default=False)
+"""
+Whether or not to enable artifacts on the flow run graph.
+"""
+
 PREFECT_EXPERIMENTAL_ENABLE_EVENTS_CLIENT = Setting(bool, default=True)
 """
 Whether or not to enable experimental Prefect work pools.
@@ -1486,10 +1491,6 @@ PREFECT_EXPERIMENTAL_ENABLE_ENHANCED_SCHEDULING_UI = Setting(bool, default=True)
 Whether or not to enable the enhanced scheduling UI.
 """
 
-PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS_ON_FLOW_RUN_GRAPH = Setting(bool, default=True)
-"""
-Whether or not to enable artifacts on the flow run graph.
-"""
 
 # Defaults -----------------------------------------------------------------------------
 

--- a/tests/server/api/test_flow_run_graph_v2.py
+++ b/tests/server/api/test_flow_run_graph_v2.py
@@ -275,6 +275,7 @@ async def test_reading_graph_for_flow_run_with_flat_tasks(
                 ),
                 parents=[],
                 children=[],
+                artifacts=[],
             ),
         )
         for task_run in flat_tasks
@@ -407,6 +408,7 @@ async def test_reading_graph_for_flow_run_with_linked_tasks(
                 children=[
                     Edge(id=linked_tasks[4].id),
                 ],
+                artifacts=[],
             ),
         ),
         (
@@ -422,6 +424,7 @@ async def test_reading_graph_for_flow_run_with_linked_tasks(
                 children=[
                     Edge(id=linked_tasks[4].id),
                 ],
+                artifacts=[],
             ),
         ),
         (
@@ -437,6 +440,7 @@ async def test_reading_graph_for_flow_run_with_linked_tasks(
                 children=[
                     Edge(id=linked_tasks[5].id),
                 ],
+                artifacts=[],
             ),
         ),
         (
@@ -452,6 +456,7 @@ async def test_reading_graph_for_flow_run_with_linked_tasks(
                 children=[
                     Edge(id=linked_tasks[5].id),
                 ],
+                artifacts=[],
             ),
         ),
         (
@@ -468,6 +473,7 @@ async def test_reading_graph_for_flow_run_with_linked_tasks(
                     Edge(id=linked_tasks[1].id),
                 ],
                 children=[],
+                artifacts=[],
             ),
         ),
         (
@@ -484,6 +490,7 @@ async def test_reading_graph_for_flow_run_with_linked_tasks(
                     Edge(id=linked_tasks[3].id),
                 ],
                 children=[],
+                artifacts=[],
             ),
         ),
     ]
@@ -536,6 +543,7 @@ async def test_reading_graph_for_flow_run_with_linked_unstarted_tasks(
                 children=[
                     Edge(id=linked_tasks[4].id),
                 ],
+                artifacts=[],
             ),
         ),
         (
@@ -551,6 +559,7 @@ async def test_reading_graph_for_flow_run_with_linked_unstarted_tasks(
                 children=[
                     Edge(id=linked_tasks[4].id),
                 ],
+                artifacts=[],
             ),
         ),
         (
@@ -566,6 +575,7 @@ async def test_reading_graph_for_flow_run_with_linked_unstarted_tasks(
                 children=[
                     Edge(id=linked_tasks[5].id),
                 ],
+                artifacts=[],
             ),
         ),
         (
@@ -581,6 +591,7 @@ async def test_reading_graph_for_flow_run_with_linked_unstarted_tasks(
                 children=[
                     Edge(id=linked_tasks[5].id),
                 ],
+                artifacts=[],
             ),
         ),
         (
@@ -597,6 +608,7 @@ async def test_reading_graph_for_flow_run_with_linked_unstarted_tasks(
                     Edge(id=linked_tasks[1].id),
                 ],
                 children=[],
+                artifacts=[],
             ),
         ),
         (
@@ -613,6 +625,7 @@ async def test_reading_graph_for_flow_run_with_linked_unstarted_tasks(
                     Edge(id=linked_tasks[3].id),
                 ],
                 children=[],
+                artifacts=[],
             ),
         ),
     ]
@@ -668,6 +681,7 @@ async def test_reading_graph_for_flow_run_with_linked_tasks_incrementally(
                 children=[
                     Edge(id=linked_tasks[5].id),
                 ],
+                artifacts=[],
             ),
         ),
         (
@@ -683,6 +697,7 @@ async def test_reading_graph_for_flow_run_with_linked_tasks_incrementally(
                 children=[
                     Edge(id=linked_tasks[5].id),
                 ],
+                artifacts=[],
             ),
         ),
         (
@@ -701,6 +716,7 @@ async def test_reading_graph_for_flow_run_with_linked_tasks_incrementally(
                     Edge(id=linked_tasks[1].id),
                 ],
                 children=[],
+                artifacts=[],
             ),
         ),
         (
@@ -717,6 +733,7 @@ async def test_reading_graph_for_flow_run_with_linked_tasks_incrementally(
                     Edge(id=linked_tasks[3].id),
                 ],
                 children=[],
+                artifacts=[],
             ),
         ),
     ]
@@ -789,6 +806,7 @@ async def test_reading_graph_with_subflow_run(
                 end_time=subflow_run.end_time,
                 parents=[],
                 children=[],
+                artifacts=[],
             ),
         )
     ]
@@ -830,6 +848,7 @@ async def test_reading_graph_with_unstarted_subflow_run(
                 end_time=subflow_run.end_time,
                 parents=[],
                 children=[],
+                artifacts=[],
             ),
         )
     ]
@@ -1063,6 +1082,7 @@ def graph() -> Graph:
         end_time=pendulum.datetime(2023, 6, 4),
         root_node_ids=[],
         nodes=[],
+        artifacts=[],
     )
 
 


### PR DESCRIPTION
## Description
This PR introduces 2 new settings:
- `PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS_ON_FLOW_RUN_GRAPH` - an opt-in flag to enable new behavior as described below. NOTE: when this is OFF, the graph response still includes both the top-level artifacts key as well as on each node but their values are empty arrays and the underlying data fetching is skipped. 
- `PREFECT_API_MAX_FLOW_RUN_GRAPH_ARTIFACTS` - an `int` setting to allow a user to set an upper limit on the # of artifacts that can load into the graph. At the moment, the default is quite high but this gives a user the ability to tune it down if they were to run into issues.

#### The new behavior
This PR makes flow run artifact data available on the graph-v2 route to enable consumption by the flow run graph in the UI.

<img width="643" alt="Screenshot 2024-02-28 at 1 30 26 PM" src="https://github.com/PrefectHQ/prefect/assets/22418768/e5098364-170e-4cb1-a2fb-4362f1d04bdf">


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.