### PR TITLE
Implement CSRF support in the UI

### DIFF
--- a/src/prefect/server/api/middleware.py
+++ b/src/prefect/server/api/middleware.py
@@ -67,6 +67,7 @@ class CsrfMiddleware(BaseHTTPMiddleware):
                     return JSONResponse(
                         {"detail": "Invalid CSRF token or client identifier."},
                         status_code=status.HTTP_403_FORBIDDEN,
+                        headers={"Access-Control-Allow-Origin": "*"},
                     )
 
         return await call_next(request)

--- a/ui/src/maps/csrfToken.ts
+++ b/ui/src/maps/csrfToken.ts
@@ -1,0 +1,11 @@
+import { CsrfToken } from "@/models/CsrfToken"
+import { CsrfTokenResponse } from "@/types/csrfTokenResponse"
+
+export const mapCsrfTokenResponseToCsrfToken = (response: CsrfTokenResponse): CsrfToken => {
+    return {
+        token: response.token,
+        expiration: new Date(response.expiration),
+        issued: new Date(),
+    }
+}
+

--- a/ui/src/maps/csrfToken.ts
+++ b/ui/src/maps/csrfToken.ts
@@ -1,10 +1,11 @@
 import { CsrfToken } from "@/models/CsrfToken"
 import { CsrfTokenResponse } from "@/types/csrfTokenResponse"
+import { MapFunction } from '@/services/mapper'
 
