### PR TITLE
Update `flow.serve` to support multiple schedules

### DIFF
--- a/src/prefect/cli/flow.py
+++ b/src/prefect/cli/flow.py
@@ -11,6 +11,7 @@ from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error
 from prefect.cli.root import app
 from prefect.client import get_client
+from prefect.client.schemas.objects import MinimalDeploymentSchedule
 from prefect.client.schemas.schedules import construct_schedule
 from prefect.client.schemas.sorting import FlowSort
 from prefect.deployments.runner import RunnerDeployment
@@ -125,7 +126,7 @@ async def serve(
     """
     runner = Runner(name=name, pause_on_shutdown=pause_on_shutdown)
     try:
-        schedule = None
+        schedules = []
         if interval or cron or rrule:
             schedule = construct_schedule(
                 interval=interval,
@@ -134,10 +135,12 @@ async def serve(
                 timezone=timezone,
                 anchor_date=interval_anchor,
             )
+            schedules = [MinimalDeploymentSchedule(schedule=schedule, active=True)]
+
         runner_deployment = RunnerDeployment.from_entrypoint(
             entrypoint=entrypoint,
             name=name,
-            schedule=schedule,
+            schedules=schedules,
             description=description,
             tags=tags or [],
             version=version,

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -1617,6 +1617,11 @@ class PrefectClient:
             f"/deployments/{deployment_id}/{path}",
         )
 
+    async def set_deployment_paused_state(self, deployment_id: UUID, paused: bool):
+        await self._client.patch(
+            f"/deployments/{deployment_id}", json={"paused": paused}
+        )
+
     async def update_deployment(
         self,
         deployment: Deployment,

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -244,7 +244,7 @@ class RunnerDeployment(BaseModel):
         schedules = values.get("schedules")
 
         if schedules is None and schedule is not None:
-            values["schedules"] = _to_deployment_schedule(schedule)
+            values["schedules"] = [_to_deployment_schedule(schedule)]
         elif schedules is not None and len(schedules) > 0:
             reconciled = []
             for obj in schedules:

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -33,7 +33,7 @@ import importlib
 import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union, get_args
 from uuid import UUID
 
 import pendulum
@@ -49,14 +49,15 @@ from prefect.settings import (
     PREFECT_DEFAULT_WORK_POOL_NAME,
     PREFECT_UI_URL,
 )
-from prefect.utilities.collections import get_from_dict
+from prefect.utilities.collections import get_from_dict, isiterable
 
 if HAS_PYDANTIC_V2:
-    from pydantic.v1 import BaseModel, Field, PrivateAttr, validator
+    from pydantic.v1 import BaseModel, Field, PrivateAttr, root_validator, validator
 else:
-    from pydantic import BaseModel, Field, PrivateAttr, validator
+    from pydantic import BaseModel, Field, PrivateAttr, root_validator, validator
 
 from prefect.client.orchestration import ServerType, get_client
+from prefect.client.schemas.objects import MinimalDeploymentSchedule
 from prefect.client.schemas.schedules import (
     SCHEDULE_TYPES,
     construct_schedule,
@@ -81,7 +82,16 @@ from prefect.utilities.slugify import slugify
 if TYPE_CHECKING:
     from prefect.flows import Flow
 
+FlexibleScheduleList = Union[MinimalDeploymentSchedule, dict, SCHEDULE_TYPES]
+
 __all__ = ["RunnerDeployment"]
+
+
+def _to_deployment_schedule(
+    schedule: Optional[SCHEDULE_TYPES] = None,
+    active: Optional[bool] = True,
+) -> MinimalDeploymentSchedule:
+    return MinimalDeploymentSchedule(schedule=schedule, active=active)
 
 
 class DeploymentApplyError(RuntimeError):
@@ -138,9 +148,16 @@ class RunnerDeployment(BaseModel):
         default_factory=list,
         description="One of more tags to apply to this deployment.",
     )
+    schedules: Optional[List[MinimalDeploymentSchedule]] = Field(
+        default=None,
+        description="The schedules that should cause this deployment to run.",
+    )
     schedule: Optional[SCHEDULE_TYPES] = None
+    paused: Optional[bool] = Field(
+        default=None, description="Whether or not the deployment is paused."
+    )
     is_schedule_active: Optional[bool] = Field(
-        default=None, description="Whether or not the schedule is active."
+        default=None, description="DEPRECATED: Whether or not the schedule is active."
     )
     parameters: Dict[str, Any] = Field(default_factory=dict)
     entrypoint: Optional[str] = Field(
@@ -204,6 +221,49 @@ class RunnerDeployment(BaseModel):
 
         return field_value
 
+    @root_validator(pre=True)
+    def reconcile_paused(cls, values):
+        paused = values.get("paused")
+        is_schedule_active = values.get("is_schedule_active")
+
+        if paused is not None:
+            values["paused"] = paused
+            values["is_schedule_active"] = not paused
+        elif is_schedule_active is not None:
+            values["paused"] = not is_schedule_active
+            values["is_schedule_active"] = is_schedule_active
+        else:
+            values["paused"] = False
+            values["is_schedule_active"] = True
+
+        return values
+
+    @root_validator(pre=True)
+    def reconcile_schedules(cls, values):
+        schedule = values.get("schedule")
+        schedules = values.get("schedules")
+
+        if schedules is None and schedule is not None:
+            values["schedules"] = _to_deployment_schedule(schedule)
+        elif schedules is not None and len(schedules) > 0:
+            reconciled = []
+            for obj in schedules:
+                if isinstance(obj, get_args(SCHEDULE_TYPES)):
+                    reconciled.append(_to_deployment_schedule(obj))
+                elif isinstance(obj, dict):
+                    reconciled.append(_to_deployment_schedule(**obj))
+                elif isinstance(obj, MinimalDeploymentSchedule):
+                    reconciled.append(obj)
+                else:
+                    raise ValueError(
+                        "Invalid schedule provided. Must be a schedule object, a dict,"
+                        " or a MinimalDeploymentSchedule."
+                    )
+
+            values["schedules"] = reconciled
+
+        return values
+
     @sync_compatible
     async def apply(
         self, work_pool_name: Optional[str] = None, image: Optional[str] = None
@@ -221,6 +281,7 @@ class RunnerDeployment(BaseModel):
         Returns:
             The ID of the created deployment.
         """
+
         work_pool_name = work_pool_name or self.work_pool_name
 
         if image and not work_pool_name:
@@ -250,8 +311,8 @@ class RunnerDeployment(BaseModel):
                 work_queue_name=self.work_queue_name,
                 work_pool_name=work_pool_name,
                 version=self.version,
-                schedule=self.schedule,
-                is_schedule_active=self.is_schedule_active,
+                paused=self.paused,
+                schedules=self.schedules,
                 parameters=self.parameters,
                 description=self.description,
                 tags=self.tags,
@@ -299,50 +360,87 @@ class RunnerDeployment(BaseModel):
             return deployment_id
 
     @staticmethod
-    def _construct_schedule(
-        interval: Optional[Union[int, float, timedelta]] = None,
+    def _construct_deployment_schedules(
+        interval: Optional[
+            Union[Iterable[Union[int, float, timedelta]], int, float, timedelta]
+        ] = None,
         anchor_date: Optional[Union[datetime, str]] = None,
-        cron: Optional[str] = None,
-        rrule: Optional[str] = None,
+        cron: Optional[Union[Iterable[str], str]] = None,
+        rrule: Optional[Union[Iterable[str], str]] = None,
         timezone: Optional[str] = None,
         schedule: Optional[SCHEDULE_TYPES] = None,
-    ) -> Optional[SCHEDULE_TYPES]:
+        schedules: Optional[List[FlexibleScheduleList]] = None,
+    ) -> Union[List[MinimalDeploymentSchedule], List[FlexibleScheduleList]]:
         """
-        Construct a schedule from the provided arguments.
+        Construct a schedule or schedules from the provided arguments.
 
-        This is a single path for all serve schedules. If schedule is provided,
-        it is returned. Otherwise, the other arguments are used to construct a schedule.
+        This method serves as a unified interface for creating deployment
+        schedules. If `schedules` is provided, it is directly returned. If
+        `schedule` is provided, it is encapsulated in a list and returned. If
+        `interval`, `cron`, or `rrule` are provided, they are used to construct
+        schedule objects.
 
         Args:
-            interval: An interval on which to schedule runs. Accepts either a number
-                or a timedelta object. If a number is given, it will be interpreted as seconds.
-            anchor_date: The start date for an interval schedule.
-            cron: A cron schedule for runs.
-            rrule: An rrule schedule of when to execute runs of this flow.
-            timezone: A timezone to use for the schedule.
-            schedule: A schedule object of when to execute runs of this flow. Used for
-                advanced scheduling options like timezone.
+            interval: An interval on which to schedule runs, either as a single
+              value or as a list of values. Accepts numbers (interpreted as
+              seconds) or `timedelta` objects. Each value defines a separate
+              scheduling interval.
+            anchor_date: The anchor date from which interval schedules should
+              start. This applies to all intervals if a list is provided.
+            cron: A cron expression or a list of cron expressions defining cron
+              schedules. Each expression defines a separate cron schedule.
+            rrule: An rrule string or a list of rrule strings for scheduling.
+              Each string defines a separate recurrence rule.
+            timezone: The timezone to apply to the cron or rrule schedules.
+              This is a single value applied uniformly to all schedules.
+            schedule: A singular schedule object, used for advanced scheduling
+              options like specifying a timezone. This is returned as a list
+              containing this single schedule.
+            schedules: A pre-defined list of schedule objects. If provided,
+              this list is returned as-is, bypassing other schedule construction
+              logic.
         """
+
         num_schedules = sum(
-            1 for entry in (interval, cron, rrule, schedule) if entry is not None
+            1
+            for entry in (interval, cron, rrule, schedule, schedules)
+            if entry is not None
         )
         if num_schedules > 1:
             raise ValueError(
-                "Only one of interval, cron, rrule, or schedule can be provided."
+                "Only one of interval, cron, rrule, schedule, or schedules can be provided."
             )
+        elif num_schedules == 0:
+            return []
 
-        if schedule:
-            return schedule
+        if schedules is not None:
+            return schedules
         elif interval or cron or rrule:
-            return construct_schedule(
-                interval=interval,
-                cron=cron,
-                rrule=rrule,
-                timezone=timezone,
-                anchor_date=anchor_date,
-            )
+            # `interval`, `cron`, and `rrule` can be lists of values. This
+            # block figures out which one is not None and uses that to
+            # construct the list of schedules via `construct_schedule`.
+            parameters = [("interval", interval), ("cron", cron), ("rrule", rrule)]
+            schedule_type, value = [
+                param for param in parameters if param[1] is not None
+            ][0]
+
+            if not isiterable(value):
+                value = [value]
+
+            return [
+                _to_deployment_schedule(
+                    construct_schedule(
+                        **{
+                            schedule_type: v,
+                            "timezone": timezone,
+                            "anchor_date": anchor_date,
+                        }
+                    )
+                )
+                for v in value
+            ]
         else:
-            return None
+            return [_to_deployment_schedule(schedule)]
 
     def _set_defaults_from_flow(self, flow: "Flow"):
         self._parameter_openapi_schema = parameter_schema(flow)
@@ -357,9 +455,13 @@ class RunnerDeployment(BaseModel):
         cls,
         flow: "Flow",
         name: str,
-        interval: Optional[Union[int, float, timedelta]] = None,
-        cron: Optional[str] = None,
-        rrule: Optional[str] = None,
+        interval: Optional[
+            Union[Iterable[Union[int, float, timedelta]], int, float, timedelta]
+        ] = None,
+        cron: Optional[Union[Iterable[str], str]] = None,
+        rrule: Optional[Union[Iterable[str], str]] = None,
+        paused: Optional[bool] = None,
+        schedules: Optional[List[FlexibleScheduleList]] = None,
         schedule: Optional[SCHEDULE_TYPES] = None,
         is_schedule_active: Optional[bool] = None,
         parameters: Optional[dict] = None,
@@ -382,6 +484,9 @@ class RunnerDeployment(BaseModel):
                 or a timedelta object. If a number is given, it will be interpreted as seconds.
             cron: A cron schedule of when to execute runs of this flow.
             rrule: An rrule schedule of when to execute runs of this flow.
+            paused: Whether or not to set this deployment as paused.
+            schedules: A list of schedule objects defining when to execute runs of this deployment.
+                Used to define multiple schedules or additional scheduling options like `timezone`.
             schedule: A schedule object of when to execute runs of this flow. Used for
                 advanced scheduling options like timezone.
             is_schedule_active: Whether or not to set the schedule for this deployment as active. If
@@ -403,8 +508,12 @@ class RunnerDeployment(BaseModel):
                 of the chosen work pool. Refer to the base job template of the chosen work pool for
                 available settings.
         """
-        schedule = cls._construct_schedule(
-            interval=interval, cron=cron, rrule=rrule, schedule=schedule
+        constructed_schedules = cls._construct_deployment_schedules(
+            interval=interval,
+            cron=cron,
+            rrule=rrule,
+            schedule=schedule,
+            schedules=schedules,
         )
 
         job_variables = job_variables or {}
@@ -413,7 +522,9 @@ class RunnerDeployment(BaseModel):
             name=Path(name).stem,
             flow_name=flow.name,
             schedule=schedule,
+            schedules=constructed_schedules,
             is_schedule_active=is_schedule_active,
+            paused=paused,
             tags=tags or [],
             triggers=triggers or [],
             parameters=parameters or {},
@@ -467,9 +578,13 @@ class RunnerDeployment(BaseModel):
         cls,
         entrypoint: str,
         name: str,
-        interval: Optional[Union[int, float, timedelta]] = None,
-        cron: Optional[str] = None,
-        rrule: Optional[str] = None,
+        interval: Optional[
+            Union[Iterable[Union[int, float, timedelta]], int, float, timedelta]
+        ] = None,
+        cron: Optional[Union[Iterable[str], str]] = None,
+        rrule: Optional[Union[Iterable[str], str]] = None,
+        paused: Optional[bool] = None,
+        schedules: Optional[List[FlexibleScheduleList]] = None,
         schedule: Optional[SCHEDULE_TYPES] = None,
         is_schedule_active: Optional[bool] = None,
         parameters: Optional[dict] = None,
@@ -493,6 +608,9 @@ class RunnerDeployment(BaseModel):
                 or a timedelta object. If a number is given, it will be interpreted as seconds.
             cron: A cron schedule of when to execute runs of this flow.
             rrule: An rrule schedule of when to execute runs of this flow.
+            paused: Whether or not to set this deployment as paused.
+            schedules: A list of schedule objects defining when to execute runs of this deployment.
+                Used to define multiple schedules or additional scheduling options like `timezone`.
             schedule: A schedule object of when to execute runs of this flow. Used for
                 advanced scheduling options like timezone.
             is_schedule_active: Whether or not to set the schedule for this deployment as active. If
@@ -519,17 +637,20 @@ class RunnerDeployment(BaseModel):
         job_variables = job_variables or {}
         flow = load_flow_from_entrypoint(entrypoint)
 
-        schedule = cls._construct_schedule(
+        constructed_schedules = cls._construct_deployment_schedules(
             interval=interval,
             cron=cron,
             rrule=rrule,
             schedule=schedule,
+            schedules=schedules,
         )
 
         deployment = cls(
             name=Path(name).stem,
             flow_name=flow.name,
             schedule=schedule,
+            schedules=constructed_schedules,
+            paused=paused,
             is_schedule_active=is_schedule_active,
             tags=tags or [],
             triggers=triggers or [],
@@ -555,9 +676,13 @@ class RunnerDeployment(BaseModel):
         storage: RunnerStorage,
         entrypoint: str,
         name: str,
-        interval: Optional[Union[int, float, timedelta]] = None,
-        cron: Optional[str] = None,
-        rrule: Optional[str] = None,
+        interval: Optional[
+            Union[Iterable[Union[int, float, timedelta]], int, float, timedelta]
+        ] = None,
+        cron: Optional[Union[Iterable[str], str]] = None,
+        rrule: Optional[Union[Iterable[str], str]] = None,
+        paused: Optional[bool] = None,
+        schedules: Optional[List[FlexibleScheduleList]] = None,
         schedule: Optional[SCHEDULE_TYPES] = None,
         is_schedule_active: Optional[bool] = None,
         parameters: Optional[dict] = None,
@@ -607,9 +732,14 @@ class RunnerDeployment(BaseModel):
         """
         from prefect.flows import load_flow_from_entrypoint
 
-        schedule = cls._construct_schedule(
-            interval=interval, cron=cron, rrule=rrule, schedule=schedule
+        constructed_schedules = cls._construct_deployment_schedules(
+            interval=interval,
+            cron=cron,
+            rrule=rrule,
+            schedule=schedule,
+            schedules=schedules,
         )
+
         job_variables = job_variables or {}
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -625,6 +755,8 @@ class RunnerDeployment(BaseModel):
             name=Path(name).stem,
             flow_name=flow.name,
             schedule=schedule,
+            schedules=constructed_schedules,
+            paused=paused,
             is_schedule_active=is_schedule_active,
             tags=tags or [],
             triggers=triggers or [],

--- a/src/prefect/server/schemas/responses.py
+++ b/src/prefect/server/schemas/responses.py
@@ -306,10 +306,10 @@ class DeploymentResponse(ORMBaseModel):
         # schedule as the primary schedule.
         if orm_deployment.schedules:
             response.schedule = orm_deployment.schedules[0].schedule
-            response.is_schedule_active = orm_deployment.schedules[0].active
         else:
             response.schedule = None
-            response.is_schedule_active = not orm_deployment.paused
+
+        response.is_schedule_active = not bool(orm_deployment.paused)
 
         return response
 

--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -748,7 +748,7 @@ class TestDeploymentSchedules:
                 "inspect",
                 "rence-griffith/test-deployment",
             ],
-            expected_output_contains=["'is_schedule_active': False"],
+            expected_output_contains=["'active': False"],
         )
 
         invoke_and_assert(
@@ -766,7 +766,7 @@ class TestDeploymentSchedules:
                 "inspect",
                 "rence-griffith/test-deployment",
             ],
