### PR TITLE
Pin uvicorn to < 0.29

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -31,7 +31,7 @@ sniffio >=1.3.0, < 2.0.0
 toml >= 0.10.0
 typing_extensions >= 4.5.0, < 5.0.0
 ujson >= 5.8.0, < 6.0.0
-uvicorn >= 0.14.0
+uvicorn >= 0.14.0, < 0.29.0
 websockets >= 10.4, < 13.0
 
 # additional dependencies of starlette, which we're currently vendoring


### PR DESCRIPTION
We've had several reports of issues with our `cloud login` command and some other random `CancelledError` in the vicinity of our uvicorn usage. Uvicorn currently has a couple open issues related to 0.29 and its new signal handling. This pins us to <0.29.0 until there is another release and then we can revisit.

Related to #12371