-export const mapCsrfTokenResponseToCsrfToken = (response: CsrfTokenResponse): CsrfToken => {
+export const mapCsrfTokenResponseToCsrfToken: MapFunction<CsrfTokenResponse, CsrfToken> = function(source) {
     return {
-        token: response.token,
-        expiration: new Date(response.expiration),
+        token: source.token,
+        expiration: this.map('string', source.expiration, 'Date'),
         issued: new Date(),
     }
 }

--- a/ui/src/maps/index.ts
+++ b/ui/src/maps/index.ts
@@ -1,9 +1,11 @@
 import { maps as designMaps } from '@prefecthq/prefect-ui-library'
 import { mapFlagResponseToFeatureFlag } from '@/maps/featureFlag'
 import { mapSettingsResponseToSettings } from '@/maps/uiSettings'
+import { mapCsrfTokenResponseToCsrfToken } from '@/maps/csrfToken'
 
 export const maps = {
   ...designMaps,
   FlagResponse: { FeatureFlag: mapFlagResponseToFeatureFlag },
   SettingsResponse: { Settings: mapSettingsResponseToSettings },
+  CsrfTokenResponse: { CsrfToken: mapCsrfTokenResponseToCsrfToken },
 }

--- a/ui/src/models/CsrfToken.ts
+++ b/ui/src/models/CsrfToken.ts
@@ -1,0 +1,5 @@
+export type CsrfToken = {
+    token: string
+    expiration: Date
+    issued: Date
+}

--- a/ui/src/pages/AppRouterView.vue
+++ b/ui/src/pages/AppRouterView.vue
@@ -38,7 +38,7 @@
 
   const { can } = useCreateCan()
   const { config } = await useApiConfig()
-  const api = createPrefectApi(config)
+  const api = await createPrefectApi(config)
   const routes = createWorkspaceRoutes()
 
   provide(canKey, can)

--- a/ui/src/pages/AppRouterView.vue
+++ b/ui/src/pages/AppRouterView.vue
@@ -38,7 +38,7 @@
 
   const { can } = useCreateCan()
   const { config } = await useApiConfig()
-  const api = await createPrefectApi(config)
+  const api = createPrefectApi(config)
   const routes = createWorkspaceRoutes()
 
   provide(canKey, can)

--- a/ui/src/services/csrfTokenApi.ts
+++ b/ui/src/services/csrfTokenApi.ts
@@ -1,0 +1,125 @@
+import { AxiosInstance, InternalAxiosRequestConfig, isAxiosError } from 'axios';
+import { randomId, showToast } from '@prefecthq/prefect-design';
+import { Api, AxiosInstanceSetupHook, PrefectConfig } from '@prefecthq/prefect-ui-library'
+
+export type CsrfToken = {
+    token: string | null;
+    expiration: Date | null;
+    client: string;
+    issued: Date | null;
+}
+
+export type CsrfTokenResponse = {
+    token: string;
+    expiration: Date;
+}
+
+export class CsrfTokenApi extends Api {
+    public csrfToken: CsrfToken = {
+        token: null,
+        expiration: null,
+        client: randomId(),
+        issued: null,
+    };
+    public csrfSupportEnabled = true;
+    private refreshTimeout: ReturnType<typeof setTimeout> | null = null;
+    private ongoingRefresh: Promise<void> | null = null;
+
+    public constructor(apiConfig: PrefectConfig, instanceSetupHook: AxiosInstanceSetupHook | null = null) {
+        super(apiConfig, instanceSetupHook)
+        this.startBackgroundTokenRefresh()
+    }
+
+    public async addCsrfHeaders(config: InternalAxiosRequestConfig) {
+        if (this.csrfSupportEnabled) {
+            await this.refreshCsrfToken()
+            config.headers = config.headers || {}
+            config.headers['Prefect-Csrf-Token'] = this.csrfToken.token
+            config.headers['Prefect-Csrf-Client'] = this.csrfToken.client
+        }
+    }
+
+    private async refreshCsrfToken(force: boolean = false) {
+        if (!force && !this.shouldRefreshToken()) {
+            return this.ongoingRefresh ?? Promise.resolve();
+        }
+
+        if (this.ongoingRefresh) {
+            return this.ongoingRefresh;
+        }
+
+        const refresh = async () => {
+            try {
+                const response = await this.get<CsrfTokenResponse>(`/csrf-token?client=${this.csrfToken.client}`);
+                const now = new Date();
+                this.csrfToken.token = response.data.token;
+                this.csrfToken.expiration = response.data.expiration;
+                this.csrfToken.issued = now;
+                this.ongoingRefresh = null;
+            } catch (error) {
+                this.ongoingRefresh = null;
+                if (isAxiosError(error)) {
+                    const status = error.response?.status;
+                    const unconfiguredServer = status === 422 && error.response?.data.detail.includes('CSRF protection is disabled.');
+
+                    if (unconfiguredServer) {
+                        this.disableCsrfSupport()
+                    } else {
+                        console.error('Failed to refresh CSRF token:', error)
+                        showToast('Failed to refresh CSRF token')
+                        throw new Error('Failed to refresh CSRF token')
+                    }
+                }
+            }
+        };
+
+        this.ongoingRefresh = refresh();
+        return this.ongoingRefresh;
+    }
+
+    private shouldRefreshToken(): boolean {
+        const now = new Date()
+        return !!(this.csrfSupportEnabled && (!this.csrfToken.token || (this.csrfToken.expiration && now > this.csrfToken.expiration)))
+    }
+
+    private disableCsrfSupport() {
+        this.csrfSupportEnabled = false
+    }
+
+    private startBackgroundTokenRefresh() {
+        const calculateTimeoutDuration = () => {
+            if (this.csrfToken.expiration && this.csrfToken.issued) {
+                const now = new Date()
+                const expiration = new Date(this.csrfToken.expiration)
+                const issuedAt = this.csrfToken.issued
+                const lifetime = expiration.getTime() - issuedAt.getTime()
+                const refreshThreshold = issuedAt.getTime() + lifetime * 0.75
+                const durationUntilRefresh = refreshThreshold - now.getTime()
+
+                return durationUntilRefresh
+            }
+            return 0; // If we don't have token data cause an immediate refresh
+        };
+
+        const refreshTask = async () => {
+            if (this.csrfSupportEnabled) {
+                await this.refreshCsrfToken(true)
+                this.refreshTimeout = setTimeout(refreshTask, calculateTimeoutDuration())
+            }
+        };
+
+        this.refreshTimeout = setTimeout(refreshTask, calculateTimeoutDuration())
+    }
+}
+
+export function setupCsrfInterceptor(csrfTokenApi: CsrfTokenApi, axiosInstance: AxiosInstance) {
+    axiosInstance.interceptors.request.use(async (config: InternalAxiosRequestConfig): Promise<InternalAxiosRequestConfig> => {
+        const method = config.method?.toLowerCase();
+
+        if (method && ['post', 'patch', 'put', 'delete'].includes(method)) {
+            await csrfTokenApi.addCsrfHeaders(config)
+        }
+
+        return config
+    })
+}

--- a/ui/src/services/csrfTokenApi.ts
+++ b/ui/src/services/csrfTokenApi.ts
@@ -3,10 +3,10 @@ import { randomId, showToast } from '@prefecthq/prefect-design';
 import { Api, AxiosInstanceSetupHook, PrefectConfig } from '@prefecthq/prefect-ui-library'
 
 export type CsrfToken = {
-    token: string | null;
-    expiration: Date | null;
-    client: string;
-    issued: Date | null;
+    token: string
+    expiration: Date
+    client: string
+    issued: Date
 }
 
 export type CsrfTokenResponse = {
@@ -15,12 +15,7 @@ export type CsrfTokenResponse = {
 }
 
 export class CsrfTokenApi extends Api {
-    public csrfToken: CsrfToken = {
-        token: null,
-        expiration: null,
-        client: randomId(),
-        issued: null,
-    };
+    public csrfToken?: CsrfToken
     public csrfSupportEnabled = true;
     private refreshTimeout: ReturnType<typeof setTimeout> | null = null;
     private ongoingRefresh: Promise<void> | null = null;
@@ -54,7 +49,7 @@ export class CsrfTokenApi extends Api {
                 const now = new Date();
                 this.csrfToken.token = response.data.token;
                 this.csrfToken.expiration = response.data.expiration;
-                this.csrfToken.issued = now;
+                this.csrfToken.issued = new Date();
                 this.ongoingRefresh = null;
             } catch (error) {
                 this.ongoingRefresh = null;
@@ -78,8 +73,17 @@ export class CsrfTokenApi extends Api {
     }
 
     private shouldRefreshToken(): boolean {
+        if(!this.csrfSupportEnabled) {
+          return false
+        }
+        
+        if(!this.csrfToken.token || !this.csrfToken.expiration) {
+          return true
+        }
+        
         const now = new Date()
-        return !!(this.csrfSupportEnabled && (!this.csrfToken.token || (this.csrfToken.expiration && now > this.csrfToken.expiration)))
+        
+        return now > this.csrfToken.expiration
     }
 
     private disableCsrfSupport() {

--- a/ui/src/services/csrfTokenApi.ts
+++ b/ui/src/services/csrfTokenApi.ts
@@ -2,17 +2,9 @@ import { AxiosError, AxiosInstance, InternalAxiosRequestConfig, isAxiosError } f
 import { randomId } from '@prefecthq/prefect-design'
 import { Api, AxiosInstanceSetupHook, PrefectConfig } from '@prefecthq/prefect-ui-library'
 import { CreateActions } from '@prefecthq/vue-compositions'
-
-export type CsrfToken = {
-    token: string
-    expiration: Date
-    issued: Date
-}
-
-export type CsrfTokenResponse = {
-    token: string
-    expiration: Date
-}
+import { CsrfToken } from '@/models/CsrfToken'
+import { CsrfTokenResponse } from '@/types/csrfTokenResponse'
+import { mapper } from '@/services/mapper'
 
 export class CsrfTokenApi extends Api {
     public csrfToken?: CsrfToken
@@ -58,13 +50,9 @@ export class CsrfTokenApi extends Api {
 
         const refresh = async () => {
             try {
+
                 const response = await this.get<CsrfTokenResponse>(`/csrf-token?client=${this.clientId}`)
-                const now = new Date()
-                this.csrfToken = {
-                    token: response.data.token,
-                    expiration: new Date(response.data.expiration),
-                    issued: now,
-                }
+                this.csrfToken = mapper.map('CsrfTokenResponse', response.data, 'CsrfToken')
                 this.ongoingRefresh = null
             } catch (error) {
                 this.ongoingRefresh = null

--- a/ui/src/services/csrfTokenApi.ts
+++ b/ui/src/services/csrfTokenApi.ts
@@ -1,24 +1,25 @@
-import { AxiosInstance, InternalAxiosRequestConfig, isAxiosError } from 'axios';
-import { randomId, showToast } from '@prefecthq/prefect-design';
+import { AxiosError, AxiosInstance, InternalAxiosRequestConfig, isAxiosError } from 'axios'
+import { randomId } from '@prefecthq/prefect-design'
 import { Api, AxiosInstanceSetupHook, PrefectConfig } from '@prefecthq/prefect-ui-library'
+import { CreateActions } from '@prefecthq/vue-compositions'
 
 export type CsrfToken = {
     token: string
     expiration: Date
-    client: string
     issued: Date
 }
 
 export type CsrfTokenResponse = {
-    token: string;
-    expiration: Date;
+    token: string
+    expiration: Date
 }
 
 export class CsrfTokenApi extends Api {
     public csrfToken?: CsrfToken
-    public csrfSupportEnabled = true;
-    private refreshTimeout: ReturnType<typeof setTimeout> | null = null;
-    private ongoingRefresh: Promise<void> | null = null;
+    public clientId: string = randomId()
+    public csrfSupportEnabled = true
+    private refreshTimeout: ReturnType<typeof setTimeout> | null = null
+    private ongoingRefresh: Promise<void> | null = null
 
     public constructor(apiConfig: PrefectConfig, instanceSetupHook: AxiosInstanceSetupHook | null = null) {
         super(apiConfig, instanceSetupHook)
@@ -27,63 +28,79 @@ export class CsrfTokenApi extends Api {
 
     public async addCsrfHeaders(config: InternalAxiosRequestConfig) {
         if (this.csrfSupportEnabled) {
-            await this.refreshCsrfToken()
+            const csrfToken = await this.getCsrfToken()
             config.headers = config.headers || {}
-            config.headers['Prefect-Csrf-Token'] = this.csrfToken.token
-            config.headers['Prefect-Csrf-Client'] = this.csrfToken.client
+            config.headers['Prefect-Csrf-Token'] = csrfToken.token
+            config.headers['Prefect-Csrf-Client'] = this.clientId
         }
+    }
+
+    private async getCsrfToken(): Promise<CsrfToken> {
+        if (this.shouldRefreshToken()) {
+            await this.refreshCsrfToken()
+        }
+
+        if (!this.csrfToken) {
+            throw new Error('CSRF token not available')
+        }
+
+        return this.csrfToken
     }
 
     private async refreshCsrfToken(force: boolean = false) {
         if (!force && !this.shouldRefreshToken()) {
-            return this.ongoingRefresh ?? Promise.resolve();
+            return this.ongoingRefresh ?? Promise.resolve()
         }
 
         if (this.ongoingRefresh) {
-            return this.ongoingRefresh;
+            return this.ongoingRefresh
         }
 
         const refresh = async () => {
             try {
-                const response = await this.get<CsrfTokenResponse>(`/csrf-token?client=${this.csrfToken.client}`);
-                const now = new Date();
-                this.csrfToken.token = response.data.token;
-                this.csrfToken.expiration = response.data.expiration;
-                this.csrfToken.issued = new Date();
-                this.ongoingRefresh = null;
+                const response = await this.get<CsrfTokenResponse>(`/csrf-token?client=${this.clientId}`)
+                const now = new Date()
+                this.csrfToken = {
+                    token: response.data.token,
+                    expiration: new Date(response.data.expiration),
+                    issued: now,
+                }
+                this.ongoingRefresh = null
             } catch (error) {
-                this.ongoingRefresh = null;
+                this.ongoingRefresh = null
                 if (isAxiosError(error)) {
-                    const status = error.response?.status;
-                    const unconfiguredServer = status === 422 && error.response?.data.detail.includes('CSRF protection is disabled.');
-
-                    if (unconfiguredServer) {
+                    if (this.isUnconfiguredServer(error)) {
                         this.disableCsrfSupport()
                     } else {
                         console.error('Failed to refresh CSRF token:', error)
-                        showToast('Failed to refresh CSRF token')
                         throw new Error('Failed to refresh CSRF token')
                     }
                 }
             }
-        };
+        }
 
-        this.ongoingRefresh = refresh();
-        return this.ongoingRefresh;
+        this.ongoingRefresh = refresh()
+        return this.ongoingRefresh
     }
 
     private shouldRefreshToken(): boolean {
-        if(!this.csrfSupportEnabled) {
-          return false
+        if (!this.csrfSupportEnabled) {
+            return false
         }
-        
-        if(!this.csrfToken.token || !this.csrfToken.expiration) {
-          return true
+
+        if (!this.csrfToken) {
+            return true;
         }
-        
-        const now = new Date()
-        
-        return now > this.csrfToken.expiration
+
+        if (!this.csrfToken.token || !this.csrfToken.expiration) {
+            return true
+        }
+
+        return new Date() > this.csrfToken.expiration
+    }
+
+    private isUnconfiguredServer(error: AxiosError<any, any>): boolean {
+        return error.response?.status === 422 && error.response?.data.detail.includes('CSRF protection is disabled.')
     }
 
     private disableCsrfSupport() {
@@ -92,7 +109,7 @@ export class CsrfTokenApi extends Api {
 
     private startBackgroundTokenRefresh() {
         const calculateTimeoutDuration = () => {
-            if (this.csrfToken.expiration && this.csrfToken.issued) {
+            if (this.csrfToken) {
                 const now = new Date()
                 const expiration = new Date(this.csrfToken.expiration)
                 const issuedAt = this.csrfToken.issued
@@ -102,23 +119,23 @@ export class CsrfTokenApi extends Api {
 
                 return durationUntilRefresh
             }
-            return 0; // If we don't have token data cause an immediate refresh
-        };
+            return 0 // If we don't have token data cause an immediate refresh
+        }
 
         const refreshTask = async () => {
             if (this.csrfSupportEnabled) {
                 await this.refreshCsrfToken(true)
                 this.refreshTimeout = setTimeout(refreshTask, calculateTimeoutDuration())
             }
-        };
+        }
 
         this.refreshTimeout = setTimeout(refreshTask, calculateTimeoutDuration())
     }
 }
 
-export function setupCsrfInterceptor(csrfTokenApi: CsrfTokenApi, axiosInstance: AxiosInstance) {
+export function setupCsrfInterceptor(csrfTokenApi: CreateActions<CsrfTokenApi>, axiosInstance: AxiosInstance) {
     axiosInstance.interceptors.request.use(async (config: InternalAxiosRequestConfig): Promise<InternalAxiosRequestConfig> => {
-        const method = config.method?.toLowerCase();
+        const method = config.method?.toLowerCase()
 
         if (method && ['post', 'patch', 'put', 'delete'].includes(method)) {
             await csrfTokenApi.addCsrfHeaders(config)

--- a/ui/src/types/csrfTokenResponse.ts
+++ b/ui/src/types/csrfTokenResponse.ts
@@ -1,0 +1,5 @@
+export type CsrfTokenResponse = {
+    token: string
+    expiration: Date
+}
+

--- a/ui/src/utilities/api.ts
+++ b/ui/src/utilities/api.ts
@@ -8,7 +8,7 @@ import { AxiosInstance } from 'axios';
 
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export async function createPrefectApi(config: PrefectConfig) {
+export function createPrefectApi(config: PrefectConfig) {
   const csrfTokenApi = createActions(new CsrfTokenApi(config))
 
   function axiosInstanceSetupHook(axiosInstance: AxiosInstance) {

--- a/ui/src/utilities/api.ts
+++ b/ui/src/utilities/api.ts
@@ -3,7 +3,7 @@ import { createActions } from '@prefecthq/vue-compositions'
 import { InjectionKey } from 'vue'
 import { AdminApi } from '@/services/adminApi'
 import { CsrfTokenApi, setupCsrfInterceptor } from '@/services/csrfTokenApi'
-import { AxiosInstance } from 'axios';
+import { AxiosInstance } from 'axios'
 
 
 

--- a/ui/src/utilities/api.ts
+++ b/ui/src/utilities/api.ts
@@ -9,7 +9,7 @@ import { AxiosInstance } from 'axios';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export async function createPrefectApi(config: PrefectConfig) {
-  const csrfTokenApi = new CsrfTokenApi(config)
+  const csrfTokenApi = createActions(new CsrfTokenApi(config))
 
   function axiosInstanceSetupHook(axiosInstance: AxiosInstance) {
     setupCsrfInterceptor(csrfTokenApi, axiosInstance)

--- a/ui/src/utilities/api.ts
+++ b/ui/src/utilities/api.ts
@@ -2,14 +2,24 @@ import { createApi, PrefectConfig } from '@prefecthq/prefect-ui-library'
 import { createActions } from '@prefecthq/vue-compositions'
 import { InjectionKey } from 'vue'
 import { AdminApi } from '@/services/adminApi'
+import { CsrfTokenApi, setupCsrfInterceptor } from '@/services/csrfTokenApi'
+import { AxiosInstance } from 'axios';
+
+
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function createPrefectApi(config: PrefectConfig) {
-  const workspaceApi = createApi(config)
+export async function createPrefectApi(config: PrefectConfig) {
+  const csrfTokenApi = new CsrfTokenApi(config)
 
+  function axiosInstanceSetupHook(axiosInstance: AxiosInstance) {
+    setupCsrfInterceptor(csrfTokenApi, axiosInstance)
+  };
+
+  const workspaceApi = createApi(config, axiosInstanceSetupHook)
   return {
     ...workspaceApi,
-    admin: createActions(new AdminApi(config)),
+    csrf: csrfTokenApi,
+    admin: createActions(new AdminApi(config, axiosInstanceSetupHook)),
   }
 }
 


### PR DESCRIPTION
This adds CSRF support to the UI. A CSRF token is retrieved when the app starts, and a background task is started to ensure that the token is refreshed before the token expires. The headers are attached to each request via an axios interceptor, this required adding a hook (https://github.com/PrefectHQ/prefect-ui-library/pull/2239) to prefect-ui-library so that the axios instance itself could be updated.

Closes #12347 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
