### PR TITLE
Add CSRF support to orchestration client

### DIFF
--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -1,9 +1,10 @@
 import copy
 import sys
 import threading
+import uuid
 from collections import defaultdict
 from contextlib import asynccontextmanager
-from functools import partial
+from datetime import datetime, timezone
 from typing import (
     Any,
     AsyncGenerator,
@@ -11,6 +12,7 @@ from typing import (
     Callable,
     Dict,
     MutableMapping,
+    Optional,
     Protocol,
     Set,
     Tuple,
@@ -21,10 +23,11 @@ from typing import (
 import anyio
 import httpx
 from asgi_lifespan import LifespanManager
-from httpx import HTTPStatusError, Response
+from httpx import HTTPStatusError, Request, Response
 from prefect._vendor.starlette import status
 from typing_extensions import Self
 
+from prefect.client.schemas.objects import CsrfToken
 from prefect.exceptions import PrefectHTTPStatusError
 from prefect.logging import get_logger
 from prefect.settings import (
@@ -188,9 +191,20 @@ class PrefectHttpxClient(httpx.AsyncClient):
     [Configuring Cloudflare Rate Limiting](https://support.cloudflare.com/hc/en-us/articles/115001635128-Configuring-Rate-Limiting-from-UI)
     """
 
+    def __init__(self, *args, enable_csrf_support: bool = False, **kwargs):
+        self.enable_csrf_support: bool = enable_csrf_support
+        self.csrf_token: Optional[str] = None
+        self.csrf_token_expiration: Optional[datetime] = None
+        self.csrf_client_id: uuid.UUID = uuid.uuid4()
+
+        super().__init__(*args, **kwargs)
+
     async def _send_with_retry(
         self,
-        request: Callable,
+        request: Request,
+        send: Callable[[Request], Awaitable[Response]],
+        send_args: Tuple,
+        send_kwargs: Dict,
         retry_codes: Set[int] = set(),
         retry_exceptions: Tuple[Exception, ...] = tuple(),
     ):
@@ -207,21 +221,34 @@ class PrefectHttpxClient(httpx.AsyncClient):
         try_count = 0
         response = None
 
+        is_change_request = request.method.lower() in {"post", "put", "patch", "delete"}
+
+        if self.enable_csrf_support and is_change_request:
+            await self._add_csrf_headers(request=request)
+
         while try_count <= PREFECT_CLIENT_MAX_RETRIES.value():
             try_count += 1
             retry_seconds = None
             exc_info = None
 
             try:
-                response = await request()
+                response = await send(request, *send_args, **send_kwargs)
             except retry_exceptions:  # type: ignore
                 if try_count > PREFECT_CLIENT_MAX_RETRIES.value():
                     raise
                 # Otherwise, we will ignore this error but capture the info for logging
                 exc_info = sys.exc_info()
             else:
-                # We got a response; return immediately if it is not retryable
-                if response.status_code not in retry_codes:
+                # We got a response; check if it's a CSRF error, otherwise
+                # return immediately if it is not retryable
+                if (
+                    response.status_code == status.HTTP_403_FORBIDDEN
+                    and "Invalid CSRF token" in response.text
+                ):
+                    # We got a CSRF error, clear the token and try again
+                    self.csrf_token = None
+                    await self._add_csrf_headers(request)
+                elif response.status_code not in retry_codes:
                     return response
 
                 if "Retry-After" in response.headers:
@@ -268,19 +295,24 @@ class PrefectHttpxClient(httpx.AsyncClient):
         # We ran out of retries, return the failed response
         return response
 
-    async def send(self, *args, **kwargs) -> Response:
+    async def send(self, request: Request, *args, **kwargs) -> Response:
         """
         Send a request with automatic retry behavior for the following status codes:
 
+        - 403 Forbidden, if the request failed due to CSRF protection
+        - 408 Request Timeout
         - 429 CloudFlare-style rate limiting
         - 502 Bad Gateway
         - 503 Service unavailable
+        - Any additional status codes provided in `PREFECT_CLIENT_RETRY_EXTRA_CODES`
         """
 
-        api_request = partial(super().send, *args, **kwargs)
-
+        super_send = super().send
         response = await self._send_with_retry(
-            request=api_request,
+            request=request,
+            send=super_send,
+            send_args=args,
+            send_kwargs=kwargs,
             retry_codes={
                 status.HTTP_429_TOO_MANY_REQUESTS,
                 status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -312,3 +344,34 @@ class PrefectHttpxClient(httpx.AsyncClient):
         response.raise_for_status()
 
         return response
+
+    async def _add_csrf_headers(self, request: Request):
+        now = datetime.now(timezone.utc)
+
+        if not self.enable_csrf_support:
+            return
+
+        if not self.csrf_token or (
+            self.csrf_token_expiration and now > self.csrf_token_expiration
+        ):
+            token_request = self.build_request(
+                "GET", f"/csrf-token?client={self.csrf_client_id}"
+            )
+
+            try:
+                token_response = await self.send(token_request)
+            except PrefectHTTPStatusError as exc:
+                if exc.response.status_code == status.HTTP_404_NOT_FOUND:
+                    # The token endpoint is not available, likely an older
+                    # server version; disable CSRF support
+                    self.enable_csrf_support = False
+                    return
+
+                raise
+
+            token: CsrfToken = CsrfToken.parse_obj(token_response.json())
+            self.csrf_token = token.token
+            self.csrf_token_expiration = token.expiration
+
+        request.headers["Prefect-Csrf-Token"] = self.csrf_token
+        request.headers["Prefect-Csrf-Client"] = str(self.csrf_client_id)

--- a/src/prefect/client/cloud.py
+++ b/src/prefect/client/cloud.py
@@ -72,7 +72,7 @@ class CloudClient:
         httpx_settings.setdefault("base_url", host)
         if not PREFECT_UNIT_TEST_MODE.value():
             httpx_settings.setdefault("follow_redirects", True)
-        self._client = PrefectHttpxClient(**httpx_settings)
+        self._client = PrefectHttpxClient(**httpx_settings, enable_csrf_support=False)
 
     async def api_healthcheck(self):
         """

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -136,6 +136,7 @@ from prefect.settings import (
     PREFECT_API_REQUEST_TIMEOUT,
     PREFECT_API_TLS_INSECURE_SKIP_VERIFY,
     PREFECT_API_URL,
+    PREFECT_CLIENT_CSRF_SUPPORT_ENABLED,
     PREFECT_CLOUD_API_URL,
     PREFECT_UNIT_TEST_MODE,
 )
@@ -316,7 +317,15 @@ class PrefectClient:
 
         if not PREFECT_UNIT_TEST_MODE:
             httpx_settings.setdefault("follow_redirects", True)
-        self._client = PrefectHttpxClient(**httpx_settings)
+
+        enable_csrf_support = (
+            self.server_type != ServerType.CLOUD
+            and PREFECT_CLIENT_CSRF_SUPPORT_ENABLED.value()
+        )
+
+        self._client = PrefectHttpxClient(
+            **httpx_settings, enable_csrf_support=enable_csrf_support
+        )
         self._loop = None
 
         # See https://www.python-httpx.org/advanced/#custom-transports

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -1632,3 +1632,16 @@ class GlobalConcurrencyLimit(ObjectBaseModel):
             " is used as a rate limit."
         ),
     )
+
+
+class CsrfToken(ObjectBaseModel):
+    token: str = Field(
+        default=...,
+        description="The CSRF token",
+    )
+    client: str = Field(
+        default=..., description="The client id associated with the CSRF token"
+    )
+    expiration: DateTimeTZ = Field(
+        default=..., description="The expiration time of the CSRF token"
+    )

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -657,6 +657,21 @@ A comma-separated list of extra HTTP status codes to retry on. Defaults to an em
 may result in unexpected behavior.
 """
 
+PREFECT_CLIENT_CSRF_SUPPORT_ENABLED = Setting(bool, default=True)
+"""
+Determines if CSRF token handling is active in the Prefect client for API
+requests.
+
+When enabled (`True`), the client automatically manages CSRF tokens by
+retrieving, storing, and including them in applicable state-changing requests
+(POST, PUT, PATCH, DELETE) to the API.
+
+Disabling this setting (`False`) means the client will not handle CSRF tokens,
+which might be suitable for environments where CSRF protection is disabled.
+
+Defaults to `True`, ensuring CSRF protection is enabled by default.
+"""
+
 PREFECT_CLOUD_API_URL = Setting(
     str,
     default="https://api.prefect.cloud/api",
@@ -1208,11 +1223,31 @@ API with another tool you will need to configure this there instead.
 """
 
 PREFECT_SERVER_CSRF_PROTECTION_ENABLED = Setting(bool, default=False)
-"""Whether or not to protect the API from CSRF attacks. Experimental and
-currently defaults to `False`."""
+"""
+Controls the activation of CSRF protection for the Prefect server API.
+
+When enabled (`True`), the server enforces CSRF validation checks on incoming
+state-changing requests (POST, PUT, PATCH, DELETE), requiring a valid CSRF
+token to be included in the request headers or body. This adds a layer of
+security by preventing unauthorized or malicious sites from making requests on
+behalf of authenticated users.
+
+It is recommended to enable this setting in production environments where the
+API is exposed to web clients to safeguard against CSRF attacks.
+
+Note: Enabling this setting requires corresponding support in the client for
+CSRF token management. See PREFECT_CLIENT_CSRF_SUPPORT_ENABLED for more.
+"""
 
 PREFECT_SERVER_CSRF_TOKEN_EXPIRATION = Setting(timedelta, default=timedelta(hours=1))
-"""How long a CSRF token is valid for. Defaults to 1 hour."""
+"""
+Specifies the duration for which a CSRF token remains valid after being issued
+by the server.
+
+The default expiration time is set to 1 hour, which offers a reasonable
+compromise. Adjust this setting based on your specific security requirements
+and usage patterns.
+"""
 
 PREFECT_UI_ENABLED = Setting(
     bool,

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -67,6 +67,7 @@ async def kubernetes_work_pool(prefect_client: PrefectClient):
     with respx.mock(
         assert_all_mocked=False, base_url=PREFECT_API_URL.value()
     ) as respx_mock:
+        respx_mock.get("/csrf-token", params={"client": ANY}).pass_through()
         respx_mock.route(path__startswith="/work_pools/").pass_through()
         respx_mock.route(path__startswith="/flow_runs/").pass_through()
         respx_mock.get("/collections/views/aggregate-worker-metadata").mock(

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -1353,6 +1353,7 @@ async def test_prefect_api_tls_insecure_skip_verify_setting_set_to_true(monkeypa
         transport=ANY,
         base_url=ANY,
         timeout=ANY,
+        enable_csrf_support=ANY,
     )
 
 
@@ -1367,6 +1368,7 @@ async def test_prefect_api_tls_insecure_skip_verify_setting_set_to_false(monkeyp
         transport=ANY,
         base_url=ANY,
         timeout=ANY,
+        enable_csrf_support=ANY,
     )
 
 
@@ -1379,6 +1381,7 @@ async def test_prefect_api_tls_insecure_skip_verify_default_setting(monkeypatch)
         transport=ANY,
         base_url=ANY,
         timeout=ANY,
+        enable_csrf_support=ANY,
     )
 
 

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -1012,6 +1012,7 @@ class TestRunDeployment:
                 ),
             ]
 
+            router.get("/csrf-token", params={"client": mock.ANY}).pass_through()
             router.get(f"/deployments/name/{d.flow_name}/{d.name}").pass_through()
             router.post(f"/deployments/{deployment_id}/create_flow_run").pass_through()
             flow_polls = router.get(re.compile("/flow_runs/.*")).mock(
@@ -1059,6 +1060,7 @@ class TestRunDeployment:
                 ),
             ]
 
+            router.get("/csrf-token", params={"client": mock.ANY}).pass_through()
             router.get(f"/deployments/name/{d.flow_name}/{d.name}").pass_through()
             router.post(f"/deployments/{deployment_id}/create_flow_run").pass_through()
             flow_polls = router.get(re.compile("/flow_runs/.*")).mock(
@@ -1184,6 +1186,7 @@ class TestRunDeployment:
         with respx.mock(
             base_url=PREFECT_API_URL.value(), assert_all_mocked=True
         ) as router:
+            router.get("/csrf-token", params={"client": mock.ANY}).pass_through()
             router.get(f"/deployments/name/{d.flow_name}/{d.name}").pass_through()
             router.post(f"/deployments/{deployment_id}/create_flow_run").pass_through()
             flow_polls = router.request(
@@ -1217,6 +1220,7 @@ class TestRunDeployment:
             assert_all_mocked=True,
             assert_all_called=False,
         ) as router:
+            router.get("/csrf-token", params={"client": mock.ANY}).pass_through()
             router.get(f"/deployments/name/{d.flow_name}/{d.name}").pass_through()
             router.post(f"/deployments/{deployment_id}/create_flow_run").pass_through()
             flow_polls = router.request(
@@ -1261,6 +1265,7 @@ class TestRunDeployment:
             assert_all_mocked=True,
             assert_all_called=False,
         ) as router:
+            router.get("/csrf-token", params={"client": mock.ANY}).pass_through()
             router.get(f"/deployments/name/{d.flow_name}/{d.name}").pass_through()
             router.post(f"/deployments/{deployment_id}/create_flow_run").pass_through()
             flow_polls = router.request(


### PR DESCRIPTION
Adds CSRF support to orchestration client.

When a request is made to a POST, PATCH, PUT, or DELETE endpoint the orchestration client will ensure that it has a valid token and attach the CSRF headers to the request. In the event that a request fails because of CSRF token validation the client will automatically retry after refreshing the CSRF token. 

This support is disabled when talking to Cloud, but is otherwise enabled by default as we need to assume that all prefect servers have CSRF enabled. In the event that a client is talking to an older server that does not have the CSRF token endpoint it will disable its csrf support after receiving a 404. 

If a user knows that they do not need CSRF support, due to an older server or one that has CSRF protection disabled they can set `PREFECT_CLIENT_CSRF_SUPPORT_ENABLED` to `False` to disable support entirely.

Closes #12304

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.