### PR TITLE
Add support for multiple schedules to `prefect deploy`

### DIFF
--- a/docs/concepts/schedules.md
+++ b/docs/concepts/schedules.md
@@ -191,16 +191,22 @@ You will be prompted to choose which type of schedule to create.
 
 ### Creating schedules in the `prefect.yaml` file's `deployments` -> `schedule` section
 
-If you save the `prefect.yaml` file from the `prefect deploy` command, you will see it has a `schedule` section for your deployment.
-Alternatively, you can create a `prefect.yaml` file from a recipe or from scratch and add a `schedule` section to it.
+If you save the `prefect.yaml` file from the `prefect deploy` command, you will see it has a `schedules` section for your deployment.
+Alternatively, you can create a `prefect.yaml` file from a recipe or from scratch and add a `schedules` section to it.
 
 ```yaml
 deployments:
   ...
-  schedule:
-    cron: 0 0 * * *
-    timezone: America/Chicago
-    active: false
+  schedules:
+    - cron: "0 0 * * *"
+      timezone: "America/Chicago"
+      active: false
+    - cron: "0 12 * * *"
+      timezone: "America/New_York"
+      active: true
+    - cron: "0 18 * * *"
+      timezone: "Europe/London"
+      active: true
 ```
 
 ### Creating schedules with a Python deployment creation file

--- a/src/prefect/cli/_prompts.py
+++ b/src/prefect/cli/_prompts.py
@@ -5,7 +5,7 @@ import os
 import shutil
 from datetime import timedelta
 from getpass import GetPassWarning
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import readchar
 from rich.console import Console, Group
@@ -19,8 +19,8 @@ from prefect.cli._utilities import exit_with_error
 from prefect.client.collections import get_collections_metadata_client
 from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.actions import BlockDocumentCreate, WorkPoolCreate
