### PR TITLE
Add flow run state data to flow run graph API

### DIFF
--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -608,7 +608,7 @@ class BaseQueryComponents(ABC):
         return [
             GraphState(
                 id=state.id,
-                occurred=state.timestamp,
+                timestamp=state.timestamp,
                 type=state.type,
             )
             for state in flow_run_states

--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -610,6 +610,7 @@ class BaseQueryComponents(ABC):
                 id=state.id,
                 timestamp=state.timestamp,
                 type=state.type,
+                name=state.name,
             )
             for state in flow_run_states
         ]

--- a/src/prefect/server/schemas/graph.py
+++ b/src/prefect/server/schemas/graph.py
@@ -6,6 +6,12 @@ from prefect.server.schemas.states import StateType
 from prefect.server.utilities.schemas import PrefectBaseModel
 
 
+class GraphStateEvent(PrefectBaseModel):
+    id: UUID
+    occurred: datetime
+    type: StateType
+
+
 class GraphArtifact(PrefectBaseModel):
     id: UUID
     created: datetime
@@ -36,3 +42,4 @@ class Graph(PrefectBaseModel):
     root_node_ids: List[UUID]
     nodes: List[Tuple[UUID, Node]]
     artifacts: List[GraphArtifact]
+    state_events: List[GraphStateEvent]

--- a/src/prefect/server/schemas/graph.py
+++ b/src/prefect/server/schemas/graph.py
@@ -10,6 +10,7 @@ class GraphState(PrefectBaseModel):
     id: UUID
     timestamp: datetime
     type: StateType
+    name: str
 
 
 class GraphArtifact(PrefectBaseModel):

--- a/src/prefect/server/schemas/graph.py
+++ b/src/prefect/server/schemas/graph.py
@@ -6,7 +6,7 @@ from prefect.server.schemas.states import StateType
 from prefect.server.utilities.schemas import PrefectBaseModel
 
 
-class GraphStateEvent(PrefectBaseModel):
+class GraphState(PrefectBaseModel):
     id: UUID
     occurred: datetime
     type: StateType
@@ -42,4 +42,4 @@ class Graph(PrefectBaseModel):
     root_node_ids: List[UUID]
     nodes: List[Tuple[UUID, Node]]
     artifacts: List[GraphArtifact]
-    state_events: List[GraphStateEvent]
+    states: List[GraphState]

--- a/src/prefect/server/schemas/graph.py
+++ b/src/prefect/server/schemas/graph.py
@@ -8,7 +8,7 @@ from prefect.server.utilities.schemas import PrefectBaseModel
 
 class GraphState(PrefectBaseModel):
     id: UUID
-    occurred: datetime
+    timestamp: datetime
     type: StateType
 
 

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1286,6 +1286,13 @@ PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS_ON_FLOW_RUN_GRAPH = Setting(bool, default=
 Whether or not to enable artifacts on the flow run graph.
 """
 
+PREFECT_EXPERIMENTAL_ENABLE_STATE_EVENTS_ON_FLOW_RUN_GRAPH = Setting(
+    bool, default=False
+)
+"""
+Whether or not to enable state events on the flow run graph.
+"""
+
 PREFECT_EXPERIMENTAL_ENABLE_EVENTS_CLIENT = Setting(bool, default=True)
 """
 Whether or not to enable experimental Prefect work pools.

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1286,11 +1286,9 @@ PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS_ON_FLOW_RUN_GRAPH = Setting(bool, default=
 Whether or not to enable artifacts on the flow run graph.
 """
 
-PREFECT_EXPERIMENTAL_ENABLE_STATE_EVENTS_ON_FLOW_RUN_GRAPH = Setting(
-    bool, default=False
-)
+PREFECT_EXPERIMENTAL_ENABLE_STATES_ON_FLOW_RUN_GRAPH = Setting(bool, default=False)
 """
-Whether or not to enable state events on the flow run graph.
+Whether or not to enable flow run states on the flow run graph.
 """
 
 PREFECT_EXPERIMENTAL_ENABLE_EVENTS_CLIENT = Setting(bool, default=True)

--- a/tests/server/api/test_flow_run_graph_v2.py
+++ b/tests/server/api/test_flow_run_graph_v2.py
@@ -1182,10 +1182,10 @@ async def test_reading_graph_for_flow_run_includes_states(
 
     expected_graph_states = sorted(
         (
-            GraphState(id=state.id, occurred=state.timestamp, type=state.type)
+            GraphState(id=state.id, timestamp=state.timestamp, type=state.type)
             for state in flow_run_states
         ),
-        key=attrgetter("occurred"),
+        key=attrgetter("timestamp"),
     )
 
     assert graph.states == expected_graph_states

--- a/tests/server/api/test_flow_run_graph_v2.py
+++ b/tests/server/api/test_flow_run_graph_v2.py
@@ -1182,7 +1182,9 @@ async def test_reading_graph_for_flow_run_includes_states(
 
     expected_graph_states = sorted(
         (
-            GraphState(id=state.id, timestamp=state.timestamp, type=state.type)
+            GraphState(
+                id=state.id, timestamp=state.timestamp, type=state.type, name=state.name
+            )
             for state in flow_run_states
         ),
         key=attrgetter("timestamp"),

--- a/tests/server/api/test_flow_run_graph_v2.py
+++ b/tests/server/api/test_flow_run_graph_v2.py
@@ -22,6 +22,7 @@ from prefect.settings import (
     PREFECT_API_MAX_FLOW_RUN_GRAPH_ARTIFACTS,
     PREFECT_API_MAX_FLOW_RUN_GRAPH_NODES,
     PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS_ON_FLOW_RUN_GRAPH,
+    PREFECT_EXPERIMENTAL_ENABLE_STATE_EVENTS_ON_FLOW_RUN_GRAPH,
     temporary_settings,
 )
 
@@ -1113,6 +1114,22 @@ async def test_artifacts_on_flow_run_graph_limited_by_setting(
     assert (
         len(graph.artifacts) + sum(len(node.artifacts) for _, node in graph.nodes)
     ) <= test_max_artifacts_setting
+
+
+@pytest.fixture
+def enable_state_events_on_flow_run_graph():
+    with temporary_settings(
+        {PREFECT_EXPERIMENTAL_ENABLE_STATE_EVENTS_ON_FLOW_RUN_GRAPH: True}
+    ):
+        yield
+
+
+@pytest.fixture
+def disable_state_events_on_flow_run_graph():
+    with temporary_settings(
+        {PREFECT_EXPERIMENTAL_ENABLE_STATE_EVENTS_ON_FLOW_RUN_GRAPH: False}
+    ):
+        yield
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR mimics #12105 in supporting upcoming enhancements to the flow run graph.
It adds 1 new experimental opt-in flag:
- `PREFECT_EXPERIMENTAL_ENABLE_STATES_ON_FLOW_RUN_GRAPH` - an opt-in flag to add flow run state data to the graph-v2 route's response. NOTE: when this is OFF, the graph response still includes the top-level states key but the value is stubbed out with an empty array and any additional query overhead is foregone.

| **OFF (default)** | **ON** |
| ---- | ---- |
| ![Screenshot 2024-03-01 at 11 27 29 AM](https://github.com/PrefectHQ/prefect/assets/22418768/f6a80b9b-2589-48a4-adc4-11b188d653c5) | ![Screenshot 2024-03-01 at 11 25 55 AM](https://github.com/PrefectHQ/prefect/assets/22418768/1c08f7c2-a14a-4930-9b9a-7d24b710ef79) |

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.