### PR TITLE
Pin `importlib-resources` to 6.1.x

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -10,6 +10,7 @@ griffe >= 0.20.0
 httpcore >=0.15.0, < 2.0.0
 httpx[http2] >= 0.23, != 0.23.2
 importlib_metadata >= 4.4; python_version < '3.10'
+importlib-resources >= 6.1.3, < 6.2.0
 jsonpatch >= 1.32, < 2.0
 jsonschema >= 3.2.0, < 5.0.0
 orjson >= 3.7, < 4.0


### PR DESCRIPTION
This pins `importlib-resources` to 6.1.x to fix the issue with our 3.8 tests failing to start because of an import error.

Related to #12265 