### PR TITLE
Try to use/reuse the same block for autonomous task scheduling storage

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -80,6 +80,7 @@ Client-side execution and orchestration of flows and tasks.
     _Ideally, for local and sequential task runners we would send the task run to the
     user thread as we do for flows. See [#9855](https://github.com/PrefectHQ/prefect/pull/9855).
 """
+
 import asyncio
 import contextlib
 import logging
@@ -2924,7 +2925,8 @@ async def create_autonomous_task_run(task: Task, parameters: Dict[str, Any]) -> 
 
             # TODO: Improve use of result storage for parameter storage / reference
             task.persist_result = True
-            factory = await ResultFactory.from_task(task, client=client)
+
+            factory = await ResultFactory.from_autonomous_task(task, client=client)
             await factory.store_parameters(parameters_id, parameters)
 
         task_run = await client.create_task_run(

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
+    Awaitable,
     Callable,
     Dict,
     Generic,
@@ -41,6 +42,7 @@ from prefect.settings import (
     PREFECT_LOCAL_STORAGE_PATH,
     PREFECT_RESULTS_DEFAULT_SERIALIZER,
     PREFECT_RESULTS_PERSIST_BY_DEFAULT,
+    PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK,
 )
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import sync_compatible
@@ -69,12 +71,57 @@ async def get_default_result_storage() -> ResultStorage:
     """
     Generate a default file system for result storage.
     """
-
     return (
         await Block.load(PREFECT_DEFAULT_RESULT_STORAGE_BLOCK.value())
         if PREFECT_DEFAULT_RESULT_STORAGE_BLOCK.value() is not None
         else LocalFileSystem(basepath=PREFECT_LOCAL_STORAGE_PATH.value())
     )
+
+
+_default_task_scheduling_storages: Dict[Tuple[str, str], WritableFileSystem] = {}
+
+
+async def get_or_create_default_task_scheduling_storage() -> ResultStorage:
+    """
+    Generate a default file system for autonomous task parameter/result storage.
+    """
+    default_storage_name, storage_path = cache_key = (
+        PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK.value(),
+        PREFECT_LOCAL_STORAGE_PATH.value(),
+    )
+
+    async def get_storage():
+        try:
+            return await Block.load(default_storage_name)
+        except ValueError as e:
+            if "Unable to find" not in str(e):
+                raise e
+
+        block_type_slug, name = default_storage_name.split("/")
+        if block_type_slug == "local-file-system":
+            block = LocalFileSystem(basepath=storage_path)
+        else:
+            raise Exception(
+                "The default task storage block does not exist, but it is of type "
+                f"'{block_type_slug}' which cannot be created implicitly.  Please create "
+                "the block manually."
+            )
+
+        try:
+            await block.save(name, overwrite=False)
+            return block
+        except ValueError as e:
+            if "already in use" not in str(e):
+                raise e
+
+        return await Block.load(default_storage_name)
+
+    try:
+        return _default_task_scheduling_storages[cache_key]
+    except KeyError:
+        storage = await get_storage()
+        _default_task_scheduling_storages[cache_key] = storage
+        return storage
 
 
 def get_default_result_serializer() -> ResultSerializer:
@@ -231,10 +278,39 @@ class ResultFactory(pydantic.BaseModel):
 
         ctx = FlowRunContext.get()
 
+        if ctx and ctx.autonomous_task_run:
+            return await cls.from_autonomous_task(task, client=client)
+
+        return await cls._from_task(task, get_default_result_storage, client=client)
+
+    @classmethod
+    @inject_client
+    async def from_autonomous_task(
+        cls: Type[Self], task: "Task", client: "PrefectClient" = None
+    ) -> Self:
+        """
+        Create a new result factory for an autonomous task.
+        """
+        return await cls._from_task(
+            task, get_or_create_default_task_scheduling_storage, client=client
+        )
+
+    @classmethod
+    @inject_client
+    async def _from_task(
+        cls: Type[Self],
+        task: "Task",
+        default_storage_getter: Callable[[], Awaitable[ResultStorage]],
+        client: "PrefectClient" = None,
+    ) -> Self:
+        from prefect.context import FlowRunContext
+
+        ctx = FlowRunContext.get()
+
         result_storage = task.result_storage or (
             ctx.result_factory.storage_block
             if ctx and ctx.result_factory
-            else await get_default_result_storage()
+            else await default_storage_getter()
         )
         result_serializer = task.result_serializer or (
             ctx.result_factory.serializer

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1417,6 +1417,14 @@ PREFECT_WORKER_WEBSERVER_PORT = Setting(
 """
 The port the worker's webserver should bind to.
 """
+
+PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK = Setting(
+    str,
+    default="local-file-system/prefect-task-scheduling",
+)
+"""The `block-type/block-document` slug of a block to use as the default result storage
+for autonomous tasks."""
+
 PREFECT_TASK_SCHEDULING_DELETE_FAILED_SUBMISSIONS = Setting(
     bool,
     default=True,
@@ -1440,6 +1448,7 @@ PREFECT_TASK_SCHEDULING_MAX_RETRY_QUEUE_SIZE = Setting(
 """
 The maximum number of retries to queue for submission.
 """
+
 
 PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES = Setting(bool, default=False)
 """

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -45,7 +45,7 @@ async def submit_autonomous_task_run_to_engine(
             task_runner=task_runner,
             client=client,
             parameters=parameters,
-            result_factory=await ResultFactory.from_task(task),
+            result_factory=await ResultFactory.from_autonomous_task(task),
             background_tasks=await stack.enter_async_context(anyio.create_task_group()),
         ) as flow_run_context:
             begin_run = create_call(

--- a/src/prefect/task_server.py
+++ b/src/prefect/task_server.py
@@ -71,6 +71,7 @@ class TaskServer:
         task_runner: Optional[Type[BaseTaskRunner]] = None,
     ):
         self.tasks: list[Task] = tasks
+
         self.task_runner: BaseTaskRunner = task_runner or ConcurrentTaskRunner()
         self.started: bool = False
         self.stopping: bool = False
@@ -155,7 +156,7 @@ class TaskServer:
         if should_try_to_read_parameters(task, task_run):
             parameters_id = task_run.state.state_details.task_parameters_id
             task.persist_result = True
-            factory = await ResultFactory.from_task(task)
+            factory = await ResultFactory.from_autonomous_task(task)
             try:
                 parameters = await factory.read_parameters(parameters_id)
             except Exception as exc:

--- a/tests/test_autonomous_tasks.py
+++ b/tests/test_autonomous_tasks.py
@@ -1,12 +1,18 @@
+from pathlib import Path
+
 import pytest
 
+import prefect.results
 from prefect import Task, task
+from prefect.blocks.core import Block
 from prefect.client.schemas import TaskRun
 from prefect.filesystems import LocalFileSystem
 from prefect.results import ResultFactory
 from prefect.server.api.task_runs import TaskQueue
 from prefect.settings import (
     PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
+    PREFECT_LOCAL_STORAGE_PATH,
+    PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK,
     temporary_settings,
 )
 from prefect.utilities.asyncutils import sync_compatible
@@ -14,7 +20,7 @@ from prefect.utilities.asyncutils import sync_compatible
 
 @sync_compatible
 async def result_factory_from_task(task):
-    return await ResultFactory.from_task(task)
+    return await ResultFactory.from_autonomous_task(task)
 
 
 @pytest.fixture
@@ -39,6 +45,13 @@ async def clear_scheduled_task_queues():
     TaskQueue.reset()
     yield
     TaskQueue.reset()
+
+
+@pytest.fixture(autouse=True)
+async def clear_cached_filesystems():
+    prefect.results._default_task_scheduling_storages.clear()
+    yield
+    prefect.results._default_task_scheduling_storages.clear()
 
 
 @pytest.fixture
@@ -77,14 +90,48 @@ def test_task_submission_fails_when_experimental_flag_off(foo_task):
             foo_task.submit(42)
 
 
-def test_task_submission_with_parameters_fails_without_result_storage(foo_task):
+def test_task_submission_with_parameters_uses_default_storage(foo_task):
     foo_task_without_result_storage = foo_task.with_options(result_storage=None)
     task_run = foo_task_without_result_storage.submit(42)
 
     result_factory = result_factory_from_task(foo_task)
 
-    with pytest.raises(AssertionError, match="Was it persisted?"):
-        result_factory.read_parameters(task_run.state.state_details.task_parameters_id)
+    result_factory.read_parameters(task_run.state.state_details.task_parameters_id)
+
+
+def test_task_submission_with_parameters_reuses_default_storage_block(
+    foo_task: Task, tmp_path: Path
+):
+    with temporary_settings(
+        {
+            PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK: "local-file-system/my-tasks",
+            PREFECT_LOCAL_STORAGE_PATH: tmp_path / "some-storage",
+        }
+    ):
+        # The block will not exist initially
+        with pytest.raises(ValueError, match="Unable to find block document"):
+            Block.load("local-file-system/my-tasks")
+
+        foo_task_without_result_storage = foo_task.with_options(result_storage=None)
+        task_run_a = foo_task_without_result_storage.submit(42)
+
+        storage_before = Block.load("local-file-system/my-tasks")
+        assert isinstance(storage_before, LocalFileSystem)
+        assert storage_before.basepath == str(tmp_path / "some-storage")
+
+        foo_task_without_result_storage = foo_task.with_options(result_storage=None)
+        task_run_b = foo_task_without_result_storage.submit(24)
+
+        storage_after = Block.load("local-file-system/my-tasks")
+        assert isinstance(storage_after, LocalFileSystem)
+
+        result_factory = result_factory_from_task(foo_task)
+        assert result_factory.read_parameters(
+            task_run_a.state.state_details.task_parameters_id
+        ) == {"x": 42}
+        assert result_factory.read_parameters(
+            task_run_b.state.state_details.task_parameters_id
+        ) == {"x": 24}
 
 
 def test_task_submission_creates_a_scheduled_task_run(foo_task_with_result_storage):

--- a/tests/test_task_server.py
+++ b/tests/test_task_server.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import prefect.results
 from prefect import task
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect.client.schemas.objects import TaskRun
@@ -28,6 +29,13 @@ def mock_settings():
         }
     ):
         yield
+
+
+@pytest.fixture(autouse=True)
+async def clear_cached_filesystems():
+    prefect.results._default_task_scheduling_storages.clear()
+    yield
+    prefect.results._default_task_scheduling_storages.clear()
 
 
 # model defined outside of the test function to avoid pickling issues


### PR DESCRIPTION
If we use the default task storage behavior, unless the user provides explicit
storage blocks, we'll create a new anonymous `local-file-system` block for each
task run.  This behavior should eventually change for all tasks, but in the
meantime we can prototype an alternative approach for autonomous tasks where
we implicitly get-or-create a named local file system storage block.  This
gives us good default behavior that's equivalent to the current behavior,
without creating many anonymous blocks.