-            expected_output_contains=["'is_schedule_active': True"],
+            expected_output_contains=["'active': True"],
         )
 
     def test_pausing_and_resuming_schedules_with_schedule_pause(
@@ -789,7 +789,7 @@ class TestDeploymentSchedules:
                 "inspect",
                 "rence-griffith/test-deployment",
             ],
-            expected_output_contains=["'is_schedule_active': False"],
+            expected_output_contains=["'active': False"],
         )
 
         invoke_and_assert(
@@ -809,7 +809,7 @@ class TestDeploymentSchedules:
                 "inspect",
                 "rence-griffith/test-deployment",
             ],
-            expected_output_contains=["'is_schedule_active': True"],
+            expected_output_contains=["'active': True"],
         )
 
     def test_pause_schedule_deployment_not_found_raises(self, flojo):

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -4,6 +4,7 @@ import re
 import signal
 import sys
 import time
+import warnings
 from itertools import combinations
 from pathlib import Path
 from textwrap import dedent
@@ -20,7 +21,7 @@ from prefect._vendor.starlette import status
 import prefect.runner
 from prefect import flow, serve, task
 from prefect.client.orchestration import PrefectClient
-from prefect.client.schemas.objects import StateType
+from prefect.client.schemas.objects import MinimalDeploymentSchedule, StateType
 from prefect.client.schemas.schedules import CronSchedule
 from prefect.deployments.runner import (
     DeploymentApplyError,
@@ -225,14 +226,16 @@ class TestServe:
         )
 
         assert deployment is not None
