### PR TITLE
Adds an on_running state change hook

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -799,6 +799,8 @@ async def orchestrate_flow_run(
     # flag to ensure we only update the flow run name once
     run_name_set = False
 
+    await _run_flow_hooks(flow=flow, flow_run=flow_run, state=state)
+
     while state.is_running():
         waited_for_task_runs = False
 
@@ -2801,7 +2803,10 @@ async def _run_flow_hooks(flow: Flow, flow_run: FlowRun, state: State) -> None:
         os.environ.get("PREFECT__ENABLE_CANCELLATION_AND_CRASHED_HOOKS", "true").lower()
         == "true"
     )
-    if state.is_failed() and flow.on_failure:
+
+    if state.is_running() and flow.on_running:
+        hooks = flow.on_running
+    elif state.is_failed() and flow.on_failure:
         hooks = flow.on_failure
     elif state.is_completed() and flow.on_completion:
         hooks = flow.on_completion

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -182,6 +182,7 @@ class Flow(Generic[P, R]):
         on_completion: An optional list of callables to run when the flow enters a completed state.
         on_cancellation: An optional list of callables to run when the flow enters a cancelling state.
         on_crashed: An optional list of callables to run when the flow enters a crashed state.
+        on_running: An optional list of callables to run when the flow enters a running state.
     """
 
     # NOTE: These parameters (types, defaults, and docstrings) should be duplicated
@@ -211,6 +212,7 @@ class Flow(Generic[P, R]):
             List[Callable[[FlowSchema, FlowRun, State], None]]
         ] = None,
         on_crashed: Optional[List[Callable[[FlowSchema, FlowRun, State], None]]] = None,
+        on_running: Optional[List[Callable[[FlowSchema, FlowRun, State], None]]] = None,
     ):
         if name is not None and not isinstance(name, str):
             raise TypeError(
@@ -226,8 +228,20 @@ class Flow(Generic[P, R]):
             )
 
         # Validate if hook passed is list and contains callables
-        hook_categories = [on_completion, on_failure, on_cancellation, on_crashed]
-        hook_names = ["on_completion", "on_failure", "on_cancellation", "on_crashed"]
+        hook_categories = [
+            on_completion,
+            on_failure,
+            on_cancellation,
+            on_crashed,
+            on_running,
+        ]
+        hook_names = [
+            "on_completion",
+            "on_failure",
+            "on_cancellation",
+            "on_crashed",
+            on_running,
+        ]
         for hooks, hook_name in zip(hook_categories, hook_names):
             if hooks is not None:
                 if not hooks:
@@ -349,6 +363,7 @@ class Flow(Generic[P, R]):
         self.on_failure = on_failure
         self.on_cancellation = on_cancellation
         self.on_crashed = on_crashed
+        self.on_running = on_running
 
         # Used for flows loaded from remote storage
         self._storage: Optional[RunnerStorage] = None
@@ -386,6 +401,7 @@ class Flow(Generic[P, R]):
             List[Callable[[FlowSchema, FlowRun, State], None]]
         ] = None,
         on_crashed: Optional[List[Callable[[FlowSchema, FlowRun, State], None]]] = None,
+        on_running: Optional[List[Callable[[FlowSchema, FlowRun, State], None]]] = None,
     ) -> Self:
         """
         Create a new flow from the current object, updating provided options.
@@ -414,6 +430,7 @@ class Flow(Generic[P, R]):
             on_completion: A new list of callables to run when the flow enters a completed state.
             on_cancellation: A new list of callables to run when the flow enters a cancelling state.
             on_crashed: A new list of callables to run when the flow enters a crashed state.
+            on_running: A new list of callables to run when the flow enters a running state.
 
         Returns:
             A new `Flow` instance.
@@ -481,6 +498,7 @@ class Flow(Generic[P, R]):
             on_failure=on_failure or self.on_failure,
             on_cancellation=on_cancellation or self.on_cancellation,
             on_crashed=on_crashed or self.on_crashed,
