### PR TITLE
[background tasks] emit pending event

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -2005,7 +2005,9 @@ async def orchestrate_task_run(
     last_event = emit_task_run_state_change_event(
         task_run=task_run, initial_state=None, validated_state=task_run.state
     )
-    last_state = task_run.state
+    last_state = (
+        task_run.state if not flow_run_context.autonomous_task_run else Pending()
+    )
 
     # Completed states with persisted results should have result data. If it's missing,
     # this could be a manual state transition, so we should use the Unknown result type

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -2002,7 +2002,7 @@ async def orchestrate_task_run(
     )
 
     # Emit an event to capture that the task run was in the `PENDING` state.
-    last_event = _emit_task_run_state_change_event(
+    last_event = emit_task_run_state_change_event(
         task_run=task_run, initial_state=None, validated_state=task_run.state
     )
     last_state = task_run.state
@@ -2094,7 +2094,7 @@ async def orchestrate_task_run(
                 break
 
     # Emit an event to capture the result of proposing a `RUNNING` state.
-    last_event = _emit_task_run_state_change_event(
+    last_event = emit_task_run_state_change_event(
         task_run=task_run,
         initial_state=last_state,
         validated_state=state,
@@ -2187,7 +2187,7 @@ async def orchestrate_task_run(
                     await _check_task_failure_retriable(task, task_run, terminal_state)
                 )
             state = await propose_state(client, terminal_state, task_run_id=task_run.id)
-            last_event = _emit_task_run_state_change_event(
+            last_event = emit_task_run_state_change_event(
                 task_run=task_run,
                 initial_state=last_state,
                 validated_state=state,
@@ -2220,7 +2220,7 @@ async def orchestrate_task_run(
                 )
                 # Attempt to enter a running state again
                 state = await propose_state(client, Running(), task_run_id=task_run.id)
-                last_event = _emit_task_run_state_change_event(
+                last_event = emit_task_run_state_change_event(
                     task_run=task_run,
                     initial_state=last_state,
                     validated_state=state,
@@ -2896,7 +2896,7 @@ async def check_api_reachable(client: PrefectClient, fail_message: str):
     API_HEALTHCHECKS[api_url] = get_deadline(60 * 10)
 
 
-def _emit_task_run_state_change_event(
+def emit_task_run_state_change_event(
     task_run: TaskRun,
     initial_state: Optional[State],
     validated_state: State,

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -2006,7 +2006,9 @@ async def orchestrate_task_run(
         task_run=task_run, initial_state=None, validated_state=task_run.state
     )
     last_state = (
-        task_run.state if not flow_run_context.autonomous_task_run else Pending()
+        Pending()
+        if flow_run_context and flow_run_context.autonomous_task_run
+        else task_run.state
     )
 
     # Completed states with persisted results should have result data. If it's missing,

--- a/src/prefect/task_server.py
+++ b/src/prefect/task_server.py
@@ -15,7 +15,7 @@ from prefect import Task, get_client
 from prefect._internal.concurrency.api import create_call, from_sync
 from prefect.client.schemas.objects import TaskRun
 from prefect.client.subscriptions import Subscription
-from prefect.engine import propose_state
+from prefect.engine import emit_task_run_state_change_event, propose_state
 from prefect.logging.loggers import get_logger
 from prefect.results import ResultFactory
 from prefect.settings import (
@@ -204,6 +204,12 @@ class TaskServer:
                 f" server returned a non-pending state {state.type.value!r}."
                 " Task run may have already begun execution."
             )
+
+        emit_task_run_state_change_event(
+            task_run=task_run,
+            initial_state=Pending(),
+            validated_state=state,
+        )
 
         self._runs_task_group.start_soon(
             partial(

--- a/src/prefect/task_server.py
+++ b/src/prefect/task_server.py
@@ -207,7 +207,7 @@ class TaskServer:
 
         emit_task_run_state_change_event(
             task_run=task_run,
-            initial_state=Pending(),
+            initial_state=task_run.state,
             validated_state=state,
         )
 

--- a/tests/events/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/instrumentation/test_task_run_state_change_events.py
@@ -175,3 +175,14 @@ async def test_background_task_state_changes(
         "prefect.task-run.Running",
         "prefect.task-run.Completed",
     ]
+
+    assert [
+        (e.payload["intended"]["from"], e.payload["intended"]["to"])
+        for e in events
+        if e.event.startswith("prefect.task-run.")
+    ] == [
+        (None, "SCHEDULED"),
+        ("SCHEDULED", "PENDING"),
+        ("PENDING", "RUNNING"),
+        ("RUNNING", "COMPLETED"),
+    ]

--- a/tests/events/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/instrumentation/test_task_run_state_change_events.py
@@ -1,6 +1,19 @@
+import pytest
+
 from prefect import flow, task
 from prefect.events.clients import AssertingEventsClient
 from prefect.events.worker import EventsWorker
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
+    temporary_settings,
+)
+from prefect.task_server import TaskServer
+
+
+@pytest.fixture
+def enable_task_scheduling():
+    with temporary_settings({PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING: True}):
+        yield
 
 
 async def test_task_state_change_happy_path(
@@ -129,3 +142,36 @@ async def test_task_state_change_task_failure(
         }
 
         last_state = task_run_state
+
+
+async def test_background_task_state_changes(
+    asserting_events_worker: EventsWorker,
+    reset_worker_events,
+    prefect_client,
+    enable_task_scheduling,
+):
+    @task
+    def foo():
+        pass
+
+    task_run = foo.submit()
+
+    await TaskServer(foo).execute_task_run(task_run)
+
+    task_run_states = await prefect_client.read_task_run_states(task_run.id)
+
+    await asserting_events_worker.drain()
+
+    events = sorted(asserting_events_worker._client.events, key=lambda e: e.occurred)
+
+    assert len(events) == 5  # 4 state changes + 1 block save
+
+    assert len(task_run_states) == 4
+
+    assert [e.event for e in events] == [
+        "prefect.task-run.Scheduled",
+        "prefect.task-run.Pending",
+        "prefect.block.local-file-system.save.called",
+        "prefect.task-run.Running",
+        "prefect.task-run.Completed",
+    ]


### PR DESCRIPTION
we were not correctly recording state changes with emitted events from

`None` -> `SCHEDULED` -> `PENDING` -> `RUNNING` -> `COMPLETED`

in particular, we need to handle the `SCHEDULED` and `PENDING` state changes differently, since historically tasks have gone from `NONE` -> `PENDING`