### PR TITLE
Remove extra field from create endpoints

### DIFF
--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -434,7 +434,6 @@ class FlowRunCreate(ActionBaseModel):
         ),
         deprecated=True,
     )
-    job_variables: Optional[Dict[str, Any]] = FieldFrom(schemas.core.FlowRun)
 
     class Config(ActionBaseModel.Config):
         json_dumps = orjson_dumps_extra_compatible


### PR DESCRIPTION
This PR fixes an issue in our compat tests in our cloud repos. The problem was that our compat test detected that OSS had an extra field in its `FlowRunCreate` object. That field is getting dropped server side here and client side in `https://github.com/PrefectHQ/prefect/pull/12195/commits/8bcf05e8f65333cbe8c0bc7194799fe41a307e39`. This should get our compat tests passing again.

<!-- Include an overview here -->

### Example

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.