### PR TITLE
handle new `typer.Option` behavior

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -271,7 +271,7 @@ async def deploy(
             prefect_file=prefect_file, ci=ci
         )
         parsed_names = []
-        for name in names:
+        for name in names or []:
             if "*" in name:
                 parsed_names.extend(_parse_name_from_pattern(deploy_configs, name))
             else:

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -884,7 +884,7 @@ async def run(
         ),
     ),
     tags: List[str] = typer.Option(
-        [],
+        None,
         "--tag",
         help=("Tag(s) to be applied to flow run."),
     ),
@@ -930,7 +930,7 @@ async def run(
             exit_with_error(
                 "`--watch-interval` can only be used with `--watch`.",
             )
-    cli_params = _load_json_key_values(params, "parameter")
+    cli_params = _load_json_key_values(params or [], "parameter")
     conflicting_keys = set(cli_params.keys()).intersection(multi_params.keys())
     if conflicting_keys:
         app.console.print(
@@ -939,7 +939,7 @@ async def run(
         )
     parameters = {**multi_params, **cli_params}
 
-    job_vars = _load_json_key_values(job_variables, "job variable")
+    job_vars = _load_json_key_values(job_variables or [], "job variable")
     if start_in and start_at:
         exit_with_error(
             "Only one of `--start-in` or `--start-at` can be set, not both."

--- a/tests/cli/test_agent.py
+++ b/tests/cli/test_agent.py
@@ -139,7 +139,7 @@ def test_start_agent_respects_work_queue_names(monkeypatch):
     )
     mock_agent.assert_called_once_with(
         work_queues=["a", "b"],
-        work_queue_prefix=[],
+        work_queue_prefix=None,
         work_pool_name=None,
         prefetch_seconds=ANY,
         limit=None,
@@ -171,7 +171,7 @@ def test_start_agent_respects_limit(monkeypatch):
     )
     mock_agent.assert_called_once_with(
         work_queues=["test"],
-        work_queue_prefix=[],
+        work_queue_prefix=None,
         work_pool_name=None,
         prefetch_seconds=ANY,
         limit=10,
@@ -187,7 +187,7 @@ def test_start_agent_respects_work_pool_name(monkeypatch):
     )
     mock_agent.assert_called_once_with(
         work_queues=["test"],
-        work_queue_prefix=[],
+        work_queue_prefix=None,
         work_pool_name="test-pool",
         prefetch_seconds=ANY,
         limit=None,
@@ -221,7 +221,7 @@ def test_start_agent_with_just_work_pool(monkeypatch):
     )
     mock_agent.assert_called_once_with(
         work_queues=[],
-        work_queue_prefix=[],
+        work_queue_prefix=None,
         work_pool_name="test-pool",
         prefetch_seconds=ANY,
         limit=None,

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -233,7 +233,7 @@ def test_start_worker_with_prefetch_seconds(monkeypatch):
     mock_worker.assert_called_once_with(
         name=None,
         work_pool_name="test",
-        work_queues=[],
+        work_queues=None,
         prefetch_seconds=30,
         limit=None,
         heartbeat_interval_seconds=30,
@@ -261,7 +261,7 @@ def test_start_worker_with_prefetch_seconds_from_setting_by_default(monkeypatch)
     mock_worker.assert_called_once_with(
         name=None,
         work_pool_name="test",
-        work_queues=[],
+        work_queues=None,
         prefetch_seconds=100,
         limit=None,
         heartbeat_interval_seconds=30,
@@ -290,7 +290,7 @@ def test_start_worker_with_limit(monkeypatch):
     mock_worker.assert_called_once_with(
         name=None,
         work_pool_name="test",
-        work_queues=[],
+        work_queues=None,
         prefetch_seconds=10,
         limit=5,
         heartbeat_interval_seconds=30,


### PR DESCRIPTION
fixes #12397

when we have some command like
```python
@deployment_app.command()
async def run(
...
    job_variables: List[str] = typer.Option(
        None,
   ...
    ),
```
[typer `0.10.x` now gives a `None` instead of an empty list](https://github.com/tiangolo/typer/releases/tag/0.10.0)

which had the effect of us trying to iterate over a `NoneType` thing that was previously a list

this PR just swaps those cases for `once_a_list or []` and/or updates `assert_called_with` cases to the right thing