### PR TITLE
prevent annoying invalid link problem for `prefect deployment run`

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -1030,7 +1030,8 @@ async def run(
         └── Scheduled start time: {scheduled_display}
         └── URL: {run_url}
         """
-        ).strip()
+        ).strip(),
+        soft_wrap=True,
     )
     if watch:
         watch_interval = 5 if watch_interval is None else watch_interval


### PR DESCRIPTION
previously cmd clicking the link would only highlight the current line, giving an invalid link to follow

<img width="1504" alt="image" src="https://github.com/PrefectHQ/prefect/assets/31014960/8058eea5-c6d6-4b9e-a8f6-1b18068044c0">
