### PR TITLE
Keep artifacts file in prefect-client

### DIFF
--- a/client/build_client.sh
+++ b/client/build_client.sh
@@ -15,7 +15,6 @@ cp -rf ./ $TMPDIR
 cd $TMPDIR/src/prefect
 
 # delete the files we don't need
-rm artifacts.py
 rm -rf cli/
 rm -rf deployments/recipes/
 rm -rf deployments/templates


### PR DESCRIPTION
This PR changes our prefect-client build process to include our artifacts module for creating and working with artifacts.

Closes #12315 
<!-- Include an overview here -->

### Example
Users who install `prefect-client` will be able to do this now:
```python
from prefect.artifacts import create_markdown_artifact
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [-] This pull request includes tests or only affects documentation.
- [X] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->