### PR TITLE
Fix `db.insert` typing

### DIFF
--- a/src/prefect/server/database/interface.py
+++ b/src/prefect/server/database/interface.py
@@ -324,7 +324,7 @@ class PrefectDBInterface(metaclass=DBSingleton):
         """Unique columns for upserting a BlockDocument"""
         return self.orm.block_document_unique_upsert_columns
 
-    async def insert(self, model):
+    def insert(self, model):
         """INSERTs a model into the database"""
         return self.queries.insert(model)
 

--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -58,7 +58,7 @@ class BaseQueryComponents(ABC):
     # --- dialect-specific SqlAlchemy bindings
 
     @abstractmethod
-    def insert(self, obj):
+    def insert(self, obj) -> Union[postgresql.Insert, sqlite.Insert]:
         """dialect-specific insert statement"""
 
     @abstractmethod
@@ -619,7 +619,7 @@ class BaseQueryComponents(ABC):
 class AsyncPostgresQueryComponents(BaseQueryComponents):
     # --- Postgres-specific SqlAlchemy bindings
 
-    def insert(self, obj):
+    def insert(self, obj) -> postgresql.Insert:
         return postgresql.insert(obj)
 
     def greatest(self, *values):
@@ -945,7 +945,7 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
 class AioSqliteQueryComponents(BaseQueryComponents):
     # --- Sqlite-specific SqlAlchemy bindings
 
-    def insert(self, obj):
+    def insert(self, obj) -> sqlite.Insert:
         return sqlite.insert(obj)
 
     def greatest(self, *values):

--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -122,7 +122,7 @@ class BaseQueryComponents(ABC):
     ):
         """Database-specific implementation of queueing notifications for a flow run"""
         # insert a <policy, state> pair into the notification queue
