### PR TITLE
Use flow run `job_variables` in workers

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -506,6 +506,7 @@ class PrefectClient:
         idempotency_key: str = None,
         parent_task_run_id: UUID = None,
         work_queue_name: str = None,
+        job_variables: Optional[Dict[str, Any]] = None,
     ) -> FlowRun:
         """
         Create a flow run for a deployment.
@@ -529,6 +530,7 @@ class PrefectClient:
             work_queue_name: An optional work queue name to add this run to. If not provided,
                 will default to the deployment's set work queue.  If one is provided that does not
                 exist, a new work queue will be created within the deployment's work pool.
+            job_variables: Optional variables that will be supplied to the flow run job.
 
         Raises:
             httpx.RequestError: if the Prefect API does not successfully create a run for any reason
@@ -549,6 +551,7 @@ class PrefectClient:
             name=name,
             idempotency_key=idempotency_key,
             parent_task_run_id=parent_task_run_id,
+            job_variables=job_variables,
         )
 
         # done separately to avoid including this field in payloads sent to older API versions
@@ -570,6 +573,7 @@ class PrefectClient:
         tags: Iterable[str] = None,
         parent_task_run_id: UUID = None,
         state: "prefect.states.State" = None,
+        job_variables: Optional[dict] = None,
     ) -> FlowRun:
         """
         Create a flow run for a flow.
@@ -613,6 +617,7 @@ class PrefectClient:
                 retries=flow.retries,
                 retry_delay=flow.retry_delay_seconds,
             ),
+            job_variables=job_variables,
         )
 
         flow_run_create_json = flow_run_create.dict(json_compatible=True)
@@ -634,6 +639,7 @@ class PrefectClient:
         tags: Optional[Iterable[str]] = None,
         empirical_policy: Optional[FlowRunPolicy] = None,
         infrastructure_pid: Optional[str] = None,
+        job_variables: Optional[dict] = None,
     ) -> httpx.Response:
         """
         Update a flow run's details.
@@ -667,6 +673,8 @@ class PrefectClient:
             params["empirical_policy"] = empirical_policy
         if infrastructure_pid:
             params["infrastructure_pid"] = infrastructure_pid
+        if job_variables is not None:
+            params["job_variables"] = job_variables
 
         flow_run_data = FlowRunUpdate(**params)
 

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -19,7 +19,16 @@ import httpcore
 import httpx
 import pendulum
 
+from prefect._internal.compatibility.experimental import (
+    EXPERIMENTAL_WARNING,
+    ExperimentalFeature,
+    experiment_enabled,
+)
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_WARN,
+    PREFECT_EXPERIMENTAL_WARN_FLOW_RUN_INFRA_OVERRIDES,
+)
 
 if HAS_PYDANTIC_V2:
     import pydantic.v1 as pydantic
@@ -538,6 +547,21 @@ class PrefectClient:
         Returns:
             The flow run model
         """
+        if job_variables is not None and experiment_enabled("flow_run_infra_overrides"):
+            if (
+                PREFECT_EXPERIMENTAL_WARN
+                and PREFECT_EXPERIMENTAL_WARN_FLOW_RUN_INFRA_OVERRIDES
+            ):
+                warnings.warn(
+                    EXPERIMENTAL_WARNING.format(
+                        feature="Flow run job variables",
+                        group="flow_run_infra_overrides",
+                        help="To use this feature, update your workers to Prefect 2.16.4 or later. ",
+                    ),
+                    ExperimentalFeature,
+                    stacklevel=3,
+                )
+
         parameters = parameters or {}
         context = context or {}
         state = state or prefect.states.Scheduled()
@@ -595,6 +619,21 @@ class PrefectClient:
         Returns:
             The flow run model
         """
+        if job_variables is not None and experiment_enabled("flow_run_infra_overrides"):
+            if (
+                PREFECT_EXPERIMENTAL_WARN
+                and PREFECT_EXPERIMENTAL_WARN_FLOW_RUN_INFRA_OVERRIDES
+            ):
+                warnings.warn(
+                    EXPERIMENTAL_WARNING.format(
+                        feature="Flow run job variables",
+                        group="flow_run_infra_overrides",
+                        help="To use this feature, update your workers to Prefect 2.16.4 or later. ",
+                    ),
+                    ExperimentalFeature,
+                    stacklevel=3,
+                )
+
         parameters = parameters or {}
         context = context or {}
 
@@ -660,6 +699,21 @@ class PrefectClient:
         Returns:
             an `httpx.Response` object from the PATCH request
         """
+        if job_variables is not None and experiment_enabled("flow_run_infra_overrides"):
+            if (
+                PREFECT_EXPERIMENTAL_WARN
+                and PREFECT_EXPERIMENTAL_WARN_FLOW_RUN_INFRA_OVERRIDES
+            ):
+                warnings.warn(
+                    EXPERIMENTAL_WARNING.format(
+                        feature="Flow run job variables",
+                        group="flow_run_infra_overrides",
+                        help="To use this feature, update your workers to Prefect 2.16.4 or later. ",
+                    ),
+                    ExperimentalFeature,
+                    stacklevel=3,
+                )
+
         params = {}
         if flow_version is not None:
             params["flow_version"] = flow_version

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -597,7 +597,6 @@ class PrefectClient:
         tags: Iterable[str] = None,
         parent_task_run_id: UUID = None,
         state: "prefect.states.State" = None,
-        job_variables: Optional[dict] = None,
     ) -> FlowRun:
         """
         Create a flow run for a flow.
@@ -619,21 +618,6 @@ class PrefectClient:
         Returns:
             The flow run model
         """
-        if job_variables is not None and experiment_enabled("flow_run_infra_overrides"):
-            if (
-                PREFECT_EXPERIMENTAL_WARN
-                and PREFECT_EXPERIMENTAL_WARN_FLOW_RUN_INFRA_OVERRIDES
-            ):
-                warnings.warn(
-                    EXPERIMENTAL_WARNING.format(
-                        feature="Flow run job variables",
-                        group="flow_run_infra_overrides",
-                        help="To use this feature, update your workers to Prefect 2.16.4 or later. ",
-                    ),
-                    ExperimentalFeature,
-                    stacklevel=3,
-                )
-
         parameters = parameters or {}
         context = context or {}
 
