### PR TITLE
ensure only scheduled runs can be marked late

### DIFF
--- a/src/prefect/server/services/late_runs.py
+++ b/src/prefect/server/services/late_runs.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import prefect.server.models as models
 from prefect.server.database.dependencies import inject_db
 from prefect.server.database.interface import PrefectDBInterface
+from prefect.server.orchestration.core_policy import MarkLateRunsPolicy
 from prefect.server.schemas import states
 from prefect.server.services.loop_service import LoopService
 from prefect.settings import (
@@ -115,7 +116,7 @@ class MarkLateRuns(LoopService):
             session=session,
             flow_run_id=flow_run.id,
             state=states.Late(scheduled_time=flow_run.next_scheduled_start_time),
-            force=True,
+            flow_policy=MarkLateRunsPolicy,  # type: ignore
         )
 
 

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -864,6 +864,7 @@ async def commit_task_run_state(
     state_type: states.StateType,
     state_details=None,
     state_data=None,
+    state_name=None,
 ):
     if state_type is None:
         return None
@@ -874,6 +875,7 @@ async def commit_task_run_state(
         timestamp=pendulum.now("UTC").subtract(seconds=5),
         state_details=state_details,
         data=state_data,
+        name=state_name,
     )
 
     result = await models.task_runs.set_task_run_state(

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -893,6 +893,7 @@ async def commit_flow_run_state(
     state_type: states.StateType,
     state_details=None,
     state_data=None,
+    state_name=None,
 ):
     if state_type is None:
         return None
@@ -903,6 +904,7 @@ async def commit_flow_run_state(
         timestamp=pendulum.now("UTC").subtract(seconds=5),
         state_details=state_details,
         data=state_data,
+        name=state_name,
     )
 
     result = await models.flow_runs.set_flow_run_state(
@@ -933,6 +935,8 @@ def initialize_orchestration(flow):
         flow_run_count: int = None,
         resuming: bool = None,
         initial_flow_run_state_details=None,
+        initial_state_name: str = None,
+        proposed_state_name: str = None,
     ):
         flow_create_kwargs = {}
         empirical_policy = {}
@@ -996,12 +1000,15 @@ def initialize_orchestration(flow):
             initial_state_type,
             initial_details,
             state_data=initial_state_data,
+            state_name=initial_state_name,
         )
 
         proposed_details = proposed_details if proposed_details else dict()
         if proposed_state_type is not None:
             psd = states.StateDetails(**proposed_details)
-            proposed_state = states.State(type=proposed_state_type, state_details=psd)
+            proposed_state = states.State(
+                type=proposed_state_type, state_details=psd, name=proposed_state_name
+            )
         else:
             proposed_state = None
 

--- a/tests/server/orchestration/test_rules.py
+++ b/tests/server/orchestration/test_rules.py
@@ -36,7 +36,7 @@ ALL_ORCHESTRATION_STATES = list(
 
 
 async def commit_task_run_state(
-    session, task_run, state_type: states.StateType, state_details=None
+    session, task_run, state_type: states.StateType, state_details=None, state_name=None
 ):
     if state_type is None:
         return None
@@ -52,6 +52,7 @@ async def commit_task_run_state(
         type=state_type,
         timestamp=pendulum.now("UTC").subtract(seconds=5),
         state_details=state_details,
+        state_name=state_name,
     )
 
     db = provide_database_interface()

--- a/tests/server/orchestration/test_rules.py
+++ b/tests/server/orchestration/test_rules.py
@@ -52,7 +52,7 @@ async def commit_task_run_state(
         type=state_type,
         timestamp=pendulum.now("UTC").subtract(seconds=5),
         state_details=state_details,
-        state_name=state_name,
+        name=state_name,
     )
 
     db = provide_database_interface()


### PR DESCRIPTION
closes: https://github.com/PrefectHQ/prefect/issues/12116

oss version of: https://github.com/PrefectHQ/nebula/pull/4569

The MarkLateRuns service will grab late SCHEDULED runs in batches and then mark those runs as late. In the current implementation it is possible for a run that was SCHEDULED and needed to be marked late, to transition to PENDING while the service is working it's way through the batch.

This PR adds a new orchestration rule `EnsureOnlyScheduledFlowsMarkedLate`. It also adds a new orchestration policy to only be used by `MarkLateRuns` that enforces this rule.

**NOTE:**If there is a race condition and a run's state is being concurrently orchestrated we may still find this is possible. However, this will drastically reduce the window in which it is possible.