### PR TITLE
Add backend support for creating and updating flow run `job_variables`

### DIFF
--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -526,6 +526,9 @@ class FlowRun(ObjectBaseModel):
         description="The state of the flow run.",
         example=State(type=StateType.COMPLETED),
     )
+    job_variables: Optional[dict] = Field(
+        default=None, description="Parameters for the flow run."
+    )
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/src/prefect/client/schemas/responses.py
+++ b/src/prefect/client/schemas/responses.py
@@ -190,6 +190,7 @@ class FlowRunResponse(ObjectBaseModel):
         example="my-work-pool",
     )
     state: Optional[objects.State] = FieldFrom(objects.FlowRun)
+    parameters: Optional[dict] = FieldFrom(objects.FlowRun)
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/src/prefect/client/schemas/responses.py
+++ b/src/prefect/client/schemas/responses.py
@@ -190,7 +190,6 @@ class FlowRunResponse(ObjectBaseModel):
         example="my-work-pool",
     )
     state: Optional[objects.State] = FieldFrom(objects.FlowRun)
-    parameters: Optional[dict] = FieldFrom(objects.FlowRun)
     job_variables: Optional[dict] = FieldFrom(objects.FlowRun)
 
     def __eq__(self, other: Any) -> bool:

--- a/src/prefect/client/schemas/responses.py
+++ b/src/prefect/client/schemas/responses.py
@@ -191,6 +191,7 @@ class FlowRunResponse(ObjectBaseModel):
     )
     state: Optional[objects.State] = FieldFrom(objects.FlowRun)
     parameters: Optional[dict] = FieldFrom(objects.FlowRun)
