### PR TITLE
Update Coiled link on integrations page

### DIFF
--- a/docs/integrations/catalog/prefect-coiled.yaml
+++ b/docs/integrations/catalog/prefect-coiled.yaml
@@ -1,6 +1,6 @@
 collectionName: coiled
 author: Coiled
 authorUrl: https://www.coiled.io/
-documentation: https://docs.coiled.io/user_guide/labs/prefect.html
+documentation: https://docs.coiled.io/user_guide/labs/prefect.html?utm_source=prefect-docs&utm_medium=integrations
 iconUrl: /img/collections/coiled.png
 tag: Coiled


### PR DESCRIPTION
A small follow-up to https://github.com/PrefectHQ/prefect/pull/12098 that updates the link to the corresponding Coiled docs. 

xref https://github.com/PrefectHQ/prefect/pull/12098#issuecomment-1969912418