@@ -656,7 +640,6 @@ class PrefectClient:
                 retries=flow.retries,
                 retry_delay=flow.retry_delay_seconds,
             ),
-            job_variables=job_variables,
         )
 
         flow_run_create_json = flow_run_create.dict(json_compatible=True)

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -358,7 +358,6 @@ class FlowRunCreate(ActionBaseModel):
     empirical_policy: objects.FlowRunPolicy = FieldFrom(objects.FlowRun)
     tags: List[str] = FieldFrom(objects.FlowRun)
     idempotency_key: Optional[str] = FieldFrom(objects.FlowRun)
-    job_variables: Optional[dict] = FieldFrom(objects.FlowRun)
 
     class Config(ActionBaseModel.Config):
         json_dumps = orjson_dumps_extra_compatible

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -298,6 +298,7 @@ class FlowRunUpdate(ActionBaseModel):
     empirical_policy: objects.FlowRunPolicy = FieldFrom(objects.FlowRun)
     tags: List[str] = FieldFrom(objects.FlowRun)
     infrastructure_pid: Optional[str] = FieldFrom(objects.FlowRun)
+    job_variables: Optional[dict] = FieldFrom(objects.FlowRun)
 
 
 @copy_model_fields
@@ -357,6 +358,7 @@ class FlowRunCreate(ActionBaseModel):
     empirical_policy: objects.FlowRunPolicy = FieldFrom(objects.FlowRun)
     tags: List[str] = FieldFrom(objects.FlowRun)
     idempotency_key: Optional[str] = FieldFrom(objects.FlowRun)
+    job_variables: Optional[dict] = FieldFrom(objects.FlowRun)
 
     class Config(ActionBaseModel.Config):
         json_dumps = orjson_dumps_extra_compatible
@@ -380,6 +382,7 @@ class DeploymentFlowRunCreate(ActionBaseModel):
     idempotency_key: Optional[str] = FieldFrom(objects.FlowRun)
     parent_task_run_id: Optional[UUID] = FieldFrom(objects.FlowRun)
     work_queue_name: Optional[str] = FieldFrom(objects.FlowRun)
+    job_variables: Optional[dict] = FieldFrom(objects.FlowRun)
 
 
 @copy_model_fields

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -527,7 +527,7 @@ class FlowRun(ObjectBaseModel):
         example=State(type=StateType.COMPLETED),
     )
     job_variables: Optional[dict] = Field(
-        default=None, description="Parameters for the flow run."
+        default=None, description="Job variables for the flow run."
     )
 
     def __eq__(self, other: Any) -> bool:

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -526,6 +526,9 @@ class FlowRun(ObjectBaseModel):
         description="The state of the flow run.",
         example=State(type=StateType.COMPLETED),
     )
+    job_variables: Optional[dict] = Field(
+        default=None, description="Parameters for the flow run."
+    )
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/src/prefect/client/schemas/responses.py
+++ b/src/prefect/client/schemas/responses.py
@@ -190,6 +190,7 @@ class FlowRunResponse(ObjectBaseModel):
         example="my-work-pool",
     )
     state: Optional[objects.State] = FieldFrom(objects.FlowRun)
+    parameters: Optional[dict] = FieldFrom(objects.FlowRun)
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/src/prefect/client/schemas/responses.py
+++ b/src/prefect/client/schemas/responses.py
@@ -190,7 +190,6 @@ class FlowRunResponse(ObjectBaseModel):
         example="my-work-pool",
     )
     state: Optional[objects.State] = FieldFrom(objects.FlowRun)
-    parameters: Optional[dict] = FieldFrom(objects.FlowRun)
     job_variables: Optional[dict] = FieldFrom(objects.FlowRun)
 
     def __eq__(self, other: Any) -> bool:

--- a/src/prefect/client/schemas/responses.py
+++ b/src/prefect/client/schemas/responses.py
@@ -191,6 +191,7 @@ class FlowRunResponse(ObjectBaseModel):
     )
     state: Optional[objects.State] = FieldFrom(objects.FlowRun)
     parameters: Optional[dict] = FieldFrom(objects.FlowRun)
+    job_variables: Optional[dict] = FieldFrom(objects.FlowRun)
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/src/prefect/deployments/deployments.py
+++ b/src/prefect/deployments/deployments.py
@@ -75,6 +75,7 @@ async def run_deployment(
     idempotency_key: Optional[str] = None,
     work_queue_name: Optional[str] = None,
     as_subflow: Optional[bool] = True,
+    job_variables: Optional[dict] = None,
 ) -> FlowRun:
     """
     Create a flow run for a deployment and return it after completion or a timeout.
@@ -194,6 +195,7 @@ async def run_deployment(
         idempotency_key=idempotency_key,
         parent_task_run_id=parent_task_run_id,
         work_queue_name=work_queue_name,
+        job_variables=job_variables,
     )
 
     flow_run_id = flow_run.id

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -94,22 +94,22 @@ async def create_deployment(
         if deployment.work_pool_name and deployment.work_queue_name:
             # If a specific pool name/queue name combination was provided, get the
             # ID for that work pool queue.
-            deployment_dict["work_queue_id"] = (
-                await worker_lookups._get_work_queue_id_from_name(
-                    session=session,
-                    work_pool_name=deployment.work_pool_name,
-                    work_queue_name=deployment.work_queue_name,
-                    create_queue_if_not_found=True,
-                )
+            deployment_dict[
+                "work_queue_id"
+            ] = await worker_lookups._get_work_queue_id_from_name(
+                session=session,
+                work_pool_name=deployment.work_pool_name,
+                work_queue_name=deployment.work_queue_name,
+                create_queue_if_not_found=True,
             )
         elif deployment.work_pool_name:
             # If just a pool name was provided, get the ID for its default
             # work pool queue.
-            deployment_dict["work_queue_id"] = (
-                await worker_lookups._get_default_work_queue_id_from_work_pool_name(
-                    session=session,
-                    work_pool_name=deployment.work_pool_name,
-                )
+            deployment_dict[
+                "work_queue_id"
+            ] = await worker_lookups._get_default_work_queue_id_from_work_pool_name(
+                session=session,
+                work_pool_name=deployment.work_pool_name,
             )
         elif deployment.work_queue_name:
             # If just a queue name was provided, ensure that the queue exists and

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -27,6 +27,7 @@ import prefect.server.models as models
 import prefect.server.schemas as schemas
 from prefect.logging import get_logger
 from prefect.server.api.run_history import run_history
+from prefect.server.api.validation import validate_job_variables_for_flow_run
 from prefect.server.database.dependencies import provide_database_interface
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.exceptions import FlowRunGraphTooLarge
@@ -40,6 +41,7 @@ from prefect.server.schemas.graph import Graph
 from prefect.server.schemas.responses import OrchestrationResult
 from prefect.server.utilities.schemas import DateTimeTZ
 from prefect.server.utilities.server import PrefectRouter
+from prefect.settings import PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES
 
 logger = get_logger("server.api")
 
@@ -95,6 +97,37 @@ async def update_flow_run(
     Updates a flow run.
     """
     async with db.session_context(begin_transaction=True) as session:
+        if PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES.value():
+            if flow_run.job_variables is not None:
+                this_run = await models.flow_runs.read_flow_run(
+                    session, flow_run_id=flow_run_id
+                )
+                if this_run is None:
+                    raise HTTPException(
+                        status.HTTP_404_NOT_FOUND, detail="Flow run not found"
+                    )
+                if this_run.state.type != schemas.states.StateType.SCHEDULED:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=f"Job variables for a flow run in state {this_run.state.type} cannot be updated",
+                    )
+                if this_run.deployment_id is None:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="A deployment for the flow run could not be found",
+                    )
+
+                deployment = await models.deployments.read_deployment(
+                    session=session, deployment_id=this_run.deployment_id
+                )
+                if deployment is None:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="A deployment for the flow run could not be found",
+                    )
+
+                validate_job_variables_for_flow_run(flow_run, deployment)
+
         result = await models.flow_runs.update_flow_run(
             session=session, flow_run=flow_run, flow_run_id=flow_run_id
         )

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -109,7 +109,7 @@ async def update_flow_run(
                 if this_run.state.type != schemas.states.StateType.SCHEDULED:
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,
-                        detail=f"Job variables for a flow run in state {this_run.state.type} cannot be updated",
+                        detail=f"Job variables for a flow run in state {this_run.state.type.name} cannot be updated",
                     )
                 if this_run.deployment_id is None:
                     raise HTTPException(

--- a/src/prefect/server/api/validation.py
+++ b/src/prefect/server/api/validation.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from prefect._vendor.fastapi import HTTPException, status
 
 import prefect.server.schemas as schemas
@@ -23,7 +25,9 @@ def _merge_job_variables(base_vars: dict, deployment_vars: dict, flow_run_vars: 
 
 
 def validate_job_variables_for_flow_run(
-    flow_run: schemas.actions.DeploymentFlowRunCreate | schemas.actions.FlowRunUpdate,
+    flow_run: Union[
+        schemas.actions.DeploymentFlowRunCreate, schemas.actions.FlowRunUpdate
+    ],
     deployment: schemas.core.Deployment,
 ) -> None:
     base_vars = _get_base_config_defaults(

--- a/src/prefect/server/api/validation.py
+++ b/src/prefect/server/api/validation.py
@@ -16,14 +16,6 @@ def _get_base_config_defaults(base_config: dict):
     return defaults
 
 
-def _merge_job_variables(base_vars: dict, deployment_vars: dict, flow_run_vars: dict):
-    result = {}
-    result.update(base_vars)
-    result.update(deployment_vars)
-    result.update(flow_run_vars)
-    return result
-
-
 def validate_job_variables_for_flow_run(
     flow_run: Union[
         schemas.actions.DeploymentFlowRunCreate, schemas.actions.FlowRunUpdate
@@ -34,9 +26,7 @@ def validate_job_variables_for_flow_run(
         deployment.work_queue.work_pool.base_job_template
     )
     flow_run_vars = flow_run.job_variables or {}
-    job_vars = _merge_job_variables(
-        base_vars, deployment.infra_overrides, flow_run_vars
-    )
+    job_vars = {**base_vars, **deployment.infra_overrides, **flow_run_vars}
 
     try:
         validate_values_conform_to_schema(

--- a/src/prefect/server/api/validation.py
+++ b/src/prefect/server/api/validation.py
@@ -1,0 +1,47 @@
+from prefect._vendor.fastapi import HTTPException, status
+
+import prefect.server.schemas as schemas
+from prefect.utilities.validation import validate_values_conform_to_schema
+
+
+def _get_base_config_defaults(base_config: dict):
+    template: dict = base_config.get("variables", {}).get("properties", {})
+    defaults = dict()
+    for variable_name, attrs in template.items():
+        if "default" in attrs:
+            defaults[variable_name] = attrs["default"]
+
+    return defaults
+
+
+def _merge_job_variables(base_vars: dict, deployment_vars: dict, flow_run_vars: dict):
+    result = {}
+    result.update(base_vars)
+    result.update(deployment_vars)
+    result.update(flow_run_vars)
+    return result
+
+
+def validate_job_variables_for_flow_run(
+    flow_run: schemas.actions.DeploymentFlowRunCreate | schemas.actions.FlowRunUpdate,
+    deployment: schemas.core.Deployment,
+) -> None:
+    base_vars = _get_base_config_defaults(
+        deployment.work_queue.work_pool.base_job_template
+    )
+    flow_run_vars = flow_run.job_variables or {}
+    job_vars = _merge_job_variables(
+        base_vars, deployment.infra_overrides, flow_run_vars
+    )
+
+    try:
+        validate_values_conform_to_schema(
+            job_vars,
+            deployment.work_queue.work_pool.base_job_template.get("variables"),
+        )
+    except ValueError as exc:
+        if isinstance(flow_run, schemas.actions.FlowRunUpdate):
+            error_msg = f"Error updating flow run: {exc}"
+        else:
+            error_msg = f"Error creating flow run: {exc}"
+        raise HTTPException(status.HTTP_409_CONFLICT, detail=error_msg)

--- a/src/prefect/server/database/migrations/MIGRATION-NOTES.md
+++ b/src/prefect/server/database/migrations/MIGRATION-NOTES.md
@@ -8,6 +8,10 @@ Each time a database migration is written, an entry is included here with:
 
 This gives us a history of changes and will create merge conflicts if two migrations are made at once, flagging situations where a branch needs to be updated before merging.
 
+# Add `job_variables` to `flow_runs`
+SQLite: `342220764f0b`
+Postgres: `121699507574`
+
 # Create `deployment_schedule` and add `Deployment.paused`
 SQLite: `265eb1a2da4c`
 Postgres: `8cf4d4933848`

--- a/src/prefect/server/database/migrations/versions/postgresql/2024_03_05_122228_121699507574_add_job_variables_column_to_flow_runs.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2024_03_05_122228_121699507574_add_job_variables_column_to_flow_runs.py
@@ -1,0 +1,33 @@
+"""Add job_variables column to flow-runs
+
+Revision ID: 121699507574
+Revises: 8cf4d4933848
+Create Date: 2024-03-05 12:22:28.460541
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "121699507574"
+down_revision = "8cf4d4933848"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "flow_run",
+        sa.Column(
+            "job_variables",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default="{}",
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("flow_run", "job_variables")

--- a/src/prefect/server/database/migrations/versions/sqlite/2024_03_05_115258_342220764f0b_add_job_variables_column_to_flow_runs.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2024_03_05_115258_342220764f0b_add_job_variables_column_to_flow_runs.py
@@ -1,0 +1,35 @@
+"""Add job_variables column to flow-runs
+
+Revision ID: 342220764f0b
+Revises: 265eb1a2da4c
+Create Date: 2024-03-05 11:52:58.330563
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import Text
+
+import prefect
+
+# revision identifiers, used by Alembic.
+revision = "342220764f0b"
+down_revision = "265eb1a2da4c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "flow_run",
+        sa.Column(
+            "job_variables",
+            prefect.server.utilities.database.JSON(astext_type=Text()),
+            server_default="{}",
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("flow_run", "job_variables")

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -511,6 +511,7 @@ class ORMFlowRun(ORMRun):
     )
 
     infrastructure_pid = sa.Column(sa.String)
+    job_variables = sa.Column(JSON, server_default="{}", default=dict, nullable=True)
 
     @declared_attr
     def infrastructure_document_id(cls):

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -1,6 +1,7 @@
 """
 Reduced schemas for accepting API actions.
 """
+
 import json
 import warnings
 from copy import copy, deepcopy
@@ -343,6 +344,7 @@ class FlowRunUpdate(ActionBaseModel):
     empirical_policy: schemas.core.FlowRunPolicy = FieldFrom(schemas.core.FlowRun)
     tags: List[str] = FieldFrom(schemas.core.FlowRun)
     infrastructure_pid: Optional[str] = FieldFrom(schemas.core.FlowRun)
+    job_variables: Optional[Dict[str, Any]] = FieldFrom(schemas.core.FlowRun)
 
 
 @copy_model_fields
@@ -432,6 +434,7 @@ class FlowRunCreate(ActionBaseModel):
         ),
         deprecated=True,
     )
+    job_variables: Optional[Dict[str, Any]] = FieldFrom(schemas.core.FlowRun)
 
     class Config(ActionBaseModel.Config):
         json_dumps = orjson_dumps_extra_compatible
@@ -455,6 +458,7 @@ class DeploymentFlowRunCreate(ActionBaseModel):
     idempotency_key: Optional[str] = FieldFrom(schemas.core.FlowRun)
     parent_task_run_id: Optional[UUID] = FieldFrom(schemas.core.FlowRun)
     work_queue_name: Optional[str] = FieldFrom(schemas.core.FlowRun)
+    job_variables: Optional[Dict[str, Any]] = FieldFrom(schemas.core.FlowRun)
 
 
 @copy_model_fields

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -434,7 +434,6 @@ class FlowRunCreate(ActionBaseModel):
         ),
         deprecated=True,
     )
-    job_variables: Optional[Dict[str, Any]] = FieldFrom(schemas.core.FlowRun)
 
     class Config(ActionBaseModel.Config):
         json_dumps = orjson_dumps_extra_compatible

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -298,6 +298,11 @@ class FlowRun(ORMBaseModel):
     )
     # parent_task_run: "TaskRun" = None
 
+    job_variables: Optional[Dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Variables used as overrides in the base job template",
+    )
+
     @validator("name", pre=True)
     def set_name(cls, name):
         return name or generate_slug(2)

--- a/src/prefect/server/schemas/responses.py
+++ b/src/prefect/server/schemas/responses.py
@@ -207,6 +207,7 @@ class FlowRunResponse(ORMBaseModel):
         example="my-work-pool",
     )
     state: Optional[schemas.states.State] = FieldFrom(schemas.core.FlowRun)