+    job_variables: Optional[dict] = FieldFrom(objects.FlowRun)
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -94,22 +94,22 @@ async def create_deployment(
         if deployment.work_pool_name and deployment.work_queue_name:
             # If a specific pool name/queue name combination was provided, get the
             # ID for that work pool queue.
-            deployment_dict["work_queue_id"] = (
-                await worker_lookups._get_work_queue_id_from_name(
-                    session=session,
-                    work_pool_name=deployment.work_pool_name,
-                    work_queue_name=deployment.work_queue_name,
-                    create_queue_if_not_found=True,
-                )
+            deployment_dict[
+                "work_queue_id"
+            ] = await worker_lookups._get_work_queue_id_from_name(
+                session=session,
+                work_pool_name=deployment.work_pool_name,
+                work_queue_name=deployment.work_queue_name,
+                create_queue_if_not_found=True,
             )
         elif deployment.work_pool_name:
             # If just a pool name was provided, get the ID for its default
             # work pool queue.
-            deployment_dict["work_queue_id"] = (
-                await worker_lookups._get_default_work_queue_id_from_work_pool_name(
-                    session=session,
-                    work_pool_name=deployment.work_pool_name,
-                )
+            deployment_dict[
+                "work_queue_id"
+            ] = await worker_lookups._get_default_work_queue_id_from_work_pool_name(
+                session=session,
+                work_pool_name=deployment.work_pool_name,
             )
         elif deployment.work_queue_name:
             # If just a queue name was provided, ensure that the queue exists and

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -652,7 +652,7 @@ async def create_flow_run_from_deployment(
                     detail="Invalid schema: Unable to validate schema with circular references.",
                 )
 
-        if PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES.value():
+        if PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES:
             validate_job_variables_for_flow_run(flow_run, deployment)
 
         work_queue_name = deployment.work_queue_name

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -97,7 +97,7 @@ async def update_flow_run(
     Updates a flow run.
     """
     async with db.session_context(begin_transaction=True) as session:
-        if PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES.value():
+        if PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES:
             if flow_run.job_variables is not None:
                 this_run = await models.flow_runs.read_flow_run(
                     session, flow_run_id=flow_run_id

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -27,6 +27,7 @@ import prefect.server.models as models
 import prefect.server.schemas as schemas
 from prefect.logging import get_logger
 from prefect.server.api.run_history import run_history
+from prefect.server.api.validation import validate_job_variables_for_flow_run
 from prefect.server.database.dependencies import provide_database_interface
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.exceptions import FlowRunGraphTooLarge
@@ -40,6 +41,7 @@ from prefect.server.schemas.graph import Graph
 from prefect.server.schemas.responses import OrchestrationResult
 from prefect.server.utilities.schemas import DateTimeTZ
 from prefect.server.utilities.server import PrefectRouter
+from prefect.settings import PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES
 
 logger = get_logger("server.api")
 
@@ -95,6 +97,37 @@ async def update_flow_run(
     Updates a flow run.
     """
     async with db.session_context(begin_transaction=True) as session:
+        if PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES.value():
+            if flow_run.job_variables is not None:
+                this_run = await models.flow_runs.read_flow_run(
+                    session, flow_run_id=flow_run_id
+                )
+                if this_run is None:
+                    raise HTTPException(
+                        status.HTTP_404_NOT_FOUND, detail="Flow run not found"
+                    )
+                if this_run.state.type != schemas.states.StateType.SCHEDULED:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=f"Job variables for a flow run in state {this_run.state.type} cannot be updated",
+                    )
+                if this_run.deployment_id is None:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="A deployment for the flow run could not be found",
+                    )
+
+                deployment = await models.deployments.read_deployment(
+                    session=session, deployment_id=this_run.deployment_id
+                )
+                if deployment is None:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="A deployment for the flow run could not be found",
+                    )
+
+                validate_job_variables_for_flow_run(flow_run, deployment)
+
         result = await models.flow_runs.update_flow_run(
             session=session, flow_run=flow_run, flow_run_id=flow_run_id
         )

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -109,7 +109,7 @@ async def update_flow_run(
                 if this_run.state.type != schemas.states.StateType.SCHEDULED:
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,
-                        detail=f"Job variables for a flow run in state {this_run.state.type} cannot be updated",
+                        detail=f"Job variables for a flow run in state {this_run.state.type.name} cannot be updated",
                     )
                 if this_run.deployment_id is None:
                     raise HTTPException(

--- a/src/prefect/server/api/validation.py
+++ b/src/prefect/server/api/validation.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from prefect._vendor.fastapi import HTTPException, status
 
 import prefect.server.schemas as schemas
@@ -23,7 +25,9 @@ def _merge_job_variables(base_vars: dict, deployment_vars: dict, flow_run_vars: 
 
 
 def validate_job_variables_for_flow_run(
-    flow_run: schemas.actions.DeploymentFlowRunCreate | schemas.actions.FlowRunUpdate,
+    flow_run: Union[
+        schemas.actions.DeploymentFlowRunCreate, schemas.actions.FlowRunUpdate
+    ],
     deployment: schemas.core.Deployment,
 ) -> None:
     base_vars = _get_base_config_defaults(

--- a/src/prefect/server/api/validation.py
+++ b/src/prefect/server/api/validation.py
@@ -16,14 +16,6 @@ def _get_base_config_defaults(base_config: dict):
     return defaults
 
 
-def _merge_job_variables(base_vars: dict, deployment_vars: dict, flow_run_vars: dict):
-    result = {}
-    result.update(base_vars)
-    result.update(deployment_vars)
-    result.update(flow_run_vars)
-    return result
-
-
 def validate_job_variables_for_flow_run(
     flow_run: Union[
         schemas.actions.DeploymentFlowRunCreate, schemas.actions.FlowRunUpdate
@@ -34,9 +26,7 @@ def validate_job_variables_for_flow_run(
         deployment.work_queue.work_pool.base_job_template
     )
     flow_run_vars = flow_run.job_variables or {}
-    job_vars = _merge_job_variables(
-        base_vars, deployment.infra_overrides, flow_run_vars
-    )
+    job_vars = {**base_vars, **deployment.infra_overrides, **flow_run_vars}
 
     try:
         validate_values_conform_to_schema(

--- a/src/prefect/server/api/validation.py
+++ b/src/prefect/server/api/validation.py
@@ -1,0 +1,47 @@
+from prefect._vendor.fastapi import HTTPException, status
+
+import prefect.server.schemas as schemas
+from prefect.utilities.validation import validate_values_conform_to_schema
+
+
+def _get_base_config_defaults(base_config: dict):
+    template: dict = base_config.get("variables", {}).get("properties", {})
+    defaults = dict()
+    for variable_name, attrs in template.items():
+        if "default" in attrs:
+            defaults[variable_name] = attrs["default"]
+
+    return defaults
+
+
+def _merge_job_variables(base_vars: dict, deployment_vars: dict, flow_run_vars: dict):
+    result = {}
+    result.update(base_vars)
+    result.update(deployment_vars)
+    result.update(flow_run_vars)
+    return result
+
+
+def validate_job_variables_for_flow_run(
+    flow_run: schemas.actions.DeploymentFlowRunCreate | schemas.actions.FlowRunUpdate,
+    deployment: schemas.core.Deployment,
+) -> None:
+    base_vars = _get_base_config_defaults(
+        deployment.work_queue.work_pool.base_job_template
+    )
+    flow_run_vars = flow_run.job_variables or {}
+    job_vars = _merge_job_variables(
+        base_vars, deployment.infra_overrides, flow_run_vars
+    )
+
+    try:
+        validate_values_conform_to_schema(
+            job_vars,
+            deployment.work_queue.work_pool.base_job_template.get("variables"),
+        )
+    except ValueError as exc:
+        if isinstance(flow_run, schemas.actions.FlowRunUpdate):
+            error_msg = f"Error updating flow run: {exc}"
+        else:
+            error_msg = f"Error creating flow run: {exc}"
+        raise HTTPException(status.HTTP_409_CONFLICT, detail=error_msg)

--- a/src/prefect/server/database/migrations/MIGRATION-NOTES.md
+++ b/src/prefect/server/database/migrations/MIGRATION-NOTES.md
@@ -8,6 +8,10 @@ Each time a database migration is written, an entry is included here with:
 
 This gives us a history of changes and will create merge conflicts if two migrations are made at once, flagging situations where a branch needs to be updated before merging.
 
+# Add `job_variables` to `flow_runs`
+SQLite: `342220764f0b`
+Postgres: `121699507574`
+
 # Create `deployment_schedule` and add `Deployment.paused`
 SQLite: `265eb1a2da4c`
 Postgres: `8cf4d4933848`

--- a/src/prefect/server/database/migrations/versions/postgresql/2024_03_05_122228_121699507574_add_job_variables_column_to_flow_runs.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2024_03_05_122228_121699507574_add_job_variables_column_to_flow_runs.py
@@ -1,0 +1,33 @@
+"""Add job_variables column to flow-runs
+
+Revision ID: 121699507574
+Revises: 8cf4d4933848
+Create Date: 2024-03-05 12:22:28.460541
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "121699507574"
+down_revision = "8cf4d4933848"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "flow_run",
+        sa.Column(
+            "job_variables",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default="{}",
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("flow_run", "job_variables")

--- a/src/prefect/server/database/migrations/versions/sqlite/2024_03_05_115258_342220764f0b_add_job_variables_column_to_flow_runs.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2024_03_05_115258_342220764f0b_add_job_variables_column_to_flow_runs.py
@@ -1,0 +1,35 @@
+"""Add job_variables column to flow-runs
+
+Revision ID: 342220764f0b
+Revises: 265eb1a2da4c
+Create Date: 2024-03-05 11:52:58.330563
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import Text
+
+import prefect
+
+# revision identifiers, used by Alembic.
+revision = "342220764f0b"
+down_revision = "265eb1a2da4c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "flow_run",
+        sa.Column(
+            "job_variables",
+            prefect.server.utilities.database.JSON(astext_type=Text()),
+            server_default="{}",
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("flow_run", "job_variables")

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -511,6 +511,7 @@ class ORMFlowRun(ORMRun):
     )
 
     infrastructure_pid = sa.Column(sa.String)
+    job_variables = sa.Column(JSON, server_default="{}", default=dict, nullable=True)
 
     @declared_attr
     def infrastructure_document_id(cls):

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -1,6 +1,7 @@
 """
 Reduced schemas for accepting API actions.
 """
+
 import json
 import warnings
 from copy import copy, deepcopy
@@ -343,6 +344,7 @@ class FlowRunUpdate(ActionBaseModel):
     empirical_policy: schemas.core.FlowRunPolicy = FieldFrom(schemas.core.FlowRun)
     tags: List[str] = FieldFrom(schemas.core.FlowRun)
     infrastructure_pid: Optional[str] = FieldFrom(schemas.core.FlowRun)
+    job_variables: Optional[Dict[str, Any]] = FieldFrom(schemas.core.FlowRun)
 
 
 @copy_model_fields
@@ -432,6 +434,7 @@ class FlowRunCreate(ActionBaseModel):
         ),
         deprecated=True,
     )
+    job_variables: Optional[Dict[str, Any]] = FieldFrom(schemas.core.FlowRun)
 
     class Config(ActionBaseModel.Config):
         json_dumps = orjson_dumps_extra_compatible
@@ -455,6 +458,7 @@ class DeploymentFlowRunCreate(ActionBaseModel):
     idempotency_key: Optional[str] = FieldFrom(schemas.core.FlowRun)
     parent_task_run_id: Optional[UUID] = FieldFrom(schemas.core.FlowRun)
     work_queue_name: Optional[str] = FieldFrom(schemas.core.FlowRun)
+    job_variables: Optional[Dict[str, Any]] = FieldFrom(schemas.core.FlowRun)
 
 
 @copy_model_fields

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -298,6 +298,11 @@ class FlowRun(ORMBaseModel):
     )
     # parent_task_run: "TaskRun" = None
 
+    job_variables: Optional[Dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Variables used as overrides in the base job template",
+    )
+
     @validator("name", pre=True)
     def set_name(cls, name):
         return name or generate_slug(2)

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -299,7 +299,7 @@ class FlowRun(ORMBaseModel):
     # parent_task_run: "TaskRun" = None
 
     job_variables: Optional[Dict[str, Any]] = Field(
-        default_factory=dict,
+        default=None,
         description="Variables used as overrides in the base job template",
     )
 

--- a/src/prefect/server/schemas/responses.py
+++ b/src/prefect/server/schemas/responses.py
@@ -207,6 +207,7 @@ class FlowRunResponse(ORMBaseModel):
         example="my-work-pool",
     )
     state: Optional[schemas.states.State] = FieldFrom(schemas.core.FlowRun)
+    job_variables: Dict[str, Any] = FieldFrom(schemas.core.FlowRun)
 
     @classmethod
     def from_orm(cls, orm_flow_run: "prefect.server.database.orm_models.ORMFlowRun"):

--- a/src/prefect/server/schemas/responses.py
+++ b/src/prefect/server/schemas/responses.py
@@ -207,7 +207,7 @@ class FlowRunResponse(ORMBaseModel):
         example="my-work-pool",
     )
     state: Optional[schemas.states.State] = FieldFrom(schemas.core.FlowRun)
-    job_variables: Dict[str, Any] = FieldFrom(schemas.core.FlowRun)
+    job_variables: Optional[Dict[str, Any]] = FieldFrom(schemas.core.FlowRun)
 
     @classmethod
     def from_orm(cls, orm_flow_run: "prefect.server.database.orm_models.ORMFlowRun"):

--- a/tests/server/api/test_deployments.py
+++ b/tests/server/api/test_deployments.py
@@ -2559,6 +2559,28 @@ class TestCreateFlowRunFromDeployment:
 
         assert deployment.work_queue_name == default_queue
 
+    async def test_create_flow_run_from_deployment_includes_job_variables(
+        self, deployment, client, session
+    ):
+        job_vars = {"foo": "bar"}
+        response = await client.post(
+            f"deployments/{deployment.id}/create_flow_run",
+            json=schemas.actions.DeploymentFlowRunCreate(job_variables=job_vars).dict(
+                json_compatible=True
+            ),
+        )
+        assert response.status_code == 201
+        flow_run_id = response.json()["id"]
+
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session, flow_run_id=flow_run_id
+        )
+        assert flow_run.job_variables == job_vars
+
+        response = await client.get(f"flow_runs/{flow_run_id}")
+        assert response.status_code == 200
+        assert response.json()["job_variables"] == job_vars
+
     async def test_create_flow_run_from_deployment_disambiguates_queue_name_from_other_pools(
         self, deployment, client, session
     ):

--- a/tests/server/api/test_infra_overrides.py
+++ b/tests/server/api/test_infra_overrides.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Optional
 
 import pytest
 
@@ -67,8 +68,8 @@ async def create_flow(session) -> schemas.core.Flow:
 async def create_objects_for_pool(
     session,
     *,
-    pool_job_config: dict | None = None,
-    deployment_vars: dict | None = None,
+    pool_job_config: Optional[dict] = None,
+    deployment_vars: Optional[dict] = None,
     pool_type: str = "None",
 ):
     pool_job_config = pool_job_config or {}

--- a/tests/server/api/test_infra_overrides.py
+++ b/tests/server/api/test_infra_overrides.py
@@ -1,0 +1,548 @@
+import uuid
+
+import pytest
+
+from prefect.server import models, schemas
+from prefect.server.models import deployments
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES,
+    temporary_settings,
+)
+
+
+@pytest.fixture
+def enable_infra_overrides():
+    with temporary_settings(
+        {PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES: True}
+    ):
+        yield
+
+
+async def create_work_pool(
+    session, job_template: dict, type: str = "None"
+) -> schemas.core.WorkPool:
+    work_pool = await models.workers.create_work_pool(
+        session=session,
+        work_pool=schemas.actions.WorkPoolCreate.construct(
+            _fields_set=schemas.actions.WorkPoolCreate.__fields_set__,
+            name="wp-1",
+            type=type,
+            description="None",
+            base_job_template=job_template,
+        ),
+    )
+    await session.commit()
+    return work_pool
+
+
+async def create_deployment(
+    session,
+    flow: schemas.core.Flow,
+    work_pool: schemas.core.WorkPool,
+    job_variables: dict,
+) -> schemas.core.Deployment:
+    deployment = await deployments.create_deployment(
+        session=session,
+        deployment=schemas.core.Deployment(
+            name="My Deployment X",
+            flow_id=flow.id,
+            paused=False,
+            work_queue_id=work_pool.default_queue_id,
+            infra_overrides=job_variables,
+        ),
+    )
+    await session.commit()
+    return deployment
+
+
+async def create_flow(session) -> schemas.core.Flow:
+    flow = await models.flows.create_flow(
+        session=session, flow=schemas.core.Flow(name="my-flow")
+    )
+    await session.commit()
+    assert flow
+    return flow
+
+
+async def create_objects_for_pool(
+    session,
+    *,
+    pool_job_config: dict | None = None,
+    deployment_vars: dict | None = None,
+    pool_type: str = "None",
+):
+    pool_job_config = pool_job_config or {}
+    deployment_vars = deployment_vars or {}
+    flow = await create_flow(session)
+    wp = await create_work_pool(session, pool_job_config, type=pool_type)
+    deployment = await create_deployment(session, flow, wp, deployment_vars)
+    return flow, wp, deployment
+
+
+class TestInfraOverrides:
+    async def test_creating_flow_run_with_unexpected_vars(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                    "thing_two": "{{ expected_variable_2 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {},
+                        "expected_variable_2": {},
+                    },
+                    "required": ["expected_variable_1", "expected_variable_2"],
+                },
+            },
+        )
+
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run",
+            json={"job_variables": {"x": 1}},
+        )
+        assert response.status_code == 409
+        assert (
+            response.json()["detail"]
+            == "Error creating flow run: Validation failed. Failure reason: 'expected_variable_1' is a required property"
+        )
+
+    async def test_creating_flow_run_with_mismatched_var_types(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                    "thing_two": "{{ expected_variable_2 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                        "expected_variable_2": {
+                            "title": "expected_variable_2",
+                            "default": "0",
+                            "type": "string",
+                        },
+                    },
+                    "required": ["expected_variable_1", "expected_variable_2"],
+                },
+            },
+        )
+
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run",
+            json={
+                "job_variables": {"expected_variable_1": 1, "expected_variable_2": 2}
+            },
+        )
+        assert response.status_code == 409
+        assert (
+            response.json()["detail"]
+            == "Error creating flow run: Validation failed for field 'expected_variable_2'. Failure reason: 2 is not of type 'string'"
+        )
+
+    @pytest.mark.parametrize(
+        "template",
+        (
+            {},
+            None,
+            {
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                    "thing_two": "{{ expected_variable_2 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {},
+                        "expected_variable_2": {},
+                    },
+                },
+            },
+        ),
+    )
+    async def test_creating_flow_run_with_vars_on_non_strict_pool(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+        template,
+    ):
+        # create a pool with a lax schema
+        *_, deployment = await create_objects_for_pool(
+            session, pool_job_config=template
+        )
+
+        # create a flow run with job vars
+        job_variables = {"x": 1}
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run",
+            json={"job_variables": job_variables},
+        )
+        assert response.status_code == 201
+
+        # verify the flow run was created with the supplied job vars
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session,
+            flow_run_id=response.json()["id"],
+        )
+        assert flow_run.job_variables == job_variables
+
+    async def test_flow_run_vars_overwrite_deployment_vars(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        # create a pool with a pool schema and a deployment with variables
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                    "thing_two": "{{ expected_variable_2 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                        "expected_variable_2": {
+                            "title": "expected_variable_2",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["expected_variable_1", "expected_variable_2"],
+                },
+            },
+            deployment_vars={"expected_variable_1": 1, "expected_variable_2": 2},
+        )
+
+        # create a flow run its own job vars
+        job_variables = {"expected_variable_1": -1, "expected_variable_2": -2}
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run",
+            json={"job_variables": job_variables},
+        )
+        assert response.status_code == 201
+
+        # verify the flow run vars took precedence over deployment vars
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session,
+            flow_run_id=response.json()["id"],
+        )
+        assert flow_run.job_variables == job_variables
+
+    async def test_merged_deployment_vars_and_flow_run_vars_are_not_stored(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        # create a pool with a pool schema and a deployment with overrides
+        deployment_vars = {"expected_variable_2": 2}
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                    "thing_two": "{{ expected_variable_2 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                        "expected_variable_2": {
+                            "title": "expected_variable_2",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["expected_variable_1", "expected_variable_2"],
+                },
+            },
+            deployment_vars=deployment_vars,
+        )
+
+        # create a flow run its own overrides
+        job_variables = {"expected_variable_1": -1}
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run",
+            json={"job_variables": job_variables},
+        )
+        assert response.status_code == 201
+
+        # verify the flow run overrides are stored unmerged
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session,
+            flow_run_id=response.json()["id"],
+        )
+        assert flow_run.job_variables == job_variables
+
+    async def test_flow_run_fails_if_missing_default_are_not_provided(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        # create a pool with a pool schema and a deployment with variables
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                    "thing_two": "{{ expected_variable_2 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["expected_variable_1"],
+                },
+            },
+        )
+
+        # create a flow run that should fail bc no override is provided
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run",
+            json={},
+        )
+
+        # verify the flow run failed due to a missing required variable
+        assert response.status_code == 409
+        assert response.json()["detail"] == (
+            "Error creating flow run: Validation failed. Failure reason: 'expected_variable_1' is a required property"
+        )
+
+    async def test_flow_run_with_base_job_template_defaults(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        # create a pool with a pool schema that has a default value
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                    "thing_two": "{{ expected_variable_2 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["expected_variable_1"],
+                },
+            },
+        )
+
+        # create a flow run has no overrides
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run", json={}
+        )
+
+        # verify validation passed since the job templates's default was used
+        assert response.status_code == 201
+
+
+class TestInfraOverridesUpdates:
+    async def test_updating_flow_run_with_valid_updates(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        # create a pool with a pool schema that has a default value
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["expected_variable_1"],
+                },
+            },
+        )
+
+        # create a flow run with no overrides
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run", json={}
+        )
+        assert response.status_code == 201
+        flow_run_id = response.json()["id"]
+
+        # update the flow run with new job vars
+        job_variables = {"expected_variable_1": 100}
+        response = await client.patch(
+            f"/flow_runs/{flow_run_id}", json={"job_variables": job_variables}
+        )
+        assert response.status_code == 204
+
+        # verify that updates were applied
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session, flow_run_id=flow_run_id
+        )
+        assert flow_run.job_variables == job_variables
+
+    async def test_updating_flow_run_with_invalid_update_type(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        # create a pool with a pool schema that has a default value
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["expected_variable_1"],
+                },
+            },
+        )
+
+        # create a flow run with no overrides
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run", json={}
+        )
+        assert response.status_code == 201
+        flow_run_id = response.json()["id"]
+
+        # update the flow run with a job var that doesn't conform to the schema
+        job_variables = {"expected_variable_1": "this_should_be_an_int"}
+        response = await client.patch(
+            f"/flow_runs/{flow_run_id}", json={"job_variables": job_variables}
+        )
+
+        # verify that the update failed
+        assert response.status_code == 409
+        assert (
+            response.json()["detail"]
+            == "Error updating flow run: Validation failed for field 'expected_variable_1'. Failure reason: 'this_should_be_an_int' is not of type 'integer'"
+        )
+
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session, flow_run_id=flow_run_id
+        )
+        assert flow_run.job_variables == {}
+
+    async def test_updating_flow_run_in_non_scheduled_state(
+        self,
+        session,
+        client,
+        db,
+        enable_infra_overrides,
+    ):
+        # create a pool with a pool schema that has a default value
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["expected_variable_1"],
+                },
+            },
+        )
+
+        # create a flow run
+        original_job_variables = {"expected_variable_1": 1}
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run",
+            json={"job_variables": original_job_variables},
+        )
+        assert response.status_code == 201
+        flow_run_id = response.json()["id"]
+
+        # set the flow run state to be non-scheduled
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session,
+            flow_run_id=flow_run_id,
+        )
+        flow_run.set_state(db.FlowRunState(**schemas.states.Pending().orm_dict()))
+        await session.commit()
+
+        # attempt to update the flow run
+        job_variables = {"expected_variable_1": 100}
+        response = await client.patch(
+            f"/flow_runs/{flow_run_id}", json={"job_variables": job_variables}
+        )
+
+        # verify that the update failed
+        assert response.status_code == 400
+        assert (
+            response.json()["detail"]
+            == "Job variables for a flow run in state PENDING cannot be updated"
+        )
+
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session, flow_run_id=flow_run_id
+        )
+        assert flow_run.job_variables == original_job_variables
+
+    async def test_updating_non_existant_flow_run(
+        self,
+        client,
+        enable_infra_overrides,
+    ):
+        # update a non-existent flow run
+        response = await client.patch(
+            f"/flow_runs/{uuid.uuid4()}", json={"job_variables": {"foo": "bar"}}
+        )
+
+        # verify the update failed
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Flow run not found"


### PR DESCRIPTION
This PR adds backend support for creating and validating flow-run level `job_variables` through the API. It also adds support and validation to updates to a flow-run's `job_variables` if that flow run is still in a scheduled state. Although the API inputs and responses will start including `job_variables`, the validation logic is behind the feature flag `PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES`.


### Example
This is an example of the input schema on server-side `FlowRunCreate` objects:
<img width="418" alt="image" src="https://github.com/PrefectHQ/prefect/assets/62311618/fe7fb512-5ab0-4a14-b4d9-0f61f8117945">


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.