-        assert deployment.schedule.interval == datetime.timedelta(seconds=3600)
+        assert deployment.schedules[0].schedule.interval == datetime.timedelta(
+            seconds=3600
+        )
 
         deployment = await prefect_client.read_deployment_by_name(
             name="dummy-flow-2/test_runner"
         )
 
         assert deployment is not None
-        assert deployment.schedule.cron == "* * * * *"
+        assert deployment.schedules[0].schedule.cron == "* * * * *"
 
     async def test_serve_starts_a_runner(
         self, prefect_client: PrefectClient, mock_runner_start: AsyncMock
@@ -259,11 +262,13 @@ class TestRunner:
 
         assert deployment_1 is not None
         assert deployment_1.name == "test_runner"
-        assert deployment_1.schedule.interval == datetime.timedelta(seconds=3600)
+        assert deployment_1.schedules[0].schedule.interval == datetime.timedelta(
+            seconds=3600
+        )
 
         assert deployment_2 is not None
         assert deployment_2.name == "test_runner"
-        assert deployment_2.schedule.cron == "* * * * *"
+        assert deployment_2.schedules[0].schedule.cron == "* * * * *"
 
     @pytest.mark.parametrize(
         "kwargs",
@@ -275,18 +280,26 @@ class TestRunner:
                     {"cron": "* * * * *"},
                     {"rrule": "FREQ=MINUTELY"},
                     {"schedule": CronSchedule(cron="* * * * *")},
+                    {
+                        "schedules": [
+                            MinimalDeploymentSchedule(
+                                schedule=CronSchedule(cron="* * * * *"), active=True
+                            )
+                        ]
+                    },
                 ],
                 2,
             )
         ],
     )