+    job_variables: Dict[str, Any] = FieldFrom(schemas.core.FlowRun)
 
     @classmethod
     def from_orm(cls, orm_flow_run: "prefect.server.database.orm_models.ORMFlowRun"):

--- a/src/prefect/server/schemas/responses.py
+++ b/src/prefect/server/schemas/responses.py
@@ -207,7 +207,7 @@ class FlowRunResponse(ORMBaseModel):
         example="my-work-pool",
     )
     state: Optional[schemas.states.State] = FieldFrom(schemas.core.FlowRun)
-    job_variables: Dict[str, Any] = FieldFrom(schemas.core.FlowRun)
+    job_variables: Optional[Dict[str, Any]] = FieldFrom(schemas.core.FlowRun)
 
     @classmethod
     def from_orm(cls, orm_flow_run: "prefect.server.database.orm_models.ORMFlowRun"):

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -966,9 +966,13 @@ class BaseWorker(abc.ABC):
     ) -> BaseJobConfiguration:
         deployment = await self._client.read_deployment(flow_run.deployment_id)
         flow = await self._client.read_flow(flow_run.flow_id)
+
+        flow_run_vars = flow_run.job_variables or {}
+        job_variables = {**deployment.infra_overrides, **flow_run_vars}
+
         configuration = await self.job_configuration.from_template_and_values(
             base_job_template=self._work_pool.base_job_template,
-            values=deployment.infra_overrides or {},
+            values=job_variables,
             client=self._client,
         )
         configuration.prepare_for_flow_run(

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -967,8 +967,12 @@ class BaseWorker(abc.ABC):
         deployment = await self._client.read_deployment(flow_run.deployment_id)
         flow = await self._client.read_flow(flow_run.flow_id)
 
-        flow_run_vars = flow_run.job_variables or {}
-        job_variables = {**deployment.infra_overrides, **flow_run_vars}
+        deployment_vars = deployment.infra_overrides or {}
+        if experiment_enabled("flow_run_infra_overrides"):
+            flow_run_vars = flow_run.job_variables or {}
+            job_variables = {**deployment_vars, **flow_run_vars}
+        else:
+            job_variables = deployment_vars
 
         configuration = await self.job_configuration.from_template_and_values(
             base_job_template=self._work_pool.base_job_template,

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -28,6 +28,7 @@ import prefect.client.schemas as client_schemas
 import prefect.context
 import prefect.exceptions
 from prefect import flow, tags
+from prefect._internal.compatibility.experimental import ExperimentalFeature
 from prefect.client.constants import SERVER_API_VERSION
 from prefect.client.orchestration import PrefectClient, ServerType, get_client
 from prefect.client.schemas.actions import (
@@ -76,12 +77,21 @@ from prefect.settings import (
     PREFECT_API_TLS_INSECURE_SKIP_VERIFY,
     PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
+    PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES,
     PREFECT_UNIT_TEST_MODE,
     temporary_settings,
 )
 from prefect.states import Completed, Pending, Running, Scheduled, State
 from prefect.tasks import task
 from prefect.testing.utilities import AsyncMock, exceptions_equal
+
+
+@pytest.fixture
+def enable_infra_overrides():
+    with temporary_settings(
+        {PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES: True}
+    ):
+        yield
 
 
 class TestGetClient:
@@ -1003,6 +1013,20 @@ async def test_create_flow_run_from_deployment_with_options(prefect_client, depl
     assert flow_run.job_variables == job_variables
 
 
+async def test_create_flow_run_from_deployment_with_options_emits_warning(
+    prefect_client, deployment, enable_infra_overrides
+):
+    with pytest.warns(
+        ExperimentalFeature,
+        match="To use this feature, update your workers to Prefect 2.16.4 or later.",
+    ):
+        await prefect_client.create_flow_run_from_deployment(
+            deployment.id,
+            name="test-run-name",
+            job_variables={"foo": "bar"},
+        )
+
+
 async def test_update_flow_run(prefect_client):
     @flow
     def foo():
@@ -1058,6 +1082,24 @@ async def test_update_flow_run_overrides_tags(prefect_client):
     )
     updated_flow_run = await prefect_client.read_flow_run(flow_run.id)
     assert updated_flow_run.tags == ["hello", "world"]
+
+
+async def test_update_flow_run_with_job_vars_emits_warning(
+    prefect_client, deployment, enable_infra_overrides
+):
+    flow_run = await prefect_client.create_flow_run_from_deployment(
+        deployment.id,
+        name="test-run-name",
+    )
+
+    with pytest.warns(
+        ExperimentalFeature,
+        match="To use this feature, update your workers to Prefect 2.16.4 or later.",
+    ):
+        await prefect_client.update_flow_run(
+            flow_run.id,
+            job_variables={"foo": "bar"},
+        )
 
 
 async def test_create_then_read_task_run(prefect_client):

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -986,18 +986,21 @@ async def test_create_flow_run_from_deployment_idempotency(prefect_client, deplo
 
 
 async def test_create_flow_run_from_deployment_with_options(prefect_client, deployment):
+    job_variables = {"foo": "bar"}
     flow_run = await prefect_client.create_flow_run_from_deployment(
         deployment.id,
         name="test-run-name",
         tags={"foo", "bar"},
         state=Pending(message="test"),
         parameters={"foo": "bar"},
+        job_variables=job_variables,
     )
     assert flow_run.name == "test-run-name"
     assert set(flow_run.tags) == {"foo", "bar"}.union(deployment.tags)
     assert flow_run.state.type == StateType.PENDING
     assert flow_run.state.message == "test"
     assert flow_run.parameters == {"foo": "bar"}
+    assert flow_run.job_variables == job_variables
 
 
 async def test_update_flow_run(prefect_client):

--- a/tests/server/api/test_deployments.py
+++ b/tests/server/api/test_deployments.py
@@ -2559,6 +2559,28 @@ class TestCreateFlowRunFromDeployment:
 
         assert deployment.work_queue_name == default_queue
 
+    async def test_create_flow_run_from_deployment_includes_job_variables(
+        self, deployment, client, session
+    ):
+        job_vars = {"foo": "bar"}
+        response = await client.post(
+            f"deployments/{deployment.id}/create_flow_run",
+            json=schemas.actions.DeploymentFlowRunCreate(job_variables=job_vars).dict(
+                json_compatible=True
+            ),
+        )
+        assert response.status_code == 201
+        flow_run_id = response.json()["id"]
+
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session, flow_run_id=flow_run_id
+        )
+        assert flow_run.job_variables == job_vars
+
+        response = await client.get(f"flow_runs/{flow_run_id}")
+        assert response.status_code == 200
+        assert response.json()["job_variables"] == job_vars
+
     async def test_create_flow_run_from_deployment_disambiguates_queue_name_from_other_pools(
         self, deployment, client, session
     ):

--- a/tests/server/api/test_flow_runs.py
+++ b/tests/server/api/test_flow_runs.py
@@ -49,23 +49,23 @@ class TestCreateFlowRun:
         )
         assert flow_run.flow_id == flow.id
 
-    async def test_create_flow_run_with_job_variables(self, flow, client, session):
-        job_vars = {"key": "value"}
+    async def test_create_flow_run_witout_job_vars_defaults_to_empty(
+        self, flow, client, session
+    ):
         response = await client.post(
             "/flow_runs/",
             json=actions.FlowRunCreate(
                 flow_id=flow.id,
                 name="",
-                job_variables=job_vars,
             ).dict(json_compatible=True),
         )
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.json()["job_variables"] == job_vars
+        assert response.json()["job_variables"] == {}
 
         flow_run = await models.flow_runs.read_flow_run(
             session=session, flow_run_id=response.json()["id"]
         )
-        assert flow_run.job_variables == job_vars
+        assert flow_run.job_variables == {}
 
     async def test_create_flow_run_with_infrastructure_document_id(
         self, flow, client, infrastructure_document_id

--- a/tests/server/api/test_infra_overrides.py
+++ b/tests/server/api/test_infra_overrides.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Optional
 
 import pytest
 
@@ -67,8 +68,8 @@ async def create_flow(session) -> schemas.core.Flow:
 async def create_objects_for_pool(
     session,
     *,
-    pool_job_config: dict | None = None,
-    deployment_vars: dict | None = None,
+    pool_job_config: Optional[dict] = None,
+    deployment_vars: Optional[dict] = None,
     pool_type: str = "None",
 ):
     pool_job_config = pool_job_config or {}

--- a/tests/server/api/test_infra_overrides.py
+++ b/tests/server/api/test_infra_overrides.py
@@ -1,0 +1,548 @@
+import uuid
+
+import pytest
+
+from prefect.server import models, schemas
+from prefect.server.models import deployments
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES,
+    temporary_settings,
+)
+
+
+@pytest.fixture
+def enable_infra_overrides():
+    with temporary_settings(
+        {PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES: True}
+    ):
+        yield
+
+
+async def create_work_pool(
+    session, job_template: dict, type: str = "None"
+) -> schemas.core.WorkPool:
+    work_pool = await models.workers.create_work_pool(
+        session=session,
+        work_pool=schemas.actions.WorkPoolCreate.construct(
+            _fields_set=schemas.actions.WorkPoolCreate.__fields_set__,
+            name="wp-1",
+            type=type,
+            description="None",
+            base_job_template=job_template,
+        ),
+    )
+    await session.commit()
+    return work_pool
+
+
+async def create_deployment(
+    session,
+    flow: schemas.core.Flow,
+    work_pool: schemas.core.WorkPool,
+    job_variables: dict,
+) -> schemas.core.Deployment:
+    deployment = await deployments.create_deployment(
+        session=session,
+        deployment=schemas.core.Deployment(
+            name="My Deployment X",
+            flow_id=flow.id,
+            paused=False,
+            work_queue_id=work_pool.default_queue_id,
+            infra_overrides=job_variables,
+        ),
+    )
+    await session.commit()
+    return deployment
+
+
+async def create_flow(session) -> schemas.core.Flow:
+    flow = await models.flows.create_flow(
+        session=session, flow=schemas.core.Flow(name="my-flow")
+    )
+    await session.commit()
+    assert flow
+    return flow
+
+
+async def create_objects_for_pool(
+    session,
+    *,
+    pool_job_config: dict | None = None,
+    deployment_vars: dict | None = None,
+    pool_type: str = "None",
+):
+    pool_job_config = pool_job_config or {}
+    deployment_vars = deployment_vars or {}
+    flow = await create_flow(session)
+    wp = await create_work_pool(session, pool_job_config, type=pool_type)
+    deployment = await create_deployment(session, flow, wp, deployment_vars)
+    return flow, wp, deployment
+
+
+class TestInfraOverrides:
+    async def test_creating_flow_run_with_unexpected_vars(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                    "thing_two": "{{ expected_variable_2 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {},
+                        "expected_variable_2": {},
+                    },
+                    "required": ["expected_variable_1", "expected_variable_2"],
+                },
+            },
+        )
+
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run",
+            json={"job_variables": {"x": 1}},
+        )
+        assert response.status_code == 409
+        assert (
+            response.json()["detail"]
+            == "Error creating flow run: Validation failed. Failure reason: 'expected_variable_1' is a required property"
+        )
+
+    async def test_creating_flow_run_with_mismatched_var_types(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                    "thing_two": "{{ expected_variable_2 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                        "expected_variable_2": {
+                            "title": "expected_variable_2",
+                            "default": "0",
+                            "type": "string",
+                        },
+                    },
+                    "required": ["expected_variable_1", "expected_variable_2"],
+                },
+            },
+        )
+
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run",
+            json={
+                "job_variables": {"expected_variable_1": 1, "expected_variable_2": 2}
+            },
+        )
+        assert response.status_code == 409
+        assert (
+            response.json()["detail"]
+            == "Error creating flow run: Validation failed for field 'expected_variable_2'. Failure reason: 2 is not of type 'string'"
+        )
+
+    @pytest.mark.parametrize(
+        "template",
+        (
+            {},
+            None,
+            {
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                    "thing_two": "{{ expected_variable_2 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {},
+                        "expected_variable_2": {},
+                    },
+                },
+            },
+        ),
+    )
+    async def test_creating_flow_run_with_vars_on_non_strict_pool(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+        template,
+    ):
+        # create a pool with a lax schema
+        *_, deployment = await create_objects_for_pool(
+            session, pool_job_config=template
+        )
+
+        # create a flow run with job vars
+        job_variables = {"x": 1}
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run",
+            json={"job_variables": job_variables},
+        )
+        assert response.status_code == 201
+
+        # verify the flow run was created with the supplied job vars
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session,
+            flow_run_id=response.json()["id"],
+        )
+        assert flow_run.job_variables == job_variables
+
+    async def test_flow_run_vars_overwrite_deployment_vars(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        # create a pool with a pool schema and a deployment with variables
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                    "thing_two": "{{ expected_variable_2 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                        "expected_variable_2": {
+                            "title": "expected_variable_2",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["expected_variable_1", "expected_variable_2"],
+                },
+            },
+            deployment_vars={"expected_variable_1": 1, "expected_variable_2": 2},
+        )
+
+        # create a flow run its own job vars
+        job_variables = {"expected_variable_1": -1, "expected_variable_2": -2}
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run",
+            json={"job_variables": job_variables},
+        )
+        assert response.status_code == 201
+
+        # verify the flow run vars took precedence over deployment vars
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session,
+            flow_run_id=response.json()["id"],
+        )
+        assert flow_run.job_variables == job_variables
+
+    async def test_merged_deployment_vars_and_flow_run_vars_are_not_stored(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        # create a pool with a pool schema and a deployment with overrides
+        deployment_vars = {"expected_variable_2": 2}
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                    "thing_two": "{{ expected_variable_2 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                        "expected_variable_2": {
+                            "title": "expected_variable_2",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["expected_variable_1", "expected_variable_2"],
+                },
+            },
+            deployment_vars=deployment_vars,
+        )
+
+        # create a flow run its own overrides
+        job_variables = {"expected_variable_1": -1}
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run",
+            json={"job_variables": job_variables},
+        )
+        assert response.status_code == 201
+
+        # verify the flow run overrides are stored unmerged
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session,
+            flow_run_id=response.json()["id"],
+        )
+        assert flow_run.job_variables == job_variables
+
+    async def test_flow_run_fails_if_missing_default_are_not_provided(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        # create a pool with a pool schema and a deployment with variables
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                    "thing_two": "{{ expected_variable_2 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["expected_variable_1"],
+                },
+            },
+        )
+
+        # create a flow run that should fail bc no override is provided
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run",
+            json={},
+        )
+
+        # verify the flow run failed due to a missing required variable
+        assert response.status_code == 409
+        assert response.json()["detail"] == (
+            "Error creating flow run: Validation failed. Failure reason: 'expected_variable_1' is a required property"
+        )
+
+    async def test_flow_run_with_base_job_template_defaults(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        # create a pool with a pool schema that has a default value
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                    "thing_two": "{{ expected_variable_2 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["expected_variable_1"],
+                },
+            },
+        )
+
+        # create a flow run has no overrides
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run", json={}
+        )
+
+        # verify validation passed since the job templates's default was used
+        assert response.status_code == 201
+
+
+class TestInfraOverridesUpdates:
+    async def test_updating_flow_run_with_valid_updates(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        # create a pool with a pool schema that has a default value
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["expected_variable_1"],
+                },
+            },
+        )
+
+        # create a flow run with no overrides
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run", json={}
+        )
+        assert response.status_code == 201
+        flow_run_id = response.json()["id"]
+
+        # update the flow run with new job vars
+        job_variables = {"expected_variable_1": 100}
+        response = await client.patch(
+            f"/flow_runs/{flow_run_id}", json={"job_variables": job_variables}
+        )
+        assert response.status_code == 204
+
+        # verify that updates were applied
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session, flow_run_id=flow_run_id
+        )
+        assert flow_run.job_variables == job_variables
+
+    async def test_updating_flow_run_with_invalid_update_type(
+        self,
+        session,
+        client,
+        enable_infra_overrides,
+    ):
+        # create a pool with a pool schema that has a default value
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["expected_variable_1"],
+                },
+            },
+        )
+
+        # create a flow run with no overrides
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run", json={}
+        )
+        assert response.status_code == 201
+        flow_run_id = response.json()["id"]
+
+        # update the flow run with a job var that doesn't conform to the schema
+        job_variables = {"expected_variable_1": "this_should_be_an_int"}
+        response = await client.patch(
+            f"/flow_runs/{flow_run_id}", json={"job_variables": job_variables}
+        )
+
+        # verify that the update failed
+        assert response.status_code == 409
+        assert (
+            response.json()["detail"]
+            == "Error updating flow run: Validation failed for field 'expected_variable_1'. Failure reason: 'this_should_be_an_int' is not of type 'integer'"
+        )
+
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session, flow_run_id=flow_run_id
+        )
+        assert flow_run.job_variables == {}
+
+    async def test_updating_flow_run_in_non_scheduled_state(
+        self,
+        session,
+        client,
+        db,
+        enable_infra_overrides,
+    ):
+        # create a pool with a pool schema that has a default value
+        *_, deployment = await create_objects_for_pool(
+            session,
+            pool_job_config={
+                "job_configuration": {
+                    "thing_one": "{{ expected_variable_1 }}",
+                },
+                "variables": {
+                    "properties": {
+                        "expected_variable_1": {
+                            "title": "expected_variable_1",
+                            "default": 0,
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["expected_variable_1"],
+                },
+            },
+        )
+
+        # create a flow run
+        original_job_variables = {"expected_variable_1": 1}
+        response = await client.post(
+            f"/deployments/{deployment.id}/create_flow_run",
+            json={"job_variables": original_job_variables},
+        )
+        assert response.status_code == 201
+        flow_run_id = response.json()["id"]
+
+        # set the flow run state to be non-scheduled
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session,
+            flow_run_id=flow_run_id,
+        )
+        flow_run.set_state(db.FlowRunState(**schemas.states.Pending().orm_dict()))
+        await session.commit()
+
+        # attempt to update the flow run
+        job_variables = {"expected_variable_1": 100}
+        response = await client.patch(
+            f"/flow_runs/{flow_run_id}", json={"job_variables": job_variables}
+        )
+
+        # verify that the update failed
+        assert response.status_code == 400
+        assert (
+            response.json()["detail"]
+            == "Job variables for a flow run in state PENDING cannot be updated"
+        )
+
+        flow_run = await models.flow_runs.read_flow_run(
+            session=session, flow_run_id=flow_run_id
+        )
+        assert flow_run.job_variables == original_job_variables
+
+    async def test_updating_non_existant_flow_run(
+        self,
+        client,
+        enable_infra_overrides,
+    ):
+        # update a non-existent flow run
+        response = await client.patch(
+            f"/flow_runs/{uuid.uuid4()}", json={"job_variables": {"foo": "bar"}}
+        )
+
+        # verify the update failed
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Flow run not found"

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -11,6 +11,7 @@ import respx
 import yaml
 from httpx import Response
 
+from prefect._internal.compatibility.experimental import ExperimentalFeature
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect.client.schemas.actions import DeploymentScheduleCreate
 from prefect.client.schemas.objects import MinimalDeploymentSchedule
@@ -36,8 +37,21 @@ from prefect.filesystems import S3, GitHub, LocalFileSystem
 from prefect.infrastructure import DockerContainer, Infrastructure, Process
 from prefect.server.schemas import states
 from prefect.server.schemas.core import TaskRunResult
-from prefect.settings import PREFECT_API_URL, PREFECT_CLOUD_API_URL, temporary_settings
+from prefect.settings import (
+    PREFECT_API_URL,
+    PREFECT_CLOUD_API_URL,
+    PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES,
+    temporary_settings,
+)
 from prefect.utilities.slugify import slugify
+
+
+@pytest.fixture
+def enable_infra_overrides():
+    with temporary_settings(
+        {PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES: True}
+    ):
+        yield
 
 
 @pytest.fixture(autouse=True)
@@ -1056,6 +1070,26 @@ class TestRunDeployment:
         )
         assert flow_run.deployment_id == deployment_id
         assert flow_run.state
