### PR TITLE
Pin Buildkit to 0.12.5 to fix issue with test image build

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -41,7 +41,7 @@ jobs:
         if: ${{ matrix.build-docker-images }}
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.12.1
+          driver-opts: image=moby/buildkit:v0.12.5
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
@@ -70,7 +70,6 @@ jobs:
             ${{ runner.os }}-${{ github.base_ref }}-
             ${{ runner.os }}-main-
 
-
       - name: Start server
         run: |
           prefect server start&
@@ -88,4 +87,3 @@ jobs:
           python benches
           --benchmark-save="${uniquename//\//_}"
           ${{ steps.bench-cache.outputs.cache-hit && '--benchmark-compare' || ''}}
-

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -8,25 +8,23 @@ on:
   push:
     branches: main
     paths:
-      - 'Dockerfile'
-      - '.dockerignore'
-      - 'setup.py'
-      - 'src/**'
-      - 'tests/**'
-      - 'requirements.txt'
-      - 'requirements-client.txt'
-      - 'MANIFEST.in'
-      - 'setup.cfg'
-      - 'versioneer.py'
-      - '.gitingore'
-      - '.gitattributes'
-      - '.github/workflows/docker-images.yaml'
-      - 'ui/**'
-
+      - "Dockerfile"
+      - ".dockerignore"
+      - "setup.py"
+      - "src/**"
+      - "tests/**"
+      - "requirements.txt"
+      - "requirements-client.txt"
+      - "MANIFEST.in"
+      - "setup.cfg"
+      - "versioneer.py"
+      - ".gitingore"
+      - ".gitattributes"
+      - ".github/workflows/docker-images.yaml"
+      - "ui/**"
 
   # On workflow_dispatch, push sha and branch patterns to prefect-dev
   workflow_dispatch:
-
 
 jobs:
   publish-docker-images:
@@ -53,7 +51,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.12.1
+          driver-opts: image=moby/buildkit:v0.12.5
 
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.12.1
+          driver-opts: image=moby/buildkit:v0.12.5
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -230,7 +230,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.12.1
+          driver-opts: image=moby/buildkit:v0.12.5
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -391,7 +391,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.12.1
+          driver-opts: image=moby/buildkit:v0.12.5
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -588,7 +588,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.12.1
+          driver-opts: image=moby/buildkit:v0.12.5
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
We had builds failing with:

```
ERROR: failed to solve: failed to compute cache key: blob sha256:3aa78131f5aa6760ebe0b219764d4ae523872584040fefe3ff754cb42c402ca0 not found
Error: buildx failed with: ERROR: failed to solve: failed to compute cache key: blob sha256:3aa78131f5aa6760ebe0b219764d4ae523872584040fefe3ff754cb42c402ca0 not found
```
-- https://github.com/PrefectHQ/prefect/actions/runs/8331581620/job/22799600345?pr=12342

Which appears to be a regression issue with buildkit 0.13 (https://github.com/moby/buildkit/pull/4771). 

This pins buildkit to 0.12.5.