### PR TITLE
Create `DeploymentFilterPaused` and update legacy filter

### DIFF
--- a/tests/server/models/test_deployments.py
+++ b/tests/server/models/test_deployments.py
@@ -388,6 +388,7 @@ class TestReadDeployments:
                 name="My Deployment",
                 manifest_path="file.json",
                 flow_id=flow.id,
+                paused=False,
                 is_schedule_active=True,
                 infrastructure_document_id=infrastructure_document_id,
             ),
@@ -400,6 +401,7 @@ class TestReadDeployments:
                 manifest_path="file.json",
                 flow_id=flow.id,
                 tags=["tb12"],
+                paused=False,
                 is_schedule_active=True,
                 infrastructure_document_id=infrastructure_document_id,
             ),
@@ -412,6 +414,7 @@ class TestReadDeployments:
                 manifest_path="file.json",
                 flow_id=flow.id,
                 tags=["tb12", "goat"],
+                paused=True,
                 is_schedule_active=False,
             ),
         )
@@ -460,6 +463,17 @@ class TestReadDeployments:
             ),
         )
         assert {res.id for res in result} == {deployment_id_2}
+
+    async def test_read_deployment_filters_by_paused(
+        self, filter_data, deployment_id_3, session
+    ):
+        result = await models.deployments.read_deployments(
+            session=session,
+            deployment_filter=filters.DeploymentFilter(
+                paused=filters.DeploymentFilterPaused(eq_=True)
+            ),
+        )
+        assert {res.id for res in result} == {deployment_id_3}
 
     async def test_read_deployment_filters_by_schedule_active(
         self, filter_data, deployment_id_3, session

--- a/tests/server/models/test_filters.py
+++ b/tests/server/models/test_filters.py
@@ -113,6 +113,7 @@ async def data(flow_function, db):
                 manifest_path="file.json",
                 schedule=schedules.IntervalSchedule(interval=timedelta(days=1)),
                 is_schedule_active=True,
+                paused=False,
             )
         )
         d_1_2 = await create_deployment(
@@ -122,6 +123,7 @@ async def data(flow_function, db):
                 manifest_path="file.json",
                 flow_id=f_1.id,
                 is_schedule_active=False,
+                paused=True,
                 work_queue_name="test-queue-for-filters",
             )
         )
@@ -133,6 +135,7 @@ async def data(flow_function, db):
                 flow_id=f_3.id,
                 schedule=schedules.IntervalSchedule(interval=timedelta(days=1)),
                 is_schedule_active=True,
+                paused=False,
                 work_queue_id=wp.default_queue_id,
             )
         )


### PR DESCRIPTION
This updates the legacy `IsScheduleActive` filter to filter on the `paused` field, and creates a new filter to filter by `Deployment.paused`.

OSS side of https://github.com/PrefectHQ/nebula/pull/7139
Related to https://github.com/PrefectHQ/nebula/issues/6877

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.