+            on_running=on_running or self.on_running,
         )
         new_flow._storage = self._storage
         new_flow._entrypoint = self._entrypoint
@@ -1310,6 +1328,7 @@ def flow(
         List[Callable[[FlowSchema, FlowRun, State], None]]
     ] = None,
     on_crashed: Optional[List[Callable[[FlowSchema, FlowRun, State], None]]] = None,
+    on_running: Optional[List[Callable[[FlowSchema, FlowRun, State], None]]] = None,
 ) -> Callable[[Callable[P, R]], Flow[P, R]]:
     ...
 
@@ -1337,6 +1356,7 @@ def flow(
         List[Callable[[FlowSchema, FlowRun, State], None]]
     ] = None,
     on_crashed: Optional[List[Callable[[FlowSchema, FlowRun, State], None]]] = None,
+    on_running: Optional[List[Callable[[FlowSchema, FlowRun, State], None]]] = None,
 ):
     """
     Decorator to designate a function as a Prefect workflow.
@@ -1400,6 +1420,8 @@ def flow(
         on_crashed: An optional list of functions to call when the flow run crashes. Each
             function should accept three arguments: the flow, the flow run, and the
             final state of the flow run.
+        on_running: An optional list of functions to call when the flow run is started. Each
+            function should accept three arguments: the flow, the flow run, and the current state
 
     Returns:
         A callable `Flow` object which, when called, will run the flow and return its
@@ -1462,6 +1484,7 @@ def flow(
                 on_failure=on_failure,
                 on_cancellation=on_cancellation,
                 on_crashed=on_crashed,
+                on_running=on_running,
             ),
         )
     else:
@@ -1487,6 +1510,7 @@ def flow(
                 on_failure=on_failure,
                 on_cancellation=on_cancellation,
                 on_crashed=on_crashed,
+                on_running=on_running,
             ),
         )
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -240,7 +240,7 @@ class Flow(Generic[P, R]):
             "on_failure",
             "on_cancellation",
             "on_crashed",
-            on_running,
+            "on_running",
         ]
         for hooks, hook_name in zip(hook_categories, hook_names):
             if hooks is not None:

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -3219,6 +3219,138 @@ class TestFlowHooksOnCrashed:
         my_mock.assert_not_called()
 
 
+class TestFlowHooksOnRunning:
+    def test_noniterable_hook_raises(self):
+        def running_hook():
+            pass
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "Expected iterable for 'on_running'; got function instead. Please"
+                " provide a list of hooks to 'on_running':\n\n"
+                "@flow(on_running=[hook1, hook2])\ndef my_flow():\n\tpass"
+            ),
+        ):
+
+            @flow(on_running=running_hook)
+            def flow1():
+                pass
+
+    def test_empty_hook_list_raises(self):
+        with pytest.raises(ValueError, match="Empty list passed for 'on_running'"):
+
+            @flow(on_running=[])
+            def flow2():
+                pass
+
+    def test_noncallable_hook_raises(self):
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "Expected callables in 'on_running'; got str instead. Please provide"
+                " a list of hooks to 'on_running':\n\n"
+                "@flow(on_running=[hook1, hook2])\ndef my_flow():\n\tpass"
+            ),
+        ):
+
+            @flow(on_running=["test"])
+            def flow1():
+                pass
+
+    def test_callable_noncallable_hook_raises(self):
+        def running_hook():
+            pass
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "Expected callables in 'on_running'; got str instead. Please provide"
+                " a list of hooks to 'on_running':\n\n"
+                "@flow(on_running=[hook1, hook2])\ndef my_flow():\n\tpass"
+            ),
+        ):
+
+            @flow(on_running=[running_hook, "test"])
+            def flow2():
+                pass
+
+    def test_on_running_hooks_run_on_running(self):
+        my_mock = MagicMock()
+
+        def running1(flow, flow_run, state):
+            my_mock("running1")
+
+        def running2(flow, flow_run, state):
+            my_mock("running2")
+
+        @flow(on_running=[running1, running2])
+        def my_flow():
+            pass
+
+        state = my_flow._run()
+        assert state.type == StateType.COMPLETED
+        assert my_mock.call_args_list == [call("running1"), call("running2")]
+
+    def test_on_running_hooks_dont_run_on_failure(self):
+        my_mock = MagicMock()
+
+        def running1(flow, flow_run, state):
+            my_mock("running1")
+
+        def running2(flow, flow_run, state):
+            my_mock("running2")
+
+        @flow(on_running=[running1, running2])
+        def my_flow():
+            raise Exception("oops")
+
+        state = my_flow._run()
+        assert state.type == StateType.FAILED
+        assert my_mock.call_args_list == [call("running1"), call("running2")]
+
+    def test_other_running_hooks_run_if_a_hook_fails(self):
+        my_mock = MagicMock()
+
+        def running1(flow, flow_run, state):
+            my_mock("running1")
+
+        def exception_hook(flow, flow_run, state):
+            raise Exception("oops")
+
+        def running2(flow, flow_run, state):
+            my_mock("running2")
+
+        @flow(on_running=[running1, exception_hook, running2])
+        def my_flow():
+            pass
+
+        state = my_flow._run()
+        assert state.type == StateType.COMPLETED
+        assert my_mock.call_args_list == [call("running1"), call("running2")]
+
+    @pytest.mark.parametrize(
+        "hook1, hook2",
+        [
+            (create_hook, create_hook),
+            (create_hook, create_async_hook),
+            (create_async_hook, create_hook),
+            (create_async_hook, create_async_hook),
+        ],
+    )
+    def test_on_running_hooks_work_with_sync_and_async(self, hook1, hook2):
+        my_mock = MagicMock()
+        hook1_with_mock = hook1(my_mock)
+        hook2_with_mock = hook2(my_mock)
+
+        @flow(on_running=[hook1_with_mock, hook2_with_mock])
+        def my_flow():
+            pass
+
+        state = my_flow._run()
+        assert state.type == StateType.COMPLETED
+        assert my_mock.call_args_list == [call(), call()]
+
 class TestFlowToDeployment:
     async def test_to_deployment_returns_runner_deployment(self):
         deployment = await test_flow.to_deployment(

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -3292,7 +3292,7 @@ class TestFlowHooksOnRunning:
         assert state.type == StateType.COMPLETED
         assert my_mock.call_args_list == [call("running1"), call("running2")]
 
-    def test_on_running_hooks_dont_run_on_failure(self):
+    def test_on_running_hooks_run_on_failure(self):
         my_mock = MagicMock()
 
         def running1(flow, flow_run, state):

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -3367,6 +3367,7 @@ class TestFlowHooksOnRunning:
         assert state.type == StateType.COMPLETED
         assert my_mock.call_args_list == [call(), call()]
 
+
 class TestFlowToDeployment:
     async def test_to_deployment_returns_runner_deployment(self):
         deployment = await test_flow.to_deployment(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

This PR adds an on_running state change hook to the list of existing hooks available for flows, this is particularly useful for maintenance tasks that may need to be performed on a flow just prior to it's execution that may need to be separated from the flow code itself.

It's worth noting that the behavior for this hook differs from others in that it's not running on a Terminal state change meaning that depending on the circumstances it's possible for these hooks to be triggered multiple times during the course of a run.

closes [`10446`](https://github.com/PrefectHQ/prefect/issues/10446)

### Example
```
from prefect import flow, task
import time 
import random

def on_running_function(flow, flow_run, state):
    print(f"I am an on_running function! The flow is currently in state {state}")

@task
def compute_task():
    time.sleep(10)

@task
def secondary_task():
    print("I'm a second task!")
    time.sleep(5)

@flow(on_running=[on_running_function])
def demo_flow():
    compute_task()

    number = random.randint(1, 10)

    if number >= 5:
        secondary_task()

    return True
```
 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.