### PR TITLE
do not create `default-agent-pool` in empty state server

### DIFF
--- a/src/prefect/server/database/migrations/versions/postgresql/2023_01_31_110543_f98ae6d8e2cc_work_queue_data_migration.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2023_01_31_110543_f98ae6d8e2cc_work_queue_data_migration.py
@@ -29,104 +29,116 @@ def upgrade():
     # Create default agent work pool and associate all existing queues with it
     connection = op.get_bind()
 
-    connection.execute(
-        sa.text(
-            "INSERT INTO work_pool (name, type) VALUES ('default-agent-pool',"
-            " 'prefect-agent')"
-        )
-    )
-
-    default_pool_id = connection.execute(
-        sa.text("SELECT id FROM work_pool WHERE name = 'default-agent-pool'")
+    n_work_queues_without_a_work_pool = connection.execute(
+        sa.text("SELECT COUNT(*) FROM work_queue WHERE work_pool_id IS NULL")
     ).fetchone()[0]
 
-    default_queue = connection.execute(
-        sa.text("SELECT id FROM work_queue WHERE name = 'default'")
-    ).fetchone()
-
-    if not default_queue:
+    if n_work_queues_without_a_work_pool > 0:
         connection.execute(
             sa.text(
-                "INSERT INTO work_queue (name, work_pool_id) VALUES ('default',"
-                " :default_pool_id)"
+                "INSERT INTO work_pool (name, type) VALUES ('default-agent-pool',"
+                " 'prefect-agent')"
+            )
+        )
+
+        default_pool_id = connection.execute(
+            sa.text("SELECT id FROM work_pool WHERE name = 'default-agent-pool'")
+        ).fetchone()[0]
+
+        default_queue = connection.execute(
+            sa.text("SELECT id FROM work_queue WHERE name = 'default'")
+        ).fetchone()
+
+        if not default_queue:
+            connection.execute(
+                sa.text(
+                    "INSERT INTO work_queue (name, work_pool_id) VALUES ('default',"
+                    " :default_pool_id)"
+                ).params({"default_pool_id": default_pool_id}),
+            )
+
+        connection.execute(
+            sa.text(
+                "UPDATE work_queue SET work_pool_id = :default_pool_id WHERE work_pool_id"
+                " IS NULL"
             ).params({"default_pool_id": default_pool_id}),
         )
 
-    connection.execute(
-        sa.text(
-            "UPDATE work_queue SET work_pool_id = :default_pool_id WHERE work_pool_id"
-            " IS NULL"
-        ).params({"default_pool_id": default_pool_id}),
-    )
+        default_queue_id = connection.execute(
+            sa.text(
+                "SELECT id FROM work_queue WHERE name = 'default' and work_pool_id ="
+                " :default_pool_id"
+            ).params({"default_pool_id": default_pool_id}),
+        ).fetchone()[0]
 
-    default_queue_id = connection.execute(
-        sa.text(
-            "SELECT id FROM work_queue WHERE name = 'default' and work_pool_id ="
-            " :default_pool_id"
-        ).params({"default_pool_id": default_pool_id}),
-    ).fetchone()[0]
+        connection.execute(
+            sa.text(
+                "UPDATE work_pool SET default_queue_id = :default_queue_id WHERE id ="
+                " :default_pool_id"
+            ).params(
+                {
+                    "default_pool_id": default_pool_id,
+                    "default_queue_id": default_queue_id,
+                }
+            ),
+        )
 
-    connection.execute(
-        sa.text(
-            "UPDATE work_pool SET default_queue_id = :default_queue_id WHERE id ="
-            " :default_pool_id"
-        ).params(
-            {"default_pool_id": default_pool_id, "default_queue_id": default_queue_id}
-        ),
-    )
+        # Set priority on all queues and update flow runs and deployments
+        queue_rows = connection.execute(
+            sa.text(
+                "SELECT id, name FROM work_queue WHERE work_pool_id = :default_pool_id"
+            ).params({"default_pool_id": default_pool_id}),
+        ).fetchall()
 
-    # Set priority on all queues and update flow runs and deployments
-    queue_rows = connection.execute(
-        sa.text(
-            "SELECT id, name FROM work_queue WHERE work_pool_id = :default_pool_id"
-        ).params({"default_pool_id": default_pool_id}),
-    ).fetchall()
-
-    with op.get_context().autocommit_block():
-        for enumeration, row in enumerate(queue_rows):
-            connection.execute(
-                sa.text(
-                    "UPDATE work_queue SET priority = :priority WHERE id = :id"
-                ).params({"priority": enumeration + 1, "id": row[0]}),
-            )
-
-            batch_size = 250
-
-            while True:
-                result = connection.execute(
+        with op.get_context().autocommit_block():
+            for enumeration, row in enumerate(queue_rows):
+                connection.execute(
                     sa.text(
-                        """
-                        UPDATE flow_run 
-                        SET work_queue_id=:id 
-                        WHERE flow_run.id in (
-                            SELECT id 
-                            FROM flow_run 
-                            WHERE flow_run.work_queue_id IS NULL and flow_run.work_queue_name=:name 
-                            LIMIT :batch_size
-                        )
-                        """
-                    ).params({"id": row[0], "name": row[1], "batch_size": batch_size}),
+                        "UPDATE work_queue SET priority = :priority WHERE id = :id"
+                    ).params({"priority": enumeration + 1, "id": row[0]}),
                 )
-                if result.rowcount <= batch_size:
-                    break
 
-            while True:
-                result = connection.execute(
-                    sa.text(
-                        """
-                        UPDATE deployment 
-                        SET work_queue_id=:id 
-                        WHERE deployment.id in (
-                            SELECT id 
-                            FROM deployment 
-                            WHERE deployment.work_queue_id IS NULL and deployment.work_queue_name=:name 
-                            LIMIT :batch_size
-                        )
-                        """
-                    ).params({"id": row[0], "name": row[1], "batch_size": batch_size}),
-                )
-                if result.rowcount <= batch_size:
-                    break
+                batch_size = 250
+
+                while True:
+                    result = connection.execute(
+                        sa.text(
+                            """
+                            UPDATE flow_run 
+                            SET work_queue_id=:id 
+                            WHERE flow_run.id in (
+                                SELECT id 
+                                FROM flow_run 
+                                WHERE flow_run.work_queue_id IS NULL and flow_run.work_queue_name=:name 
+                                LIMIT :batch_size
+                            )
+                            """
+                        ).params(
+                            {"id": row[0], "name": row[1], "batch_size": batch_size}
+                        ),
+                    )
+                    if result.rowcount <= batch_size:
+                        break
+
+                while True:
+                    result = connection.execute(
+                        sa.text(
+                            """
+                            UPDATE deployment 
+                            SET work_queue_id=:id 
+                            WHERE deployment.id in (
+                                SELECT id 
+                                FROM deployment 
+                                WHERE deployment.work_queue_id IS NULL and deployment.work_queue_name=:name 
+                                LIMIT :batch_size
+                            )
+                            """
+                        ).params(
+                            {"id": row[0], "name": row[1], "batch_size": batch_size}
+                        ),
+                    )
+                    if result.rowcount <= batch_size:
+                        break
 
     with op.batch_alter_table("work_queue", schema=None) as batch_op:
         batch_op.drop_constraint("uq_work_queue__name")

--- a/src/prefect/server/database/migrations/versions/sqlite/2023_01_31_105442_1678f2fb8b33_work_queue_data_migration.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2023_01_31_105442_1678f2fb8b33_work_queue_data_migration.py
@@ -29,104 +29,116 @@ def upgrade():
     # Create default agent work pool and associate all existing queues with it
     connection = op.get_bind()
 
-    connection.execute(
-        sa.text(
-            "INSERT INTO work_pool (name, type) VALUES ('default-agent-pool',"
-            " 'prefect-agent')"
-        )
-    )
-
-    default_pool_id = connection.execute(
-        sa.text("SELECT id FROM work_pool WHERE name = 'default-agent-pool'")
+    n_work_queues_without_a_work_pool = connection.execute(
+        sa.text("SELECT COUNT(*) FROM work_queue WHERE work_pool_id IS NULL")
     ).fetchone()[0]
 
-    default_queue = connection.execute(
-        sa.text("SELECT id FROM work_queue WHERE name = 'default'")
-    ).fetchone()
-
-    if not default_queue:
+    if n_work_queues_without_a_work_pool > 0:
         connection.execute(
             sa.text(
-                "INSERT INTO work_queue (name, work_pool_id) VALUES ('default',"
-                " :default_pool_id)"
+                "INSERT INTO work_pool (name, type) VALUES ('default-agent-pool',"
+                " 'prefect-agent')"
+            )
+        )
+
+        default_pool_id = connection.execute(
+            sa.text("SELECT id FROM work_pool WHERE name = 'default-agent-pool'")
+        ).fetchone()[0]
+
+        default_queue = connection.execute(
+            sa.text("SELECT id FROM work_queue WHERE name = 'default'")
+        ).fetchone()
+
+        if not default_queue:
+            connection.execute(
+                sa.text(
+                    "INSERT INTO work_queue (name, work_pool_id) VALUES ('default',"
+                    " :default_pool_id)"
+                ).params({"default_pool_id": default_pool_id}),
+            )
+
+        connection.execute(
+            sa.text(
+                "UPDATE work_queue SET work_pool_id = :default_pool_id WHERE work_pool_id"
+                " IS NULL"
             ).params({"default_pool_id": default_pool_id}),
         )
 
-    connection.execute(
-        sa.text(
-            "UPDATE work_queue SET work_pool_id = :default_pool_id WHERE work_pool_id"
-            " IS NULL"
-        ).params({"default_pool_id": default_pool_id}),
-    )
+        default_queue_id = connection.execute(
+            sa.text(
+                "SELECT id FROM work_queue WHERE name = 'default' and work_pool_id ="
+                " :default_pool_id"
+            ).params({"default_pool_id": default_pool_id}),
+        ).fetchone()[0]
 
-    default_queue_id = connection.execute(
-        sa.text(
-            "SELECT id FROM work_queue WHERE name = 'default' and work_pool_id ="
-            " :default_pool_id"
-        ).params({"default_pool_id": default_pool_id}),
-    ).fetchone()[0]
+        connection.execute(
+            sa.text(
+                "UPDATE work_pool SET default_queue_id = :default_queue_id WHERE id ="
+                " :default_pool_id"
+            ).params(
+                {
+                    "default_pool_id": default_pool_id,
+                    "default_queue_id": default_queue_id,
+                }
+            ),
+        )
 
-    connection.execute(
-        sa.text(
-            "UPDATE work_pool SET default_queue_id = :default_queue_id WHERE id ="
-            " :default_pool_id"
-        ).params(
-            {"default_pool_id": default_pool_id, "default_queue_id": default_queue_id}
-        ),
-    )
+        # Set priority on all queues and update flow runs and deployments
+        queue_rows = connection.execute(
+            sa.text(
+                "SELECT id, name FROM work_queue WHERE work_pool_id = :default_pool_id"
+            ).params({"default_pool_id": default_pool_id}),
+        ).fetchall()
 
-    # Set priority on all queues and update flow runs and deployments
-    queue_rows = connection.execute(
-        sa.text(
-            "SELECT id, name FROM work_queue WHERE work_pool_id = :default_pool_id"
-        ).params({"default_pool_id": default_pool_id}),
-    ).fetchall()
-
-    with op.get_context().autocommit_block():
-        for enumeration, row in enumerate(queue_rows):
-            connection.execute(
-                sa.text(
-                    "UPDATE work_queue SET priority = :priority WHERE id = :id"
-                ).params({"priority": enumeration + 1, "id": row[0]}),
-            )
-
-            batch_size = 250
-
-            while True:
-                result = connection.execute(
+        with op.get_context().autocommit_block():
+            for enumeration, row in enumerate(queue_rows):
+                connection.execute(
                     sa.text(
-                        """
-                        UPDATE flow_run 
-                        SET work_queue_id=:id 
-                        WHERE flow_run.id in (
-                            SELECT id 
-                            FROM flow_run 
-                            WHERE flow_run.work_queue_id IS NULL and flow_run.work_queue_name=:name 
-                            LIMIT :batch_size
-                        )
-                        """
-                    ).params({"id": row[0], "name": row[1], "batch_size": batch_size}),
+                        "UPDATE work_queue SET priority = :priority WHERE id = :id"
+                    ).params({"priority": enumeration + 1, "id": row[0]}),
                 )
-                if result.rowcount <= batch_size:
-                    break
 
-            while True:
-                result = connection.execute(
-                    sa.text(
-                        """
-                        UPDATE deployment 
-                        SET work_queue_id=:id 
-                        WHERE deployment.id in (
-                            SELECT id 
-                            FROM deployment 
-                            WHERE deployment.work_queue_id IS NULL and deployment.work_queue_name=:name 
-                            LIMIT :batch_size
-                        )
-                        """
-                    ).params({"id": row[0], "name": row[1], "batch_size": batch_size}),
-                )
-                if result.rowcount <= batch_size:
-                    break
+                batch_size = 250
+
+                while True:
+                    result = connection.execute(
+                        sa.text(
+                            """
+                            UPDATE flow_run 
+                            SET work_queue_id=:id 
+                            WHERE flow_run.id in (
+                                SELECT id 
+                                FROM flow_run 
+                                WHERE flow_run.work_queue_id IS NULL and flow_run.work_queue_name=:name 
+                                LIMIT :batch_size
+                            )
+                            """
+                        ).params(
+                            {"id": row[0], "name": row[1], "batch_size": batch_size}
+                        ),
+                    )
+                    if result.rowcount <= batch_size:
+                        break
+
+                while True:
+                    result = connection.execute(
+                        sa.text(
+                            """
+                            UPDATE deployment 
+                            SET work_queue_id=:id 
+                            WHERE deployment.id in (
+                                SELECT id 
+                                FROM deployment 
+                                WHERE deployment.work_queue_id IS NULL and deployment.work_queue_name=:name 
+                                LIMIT :batch_size
+                            )
+                            """
+                        ).params(
+                            {"id": row[0], "name": row[1], "batch_size": batch_size}
+                        ),
+                    )
+                    if result.rowcount <= batch_size:
+                        break
 
     with op.batch_alter_table("work_queue", schema=None) as batch_op:
         batch_op.drop_constraint("uq_work_queue__name")


### PR DESCRIPTION
closes #11984 

edits an old data migration that was creating a `default-agent-pool` work pool by default, and associating work-queues with this work pool

as it was, this data migration had the misleading side-effect of seeming like a recommendation to new users of the open source server

## previously
![image](https://github.com/PrefectHQ/prefect/assets/31014960/745613ff-0831-42fb-94d6-ed12cd73e485)

### changes
if we find any work queues that have a `null` work pool, we keep the status quo and create the `default agent pool`, but in the empty case, we shouldn't find any such work queues, so we just do not create the `default agent pool` or do the downstream queue association