### PR TITLE
Return 422 when CSRF is disabled and delete expired tokens

### DIFF
--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -361,9 +361,16 @@ class PrefectHttpxClient(httpx.AsyncClient):
             try:
                 token_response = await self.send(token_request)
             except PrefectHTTPStatusError as exc:
-                if exc.response.status_code == status.HTTP_404_NOT_FOUND:
-                    # The token endpoint is not available, likely an older
-                    # server version; disable CSRF support
+                old_sever = exc.response.status_code == status.HTTP_404_NOT_FOUND
+                unconfigured_server = (
+                    exc.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+                    and "CSRF protection is disabled." in exc.response.text
+                )
+
+                if old_sever or unconfigured_server:
+                    # The token endpoint is either unavailable, suggesting an
+                    # older server, or CSRF protection is disabled. In either
+                    # case we should disable CSRF support.
                     self.enable_csrf_support = False
                     return
 

--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -361,13 +361,13 @@ class PrefectHttpxClient(httpx.AsyncClient):
             try:
                 token_response = await self.send(token_request)
             except PrefectHTTPStatusError as exc:
-                old_sever = exc.response.status_code == status.HTTP_404_NOT_FOUND
+                old_server = exc.response.status_code == status.HTTP_404_NOT_FOUND
                 unconfigured_server = (
                     exc.response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
                     and "CSRF protection is disabled." in exc.response.text
                 )
 
-                if old_sever or unconfigured_server:
+                if old_server or unconfigured_server:
                     # The token endpoint is either unavailable, suggesting an
                     # older server, or CSRF protection is disabled. In either
                     # case we should disable CSRF support.

--- a/src/prefect/server/api/csrf_token.py
+++ b/src/prefect/server/api/csrf_token.py
@@ -1,14 +1,25 @@
-from prefect._vendor.fastapi import Depends, Query
+import random
+
+from prefect._vendor.fastapi import Depends, Query, status
+from prefect._vendor.starlette.exceptions import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.logging import get_logger
 from prefect.server import models, schemas
 from prefect.server.database.dependencies import provide_database_interface
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.utilities.server import PrefectRouter
+from prefect.settings import PREFECT_SERVER_CSRF_PROTECTION_ENABLED
 
 logger = get_logger("server.api")
 
 router = PrefectRouter(prefix="/csrf-token")
+
+
+async def _cleanup_expired_tokens(session: AsyncSession):
+    # Clean up expired tokens on 10% of requests.
+    if random.random() < 0.1:
+        await models.csrf_token.delete_expired_tokens(session=session)
 
 
 @router.get("")
@@ -17,7 +28,16 @@ async def create_csrf_token(
     client: str = Query(..., description="The client to create a CSRF token for"),
 ) -> schemas.core.CsrfToken:
     """Create or update a CSRF token for a client"""
+    if PREFECT_SERVER_CSRF_PROTECTION_ENABLED.value() is False:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="CSRF protection is disabled.",
+        )
+
     async with db.session_context(begin_transaction=True) as session:
-        return await models.csrf_token.create_or_update_csrf_token(
+        token = await models.csrf_token.create_or_update_csrf_token(
             session=session, client=client
         )
+        await _cleanup_expired_tokens(session=session)
+
+    return token

--- a/src/prefect/server/api/csrf_token.py
+++ b/src/prefect/server/api/csrf_token.py
@@ -1,8 +1,5 @@
-import random
-
 from prefect._vendor.fastapi import Depends, Query, status
 from prefect._vendor.starlette.exceptions import HTTPException
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.logging import get_logger
 from prefect.server import models, schemas
@@ -14,12 +11,6 @@ from prefect.settings import PREFECT_SERVER_CSRF_PROTECTION_ENABLED
 logger = get_logger("server.api")
 
 router = PrefectRouter(prefix="/csrf-token")
-
-
-async def _cleanup_expired_tokens(session: AsyncSession):
-    # Clean up expired tokens on 10% of requests.
-    if random.random() < 0.1:
-        await models.csrf_token.delete_expired_tokens(session=session)
 
 
 @router.get("")
@@ -38,6 +29,6 @@ async def create_csrf_token(
         token = await models.csrf_token.create_or_update_csrf_token(
             session=session, client=client
         )
-        await _cleanup_expired_tokens(session=session)
+        await models.csrf_token.delete_expired_tokens(session=session)
 
     return token

--- a/tests/client/test_base_client.py
+++ b/tests/client/test_base_client.py
@@ -57,6 +57,12 @@ RESPONSE_404 = Response(
     request=Request("a test request", "fake.url/fake/route"),
 )
 
+RESPONSE_CSRF_DISABLED = Response(
+    status.HTTP_422_UNPROCESSABLE_ENTITY,
+    json={"detail": "CSRF protection is disabled."},
+    request=Request("a test request", "fake.url/fake/route"),
+)
+
 RESPONSE_INVALID_TOKEN = Response(
     status_code=status.HTTP_403_FORBIDDEN,
     json={"detail": "Invalid CSRF token or client identifier."},
@@ -675,6 +681,15 @@ class TestCsrfSupport:
 
     async def test_disables_csrf_support_404_token_endpoint(self):
         async with mocked_client(responses=[RESPONSE_404, RESPONSE_200]) as (
+            client,
+            send,
+        ):
+            assert client.enable_csrf_support is True
+            await client.post(url="fake.url/fake/route")
+            assert client.enable_csrf_support is False
+
+    async def test_disables_csrf_support_422_csrf_disabled(self):
+        async with mocked_client(responses=[RESPONSE_CSRF_DISABLED, RESPONSE_200]) as (
             client,
             send,
         ):

--- a/tests/server/models/test_csrf_token.py
+++ b/tests/server/models/test_csrf_token.py
@@ -124,19 +124,8 @@ class TestDeleteExpiredTokens:
 
         await models.csrf_token.delete_expired_tokens(session=session)
 
-        removed = [
-            await models.csrf_token.read_token_for_client(
-                session=session, client=f"client{i}"
-            )
-            for i in range(2)
-        ]
+        all_tokens = (await session.execute(sa.select(db.CsrfToken))).scalars().all()
 
-        existing = [
-            await models.csrf_token.read_token_for_client(
-                session=session, client=f"client{i}"
-            )
-            for i in range(2, 5)
-        ]
-
-        assert removed == [None, None]
-        assert all(token is not None for token in existing)
+        assert len(all_tokens) == 3
+        assert "client0" not in [t.client for t in all_tokens]
+        assert "client1" not in [t.client for t in all_tokens]


### PR DESCRIPTION
This PR has a couple UX enhancements for the CSRF endpoint:

1. When CSRF protection is disabled, the server will now respond with a `422` noting that CSRF protection is disabled. The client will look for this and turn off CSRF support in the event that it receives this response.
2. Expired tokens are deleted when creating new tokens.

Closes #12338 
Closes #12339 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.