### PR TITLE
only do docker builds/intregration tests on changes to deps/src

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -9,12 +9,20 @@ on:
     branches: main
     paths:
       - 'Dockerfile'
+      - '.dockerignore'
       - 'setup.py'
       - 'src/**'
       - 'tests/**'
       - 'requirements.txt'
       - 'requirements-client.txt'
-      - .github/workflows/docker-images.yaml
+      - 'MANIFEST.in'
+      - 'setup.cfg'
+      - 'versioneer.py'
+      - '.gitingore'
+      - '.gitattributes'
+      - '.github/workflows/docker-images.yaml'
+      - 'ui/**'
+
 
   # On workflow_dispatch, push sha and branch patterns to prefect-dev
   workflow_dispatch:

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -7,8 +7,18 @@ on:
   # On each commit merged into main, push sha and branch patterns to prefect-dev
   push:
     branches: main
+    paths:
+      - 'Dockerfile'
+      - 'setup.py'
+      - 'src/**'
+      - 'tests/**'
+      - 'requirements.txt'
+      - 'requirements-client.txt'
+      - .github/workflows/docker-images.yaml
+
   # On workflow_dispatch, push sha and branch patterns to prefect-dev
   workflow_dispatch:
+
 
 jobs:
   publish-docker-images:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -5,6 +5,7 @@ on:
       - .github/workflows/integration-tests.yaml
       - "**/*.py"
       - requirements.txt
+      - requirements-client.txt
       - requirements-dev.txt
       - ui/**
       - .nvmrc
@@ -12,6 +13,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - .github/workflows/integration-tests.yaml
+      - "**/*.py"
+      - requirements.txt
+      - requirements-client.txt
+      - requirements-dev.txt
+      - ui/**
+      - .nvmrc
+      - Dockerfile
 
 jobs:
   compatibility-tests:


### PR DESCRIPTION
closes #12161

I don't see why we'd need to build images / do integration tests for changes outside of any of these paths, but let me know if there's some reason I'm missing