### PR TITLE
Reliability improvements for autonomous task scheduling

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -563,6 +563,9 @@ def create_app(
                 services.flow_run_notifications.FlowRunNotifications()
             )
 
+        if prefect.settings.PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING.value():
+            service_instances.append(services.task_scheduling.TaskSchedulingTimeouts())
+
         loop = asyncio.get_running_loop()
 
         app.state.services = {

--- a/src/prefect/server/api/task_runs.py
+++ b/src/prefect/server/api/task_runs.py
@@ -2,9 +2,8 @@
 Routes for interacting with task run objects.
 """
 
-import asyncio
 import datetime
-from typing import Dict, List, Optional, Tuple
+from typing import List
 from uuid import UUID
 
 import pendulum
@@ -17,27 +16,21 @@ from prefect._vendor.fastapi import (
     WebSocket,
     status,
 )
-from typing_extensions import Self
 
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models
 import prefect.server.schemas as schemas
 from prefect.logging import get_logger
 from prefect.server.api.run_history import run_history
-from prefect.server.database.dependencies import inject_db, provide_database_interface
+from prefect.server.database.dependencies import provide_database_interface
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.orchestration import dependencies as orchestration_dependencies
 from prefect.server.orchestration.policies import BaseOrchestrationPolicy
-from prefect.server.schemas import filters, states
 from prefect.server.schemas.responses import OrchestrationResult
+from prefect.server.task_queue import MultiQueue, TaskQueue
 from prefect.server.utilities import subscriptions
 from prefect.server.utilities.schemas import DateTimeTZ
 from prefect.server.utilities.server import PrefectRouter
-from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
-    PREFECT_TASK_SCHEDULING_MAX_RETRY_QUEUE_SIZE,
-    PREFECT_TASK_SCHEDULING_MAX_SCHEDULED_QUEUE_SIZE,
-)
 
 logger = get_logger("server.api")
 
@@ -80,15 +73,6 @@ async def create_task_run(
         response.status_code = status.HTTP_201_CREATED
 
     new_task_run: schemas.core.TaskRun = schemas.core.TaskRun.from_orm(model)
-
-    # Place autonomously scheduled task runs onto a notification queue for the websocket
-    if (
-        PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING.value()
-        and new_task_run.flow_run_id is None
-        and new_task_run.state
-        and new_task_run.state.is_scheduled()
-    ):
-        await TaskQueue.enqueue(new_task_run)
 
     return new_task_run
 
@@ -277,134 +261,6 @@ async def set_task_run_state(
         response.status_code = status.HTTP_200_OK
 
     return orchestration_result
-
-
-class TaskQueue:
-    _task_queues: Dict[str, Self] = {}
-    _scheduled_tasks_already_restored: bool = False
-
-    default_scheduled_max_size: int = (
-        PREFECT_TASK_SCHEDULING_MAX_SCHEDULED_QUEUE_SIZE.value()
-    )
-    default_retry_max_size: int = PREFECT_TASK_SCHEDULING_MAX_RETRY_QUEUE_SIZE.value()
-
-    _queue_size_configs: Dict[str, Tuple[int, int]] = {}
-
-    task_key: str
-    _scheduled_queue: asyncio.Queue
-    _retry_queue: asyncio.Queue
-
-    @classmethod
-    async def enqueue(cls, task_run: schemas.core.TaskRun) -> None:
-        await cls.for_key(task_run.task_key).put(task_run)
-
-    @classmethod
-    def configure_task_key(
-        cls,
-        task_key: str,
-        scheduled_size: Optional[int] = None,
-        retry_size: Optional[int] = None,
-    ):
-        scheduled_size = scheduled_size or cls.default_scheduled_max_size
-        retry_size = retry_size or cls.default_retry_max_size
-        cls._queue_size_configs[task_key] = (scheduled_size, retry_size)
-
-    @classmethod
-    def for_key(cls, task_key: str) -> Self:
-        if task_key not in cls._task_queues:
-            sizes = cls._queue_size_configs.get(
-                task_key, (cls.default_scheduled_max_size, cls.default_retry_max_size)
-            )
-            cls._task_queues[task_key] = cls(task_key, *sizes)
-        return cls._task_queues[task_key]
-
-    @classmethod
-    def reset(cls) -> None:
-        """A unit testing utility to reset the state of the task queues subsystem"""
-        cls._task_queues.clear()
-        cls._scheduled_tasks_already_restored = False
-
-    def __init__(self, task_key: str, scheduled_queue_size: int, retry_queue_size: int):
-        self.task_key = task_key
-        self._scheduled_queue = asyncio.Queue(maxsize=scheduled_queue_size)
-        self._retry_queue = asyncio.Queue(maxsize=retry_queue_size)
-
-    async def get(self) -> schemas.core.TaskRun:
-        # First, check if there's anything in the retry queue
-        try:
-            return self._retry_queue.get_nowait()
-        except asyncio.QueueEmpty:
-            return await self._scheduled_queue.get()
-
-    def get_nowait(self) -> schemas.core.TaskRun:
-        # First, check if there's anything in the retry queue
-        try:
-            return self._retry_queue.get_nowait()
-        except asyncio.QueueEmpty:
-            return self._scheduled_queue.get_nowait()
-
-    async def put(self, task_run: schemas.core.TaskRun) -> None:
-        await self._scheduled_queue.put(task_run)
-
-    async def retry(self, task_run: schemas.core.TaskRun) -> None:
-        await self._retry_queue.put(task_run)
-
-    @classmethod
-    @inject_db
-    async def restore_scheduled_tasks_if_necessary(cls, db: PrefectDBInterface):
-        """Restores scheduled task runs from the database, if necessary."""
-        if cls._scheduled_tasks_already_restored:
-            return
-
-        cls._scheduled_tasks_already_restored = True
-
-        if not PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING.value():
-            return
-
-        async with db.session_context() as session:
-            task_runs = await models.task_runs.read_task_runs(
-                session=session,
-                task_run_filter=filters.TaskRunFilter(
-                    flow_run_id=filters.TaskRunFilterFlowRunId(is_null_=True),
-                    state=filters.TaskRunFilterState(
-                        type=filters.TaskRunFilterStateType(
-                            any_=[states.StateType.SCHEDULED]
-                        )
-                    ),
-                ),
-            )
-
-        if not task_runs:
-            return
-
-        for task_run_model in task_runs:
-            task_run: schemas.core.TaskRun = schemas.core.TaskRun.from_orm(
-                task_run_model
-            )
-            await cls.for_key(task_run.task_key).retry(task_run)
-
-        logger.info("Restored %s scheduled task runs", len(task_runs))
-
-
-class MultiQueue:
-    """A queue that can pull tasks from from any of a number of task queues"""
-
-    _queues: List[TaskQueue]
-
-    def __init__(self, task_keys: List[str]):
-        self._queues = [TaskQueue.for_key(task_key) for task_key in task_keys]
-
-    async def get(self) -> schemas.core.TaskRun:
-        """Gets the next task_run from any of the given queues"""
-        await TaskQueue.restore_scheduled_tasks_if_necessary()
-
-        while True:
-            for queue in self._queues:
-                try:
-                    return queue.get_nowait()
-                except asyncio.QueueEmpty:
-                    continue
-            await asyncio.sleep(0.01)
 
 
 @router.websocket("/subscriptions/scheduled")

--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -13,6 +13,7 @@ import sqlalchemy as sa
 from packaging.version import Version
 from sqlalchemy import select
 
+from prefect.client.schemas.objects import TaskRun
 from prefect.results import UnknownResult
 from prefect.server import models
 from prefect.server.database.dependencies import inject_db
@@ -31,7 +32,11 @@ from prefect.server.orchestration.rules import (
 )
 from prefect.server.schemas import core, filters, states
 from prefect.server.schemas.states import StateType
-from prefect.settings import PREFECT_TASK_RUN_TAG_CONCURRENCY_SLOT_WAIT_SECONDS
+from prefect.server.task_queue import TaskQueue
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
+    PREFECT_TASK_RUN_TAG_CONCURRENCY_SLOT_WAIT_SECONDS,
+)
 from prefect.utilities.math import clamped_poisson_interval
 
 
@@ -94,6 +99,7 @@ class AutonomousTaskPolicy(BaseOrchestrationPolicy):
             UpdateFlowRunTrackerOnTasks,
             CacheInsertion,
             ReleaseTaskConcurrencySlots,
+            EnqueueScheduledTasks,
         ]
 
 
@@ -450,6 +456,41 @@ class RetryFailedTasks(BaseOrchestrationRule):
                 data=proposed_state.data,
             )
             await self.reject_transition(state=retry_state, reason="Retrying")
+
+
+class EnqueueScheduledTasks(BaseOrchestrationRule):
+    """
+    Enqueues autonomous task runs when they are scheduled
+    """
+
+    FROM_STATES = ALL_ORCHESTRATION_STATES
+    TO_STATES = [StateType.SCHEDULED]
+
+    async def after_transition(
+        self,
+        initial_state: Optional[states.State],
+        validated_state: Optional[states.State],
+        context: OrchestrationContext,
+    ) -> None:
+        if not PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING.value():
+            # Only if task scheduling is enabled
+            return
+
+        if not validated_state:
+            # Only if the transition was valid
+            return
+
+        if context.run.flow_run_id:
+            # Only for autonomous tasks
+            return
+
+        task_run: TaskRun = TaskRun.from_orm(context.run)
+        queue = TaskQueue.for_key(task_run.task_key)
+
+        if validated_state.name == "AwaitingRetry":
+            await queue.retry(task_run)
+        else:
+            await queue.enqueue(task_run)
 
 
 class RenameReruns(BaseOrchestrationRule):

--- a/src/prefect/server/services/__init__.py
+++ b/src/prefect/server/services/__init__.py
@@ -4,3 +4,4 @@ import prefect.server.services.late_runs
 import prefect.server.services.pause_expirations
 import prefect.server.services.scheduler
 import prefect.server.services.telemetry
+import prefect.server.services.task_scheduling

--- a/src/prefect/server/services/task_scheduling.py
+++ b/src/prefect/server/services/task_scheduling.py
@@ -1,0 +1,123 @@
+"""
+The TaskSchedulingTimeouts service reschedules autonomous tasks that are stuck PENDING.
+"""
+
+import asyncio
+
+import pendulum
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import prefect.server.models as models
+import prefect.server.schemas as schemas
+from prefect.server.api.task_runs import TaskQueue
+from prefect.server.database.dependencies import inject_db
+from prefect.server.database.interface import PrefectDBInterface
+from prefect.server.orchestration import dependencies as orchestration_dependencies
+from prefect.server.schemas import filters, states
+from prefect.server.services.loop_service import LoopService
+from prefect.settings import PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT
+
+
+class TaskSchedulingTimeouts(LoopService):
+    _first_run: bool
+
+    def __init__(self, loop_seconds: float = None, **kwargs):
+        self._first_run = True
+        super().__init__(
+            loop_seconds=loop_seconds
+            or PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT.value().total_seconds(),
+            **kwargs,
+        )
+
+    @inject_db
+    async def run_once(self, db: PrefectDBInterface):
+        """
+        Periodically reschedules pending task runs that have been pending for too long.
+        """
+        async with db.session_context() as session:
+            if self._first_run:
+                await self.restore_scheduled_tasks_if_necessary(session)
+                self._first_run = False
+
+            await self.reschedule_pending_runs(session)
+
+    async def restore_scheduled_tasks_if_necessary(self, session: AsyncSession):
+        """
+        Restores scheduled task runs from the database to the in-memory queues.
+        """
+        task_runs = await models.task_runs.read_task_runs(
+            session=session,
+            task_run_filter=filters.TaskRunFilter(
+                flow_run_id=filters.TaskRunFilterFlowRunId(is_null_=True),
+                state=filters.TaskRunFilterState(
+                    type=filters.TaskRunFilterStateType(
+                        any_=[states.StateType.SCHEDULED]
+                    )
+                ),
+            ),
+        )
+
+        for task_run_model in task_runs:
+            task_run: schemas.core.TaskRun = schemas.core.TaskRun.from_orm(
+                task_run_model
+            )
+            await TaskQueue.for_key(task_run.task_key).retry(task_run)
+
+        self.logger.info("Restored %s scheduled task runs", len(task_runs))
+
+    async def reschedule_pending_runs(self, session: AsyncSession):
+        """
+        Transitions any autonomous task runs that have been PENDING too long into
+        SCHEDULED, and reenqueues them.
+        """
+        task_runs = await models.task_runs.read_task_runs(
+            session=session,
+            task_run_filter=filters.TaskRunFilter(
+                flow_run_id=filters.TaskRunFilterFlowRunId(is_null_=True),
+                state=filters.TaskRunFilterState(
+                    type=filters.TaskRunFilterStateType(any_=[states.StateType.PENDING])
+                ),
+            ),
+        )
+
+        older_than = (
+            pendulum.now("UTC") - PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT.value()
+        )
+        task_runs = [t for t in task_runs if t.state.timestamp <= older_than]
+
+        orchestration_parameters = (
+            await orchestration_dependencies.provide_task_orchestration_parameters()
+        )
+        for task_run in task_runs:
+            self.logger.info("Rescheduling task run %s", task_run.id)
+            previous_states = await models.task_run_states.read_task_run_states(
+                session=session, task_run_id=task_run.id
+            )
+            previous_states.sort(key=lambda s: s.timestamp)
+            for prior_scheduled_state in previous_states:
+                if prior_scheduled_state.type == states.StateType.SCHEDULED:
+                    break
+            else:
+                self.logger.warn(
+                    "No prior scheduled state found for task run %s", task_run.id
+                )
+                continue
+
+            rescheduled = states.Scheduled()
+            rescheduled.state_details.task_parameters_id = (
+                prior_scheduled_state.state_details.task_parameters_id
+            )
+
+            await models.task_runs.set_task_run_state(
+                session=session,
+                task_run_id=task_run.id,
+                state=rescheduled,
+                force=True,
+                orchestration_parameters=orchestration_parameters,
+            )
+
+        self.logger.info("Rescheduled %s pending task runs", len(task_runs))
+
+
+if __name__ == "__main__":
+    asyncio.run(TaskSchedulingTimeouts().start())

--- a/src/prefect/server/services/task_scheduling.py
+++ b/src/prefect/server/services/task_scheduling.py
@@ -34,7 +34,7 @@ class TaskSchedulingTimeouts(LoopService):
         """
         Periodically reschedules pending task runs that have been pending for too long.
         """
-        async with db.session_context() as session:
+        async with db.session_context(begin_transaction=True) as session:
             if self._first_run:
                 await self.restore_scheduled_tasks_if_necessary(session)
                 self._first_run = False

--- a/src/prefect/server/task_queue.py
+++ b/src/prefect/server/task_queue.py
@@ -1,0 +1,103 @@
+"""
+Implements an in-memory task queue for delivering autonomous task runs to TaskServers.
+"""
+
+import asyncio
+from typing import Dict, List, Optional, Tuple
+
+from typing_extensions import Self
+
+import prefect.server.schemas as schemas
+from prefect.settings import (
+    PREFECT_TASK_SCHEDULING_MAX_RETRY_QUEUE_SIZE,
+    PREFECT_TASK_SCHEDULING_MAX_SCHEDULED_QUEUE_SIZE,
+)
+
+
+class TaskQueue:
+    _task_queues: Dict[str, Self] = {}
+
+    default_scheduled_max_size: int = (
+        PREFECT_TASK_SCHEDULING_MAX_SCHEDULED_QUEUE_SIZE.value()
+    )
+    default_retry_max_size: int = PREFECT_TASK_SCHEDULING_MAX_RETRY_QUEUE_SIZE.value()
+
+    _queue_size_configs: Dict[str, Tuple[int, int]] = {}
+
+    task_key: str
+    _scheduled_queue: asyncio.Queue
+    _retry_queue: asyncio.Queue
+
+    @classmethod
+    async def enqueue(cls, task_run: schemas.core.TaskRun) -> None:
+        await cls.for_key(task_run.task_key).put(task_run)
+
+    @classmethod
+    def configure_task_key(
+        cls,
+        task_key: str,
+        scheduled_size: Optional[int] = None,
+        retry_size: Optional[int] = None,
+    ):
+        scheduled_size = scheduled_size or cls.default_scheduled_max_size
+        retry_size = retry_size or cls.default_retry_max_size
+        cls._queue_size_configs[task_key] = (scheduled_size, retry_size)
+
+    @classmethod
+    def for_key(cls, task_key: str) -> Self:
+        if task_key not in cls._task_queues:
+            sizes = cls._queue_size_configs.get(
+                task_key, (cls.default_scheduled_max_size, cls.default_retry_max_size)
+            )
+            cls._task_queues[task_key] = cls(task_key, *sizes)
+        return cls._task_queues[task_key]
+
+    @classmethod
+    def reset(cls) -> None:
+        """A unit testing utility to reset the state of the task queues subsystem"""
+        cls._task_queues.clear()
+        cls._scheduled_tasks_already_restored = False
+
+    def __init__(self, task_key: str, scheduled_queue_size: int, retry_queue_size: int):
+        self.task_key = task_key
+        self._scheduled_queue = asyncio.Queue(maxsize=scheduled_queue_size)
+        self._retry_queue = asyncio.Queue(maxsize=retry_queue_size)
+
+    async def get(self) -> schemas.core.TaskRun:
+        # First, check if there's anything in the retry queue
+        try:
+            return self._retry_queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return await self._scheduled_queue.get()
+
+    def get_nowait(self) -> schemas.core.TaskRun:
+        # First, check if there's anything in the retry queue
+        try:
+            return self._retry_queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return self._scheduled_queue.get_nowait()
+
+    async def put(self, task_run: schemas.core.TaskRun) -> None:
+        await self._scheduled_queue.put(task_run)
+
+    async def retry(self, task_run: schemas.core.TaskRun) -> None:
+        await self._retry_queue.put(task_run)
+
+
+class MultiQueue:
+    """A queue that can pull tasks from from any of a number of task queues"""
+
+    _queues: List[TaskQueue]
+
+    def __init__(self, task_keys: List[str]):
+        self._queues = [TaskQueue.for_key(task_key) for task_key in task_keys]
+
+    async def get(self) -> schemas.core.TaskRun:
+        """Gets the next task_run from any of the given queues"""
+        while True:
+            for queue in self._queues:
+                try:
+                    return queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    continue
+            await asyncio.sleep(0.01)

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1441,6 +1441,17 @@ PREFECT_TASK_SCHEDULING_MAX_RETRY_QUEUE_SIZE = Setting(
 The maximum number of retries to queue for submission.
 """
 
+PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT = Setting(
+    timedelta,
+    default=timedelta(seconds=30),
+)
+"""
+How long before a PENDING task are made available to another task server.  In practice,
+a task server should move a task from PENDING to RUNNING very quickly, so runs stuck in
+PENDING for a while is a sign that the task server may have crashed.
+"""
+
+
 PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES = Setting(bool, default=False)
 """
 Whether or not to enable infrastructure overrides made on flow runs.

--- a/tests/server/api/test_task_run_subscriptions.py
+++ b/tests/server/api/test_task_run_subscriptions.py
@@ -10,9 +10,9 @@ from prefect._vendor.fastapi import FastAPI
 from prefect._vendor.starlette.testclient import TestClient, WebSocketTestSession
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from prefect.client.schemas import TaskRun
 from prefect.server import models
 from prefect.server.api import task_runs
-from prefect.server.schemas.core import TaskRun
 from prefect.settings import (
     PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
     temporary_settings,
@@ -21,7 +21,7 @@ from prefect.states import Scheduled
 
 
 @pytest.fixture
-def task_scheduling_enabled() -> None:
+def task_scheduling_enabled() -> Generator[None, None, None]:
     with temporary_settings(
         {
             PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING: True,
@@ -31,7 +31,7 @@ def task_scheduling_enabled() -> None:
 
 
 @pytest.fixture
-def reset_task_queues(task_scheduling_enabled: None) -> None:
+def reset_task_queues(task_scheduling_enabled: None) -> Generator[None, None, None]:
     task_runs.TaskQueue.reset()
 
     yield

--- a/tests/test_autonomous_tasks.py
+++ b/tests/test_autonomous_tasks.py
@@ -1,14 +1,23 @@
+import asyncio
+from typing import AsyncGenerator
+from unittest import mock
+
 import pytest
 
 from prefect import Task, task
+from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas import TaskRun
+from prefect.client.schemas.objects import StateType
 from prefect.filesystems import LocalFileSystem
 from prefect.results import ResultFactory
 from prefect.server.api.task_runs import TaskQueue
+from prefect.server.services.task_scheduling import TaskSchedulingTimeouts
 from prefect.settings import (
     PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
+    PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT,
     temporary_settings,
 )
+from prefect.task_server import TaskServer
 from prefect.utilities.asyncutils import sync_compatible
 
 
@@ -140,17 +149,121 @@ async def test_task_submission_via_map_raises_error(async_foo_task_with_result_s
         async_foo_task_with_result_storage.map([42])
 
 
-class TestServerSideBehavior:
-    async def test_scheduled_tasks_are_enqueued_server_side(
-        self,
-        foo_task_with_result_storage: Task,
-    ):
-        task_run: TaskRun = foo_task_with_result_storage.submit(42)
-        assert task_run.state.is_scheduled()
+async def test_scheduled_tasks_are_enqueued_server_side(
+    foo_task_with_result_storage: Task,
+):
+    task_run: TaskRun = foo_task_with_result_storage.submit(42)
+    assert task_run.state.is_scheduled()
 
-        enqueued: TaskRun = await TaskQueue.for_key(task_run.task_key).get()
+    enqueued: TaskRun = await TaskQueue.for_key(task_run.task_key).get()
 
-        # The server-side task run through API-like serialization for comparison
-        enqueued = TaskRun.parse_obj(enqueued.dict(json_compatible=True))
+    # The server-side task run through API-like serialization for comparison
+    enqueued = TaskRun.parse_obj(enqueued.dict(json_compatible=True))
 
-        assert enqueued == task_run
+    # The server-side task run in the queue should be the same as the one returned
+    # to the client, but some of the calculated fields will be populated server-side
+    # after orchestration in a way that differs by microseconds, or the
+    # created/updated dates are populated.
+
+    assert task_run.state.created is None
+    assert enqueued.state.created is not None
+    task_run.state.created = enqueued.state.created
+
+    assert task_run.state.updated is None
+    assert enqueued.state.updated is not None
+    task_run.state.updated = enqueued.state.updated
+
+    assert task_run.estimated_start_time_delta is not None
+    assert enqueued.estimated_start_time_delta is not None
+    task_run.estimated_start_time_delta = enqueued.estimated_start_time_delta
+
+    assert enqueued.dict() == task_run.dict()
+
+
+@pytest.fixture
+async def prefect_client() -> AsyncGenerator[PrefectClient, None]:
+    async with get_client() as client:
+        yield client
+
+
+async def test_scheduled_tasks_are_restored_at_server_startup(
+    foo_task_with_result_storage: Task, prefect_client: PrefectClient
+):
+    # run one iteration of the timeouts service
+    service = TaskSchedulingTimeouts()
+    await service.start(loops=1)
+
+    # schedule a task
+    task_run: TaskRun = foo_task_with_result_storage.submit(42)
+    assert task_run.state.is_scheduled()
+
+    # pull the task from the queue to make sure it's cleared; this simulates when a task
+    # server pulls a task, then the prefect server dies
+    enqueued: TaskRun = await TaskQueue.for_key(task_run.task_key).get()
+    assert enqueued.id == task_run.id
+
+    # verify there is no other task in queue
+    with pytest.raises(asyncio.QueueEmpty):
+        await TaskQueue.for_key(task_run.task_key).get_nowait()
+
+    # Run another loop to show that the task is NOT re-enqueued after the first run
+    await service.start(loops=1)
+
+    with pytest.raises(asyncio.QueueEmpty):
+        await TaskQueue.for_key(task_run.task_key).get_nowait()
+
+    # now emulate that we've restarted the Prefect server by resetting the
+    # TaskSchedulingTimeouts service
+    service = TaskSchedulingTimeouts()
+    await service.start(loops=1)
+
+    # the task will still be SCHEDULED
+    task_run = await prefect_client.read_task_run(task_run.id)
+    assert task_run.state.type == StateType.SCHEDULED
+
+    # ...and it should be re-enqueued
+    enqueued: TaskRun = await TaskQueue.for_key(task_run.task_key).get()
+    assert enqueued.id == task_run.id
+
+
+async def test_stuck_pending_tasks_are_reenqueued(
+    foo_task_with_result_storage: Task, prefect_client: PrefectClient
+):
+    task_run: TaskRun = foo_task_with_result_storage.submit(42)
+    assert task_run.state.is_scheduled()
+
+    # now we simulate a stuck task by having the TaskServer try to run it but fail
+    server = TaskServer(foo_task_with_result_storage)
+    with pytest.raises(ValueError):
+        with mock.patch(
+            "prefect.task_server.submit_autonomous_task_run_to_engine",
+            side_effect=ValueError("woops"),
+        ):
+            await server.execute_task_run(task_run)
+
+    # now the task will be in a stuck pending state
+    task_run = await prefect_client.read_task_run(task_run.id)
+    assert task_run.state.type == StateType.PENDING
+
+    # now run an iteration of the TaskSchedulingTimeouts loop service with an absurdly
+    # long timeout so that it will never happen
+    with temporary_settings({PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT: 1000000}):
+        await TaskSchedulingTimeouts().start(loops=1)
+
+    # the task will still be PENDING
+    task_run = await prefect_client.read_task_run(task_run.id)
+    assert task_run.state.type == StateType.PENDING
+
+    # now run an iteration of the TaskSchedulingTimeouts loop service with a short
+    # timeout so we can sleep past it and ensure that this task run will get picked up
+    with temporary_settings({PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT: 0.1}):
+        await asyncio.sleep(0.2)
+        await TaskSchedulingTimeouts().start(loops=1)
+
+    # now the task will now be SCHEDULED
+    task_run = await prefect_client.read_task_run(task_run.id)
+    assert task_run.state.type == StateType.SCHEDULED
+
+    # ...and it should be re-enqueued
+    enqueued: TaskRun = await TaskQueue.for_key(task_run.task_key).get()
+    assert enqueued.id == task_run.id


### PR DESCRIPTION
* Moves enqueuing to an orchestration rule when tasks enter `SCHEDULED`
* Adds a loop service that rescheduled timed out `PENDING` tasks
* Moves the enqueuing of scheduled tasks at startup to that loop service