### PR TITLE
Handle `KeyboardInterrupt` coming from `uvicorn.serve`

### DIFF
--- a/src/prefect/cli/cloud/__init__.py
+++ b/src/prefect/cli/cloud/__init__.py
@@ -129,6 +129,9 @@ async def serve_login_api(cancel_scope, task_status):
         cause = exc.__context__  # Hide the system exit
         traceback.print_exception(type(cause), value=cause, tb=cause.__traceback__)
         cancel_scope.cancel()
+    except KeyboardInterrupt:
+        # `uvicorn.serve` can raise `KeyboardInterrupt` when it's done serving.
+        cancel_scope.cancel()
     else:
         # Exit if we are done serving the API
         # Uvicorn overrides signal handlers so without this Ctrl-C is broken


### PR DESCRIPTION
Uvicorn just released `0.29.0` which fixes some issues it had with signal handlers, but it also causes `uvicorn.serve` to raise a `KeyboardInterrupt` when it's done serving. This ensures that we're handling `KeyboardInterrupt` exceptions coming from `.serve`.