### PR TITLE
Giving better client-side feedback on websocket authT/authZ issues

### DIFF
--- a/src/prefect/client/subscriptions.py
+++ b/src/prefect/client/subscriptions.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Generic, List, Optional, Type, TypeVar
+from typing import Any, Dict, Generic, List, Optional, Type, TypeVar
 
 import orjson
 import websockets
@@ -71,7 +71,7 @@ class Subscription(Generic[S]):
                 ).decode()
             )
 
-            auth: dict[str, Any] = orjson.loads(await websocket.recv())
+            auth: Dict[str, Any] = orjson.loads(await websocket.recv())
             assert auth["type"] == "auth_success", auth.get("message")
 
             message = {"type": "subscribe", "keys": self.keys} | {

--- a/src/prefect/client/subscriptions.py
+++ b/src/prefect/client/subscriptions.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Generic, List, Optional, Type, TypeVar
+from typing import Any, Generic, List, Optional, Type, TypeVar
 
 import orjson
 import websockets
@@ -71,8 +71,8 @@ class Subscription(Generic[S]):
                 ).decode()
             )
 
-            auth = orjson.loads(await websocket.recv())
-            assert auth["type"] == "auth_success"
+            auth: dict[str, Any] = orjson.loads(await websocket.recv())
+            assert auth["type"] == "auth_success", auth.get("message")
 
             message = {"type": "subscribe", "keys": self.keys} | {
                 **(dict(client_id=self.client_id) if self.client_id else {})
@@ -84,10 +84,16 @@ class Subscription(Generic[S]):
             websockets.exceptions.ConnectionClosedError,
         ) as e:
             if isinstance(e, AssertionError) or e.code == WS_1008_POLICY_VIOLATION:
+                if isinstance(e, AssertionError):
+                    reason = e.args[0]
+                elif isinstance(e, websockets.exceptions.ConnectionClosedError):
+                    reason = e.reason
+
+            if isinstance(e, AssertionError) or e.code == WS_1008_POLICY_VIOLATION:
                 raise Exception(
                     "Unable to authenticate to the subscription. Please "
                     "ensure the provided `PREFECT_API_KEY` you are using is "
-                    "valid for this environment."
+                    f"valid for this environment. Reason: {reason}"
                 ) from e
             raise
         else:

--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -330,14 +330,20 @@ class PrefectCloudEventSubscriber:
         )
 
         try:
-            message = orjson.loads(await self._websocket.recv())
+            message: dict[str, Any] = orjson.loads(await self._websocket.recv())
             logger.debug("  auth result %s", message)
-            assert message["type"] == "auth_success"
+            assert message["type"] == "auth_success", message.get("reason", "")
         except (AssertionError, ConnectionClosedError) as e:
             if isinstance(e, AssertionError) or e.code == WS_1008_POLICY_VIOLATION:
+                if isinstance(e, AssertionError):
+                    reason = e.args[0]
+                elif isinstance(e, ConnectionClosedError):
+                    reason = e.reason
+
                 raise Exception(
                     "Unable to authenticate to the event stream. Please ensure the "
-                    "provided api_key you are using is valid for this environment."
+                    "provided api_key you are using is valid for this environment. "
+                    f"Reason: {reason}"
                 ) from e
             raise
 

--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -330,7 +330,7 @@ class PrefectCloudEventSubscriber:
         )
 
         try:
-            message: dict[str, Any] = orjson.loads(await self._websocket.recv())
+            message: Dict[str, Any] = orjson.loads(await self._websocket.recv())
             logger.debug("  auth result %s", message)
             assert message["type"] == "auth_success", message.get("reason", "")
         except (AssertionError, ConnectionClosedError) as e:

--- a/tests/events/test_v1_triggers_deserialization.py
+++ b/tests/events/test_v1_triggers_deserialization.py
@@ -9,7 +9,7 @@ These tests will help to ensure that as we're refactoring Triggers as part of
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import Any, List, Optional, Set, Type
+from typing import Any, Dict, List, Optional, Set, Type
 
 import orjson
 import pytest
@@ -134,7 +134,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
 
 
 def test_deserializing_as_v1_trigger(
-    trigger_type: Type[ResourceTrigger], json: dict[str, Any]
+    trigger_type: Type[ResourceTrigger], json: Dict[str, Any]
 ):
     """A baseline test that just confirms that all of the example JSON triggers are
     actually parseable as v1 Triggers."""
@@ -173,7 +173,7 @@ def assert_triggers_match(v1_trigger: V1Trigger, v2_trigger: ResourceTrigger):
 
 
 def test_deserializing_as_v2_trigger(
-    trigger_type: Type[ResourceTrigger], json: dict[str, Any]
+    trigger_type: Type[ResourceTrigger], json: Dict[str, Any]
 ):
     """A test that confirms that the example JSON triggers can be deserialized directly
     into their corresponding v2 classes."""
@@ -186,7 +186,7 @@ def test_deserializing_as_v2_trigger(
 
 
 def test_deserializing_polymorphic(
-    trigger_type: Type[ResourceTrigger], json: dict[str, Any]
+    trigger_type: Type[ResourceTrigger], json: Dict[str, Any]
 ):
     """A test that confirms that the example JSON triggers can be deserialized into
     their corresponding v2 classes using polymorphism."""
@@ -203,7 +203,7 @@ class Referencer(PrefectBaseModel):
 
 
 def test_deserializing_into_polymorphic_attribute(
-    trigger_type: Type[ResourceTrigger], json: dict[str, Any]
+    trigger_type: Type[ResourceTrigger], json: Dict[str, Any]
 ):
     """A test that confirms that the example JSON triggers can be deserialized into
     their corresponding v2 classes when referenced in an attribute."""


### PR DESCRIPTION
In Prefect Cloud, we're now giving better error messages when authentication
fails on a websocket connection, and this change has the clients show those
error reasons to the users in the exceptions thrown during
connection/reconnection.
