### PR TITLE
Add a --replace option to "schedule create" command

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -340,6 +340,17 @@ async def create_schedule(
         "--active",
         help="Whether the schedule is active. Defaults to True.",
     ),
+    replace: Optional[bool] = typer.Option(
+        False,
+        "--replace",
+        help="Replace the deployment's current schedule(s) with this new schedule.",
+    ),
+    assume_yes: Optional[bool] = typer.Option(
+        False,
+        "--accept-yes",
+        "-y",
+        help="Accept the confirmation prompt without prompting",
+    ),
 ):
     """
     Create a schedule for a given deployment.
@@ -409,8 +420,29 @@ async def create_schedule(
         except ObjectNotFound:
             return exit_with_error(f"Deployment {name!r} not found!")
 
+        num_schedules = len(deployment.schedules)
+        noun = "schedule" if num_schedules == 1 else "schedules"
+
+        if replace and num_schedules > 0:
+            if not assume_yes and not typer.confirm(
+                f"Are you sure you want to replace {num_schedules} {noun} for {name}?"
+            ):
+                return exit_with_error("Schedule replacement cancelled.")
+
+            for existing_schedule in deployment.schedules:
+                try:
+                    await client.delete_deployment_schedule(
+                        deployment.id, existing_schedule.id
+                    )
+                except ObjectNotFound:
+                    pass
+
         await client.create_deployment_schedules(deployment.id, [(schedule, active)])
-        exit_with_success("Created deployment schedule!")
+
+        if replace and num_schedules > 0:
+            exit_with_success(f"Replaced existing deployment {noun} with new schedule!")
+        else:
+            exit_with_success("Created deployment schedule!")
 
 
 @schedule_app.command("delete")
@@ -440,8 +472,8 @@ async def delete_schedule(
         except IndexError:
             return exit_with_error("Deployment schedule not found!")
 
-        if not assume_yes and not typer.prompt(
-            f"Are you sure you want to delete this schedule: {schedule.schedule} (y/n)",
+        if not assume_yes and not typer.confirm(
+            f"Are you sure you want to delete this schedule: {schedule.schedule}",
         ):
             return exit_with_error("Deletion cancelled.")
 
@@ -578,9 +610,8 @@ async def clear_schedules(
         await client.read_flow(deployment.flow_id)
 
         # Get input from user: confirm removal of all schedules
-        if not assume_yes and not typer.prompt(
-            "Are you sure you want to clear all schedules for this deployment? (y/n)",
-            type=bool,
+        if not assume_yes and not typer.confirm(
+            "Are you sure you want to clear all schedules for this deployment?",
         ):
             exit_with_error("Clearing schedules cancelled.")
 

--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -943,6 +943,177 @@ class TestDeploymentSchedules:
             expected_output_contains=error,
         )
 
+    def test_create_schedule_replace_replaces_existing_schedules_many(self, flojo):
+        create_args = [
+            "deployment",
+            "schedule",
+            "create",
+            "rence-griffith/test-deployment",
+            "--interval",
+        ]
+
+        invoke_and_assert(
+            [
+                *create_args,
+                "90",
+            ],
+            expected_code=0,
+            expected_output_contains="Created deployment schedule!",
+        )
+
+        invoke_and_assert(
+            [
+                *create_args,
+                "1800",
+            ],
+            expected_code=0,
+            expected_output_contains="Created deployment schedule!",
+        )
+
+        invoke_and_assert(
+            [
+                "deployment",
+                "inspect",
+                "rence-griffith/test-deployment",
+            ],
+            expected_output_contains=["'interval': 90.0,", "'interval': 1800.0,"],
+            expected_code=0,
+        )
+
+        invoke_and_assert(
+            [*create_args, "10", "--replace", "-y"],
+            expected_code=0,
+            expected_output_contains="Replaced existing deployment schedules with new schedule!",
+        )
+
+        invoke_and_assert(
+            [
+                "deployment",
+                "inspect",
+                "rence-griffith/test-deployment",
+            ],
+            expected_output_contains=["'interval': 10.0,"],
+            expected_output_does_not_contain=[
+                "'interval': 90.0,",
+                "'interval': 1800.0,",
+            ],
+            expected_code=0,
+        )
+
+    def test_create_schedule_replace_replaces_existing_schedule(self, flojo):
+        invoke_and_assert(
+            [
+                "deployment",
+                "schedule",
+                "clear",
+                "rence-griffith/test-deployment",
+                "-y",
+            ],
+            expected_code=0,
+            expected_output_contains="Cleared all schedules",
+        )
+
+        create_args = [
+            "deployment",
+            "schedule",
+            "create",
+            "rence-griffith/test-deployment",
+            "--interval",
+        ]
+
+        invoke_and_assert(
+            [
+                *create_args,
+                "90",
+            ],
+            expected_code=0,
+            expected_output_contains="Created deployment schedule!",
+        )
+
+        invoke_and_assert(
+            [
+                "deployment",
+                "inspect",
+                "rence-griffith/test-deployment",
+            ],
+            expected_output_contains=["'interval': 90.0,"],
+            expected_code=0,
+        )
+
+        invoke_and_assert(
+            [*create_args, "10", "--replace", "-y"],
+            expected_code=0,
+            expected_output_contains="Replaced existing deployment schedule with new schedule!",
+        )
+
+        invoke_and_assert(
+            [
+                "deployment",
+                "inspect",
+                "rence-griffith/test-deployment",
+            ],
+            expected_output_contains=["'interval': 10.0,"],
+            expected_output_does_not_contain=["'interval': 1800.0,"],
+            expected_code=0,
+        )
+
+    def test_create_schedule_replace_seeks_confirmation(self, flojo):
+        deployment_name = "rence-griffith/test-deployment"
+        invoke_and_assert(
+            [
+                "deployment",
+                "schedule",
+                "create",
+                deployment_name,
+                "--interval",
+                "60",
+                "--replace",
+            ],
+            user_input="N",
+            expected_code=1,
+            expected_output_contains=f"Are you sure you want to replace 1 schedule for {deployment_name}?",
+        )
+
+        invoke_and_assert(
+            [
+                "deployment",
+                "inspect",
+                "rence-griffith/test-deployment",
+            ],
+            expected_output_contains=["'interval': 10.76,"],  # original schedule
+            expected_code=0,
+        )
+
+    def test_create_schedule_replace_accepts_confirmation(self, flojo):
+        deployment_name = "rence-griffith/test-deployment"
+        invoke_and_assert(
+            [
+                "deployment",
+                "schedule",
+                "create",
+                deployment_name,
+                "--interval",
+                "60",
+                "--replace",
+            ],
+            user_input="y",
+            expected_code=0,
+            expected_output_contains=f"Are you sure you want to replace 1 schedule for {deployment_name}?",
+        )
+
+        invoke_and_assert(
+            [
+                "deployment",
+                "inspect",
+                "rence-griffith/test-deployment",
+            ],
+            expected_output_contains=["'interval': 60.0,"],  # new schedule
+            expected_output_does_not_contain=[
+                "'interval': 10.76,"
+            ],  # original schedule
+            expected_code=0,
+        )
+
     def test_clear_schedule_deletes(self, flojo):
         invoke_and_assert(
             [


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

Adds a `--replace` option to the `prefect deployment schedule create` command, so that `prefect deployment schedule create <options> --replace -y` works like the now-deprecated command `prefect deployment set-schedule`, replacing all current schedules with the new one.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.