### PR TITLE
Workers use flow run overrides

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -966,9 +966,13 @@ class BaseWorker(abc.ABC):
     ) -> BaseJobConfiguration:
         deployment = await self._client.read_deployment(flow_run.deployment_id)
         flow = await self._client.read_flow(flow_run.flow_id)
+
+        flow_run_vars = flow_run.job_variables or {}
+        job_variables = {**deployment.infra_overrides, **flow_run_vars}
+
         configuration = await self.job_configuration.from_template_and_values(
             base_job_template=self._work_pool.base_job_template,
-            values=deployment.infra_overrides or {},
+            values=job_variables,
             client=self._client,
         )
         configuration.prepare_for_flow_run(

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -49,7 +49,6 @@ from prefect.exceptions import (
 from prefect.logging.loggers import PrefectLogAdapter, flow_run_logger, get_logger
 from prefect.plugins import load_prefect_collections
 from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES,
     PREFECT_EXPERIMENTAL_WARN,
     PREFECT_EXPERIMENTAL_WARN_ENHANCED_CANCELLATION,
     PREFECT_WORKER_HEARTBEAT_SECONDS,
@@ -969,11 +968,8 @@ class BaseWorker(abc.ABC):
         flow = await self._client.read_flow(flow_run.flow_id)
 
         deployment_vars = deployment.infra_overrides or {}
-        if PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES:
-            flow_run_vars = flow_run.job_variables or {}
-            job_variables = {**deployment_vars, **flow_run_vars}
-        else:
-            job_variables = deployment_vars
+        flow_run_vars = flow_run.job_variables or {}
+        job_variables = {**deployment_vars, **flow_run_vars}
 
         configuration = await self.job_configuration.from_template_and_values(
             base_job_template=self._work_pool.base_job_template,

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -49,6 +49,7 @@ from prefect.exceptions import (
 from prefect.logging.loggers import PrefectLogAdapter, flow_run_logger, get_logger
 from prefect.plugins import load_prefect_collections
 from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES,
     PREFECT_EXPERIMENTAL_WARN,
     PREFECT_EXPERIMENTAL_WARN_ENHANCED_CANCELLATION,
     PREFECT_WORKER_HEARTBEAT_SECONDS,
@@ -968,7 +969,7 @@ class BaseWorker(abc.ABC):
         flow = await self._client.read_flow(flow_run.flow_id)
 
         deployment_vars = deployment.infra_overrides or {}
-        if experiment_enabled("flow_run_infra_overrides"):
+        if PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES:
             flow_run_vars = flow_run.job_variables or {}
             job_variables = {**deployment_vars, **flow_run_vars}
         else:

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -967,8 +967,12 @@ class BaseWorker(abc.ABC):
         deployment = await self._client.read_deployment(flow_run.deployment_id)
         flow = await self._client.read_flow(flow_run.flow_id)
 
-        flow_run_vars = flow_run.job_variables or {}
-        job_variables = {**deployment.infra_overrides, **flow_run_vars}
+        deployment_vars = deployment.infra_overrides or {}
+        if experiment_enabled("flow_run_infra_overrides"):
+            flow_run_vars = flow_run.job_variables or {}
+            job_variables = {**deployment_vars, **flow_run_vars}
+        else:
+            job_variables = deployment_vars
 
         configuration = await self.job_configuration.from_template_and_values(
             base_job_template=self._work_pool.base_job_template,

--- a/tests/workers/test_process_worker.py
+++ b/tests/workers/test_process_worker.py
@@ -299,22 +299,6 @@ async def test_flow_run_vars_take_precedence(
         )
 
 
-async def test_deployment_vars_take_precedence_if_flag_disabled(
-    flow_run_with_overrides,
-    work_pool_with_default_env,
-    monkeypatch,
-):
-    deployment_job_vars = {"working_dir": "/deployment/tmp/test"}
-    patch_client(monkeypatch, overrides=deployment_job_vars)
-
-    async with ProcessWorker(
-        work_pool_name=work_pool_with_default_env.name,
-    ) as worker:
-        worker._work_pool = work_pool_with_default_env
-        config = await worker._get_configuration(flow_run_with_overrides)
-        assert str(config.working_dir) == deployment_job_vars["working_dir"]
-
-
 async def test_flow_run_vars_and_deployment_vars_get_merged(
     flow_run_with_overrides,
     work_pool_with_default_env,

--- a/tests/workers/test_process_worker.py
+++ b/tests/workers/test_process_worker.py
@@ -25,6 +25,10 @@ from prefect.client.schemas import State
 from prefect.exceptions import InfrastructureNotAvailable
 from prefect.server.schemas.core import WorkPool
 from prefect.server.schemas.states import StateDetails, StateType
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES,
+    temporary_settings,
+)
 from prefect.testing.utilities import AsyncMock, MagicMock
 from prefect.workers.process import (
     ProcessJobConfiguration,
@@ -36,6 +40,14 @@ from prefect.workers.process import (
 @flow
 def example_process_worker_flow():
     return 1
+
+
+@pytest.fixture
+def enable_infra_overrides():
+    with temporary_settings(
+        {PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES: True}
+    ):
+        yield
 
 
 @pytest.fixture
@@ -62,6 +74,26 @@ async def flow_run(prefect_client: PrefectClient):
             ),
         ),
     )
+
+    return flow_run
+
+
+@pytest.fixture
+async def flow_run_with_overrides(prefect_client: PrefectClient):
+    flow_run = await prefect_client.create_flow_run(
+        flow=example_process_worker_flow,
+        state=State(
+            type=StateType.SCHEDULED,
+            state_details=StateDetails(
+                scheduled_time=pendulum.now("utc").subtract(minutes=5)
+            ),
+        ),
+    )
+    await prefect_client.update_flow_run(
+        flow_run_id=flow_run.id,
+        job_variables={"working_dir": "/tmp/test"},
+    )
+    return await prefect_client.read_flow_run(flow_run.id)
 
     return flow_run
 
@@ -228,6 +260,63 @@ async def test_worker_process_run_flow_run_with_env_variables_from_overrides(
         assert mock.call_args.kwargs["env"]["PREFECT__FLOW_RUN_ID"] == str(flow_run.id)
         assert mock.call_args.kwargs["env"]["EXISTING_ENV_VAR"] == "from_os"
         assert mock.call_args.kwargs["env"]["NEW_ENV_VAR"] == "from_deployment"
+
+
+async def test_flow_run_vars_take_precedence(
+    flow_run_with_overrides,
+    work_pool_with_default_env,
+    enable_infra_overrides,
+    monkeypatch,
+):
+    deployment_job_vars = {"working_dir": "/deployment/tmp/test"}
+    patch_client(monkeypatch, overrides=deployment_job_vars)
+
+    async with ProcessWorker(
+        work_pool_name=work_pool_with_default_env.name,
+    ) as worker:
+        worker._work_pool = work_pool_with_default_env
+        config = await worker._get_configuration(flow_run_with_overrides)
+        assert (
+            str(config.working_dir)
+            == flow_run_with_overrides.job_variables["working_dir"]
+        )
+
+
+async def test_deployment_vars_take_precedence_if_flag_disabled(
+    flow_run_with_overrides,
+    work_pool_with_default_env,
+    monkeypatch,
+):
+    deployment_job_vars = {"working_dir": "/deployment/tmp/test"}
+    patch_client(monkeypatch, overrides=deployment_job_vars)
+
+    async with ProcessWorker(
+        work_pool_name=work_pool_with_default_env.name,
+    ) as worker:
+        worker._work_pool = work_pool_with_default_env
+        config = await worker._get_configuration(flow_run_with_overrides)
+        assert str(config.working_dir) == deployment_job_vars["working_dir"]
+
+
+async def test_flow_run_vars_and_deployment_vars_get_merged(
+    flow_run_with_overrides,
+    work_pool_with_default_env,
+    monkeypatch,
+    enable_infra_overrides,
+):
+    deployment_job_vars = {"stream_output": False}
+    patch_client(monkeypatch, overrides=deployment_job_vars)
+
+    async with ProcessWorker(
+        work_pool_name=work_pool_with_default_env.name,
+    ) as worker:
+        worker._work_pool = work_pool_with_default_env
+        config = await worker._get_configuration(flow_run_with_overrides)
+        assert (
+            str(config.working_dir)
+            == flow_run_with_overrides.job_variables["working_dir"]
+        )
+        assert config.stream_output == deployment_job_vars["stream_output"]
 
 
 async def test_process_created_then_marked_as_started(

--- a/tests/workers/test_process_worker.py
+++ b/tests/workers/test_process_worker.py
@@ -262,6 +262,23 @@ async def test_worker_process_run_flow_run_with_env_variables_from_overrides(
         assert mock.call_args.kwargs["env"]["NEW_ENV_VAR"] == "from_deployment"
 
 
+async def test_flow_run_without_job_vars(
+    flow_run,
+    work_pool_with_default_env,
+    enable_infra_overrides,
+    monkeypatch,
+):
+    deployment_job_vars = {"working_dir": "/deployment/tmp/test"}
+    patch_client(monkeypatch, overrides=deployment_job_vars)
+
+    async with ProcessWorker(
+        work_pool_name=work_pool_with_default_env.name,
+    ) as worker:
+        worker._work_pool = work_pool_with_default_env
+        config = await worker._get_configuration(flow_run)
+        assert str(config.working_dir) == deployment_job_vars["working_dir"]
+
+
 async def test_flow_run_vars_take_precedence(
     flow_run_with_overrides,
     work_pool_with_default_env,


### PR DESCRIPTION
This PR adds the final functionality for propagating `job_variables` onto workers -- if the FF is enabled the worker will pull job_variables off the flow run object and combine those with the deployment's infra-overrides before using the result to build the run's final configuration.

Note: This PR depends on https://github.com/PrefectHQ/prefect/pull/12195
### Example


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation.
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [X] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.