-        stmt = (await db.insert(db.FlowRunNotificationQueue)).from_select(
+        stmt = db.insert(db.FlowRunNotificationQueue).from_select(
             [
                 db.FlowRunNotificationQueue.flow_run_notification_policy_id,
                 db.FlowRunNotificationQueue.flow_run_state_id,

--- a/src/prefect/server/models/agents.py
+++ b/src/prefect/server/models/agents.py
@@ -143,7 +143,7 @@ async def record_agent_poll(
         id=agent_id, work_queue_id=work_queue_id, last_activity_time=pendulum.now("UTC")
     )
     insert_stmt = (
-        (await db.insert(db.Agent))
+        db.insert(db.Agent)
         .values(
             **agent_data.dict(
                 include={"id", "name", "work_queue_id", "last_activity_time"}

--- a/src/prefect/server/models/artifacts.py
+++ b/src/prefect/server/models/artifacts.py
@@ -24,7 +24,7 @@ async def _insert_into_artifact_collection(
         shallow=True, exclude_unset=True, exclude={"id", "updated", "created"}
     )
     upsert_new_latest_id = (
-        (await db.insert(db.ArtifactCollection))
+        db.insert(db.ArtifactCollection)
         .values(latest_id=artifact.id, updated=now, created=now, **insert_values)
         .on_conflict_do_update(
             index_elements=db.artifact_collection_unique_upsert_columns,
@@ -78,7 +78,7 @@ async def _insert_into_artifact(
     Inserts a new artifact into the artifact table.
     """
     artifact_id = artifact.id
-    insert_stmt = (await db.insert(db.Artifact)).values(
+    insert_stmt = db.insert(db.Artifact).values(
         created=now,
         updated=now,
         **artifact.dict(exclude={"created", "updated"}, shallow=True),

--- a/src/prefect/server/models/block_documents.py
+++ b/src/prefect/server/models/block_documents.py
@@ -2,6 +2,7 @@
 Functions for interacting with block document ORM objects.
 Intended for internal use by the Prefect REST API.
 """
+
 from copy import copy
 from typing import Dict, List, Optional, Tuple
 from uuid import UUID, uuid4
@@ -625,7 +626,7 @@ async def create_block_document_reference(
     block_document_reference: schemas.actions.BlockDocumentReferenceCreate,
     db: PrefectDBInterface,
 ):
-    insert_stmt = (await db.insert(db.BlockDocumentReference)).values(
+    insert_stmt = db.insert(db.BlockDocumentReference).values(
         **block_document_reference.dict(
             shallow=True, exclude_unset=True, exclude={"created", "updated"}
         )

--- a/src/prefect/server/models/block_schemas.py
+++ b/src/prefect/server/models/block_schemas.py
@@ -2,6 +2,7 @@
 Functions for interacting with block schema ORM objects.
 Intended for internal use by the Prefect REST API.
 """
+
 import json
 from copy import copy
 from typing import Dict, List, Optional, Tuple, Union
@@ -90,7 +91,7 @@ async def create_block_schema(
         "block_schema_references", {}
     )
 
-    insert_stmt = (await db.insert(db.BlockSchema)).values(**insert_values)
+    insert_stmt = db.insert(db.BlockSchema).values(**insert_values)
     if override:
         insert_stmt = insert_stmt.on_conflict_do_update(
             index_elements=db.block_schema_unique_upsert_columns,
@@ -799,7 +800,7 @@ async def create_block_schema_reference(
     if existing_reference:
         return existing_reference
 
-    insert_stmt = (await db.insert(db.BlockSchemaReference)).values(
+    insert_stmt = db.insert(db.BlockSchemaReference).values(
         **block_schema_reference.dict(
             shallow=True, exclude_unset=True, exclude={"created", "updated"}
         )

--- a/src/prefect/server/models/block_types.py
+++ b/src/prefect/server/models/block_types.py
@@ -2,6 +2,7 @@
 Functions for interacting with block type ORM objects.
 Intended for internal use by the Prefect REST API.
 """
+
 import html
 from typing import Optional
 from uuid import UUID
@@ -42,7 +43,7 @@ async def create_block_type(
         insert_values["code_example"] = html.escape(
             insert_values["code_example"], quote=False
         )
-    insert_stmt = (await db.insert(db.BlockType)).values(**insert_values)
+    insert_stmt = db.insert(db.BlockType).values(**insert_values)
     if override:
         insert_stmt = insert_stmt.on_conflict_do_update(
             index_elements=db.block_type_unique_upsert_columns,

--- a/src/prefect/server/models/concurrency_limits.py
+++ b/src/prefect/server/models/concurrency_limits.py
@@ -31,7 +31,7 @@ async def create_concurrency_limit(
     concurrency_limit.updated = pendulum.now("UTC")
 
     insert_stmt = (
-        (await db.insert(db.ConcurrencyLimit))
+        db.insert(db.ConcurrencyLimit)
         .values(**insert_values)
         .on_conflict_do_update(
             index_elements=db.concurrency_limit_unique_upsert_columns,

--- a/src/prefect/server/models/csrf_token.py
+++ b/src/prefect/server/models/csrf_token.py
@@ -35,7 +35,7 @@ async def create_or_update_csrf_token(
     token = secrets.token_hex(32)
 
     await session.execute(
-        (await db.insert(db.CsrfToken))
+        db.insert(db.CsrfToken)
         .values(
             client=client,
             token=token,

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -83,7 +83,7 @@ async def create_deployment(
     )
 
     insert_stmt = (
-        (await db.insert(db.Deployment))
+        db.insert(db.Deployment)
         .values(**insert_values)
         .on_conflict_do_update(
             index_elements=db.deployment_unique_upsert_columns,

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -663,9 +663,10 @@ async def _insert_scheduled_flow_runs(
     # gracefully insert the flow runs against the idempotency key
     # this syntax (insert statement, values to insert) is most efficient
     # because it uses a single bind parameter
-    insert = await db.insert(db.FlowRun)
     await session.execute(
-        insert.on_conflict_do_nothing(index_elements=db.flow_run_unique_upsert_columns),
+        db.insert(db.FlowRun).on_conflict_do_nothing(
+            index_elements=db.flow_run_unique_upsert_columns
+        ),
         runs,
     )
 

--- a/src/prefect/server/models/flow_runs.py
+++ b/src/prefect/server/models/flow_runs.py
@@ -78,7 +78,7 @@ async def create_flow_run(
     # otherwise let the database take care of enforcing idempotency
     else:
         insert_stmt = (
-            (await db.insert(db.FlowRun))
+            db.insert(db.FlowRun)
             .values(**flow_run_dict)
             .on_conflict_do_nothing(
                 index_elements=db.flow_run_unique_upsert_columns,

--- a/src/prefect/server/models/flows.py
+++ b/src/prefect/server/models/flows.py
@@ -31,7 +31,7 @@ async def create_flow(
     """
 
     insert_stmt = (
-        (await db.insert(db.Flow))
+        db.insert(db.Flow)
         .values(**flow.dict(shallow=True, exclude_unset=True))
         .on_conflict_do_nothing(
             index_elements=db.flow_unique_upsert_columns,

--- a/src/prefect/server/models/logs.py
+++ b/src/prefect/server/models/logs.py
@@ -2,6 +2,7 @@
 Functions for interacting with log ORM objects.
 Intended for internal use by the Prefect REST API.
 """
+
 from typing import List
 
 from sqlalchemy import select
@@ -41,8 +42,7 @@ async def create_logs(
     Returns:
         None
     """
-    log_insert = await db.insert(db.Log)
-    await session.execute(log_insert.values([log.dict() for log in logs]))
+    await session.execute(db.insert(db.Log).values([log.dict() for log in logs]))
 
 
 @inject_db

--- a/src/prefect/server/models/saved_searches.py
+++ b/src/prefect/server/models/saved_searches.py
@@ -34,7 +34,7 @@ async def create_saved_search(
     """
 
     insert_stmt = (
-        (await db.insert(db.SavedSearch))
+        db.insert(db.SavedSearch)
         .values(**saved_search.dict(shallow=True, exclude_unset=True))
         .on_conflict_do_update(
             index_elements=db.saved_search_unique_upsert_columns,

--- a/src/prefect/server/models/task_runs.py
+++ b/src/prefect/server/models/task_runs.py
@@ -57,7 +57,7 @@ async def create_task_run(
     # if a dynamic key exists, we need to guard against conflicts
     if task_run.flow_run_id:
         insert_stmt = (
-            (await db.insert(db.TaskRun))
+            db.insert(db.TaskRun)
             .values(
                 created=now,
                 **task_run.dict(

--- a/src/prefect/server/models/workers.py
+++ b/src/prefect/server/models/workers.py
@@ -2,6 +2,7 @@
 Functions for interacting with worker ORM objects.
 Intended for internal use by the Prefect REST API.
 """
+
 import datetime
 from typing import Dict, List, Optional
 from uuid import UUID
@@ -629,7 +630,7 @@ async def worker_heartbeat(
         update_values["heartbeat_interval_seconds"] = heartbeat_interval_seconds
 
     insert_stmt = (
-        (await db.insert(db.Worker))
+        db.insert(db.Worker)
         .values(**base_values, **update_values)
         .on_conflict_do_update(
             index_elements=[

--- a/tests/server/api/test_workers.py
+++ b/tests/server/api/test_workers.py
@@ -681,7 +681,7 @@ class TestWorkPoolStatus:
         """Work pools with only offline workers should have a status of NOT_READY."""
         now = pendulum.now("UTC")
 
-        insert_stmt = (await db.insert(db.Worker)).values(
+        insert_stmt = db.insert(db.Worker).values(
             name="old-worker",
             work_pool_id=work_pool.id,
             last_heartbeat_time=now.subtract(minutes=5),
@@ -805,7 +805,7 @@ class TestWorkerProcess:
     ):
         now = pendulum.now("UTC")
 
-        insert_stmt = (await db.insert(db.Worker)).values(
+        insert_stmt = db.insert(db.Worker).values(
             name="old-worker",
             work_pool_id=work_pool.id,
             last_heartbeat_time=now.subtract(minutes=5),
@@ -832,7 +832,7 @@ class TestWorkerProcess:
         """
         now = pendulum.now("UTC")
 
-        insert_stmt = (await db.insert(db.Worker)).values(
+        insert_stmt = db.insert(db.Worker).values(
             name="old-worker",
             work_pool_id=work_pool.id,
             last_heartbeat_time=now.subtract(seconds=10),


### PR DESCRIPTION
This updates the typing on `db.insert` to be accurate as well as makes it a sync function as it does not do anything async.

Before:

![Screenshot 2024-03-15 at 3 27 28 PM](https://github.com/PrefectHQ/prefect/assets/354286/19ba9dc6-53a4-4411-8d9a-8a2dad0141d6)

After:

![Screenshot 2024-03-15 at 3 27 39 PM](https://github.com/PrefectHQ/prefect/assets/354286/b3a98972-2048-4d16-9060-fe721eb106f7)
