### PR TITLE
Update `flow.serve` and `flow.deploy` docstrings and docs for multiple schedules

### DIFF
--- a/docs/concepts/schedules.md
+++ b/docs/concepts/schedules.md
@@ -143,7 +143,6 @@ schedule:
     Note that as a calendar-oriented standard, `RRules` are sensitive to the initial timezone provided.
     A 9am daily schedule with a DST-aware start date will maintain a local 9am time through DST boundaries. A 9am daily schedule with a UTC start date will maintain a 9am UTC time.
 
-
 ## Creating schedules
 
 There are several ways to create a schedule for a deployment:
@@ -151,11 +150,11 @@ There are several ways to create a schedule for a deployment:
 - Through the Prefect UI
 - Via the `cron`, `interval`, or `rrule` parameters if building your deployment via the [`serve` method](/concepts/flows/#serving-a-flow) of the `Flow` object or [the `serve` utility](/concepts/flows/#serving-multiple-flows-at-once) for managing multiple flows simultaneously
 - If using [worker-based deployments](/concepts/work-pools/)
-    * Through the interactive `prefect deploy` command
-    * With the `deployments` -> `schedule` section of the `prefect.yaml` file )
+  - Through the interactive `prefect deploy` command
+  - With the `deployments` -> `schedule` section of the `prefect.yaml` file )
 - If using [block-based deployments](/concepts/deployments/#block-based-deployments)
-    * `Through the schedules` section of the deployment YAML file
-    * By passing `schedules` into the `Deployment` class or `Deployment.build_from_flow`
+  - `Through the schedules` section of the deployment YAML file
+  - By passing `schedules` into the `Deployment` class or `Deployment.build_from_flow`
 
 ### Creating schedules in the UI
 
@@ -166,6 +165,7 @@ You can add schedules in the **Schedules** section on a **Deployment** page in t
 On larger displays, the **Schedules** section will appear in a sidebar on the right side of the page. On smaller displays, it will appear on the "Details" tab of the page.
 
 #### Adding a schedule
+
 Under **Schedules**, select the **+ Schedule** button. A modal dialog will open. Choose **Interval** or **Cron** to create a schedule.
 
 ![Prefect UI with Interval button selected](/img/ui/interval-schedule.png)
@@ -178,11 +178,12 @@ The new schedule will appear on the **Deployment** page where you created it. In
 After you create a schedule, new scheduled flow runs will be visible in the **Upcoming** tab of the **Deployment** page where you created it.
 
 #### Editing schedules
+
 You can edit a schedule by selecting **Edit** from the three-dot menu next to a schedule on a **Deployment** page.
 
 ### Creating schedules with a Python deployment creation file
 
-When you create a deployment in a Python file with `flow.serve()`, `serve`, `flow.deploy()`, or `deploy` you can specify the schedule. Just add the keyword argument `cron`, `interval`, or `rrule`. 
+When you create a deployment in a Python file with `flow.serve()`, `serve`, `flow.deploy()`, or `deploy` you can specify the schedule. Just add the keyword argument `cron`, `interval`, or `rrule`.
 
 ```
 interval: An interval on which to execute the deployment. Accepts a number or a 

--- a/docs/concepts/schedules.md
+++ b/docs/concepts/schedules.md
@@ -180,9 +180,57 @@ After you create a schedule, new scheduled flow runs will be visible in the **Up
 #### Editing schedules
 You can edit a schedule by selecting **Edit** from the three-dot menu next to a schedule on a **Deployment** page.
 
-### Creating schedules with the `serve` method
+### Creating schedules with a Python deployment creation file
 
-As seen in the [Quickstart](/getting-started/quickstart/#step-5-add-a-schedule), you can create a schedule by passing a `cron`, `interval`, or `rrule` parameters to the `Flow.serve` method or the `serve` utility.
+When you create a deployment in a Python file with `flow.serve()`, `serve`, `flow.deploy()`, or `deploy` you can specify the schedule. Just add the keyword argument `cron`, `interval`, or `rrule`. 
+
+```
+interval: An interval on which to execute the deployment. Accepts a number or a 
+    timedelta object to create a single schedule. If a number is given, it will be 
+    interpreted as seconds. Also accepts an iterable of numbers or timedelta to create 
+    multiple schedules.
+cron: A cron schedule string of when to execute runs of this deployment. 
+    Also accepts an iterable of cron schedule strings to create multiple schedules.
+rrule: An rrule schedule string of when to execute runs of this deployment.
+    Also accepts an iterable of rrule schedule strings to create multiple schedules.
+schedules: A list of schedule objects defining when to execute runs of this deployment.
+    Used to define multiple schedules or additional scheduling options such as `timezone`.
+schedule: A schedule object defining when to execute runs of this deployment. Used to
+    define additional scheduling options like `timezone`.
+
+```
+
+Here's an example of creating a cron schedule with `serve` for a deployment flow that will run every minute of every day:
+
+```python
+my_flow.serve(name="flowing", cron="* * * * *")
+```
+
+Here's an example of creating an interval schedule with `serve` for a deployment flow that will run every 10 minutes with an anchor date and a timezone:
+
+```python
+from datetime import timedelta, datetime
+from prefect.client.schemas.schedules import IntervalSchedule
+
+my_flow.serve(name="flowing", schedule=IntervalSchedule(interval=timedelta(minutes=10), anchor_date=datetime(2023, 1, 1, 0, 0), timezone="America/Chicago"))
+```
+
+Block and agent-based deployments with Python files are not a recommended way to create deployments.
+However, if you are using that deployment creation method you can create a schedule by passing a `schedule` argument to the `Deployment.build_from_flow` method.
+
+Here's how you create the equivalent schedule in a Python deployment file, with a timezone specified.
+
+```python
+from prefect.server.schemas.schedules import CronSchedule
+
+cron_demo = Deployment.build_from_flow(
+    pipeline,
+    "etl",
+    schedule=(CronSchedule(cron="0 0 * * *", timezone="America/Chicago"))
+)
+```
+
+`IntervalSchedule` and `RRuleSchedule` are the other two Python class schedule options.
 
 ### Creating schedules with the interactive `prefect deploy` command
 
@@ -208,51 +256,6 @@ deployments:
       timezone: "Europe/London"
       active: true
 ```
-
-### Creating schedules with a Python deployment creation file
-
-When you create a deployment in a Python file with `flow.serve()`, `serve`, `flow.deploy()`, or `deploy` you can specify the schedule. Just add the keyword argument `cron`, `interval`, or `rrule`. 
-
-```
-interval: An interval on which to execute the new deployment. Accepts either a number
-    or a timedelta object. If a number is given, it will be interpreted as seconds.
-cron: A cron schedule of when to execute runs of this deployment.
-rrule: An rrule schedule of when to execute runs of this deployment.
-schedule: A schedule object defining when to execute runs of this deployment. Used to
-  define additional scheduling options like `timezone`.
-```
-
-Here's an example of creating a cron schedule with `serve` for a deployment flow that will run every minute of every day:
-
-```python
-my_flow.serve(name="flowing", cron="* * * * *")
-```
-
-Here's an example of creating an interval schedule with `serve` for a deployment flow that will run every 10 minutes with an anchor date and a timezone:
-
-```python
-from datetime import timedelta, datetime
-from prefect.client.schemas.schedules import IntervalSchedule
-
-my_flow.serve(name="flowing", schedule=IntervalSchedule(interval=timedelta(minutes=10), anchor_date=datetime(2023, 1, 1, 0, 0), timezone="America/Chicago"))
-```
-
-Block and agent-based deployments with Python files are not a recommended way to create deployments.
-However, if you are using that deployment creation method you can create a schedule by passing a `schedule` parameter to the `Deployment.build_from_flow` method.
-
-Here's how you create the equivalent schedule in a Python deployment file, with a timezone specified.
-
-```python
-from prefect.server.schemas.schedules import CronSchedule
-
-cron_demo = Deployment.build_from_flow(
-    pipeline,
-    "etl",
-    schedule=(CronSchedule(cron="0 0 * * *", timezone="America/Chicago"))
-)
-```
-
-`IntervalSchedule` and `RRuleSchedule` are the other two Python class schedule options.
 
 ## The `Scheduler` service
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1,6 +1,7 @@
 """
 Module containing the base workflow class and decorator - for most use cases, using the [`@flow` decorator][prefect.flows.flow] is preferred.
 """
+
 # This file requires type-checking with pyright because mypy does not yet support PEP612
 # See https://github.com/python/mypy/issues/8645
 
@@ -449,9 +450,11 @@ class Flow(Generic[P, R]):
             version=version or self.version,
             task_runner=task_runner or self.task_runner,
             retries=retries if retries is not None else self.retries,
-            retry_delay_seconds=retry_delay_seconds
-            if retry_delay_seconds is not None
-            else self.retry_delay_seconds,
+            retry_delay_seconds=(
+                retry_delay_seconds
+                if retry_delay_seconds is not None
+                else self.retry_delay_seconds
+            ),
             timeout_seconds=(
                 timeout_seconds if timeout_seconds is not None else self.timeout_seconds
             ),
@@ -739,11 +742,11 @@ class Flow(Generic[P, R]):
 
         Args:
             name: The name to give the created deployment.
-            interval: An interval on which to execute the deployment. Accepts a number or a 
-                timedelta object to create a single schedule. If a number is given, it will be 
-                interpreted as seconds. Also accepts an iterable of numbers or timedelta to create 
+            interval: An interval on which to execute the deployment. Accepts a number or a
+                timedelta object to create a single schedule. If a number is given, it will be
+                interpreted as seconds. Also accepts an iterable of numbers or timedelta to create
                 multiple schedules.
-            cron: A cron schedule string of when to execute runs of this deployment. 
+            cron: A cron schedule string of when to execute runs of this deployment.
                 Also accepts an iterable of cron schedule strings to create multiple schedules.
             rrule: An rrule schedule string of when to execute runs of this deployment.
                 Also accepts an iterable of rrule schedule strings to create multiple schedules.
@@ -965,11 +968,11 @@ class Flow(Generic[P, R]):
             job_variables: Settings used to override the values specified default base job template
                 of the chosen work pool. Refer to the base job template of the chosen work pool for
                 available settings.
-            interval: An interval on which to execute the deployment. Accepts a number or a 
-                timedelta object to create a single schedule. If a number is given, it will be 
-                interpreted as seconds. Also accepts an iterable of numbers or timedelta to create 
+            interval: An interval on which to execute the deployment. Accepts a number or a
+                timedelta object to create a single schedule. If a number is given, it will be
+                interpreted as seconds. Also accepts an iterable of numbers or timedelta to create
                 multiple schedules.
-            cron: A cron schedule string of when to execute runs of this deployment. 
+            cron: A cron schedule string of when to execute runs of this deployment.
                 Also accepts an iterable of cron schedule strings to create multiple schedules.
             rrule: An rrule schedule string of when to execute runs of this deployment.
                 Also accepts an iterable of rrule schedule strings to create multiple schedules.

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -617,7 +617,7 @@ class Flow(Generic[P, R]):
             rrule: An rrule schedule of when to execute runs of this deployment.
             paused: Whether or not to set this deployment as paused.
             schedules: A list of schedule objects defining when to execute runs of this deployment.
-                Used to define multiple schedules or additional scheduling options like `timezone`.
+                Used to define multiple schedules or additional scheduling options such as `timezone`.
             schedule: A schedule object defining when to execute runs of this deployment.
             is_schedule_active: Whether or not to set the schedule for this deployment as active. If
                 not provided when creating a deployment, the schedule will be set as active. If not
@@ -752,7 +752,7 @@ class Flow(Generic[P, R]):
             schedules: A list of schedule objects defining when to execute runs of this deployment.
                 Used to define multiple schedules or additional scheduling options like `timezone`.
             schedule: A schedule object defining when to execute runs of this deployment. Used to
-                define additional scheduling options like `timezone`.
+                define additional scheduling options such as `timezone`.
             is_schedule_active: Whether or not to set the schedule for this deployment as active. If
                 not provided when creating a deployment, the schedule will be set as active. If not
                 provided when updating a deployment, the schedule's activation will not be changed.
@@ -965,10 +965,14 @@ class Flow(Generic[P, R]):
             job_variables: Settings used to override the values specified default base job template
                 of the chosen work pool. Refer to the base job template of the chosen work pool for
                 available settings.
-            interval: An interval on which to execute the new deployment. Accepts either a number
-                or a timedelta object. If a number is given, it will be interpreted as seconds.
-            cron: A cron schedule of when to execute runs of this deployment.
-            rrule: An rrule schedule of when to execute runs of this deployment.
+            interval: An interval on which to execute the deployment. Accepts a number or a 
+                timedelta object to create a single schedule. If a number is given, it will be 
+                interpreted as seconds. Also accepts an iterable of numbers or timedelta to create 
+                multiple schedules.
+            cron: A cron schedule string of when to execute runs of this deployment. 
+                Also accepts an iterable of cron schedule strings to create multiple schedules.
+            rrule: An rrule schedule string of when to execute runs of this deployment.
+                Also accepts an iterable of rrule schedule strings to create multiple schedules.
             triggers: A list of triggers that will kick off runs of this deployment.
             paused: Whether or not to set this deployment as paused.
             schedules: A list of schedule objects defining when to execute runs of this deployment.

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -739,10 +739,14 @@ class Flow(Generic[P, R]):
 
         Args:
             name: The name to give the created deployment.
-            interval: An interval on which to execute the new deployment. Accepts either a number
-                or a timedelta object. If a number is given, it will be interpreted as seconds.
-            cron: A cron schedule of when to execute runs of this deployment.
-            rrule: An rrule schedule of when to execute runs of this deployment.
+            interval: An interval on which to execute the deployment. Accepts a number or a 
+                timedelta object to create a single schedule. If a number is given, it will be 
+                interpreted as seconds. Also accepts an iterable of numbers or timedelta to create 
+                multiple schedules.
+            cron: A cron schedule string of when to execute runs of this deployment. 
+                Also accepts an iterable of cron schedule strings to create multiple schedules.
+            rrule: An rrule schedule string of when to execute runs of this deployment.
+                Also accepts an iterable of rrule schedule strings to create multiple schedules.
             triggers: A list of triggers that will kick off runs of this deployment.
             paused: Whether or not to set this deployment as paused.
             schedules: A list of schedule objects defining when to execute runs of this deployment.


### PR DESCRIPTION
Docstring params for flow.deploy and flow.serve now reference multiple parameters.
Removes redundant section in schedules doc and updates the docstring language on that page.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [X] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.