### PR TITLE
Update `aggregate-worker-metadata` from `prefect-gcp` release

### DIFF
--- a/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
+++ b/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
@@ -912,8 +912,7 @@
             "metadata": {
               "name": "{{ name }}",
               "annotations": {
-                "run.googleapis.com/launch-stage": "BETA",
-                "run.googleapis.com/vpc-access-connector": "{{ vpc_connector_name }}"
+                "run.googleapis.com/launch-stage": "BETA"
               }
             },
             "spec": {
@@ -940,6 +939,11 @@
                       "timeoutSeconds": "{{ timeout }}",
                       "serviceAccountName": "{{ service_account_name }}"
                     }
+                  }
+                },
+                "metadata": {
+                  "annotations": {
+                    "run.googleapis.com/vpc-access-connector": "{{ vpc_connector_name }}"
                   }
                 }
               }
@@ -1093,8 +1097,10 @@
             "launchStage": "{{ launch_stage }}",
             "template": {
               "template": {
+                "serviceAccount": "{{ service_account_name }}",
                 "maxRetries": "{{ max_retries }}",
                 "timeout": "{{ timeout }}",
+                "vpcAccess": "{{ vpc_connector_name }}",
                 "containers": [
                   {
                     "env": [],
@@ -1229,6 +1235,12 @@
               "title": "VPC Connector Name",
               "description": "The name of the VPC connector to use for the Cloud Run job.",
               "type": "string"
+            },
+            "service_account_name": {
+              "title": "Service Account Name",
+              "description": "The name of the service account to use for the task execution of Cloud Run Job. By default Cloud Run jobs run as the default Compute Engine Service Account.",
+              "example": "service-account@example.iam.gserviceaccount.com",
+              "type": "string"
             }
           },
           "definitions": {
@@ -1268,7 +1280,7 @@
       "documentation_url": "https://prefecthq.github.io/prefect-gcp/worker_v2/",
       "install_command": "pip install prefect-gcp",
       "is_beta": false,
-      "logo_url": "https://cdn.sanity.io/images/3ugk85nk/production/10424e311932e31c477ac2b9ef3d53cefbaad708-250x250.png",
+      "logo_url": "https://images.ctfassets.net/gm98wzqotmnx/4SpnOBvMYkHp6z939MDKP6/549a91bc1ce9afd4fb12c68db7b68106/social-icon-google-cloud-1200-630.png?h=250",
       "type": "cloud-run-v2"
     },
     "vertex-ai": {

--- a/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
+++ b/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
@@ -1280,7 +1280,7 @@
       "documentation_url": "https://prefecthq.github.io/prefect-gcp/worker_v2/",
       "install_command": "pip install prefect-gcp",
       "is_beta": false,
-      "logo_url": "https://images.ctfassets.net/gm98wzqotmnx/4SpnOBvMYkHp6z939MDKP6/549a91bc1ce9afd4fb12c68db7b68106/social-icon-google-cloud-1200-630.png?h=250",
+      "logo_url": "https://cdn.sanity.io/images/3ugk85nk/production/10424e311932e31c477ac2b9ef3d53cefbaad708-250x250.png",
       "type": "cloud-run-v2"
     },
     "vertex-ai": {


### PR DESCRIPTION
ports changes for `cloud-run` worker from recent `prefect-gcp` release