+
+    async def test_run_deployment_emits_warning(
+        self,
+        test_deployment,
+        prefect_client,
+        enable_infra_overrides,
+    ):
+        # This can be removed once the flow run infra overrides is no longer an experiment
+        _, deployment_id = test_deployment
+
+        with pytest.warns(
+            ExperimentalFeature,
+            match="To use this feature, update your workers to Prefect 2.16.4 or later.",
+        ):
+            await run_deployment(
+                deployment_id,
+                timeout=0,
+                job_variables={"foo": "bar"},
+                client=prefect_client,
+            )
 
     def test_returns_flow_run_on_timeout(
         self,

--- a/tests/workers/test_process_worker.py
+++ b/tests/workers/test_process_worker.py
@@ -25,6 +25,10 @@ from prefect.client.schemas import State
 from prefect.exceptions import InfrastructureNotAvailable
 from prefect.server.schemas.core import WorkPool
 from prefect.server.schemas.states import StateDetails, StateType
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES,
+    temporary_settings,
+)
 from prefect.testing.utilities import AsyncMock, MagicMock
 from prefect.workers.process import (
     ProcessJobConfiguration,
@@ -36,6 +40,14 @@ from prefect.workers.process import (
 @flow
 def example_process_worker_flow():
     return 1
+
+
+@pytest.fixture
+def enable_infra_overrides():
+    with temporary_settings(
+        {PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES: True}
+    ):
+        yield
 
 
 @pytest.fixture
@@ -62,6 +74,26 @@ async def flow_run(prefect_client: PrefectClient):
             ),
         ),
     )