-    async def test_add_flow_raises_on_multiple_schedules(self, kwargs):
-        expected_message = (
-            "Only one of interval, cron, rrule, or schedule can be provided."
-        )
-        runner = Runner()
-        with pytest.raises(ValueError, match=expected_message):
-            await runner.add_flow(dummy_flow_1, __file__, **kwargs)
+    async def test_add_flow_raises_on_multiple_schedule_parameters(self, kwargs):
+        with warnings.catch_warnings():
+            # `schedule` parameter is deprecated and will raise a warning
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            expected_message = "Only one of interval, cron, rrule, schedule, or schedules can be provided."
+            runner = Runner()
+            with pytest.raises(ValueError, match=expected_message):
+                await runner.add_flow(dummy_flow_1, __file__, **kwargs)
 
     async def test_add_deployments_to_runner(self, prefect_client: PrefectClient):
         """Runner.add_deployment should apply the deployment passed to it"""
@@ -303,11 +316,13 @@ class TestRunner:
 
         assert deployment_1 is not None
         assert deployment_1.name == "test_runner"
-        assert deployment_1.schedule.interval == datetime.timedelta(seconds=3600)
+        assert deployment_1.schedules[0].schedule.interval == datetime.timedelta(
+            seconds=3600
+        )
 
         assert deployment_2 is not None
         assert deployment_2.name == "test_runner"
