### PR TITLE
allow 500s on docker test flake

### DIFF
--- a/tests/docker/test_image_builds.py
+++ b/tests/docker/test_image_builds.py
@@ -135,7 +135,8 @@ def test_raises_exception_on_bad_base_image(
     # Occasionally, Dockerhub will rate limit us and return a 429
     # so we will allow this as an acceptable error since we know that
     # the image pull attempt occurred.
-    with pytest.raises(BuildError, match=expected_error + "|429"):
+    # We also allow 500 errors since they are often transient.
+    with pytest.raises(BuildError, match=expected_error + "|429" + "|500"):
         build_image(contexts / example_context, stream_progress_to=sys.stdout)
 
 

--- a/tests/docker/test_image_builds.py
+++ b/tests/docker/test_image_builds.py
@@ -134,8 +134,8 @@ def test_raises_exception_on_bad_base_image(
 ):
     # Occasionally, Dockerhub will rate limit us and return a 429
     # so we will allow this as an acceptable error since we know that
-    # the image pull attempt occurred.
-    # We also allow 500 errors since they are often transient.
+    # the image pull attempt occurred. For this same reason we also
+    # allow 500 errors to be acceptable.
     with pytest.raises(BuildError, match=expected_error + "|429" + "|500"):
         build_image(contexts / example_context, stream_progress_to=sys.stdout)
 


### PR DESCRIPTION
Fix a test flake where we can get a `500` from dockerhub while trying to build an image. I'm not super familiar with these tests but it seems like we already allow for a 429 as an acceptable response. 

https://github.com/PrefectHQ/prefect/actions/runs/8098803080/job/22133077817?pr=12113

```
E       AssertionError: Regex pattern did not match.
E        Regex: 'pull access denied|429'
E        Input: 'Head "https://registry-1.docker.io/v2/library/flibbity-gibbity-jabberty/manifests/never-nohow-whowouldmakethis-oh-the-humanity": received unexpected HTTP status: 500 Internal Server Error'

tests/docker/test_image_builds.py:138: AssertionError
```

