### PR TITLE
UI: enable sourcemaps by default

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from 'vite'
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const base = mode == 'development' ? '' : '/PREFECT_UI_SERVE_BASE_REPLACE_PLACEHOLDER'
+
   return {
     plugins: [vue()],
     base,
@@ -12,8 +13,8 @@ export default defineConfig(({ mode }) => {
       alias: [{ find: '@', replacement: resolve(__dirname, './src') }],
       dedupe: ['vue', 'vue-router'],
     },
-    css: {
-      devSourcemap: true,
+    build: {
+      sourcemap: true,
     },
   }
 })


### PR DESCRIPTION
# Description
Since the ui code is open source theres no reason to not have source maps all the time. Will make the package slightly larger but will make debugging customer ui issues much easier. 