### PR TITLE
Render artifacts and states on the flow run graph by default.

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1292,12 +1292,12 @@ PREFECT_API_MAX_FLOW_RUN_GRAPH_ARTIFACTS = Setting(int, default=10000)
 The maximum number of artifacts to show on a flow run graph on the v2 API
 """
 
-PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS_ON_FLOW_RUN_GRAPH = Setting(bool, default=False)
+PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS_ON_FLOW_RUN_GRAPH = Setting(bool, default=True)
 """
 Whether or not to enable artifacts on the flow run graph.
 """
 
-PREFECT_EXPERIMENTAL_ENABLE_STATES_ON_FLOW_RUN_GRAPH = Setting(bool, default=False)
+PREFECT_EXPERIMENTAL_ENABLE_STATES_ON_FLOW_RUN_GRAPH = Setting(bool, default=True)
 """
 Whether or not to enable flow run states on the flow run graph.
 """

--- a/tests/_internal/compatibility/test_experimental.py
+++ b/tests/_internal/compatibility/test_experimental.py
@@ -476,6 +476,8 @@ def test_enabled_experiments_with_opt_in():
         "enhanced_cancellation",
         "enhanced_deployment_parameters",
         "work_queue_status",
+        "artifacts_on_flow_run_graph",
+        "states_on_flow_run_graph",
     }
 
 
@@ -490,4 +492,6 @@ def test_enabled_experiments_without_opt_in():
         "enhanced_cancellation",
         "enhanced_deployment_parameters",
         "work_queue_status",
+        "artifacts_on_flow_run_graph",
+        "states_on_flow_run_graph",
     }

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -39,6 +39,8 @@ def test_app_exposes_ui_settings():
         "enhanced_cancellation",
         "enhanced_deployment_parameters",
         "work_queue_status",
+        "artifacts_on_flow_run_graph",
+        "states_on_flow_run_graph",
     }
 
 
@@ -61,4 +63,6 @@ def test_app_exposes_ui_settings_with_experiments_enabled():
         "enhanced_deployment_parameters",
         "enhanced_cancellation",
         "work_queue_status",
+        "artifacts_on_flow_run_graph",
+        "states_on_flow_run_graph",
     }


### PR DESCRIPTION
This PR enables artifacts and states on the flow run graph by default. 

The respective experimental settings will now be enabled by default providing an opt-out experience at the api level if a user were to run into issues in their environment. 

For example, by setting `PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS_ON_FLOW_RUN_GRAPH` to a falsey value, the server will skip fetching artifacts for all flow run graphs. Similarly so for `PREFECT_EXPERIMENTAL_ENABLE_STATES_ON_FLOW_RUN_GRAPH` but for flow run states.

As a user, if you'd like to just toggle either layer off while viewing the graph, the graph has built-in toggles to do just that! These flags are intended more as escape hatches server-side in the event that you run into performance issues loading the extra data required for the graph. 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.