### PR TITLE
move uses of `logger.warn` to `logger.warning`

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -459,7 +459,7 @@ def _memoize_block_auto_registration(fn: Callable[[], Awaitable[None]]):
                         )
                     return
         except Exception as exc:
-            logger.warn(
+            logger.warning(
                 ""
                 f"Unable to read memo_store.toml from {PREFECT_MEMO_STORE_PATH} during "
                 f"block auto-registration: {exc!r}.\n"
@@ -477,7 +477,7 @@ def _memoize_block_auto_registration(fn: Callable[[], Awaitable[None]]):
                     toml.dumps({"block_auto_registration": current_blocks_loading_hash})
                 )
             except Exception as exc:
-                logger.warn(
+                logger.warning(
                     "Unable to write to memo_store.toml at"
                     f" {PREFECT_MEMO_STORE_PATH} after block auto-registration:"
                     f" {exc!r}.\n Subsequent server start ups will perform block"

--- a/src/prefect/server/services/task_scheduling.py
+++ b/src/prefect/server/services/task_scheduling.py
@@ -98,7 +98,7 @@ class TaskSchedulingTimeouts(LoopService):
                 if prior_scheduled_state.type == states.StateType.SCHEDULED:
                     break
             else:
-                self.logger.warn(
+                self.logger.warning(
                     "No prior scheduled state found for task run %s", task_run.id
                 )
                 continue

--- a/src/prefect/utilities/asyncutils.py
+++ b/src/prefect/utilities/asyncutils.py
@@ -343,7 +343,7 @@ async def add_event_loop_shutdown_callback(coroutine_fn: Callable[[], Awaitable]
     # There is a poorly understood edge case we've seen in CI where the key is
     # removed from the dict before we begin generator iteration.
     except KeyError:
-        logger.warn("The event loop shutdown callback was not properly registered. ")
+        logger.warning("The event loop shutdown callback was not properly registered. ")
         pass
 
 


### PR DESCRIPTION
to avoid deprecation warnings like
```python
    logger.warn("The event loop shutdown callback was not properly registered. ")
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/logging/__init__.py", line 1492, in warn
    warnings.warn("The 'warn' method is deprecated, "
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```