### PR TITLE
Updating client-side schemas for Triggers to reflect updates in Prefect Cloud

### DIFF
--- a/src/prefect/events/schemas.py
+++ b/src/prefect/events/schemas.py
@@ -282,8 +282,8 @@ class EventTrigger(ResourceTrigger):
 
     @root_validator(skip_on_failure=True)
     def enforce_minimum_within_for_proactive_triggers(cls, values: Dict[str, Any]):
-        posture: Posture | None = values.get("posture")
-        within: timedelta | None = values.get("within")
+        posture: Optional[Posture] = values.get("posture")
+        within: Optional[timedelta] = values.get("within")
 
         if posture == Posture.Proactive:
             if not within or within == timedelta(0):

--- a/src/prefect/events/schemas.py
+++ b/src/prefect/events/schemas.py
@@ -1,8 +1,22 @@
+import abc
 from datetime import timedelta
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union, cast
+from enum import Enum
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 from uuid import UUID, uuid4
 
 import pendulum
+from typing_extensions import TypeAlias
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 
@@ -15,7 +29,6 @@ else:
 
 from prefect._internal.schemas.bases import PrefectBaseModel
 from prefect._internal.schemas.fields import DateTimeTZ
-from prefect._internal.schemas.transformations import FieldFrom, copy_model_fields
 from prefect.events.actions import ActionTypes, RunDeployment
 from prefect.utilities.collections import AutoEnum
 
@@ -27,6 +40,7 @@ MAXIMUM_RELATED_RESOURCES = 500
 class Posture(AutoEnum):
     Reactive = "Reactive"
     Proactive = "Proactive"
+    Metric = "Metric"
 
 
 class ResourceSpecification(PrefectBaseModel):
@@ -164,32 +178,56 @@ class Event(PrefectBaseModel):
         return value
 
 
-class Trigger(PrefectBaseModel):
-    """Defines the criteria for the events and conditions under which an Automation
-    will trigger an action"""
+class Trigger(PrefectBaseModel, abc.ABC):
+    """
+    Base class describing a set of criteria that must be satisfied in order to trigger
+    an automation.
+    """
+
+    class Config:
+        extra = Extra.ignore
+
+    type: str
+
+
+class ResourceTrigger(Trigger, abc.ABC):
+    """
+    Base class for triggers that may filter by the labels of resources.
+    """
+
+    type: str
 
     match: ResourceSpecification = Field(
         default_factory=lambda: ResourceSpecification(__root__={}),
-        description="Labels for resources which this Automation will match.",
+        description="Labels for resources which this trigger will match.",
     )
     match_related: ResourceSpecification = Field(
         default_factory=lambda: ResourceSpecification(__root__={}),
-        description="Labels for related resources which this Automation will match.",
+        description="Labels for related resources which this trigger will match.",
     )
+
+
+class EventTrigger(ResourceTrigger):
+    """
+    A trigger that fires based on the presence or absence of events within a given
+    period of time.
+    """
+
+    type: Literal["event"] = "event"
 
     after: Set[str] = Field(
         default_factory=set,
         description=(
-            "The event(s) which must first been seen to start this automation.  If "
-            "empty, then start this Automation immediately.  Events may include "
+            "The event(s) which must first been seen to fire this trigger.  If "
+            "empty, then fire this trigger immediately.  Events may include "
             "trailing wildcards, like `prefect.flow-run.*`"
         ),
     )
     expect: Set[str] = Field(
         default_factory=set,
         description=(
-            "The event(s) this automation is expecting to see.  If empty, this "
-            "automation will match any event.  Events may include trailing wildcards, "
+            "The event(s) this trigger is expecting to see.  If empty, this "
+            "trigger will match any event.  Events may include trailing wildcards, "
             "like `prefect.flow-run.*`"
         ),
     )
@@ -197,24 +235,29 @@ class Trigger(PrefectBaseModel):
     for_each: Set[str] = Field(
         default_factory=set,
         description=(
-            "Evaluate the Automation separately for each distinct value of these labels"
-            " on the resource"
+            "Evaluate the trigger separately for each distinct value of these labels "
+            "on the resource.  By default, labels refer to the primary resource of the "
+            "triggering event.  You may also refer to labels from related "
+            "resources by specifying `related:<role>:<label>`.  This will use the "
+            "value of that label for the first related resource in that role.  For "
+            'example, `"for_each": ["related:flow:prefect.resource.id"]` would '
+            "evaluate the trigger for each flow."
         ),
     )
