### PR TITLE
Revert "Update uvicorn requirement from <0.29.0,>=0.14.0 to >=0.14.0,<0.30.0"

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -31,7 +31,7 @@ sniffio >=1.3.0, < 2.0.0
 toml >= 0.10.0
 typing_extensions >= 4.5.0, < 5.0.0
 ujson >= 5.8.0, < 6.0.0
-uvicorn >= 0.14.0, < 0.30.0
+uvicorn >= 0.14.0, < 0.29.0
 websockets >= 10.4, < 13.0
 
 # additional dependencies of starlette, which we're currently vendoring


### PR DESCRIPTION
We want to stay under .29 for now, it's causing some `CancelledError` issues, specifically with `cloud login`.

Reverts PrefectHQ/prefect#12477