### PR TITLE
Turn CSRF protection on by default

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -67,54 +67,54 @@ jobs:
 
           - prefect-version: "2.0"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
           - prefect-version: "2.1"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
           - prefect-version: "2.2"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
           - prefect-version: "2.3"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
           - prefect-version: "2.4"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
           - prefect-version: "2.5"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
           - prefect-version: "2.6"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
             # 2.6 containers have a bad version of httpcore installed
             extra_docker_run_options: '--env EXTRA_PIP_PACKAGES="httpcore>=0.16.2"'
           - prefect-version: "2.7"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
           - prefect-version: "2.8"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
           - prefect-version: "2.9"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
           - prefect-version: "2.10"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
           - prefect-version: "2.11"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
           - prefect-version: "2.12"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
           - prefect-version: "2.13"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
           - prefect-version: "2.14"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
           - prefect-version: "2.15"
             server-incompatible: true
-            server-csrf: false
+            server-disable-csrf: true
           - prefect-version: "2.16"
             server-incompatible: false
 
@@ -162,7 +162,7 @@ jobs:
           ./scripts/run-integration-flows.py
 
       - name: Turn off CSRF protection for older clients.
-        if: ${{ ! matrix.server-csrf }}
+        if: ${{ matrix.server-disable-csrf }}
         run: |
           echo "PREFECT_SERVER_CSRF_PROTECTION_ENABLED=0" >> $GITHUB_ENV
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -27,8 +27,9 @@ jobs:
   compatibility-tests:
     name: "Check compatibility with Prefect ${{ matrix.prefect-version }}"
     timeout-minutes: 10
-
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: true
       matrix:
         prefect-version:
           # These versions correspond to Prefect image tags, the patch version is
@@ -49,6 +50,7 @@ jobs:
           - "2.13"
           - "2.14"
           - "2.15"
+          - "2.16"
 
           # We can include the following to always test against the last release
           # but the value is not particularly clear and we can just append the
@@ -61,53 +63,61 @@ jobs:
           # incompatibilities are allowed.
 
           # All servers prior to 2.6.0 will not accept 2.6.0+ result types
+          # All servers prior to 2.16.0 will not accept `Deployment.schedules`
+
           - prefect-version: "2.0"
             server-incompatible: true
+            server-csrf: false
           - prefect-version: "2.1"
             server-incompatible: true
+            server-csrf: false
           - prefect-version: "2.2"
             server-incompatible: true
+            server-csrf: false
           - prefect-version: "2.3"
             server-incompatible: true
+            server-csrf: false
           - prefect-version: "2.4"
             server-incompatible: true
+            server-csrf: false
           - prefect-version: "2.5"
             server-incompatible: true
-
-          # All servers prior to 2.16.0 will not accept `Deployment.schedules`
+            server-csrf: false
           - prefect-version: "2.6"
             server-incompatible: true
+            server-csrf: false
+            # 2.6 containers have a bad version of httpcore installed
+            extra_docker_run_options: '--env EXTRA_PIP_PACKAGES="httpcore>=0.16.2"'
           - prefect-version: "2.7"
             server-incompatible: true
+            server-csrf: false
           - prefect-version: "2.8"
             server-incompatible: true
+            server-csrf: false
           - prefect-version: "2.9"
             server-incompatible: true
+            server-csrf: false
           - prefect-version: "2.10"
             server-incompatible: true
+            server-csrf: false
           - prefect-version: "2.11"
             server-incompatible: true
+            server-csrf: false
           - prefect-version: "2.12"
             server-incompatible: true
+            server-csrf: false
           - prefect-version: "2.13"
             server-incompatible: true
+            server-csrf: false
           - prefect-version: "2.14"
             server-incompatible: true
+            server-csrf: false
           - prefect-version: "2.15"
             server-incompatible: true
+            server-csrf: false
+          - prefect-version: "2.16"
+            server-incompatible: false
 
-          # 2.6 containers have a bad version of httpcore installed
-          - prefect-version: "2.6"
-            extra_docker_run_options: '--env EXTRA_PIP_PACKAGES="httpcore>=0.16.2"'
-            server_command: "prefect orion start"
-
-          # 2.6/2.7 require `prefect orion start` instead of prefect server start
-          - prefect-version: "2.7"
-            server_command: "prefect orion start"
-
-      fail-fast: true
-
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -150,6 +160,11 @@ jobs:
           PREFECT_API_URL="http://127.0.0.1:4200/api"
           TEST_CLIENT_VERSION=$(python -c 'import prefect; print(prefect.__version__)')
           ./scripts/run-integration-flows.py
+
+      - name: Turn off CSRF protection for older clients.
+        if: ${{ ! matrix.server-csrf }}
+        run: |
+          echo "PREFECT_SERVER_CSRF_PROTECTION_ENABLED=0" >> $GITHUB_ENV
 
       - name: Start server@dev
         run: |

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1235,7 +1235,7 @@ Note this setting only applies when calling `prefect server start`; if hosting t
 API with another tool you will need to configure this there instead.
 """
 
-PREFECT_SERVER_CSRF_PROTECTION_ENABLED = Setting(bool, default=False)
+PREFECT_SERVER_CSRF_PROTECTION_ENABLED = Setting(bool, default=True)
 """
 Controls the activation of CSRF protection for the Prefect server API.
 

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -18,7 +18,12 @@ from prefect.events import Event
 from prefect.events.clients import AssertingEventsClient
 from prefect.events.filters import EventFilter
 from prefect.events.worker import EventsWorker
-from prefect.settings import PREFECT_API_URL, get_current_settings, temporary_settings
+from prefect.settings import (
+    PREFECT_API_URL,
+    PREFECT_SERVER_CSRF_PROTECTION_ENABLED,
+    get_current_settings,
+    temporary_settings,
+)
 from prefect.testing.utilities import AsyncMock
 from prefect.utilities.processutils import open_process
 
@@ -118,7 +123,12 @@ def use_hosted_api_server(hosted_api_server):
     """
     Sets `PREFECT_API_URL` to the test session's hosted API endpoint.
     """
-    with temporary_settings({PREFECT_API_URL: hosted_api_server}):
+    with temporary_settings(
+        {
+            PREFECT_API_URL: hosted_api_server,
+            PREFECT_SERVER_CSRF_PROTECTION_ENABLED: False,
+        }
+    ):
         yield hosted_api_server
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ from prefect.settings import (
     PREFECT_MEMOIZE_BLOCK_AUTO_REGISTRATION,
     PREFECT_PROFILES_PATH,
     PREFECT_SERVER_ANALYTICS_ENABLED,
+    PREFECT_SERVER_CSRF_PROTECTION_ENABLED,
     PREFECT_UNIT_TEST_MODE,
 )
 from prefect.utilities.dispatch import get_registry_for_type
@@ -508,6 +509,12 @@ def caplog(caplog):
                 logger.handlers.append(caplog.handler)
 
     yield caplog
+
+
+@pytest.fixture(autouse=True)
+def disable_csrf_protection():
+    with temporary_settings({PREFECT_SERVER_CSRF_PROTECTION_ENABLED: False}):
+        yield
 
 
 @pytest.fixture


### PR DESCRIPTION
This updates the `PREFECT_SERVER_CSRF_PROTECTION_ENABLED` setting to be on by default. It also updates our main `conftest` to disable it in the test suite, just to avoid the noise of the extra requests where they're not important.