### PR TITLE
Remove outdated sqlite version info from install docs

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -49,7 +49,7 @@ To install a specific version, specify the version number like this:
 
 <div class="terminal">
 ```bash
-pip install -U "prefect==2.10.4"
+pip install -U "prefect==2.16.2"
 ```
 </div>
 
@@ -153,17 +153,9 @@ Prefect supports communicating via proxies through environment variables. Simply
 
 You can use [Prefect Cloud](/ui/cloud/) as your API server, or [host your own Prefect server](/host/) backed by [PostgreSQL](/concepts/database/#configuring_a_postgresql_database).
 
-By default, a local Prefect server instance uses SQLite as the backing database. SQLite is not packaged with the Prefect installation. Most systems will already have SQLite installed, because it is typically bundled as a part of Python. Prefect requires SQLite version 3.24.0 or later.
+By default, a local Prefect server instance uses SQLite as the backing database. SQLite is not packaged with the Prefect installation. Most systems will already have SQLite installed, because it is typically bundled as a part of Python. 
 
-You can check your SQLite version by executing the following command in a terminal:
-
-<div class="terminal">
-```bash
-$ sqlite3 --version
-```
-</div>
-
-Or use the Prefect CLI command `prefect version`, which prints version and environment details to your console, including the server database and version. For example:
+The Prefect CLI command `prefect version` prints environment details to your console, including the server database. For example:
 
 <div class="terminal">
 ```


### PR DESCRIPTION
This PR removes mention of the SQLite version from the install docs. Closes #5197 

Context: 
- The minimum required version of SQLite in the docs is incorrect.
- We don't test against a matrix of sqlite libraries.
- It's not straightforward or efficient to install old sqlite libraries. 
- We have very few reported issues of problems with old versions of SQLite, as the Python versions that we support (3.8 and up) generally install with SQLite versions that work.



<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.