+
+    return flow_run
+
+
+@pytest.fixture
+async def flow_run_with_overrides(prefect_client: PrefectClient):
+    flow_run = await prefect_client.create_flow_run(
+        flow=example_process_worker_flow,
+        state=State(
+            type=StateType.SCHEDULED,
+            state_details=StateDetails(
+                scheduled_time=pendulum.now("utc").subtract(minutes=5)
+            ),
+        ),
+    )
+    await prefect_client.update_flow_run(
+        flow_run_id=flow_run.id,
+        job_variables={"working_dir": "/tmp/test"},
+    )
+    return await prefect_client.read_flow_run(flow_run.id)
 
     return flow_run
 
@@ -228,6 +260,63 @@ async def test_worker_process_run_flow_run_with_env_variables_from_overrides(
         assert mock.call_args.kwargs["env"]["PREFECT__FLOW_RUN_ID"] == str(flow_run.id)
         assert mock.call_args.kwargs["env"]["EXISTING_ENV_VAR"] == "from_os"
         assert mock.call_args.kwargs["env"]["NEW_ENV_VAR"] == "from_deployment"
+
+
+async def test_flow_run_vars_take_precedence(
+    flow_run_with_overrides,
+    work_pool_with_default_env,
+    enable_infra_overrides,
+    monkeypatch,
+):
+    deployment_job_vars = {"working_dir": "/deployment/tmp/test"}
+    patch_client(monkeypatch, overrides=deployment_job_vars)
+
+    async with ProcessWorker(
+        work_pool_name=work_pool_with_default_env.name,
+    ) as worker:
+        worker._work_pool = work_pool_with_default_env
+        config = await worker._get_configuration(flow_run_with_overrides)
+        assert (
+            str(config.working_dir)
+            == flow_run_with_overrides.job_variables["working_dir"]
+        )
+
+
+async def test_deployment_vars_take_precedence_if_flag_disabled(
+    flow_run_with_overrides,
+    work_pool_with_default_env,
+    monkeypatch,
+):
+    deployment_job_vars = {"working_dir": "/deployment/tmp/test"}
+    patch_client(monkeypatch, overrides=deployment_job_vars)
+
+    async with ProcessWorker(
+        work_pool_name=work_pool_with_default_env.name,
+    ) as worker:
+        worker._work_pool = work_pool_with_default_env
+        config = await worker._get_configuration(flow_run_with_overrides)
+        assert str(config.working_dir) == deployment_job_vars["working_dir"]
+
+
+async def test_flow_run_vars_and_deployment_vars_get_merged(
+    flow_run_with_overrides,
+    work_pool_with_default_env,
+    monkeypatch,
+    enable_infra_overrides,
+):
+    deployment_job_vars = {"stream_output": False}
+    patch_client(monkeypatch, overrides=deployment_job_vars)
+
+    async with ProcessWorker(
+        work_pool_name=work_pool_with_default_env.name,
+    ) as worker:
+        worker._work_pool = work_pool_with_default_env
+        config = await worker._get_configuration(flow_run_with_overrides)
+        assert (
+            str(config.working_dir)
+            == flow_run_with_overrides.job_variables["working_dir"]
+        )
+        assert config.stream_output == deployment_job_vars["stream_output"]
 
 
 async def test_process_created_then_marked_as_started(


### PR DESCRIPTION
This PR adds the final functionality for propagating `job_variables` onto workers -- if the FF is enabled the worker will pull job_variables off the flow run object and combine those with the deployment's infra-overrides before using the result to build the run's final configuration.

### Example


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [X] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.