### PR TITLE
Bugfix: Upgrading should upgrade the UI as well

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -384,7 +384,7 @@ def create_ui_app(ephemeral: bool) -> FastAPI:
         # This is used to determine if the static files need to be copied again
         # when the server is restarted
         with open(os.path.join(static_dir, reference_file_name), "w") as f:
-            f.write(base_url)
+            f.write(f"{prefect.__version__}:{base_url}")
 
     ui_app.add_middleware(GZipMiddleware)
 

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -338,6 +338,7 @@ def create_api_app(
 def create_ui_app(ephemeral: bool) -> FastAPI:
     ui_app = FastAPI(title=UI_TITLE)
     base_url = prefect.settings.PREFECT_UI_SERVE_BASE.value()
+    cache_key = f"{prefect.__version__}:{base_url}"
     stripped_base_url = base_url.rstrip("/")
     static_dir = (
         prefect.settings.PREFECT_UI_STATIC_DIRECTORY.value()
@@ -363,7 +364,7 @@ def create_ui_app(ephemeral: bool) -> FastAPI:
         if os.path.exists(static_dir):
             try:
                 with open(reference_file_path, "r") as f:
-                    return f.read() == base_url
+                    return f.read() == cache_key
             except FileNotFoundError:
                 return False
         else:
@@ -384,7 +385,7 @@ def create_ui_app(ephemeral: bool) -> FastAPI:
         # This is used to determine if the static files need to be copied again
         # when the server is restarted
         with open(os.path.join(static_dir, reference_file_name), "w") as f:
-            f.write(f"{prefect.__version__}:{base_url}")
+            f.write(cache_key)
 
     ui_app.add_middleware(GZipMiddleware)
 


### PR DESCRIPTION
This PR updates the UI server utilities to write the version of Prefect into the stored reference file in addition to the base path. This should invalidate the file when the version gets upgraded and cause the UI to be recreated. 


Resolves #12427