-        assert deployment_2.schedule.cron == "* * * * *"
+        assert deployment_2.schedules[0].schedule.cron == "* * * * *"
 
     async def test_runner_can_pause_schedules_on_stop(
         self, prefect_client: PrefectClient, caplog
@@ -344,8 +359,8 @@ class TestRunner:
 
         assert not deployment_2.is_schedule_active
 
-        assert "Pausing schedules for all deployments" in caplog.text
-        assert "All deployment schedules have been paused" in caplog.text
+        assert "Pausing all deployments" in caplog.text
+        assert "All deployments have been paused" in caplog.text
 
     @pytest.mark.usefixtures("use_hosted_api_server")
     async def test_runner_executes_flow_runs(self, prefect_client: PrefectClient):
@@ -368,6 +383,7 @@ class TestRunner:
         await runner.start(run_once=True)
         flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
 
+        assert flow_run.state
         assert flow_run.state.is_completed()
 
     @pytest.mark.usefixtures("use_hosted_api_server")
@@ -411,6 +427,7 @@ class TestRunner:
             while True:
                 await anyio.sleep(0.5)
                 flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+                assert flow_run.state
                 if flow_run.state.is_running():
                     break
 
@@ -426,6 +443,7 @@ class TestRunner:
             while True:
                 await anyio.sleep(0.5)
                 flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+                assert flow_run.state
                 if flow_run.state.is_cancelled():
                     break
 
@@ -473,6 +491,7 @@ class TestRunner:
         await runner.execute_flow_run(flow_run.id)
 
         flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+        assert flow_run.state
         assert flow_run.state.is_crashed()
         # check to make sure on_cancellation hook was called
         assert "This flow crashed!" in caplog.text
@@ -491,6 +510,7 @@ class TestRunner:
         await runner.execute_flow_run(flow_run.id)
 
         flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+        assert flow_run.state
         assert flow_run.state.is_completed()
 
     @pytest.mark.usefixtures("use_hosted_api_server")
@@ -507,6 +527,7 @@ class TestRunner:
         bad_run = await prefect_client.create_flow_run_from_deployment(
             deployment_id=deployment_id
         )
+
         runner._acquire_limit_slot(good_run.id)
         await runner.execute_flow_run(bad_run.id)
         assert "run limit reached" in caplog.text
@@ -697,31 +718,100 @@ class TestRunnerDeployment:
         assert deployment.description == "Deployment descriptions"
         assert deployment.version == "alpha"
         assert deployment.tags == ["test"]
-        assert deployment.is_schedule_active is None
+        assert deployment.is_schedule_active is True
         assert deployment.enforce_parameter_schema
 
     def test_from_flow_accepts_interval(self):
         deployment = RunnerDeployment.from_flow(dummy_flow_1, __file__, interval=3600)
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule.interval == datetime.timedelta(
+            seconds=3600
+        )
 
-        assert deployment.schedule.interval == datetime.timedelta(seconds=3600)
+    def test_from_flow_accepts_interval_as_list(self):
+        deployment = RunnerDeployment.from_flow(
+            dummy_flow_1, __file__, interval=[3600, 7200]
+        )
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule.interval == datetime.timedelta(
+            seconds=3600
+        )
+        assert deployment.schedules[1].schedule.interval == datetime.timedelta(
+            seconds=7200
+        )
 
     def test_from_flow_accepts_cron(self):
         deployment = RunnerDeployment.from_flow(
             dummy_flow_1, __file__, cron="* * * * *"
         )
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule.cron == "* * * * *"
 
-        assert deployment.schedule.cron == "* * * * *"
+    def test_from_flow_accepts_cron_as_list(self):
+        deployment = RunnerDeployment.from_flow(
+            dummy_flow_1,
+            __file__,
+            cron=[
+                "0 * * * *",
+                "0 0 1 * *",
+                "*/10 * * * *",
+            ],
+        )
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule.cron == "0 * * * *"
+        assert deployment.schedules[1].schedule.cron == "0 0 1 * *"
+        assert deployment.schedules[2].schedule.cron == "*/10 * * * *"
 
     def test_from_flow_accepts_rrule(self):
         deployment = RunnerDeployment.from_flow(
             dummy_flow_1, __file__, rrule="FREQ=MINUTELY"
         )
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule.rrule == "FREQ=MINUTELY"
 
-        assert deployment.schedule.rrule == "FREQ=MINUTELY"
+    def test_from_flow_accepts_rrule_as_list(self):
+        deployment = RunnerDeployment.from_flow(
+            dummy_flow_1,
+            __file__,
+            rrule=[
+                "FREQ=DAILY",
+                "FREQ=WEEKLY",
+                "FREQ=MONTHLY",
+            ],
+        )
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule.rrule == "FREQ=DAILY"
+        assert deployment.schedules[1].schedule.rrule == "FREQ=WEEKLY"
+        assert deployment.schedules[2].schedule.rrule == "FREQ=MONTHLY"
+
+    def test_from_flow_accepts_schedules(self):
+        deployment = RunnerDeployment.from_flow(
+            dummy_flow_1,
+            __file__,
+            schedules=[
+                MinimalDeploymentSchedule(
+                    schedule=CronSchedule(cron="* * * * *"), active=True
+                )
+            ],
+        )
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule.cron == "* * * * *"
+        assert deployment.schedules[0].active is True
 
     @pytest.mark.parametrize(
         "value,expected",
-        [(True, True), (False, False), (None, None)],
+        [(True, True), (False, False), (None, False)],
+    )
+    def test_from_flow_accepts_paused(self, value, expected):
+        deployment = RunnerDeployment.from_flow(dummy_flow_1, __file__, paused=value)
+
+        assert deployment.paused is expected
+        # `is_schedule_active` is the opposite of `paused`
+        assert deployment.is_schedule_active is not expected
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [(True, True), (False, False), (None, True)],
     )
     def test_from_flow_accepts_is_schedule_active(self, value, expected):
         deployment = RunnerDeployment.from_flow(
@@ -740,14 +830,21 @@ class TestRunnerDeployment:
                     {"cron": "* * * * *"},
                     {"rrule": "FREQ=MINUTELY"},
                     {"schedule": CronSchedule(cron="* * * * *")},
+                    {
+                        "schedules": [
+                            MinimalDeploymentSchedule(
+                                schedule=CronSchedule(cron="* * * * *"), active=True
+                            )
+                        ],
+                    },
                 ],
                 2,
             )
         ],
     )
