### PR TITLE
pass `additional_context` to `BaseTaskRunner.start()`

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -542,7 +542,7 @@ async def begin_flow_run(
         )
 
         flow_run_context.task_runner = await stack.enter_async_context(
-            task_runner.start()
+            task_runner.start(additional_context={"flow_run": flow_run})
         )
 
         flow_run_context.result_factory = await ResultFactory.from_flow(

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -167,6 +167,7 @@ class BaseTaskRunner(metaclass=abc.ABCMeta):
     @asynccontextmanager
     async def start(
         self: T,
+        additional_context: Optional[Dict[str, Any]] = None,
     ) -> AsyncIterator[T]:
         """
         Start the task runner, preparing any resources necessary for task submission.
@@ -182,14 +183,18 @@ class BaseTaskRunner(metaclass=abc.ABCMeta):
         async with AsyncExitStack() as exit_stack:
             self.logger.debug("Starting task runner...")
             try:
-                await self._start(exit_stack)
+                await self._start(exit_stack, additional_context)
                 self._started = True
                 yield self
             finally:
                 self.logger.debug("Shutting down task runner...")
                 self._started = False
 
-    async def _start(self, exit_stack: AsyncExitStack) -> None:
+    async def _start(
+        self,
+        exit_stack: AsyncExitStack,
+        additional_context: Optional[Dict[str, Any]] = None,
+    ):
         """
         Create any resources required for this task runner to submit work.
 
@@ -341,7 +346,11 @@ class ConcurrentTaskRunner(BaseTaskRunner):
 
         return result  # timeout reached
 
-    async def _start(self, exit_stack: AsyncExitStack):
+    async def _start(
+        self,
+        exit_stack: AsyncExitStack,
+        additional_context: Optional[Dict[str, Any]] = None,
+    ):
         """
         Start the process pool
         """


### PR DESCRIPTION
first step in addressing #10373

