### PR TITLE
refactor task key logic

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -283,13 +283,14 @@ class Task(Generic[P, R]):
         if not hasattr(self.fn, "__qualname__"):
             self.task_key = to_qualified_name(type(self.fn))
         else:
-            if self.fn.__module__ == "__main__":
-                task_definition_path = inspect.getsourcefile(self.fn)
-                self.task_key = hash_objects(
-                    self.name, os.path.abspath(task_definition_path)
+            try:
+                task_origin_hash = hash_objects(
+                    self.name, os.path.abspath(inspect.getsourcefile(self.fn))
                 )
-            else:
-                self.task_key = to_qualified_name(self.fn)
+            except TypeError:
+                task_origin_hash = "unknown-source-file"
+
+            self.task_key = f"{self.fn.__qualname__}-{task_origin_hash}"
 
         self.cache_key_fn = cache_key_fn
         self.cache_expiration = cache_expiration


### PR DESCRIPTION
https://github.com/PrefectHQ/prefect/pull/12227 didn't quite cover everything we needed

because tasks would go through their `__init__` again at import time when submitting a task defined elsewhere, the `__module__` is not guaranteed to be the same between where the task is served and submitted. Therefore checking if `__main__` is in the module would only solve half the problem.

this PR updates the `task_key` of `Task` (when a `__qualname__` exists) to be a composite of the `__qualname__` (static, not relative to the importer) and a hash of the absolute path where the task is defined, which leaves the door open to referring to the tasks by string name, in arq-style.

note that this still works in interactive environments like `ipython`
```python
In [2]: from prefect import task
   ...: from prefect.task_server import serve
   ...:
   ...: with temporary_settings({PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING: True}):
   ...:     @task
   ...:     def foo():
   ...:         pass
   ...:     foo.submit()
   ...:     serve(foo)
   ```