### PR TITLE
Better parity between Prefect and Prefect Cloud for task scheduling protocol

### DIFF
--- a/src/prefect/server/api/task_runs.py
+++ b/src/prefect/server/api/task_runs.py
@@ -295,7 +295,11 @@ async def scheduled_task_subscription(websocket: WebSocket):
             await websocket.send_json(task_run.dict(json_compatible=True))
 
             acknowledgement = await websocket.receive_json()
-            if acknowledgement.get("type") != "ack":
+            ack_type = acknowledgement.get("type")
+            if ack_type != "ack":
+                if ack_type == "quit":
+                    return await websocket.close()
+
                 raise WebSocketDisconnect(
                     code=4001, reason="Protocol violation: expected 'ack' message"
                 )

--- a/tests/server/api/test_task_run_subscriptions.py
+++ b/tests/server/api/test_task_run_subscriptions.py
@@ -92,7 +92,7 @@ async def taskA_run1(reset_task_queues: None) -> TaskRun:
 
 def test_receiving_task_run(app: FastAPI, taskA_run1: TaskRun):
     with authenticated_socket(app) as socket:
-        socket.send_json({"type": "subscription", "keys": ["mytasks.taskA"]})
+        socket.send_json({"type": "subscribe", "keys": ["mytasks.taskA"]})
 
         (received,) = drain(socket)
 
@@ -115,7 +115,7 @@ def test_acknowledging_between_each_run(
     app: FastAPI, taskA_run1: TaskRun, taskA_run2: TaskRun
 ):
     with authenticated_socket(app) as socket:
-        socket.send_json({"type": "subscription", "keys": ["mytasks.taskA"]})
+        socket.send_json({"type": "subscribe", "keys": ["mytasks.taskA"]})
 
         (first, second) = drain(socket, 2)
 
@@ -170,7 +170,7 @@ def test_server_only_delivers_tasks_for_subscribed_keys(
 ):
     with authenticated_socket(app) as socket:
         socket.send_json(
-            {"type": "subscription", "keys": ["mytasks.taskA", "other_tasks.taskB"]}
+            {"type": "subscribe", "keys": ["mytasks.taskA", "other_tasks.taskB"]}
         )
 
         received = drain(socket, 3)
@@ -203,8 +203,8 @@ def test_only_one_socket_gets_each_task_run(
     received2: List[TaskRun] = []
 
     with authenticated_socket(app) as first, authenticated_socket(app) as second:
-        first.send_json({"type": "subscription", "keys": ["mytasks.taskA"]})
-        second.send_json({"type": "subscription", "keys": ["mytasks.taskA"]})
+        first.send_json({"type": "subscribe", "keys": ["mytasks.taskA"]})
+        second.send_json({"type": "subscribe", "keys": ["mytasks.taskA"]})
 
         for i in range(5):
             received1 += drain(first, 1, quit=(i == 4))
@@ -231,7 +231,7 @@ def test_only_one_socket_gets_each_task_run(
 
 def test_server_redelivers_unacknowledged_runs(app: FastAPI, taskA_run1: TaskRun):
     with authenticated_socket(app) as socket:
-        socket.send_json({"type": "subscription", "keys": ["mytasks.taskA"]})
+        socket.send_json({"type": "subscribe", "keys": ["mytasks.taskA"]})
 
         received = socket.receive_json()
         assert received["id"] == str(taskA_run1.id)
@@ -240,7 +240,7 @@ def test_server_redelivers_unacknowledged_runs(app: FastAPI, taskA_run1: TaskRun
         socket.close()
 
     with authenticated_socket(app) as socket:
-        socket.send_json({"type": "subscription", "keys": ["mytasks.taskA"]})
+        socket.send_json({"type": "subscribe", "keys": ["mytasks.taskA"]})
 
         (received,) = drain(socket)
         assert received.id == taskA_run1.id
@@ -284,7 +284,7 @@ def test_server_restores_scheduled_task_runs_at_startup(
     preexisting_runs: List[TaskRun],
 ):
     with authenticated_socket(app) as socket:
-        socket.send_json({"type": "subscription", "keys": ["mytasks.taskA"]})
+        socket.send_json({"type": "subscribe", "keys": ["mytasks.taskA"]})
 
         received = drain(socket, expecting=len(preexisting_runs))
 


### PR DESCRIPTION
We had a little bit of drift between Prefect and Prefect Cloud, mostly in how
error handling in the socket works.  This reconciles the changes.