### PR TITLE
Stop creating artifacts for unpersisted results

### DIFF
--- a/src/prefect/server/orchestration/rules.py
+++ b/src/prefect/server/orchestration/rules.py
@@ -280,7 +280,7 @@ class FlowOrchestrationContext(OrchestrationContext):
             state_payload = self.proposed_state.dict(shallow=True)
             state_data = state_payload.pop("data", None)
 
-            if state_data is not None:
+            if state_data is not None and state_data.get("type") != "unpersisted":
                 state_result_artifact = core.Artifact.from_result(state_data)
                 state_result_artifact.flow_run_id = self.run.id
                 await artifacts.create_artifact(self.session, state_result_artifact)
@@ -432,7 +432,7 @@ class TaskOrchestrationContext(OrchestrationContext):
             state_payload = self.proposed_state.dict(shallow=True)
             state_data = state_payload.pop("data", None)
 
-            if state_data is not None:
+            if state_data is not None and state_data.get("type") != "unpersisted":
                 state_result_artifact = core.Artifact.from_result(state_data)
                 state_result_artifact.task_run_id = self.run.id
 

--- a/src/prefect/server/orchestration/rules.py
+++ b/src/prefect/server/orchestration/rules.py
@@ -280,7 +280,9 @@ class FlowOrchestrationContext(OrchestrationContext):
             state_payload = self.proposed_state.dict(shallow=True)
             state_data = state_payload.pop("data", None)
 
-            if state_data is not None and state_data.get("type") != "unpersisted":
+            if state_data is not None and not (
+                isinstance(state_data, dict) and state_data.get("type") == "unpersisted"
+            ):
                 state_result_artifact = core.Artifact.from_result(state_data)
                 state_result_artifact.flow_run_id = self.run.id
                 await artifacts.create_artifact(self.session, state_result_artifact)
@@ -432,7 +434,9 @@ class TaskOrchestrationContext(OrchestrationContext):
             state_payload = self.proposed_state.dict(shallow=True)
             state_data = state_payload.pop("data", None)
 
-            if state_data is not None and state_data.get("type") != "unpersisted":
+            if state_data is not None and not (
+                isinstance(state_data, dict) and state_data.get("type") == "unpersisted"
+            ):
                 state_result_artifact = core.Artifact.from_result(state_data)
                 state_result_artifact.task_run_id = self.run.id
 

--- a/tests/test_task_server.py
+++ b/tests/test_task_server.py
@@ -323,7 +323,10 @@ class TestTaskServerTaskResults:
         if persist_result:
             assert await updated_task_run.state.result() == 42
         else:
-            with pytest.raises(MissingResult, match="The result was not persisted"):
+            with pytest.raises(
+                MissingResult,
+                match="The result was not persisted|State data is missing",
+            ):
                 await updated_task_run.state.result()
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Right now we flood the orchestration database with artifacts representing "unpersisted" results. These are functionally useless and create more noise than is necessary, so we are removing them.

The only change this makes is that retried flows without persisted results have a _slightly_ different error message now - instead of saying "Unpersisted result" the message says "State data is missing", but the exception type is the same.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [x] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [x] This pull request includes helpful docstrings.
- [x] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.