-    def test_from_flow_raises_on_multiple_schedules(self, kwargs):
+    def test_from_flow_raises_on_multiple_schedule_parameters(self, kwargs):
         expected_message = (
-            "Only one of interval, cron, rrule, or schedule can be provided."
+            "Only one of interval, cron, rrule, schedule, or schedules can be provided."
         )
         with pytest.raises(ValueError, match=expected_message):
             RunnerDeployment.from_flow(dummy_flow_1, __file__, **kwargs)
@@ -815,26 +912,99 @@ class TestRunnerDeployment:
         deployment = RunnerDeployment.from_entrypoint(
             dummy_flow_1_entrypoint, __file__, interval=3600
         )
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule.interval == datetime.timedelta(
+            seconds=3600
+        )
 
-        assert deployment.schedule.interval == datetime.timedelta(seconds=3600)
+    def test_from_entrypoint_accepts_interval_as_list(self, dummy_flow_1_entrypoint):
+        deployment = RunnerDeployment.from_entrypoint(
+            dummy_flow_1_entrypoint, __file__, interval=[3600, 7200]
+        )
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule.interval == datetime.timedelta(
+            seconds=3600
+        )
+        assert deployment.schedules[1].schedule.interval == datetime.timedelta(
+            seconds=7200
+        )
 
     def test_from_entrypoint_accepts_cron(self, dummy_flow_1_entrypoint):
         deployment = RunnerDeployment.from_entrypoint(
             dummy_flow_1_entrypoint, __file__, cron="* * * * *"
         )
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule.cron == "* * * * *"
 
-        assert deployment.schedule.cron == "* * * * *"
+    def test_from_entrypoint_accepts_cron_as_list(self, dummy_flow_1_entrypoint):
+        deployment = RunnerDeployment.from_entrypoint(
+            dummy_flow_1_entrypoint,
+            __file__,
+            cron=[
+                "0 * * * *",
+                "0 0 1 * *",
+                "*/10 * * * *",
+            ],
+        )
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule.cron == "0 * * * *"
+        assert deployment.schedules[1].schedule.cron == "0 0 1 * *"
+        assert deployment.schedules[2].schedule.cron == "*/10 * * * *"
 
     def test_from_entrypoint_accepts_rrule(self, dummy_flow_1_entrypoint):
         deployment = RunnerDeployment.from_entrypoint(
             dummy_flow_1_entrypoint, __file__, rrule="FREQ=MINUTELY"
         )
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule.rrule == "FREQ=MINUTELY"
 
