### PR TITLE
Fixes: 11781 Handle state parameter case in CLI flow-run ls

### DIFF
--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -67,7 +67,7 @@ async def ls(
 
     state_filter = {}
     if state:
-        state_filter["name"] = {"any_": state}
+        state_filter["name"] = {"any_": [s.capitalize() for s in state]}
     if state_type:
         state_filter["type"] = {"any_": state_type}
 

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -57,19 +57,24 @@ async def ls(
     flow_name: List[str] = typer.Option(None, help="Name of the flow"),
     limit: int = typer.Option(15, help="Maximum number of flow runs to list"),
     state: List[str] = typer.Option(None, help="Name of the flow run's state"),
-    state_type: List[StateType] = typer.Option(
-        None, help="Type of the flow run's state"
-    ),
+    state_type: List[str] = typer.Option(None, help="Type of the flow run's state"),
 ):
     """
     View recent flow runs or flow runs for specific flows
     """
+    for state_type_value in state_type:
+        enum_values = [item.value for item in StateType]
+        if state_type_value.upper() not in enum_values:
+            exit_with_error(
+                f"Invalid value for '--state-type': '{state_type_value}' is not one of"
+                f" '{enum_values}'."
+            )
 
     state_filter = {}
     if state:
         state_filter["name"] = {"any_": [s.capitalize() for s in state]}
     if state_type:
-        state_filter["type"] = {"any_": state_type}
+        state_filter["type"] = {"any_": [s.upper() for s in state_type]}
 
     async with get_client() as client:
         flow_runs = await client.read_flow_runs(

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -192,6 +192,24 @@ def test_ls_state_name_filter(
     )
 
 
+def test_ls_state_name_case_insensitive_filter(
+    scheduled_flow_run,
+    completed_flow_run,
+    running_flow_run,
+    late_flow_run,
+):
+    result = invoke_and_assert(
+        command=["flow-run", "ls", "--state", "late"],
+        expected_code=0,
+    )
+
+    assert_flow_runs_in_result(
+        result,
+        expected=[late_flow_run],
+        unexpected=[running_flow_run, scheduled_flow_run, completed_flow_run],
+    )
+
+
 def test_ls_limit(
     scheduled_flow_run,
     completed_flow_run,

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -210,6 +210,31 @@ def test_ls_state_name_case_insensitive_filter(
     )
 
 
+def test_ls_state_type_case_insensitive_filter(
+    scheduled_flow_run,
+    completed_flow_run,
+    running_flow_run,
+    late_flow_run,
+):
+    result = invoke_and_assert(
+        command=[
+            "flow-run",
+            "ls",
+            "--state-type",
+            "cOMPLETED",
+            "--state-type",
+            "RUNnING",
+        ],
+        expected_code=0,
+    )
+
+    assert_flow_runs_in_result(
+        result,
+        expected=[running_flow_run, completed_flow_run],
+        unexpected=[scheduled_flow_run, late_flow_run],
+    )
+
+
 def test_ls_limit(
     scheduled_flow_run,
     completed_flow_run,


### PR DESCRIPTION
closes #11781 

<!-- Include an overview here -->
when we try to use improper casing for state-type , we get what all are the possible state-type, so not made any change to it
![image](https://github.com/PrefectHQ/prefect/assets/145117767/c5368c5c-5b91-447f-aff5-77b123128b34)


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.


