### PR TITLE
Add schedules shorthand support to `Deployment.build_from_flow`

### DIFF
--- a/docs/api-ref/prefect/deployments/schedules.md
+++ b/docs/api-ref/prefect/deployments/schedules.md
@@ -1,0 +1,11 @@
+---
+description: Prefect Python API for normalizing and interacting with schedules.
+
+tags:
+    - Python API
+    - flow runs
+    - deployments
+    - schedules
+---
+
+::: prefect.deployments.schedules

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -288,6 +288,7 @@ nav:
                       - "deployments": api-ref/prefect/deployments/deployments.md
                       - "base": api-ref/prefect/deployments/base.md
                       - "runner": api-ref/prefect/deployments/runner.md
+                      - "schedules": api-ref/prefect/deployments/schedules.md
                       - "steps.core": api-ref/prefect/deployments/steps/core.md
                       - "steps.pull": api-ref/prefect/deployments/steps/pull.md
                       - "steps.utility": api-ref/prefect/deployments/steps/utility.md

--- a/src/prefect/deployments/schedules.py
+++ b/src/prefect/deployments/schedules.py
@@ -1,0 +1,37 @@
+from typing import List, Optional, Sequence, Union, get_args
+
+from prefect.client.schemas.objects import MinimalDeploymentSchedule
+from prefect.client.schemas.schedules import SCHEDULE_TYPES
+
+FlexibleScheduleList = Sequence[Union[MinimalDeploymentSchedule, dict, SCHEDULE_TYPES]]
+
+
+def create_minimal_deployment_schedule(
+    schedule: SCHEDULE_TYPES,
+    active: Optional[bool] = True,
+) -> MinimalDeploymentSchedule:
+    return MinimalDeploymentSchedule(
+        schedule=schedule,
+        active=active if active is not None else True,
+    )
+
+
+def normalize_to_minimal_deployment_schedules(
+    schedules: Optional[FlexibleScheduleList],
+) -> List[MinimalDeploymentSchedule]:
+    normalized = []
+    if schedules is not None:
+        for obj in schedules:
+            if isinstance(obj, get_args(SCHEDULE_TYPES)):
+                normalized.append(create_minimal_deployment_schedule(obj))
+            elif isinstance(obj, dict):
+                normalized.append(create_minimal_deployment_schedule(**obj))
+            elif isinstance(obj, MinimalDeploymentSchedule):
+                normalized.append(obj)
+            else:
+                raise ValueError(
+                    "Invalid schedule provided. Must be a schedule object, a dict,"
+                    " or a MinimalDeploymentSchedule."
+                )
+
+    return normalized

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -76,9 +76,9 @@ from prefect.client.schemas.schedules import SCHEDULE_TYPES
 from prefect.deployments.deployments import load_flow_from_flow_run
 from prefect.deployments.runner import (
     EntrypointType,
-    FlexibleScheduleList,
     RunnerDeployment,
 )