-        assert deployment.schedule.rrule == "FREQ=MINUTELY"
+    def test_from_entrypoint_accepts_rrule_as_list(self, dummy_flow_1_entrypoint):
+        deployment = RunnerDeployment.from_entrypoint(
+            dummy_flow_1_entrypoint,
+            __file__,
+            rrule=[
+                "FREQ=DAILY",
+                "FREQ=WEEKLY",
+                "FREQ=MONTHLY",
+            ],
+        )
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule.rrule == "FREQ=DAILY"
+        assert deployment.schedules[1].schedule.rrule == "FREQ=WEEKLY"
+        assert deployment.schedules[2].schedule.rrule == "FREQ=MONTHLY"
+
+    def test_from_entrypoint_accepts_schedules(self, dummy_flow_1_entrypoint):
+        deployment = RunnerDeployment.from_entrypoint(
+            dummy_flow_1_entrypoint,
+            __file__,
+            schedules=[
+                MinimalDeploymentSchedule(
+                    schedule=CronSchedule(cron="* * * * *"), active=True
+                )
+            ],
+        )
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule.cron == "* * * * *"
+        assert deployment.schedules[0].active is True
 
     @pytest.mark.parametrize(
         "value,expected",
-        [(True, True), (False, False), (None, None)],
+        [(True, True), (False, False), (None, False)],
+    )
+    def test_from_entrypoint_accepts_paused(
+        self, value, expected, dummy_flow_1_entrypoint
+    ):
+        deployment = RunnerDeployment.from_entrypoint(
+            dummy_flow_1_entrypoint, __file__, paused=value
+        )
+
+        assert deployment.paused is expected
+        # `is_schedule_active` is the opposite of `paused`
+        assert deployment.is_schedule_active is not expected
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [(True, True), (False, False), (None, True)],
     )
     def test_from_entrypoint_accepts_is_schedule_active(
         self, dummy_flow_1_entrypoint, value, expected
@@ -855,16 +1025,23 @@ class TestRunnerDeployment:
                     {"cron": "* * * * *"},
                     {"rrule": "FREQ=MINUTELY"},
                     {"schedule": CronSchedule(cron="* * * * *")},
+                    {
+                        "schedules": [
+                            MinimalDeploymentSchedule(
+                                schedule=CronSchedule(cron="* * * * *"), active=True
+                            )
+                        ]
+                    },
                 ],
                 2,
             )
         ],
     )
-    def test_from_entrypoint_raises_on_multiple_schedules(
+    def test_from_entrypoint_raises_on_multiple_schedule_parameters(
         self, dummy_flow_1_entrypoint, kwargs
     ):
         expected_message = (
-            "Only one of interval, cron, rrule, or schedule can be provided."
+            "Only one of interval, cron, rrule, schedule, or schedules can be provided."
         )
         with pytest.raises(ValueError, match=expected_message):
             RunnerDeployment.from_entrypoint(
@@ -890,7 +1067,9 @@ class TestRunnerDeployment:
         assert deployment.entrypoint == "tests/runner/test_runner.py:dummy_flow_1"
         assert deployment.version == "test"
         assert deployment.description == "I'm just here for tests"
-        assert deployment.schedule.interval == datetime.timedelta(seconds=3600)
+        assert deployment.schedules[0].schedule.interval == datetime.timedelta(
+            seconds=3600
+        )
         assert deployment.work_pool_name is None
         assert deployment.work_queue_name is None
         assert deployment.path == "."
@@ -1007,7 +1186,9 @@ class TestRunnerDeployment:
         # Verify the created RunnerDeployment's attributes
         assert deployment.name == "test-deployment"
         assert deployment.flow_name == "test-flow"
-        assert deployment.schedule.interval == datetime.timedelta(seconds=30)
+        assert deployment.schedules[0].schedule.interval == datetime.timedelta(
+            seconds=30
+        )
         assert deployment.tags == ["tag1", "tag2"]
         assert deployment.version == "1.0.0"
         assert deployment.description == "Test Deployment Description"
@@ -1015,6 +1196,41 @@ class TestRunnerDeployment:
         assert "$STORAGE_BASE_PATH" in deployment._path
         assert deployment.entrypoint == "flows.py:test_flow"
         assert deployment.storage == storage
+
+    async def test_from_storage_accepts_schedules(self):
+        storage = MockStorage()
+
+        deployment = await RunnerDeployment.from_storage(
+            storage=storage,
+            entrypoint="flows.py:test_flow",
+            name="test-deployment",
+            schedules=[
+                MinimalDeploymentSchedule(
+                    schedule=CronSchedule(cron="* * * * *"), active=True
+                )
+            ],
+        )
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule.cron == "* * * * *"
+        assert deployment.schedules[0].active is True
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [(True, True), (False, False), (None, False)],
+    )
+    async def test_from_storage_accepts_paused(self, value, expected):
+        storage = MockStorage()
+
+        deployment = await RunnerDeployment.from_storage(
+            storage=storage,
+            entrypoint="flows.py:test_flow",
+            name="test-deployment",
+            paused=value,
+        )
+
+        assert deployment.paused is expected
+        # `is_schedule_active` is the opposite of `paused`
+        assert deployment.is_schedule_active is not expected
 
 
 class TestServer:

--- a/tests/server/api/test_deployments.py
+++ b/tests/server/api/test_deployments.py
@@ -271,20 +271,20 @@ class TestCreateDeployment:
         deployment_id = data["id"]
         schedules = [schemas.core.DeploymentSchedule(**s) for s in data["schedules"]]
 
-        assert response.status_code == 200
         assert data["name"] == "My Deployment"
 
         assert len(schedules) == 2
         assert schedules[0].id == first_schedule.id
 
         # When a deployment has multiple schedules, we still populate `schedule`
-        # and `is_schedule_active` with the most recently updated schedule.
+        # and with the most recently updated schedule and `is_schedule_active`
+        # with the opposite value of `paused`.
 
         assert (
             schemas.schedules.IntervalSchedule(**data["schedule"])
             == schedules[0].schedule
         )
-        assert data["is_schedule_active"] is schedules[0].active
+        assert data["is_schedule_active"] is not data["paused"]
 
     async def test_create_deployment_with_no_schedules_flag_on_populates_legacy_schedule_as_none(
         self,

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -7,6 +7,7 @@ import signal
 import sys
 import threading
 import time
+import warnings
 from functools import partial
 from itertools import combinations
 from pathlib import Path
@@ -3264,18 +3265,23 @@ class TestFlowToDeployment:
     async def test_to_deployment_accepts_interval(self):
         deployment = await test_flow.to_deployment(name="test", interval=3600)
 
-        assert isinstance(deployment.schedule, IntervalSchedule)
-        assert deployment.schedule.interval == datetime.timedelta(seconds=3600)
+        assert deployment.schedules
+        assert isinstance(deployment.schedules[0].schedule, IntervalSchedule)
+        assert deployment.schedules[0].schedule.interval == datetime.timedelta(
+            seconds=3600
+        )
 
     async def test_to_deployment_accepts_cron(self):
         deployment = await test_flow.to_deployment(name="test", cron="* * * * *")
 
-        assert deployment.schedule == CronSchedule(cron="* * * * *")
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule == CronSchedule(cron="* * * * *")
 
     async def test_to_deployment_accepts_rrule(self):
         deployment = await test_flow.to_deployment(name="test", rrule="FREQ=MINUTELY")
 
-        assert deployment.schedule == RRuleSchedule(rrule="FREQ=MINUTELY")
+        assert deployment.schedules
+        assert deployment.schedules[0].schedule == RRuleSchedule(rrule="FREQ=MINUTELY")
 
     async def test_to_deployment_invalid_name_raises(self):
         with pytest.raises(InvalidNameError, match="contains an invalid character"):
@@ -3296,12 +3302,13 @@ class TestFlowToDeployment:
             )
         ],
     )
