### PR TITLE
Support obfuscation of more complex log record messages

### DIFF
--- a/src/prefect/logging/filters.py
+++ b/src/prefect/logging/filters.py
@@ -1,6 +1,29 @@
 import logging
+from typing import Any
 
+from prefect.utilities.collections import visit_collection
 from prefect.utilities.names import obfuscate
+
+
+def redact_substr(obj: Any, substr: str):
+    """
+    Redact a string from a potentially nested object.
+
+    Args:
+        obj (Any): The object to redact the
+        substr (str): The substr to redact.
+
+    Returns:
+        Any: The object with the API key redacted.
+    """
+
+    def redact_item(item):
+        if isinstance(item, str):
+            return item.replace(substr, obfuscate(substr))
+        return item
+
+    redacted_obj = visit_collection(obj, visit_fn=redact_item, return_data=True)
+    return redacted_obj
 
 
 class ObfuscateApiKeyFilter(logging.Filter):
@@ -13,7 +36,6 @@ class ObfuscateApiKeyFilter(logging.Filter):
         from prefect.settings import PREFECT_API_KEY
 
         if PREFECT_API_KEY:
-            record.msg = record.msg.replace(
-                PREFECT_API_KEY.value(), obfuscate(PREFECT_API_KEY.value())
-            )
+            record.msg = redact_substr(record.msg, PREFECT_API_KEY.value())
+
         return True

--- a/src/prefect/logging/filters.py
+++ b/src/prefect/logging/filters.py
@@ -10,8 +10,8 @@ def redact_substr(obj: Any, substr: str):
     Redact a string from a potentially nested object.
 
     Args:
-        obj (Any): The object to redact the
-        substr (str): The substr to redact.
+        obj: The object to redact the string from
+        substr: The string to redact.
 
     Returns:
         Any: The object with the API key redacted.


### PR DESCRIPTION
closes #12139

`ObfuscateApiKeyFilter` as introduced by https://github.com/PrefectHQ/prefect/pull/12072 was assuming log record messages were strings, so when we attempted to remove a `PREFECT_API_KEY` from the message, we saw attribute errors like in the original issue.

this pr uses `visit_collection` to allow us to redact arbitrary collections recursively


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
