### PR TITLE
[task scheduling] map autonomous task runs

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1698,7 +1698,10 @@ async def create_task_run(
         task_inputs=task_inputs,
     )
 
-    logger.info(f"Created task run {task_run.name!r} for task {task.name!r}")
+    if flow_run_context.flow_run:
+        logger.info(f"Created task run {task_run.name!r} for task {task.name!r}")
+    else:
+        engine_logger.info(f"Created task run {task_run.name!r} for task {task.name!r}")
 
     return task_run
 
@@ -1716,7 +1719,7 @@ async def submit_task_run(
 
     if (
         task_runner.concurrency_type == TaskConcurrencyType.SEQUENTIAL
-        and not flow_run_context.autonomous_task_run
+        and flow_run_context.flow_run
     ):
         logger.info(f"Executing {task_run.name!r} immediately...")
 

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -170,6 +170,7 @@ from prefect.logging.loggers import (
 from prefect.results import BaseResult, ResultFactory, UnknownResult
 from prefect.settings import (
     PREFECT_DEBUG_MODE,
+    PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
     PREFECT_LOGGING_LOG_PRINTS,
     PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD,
     PREFECT_TASKS_REFRESH_CACHE,
@@ -1369,10 +1370,27 @@ def enter_task_run_engine(
     flow_run_context = FlowRunContext.get()
 
     if not flow_run_context:
-        raise RuntimeError(
-            "Tasks cannot be run outside of a flow"
-            " - if you meant to submit an autonomous task, you need to set"
-            " `prefect config set PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING=true`"
+        if (
+            not PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING.value()
+            or return_type == "future"
+            or mapped
+        ):
+            raise RuntimeError(
+                "Tasks cannot be run outside of a flow by default."
+                " If you meant to submit an autonomous task, you need to set"
+                " `prefect config set PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING=true`"
+                " and use `your_task.submit()` instead of `your_task()`."
+                " Mapping autonomous tasks is not yet supported."
+            )
+        from prefect.task_engine import submit_autonomous_task_run_to_engine
+
+        return submit_autonomous_task_run_to_engine(
+            task=task,
+            parameters=parameters,
+            task_runner=task_runner,
+            wait_for=wait_for,
+            return_type=return_type,
+            client=get_client(),
         )
 
     if TaskRunContext.get():

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -1,5 +1,6 @@
 from contextlib import AsyncExitStack
 from typing import (
+    Any,
     Dict,
     Iterable,
     Optional,
@@ -31,7 +32,7 @@ async def submit_autonomous_task_run_to_engine(
     task: Task,
     task_run: TaskRun,
     task_runner: BaseTaskRunner,
-    parameters: Optional[Dict] = None,
+    parameters: Optional[Dict[str, Any]] = None,
     wait_for: Optional[Iterable[PrefectFuture]] = None,
     mapped: bool = False,
     return_type: EngineReturnType = "future",

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -554,7 +554,8 @@ class Task(Generic[P, R]):
         Run the task and return the result. If `return_state` is True returns
         the result is wrapped in a Prefect State which provides error handling.
         """
-        from prefect.engine import create_autonomous_task_run, enter_task_run_engine
+        from prefect.engine import enter_task_run_engine
+        from prefect.task_engine import submit_autonomous_task_run_to_engine
         from prefect.task_runners import SequentialTaskRunner
 
         # Convert the call args/kwargs to a parameter dict
@@ -572,17 +573,16 @@ class Task(Generic[P, R]):
             PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING.value()
             and not FlowRunContext.get()
         ):
-            create_autonomous_task_run = create_call(
-                create_autonomous_task_run, task=self, parameters=parameters
+            from prefect import get_client
+
+            return submit_autonomous_task_run_to_engine(
+                task=self,
+                task_run=None,
+                task_runner=SequentialTaskRunner(),
+                parameters=parameters,
+                return_type="result",
+                client=get_client(),
             )
-            if self.isasync:
-                return from_async.wait_for_call_in_loop_thread(
-                    create_autonomous_task_run
-                )
-            else:
-                return from_sync.wait_for_call_in_loop_thread(
-                    create_autonomous_task_run
-                )
 
         return enter_task_run_engine(
             self,

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -580,7 +580,7 @@ class Task(Generic[P, R]):
                 task_run=None,
                 task_runner=SequentialTaskRunner(),
                 parameters=parameters,
-                return_type="result",
+                return_type=return_type,
                 client=get_client(),
             )
 

--- a/tests/test_autonomous_tasks.py
+++ b/tests/test_autonomous_tasks.py
@@ -183,34 +183,6 @@ async def test_async_task_submission_creates_a_scheduled_task_run(
     assert parameters == dict(x=42)
 
 
-async def test_task_submission_via_call(foo_task_with_result_storage):
-    task_run = foo_task_with_result_storage(42)
-    assert task_run.state.is_scheduled()
-
-    result_factory = await result_factory_from_task(foo_task_with_result_storage)
-
-    parameters = await result_factory.read_parameters(
-        task_run.state.state_details.task_parameters_id
-    )
-
-    assert parameters == dict(x=42)
-
-
-async def test_async_task_submission_via_call(
-    async_foo_task_with_result_storage,
-):
-    task_run = await async_foo_task_with_result_storage(42)
-    assert task_run.state.is_scheduled()
-
-    result_factory = await result_factory_from_task(async_foo_task_with_result_storage)
-
-    parameters = await result_factory.read_parameters(
-        task_run.state.state_details.task_parameters_id
-    )
-
-    assert parameters == dict(x=42)
-
-
 async def test_task_submission_via_map_raises_error(async_foo_task_with_result_storage):
     with pytest.raises(RuntimeError, match="Tasks cannot be run outside of a flow"):
         async_foo_task_with_result_storage.map([42])
@@ -334,3 +306,11 @@ async def test_stuck_pending_tasks_are_reenqueued(
     # ...and it should be re-enqueued
     enqueued: TaskRun = await TaskQueue.for_key(task_run.task_key).get()
     assert enqueued.id == task_run.id
+
+
+class TestCall:
+    @pytest.mark.timeout(5)
+    def test_call(self, foo_task):
+        result = foo_task(42)
+
+        assert result == 42

--- a/tests/test_autonomous_tasks.py
+++ b/tests/test_autonomous_tasks.py
@@ -309,8 +309,14 @@ async def test_stuck_pending_tasks_are_reenqueued(
 
 
 class TestCall:
-    @pytest.mark.timeout(5)
-    def test_call(self, foo_task):
-        result = foo_task(42)
+    async def test_call(self, async_foo_task):
+        result = await async_foo_task(42)
 
         assert result == 42
+
+    async def test_call_with_return_state(self, async_foo_task):
+        state = await async_foo_task(42, return_state=True)
+
+        assert state.is_completed()
+
+        assert await state.result() == 42

--- a/tests/test_autonomous_tasks.py
+++ b/tests/test_autonomous_tasks.py
@@ -1,12 +1,12 @@
 import asyncio
 from pathlib import Path
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Iterable, Tuple
 from unittest import mock
 
 import pytest
 
 import prefect.results
-from prefect import Task, task
+from prefect import Task, task, unmapped
 from prefect.blocks.core import Block
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas import TaskRun
@@ -27,7 +27,7 @@ from prefect.utilities.asyncutils import sync_compatible
 
 
 @sync_compatible
-async def result_factory_from_task(task):
+async def result_factory_from_task(task) -> ResultFactory:
     return await ResultFactory.from_autonomous_task(task)
 
 
@@ -63,7 +63,7 @@ async def clear_cached_filesystems():
 
 
 @pytest.fixture
-def foo_task():
+def foo_task() -> Task:
     @task
     def foo(x: int) -> int:
         print(x)
@@ -73,7 +73,7 @@ def foo_task():
 
 
 @pytest.fixture
-def async_foo_task():
+def async_foo_task() -> Task:
     @task
     async def async_foo(x: int) -> int:
         print(x)
@@ -181,11 +181,6 @@ async def test_async_task_submission_creates_a_scheduled_task_run(
     )
 
     assert parameters == dict(x=42)
-
-
-async def test_task_submission_via_map_raises_error(async_foo_task_with_result_storage):
-    with pytest.raises(RuntimeError, match="Tasks cannot be run outside of a flow"):
-        async_foo_task_with_result_storage.map([42])
 
 
 async def test_scheduled_tasks_are_enqueued_server_side(
@@ -320,3 +315,86 @@ class TestCall:
         assert state.is_completed()
 
         assert await state.result() == 42
+
+
+class TestMap:
+    async def test_map(self, async_foo_task):
+        task_runs = await async_foo_task.map([1, 2, 3])
+
+        assert len(task_runs) == 3
+
+        result_factory = await result_factory_from_task(async_foo_task)
+
+        for i, task_run in enumerate(task_runs):
+            assert task_run.state.is_scheduled()
+            assert await result_factory.read_parameters(
+                task_run.state.state_details.task_parameters_id
+            ) == {"x": i + 1}
+
+    async def test_map_with_implicitly_unmapped_kwargs(self):
+        @task
+        def bar(x: int, unmappable: int) -> Tuple[int, int]:
+            return (x, unmappable)
+
+        task_runs = bar.map([1, 2, 3], unmappable=42)
+
+        assert len(task_runs) == 3
+
+        result_factory = await result_factory_from_task(bar)
+
+        for i, task_run in enumerate(task_runs):
+            assert task_run.state.is_scheduled()
+            assert await result_factory.read_parameters(
+                task_run.state.state_details.task_parameters_id
+            ) == {"x": i + 1, "unmappable": 42}
+
+    async def test_async_map_with_implicitly_unmapped_kwargs(self):
+        @task
+        async def bar(x: int, unmappable: int) -> Tuple[int, int]:
+            return (x, unmappable)
+
+        task_runs = await bar.map([1, 2, 3], unmappable=42)
+
+        assert len(task_runs) == 3
+
+        result_factory = await result_factory_from_task(bar)
+
+        for i, task_run in enumerate(task_runs):
+            assert task_run.state.is_scheduled()
+            assert await result_factory.read_parameters(
+                task_run.state.state_details.task_parameters_id
+            ) == {"x": i + 1, "unmappable": 42}
+
+    async def test_map_with_explicit_unmapped_kwargs(self):
+        @task
+        def bar(x: int, mappable: Iterable) -> Tuple[int, Iterable]:
+            return (x, mappable)
+
+        task_runs = bar.map([1, 2, 3], mappable=unmapped(["some", "iterable"]))
+
+        assert len(task_runs) == 3
+
+        result_factory = await result_factory_from_task(bar)
+
+        for i, task_run in enumerate(task_runs):
+            assert task_run.state.is_scheduled()
+            assert await result_factory.read_parameters(
+                task_run.state.state_details.task_parameters_id
+            ) == {"x": i + 1, "mappable": ["some", "iterable"]}
+
+    async def test_async_map_with_explicit_unmapped_kwargs(self):
+        @task
+        async def bar(x: int, mappable: Iterable) -> Tuple[int, Iterable]:
+            return (x, mappable)
+
+        task_runs = await bar.map([1, 2, 3], mappable=unmapped(["some", "iterable"]))
+
+        assert len(task_runs) == 3
+
+        result_factory = await result_factory_from_task(bar)
+
+        for i, task_run in enumerate(task_runs):
+            assert task_run.state.is_scheduled()
+            assert await result_factory.read_parameters(
+                task_run.state.state_details.task_parameters_id
+            ) == {"x": i + 1, "mappable": ["some", "iterable"]}

--- a/tests/test_autonomous_tasks.py
+++ b/tests/test_autonomous_tasks.py
@@ -183,11 +183,32 @@ async def test_async_task_submission_creates_a_scheduled_task_run(
     assert parameters == dict(x=42)
 
 
-async def test_task_submission_via_call_raises_error(
+async def test_task_submission_via_call(foo_task_with_result_storage):
+    task_run = foo_task_with_result_storage(42)
+    assert task_run.state.is_scheduled()
+
+    result_factory = await result_factory_from_task(foo_task_with_result_storage)
+
+    parameters = await result_factory.read_parameters(
+        task_run.state.state_details.task_parameters_id
+    )
+
+    assert parameters == dict(x=42)
+
+
+async def test_async_task_submission_via_call(
     async_foo_task_with_result_storage,
 ):
-    with pytest.raises(RuntimeError, match="Tasks cannot be run outside of a flow"):
-        async_foo_task_with_result_storage(42)
+    task_run = await async_foo_task_with_result_storage(42)
+    assert task_run.state.is_scheduled()
+
+    result_factory = await result_factory_from_task(async_foo_task_with_result_storage)
+
+    parameters = await result_factory.read_parameters(
+        task_run.state.state_details.task_parameters_id
+    )
+
+    assert parameters == dict(x=42)
 
 
 async def test_task_submission_via_map_raises_error(async_foo_task_with_result_storage):


### PR DESCRIPTION
closes #12154

stacked on https://github.com/PrefectHQ/prefect/pull/12158/files

<hr>

this PR adds support for calling `.map` outside the context of a flow run (if flag is enabled)

- similar to the traditional `.map`, a task run is created for each parameter set accepted by `.map`'s signature (how you call `.map` has not changed)

- however, since autonomous `.submit` returns a `TaskRun` and (in the traditional case) `.map` is really just calling `.submit` for you under the hood for each parameter set, we follow the theme here. `.map` will return a `list[TaskRun]` according to the parameter sets we pull out of `.maps` args and kwargs (that logic hasnt changed either)

- the exeuction of the submitted runs are assumed to be handled by a running `TaskServer`

## example
```python
    async def test_map_with_implicitly_unmapped_kwargs(self):
        @task
        def bar(x: int, unmappable: int) -> Tuple[int, int]:
            return (x, unmappable)

        task_runs = bar.map([1, 2, 3], unmappable=42)

        assert len(task_runs) == 3

        result_factory = await result_factory_from_task(bar)

        for i, task_run in enumerate(task_runs):
            assert task_run.state.is_scheduled()
            assert await result_factory.read_parameters(
                task_run.state.state_details.task_parameters_id
            ) == {"x": i + 1, "unmappable": 42}
```