-    def test_to_deployment_raises_on_multiple_schedules(self, kwargs):
-        expected_message = (
-            "Only one of interval, cron, rrule, or schedule can be provided."
-        )
-        with pytest.raises(ValueError, match=expected_message):
-            test_flow.to_deployment(__file__, **kwargs)
+    def test_to_deployment_raises_on_multiple_schedule_parameters(self, kwargs):
+        with warnings.catch_warnings():
+            # `schedule` parameter is deprecated and will raise a warning
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            expected_message = "Only one of interval, cron, rrule, schedule, or schedules can be provided."
+            with pytest.raises(ValueError, match=expected_message):
+                test_flow.to_deployment(__file__, **kwargs)
 
 
 class TestFlowServe:
@@ -3330,7 +3337,7 @@ class TestFlowServe:
             description="This is a test",
             version="alpha",
             enforce_parameter_schema=True,
-            is_schedule_active=False,
+            paused=True,
         )
 
         deployment = await prefect_client.read_deployment_by_name(name="test-flow/test")
@@ -3345,6 +3352,7 @@ class TestFlowServe:
         assert deployment.description == "This is a test"
         assert deployment.version == "alpha"
         assert deployment.enforce_parameter_schema
+        assert deployment.paused
         assert not deployment.is_schedule_active
 
     async def test_serve_handles__file__(self, prefect_client: PrefectClient):
@@ -3406,11 +3414,12 @@ class TestFlowServe:
         ],
     )
     async def test_serve_raises_on_multiple_schedules(self, kwargs):
-        expected_message = (
-            "Only one of interval, cron, rrule, or schedule can be provided."
-        )
-        with pytest.raises(ValueError, match=expected_message):
-            await test_flow.serve(__file__, **kwargs)
+        with warnings.catch_warnings():
+            # `schedule` parameter is deprecated and will raise a warning
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            expected_message = "Only one of interval, cron, rrule, schedule, or schedules can be provided."
+            with pytest.raises(ValueError, match=expected_message):
+                await test_flow.serve(__file__, **kwargs)
 
     async def test_serve_starts_a_runner(self, mock_runner_start):
         """
@@ -3598,7 +3607,7 @@ class TestFlowDeploy:
             build=False,
             push=False,
             enforce_parameter_schema=True,
-            is_schedule_active=False,
+            paused=True,
         )
 
         mock_deploy.assert_called_once_with(
@@ -3611,7 +3620,7 @@ class TestFlowDeploy:
                 work_queue_name="line",
                 job_variables={"foo": "bar"},
                 enforce_parameter_schema=True,
-                is_schedule_active=False,
+                paused=True,
             ),
             work_pool_name=work_pool.name,
             image=image,
@@ -3646,7 +3655,7 @@ class TestFlowDeploy:
             image=image,
             push=False,
             enforce_parameter_schema=True,
-            is_schedule_active=False,
+            paused=True,
         )
 
         mock_deploy.assert_called_once_with(
@@ -3659,7 +3668,7 @@ class TestFlowDeploy:
                 work_queue_name="line",
                 job_variables={"foo": "bar"},
                 enforce_parameter_schema=True,
-                is_schedule_active=False,
+                paused=True,
             ),
             work_pool_name=work_pool.name,
             image=image,


### PR DESCRIPTION
This updates `flow.serve` to support multiple schedules. The schedules can be given in many different forms:

```
schedules=[IntervalSchedule(...), CronSchedule(...), ...]
schedules=[{"schedule": IntervalSchedule(...), "active": False}]
schedules=[MinimalDeploymentSchedule(schedule=IntervalSchedule(...), active=False)]
```

You can also specify multiple `interval`, `cron`, and `rrule` schedules via shorthand:

```
cron=["* * * *", ...]
interval=(3600, 7200, ...)
rrule={"FREQ=DAILY", "FREQ=WEEKLY", ...}
```
Closes #12090 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.