### PR TITLE
Wire up vermin to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,5 +9,9 @@ repos:
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:
-    - id: codespell
-      exclude: package-lock.json|_vendor/.*
+      - id: codespell
+        exclude: package-lock.json|_vendor/.*
+  - repo: https://github.com/netromdk/vermin
+    rev: v1.6.0
+    hooks:
+      - id: vermin

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,6 +31,7 @@ pytkdocs >= 0.14.2
 pyyaml
 requests
 setuptools != 60.9.0; python_version < '3.8'
+vermin
 virtualenv
 watchfiles
 respx

--- a/setup.cfg
+++ b/setup.cfg
@@ -118,3 +118,14 @@ omit =
     src/prefect/server/database/migrations/versions/*
 
 ignore_errors = True
+
+[vermin]
+make_paths_absolute = no
+backports =
+    typing_extensions
+format = parsable
+eval_annotations = yes
+only_show_violations = yes
+targets = 3.8-
+exclusion_regex = ^src/prefect/_vendor/.*$|^src/prefect/utilities/compat\.py$
+

--- a/src/prefect/_internal/concurrency/calls.py
+++ b/src/prefect/_internal/concurrency/calls.py
@@ -2,6 +2,7 @@
 Implementation of the `Call` data structure for transport of deferred function calls
 and low-level management of call execution.
 """
+
 import abc
 import asyncio
 import concurrent.futures
@@ -40,8 +41,8 @@ P = ParamSpec("P")
 # we already have strong references to the `Call` objects in other places
 # and b) this is used for performance optimizations where we have fallback
 # behavior if this weakref is garbage collected. A fix for issue #10952.
-current_call: contextvars.ContextVar["weakref.ref[Call]"] = contextvars.ContextVar(
-    "current_call"
+current_call: contextvars.ContextVar["weakref.ref[Call]"] = (  # novm
+    contextvars.ContextVar("current_call")
 )
 
 # Create a strong reference to tasks to prevent destruction during execution errors

--- a/src/prefect/client/subscriptions.py
+++ b/src/prefect/client/subscriptions.py
@@ -74,9 +74,9 @@ class Subscription(Generic[S]):
             auth: Dict[str, Any] = orjson.loads(await websocket.recv())
             assert auth["type"] == "auth_success", auth.get("message")
 
-            message = {"type": "subscribe", "keys": self.keys} | {
-                **(dict(client_id=self.client_id) if self.client_id else {})
-            }
+            message = {"type": "subscribe", "keys": self.keys}
+            if self.client_id:
+                message.update({"client_id": self.client_id})
 
             await websocket.send(orjson.dumps(message).decode())
         except (

--- a/src/prefect/events/related.py
+++ b/src/prefect/events/related.py
@@ -74,7 +74,7 @@ async def related_resources_from_run_context(
     if flow_run_id is None:
         return []
 
-    related_objects: list[ResourceCacheEntry] = []
+    related_objects: List[ResourceCacheEntry] = []
 
     async with get_client() as client:
 

--- a/src/prefect/server/database/configurations.py
+++ b/src/prefect/server/database/configurations.py
@@ -30,7 +30,7 @@ from prefect.settings import (
 )
 from prefect.utilities.asyncutils import add_event_loop_shutdown_callback
 
-SQLITE_BEGIN_MODE: ContextVar[Optional[str]] = ContextVar(
+SQLITE_BEGIN_MODE: ContextVar[Optional[str]] = ContextVar(  # novm
     "SQLITE_BEGIN_MODE", default=None
 )
 

--- a/src/prefect/task_server.py
+++ b/src/prefect/task_server.py
@@ -6,7 +6,7 @@ import socket
 import sys
 from contextlib import AsyncExitStack
 from functools import partial
-from typing import Optional, Type
+from typing import List, Optional, Type
 
 import anyio
 from websockets.exceptions import InvalidStatusCode
@@ -72,7 +72,7 @@ class TaskServer:
         *tasks: Task,
         task_runner: Optional[Type[BaseTaskRunner]] = None,
     ):
-        self.tasks: list[Task] = tasks
+        self.tasks: List[Task] = tasks
 
         self.task_runner: BaseTaskRunner = task_runner or ConcurrentTaskRunner()
         self.started: bool = False

--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -1,6 +1,7 @@
 """
 Utilities for working with Python callables.
 """
+
 import inspect
 from functools import partial
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
@@ -312,8 +313,9 @@ def parameter_schema(fn: Callable) -> ParameterSchema:
         ParameterSchema: the argument schema
     """
     try:
-        signature = inspect.signature(fn, eval_str=True)
+        signature = inspect.signature(fn, eval_str=True)  # novm
     except (NameError, TypeError):
+        # `eval_str` is not available in Python < 3.10
         signature = inspect.signature(fn)
 
     model_fields = {}

--- a/tests/_internal/concurrency/conftest.py
+++ b/tests/_internal/concurrency/conftest.py
@@ -1,5 +1,6 @@
 import threading
 import time
+from typing import List
 
 import pytest
 
@@ -29,7 +30,7 @@ def check_thread_leak():
 
         # Give leaked threads a 5 second grace period to teardown
         if time.time() > start + 5:
-            lines: list[str] = [f"{len(bad_threads)} thread(s) were leaked from test\n"]
+            lines: List[str] = [f"{len(bad_threads)} thread(s) were leaked from test\n"]
             lines += [
                 f"\t{hex(thread.ident)} - {thread.name}\n" for thread in bad_threads
             ]

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -196,7 +196,7 @@ class TestServe:
         else:
 
             @flow
-            def type_container_input_flow(arg1: list[str]) -> str:
+            def type_container_input_flow(arg1: List[str]) -> str:
                 print(arg1)
                 return ",".join(arg1)
 

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1391,7 +1391,7 @@ class TestFlowParameterTypes:
         else:
 
             @flow
-            def type_container_input_flow(arg1: list[str]) -> str:
+            def type_container_input_flow(arg1: List[str]) -> str:
                 print(arg1)
                 return ",".join(arg1)
 


### PR DESCRIPTION
Vermin is a utility for detecting which python version is supported for a given python file. This wires it up to our pre-commit and sets the config such that any file that doesn't pass at our minimum python version, 3.8, will get a pre-commit failure:

```
Check minimum Python version.............................................Failed
- hook id: vermin
- exit code: 1

tests/test_flows.py:1394::!2:3.9:builtin generic type annotation (list[..])
tests/test_flows.py:::!2:3.9:
:::!2:3.9:
```
