### PR TITLE
Simplify already authenticated logic for `prefect cloud login`

### DIFF
--- a/src/prefect/cli/cloud/__init__.py
+++ b/src/prefect/cli/cloud/__init__.py
@@ -372,25 +372,19 @@ async def login(
         app.console.print(
             "It looks like you're already authenticated with another profile."
         )
-        if not typer.confirm(
-            "? Would you like to reauthenticate with this profile?", default=False
+        if typer.confirm(
+            "? Would you like to switch profiles?",
+            default=True,
         ):
-            if typer.confirm(
-                "? Would you like to switch to an authenticated profile?", default=True
-            ):
-                profile_name = prompt_select_from_list(
-                    app.console,
-                    "Which authenticated profile would you like to switch to?",
-                    already_logged_in_profiles,
-                )
+            profile_name = prompt_select_from_list(
+                app.console,
+                "Which authenticated profile would you like to switch to?",
+                already_logged_in_profiles,
+            )
 
-                profiles.set_active(profile_name)
-                save_profiles(profiles)
-                exit_with_success(
-                    f"Switched to authenticated profile {profile_name!r}."
-                )
-            else:
-                return
+            profiles.set_active(profile_name)
+            save_profiles(profiles)
+            exit_with_success(f"Switched to authenticated profile {profile_name!r}.")
 
     if not key:
         choice = prompt_select_from_list(

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -776,17 +776,14 @@ def test_login_already_logged_in_to_another_profile(respx_mock):
         ["cloud", "login"],
         expected_code=0,
         user_input=(
-            # No, do not reauth
-            "n"
-            + readchar.key.ENTER
             # Yes, switch profiles
-            + "y"
+            "y"
             + readchar.key.ENTER
             # Use the first profile
             + readchar.key.ENTER
         ),
         expected_output_contains=[
-            "? Would you like to switch to an authenticated profile? [Y/n]:",
+            "? Would you like to switch profiles? [Y/n]:",
             "? Which authenticated profile would you like to switch to?",
             "logged-in-profile",
             "Switched to authenticated profile 'logged-in-profile'.",
@@ -837,17 +834,14 @@ def test_login_already_logged_in_to_another_profile_cancel_during_select(respx_m
         ["cloud", "login"],
         expected_code=1,
         user_input=(
-            # No, do not reauth
-            "n"
-            + readchar.key.ENTER
             # Yes, switch profiles
-            + "y"
+            "y"
             + readchar.key.ENTER
             # Abort!
             + readchar.key.CTRL_C
         ),
         expected_output_contains=[
-            "? Would you like to switch to an authenticated profile? [Y/n]:",
+            "? Would you like to switch profiles? [Y/n]:",
             "? Which authenticated profile would you like to switch to?",
             "logged-in-profile",
             "Aborted",


### PR DESCRIPTION
Removes an ambiguous question in the `prefect cloud login` flow when a user has one or more profiles already authenticated to cloud.

Closes #10689 

### Example

The command had an ambiguous question that was meant to tell if the user wanted to authenticate with the current profile or switch profiles. Essentially, asking them a question so we can ask a question, here I'm just removing that question altogether and asking if they want to switch profiles immediately. This takes it from:

<img width="939" alt="Screenshot 2024-03-07 at 2 05 28 PM" src="https://github.com/PrefectHQ/prefect/assets/354286/a5ef37cd-da48-48f6-846f-1cff2325c66d">

to:

<img width="900" alt="Screenshot 2024-03-07 at 2 06 02 PM" src="https://github.com/PrefectHQ/prefect/assets/354286/b8ac846f-3d0d-4fd8-9e4d-5dc96085f0c4">

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.