### PR TITLE
Fix support for legacy schedule in `build_from_flow`

### DIFF
--- a/src/prefect/deployments/schedules.py
+++ b/src/prefect/deployments/schedules.py
@@ -2,7 +2,14 @@ from typing import List, Optional, Sequence, Union, get_args
 
 from prefect.client.schemas.objects import MinimalDeploymentSchedule
 from prefect.client.schemas.schedules import SCHEDULE_TYPES
-from prefect.server.schemas.schedules import SCHEDULE_TYPES as SERVER_SCHEDULE_TYPES
+
+try:
+    from prefect.server.schemas.schedules import SCHEDULE_TYPES as SERVER_SCHEDULE_TYPES
+
+    SERVER_SCHEDULE_TYPES = get_args(SERVER_SCHEDULE_TYPES)
+except ImportError:
+    # `prefect-client` does not have access to the server schemas.
+    SERVER_SCHEDULE_TYPES = ()
 
 FlexibleScheduleList = Sequence[Union[MinimalDeploymentSchedule, dict, SCHEDULE_TYPES]]
 
@@ -29,7 +36,7 @@ def normalize_to_minimal_deployment_schedules(
                 normalized.append(create_minimal_deployment_schedule(**obj))
             elif isinstance(obj, MinimalDeploymentSchedule):
                 normalized.append(obj)
-            elif isinstance(obj, get_args(SERVER_SCHEDULE_TYPES)):
+            elif isinstance(obj, SERVER_SCHEDULE_TYPES):
                 raise ValueError(
                     "Server schema schedules are not supported. Please use "
                     "the schedule objects from `prefect.client.schemas.schedules`"

--- a/src/prefect/deployments/schedules.py
+++ b/src/prefect/deployments/schedules.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Sequence, Union, get_args
 
 from prefect.client.schemas.objects import MinimalDeploymentSchedule
 from prefect.client.schemas.schedules import SCHEDULE_TYPES
+from prefect.server.schemas.schedules import SCHEDULE_TYPES as SERVER_SCHEDULE_TYPES
 
 FlexibleScheduleList = Sequence[Union[MinimalDeploymentSchedule, dict, SCHEDULE_TYPES]]
 
@@ -28,6 +29,11 @@ def normalize_to_minimal_deployment_schedules(
                 normalized.append(create_minimal_deployment_schedule(**obj))
             elif isinstance(obj, MinimalDeploymentSchedule):
                 normalized.append(obj)
+            elif isinstance(obj, get_args(SERVER_SCHEDULE_TYPES)):
+                raise ValueError(
+                    "Server schema schedules are not supported. Please use "
+                    "the schedule objects from `prefect.client.schemas.schedules`"
+                )
             else:
                 raise ValueError(
                     "Invalid schedule provided. Must be a schedule object, a dict,"

--- a/tests/cli/deployment/test_deployment_build.py
+++ b/tests/cli/deployment/test_deployment_build.py
@@ -205,7 +205,7 @@ class TestSchedules:
         )
 
         deployment = Deployment.load_from_yaml(tmp_path / "test.yaml")
-        assert deployment.schedule is None
+        assert deployment.schedules == []
 
     def test_passing_cron_schedules_to_build(self, patch_import, tmp_path):
         invoke_and_assert(
@@ -227,8 +227,9 @@ class TestSchedules:
         )
 
         deployment = Deployment.load_from_yaml(tmp_path / "test.yaml")
-        assert deployment.schedule.cron == "0 4 * * *"
-        assert deployment.schedule.timezone == "Europe/Berlin"
+        schedule = deployment.schedules[0].schedule
+        assert schedule.cron == "0 4 * * *"
+        assert schedule.timezone == "Europe/Berlin"
 
     def test_passing_interval_schedules_to_build(self, patch_import, tmp_path):
         invoke_and_assert(
@@ -252,9 +253,10 @@ class TestSchedules:
         )
 
         deployment = Deployment.load_from_yaml(tmp_path / "test.yaml")
-        assert deployment.schedule.interval == timedelta(seconds=42)
-        assert deployment.schedule.anchor_date == pendulum.parse("2040-02-02")
-        assert deployment.schedule.timezone == "America/New_York"
+        schedule = deployment.schedules[0].schedule
+        assert schedule.interval == timedelta(seconds=42)
+        assert schedule.anchor_date == pendulum.parse("2040-02-02")
+        assert schedule.timezone == "America/New_York"
 
     def test_passing_anchor_without_interval_exits(self, patch_import, tmp_path):
         invoke_and_assert(
@@ -294,8 +296,9 @@ class TestSchedules:
         )
 
         deployment = Deployment.load_from_yaml(tmp_path / "test.yaml")
+        schedule = deployment.schedules[0].schedule
         assert (
-            deployment.schedule.rrule
+            schedule.rrule
             == "DTSTART:20220910T110000\nRRULE:FREQ=HOURLY;BYDAY=MO,TU,WE,TH,FR,SA;BYHOUR=9,10,11,12,13,14,15,16,17"
         )
 
@@ -321,11 +324,12 @@ class TestSchedules:
         )
 
         deployment = Deployment.load_from_yaml(tmp_path / "test.yaml")
+        schedule = deployment.schedules[0].schedule
         assert (
-            deployment.schedule.rrule
+            schedule.rrule
             == "DTSTART:20220910T110000\nRRULE:FREQ=HOURLY;BYDAY=MO,TU,WE,TH,FR,SA;BYHOUR=9,10,11,12,13,14,15,16,17"
         )
-        assert deployment.schedule.timezone == "America/New_York"
+        assert schedule.timezone == "America/New_York"
 
     def test_parsing_rrule_timezone_overrides_if_passed_explicitly(
         self, patch_import, tmp_path
@@ -353,11 +357,12 @@ class TestSchedules:
         )
 
         deployment = Deployment.load_from_yaml(tmp_path / "test.yaml")
+        schedule = deployment.schedules[0].schedule
         assert (
-            deployment.schedule.rrule
+            schedule.rrule
             == "DTSTART:20220910T110000\nRRULE:FREQ=HOURLY;BYDAY=MO,TU,WE,TH,FR,SA;BYHOUR=9,10,11,12,13,14,15,16,17"
         )
-        assert deployment.schedule.timezone == "Europe/Berlin"
+        assert schedule.timezone == "Europe/Berlin"
 
     @pytest.mark.parametrize(
         "schedules",
@@ -687,7 +692,7 @@ class TestEntrypoint:
     ):
         flow_code = """
         from prefect import flow
-        
+
         @flow
         def dog_flow_func():
             pass

--- a/tests/deployment/test_schedules.py
+++ b/tests/deployment/test_schedules.py
@@ -13,6 +13,7 @@ from prefect.deployments.schedules import (
     create_minimal_deployment_schedule,
     normalize_to_minimal_deployment_schedules,
 )
+from prefect.server.schemas.schedules import CronSchedule as ServerCronSchedule
 
 
 @pytest.mark.parametrize(
@@ -106,6 +107,13 @@ def test_normalize_mixed():
 
     assert normalized[2].active is False
     assert normalized[2].schedule.rrule == "FREQ=DAILY"
+
+
+def test_normalize_server_schema():
+    with pytest.raises(ValueError, match="Server schema schedules are not supported"):
+        normalize_to_minimal_deployment_schedules(
+            schedules=[ServerCronSchedule(cron="0 0 * * *")]
+        )
 
 
 def test_normalize_incompatible():


### PR DESCRIPTION
The recent changes for enhanced scheduling broke the way the legacy `schedule` parameter worked for `build_from_flow`. This ensures that the legacy field is able to add and remove schedules, but in the case that both `schedule` and `schedules` are provided `schedules` will be the source of truth.

Closes #12255 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.