+from prefect.client.schemas.objects import MinimalDeploymentSchedule
 from prefect.client.schemas.schedules import (
-    SCHEDULE_TYPES,
     CronSchedule,
     IntervalSchedule,
     RRuleSchedule,
@@ -328,26 +328,36 @@ def prompt_schedule_type(console):
     return selection["type"]
 
 
-def prompt_schedule(console) -> Tuple[SCHEDULE_TYPES, bool]:
+def prompt_schedules(console) -> List[MinimalDeploymentSchedule]:
     """
     Prompt the user for a schedule type. Once a schedule type is selected, prompt
     the user for the schedule details and return the schedule.
     """
-    schedule_type = prompt_schedule_type(console)
-    if schedule_type == "Cron":
-        schedule = prompt_cron_schedule(console)
-    elif schedule_type == "Interval":
-        schedule = prompt_interval_schedule(console)
-    elif schedule_type == "RRule":
-        schedule = prompt_rrule_schedule(console)
-    else:
-        raise Exception("Invalid schedule type")
+    schedules = []
 
-    is_schedule_active = confirm(
-        "Would you like to activate this schedule?", default=True
-    )
+    add_schedule = True
+    while add_schedule:
+        schedule_type = prompt_schedule_type(console)
+        if schedule_type == "Cron":
+            schedule = prompt_cron_schedule(console)
+        elif schedule_type == "Interval":
+            schedule = prompt_interval_schedule(console)
+        elif schedule_type == "RRule":
+            schedule = prompt_rrule_schedule(console)
+        else:
+            raise Exception("Invalid schedule type")
 
-    return (schedule, is_schedule_active)
+        is_schedule_active = confirm(
+            "Would you like to activate this schedule?", default=True
+        )
+
+        schedules.append(
+            MinimalDeploymentSchedule(schedule=schedule, active=is_schedule_active)
+        )
+
+        add_schedule = confirm("Would you like to add another schedule?", default=False)
+
+    return schedules
 
 
 @inject_client

--- a/src/prefect/cli/_prompts.py
+++ b/src/prefect/cli/_prompts.py
@@ -330,32 +330,36 @@ def prompt_schedule_type(console):
 
 def prompt_schedules(console) -> List[MinimalDeploymentSchedule]:
     """
-    Prompt the user for a schedule type. Once a schedule type is selected, prompt
-    the user for the schedule details and return the schedule.
+    Prompt the user to configure schedules for a deployment.
     """
     schedules = []
 
-    add_schedule = True
-    while add_schedule:
-        schedule_type = prompt_schedule_type(console)
-        if schedule_type == "Cron":
-            schedule = prompt_cron_schedule(console)
-        elif schedule_type == "Interval":
-            schedule = prompt_interval_schedule(console)
-        elif schedule_type == "RRule":
-            schedule = prompt_rrule_schedule(console)
-        else:
-            raise Exception("Invalid schedule type")
+    if confirm(
+        "Would you like to configure schedules for this deployment?", default=True
+    ):
+        add_schedule = True
+        while add_schedule:
+            schedule_type = prompt_schedule_type(console)
+            if schedule_type == "Cron":
+                schedule = prompt_cron_schedule(console)
+            elif schedule_type == "Interval":
+                schedule = prompt_interval_schedule(console)
+            elif schedule_type == "RRule":
+                schedule = prompt_rrule_schedule(console)
+            else:
+                raise Exception("Invalid schedule type")
 
-        is_schedule_active = confirm(
-            "Would you like to activate this schedule?", default=True
-        )
+            is_schedule_active = confirm(
+                "Would you like to activate this schedule?", default=True
+            )
 
-        schedules.append(
-            MinimalDeploymentSchedule(schedule=schedule, active=is_schedule_active)
-        )
+            schedules.append(
+                MinimalDeploymentSchedule(schedule=schedule, active=is_schedule_active)
+            )
 
-        add_schedule = confirm("Would you like to add another schedule?", default=False)
+            add_schedule = confirm(
+                "Would you like to add another schedule?", default=False
+            )
 
     return schedules
 

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -26,7 +26,7 @@ from prefect.cli._prompts import (
     prompt_build_custom_docker_image,
     prompt_entrypoint,
     prompt_push_custom_docker_image,
-    prompt_schedule,
+    prompt_schedules,
     prompt_select_blob_storage_credentials,
     prompt_select_from_table,
     prompt_select_remote_flow_storage,
@@ -38,8 +38,8 @@ from prefect.cli._utilities import (
 )
 from prefect.cli.root import app, is_interactive
 from prefect.client.orchestration import PrefectClient, ServerType
+from prefect.client.schemas.objects import MinimalDeploymentSchedule
 from prefect.client.schemas.schedules import (
-    SCHEDULE_TYPES,
     CronSchedule,
     IntervalSchedule,
     RRuleSchedule,
@@ -145,12 +145,12 @@ async def deploy(
             " format of key=value string or a JSON object"
         ),
     ),
-    cron: str = typer.Option(
+    cron: List[str] = typer.Option(
         None,
         "--cron",
         help="A cron string that will be used to set a CronSchedule on the deployment.",
     ),
-    interval: int = typer.Option(
+    interval: List[int] = typer.Option(
         None,
         "--interval",
         help=(
@@ -159,9 +159,9 @@ async def deploy(
         ),
     ),
     interval_anchor: Optional[str] = typer.Option(
-        None, "--anchor-date", help="The anchor date for an interval schedule"
+        None, "--anchor-date", help="The anchor date for all interval schedules"
     ),
-    rrule: str = typer.Option(
+    rrule: List[str] = typer.Option(
         None,
         "--rrule",
         help="An RRule that will be used to set an RRuleSchedule on the deployment.",
@@ -330,6 +330,7 @@ async def _run_single_deploy(
     should_prompt_for_save = is_interactive() and not ci
 
     deploy_config = _merge_with_default_deploy_config(deploy_config)
+    deploy_config = _handle_deprecated_schedule_fields(deploy_config)
     (
         deploy_config,
         variable_overrides,
@@ -344,28 +345,6 @@ async def _run_single_deploy(
 
     # check for env var placeholders early so users can pass work pool names, etc.
     deploy_config = apply_values(deploy_config, os.environ, remove_notset=False)
-
-    if get_from_dict(deploy_config, "schedule.anchor_date") and not get_from_dict(
-        deploy_config, "schedule.interval"
-    ):
-        raise ValueError(
-            "An anchor date can only be provided with an interval schedule"
-        )
-
-    number_of_schedules_provided = len(
-        [
-            value
-            for value in (
-                get_from_dict(deploy_config, "schedule.cron"),
-                get_from_dict(deploy_config, "schedule.rrule"),
-                get_from_dict(deploy_config, "schedule.interval"),
-            )
-            if value is not None
-        ]
-    )
-
-    if number_of_schedules_provided > 1:
-        raise ValueError("Only one schedule type can be provided.")
 
     if not deploy_config.get("flow_name") and not deploy_config.get("entrypoint"):
         if not is_interactive() and not ci:
@@ -452,10 +431,7 @@ async def _run_single_deploy(
 
     deploy_config["parameter_openapi_schema"] = parameter_schema(flow)
 
-    (
-        deploy_config["schedule"],
-        deploy_config["is_schedule_active"],
-    ) = _construct_schedule(deploy_config, ci=ci)
+    deploy_config["schedules"] = _construct_schedules(deploy_config, ci=ci)
 
     # determine work pool
     work_pool_name = get_from_dict(deploy_config, "work_pool.name")
@@ -642,10 +618,12 @@ async def _run_single_deploy(
     deploy_config_before_templating = deepcopy(deploy_config)
     ## apply templating from build and push steps to the final deployment spec
     _parameter_schema = deploy_config.pop("parameter_openapi_schema")
-    _schedule = deploy_config.pop("schedule")
+
+    _schedules = deploy_config.pop("schedules")
+
     deploy_config = apply_values(deploy_config, step_outputs)
     deploy_config["parameter_openapi_schema"] = _parameter_schema
-    deploy_config["schedule"] = _schedule
+    deploy_config["schedules"] = _schedules
 
     pull_steps = apply_values(pull_steps, step_outputs, remove_notset=False)
 
@@ -657,8 +635,8 @@ async def _run_single_deploy(
         work_queue_name=get_from_dict(deploy_config, "work_pool.work_queue_name"),
         work_pool_name=get_from_dict(deploy_config, "work_pool.name"),
         version=deploy_config.get("version"),
-        schedule=deploy_config.get("schedule"),
-        is_schedule_active=deploy_config.get("is_schedule_active"),
+        schedules=deploy_config.get("schedules"),
+        paused=deploy_config.get("paused"),
         enforce_parameter_schema=deploy_config.get("enforce_parameter_schema", False),
         parameter_openapi_schema=deploy_config.get("parameter_openapi_schema").dict(),
         parameters=deploy_config.get("parameters"),
@@ -802,10 +780,10 @@ async def _run_multi_deploy(
         )
 
 
-def _construct_schedule(
+def _construct_schedules(
     deploy_config: Dict,
     ci: bool = False,
-) -> Tuple[Optional[SCHEDULE_TYPES], Optional[bool]]:
+) -> List[MinimalDeploymentSchedule]:
     """
     Constructs a schedule from a deployment configuration.
 
@@ -814,15 +792,41 @@ def _construct_schedule(
         ci: Disable interactive prompts if True
 
     Returns:
-        A schedule object
+        A list of schedule objects
     """
-    schedule = deploy_config.get("schedule", NotSet)
-    cron = get_from_dict(deploy_config, "schedule.cron")
-    interval = get_from_dict(deploy_config, "schedule.interval")
-    anchor_date = get_from_dict(deploy_config, "schedule.anchor_date")
-    rrule = get_from_dict(deploy_config, "schedule.rrule")
-    timezone = get_from_dict(deploy_config, "schedule.timezone")
-    schedule_active = get_from_dict(deploy_config, "schedule.active", True)
+    schedule_configs = deploy_config.get("schedules", NotSet)
+
+    if schedule_configs is not NotSet:
+        schedules = [
+            _schedule_config_to_deployment_schedule(schedule_config)
+            for schedule_config in schedule_configs
+        ]
+    elif schedule_configs is NotSet:
+        if (
+            not ci
+            and is_interactive()
+            and confirm(
+                "Would you like to configure schedules for this deployment?",
+                default=True,
+                console=app.console,
+            )
+        ):
+            schedules = prompt_schedules(app.console)
+        else:
+            schedules = []
+
+    return schedules
+
+
+def _schedule_config_to_deployment_schedule(
+    schedule_config: Dict,
+) -> MinimalDeploymentSchedule:
+    cron = schedule_config.get("cron")
+    interval = schedule_config.get("interval")
+    anchor_date = schedule_config.get("anchor_date")
+    rrule = schedule_config.get("rrule")
+    timezone = schedule_config.get("timezone")
+    schedule_active = schedule_config.get("active", True)
 
     if cron:
         cron_kwargs = {"cron": cron, "timezone": timezone}
@@ -846,28 +850,12 @@ def _construct_schedule(
                 schedule.timezone = timezone
         except json.JSONDecodeError:
             schedule = RRuleSchedule(rrule=rrule, timezone=timezone)
-    elif schedule is NotSet:
-        if (
-            not ci
-            and is_interactive()
-            and confirm(
-                "Would you like to configure a schedule for this deployment?",
-                default=True,
-                console=app.console,
-            )
-        ):
-            schedule, schedule_active = prompt_schedule(app.console)
-        else:
-            schedule = None
-            schedule_active = None
     else:
-        schedule = None
-        schedule_active = None
+        raise ValueError(
+            f"Unknown schedule type. Please provide a valid schedule. schedule={schedule_config}"
+        )
 
-    if schedule_active is None:
-        schedule_active = True
-
-    return (schedule, schedule_active)
+    return MinimalDeploymentSchedule(schedule=schedule, active=schedule_active)
 
 
 def _merge_with_default_deploy_config(deploy_config: Dict):
@@ -1525,13 +1513,12 @@ def _apply_cli_options_to_deploy_config(deploy_config, cli_options):
             else:
                 deploy_config["work_pool"][cli_option] = cli_value
 
-        elif (
-            cli_option in ["cron", "interval", "anchor_date", "rrule", "timezone"]
-            and cli_value
-        ):
-            if not isinstance(deploy_config.get("schedule"), dict):
-                deploy_config["schedule"] = {}
-            deploy_config["schedule"][cli_option] = cli_value
+        elif cli_option in ["cron", "interval", "rrule"] and cli_value:
+            if not isinstance(deploy_config.get("schedules"), list):
+                deploy_config["schedules"] = []
+
+            for value in cli_value:
+                deploy_config["schedules"].append({cli_option: value})
 
         elif cli_option in ["param", "params"] and cli_value:
             parameters = dict()
@@ -1554,6 +1541,16 @@ def _apply_cli_options_to_deploy_config(deploy_config, cli_options):
             if not isinstance(deploy_config.get("parameters"), dict):
                 deploy_config["parameters"] = {}
             deploy_config["parameters"].update(parameters)
+
+    anchor_date = cli_options.get("anchor_date")
+    timezone = cli_options.get("timezone")
+
+    # Apply anchor_date and timezone to new and existing schedules
+    for schedule_config in deploy_config.get("schedules", []):
+        if anchor_date and schedule_config.get("interval"):
+            schedule_config["anchor_date"] = anchor_date
+        if timezone:
+            schedule_config["timezone"] = timezone
 
     return deploy_config, variable_overrides
 
@@ -1664,3 +1661,44 @@ def _gather_deployment_trigger_definitions(
         return trigger_specs
 
     return existing_triggers
+
+
+def _handle_deprecated_schedule_fields(deploy_config: Dict):
+    deploy_config = deepcopy(deploy_config)
+
+    legacy_schedule = deploy_config.get("schedule", NotSet)
+    schedule_configs = deploy_config.get("schedules", NotSet)
+
+    if (
+        legacy_schedule
+        and legacy_schedule is not NotSet
+        and schedule_configs is not NotSet
+    ):
+        raise ValueError(
+            "Both 'schedule' and 'schedules' keys are present in the deployment"
+            " configuration. Please use only use `schedules`."
+        )
+
+    if legacy_schedule and isinstance(legacy_schedule, dict):
+        # The yaml has a legacy schedule key, we should honor whatever
+        # is there while still appending these new schedules.
+        deploy_config["schedules"] = [deploy_config["schedule"]]
+
+        app.console.print(
+            generate_deprecation_message(
+                "Defining a schedule via the `schedule` key in the deployment",
+                start_date="Mar 2023",
+                help=(
+                    "Please use `schedules` instead by renaming the "
+                    "`schedule` key to `schedules` and providing a list of "
+                    "schedule objects."
+                ),
+            ),
+            style="yellow",
+        )
+
+    # Pop the legacy schedule keys if they exist
+    deploy_config.pop("schedule", None)
+    deploy_config.pop("is_schedule_active", None)
+
+    return deploy_config

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -802,15 +802,7 @@ def _construct_schedules(
             for schedule_config in schedule_configs
         ]
     elif schedule_configs is NotSet:
-        if (
-            not ci
-            and is_interactive()
-            and confirm(
-                "Would you like to configure schedules for this deployment?",
-                default=True,
-                console=app.console,
-            )
-        ):
+        if not ci and is_interactive():
             schedules = prompt_schedules(app.console)
         else:
             schedules = []

--- a/src/prefect/testing/cli.py
+++ b/src/prefect/testing/cli.py
@@ -76,13 +76,13 @@ def invoke_and_assert(
         raise RuntimeError(
             textwrap.dedent(
                 """
-                You cannot run `invoke_and_assert` directly from an async 
-                function. If you need to run `invoke_and_assert` in an async 
-                function, run it with `run_sync_in_worker_thread`. 
+                You cannot run `invoke_and_assert` directly from an async
+                function. If you need to run `invoke_and_assert` in an async
+                function, run it with `run_sync_in_worker_thread`.
 
-                Example: 
+                Example:
                     run_sync_in_worker_thread(
-                        invoke_and_assert, 
+                        invoke_and_assert,
                         command=['my', 'command'],
                         expected_code=0,
                     )

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -3207,9 +3207,11 @@ class TestSchedules:
         deployment = await prefect_client.read_deployment_by_name(
             "An important name/test-name"
         )
-        assert deployment.is_schedule_active is False
-        assert deployment.schedule.cron == "0 4 * * *"
-        assert deployment.schedule.timezone == "America/Chicago"
+
+        deployment_schedule = deployment.schedules[0]
+        assert deployment_schedule.active is False
+        assert deployment_schedule.schedule.cron == "0 4 * * *"
+        assert deployment_schedule.schedule.timezone == "America/Chicago"
 
 
 class TestMultiDeploy:
@@ -3313,9 +3315,9 @@ class TestMultiDeploy:
         )
 
         assert deployment1.name == "test-name-1"
-        assert deployment1.is_schedule_active is True
+        assert deployment1.schedules[0].active is True
         assert deployment2.name == "test-name-2"
-        assert deployment2.is_schedule_active is False
+        assert deployment2.schedules[0].active is False
 
     async def test_deploy_selected_deployments(
         self, project_dir, prefect_client, work_pool

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -27,6 +27,11 @@ from prefect.cli.deploy import (
 )
 from prefect.client.orchestration import PrefectClient, ServerType
 from prefect.client.schemas.objects import WorkPool
+from prefect.client.schemas.schedules import (
+    CronSchedule,
+    IntervalSchedule,
+    RRuleSchedule,
+)
 from prefect.deployments import register_flow
 from prefect.deployments.base import (
     _save_deployment_to_prefect_file,
@@ -43,7 +48,6 @@ from prefect.server.schemas.actions import (
     BlockTypeCreate,
     WorkPoolCreate,
 )
-from prefect.server.schemas.schedules import CronSchedule
 from prefect.settings import (
     PREFECT_DEFAULT_WORK_POOL_NAME,
     PREFECT_UI_URL,
@@ -2674,8 +2678,10 @@ class TestSchedules:
         deployment = await prefect_client.read_deployment_by_name(
             "An important name/test-name"
         )
-        assert deployment.schedule.cron == "0 4 * * *"
-        assert deployment.schedule.timezone == "Europe/Berlin"
+
+        schedule = deployment.schedules[0].schedule
+        assert schedule.cron == "0 4 * * *"
+        assert schedule.timezone == "Europe/Berlin"
 
     @pytest.mark.usefixtures("project_dir")
     async def test_deployment_yaml_cron_schedule(self, work_pool, prefect_client):
@@ -2701,8 +2707,9 @@ class TestSchedules:
         deployment = await prefect_client.read_deployment_by_name(
             "An important name/test-name"
         )
-        assert deployment.schedule.cron == "0 4 * * *"
-        assert deployment.schedule.timezone == "America/Chicago"
+        schedule = deployment.schedules[0].schedule
+        assert schedule.cron == "0 4 * * *"
+        assert schedule.timezone == "America/Chicago"
 
     @pytest.mark.usefixtures("project_dir")
     async def test_deployment_yaml_cron_schedule_timezone_cli(
@@ -2785,19 +2792,6 @@ class TestSchedules:
         assert deployment.schedule.timezone == "America/Chicago"
 
     @pytest.mark.usefixtures("project_dir")
-    async def test_passing_anchor_without_interval_exits(self):
-        await run_sync_in_worker_thread(
-            invoke_and_assert,
-            command=(
-                "deploy ./flows/hello.py:my_flow -n test-name --anchor-date 2040-02-02"
-            ),
-            expected_code=1,
-            expected_output_contains=(
-                "An anchor date can only be provided with an interval schedule"
-            ),
-        )
-
-    @pytest.mark.usefixtures("project_dir")
     async def test_parsing_rrule_schedule_string_literal(
         self, prefect_client, work_pool
     ):
@@ -2851,23 +2845,159 @@ class TestSchedules:
         )
 
     @pytest.mark.usefixtures("project_dir")
-    @pytest.mark.parametrize(
-        "schedules",
-        [
-            ["--cron", "cron-str", "--interval", "42"],
-            ["--rrule", "rrule-str", "--interval", "42"],
-            ["--rrule", "rrule-str", "--cron", "cron-str"],
-            ["--rrule", "rrule-str", "--cron", "cron-str", "--interval", "42"],
-        ],
-    )
-    async def test_providing_multiple_schedules_exits_with_error(self, schedules):
+    async def test_can_provide_multiple_schedules_via_command(
+        self, prefect_client, work_pool
+    ):
         await run_sync_in_worker_thread(
             invoke_and_assert,
-            command="deploy ./flows/hello.py:my_flow -n test-name "
-            + " ".join(schedules),
-            expected_code=1,
-            expected_output_contains=["Only one schedule type can be provided."],
+            command=f"deploy ./flows/hello.py:my_flow -n test-name --cron '* * * * *' --interval 42 --rrule 'FREQ=HOURLY' --pool {work_pool.name}",
+            expected_code=0,
+            expected_output_contains=[
+                "Deployment 'An important name/test-name' successfully created"
+            ],
         )
+
+        deployment = await prefect_client.read_deployment_by_name(
+            "An important name/test-name"
+        )
+
+        schedule_config = {}
+        for deployment_schedule in deployment.schedules:
+            schedule = deployment_schedule.schedule
+            if isinstance(schedule, IntervalSchedule):
+                schedule_config["interval"] = schedule.interval
+            elif isinstance(schedule, CronSchedule):
+                schedule_config["cron"] = schedule.cron
+            elif isinstance(schedule, RRuleSchedule):
+                schedule_config["rrule"] = schedule.rrule
+            else:
+                raise AssertionError("Unknown schedule type received")
+
+        assert schedule_config == {
+            "interval": timedelta(seconds=42),
+            "cron": "* * * * *",
+            "rrule": "FREQ=HOURLY",
+        }
+
+    @pytest.mark.usefixtures("project_dir")
+    async def test_can_provide_multiple_schedules_via_yaml(
+        self, prefect_client, work_pool
+    ):
+        prefect_yaml = Path("prefect.yaml")
+        with prefect_yaml.open(mode="r") as f:
+            deploy_config = yaml.safe_load(f)
+
+        deploy_config["deployments"][0]["name"] = "test-name"
+        deploy_config["deployments"][0]["schedules"] = [
+            {"interval": 42},
+            {"cron": "* * * * *"},
+            {"rrule": "FREQ=HOURLY"},
+        ]
+
+        with prefect_yaml.open(mode="w") as f:
+            yaml.safe_dump(deploy_config, f)
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=f"deploy ./flows/hello.py:my_flow -n test-name --pool {work_pool.name}",
+            expected_code=0,
+            expected_output_contains=[
+                "Deployment 'An important name/test-name' successfully created"
+            ],
+        )
+
+        deployment = await prefect_client.read_deployment_by_name(
+            "An important name/test-name"
+        )
+
+        schedule_config = {}
+        for deployment_schedule in deployment.schedules:
+            schedule = deployment_schedule.schedule
+            if isinstance(schedule, IntervalSchedule):
+                schedule_config["interval"] = schedule.interval
+            elif isinstance(schedule, CronSchedule):
+                schedule_config["cron"] = schedule.cron
+            elif isinstance(schedule, RRuleSchedule):
+                schedule_config["rrule"] = schedule.rrule
+            else:
+                raise AssertionError("Unknown schedule type received")
+
+        assert schedule_config == {
+            "interval": timedelta(seconds=42),
+            "cron": "* * * * *",
+            "rrule": "FREQ=HOURLY",
+        }
+
+    @pytest.mark.usefixtures("project_dir")
+    async def test_yaml_with_schedule_and_schedules_raises_error(self, work_pool):
+        prefect_yaml = Path("prefect.yaml")
+        with prefect_yaml.open(mode="r") as f:
+            deploy_config = yaml.safe_load(f)
+
+        deploy_config["deployments"][0]["name"] = "test-name"
+        deploy_config["deployments"][0]["schedule"]["interval"] = 42
+        deploy_config["deployments"][0]["schedules"] = [{"interval": 42}]
+
+        with prefect_yaml.open(mode="w") as f:
+            yaml.safe_dump(deploy_config, f)
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=(
+                f"deploy ./flows/hello.py:my_flow -n test-name --pool {work_pool.name}"
+            ),
+            expected_code=1,
+            expected_output_contains="Both 'schedule' and 'schedules' keys are present in the deployment configuration. Please use only use `schedules`.",
+        )
+
+    @pytest.mark.usefixtures("project_dir")
+    async def test_yaml_with_schedule_prints_deprecation_warning(self, work_pool):
+        prefect_yaml = Path("prefect.yaml")
+        with prefect_yaml.open(mode="r") as f:
+            deploy_config = yaml.safe_load(f)
+
+        deploy_config["deployments"][0]["name"] = "test-name"
+        deploy_config["deployments"][0]["schedule"]["interval"] = 42
+
+        with prefect_yaml.open(mode="w") as f:
+            yaml.safe_dump(deploy_config, f)
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=(
+                f"deploy ./flows/hello.py:my_flow -n test-name --pool {work_pool.name}"
+            ),
+            expected_code=0,
+            expected_output_contains="Defining a schedule via the `schedule` key in the deployment",
+        )
+
+    @pytest.mark.usefixtures("project_dir")
+    async def test_can_provide_multiple_schedules_of_the_same_type_via_command(
+        self, prefect_client, work_pool
+    ):
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=f"deploy ./flows/hello.py:my_flow -n test-name --cron '* * * * *' --cron '0 * * * *' --pool {work_pool.name}",
+            expected_code=0,
+            expected_output_contains=[
+                "Deployment 'An important name/test-name' successfully created"
+            ],
+        )
+
+        deployment = await prefect_client.read_deployment_by_name(
+            "An important name/test-name"
+        )
+
+        schedules = set()
+        for deployment_schedule in deployment.schedules:
+            schedule = deployment_schedule.schedule
+            assert isinstance(schedule, CronSchedule)
+            schedules.add(schedule.cron)
+
+        assert schedules == {
+            "* * * * *",
+            "0 * * * *",
+        }
 
     @pytest.mark.usefixtures("interactive_console", "project_dir")
     async def test_deploy_interval_schedule_interactive(
@@ -2881,25 +3011,22 @@ class TestSchedules:
             user_input=(
                 # Confirm schedule creation
                 readchar.key.ENTER
-                +
                 # Select interval schedule
-                readchar.key.ENTER
-                +
+                + readchar.key.ENTER
                 # Enter invalid interval
-                "bad interval"
+                + "bad interval"
                 + readchar.key.ENTER
-                +
                 # Enter another invalid interval
-                "0"
+                + "0"
                 + readchar.key.ENTER
-                +
                 # Enter valid interval
-                "42"
+                + "42"
                 + readchar.key.ENTER
-                # Decline remote storage
-                + "n"
+                # accept schedule being active
                 + readchar.key.ENTER
-                # Decline save
+                # decline adding another schedule
+                + readchar.key.ENTER
+                # decline save
                 + "n"
                 + readchar.key.ENTER
             ),
@@ -2914,7 +3041,7 @@ class TestSchedules:
         deployment = await prefect_client.read_deployment_by_name(
             "An important name/test-name"
         )
-        assert deployment.schedule.interval == timedelta(seconds=42)
+        assert deployment.schedules[0].schedule.interval == timedelta(seconds=42)
 
     @pytest.mark.usefixtures("interactive_console", "project_dir")
     async def test_deploy_cron_schedule_interactive(self, prefect_client, work_pool):
@@ -2926,30 +3053,25 @@ class TestSchedules:
             user_input=(
                 # Confirm schedule creation
                 readchar.key.ENTER
-                +
                 # Select cron schedule
-                readchar.key.DOWN
+                + readchar.key.DOWN
                 + readchar.key.ENTER
-                +
                 # Enter invalid cron string
-                "bad cron string"
+                + "bad cron string"
                 + readchar.key.ENTER
-                +
                 # Enter cron
-                "* * * * *"
+                + "* * * * *"
                 + readchar.key.ENTER
-                +
                 # Enter invalid timezone
-                "bad timezone"
+                + "bad timezone"
                 + readchar.key.ENTER
-                +
                 # Select default timezone
-                readchar.key.ENTER
-                +
-                # Decline remote storage
-                "n"
                 + readchar.key.ENTER
-                # Decline save
+                # accept schedule being active
+                + readchar.key.ENTER
+                # decline adding another schedule
+                + readchar.key.ENTER
+                # decline save
                 + "n"
                 + readchar.key.ENTER
             ),
@@ -2965,7 +3087,7 @@ class TestSchedules:
         deployment = await prefect_client.read_deployment_by_name(
             "An important name/test-name"
         )
-        assert deployment.schedule.cron == "* * * * *"
+        assert deployment.schedules[0].schedule.cron == "* * * * *"
 
     @pytest.mark.usefixtures("interactive_console", "project_dir")
     async def test_deploy_rrule_schedule_interactive(self, prefect_client, work_pool):
@@ -2977,32 +3099,27 @@ class TestSchedules:
             user_input=(
                 # Confirm schedule creation
                 readchar.key.ENTER
-                +
                 # Select rrule schedule
-                readchar.key.DOWN
+                + readchar.key.DOWN
                 + readchar.key.DOWN
                 + readchar.key.ENTER
-                +
                 # Enter invalid rrule string
-                "bad rrule string"
+                + "bad rrule string"
                 + readchar.key.ENTER
-                +
                 # Enter valid rrule string
-                "FREQ=WEEKLY;BYDAY=MO,WE,FR;UNTIL=20240730T040000Z"
+                + "FREQ=WEEKLY;BYDAY=MO,WE,FR;UNTIL=20240730T040000Z"
                 + readchar.key.ENTER
                 # Enter invalid timezone
                 + "bad timezone"
                 + readchar.key.ENTER
-                +
                 # Select default timezone
-                readchar.key.ENTER
-                +
-                # Decline remote storage
-                "n"
                 + readchar.key.ENTER
-                +
-                # Decline save
-                "n"
+                # accept schedule being active
+                + readchar.key.ENTER
+                # decline adding another schedule
+                + readchar.key.ENTER
+                # decline save
+                + "n"
                 + readchar.key.ENTER
             ),
             expected_code=0,
@@ -3012,7 +3129,7 @@ class TestSchedules:
             "An important name/test-name"
         )
         assert (
-            deployment.schedule.rrule
+            deployment.schedules[0].schedule.rrule
             == "FREQ=WEEKLY;BYDAY=MO,WE,FR;UNTIL=20240730T040000Z"
         )
 
@@ -4579,7 +4696,7 @@ class TestSaveUserInputs:
         assert len(config["deployments"]) == 1
         assert config["deployments"][0]["name"] == "default"
         assert config["deployments"][0]["entrypoint"] == "flows/hello.py:my_flow"
-        assert config["deployments"][0]["schedule"] is None
+        assert config["deployments"][0]["schedules"] == []
         assert config["deployments"][0]["work_pool"]["name"] == "inflatable"
 
     def test_save_user_inputs_existing_prefect_file(self):
@@ -4625,7 +4742,7 @@ class TestSaveUserInputs:
         assert len(config["deployments"]) == 2
         assert config["deployments"][1]["name"] == "default"
         assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
-        assert config["deployments"][1]["schedule"] is None
+        assert config["deployments"][1]["schedules"] == []
         assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
 
     def test_save_user_inputs_with_interval_schedule(self):
@@ -4646,6 +4763,8 @@ class TestSaveUserInputs:
                 + readchar.key.ENTER
                 # accept schedule being active
                 + readchar.key.ENTER
+                # decline adding another schedule
+                + readchar.key.ENTER
                 +
                 # accept create work pool
                 readchar.key.ENTER
@@ -4677,10 +4796,12 @@ class TestSaveUserInputs:
         assert config["deployments"][1]["name"] == "default"
         assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
         assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
-        assert config["deployments"][1]["schedule"]["interval"] == 3600
-        assert config["deployments"][1]["schedule"]["timezone"] == "UTC"
-        assert config["deployments"][1]["schedule"]["anchor_date"] is not None
-        assert config["deployments"][1]["schedule"]["active"]
+
+        schedule = config["deployments"][1]["schedules"][0]
+        assert schedule["interval"] == 3600
+        assert schedule["timezone"] == "UTC"
+        assert schedule["anchor_date"] is not None
+        assert schedule["active"]
 
     def test_save_user_inputs_with_cron_schedule(self):
         invoke_and_assert(
@@ -4695,24 +4816,21 @@ class TestSaveUserInputs:
                 # select cron schedule
                 readchar.key.DOWN
                 + readchar.key.ENTER
-                +
                 # enter cron schedule
-                "* * * * *"
+                + "* * * * *"
                 + readchar.key.ENTER
-                +
                 # accept default timezone
-                readchar.key.ENTER
+                + readchar.key.ENTER
                 # accept schedule being active
                 + readchar.key.ENTER
-                +
+                # decline adding another schedule
+                + readchar.key.ENTER
                 # accept create work pool
-                readchar.key.ENTER
-                +
+                + readchar.key.ENTER
                 # choose process work pool
-                readchar.key.ENTER
-                +
+                + readchar.key.ENTER
                 # enter work pool name
-                "inflatable"
+                + "inflatable"
                 + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
@@ -4735,10 +4853,14 @@ class TestSaveUserInputs:
         assert config["deployments"][1]["name"] == "default"
         assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
         assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
-        assert config["deployments"][1]["schedule"]["cron"] == "* * * * *"
-        assert config["deployments"][1]["schedule"]["timezone"] == "UTC"
-        assert config["deployments"][1]["schedule"]["day_or"]
-        assert config["deployments"][1]["schedule"]["active"]
+
+        schedule = config["deployments"][1]["schedules"][0]
+        assert schedule == {
+            "cron": "* * * * *",
+            "day_or": True,
+            "timezone": "UTC",
+            "active": True,
+        }
 
     def test_deploy_existing_deployment_with_no_changes_does_not_prompt_save(self):
         # Set up initial deployment deployment
@@ -4756,6 +4878,9 @@ class TestSaveUserInputs:
                 + readchar.key.ENTER
                 # enter cron schedule
                 + "* * * * *"
+                # accept schedule being active
+                + readchar.key.ENTER
+                # decline adding another schedule
                 + readchar.key.ENTER
                 # accept default timezone
                 + readchar.key.ENTER
@@ -4794,7 +4919,7 @@ class TestSaveUserInputs:
         assert config["deployments"][1]["name"] == "existing-deployment"
         assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
         assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
-        assert config["deployments"][1]["schedule"] == {
+        assert config["deployments"][1]["schedules"][0] == {
             "cron": "* * * * *",
             "day_or": True,
             "timezone": "UTC",
@@ -4833,7 +4958,7 @@ class TestSaveUserInputs:
         assert config["deployments"][1]["name"] == "existing-deployment"
         assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
         assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
-        assert config["deployments"][1]["schedule"] == {
+        assert config["deployments"][1]["schedules"][0] == {
             "cron": "* * * * *",
             "day_or": True,
             "timezone": "UTC",
@@ -4884,7 +5009,7 @@ class TestSaveUserInputs:
         assert config["deployments"][1]["name"] == "existing-deployment"
         assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
         assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
-        assert config["deployments"][1]["schedule"] is None
+        assert config["deployments"][1]["schedules"] == []
 
         invoke_and_assert(
             command="deploy -n existing-deployment --cron '* * * * *'",
@@ -4922,7 +5047,7 @@ class TestSaveUserInputs:
         assert config["deployments"][1]["name"] == "existing-deployment"
         assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
         assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
-        assert config["deployments"][1]["schedule"]["cron"] == "* * * * *"
+        assert config["deployments"][1]["schedules"][0]["cron"] == "* * * * *"
 
     def test_save_user_inputs_with_rrule_schedule(self):
         invoke_and_assert(
@@ -4943,6 +5068,8 @@ class TestSaveUserInputs:
                 "FREQ=MINUTELY"
                 + readchar.key.ENTER
                 # accept schedule being active
+                + readchar.key.ENTER
+                # decline adding another schedule
                 + readchar.key.ENTER
                 # accept create work pool
                 + readchar.key.ENTER
@@ -4977,9 +5104,13 @@ class TestSaveUserInputs:
         assert config["deployments"][1]["name"] == "default"
         assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
         assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
-        assert config["deployments"][1]["schedule"]["rrule"] == "FREQ=MINUTELY"
-        assert config["deployments"][1]["schedule"]["timezone"] == "UTC"
-        assert config["deployments"][1]["schedule"]["active"]
+
+        schedule = config["deployments"][1]["schedules"][0]
+        assert schedule == {
+            "rrule": "FREQ=MINUTELY",
+            "timezone": "UTC",
+            "active": True,
+        }
 
     async def test_save_user_inputs_with_actions(self):
         new_deployment_to_save = {
@@ -5131,7 +5262,7 @@ class TestSaveUserInputs:
         assert len(config["deployments"]) == 2
         assert config["deployments"][1]["name"] == "default"
         assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
-        assert config["deployments"][1]["schedule"] is None
+        assert config["deployments"][1]["schedules"] == []
         assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
 
         invoke_and_assert(
@@ -5180,7 +5311,7 @@ class TestSaveUserInputs:
         assert len(config["deployments"]) == 2
         assert config["deployments"][1]["name"] == "default"
         assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
-        assert config["deployments"][1]["schedule"]["interval"] == 3600
+        assert config["deployments"][1]["schedules"][0]["interval"] == 3600
         assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
 
     def test_save_user_inputs_overwrite_rejected_saving_cancelled(self):
@@ -5223,7 +5354,7 @@ class TestSaveUserInputs:
         assert len(config["deployments"]) == 2
         assert config["deployments"][1]["name"] == "default"
         assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
-        assert config["deployments"][1]["schedule"] is None
+        assert config["deployments"][1]["schedules"] == []
         assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
 
         invoke_and_assert(
@@ -5232,19 +5363,18 @@ class TestSaveUserInputs:
                 # configure new deployment
                 "n"
                 + readchar.key.ENTER
-                # accept schedule
+                # configure schedule
                 + readchar.key.ENTER
                 # select interval schedule
                 + readchar.key.ENTER
                 # enter interval schedule
                 + "3600"
                 + readchar.key.ENTER
-                # accept create work pool
+                # accept schedule being active
                 + readchar.key.ENTER
-                # choose process work pool
+                # decline adding another schedule
                 + readchar.key.ENTER
-                # enter work pool name
-                + "inflatable"
+                # accept existing work pool
                 + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
@@ -5266,7 +5396,7 @@ class TestSaveUserInputs:
         assert len(config["deployments"]) == 2
         assert config["deployments"][1]["name"] == "default"
         assert config["deployments"][1]["entrypoint"] == "flows/hello.py:my_flow"
-        assert config["deployments"][1]["schedule"] is None
+        assert config["deployments"][1]["schedules"] == []
         assert config["deployments"][1]["work_pool"]["name"] == "inflatable"
 
     @pytest.mark.usefixtures("project_dir", "interactive_console")


### PR DESCRIPTION
This adds support for multiple schedules to `prefect deploy`. It allows for the `prefect.yaml` to contain a `schedules` list, all schedules in that list will be added to that deployment when it's created/updated. Setting it to an empty list will result in all schedules being removed. It also allows you to interactively define multiple schedules.

Additionally you can specify multiple schedules via the command line:

`prefect deploy ... --cron '4 * * * *' --cron '1 * * * *' --rrule 'FREQ=DAILY'`

Lastly I opted to keep the behavior where passing `--anchor_date` or `--timezone` would update the existing schedule to use that timezone/anchor_date, but now it applies to both new and existing schedules for the deployment.

Closes #12092 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.