### PR TITLE
[pydantic v2] init compat layer

### DIFF
--- a/src/prefect/_internal/pydantic/__init__.py
+++ b/src/prefect/_internal/pydantic/__init__.py
@@ -9,3 +9,5 @@
 from pydantic.version import VERSION as PYDANTIC_VERSION
 
 HAS_PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
+
+from ._compat import model_dump, IncEx

--- a/src/prefect/_internal/pydantic/_compat.py
+++ b/src/prefect/_internal/pydantic/_compat.py
@@ -27,12 +27,13 @@ def model_dump(
     round_trip: bool = False,
     warnings: bool = True,
 ) -> Dict[str, Any]:
-    should_dump_as_v2_model = all(
-        [
-            HAS_PYDANTIC_V2,
-            PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS,
-            isinstance(model_instance, BaseModel),
-        ]
+    if not isinstance(model_instance, BaseModel):
+        raise TypeError(
+            f"Expected a Pydantic model, but got {type(model_instance).__name__}"
+        )
+
+    should_dump_as_v2_model = (
+        HAS_PYDANTIC_V2 and PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS
     )
 
     if should_dump_as_v2_model:

--- a/src/prefect/_internal/pydantic/_compat.py
+++ b/src/prefect/_internal/pydantic/_compat.py
@@ -1,0 +1,57 @@
+from typing import Any, Dict, Literal, Set, Union
+
+import typing_extensions
+from pydantic import BaseModel
+
+from prefect._internal.pydantic import HAS_PYDANTIC_V2
+from prefect.settings import PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS
+
+IncEx: typing_extensions.TypeAlias = (
+    "Union[Set[int], Set[str], Dict[int, Any], Dict[str, Any], None]"
+)
+
+
+def model_dump(
+    model_instance: BaseModel,
+    *,
+    mode: Union[Literal["json", "python"], str] = "python",
+    include: IncEx = None,
+    exclude: IncEx = None,
+    by_alias: bool = False,
+    exclude_unset: bool = False,
+    exclude_defaults: bool = False,
+    exclude_none: bool = False,
+    round_trip: bool = False,
+    warnings: bool = True,
+) -> Dict[str, Any]:
+    if HAS_PYDANTIC_V2:
+        if PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS:
+            return model_instance.model_dump(
+                mode=mode,
+                include=include,
+                exclude=exclude,
+                by_alias=by_alias,
+                exclude_unset=exclude_unset,
+                exclude_defaults=exclude_defaults,
+                exclude_none=exclude_none,
+                round_trip=round_trip,
+                warnings=warnings,
+            )
+        else:
+            return model_instance.dict(
+                include=include,
+                exclude=exclude,
+                by_alias=by_alias,
+                exclude_unset=exclude_unset,
+                exclude_defaults=exclude_defaults,
+                exclude_none=exclude_none,
+            )
+    else:
+        return model_instance.dict(
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+        )

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1567,6 +1567,10 @@ PREFECT_EXPERIMENTAL_ENABLE_WORK_QUEUE_STATUS = Setting(bool, default=True)
 Whether or not to enable experimental work queue status in-place of work queue health.
 """
 
+PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS = Setting(bool, default=False)
+"""
+Whether or not to enable internal experimental Pydantic v2 behavior.
+"""
 
 # Defaults -----------------------------------------------------------------------------
 

--- a/tests/_internal/pydantic/test_model_dump.py
+++ b/tests/_internal/pydantic/test_model_dump.py
@@ -43,3 +43,8 @@ def test_model_dump_with_flag_disabled(caplog):
         assert "Pydantic v2 compatibility layer is disabled" in caplog.text
     else:
         assert "Pydantic v2 is not installed." in caplog.text
+
+
+def test_model_dump_with_non_basemodel_raises():
+    with pytest.raises(TypeError, match="Expected a Pydantic model"):
+        model_dump("not a model")

--- a/tests/_internal/pydantic/test_model_dump.py
+++ b/tests/_internal/pydantic/test_model_dump.py
@@ -1,0 +1,45 @@
+import pytest
+from pydantic import BaseModel
+
+from prefect._internal.pydantic import HAS_PYDANTIC_V2, model_dump
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS,
+    temporary_settings,
+)
+
+
+@pytest.fixture(autouse=True)
+def enable_v2_internals():
+    with temporary_settings({PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS: True}):
+        yield
+
+
+def test_model_dump(caplog):
+    class TestModel(BaseModel):
+        a: int
+        b: str
+
+    model = TestModel(a=1, b="2")
+
+    assert model_dump(model) == {"a": 1, "b": "2"}
+
+    if HAS_PYDANTIC_V2:
+        assert "Using Pydantic v2 compatibility layer for `model_dump`" in caplog.text
+    else:
+        assert "Pydantic v2 is not installed." in caplog.text
+
+
+def test_model_dump_with_flag_disabled(caplog):
+    class TestModel(BaseModel):
+        a: int
+        b: str
+
+    model = TestModel(a=1, b="2")
+
+    with temporary_settings({PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS: False}):
+        assert model_dump(model) == {"a": 1, "b": "2"}
+
+    if HAS_PYDANTIC_V2:
+        assert "Pydantic v2 compatibility layer is disabled" in caplog.text
+    else:
+        assert "Pydantic v2 is not installed." in caplog.text


### PR DESCRIPTION
this PR starts laying the groundwork for a more complete compat layer that we can begin adopting incrementally.

here we add only a `model_dump` function that can be used anywhere we use `some_model_instance.dict()` on a v1 `BaseModel` today.

it may be possible to reduce the surface area of changes that would stem from replacing every use of `.dict()` with a `model_dump(some_model_instance)` call by mirroring the v2 `BaseModel` interface on classes like `PrefectBaseModel`, but even that will require this initial layer (that we could call from some method like `PrefectBaseModel.model_dump` based on the switching logic inside `_compat`'s `model_dump`)