-    posture: Posture = Field(
-        Posture.Reactive,
+    posture: Literal[Posture.Reactive, Posture.Proactive] = Field(  # type: ignore[valid-type]
+        ...,
         description=(
-            "The posture of this Automation, either Reactive or Proactive.  Reactive "
-            "automations respond to the _presence_ of the expected events, while "
-            "Proactive  automations respond to the _absence_ of those expected events."
+            "The posture of this trigger, either Reactive or Proactive.  Reactive "
+            "triggers respond to the _presence_ of the expected events, while "
+            "Proactive triggers respond to the _absence_ of those expected events."
         ),
     )
     threshold: int = Field(
         1,
         description=(
-            "The number of events required for this Automation to trigger (for "
-            "Reactive automations), or the number of events expected (for Proactive "
-            "automations)"
+            "The number of events required for this trigger to fire (for "
+            "Reactive triggers), or the number of events expected (for Proactive "
+            "triggers)"
         ),
     )
     within: timedelta = Field(
@@ -239,8 +282,8 @@ class Trigger(PrefectBaseModel):
 
     @root_validator(skip_on_failure=True)
     def enforce_minimum_within_for_proactive_triggers(cls, values: Dict[str, Any]):
-        posture: Optional[Posture] = values.get("posture")
-        within: Optional[timedelta] = values.get("within")
+        posture: Posture | None = values.get("posture")
+        within: timedelta | None = values.get("within")
 
         if posture == Posture.Proactive:
             if not within or within == timedelta(0):
@@ -251,6 +294,86 @@ class Trigger(PrefectBaseModel):
                 )
 
         return values
+
+
+class MetricTriggerOperator(Enum):
+    LT = "<"
+    LTE = "<="
+    GT = ">"
+    GTE = ">="
+
+
+class PrefectMetric(Enum):
+    lateness = "lateness"
+    duration = "duration"
+    successes = "successes"
+
+
+class MetricTriggerQuery(PrefectBaseModel):
+    """Defines a subset of the Trigger subclass, which is specific
+    to Metric automations, that specify the query configurations
+    and breaching conditions for the Automation"""
+
+    name: PrefectMetric = Field(
+        ...,
+        description="The name of the metric to query.",
+    )
+    threshold: float = Field(
+        ...,
+        description=(
+            "The threshold value against which we'll compare " "the query result."
+        ),
+    )
+    operator: MetricTriggerOperator = Field(
+        ...,
+        description=(
+            "The comparative operator (LT / LTE / GT / GTE) used to compare "
+            "the query result against the threshold value."
+        ),
+    )
+    range: timedelta = Field(
+        timedelta(seconds=300),  # defaults to 5 minutes
+        minimum=300.0,
+        exclusiveMinimum=False,
+        description=(
+            "The lookback duration (seconds) for a metric query. This duration is "
+            "used to determine the time range over which the query will be executed. "
+            "The minimum value is 300 seconds (5 minutes)."
+        ),
+    )
+    firing_for: timedelta = Field(
+        timedelta(seconds=300),  # defaults to 5 minutes
+        minimum=300.0,
+        exclusiveMinimum=False,
+        description=(
+            "The duration (seconds) for which the metric query must breach "
+            "or resolve continuously before the state is updated and the "
+            "automation is triggered. "
+            "The minimum value is 300 seconds (5 minutes)."
+        ),
+    )
+
+
+class MetricTrigger(ResourceTrigger):
+    """
+    A trigger that fires based on the results of a metric query.
+    """
+
+    type: Literal["metric"] = "metric"
+
+    posture: Literal[Posture.Metric] = Field(  # type: ignore[valid-type]
+        Posture.Metric,
+        description="Periodically evaluate the configured metric query.",
+    )
+
+    metric: MetricTriggerQuery = Field(
+        ...,
+        description="The metric query to evaluate for this trigger. ",
+    )
+
+
+TriggerTypes: TypeAlias = Union[EventTrigger, MetricTrigger]
+"""The union of all concrete trigger types that a user may actually create"""
 
 
 class Automation(PrefectBaseModel):
@@ -265,7 +388,7 @@ class Automation(PrefectBaseModel):
 
     enabled: bool = Field(True, description="Whether this automation will be evaluated")
 
-    trigger: Trigger = Field(
+    trigger: TriggerTypes = Field(
         ...,
         description=(
             "The criteria for which events this Automation covers and how it will "
@@ -286,30 +409,106 @@ class ExistingAutomation(Automation):
     id: UUID = Field(..., description="The ID of this automation")
 
 
-@copy_model_fields
-class ResourceTrigger(PrefectBaseModel):
+class AutomationCreateFromTrigger(PrefectBaseModel):
     name: Optional[str] = Field(
         None, description="The name to give to the automation created for this trigger."
     )
-    description: str = FieldFrom(Automation)
-    enabled: bool = FieldFrom(Automation)
+    description: str = Field("", description="A longer description of this automation")
+    enabled: bool = Field(True, description="Whether this automation will be evaluated")
 
-    match: ResourceSpecification = FieldFrom(Trigger)
-    match_related: ResourceSpecification = FieldFrom(Trigger)
-    after: Set[str] = FieldFrom(Trigger)
-    expect: Set[str] = FieldFrom(Trigger)
-    for_each: Set[str] = FieldFrom(Trigger)
-    posture: Posture = FieldFrom(Trigger)
-    threshold: int = FieldFrom(Trigger)
-    within: timedelta = FieldFrom(Trigger)
+    # from ResourceTrigger
+
+    match: ResourceSpecification = Field(
+        default_factory=lambda: ResourceSpecification(__root__={}),
+        description="Labels for resources which this trigger will match.",
+    )
+    match_related: ResourceSpecification = Field(
+        default_factory=lambda: ResourceSpecification(__root__={}),
+        description="Labels for related resources which this trigger will match.",
+    )
+
+    # from both EventTrigger and MetricTrigger
+
+    posture: Posture = Field(
+        Posture.Reactive,
+        description=(
+            "The posture of this trigger, either Reactive, Proactive, or Metric. "
+            "Reactive triggers respond to the _presence_ of the expected events, while "
+            "Proactive triggers respond to the _absence_ of those expected events.  "
+            "Metric triggers periodically evaluate the configured metric query."
+        ),
+    )
+
+    # from EventTrigger
+
+    after: Set[str] = Field(
+        default_factory=set,
+        description=(
+            "The event(s) which must first been seen to fire this trigger.  If "
+            "empty, then fire this trigger immediately.  Events may include "
+            "trailing wildcards, like `prefect.flow-run.*`"
+        ),
+    )
+    expect: Set[str] = Field(
+        default_factory=set,
+        description=(
+            "The event(s) this trigger is expecting to see.  If empty, this "
+            "trigger will match any event.  Events may include trailing wildcards, "
+            "like `prefect.flow-run.*`"
+        ),
+    )
+
+    for_each: Set[str] = Field(
+        default_factory=set,
+        description=(
+            "Evaluate the trigger separately for each distinct value of these labels "
+            "on the resource.  By default, labels refer to the primary resource of the "
+            "triggering event.  You may also refer to labels from related "
+            "resources by specifying `related:<role>:<label>`.  This will use the "
+            "value of that label for the first related resource in that role.  For "
+            'example, `"for_each": ["related:flow:prefect.resource.id"]` would '
+            "evaluate the trigger for each flow."
+        ),
+    )
+    threshold: int = Field(
+        1,
+        description=(
+            "The number of events required for this trigger to fire (for "
+            "Reactive triggers), or the number of events expected (for Proactive "
+            "triggers)"
+        ),
+    )
+    within: timedelta = Field(
+        timedelta(0),
+        minimum=0.0,
+        exclusiveMinimum=False,
+        description=(
+            "The time period over which the events must occur.  For Reactive triggers, "
+            "this may be as low as 0 seconds, but must be at least 10 seconds for "
+            "Proactive triggers"
+        ),
+    )
+
+    # from MetricTrigger
+
+    metric: Optional[MetricTriggerQuery] = Field(
+        None,
+        description="The metric query to evaluate for this trigger. ",
+    )
 
     def as_automation(self) -> Automation:
         assert self.name
-        return Automation(
-            name=self.name,
-            description=self.description,
-            enabled=self.enabled,
-            trigger=Trigger(
+
+        if self.posture == Posture.Metric:
+            trigger = MetricTrigger(
+                type="metric",
+                match=self.match,
+                match_related=self.match_related,
+                posture=self.posture,
+                metric=self.metric,
+            )
+        else:
+            trigger = EventTrigger(
                 match=self.match,
                 match_related=self.match_related,
                 after=self.after,
@@ -318,7 +517,13 @@ class ResourceTrigger(PrefectBaseModel):
                 posture=self.posture,
                 threshold=self.threshold,
                 within=self.within,
-            ),
+            )
+
+        return Automation(
+            name=self.name,
+            description=self.description,
+            enabled=self.enabled,
+            trigger=trigger,
             actions=self.actions(),
             owner_resource=self.owner_resource(),
         )
@@ -330,10 +535,15 @@ class ResourceTrigger(PrefectBaseModel):
         raise NotImplementedError
 
 
-@copy_model_fields
-class DeploymentTrigger(ResourceTrigger):
+class DeploymentTrigger(AutomationCreateFromTrigger):
     _deployment_id: Optional[UUID] = PrivateAttr(default=None)
-    parameters: Optional[Dict[str, Any]] = FieldFrom(RunDeployment)
+    parameters: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "The parameters to pass to the deployment, or None to use the "
+            "deployment's default parameters"
+        ),
+    )
 
     def set_deployment_id(self, deployment_id: UUID):
         self._deployment_id = deployment_id

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -39,7 +39,7 @@ from prefect.deployments.base import (
     initialize_project,
 )
 from prefect.deployments.steps.core import StepExecutionError
-from prefect.events.schemas import Posture
+from prefect.events.schemas import DeploymentTrigger, Posture
 from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
 from prefect.infrastructure.container import DockerRegistry
 from prefect.server.schemas.actions import (
@@ -5805,23 +5805,26 @@ class TestDeploymentTrigger:
 
             triggers = _initialize_deployment_triggers("my_deployment", [trigger_spec])
             assert triggers == [
-                {
-                    "name": "Trigger McTriggerson",
-                    "description": "",
-                    "enabled": True,
-                    "match": {"prefect.resource.id": "prefect.flow-run.*"},
-                    "match_related": {
-                        "prefect.resource.name": "seed",
-                        "prefect.resource.role": "flow",
-                    },
-                    "after": set(),
-                    "expect": {"prefect.flow-run.Completed"},
-                    "for_each": set(),
-                    "posture": Posture.Reactive,
-                    "threshold": 1,
-                    "within": datetime.timedelta(0),
-                    "parameters": None,
-                }
+                DeploymentTrigger(
+                    **{
+                        "name": "Trigger McTriggerson",
+                        "description": "",
+                        "enabled": True,
+                        "match": {"prefect.resource.id": "prefect.flow-run.*"},
+                        "match_related": {
+                            "prefect.resource.name": "seed",
+                            "prefect.resource.role": "flow",
+                        },
+                        "after": set(),
+                        "expect": {"prefect.flow-run.Completed"},
+                        "for_each": set(),
+                        "posture": Posture.Reactive,
+                        "threshold": 1,
+                        "within": datetime.timedelta(0),
+                        "parameters": None,
+                        "metric": None,
+                    }
+                )
             ]
 
         async def test_initialize_deployment_triggers_implicit_name(self):

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -68,7 +68,7 @@ from prefect.client.schemas.responses import (
 from prefect.client.schemas.schedules import CronSchedule, IntervalSchedule, NoSchedule
 from prefect.client.utilities import inject_client
 from prefect.deprecated.data_documents import DataDocument
-from prefect.events.schemas import Automation, Posture, Trigger
+from prefect.events.schemas import Automation, EventTrigger, Posture
 from prefect.server.api.server import create_app
 from prefect.settings import (
     PREFECT_API_DATABASE_MIGRATE_ON_START,
@@ -1943,7 +1943,7 @@ class TestAutomations:
     def automation(self):
         return Automation(
             name="test-automation",
-            trigger=Trigger(
+            trigger=EventTrigger(
                 match={"flow_run_id": "123"},
                 posture=Posture.Reactive,
                 threshold=1,

--- a/tests/events/test_event_schemas.py
+++ b/tests/events/test_event_schemas.py
@@ -16,13 +16,13 @@ else:
 from prefect.events.actions import RunDeployment
 from prefect.events.schemas import (
     Automation,
+    AutomationCreateFromTrigger,
     DeploymentTrigger,
     Event,
+    EventTrigger,
     Posture,
     RelatedResource,
     Resource,
-    ResourceTrigger,
-    Trigger,
 )
 
 
@@ -161,7 +161,7 @@ def test_client_event_involved_resources():
 
 
 def test_resource_trigger_actions_not_implemented():
-    trigger = ResourceTrigger()
+    trigger = AutomationCreateFromTrigger()
     with pytest.raises(NotImplementedError):
         trigger.actions()
 
@@ -178,7 +178,7 @@ def test_deployment_trigger_as_automation():
         name="A deployment automation",
         description="",
         enabled=True,
-        trigger=Trigger(
+        trigger=EventTrigger(
             posture=Posture.Reactive,
             threshold=1,
             within=datetime.timedelta(0),

--- a/tests/events/test_v1_triggers_deserialization.py
+++ b/tests/events/test_v1_triggers_deserialization.py
@@ -1,0 +1,265 @@
+"""
+Tests that confirm that the deserialization of the triggers stored in the "v1" style
+(prior to the introduction of various subclasses) can be deserialized into "v2" classes.
+
+These tests will help to ensure that as we're refactoring Triggers as part of
+#raft-fan-in-triggers
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any, List, Optional, Set, Type
+
+import orjson
+import pytest
+
+from prefect._internal.pydantic import HAS_PYDANTIC_V2
+
+if HAS_PYDANTIC_V2:
+    import pydantic.v1 as pydantic
+    from pydantic.v1 import Field
+else:
+    import pydantic
+    from pydantic import Field
+
+from prefect.events.schemas import (
+    EventTrigger,
+    MetricTrigger,
+    MetricTriggerQuery,
+    Posture,
+    ResourceSpecification,
+    ResourceTrigger,
+    TriggerTypes,
+)
+from prefect.server.utilities.schemas import PrefectBaseModel
+
+
+class V1Trigger(PrefectBaseModel):
+    """A copy of the original events.automations.Trigger class for reference."""
+
+    match: ResourceSpecification = Field(
+        default_factory=lambda: ResourceSpecification(__root__={}),
+        description="Labels for resources which this Automation will match.",
+    )
+    match_related: ResourceSpecification = Field(
+        default_factory=lambda: ResourceSpecification(__root__={}),
+        description="Labels for related resources which this Automation will match.",
+    )
+
+    after: Set[str] = Field(
+        default_factory=set,
+        description=(
+            "The event(s) which must first been seen to start this automation.  If "
+            "empty, then start this Automation immediately.  Events may include "
+            "trailing wildcards, like `prefect.flow-run.*`"
+        ),
+    )
+    expect: Set[str] = Field(
+        default_factory=set,
+        description=(
+            "The event(s) this automation is expecting to see.  If empty, this "
+            "automation will match any event.  Events may include trailing wildcards, "
+            "like `prefect.flow-run.*`"
+        ),
+    )
+
+    for_each: Set[str] = Field(
+        default_factory=set,
+        description=(
+            "Evaluate the Automation separately for each distinct value of these labels "
+            "on the resource.  By default, labels refer to the primary resource of the "
+            "triggering event.  You may also refer to labels from related "
+            "resources by specifying `related:<role>:<label>`.  This will use the "
+            "value of that label for the first related resource in that role.  For "
+            'example, `"for_each": ["related:flow:prefect.resource.id"]` would '
+            "evaluate the automation for each flow."
+        ),
+    )
+    posture: Posture = Field(
+        ...,
+        description=(
+            "The posture of this Automation, either Reactive or Proactive.  Reactive "
+            "automations respond to the _presence_ of the expected events, while "
+            "Proactive automations respond to the _absence_ of those expected events. "
+            "Metric automations are unique in that they are not triggered by the "
+            "presence or absence of events, but rather by periodically evaluating a "
+            "configured metric query."
+        ),
+    )
+    threshold: int = Field(
+        1,
+        description=(
+            "The number of events required for this Automation to trigger (for "
+            "Reactive automations), or the number of events expected (for Proactive "
+            "automations)"
+        ),
+    )
+    within: timedelta = Field(
+        timedelta(0),
+        minimum=0.0,
+        exclusiveMinimum=False,
+        description=(
+            "The time period over which the events must occur.  For Reactive triggers, "
+            "this may be as low as 0 seconds, but must be at least 10 seconds for "
+            "Proactive triggers"
+        ),
+    )
+
+    metric: Optional[MetricTriggerQuery] = Field(
+        None,
+        description=(
+            "The metric query configuration for this trigger. "
+            "This field is only applicable to Metric automations."
+        ),
+    )
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc):
+    fixtures = set(metafunc.fixturenames)
+
+    if fixtures.issuperset({"trigger_type", "json"}):
+        metafunc.parametrize(
+            "trigger_type, json",
+            [
+                pytest.param(
+                    MetricTrigger if kind == "metric-triggers" else EventTrigger,
+                    orjson.loads(json),
+                    id=f"{kind}-{i}",
+                )
+                for kind, examples in V1_TRIGGERS.items()
+                for i, json in enumerate(examples)
+            ],
+        )
+
+
+def test_deserializing_as_v1_trigger(
+    trigger_type: Type[ResourceTrigger], json: dict[str, Any]
+):
+    """A baseline test that just confirms that all of the example JSON triggers are
+    actually parseable as v1 Triggers."""
+    v1_trigger = V1Trigger.parse_obj(json)
+    assert isinstance(v1_trigger, V1Trigger)
+
+
+def assert_triggers_match(v1_trigger: V1Trigger, v2_trigger: ResourceTrigger):
+    assert isinstance(v1_trigger, V1Trigger)
+    assert isinstance(v2_trigger, ResourceTrigger)
+
+    assert v2_trigger.match == v1_trigger.match
+    assert v2_trigger.match_related == v1_trigger.match_related
+
+    if isinstance(v2_trigger, EventTrigger):
+        assert v2_trigger.type == "event"
+        assert v2_trigger.dict()["type"] == "event"
+
+        assert v1_trigger.posture in {Posture.Reactive, Posture.Proactive}
+        assert v2_trigger.posture == v1_trigger.posture
+
+        assert v2_trigger.after == v1_trigger.after
+        assert v2_trigger.expect == v1_trigger.expect
+        assert v2_trigger.for_each == v1_trigger.for_each
+        assert v2_trigger.threshold == v1_trigger.threshold
+        assert v2_trigger.within == v1_trigger.within
+
+    elif isinstance(v2_trigger, MetricTrigger):
+        assert v2_trigger.type == "metric"
+        assert v2_trigger.dict()["type"] == "metric"
+
+        assert v1_trigger.posture == Posture.Metric
+        assert v2_trigger.posture == Posture.Metric
+
+        assert v2_trigger.metric == v1_trigger.metric
+
+
+def test_deserializing_as_v2_trigger(
+    trigger_type: Type[ResourceTrigger], json: dict[str, Any]
+):
+    """A test that confirms that the example JSON triggers can be deserialized directly
+    into their corresponding v2 classes."""
+    v1_trigger = V1Trigger.parse_obj(json)
+    v2_trigger = trigger_type.parse_obj(json)
+
+    assert isinstance(v2_trigger, trigger_type)
+
+    assert_triggers_match(v1_trigger, v2_trigger)
+
+
+def test_deserializing_polymorphic(
+    trigger_type: Type[ResourceTrigger], json: dict[str, Any]
+):
+    """A test that confirms that the example JSON triggers can be deserialized into
+    their corresponding v2 classes using polymorphism."""
+    v1_trigger = V1Trigger.parse_obj(json)
+    v2_trigger: ResourceTrigger = pydantic.parse_obj_as(TriggerTypes, json)  # type: ignore[arg-type]
+
+    assert isinstance(v2_trigger, trigger_type)
+
+    assert_triggers_match(v1_trigger, v2_trigger)
+
+
+class Referencer(PrefectBaseModel):
+    trigger: TriggerTypes
+
+
+def test_deserializing_into_polymorphic_attribute(
+    trigger_type: Type[ResourceTrigger], json: dict[str, Any]
+):
+    """A test that confirms that the example JSON triggers can be deserialized into
+    their corresponding v2 classes when referenced in an attribute."""
+    v1_trigger = V1Trigger.parse_obj(json)
+
+    v2_container = Referencer.parse_obj({"trigger": json})
+    v2_trigger = v2_container.trigger
+
+    assert isinstance(v2_trigger, trigger_type)
+
+    assert_triggers_match(v1_trigger, v2_trigger)
+
+
+class Container(PrefectBaseModel):
+    triggers: List[TriggerTypes]
+
+
+def test_deserializing_into_polymorphic_collection_attribute():
+    """A test that confirms that the example JSON triggers can be deserialized into
+    their corresponding v2 classes when referenced in a mixed collection."""
+    json = [
+        orjson.loads(trigger)
+        for trigger in V1_TRIGGERS["event-triggers"] + V1_TRIGGERS["metric-triggers"]
+    ]
+    v1_triggers = pydantic.parse_obj_as(List[V1Trigger], json)
+
+    v2_container = Container.parse_obj({"triggers": json})
+    v2_triggers = v2_container.triggers
+
+    for v1_trigger, v2_trigger in zip(v1_triggers, v2_triggers):
+        assert_triggers_match(v1_trigger, v2_trigger)
+
+
+# The following triggers were sampled from Prefect Cloud as of 2024-03-06.  Feel free to
+# add any additional examples that may represent edge cases.
+
+V1_TRIGGERS = {
+    "event-triggers": [
+        """{"after": [], "match": {"prefect.resource.id": "prefect.flow-run.*"}, "expect": ["prefect.flow-run.Crashed"], "within": 10.0, "posture": "Reactive", "for_each": ["prefect.resource.id"], "threshold": 1, "match_related": {"prefect.resource.id": ["prefect.flow.632cee21-fea1-490c-91cc-d97abbcf6870"], "prefect.resource.role": "flow"}}""",
+        """{"after": [], "match": {"prefect.resource.id": "prefect.flow-run.*"}, "expect": ["prefect.flow-run.Late"], "within": 10.0, "posture": "Reactive", "for_each": ["prefect.resource.id"], "threshold": 1, "match_related": {"prefect.resource.id": ["prefect.flow.158dd08b-c0fb-4898-af4a-d7d2737bb4ba"], "prefect.resource.role": "flow"}}""",
+        """{"after": [], "match": {"prefect.resource.id": "prefect.flow-run.*"}, "expect": ["prefect.flow-run.*"], "within": 10.0, "posture": "Reactive", "for_each": ["prefect.resource.id"], "threshold": 1, "match_related": {}}""",
+        """{"after": [], "match": {"prefect.resource.id": "file.normalized-data.*"}, "expect": ["file.uploaded"], "metric": null, "within": 0.0, "posture": "Reactive", "for_each": [], "threshold": 1, "match_related": {}}""",
+        """{"after": [], "match": {"prefect.resource.id": "prefect.flow-run.*"}, "expect": ["prefect.flow-run.Running"], "metric": null, "within": 10.0, "posture": "Reactive", "for_each": ["prefect.resource.id"], "threshold": 1, "match_related": {"prefect.resource.id": ["prefect.flow.64767c2a-f6b6-44b6-8a84-aaa2d21534ae"], "prefect.resource.role": "flow"}}""",
+        """{"after": [], "match": {"prefect.resource.id": "prefect.flow-run.*"}, "expect": ["prefect.flow-run.Crashed", "prefect.flow-run.TimedOut", "prefect.flow-run.Failed"], "metric": null, "within": 10.0, "posture": "Reactive", "for_each": ["prefect.resource.id"], "threshold": 1, "match_related": {"prefect.resource.id": ["prefect.flow.ab9279f8-0c24-4ff0-b3c4-a9562afcf30f", "prefect.flow.1b384893-b552-4cfa-9496-c4a7bc99f27d", "prefect.flow.bf237a78-d460-4e84-9fb7-f6ee02f2f3d8"], "prefect.resource.role": "flow"}}""",
+        """{"after": ["prefect.flow-run.Late"], "match": {"prefect.resource.id": "prefect.flow-run.*"}, "expect": ["prefect.flow-run.*"], "within": 180.0, "posture": "Proactive", "for_each": ["prefect.resource.id"], "threshold": 1, "match_related": {}}""",
+        """{"after": ["prefect.flow-run.Pending", "prefect.flow-run.Late"], "match": {"prefect.resource.id": "prefect.flow-run.*"}, "expect": ["prefect.flow-run.*"], "within": 1800.0, "posture": "Proactive", "for_each": ["prefect.resource.id"], "threshold": 1, "match_related": {}}""",
+        """{"after": ["prefect.flow-run.Pending"], "match": {"prefect.resource.id": "prefect.flow-run.*"}, "expect": ["prefect.flow-run.*"], "within": 3600.0, "posture": "Proactive", "for_each": ["prefect.resource.id"], "threshold": 1, "match_related": {"prefect.resource.id": ["prefect.flow.80544b38-1f76-4ddf-95e8-4910b4b1fbf1"], "prefect.resource.role": "flow"}}""",
+        """{"after": ["prefect.flow-run.Running"], "match": {"prefect.resource.id": "prefect.flow-run.*"}, "expect": ["prefect.flow-run.*"], "metric": null, "within": 900.0, "posture": "Proactive", "for_each": ["prefect.resource.id"], "threshold": 1, "match_related": {"prefect.resource.id": ["prefect.flow.bf2a955a-7394-41eb-b690-f7f54dd6d194"], "prefect.resource.role": "flow"}}""",
+        """{"after": ["prefect.flow-run.Running"], "match": {"prefect.resource.id": "prefect.flow-run.*"}, "expect": ["prefect.flow-run.*"], "metric": null, "within": 900.0, "posture": "Proactive", "for_each": ["prefect.resource.id"], "threshold": 1, "match_related": {"prefect.resource.id": ["prefect.flow.5ff0e4e7-7da8-476e-b9df-91f3069375d8", "prefect.flow.14c16080-21f8-4d2f-ba0d-aeff18f5e2d1", "prefect.flow.8ca556d3-6c7b-4598-80bf-5bff306931da", "..."], "prefect.resource.role": "flow"}}""",
+        """{"after": ["prefect.flow-run.Late", "prefect.flow-run.Pending"], "match": {"prefect.resource.id": "prefect.flow-run.*"}, "expect": ["prefect.flow-run.*"], "metric": null, "within": 600.0, "posture": "Proactive", "for_each": ["prefect.resource.id"], "threshold": 1, "match_related": {"prefect.resource.id": ["prefect.flow.ab9279f8-0c24-4ff0-b3c4-a9562afcf30f", "prefect.flow.1b384893-b552-4cfa-9496-c4a7bc99f27d", "..."], "prefect.resource.role": "flow"}}""",
+        """{"after": [], "match": {"prefect.resource.id": "prefect.work-queue.*"}, "expect": ["prefect.work-queue.unhealthy"], "metric": null, "within": 300.0, "posture": "Proactive", "for_each": ["prefect.resource.id"], "threshold": 1, "match_related": {}}""",
+    ],
+    "metric-triggers": [
+        """{"after": [], "match": {"prefect.resource.id": "prefect.flow-run.*"}, "expect": [], "metric": {"name": "successes", "range": 10800.0, "operator": "<", "threshold": 0.99, "firing_for": 21600.0}, "within": 0.0, "posture": "Metric", "for_each": [], "threshold": 1, "match_related": {"prefect.resource.id": ["prefect.tag.3-hour-sla"], "prefect.resource.role": "tag"}}""",
+        """{"after": [], "match": {"prefect.resource.id": "prefect.flow-run.*"}, "expect": [], "metric": {"name": "successes", "range": 3600.0, "operator": "<", "threshold": 0.99, "firing_for": 7200.0}, "within": 0.0, "posture": "Metric", "for_each": [], "threshold": 1, "match_related": {"prefect.resource.id": ["prefect.tag.hourly-sla"], "prefect.resource.role": "tag"}}""",
+        """{"after": [], "match": {"prefect.resource.id": "prefect.flow-run.*"}, "expect": [], "metric": {"name": "lateness", "range": 3600.0, "operator": ">", "threshold": 1200.0, "firing_for": 600.0}, "within": 0.0, "posture": "Metric", "for_each": [], "threshold": 1, "match_related": {}}""",
+        """{"after": [], "match": {"prefect.resource.id": "prefect.flow-run.*"}, "expect": [], "metric": {"name": "successes", "range": 86400.0, "operator": "<", "threshold": 0.9, "firing_for": 60.0}, "within": 0.0, "posture": "Metric", "for_each": [], "threshold": 1, "match_related": {"prefect.resource.id": ["prefect.flow.a447ae13-3e6e-4ed2-9248-88addc3af2ca"], "prefect.resource.role": "flow"}}""",
+    ],
+}


### PR DESCRIPTION
This backports the new `Trigger`s schema class hierarchy from Prefect Cloud,
with a unit test confirming that we are maintaining full backwards compatibility
with prior versions of `Trigger`.  This also allows clients to start specifying
Metric triggers in their deployments as well.

<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.