+from prefect.deployments.schedules import FlexibleScheduleList
 from prefect.engine import propose_state
 from prefect.events.schemas import DeploymentTrigger
 from prefect.exceptions import (
@@ -228,7 +228,7 @@ class Runner:
         cron: Optional[Union[Iterable[str], str]] = None,
         rrule: Optional[Union[Iterable[str], str]] = None,
         paused: Optional[bool] = None,
-        schedules: Optional[List[FlexibleScheduleList]] = None,
+        schedules: Optional[FlexibleScheduleList] = None,
         schedule: Optional[SCHEDULE_TYPES] = None,
         is_schedule_active: Optional[bool] = None,
         parameters: Optional[dict] = None,

--- a/tests/deployment/test_schedules.py
+++ b/tests/deployment/test_schedules.py
@@ -1,0 +1,113 @@
+import datetime
+from typing import Optional
+
+import pytest
+
+from prefect.client.schemas.objects import MinimalDeploymentSchedule
+from prefect.client.schemas.schedules import (
+    CronSchedule,
+    IntervalSchedule,
+    RRuleSchedule,
+)
+from prefect.deployments.schedules import (
+    create_minimal_deployment_schedule,
+    normalize_to_minimal_deployment_schedules,
+)
+
+
+@pytest.mark.parametrize(
+    "active, expected",
+    [(False, False), (True, True), (None, True)],
+)
+def test_create_minimal_deployment_schedule(active: Optional[bool], expected: bool):
+    schedule = create_minimal_deployment_schedule(
+        schedule=CronSchedule(cron="0 0 * * *"), active=active
+    )
+    assert schedule.schedule.cron == "0 0 * * *"
+    assert schedule.active is expected
+
+
+def test_normalize_none_returns_empty_list():
+    assert normalize_to_minimal_deployment_schedules(None) == []
+
+
+def test_normalize_schedule_objects():
+    normalized = normalize_to_minimal_deployment_schedules(
+        schedules=[
+            CronSchedule(cron="0 0 * * *"),
+            IntervalSchedule(interval=datetime.timedelta(minutes=10)),
+            RRuleSchedule(rrule="FREQ=DAILY"),
+        ]
+    )
+
+    assert all(isinstance(s, MinimalDeploymentSchedule) for s in normalized)
+    assert all(s.active is True for s in normalized)
+
+    assert normalized[0].schedule.cron == "0 0 * * *"
+    assert normalized[1].schedule.interval == datetime.timedelta(minutes=10)
+    assert normalized[2].schedule.rrule == "FREQ=DAILY"
+
+
+def test_normalize_dicts():
+    normalized = normalize_to_minimal_deployment_schedules(
+        schedules=[
+            {"schedule": {"interval": datetime.timedelta(minutes=10)}},
+            {"schedule": {"cron": "0 0 * * *"}, "active": False},
+            {"schedule": {"rrule": "FREQ=DAILY"}, "active": True},
+        ]
+    )
+
+    assert all(isinstance(s, MinimalDeploymentSchedule) for s in normalized)
+
+    assert normalized[0].active is True
+    assert normalized[0].schedule.interval == datetime.timedelta(minutes=10)
+
+    assert normalized[1].active is False
+    assert normalized[1].schedule.cron == "0 0 * * *"
+
+    assert normalized[2].active is True
+    assert normalized[2].schedule.rrule == "FREQ=DAILY"
+
+
+def test_normalize_minimal_deployment_schedules():
+    schedules = [
+        MinimalDeploymentSchedule(schedule=CronSchedule(cron="0 0 * * *")),
+        MinimalDeploymentSchedule(
+            schedule=IntervalSchedule(interval=datetime.timedelta(minutes=10))
+        ),
+        MinimalDeploymentSchedule(
+            schedule=RRuleSchedule(rrule="FREQ=DAILY"), active=False
+        ),
+    ]
+
+    normalized = normalize_to_minimal_deployment_schedules(schedules=schedules)
+
+    assert normalized == schedules
+
+
+def test_normalize_mixed():
+    normalized = normalize_to_minimal_deployment_schedules(
+        schedules=[
+            CronSchedule(cron="0 0 * * *"),
+            {"schedule": {"interval": datetime.timedelta(minutes=10)}},
+            MinimalDeploymentSchedule(
+                schedule=RRuleSchedule(rrule="FREQ=DAILY"), active=False
+            ),
+        ]
+    )
+
+    assert all(isinstance(s, MinimalDeploymentSchedule) for s in normalized)
+
+    assert normalized[0].active is True
+    assert normalized[0].schedule.cron == "0 0 * * *"
+
+    assert normalized[1].active is True
+    assert normalized[1].schedule.interval == datetime.timedelta(minutes=10)
+
+    assert normalized[2].active is False
+    assert normalized[2].schedule.rrule == "FREQ=DAILY"
+
+
+def test_normalize_incompatible():
+    with pytest.raises(ValueError, match="Invalid schedule provided"):
+        normalize_to_minimal_deployment_schedules(schedules=[1, 2, 3])


### PR DESCRIPTION
This adds 'shorthand' schedules support to `Deployment`, and specifically `Deployment.build_from_flow`, so now you can do:

```python
        deployment = await Deployment.build_from_flow(
            flow=my_flow,
            name="The best flow in the world",
            schedules=[
                CronSchedule(cron="0 0 * * *"),
                {"schedule": {"interval": datetime.timedelta(minutes=10)}},
            ],
        )
```

Without needing `MinimalDeploymentSchedule`

Closes #12177 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [x] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.