### PR TITLE
Message Publisher and Consumer abstractions, with in-memory implementation

### DIFF
--- a/src/prefect/server/utilities/messaging/__init__.py
+++ b/src/prefect/server/utilities/messaging/__init__.py
@@ -71,12 +71,8 @@ MessageHandler = Callable[[Message], Awaitable[None]]
 @asynccontextmanager
 async def ephemeral_subscription(topic: str) -> AsyncGenerator[Dict[str, Any], None]:
     """
-    Creates an ephemeral subscription to the given source, removing it when the context exits.
-
-    Will create a subscription for PubSub. If the process crashes, the subscription will expire in 1 day (the
-    lowest value that Pub/Sub supports).
-
-    Will create a consumer group for Redis Streams.
+    Creates an ephemeral subscription to the given source, removing it when the context
+    exits.
     """
     if PREFECT_MESSAGING_BROKER.value() == "memory":
         from . import memory

--- a/src/prefect/server/utilities/messaging/__init__.py
+++ b/src/prefect/server/utilities/messaging/__init__.py
@@ -1,0 +1,167 @@
+import abc
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from typing import (
+    Any,
+    AsyncGenerator,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Protocol,
+    TypeVar,
+    Union,
+)
+from typing_extensions import Self
+
+from cachetools import TTLCache
+
+from prefect.settings import PREFECT_MESSAGING_CACHE, PREFECT_MESSAGING_BROKER
+from prefect.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class Message(Protocol):
+    """
+    A protocol representing a message sent to a message broker.
+    """
+
+    data: Union[bytes, str]
+    attributes: Dict[str, Any]
+
+
+M = TypeVar("M", bound=Message)
+
+
+class Cache(abc.ABC):
+    @abc.abstractmethod
+    async def clear_recently_seen_messages(self) -> None:
+        ...
+
+    @abc.abstractmethod
+    async def without_duplicates(self, attribute: str, messages: List[M]) -> List[M]:
+        ...
+
+    @abc.abstractmethod
+    async def forget_duplicates(self, attribute: str, messages: List[M]) -> None:
+        ...
+
+
+class Publisher(abc.ABC):
+    @abc.abstractmethod
+    async def __aenter__(self) -> Self:
+        ...
+
+    @abc.abstractmethod
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        ...
+
+    @abc.abstractmethod
+    async def publish_data(self, data: bytes, attributes: Dict[str, str]):
+        ...
+
+
+MessageHandler = Callable[[Message], Awaitable[None]]
+
+
+@asynccontextmanager
+async def ephemeral_subscription(topic: str) -> AsyncGenerator[Dict[str, Any], None]:
+    """
+    Creates an ephemeral subscription to the given source, removing it when the context exits.
+
+    Will create a subscription for PubSub. If the process crashes, the subscription will expire in 1 day (the
+    lowest value that Pub/Sub supports).
+
+    Will create a consumer group for Redis Streams.
+    """
+    if PREFECT_MESSAGING_BROKER.value() == "memory":
+        from . import memory
+
+        subscription = memory.ephemeral_subscription(topic)
+
+    else:
+        raise ValueError(
+            f"Unknown message broker configured: {PREFECT_MESSAGING_BROKER.value()}"
+        )
+
+    async with subscription as info:
+        yield info
+
+
+class StopConsumer(Exception):
+    """
+    Exception to raise to stop a consumer.
+    """
+
+    def __init__(self, ack: bool = False):
+        self.ack = ack
+
+
+class Consumer(abc.ABC):
+    """
+    Abstract base class for consumers that receive messages from a message broker and
+    call a handler function for each message received.
+    """
+
+    @abc.abstractmethod
+    async def run(self, handler: MessageHandler) -> None:
+        """Runs the consumer (indefinitely)"""
+        ...
+
+
+def create_cache() -> Cache:
+    """
+    Creates a new cache with the applications default settings.
+    Returns:
+        a new Cache instance
+    """
+    if PREFECT_MESSAGING_CACHE.value() == "memory":
+        from . import memory
+
+        return memory.MemoryCache()
+    else:
+        raise ValueError(f"Unknown cache configured: {PREFECT_MESSAGING_CACHE.value()}")
+
+
+def create_publisher(
+    topic: str, cache: Optional[Cache] = None, deduplicate_by: Optional[str] = None
+) -> Publisher:
+    """
+    Creates a new publisher with the applications default settings.
+    Args:
+        topic: the topic to publish to
+    Returns:
+        a new Consumer instance
+    """
+    cache = cache or create_cache()
+
+    if PREFECT_MESSAGING_BROKER.value() == "memory":
+        from . import memory
+
+        return memory.MemoryPublisher(topic, cache, deduplicate_by=deduplicate_by)
+    else:
+        raise ValueError(
+            f"Unknown message broker configured: {PREFECT_MESSAGING_BROKER.value()}"
+        )
+
+
+def create_consumer(topic: str, **kwargs) -> Consumer:
+    """
+    Creates a new consumer with the applications default settings.
+    Args:
+        topic: the topic to consume from
+    Returns:
+        a new Consumer instance
+    """
+    if PREFECT_MESSAGING_BROKER.value() == "memory":
+        from . import memory
+
+        return memory.MemoryConsumer(topic, **kwargs)
+    else:
+        raise ValueError(
+            f"Unknown message broker configured: {PREFECT_MESSAGING_BROKER.value()}"
+        )

--- a/src/prefect/server/utilities/messaging/memory.py
+++ b/src/prefect/server/utilities/messaging/memory.py
@@ -1,0 +1,204 @@
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import (
+    Any,
+    AsyncGenerator,
+    Dict,
+    List,
+    MutableMapping,
+    Optional,
+    TypeVar,
+    Union,
+)
+
+from cachetools import TTLCache
+from typing_extensions import Self
+
+from prefect.logging import get_logger
+from prefect.server.utilities.messaging import (
+    Cache,
+    Consumer,
+    Message,
+    MessageHandler,
+    Publisher,
+    StopConsumer,
+)
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class MemoryMessage:
+    data: Union[bytes, str]
+    attributes: Dict[str, Any]
+
+
+class Subscription:
+    topic: "Topic"
+    _queue: asyncio.Queue
+    _retry: asyncio.Queue
+
+    def __init__(self, topic: "Topic") -> None:
+        self.topic = topic
+        self._queue = asyncio.Queue()
+        self._retry = asyncio.Queue()
+
+    async def deliver(self, message: MemoryMessage) -> None:
+        await self._queue.put(message)
+
+    async def retry(self, message: MemoryMessage) -> None:
+        await self._retry.put(message)
+
+    async def get(self) -> MemoryMessage:
+        if self._retry.qsize() > 0:
+            return await self._retry.get()
+        return await self._queue.get()
+
+
+class Topic:
+    _topics: Dict[str, "Topic"] = {}
+
+    name: str
+    _subscriptions: List[Subscription]
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._subscriptions = []
+
+    @classmethod
+    def by_name(cls, name: str) -> Self:
+        try:
+            return cls._topics[name]
+        except KeyError:
+            topic = cls(name)
+            cls._topics[name] = topic
+            return topic
+
+    @classmethod
+    def clear_all(cls):
+        for topic in cls._topics.values():
+            topic.clear()
+        cls._topics = {}
+
+    def subscribe(self) -> Subscription:
+        subscription = Subscription(self)
+        self._subscriptions.append(subscription)
+        return subscription
+
+    def unsubscribe(self, subscription: Subscription) -> None:
+        self._subscriptions.remove(subscription)
+
+    def clear(self):
+        for subscription in self._subscriptions:
+            self.unsubscribe(subscription)
+        self._subscriptions = []
+
+    async def publish(self, message: MemoryMessage) -> None:
+        for subscription in self._subscriptions:
+            await subscription.deliver(message)
+
+
+M = TypeVar("M", bound=Message)
+
+
+class MemoryCache(Cache):
+    _recently_seen_messages: MutableMapping[str, bool] = TTLCache(
+        maxsize=1000,
+        ttl=timedelta(minutes=5).total_seconds(),
+    )
+
+    async def clear_recently_seen_messages(self) -> None:
+        self._recently_seen_messages.clear()
+
+    async def without_duplicates(self, attribute: str, messages: List[M]) -> List[M]:
+        messages_with_attribute = []
+        messages_without_attribute = []
+
+        for m in messages:
+            if m.attributes is None or attribute not in m.attributes:
+                logger.warning(
+                    "Message is missing deduplication attribute %r",
+                    attribute,
+                    extra={"event_message": m},
+                )
+                messages_without_attribute.append(m)
+                continue
+
+            if self._recently_seen_messages.get(m.attributes[attribute]):
+                continue
+
+            self._recently_seen_messages[m.attributes[attribute]] = True
+            messages_with_attribute.append(m)
+
+        return messages_with_attribute + messages_without_attribute
+
+    async def forget_duplicates(self, attribute: str, messages: List[M]) -> None:
+        for m in messages:
+            if m.attributes is None or attribute not in m.attributes:
+                logger.warning(
+                    "Message is missing deduplication attribute %r",
+                    attribute,
+                    extra={"event_message": m},
+                )
+                continue
+            self._recently_seen_messages.pop(m.attributes[attribute], None)
+
+
+class MemoryPublisher(Publisher):
+    def __init__(self, topic: str, cache: Cache, deduplicate_by: Optional[str] = None):
+        self.topic = Topic.by_name(topic)
+        self.deduplicate_by = deduplicate_by
+        self._cache = cache
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return None
+
+    async def publish_data(self, data: bytes, attributes: Dict[str, str]):
+        to_publish = [MemoryMessage(data, attributes)]
+        if self.deduplicate_by:
+            to_publish = await self._cache.without_duplicates(
+                self.deduplicate_by, to_publish
+            )
+
+        try:
+            for message in to_publish:
+                await self.topic.publish(message)
+        except Exception:
+            if self.deduplicate_by:
+                await self._cache.forget_duplicates(self.deduplicate_by, to_publish)
+            raise
+
+
+class MemoryConsumer(Consumer):
+    def __init__(self, topic: str, subscription: Optional[Subscription] = None):
+        self.topic = Topic.by_name(topic)
+        if not subscription:
+            subscription = self.topic.subscribe()
+        assert subscription.topic is self.topic
+        self.subscription = subscription
+
+    async def run(self, handler: MessageHandler) -> None:
+        while True:
+            message = await self.subscription.get()
+            try:
+                await handler(message)
+            except StopConsumer as e:
+                if not e.ack:
+                    await self.subscription.retry(message)
+                return
+            except Exception:
+                await self.subscription.retry(message)
+
+
+@asynccontextmanager
+async def ephemeral_subscription(topic: str) -> AsyncGenerator[Dict[str, Any], None]:
+    subscription = Topic.by_name(topic).subscribe()
+    try:
+        yield {"topic": topic, "subscription": subscription}
+    finally:
+        Topic.by_name(topic).unsubscribe(subscription)

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1629,8 +1629,20 @@ The directory to serve static files from. This should be used when running into 
 when attempting to serve the UI from the default directory (for example when running in a Docker container)
 """
 
+# Messaging system settings
 
-# Events settings ------------------------------------------------------------------
+PREFECT_MESSAGING_BROKER = Setting(str, default="memory")
+"""
+Which message broker implementation to use for the messaging system.
+"""
+
+PREFECT_MESSAGING_CACHE = Setting(str, default="memory")
+"""
+Which cache implementation to use for the events system.
+"""
+
+
+# Events settings
 
 PREFECT_EVENTS_MAXIMUM_LABELS_PER_RESOURCE = Setting(int, default=500)
 """

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1631,14 +1631,20 @@ when attempting to serve the UI from the default directory (for example when run
 
 # Messaging system settings
 
-PREFECT_MESSAGING_BROKER = Setting(str, default="memory")
+PREFECT_MESSAGING_BROKER = Setting(
+    str, default="prefect.server.utilities.messaging.memory"
+)
 """
-Which message broker implementation to use for the messaging system.
+Which message broker implementation to use for the messaging system, should point to a
+module that exports a Publisher and Consumer class.
 """
 
-PREFECT_MESSAGING_CACHE = Setting(str, default="memory")
+PREFECT_MESSAGING_CACHE = Setting(
+    str, default="prefect.server.utilities.messaging.memory"
+)
 """
-Which cache implementation to use for the events system.
+Which cache implementation to use for the events system.  Should point to a module that
+exports a Cache class.
 """
 
 

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -1,0 +1,34 @@
+import pytest
+
+from prefect.server.utilities.messaging import create_cache
+from prefect.server.utilities.messaging.memory import Topic
+from prefect.settings import (
+    PREFECT_MESSAGING_BROKER,
+    PREFECT_MESSAGING_CACHE,
+    temporary_settings,
+)
+
+# Use the in-memory implementation of the cache and message broker for server testing
+
+
+@pytest.fixture(autouse=True)
+def events_configuration():
+    with temporary_settings(
+        {PREFECT_MESSAGING_CACHE: "memory", PREFECT_MESSAGING_BROKER: "memory"}
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def clear_topics(events_configuration: None):
+    Topic.clear_all()
+    yield
+    Topic.clear_all()
+
+
+@pytest.fixture(autouse=True)
+async def reset_recently_seen_messages(events_configuration: None):
+    cache = create_cache()
+    await cache.clear_recently_seen_messages()
+    yield
+    await cache.clear_recently_seen_messages()

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -14,7 +14,10 @@ from prefect.settings import (
 @pytest.fixture(autouse=True)
 def events_configuration():
     with temporary_settings(
-        {PREFECT_MESSAGING_CACHE: "memory", PREFECT_MESSAGING_BROKER: "memory"}
+        {
+            PREFECT_MESSAGING_CACHE: "prefect.server.utilities.messaging.memory",
+            PREFECT_MESSAGING_BROKER: "prefect.server.utilities.messaging.memory",
+        }
     ):
         yield
 

--- a/tests/server/utilities/test_messaging.py
+++ b/tests/server/utilities/test_messaging.py
@@ -97,10 +97,7 @@ def configured_cache(cache_name: str) -> Generator[str, None, None]:
 
 
 @pytest.fixture
-async def cache(
-    event_loop: asyncio.AbstractEventLoop,
-    configured_cache: str,
-) -> AsyncGenerator[Cache, None]:
+async def cache(configured_cache: str) -> AsyncGenerator[Cache, None]:
     cache = create_cache()
     await cache.clear_recently_seen_messages()
     yield cache
@@ -108,20 +105,12 @@ async def cache(
 
 
 @pytest.fixture
-def publisher(
-    event_loop: asyncio.AbstractEventLoop,
-    broker: str,
-    cache: Cache,
-) -> Publisher:
+async def publisher(broker: str, cache: Cache) -> Publisher:
     return create_publisher("my-topic", cache=Cache)
 
 
 @pytest.fixture
-def consumer(
-    event_loop: asyncio.AbstractEventLoop,
-    broker: str,
-    clear_topics: None,
-) -> Consumer:
+async def consumer(broker: str, clear_topics: None) -> Consumer:
     return create_consumer("my-topic")
 
 

--- a/tests/server/utilities/test_messaging.py
+++ b/tests/server/utilities/test_messaging.py
@@ -1,0 +1,452 @@
+import asyncio
+from contextlib import asynccontextmanager
+from typing import (
+    AsyncContextManager,
+    AsyncGenerator,
+    Callable,
+    Generator,
+    List,
+    Optional,
+)
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import anyio
+import pytest
+
+from prefect.server.utilities.messaging import (
+    Cache,
+    Consumer,
+    Message,
+    Publisher,
+    StopConsumer,
+    create_cache,
+    create_consumer,
+    create_publisher,
+    ephemeral_subscription,
+)
+from prefect.settings import (
+    PREFECT_MESSAGING_BROKER,
+    PREFECT_MESSAGING_CACHE,
+    temporary_settings,
+)
+
+
+@pytest.fixture
+def busted_broker():
+    with temporary_settings(updates={PREFECT_MESSAGING_BROKER: "whodis"}):
+        yield
+
+
+@pytest.fixture
+def busted_cache():
+    with temporary_settings(updates={PREFECT_MESSAGING_CACHE: "whodis"}):
+        yield
+
+
+def test_unknown_broker_raises_for_creating_publisher(busted_broker):
+    with pytest.raises(ValueError, match="Unknown message broker configured: whodis"):
+        create_publisher("my-topic")
+
+
+def test_unknown_broker_raises_for_creating_consumer(busted_broker):
+    with pytest.raises(ValueError, match="Unknown message broker configured: whodis"):
+        create_consumer("my-topic")
+
+
+async def test_unknown_broker_raises_for_ephemeral_subscription(busted_broker):
+    with pytest.raises(ValueError, match="Unknown message broker configured: whodis"):
+        context = ephemeral_subscription("my-topic")
+        await context.__aenter__()
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc):
+    if "broker_name" in metafunc.fixturenames:
+        metafunc.parametrize("broker_name", ["memory"])
+    if "cache_name" in metafunc.fixturenames:
+        metafunc.parametrize("cache_name", ["memory"])
+
+
+def test_unknown_cache_raises_for_creating_publisher(broker_name: str, busted_cache):
+    with pytest.raises(ValueError, match="Unknown cache configured: whodis"):
+        create_publisher("my-topic")
+
+
+@pytest.fixture
+def broker(broker_name: str) -> Generator[str, None, None]:
+    with temporary_settings(updates={PREFECT_MESSAGING_BROKER: broker_name}):
+        yield broker_name
+
+
+@pytest.fixture
+def configured_cache(cache_name: str) -> Generator[str, None, None]:
+    with temporary_settings(updates={PREFECT_MESSAGING_CACHE: cache_name}):
+        yield cache_name
+
+
+@pytest.fixture
+async def cache(configured_cache: str) -> AsyncGenerator[Cache, None]:
+    cache = create_cache()
+    await cache.clear_recently_seen_messages()
+    yield cache
+    await cache.clear_recently_seen_messages()
+
+
+@pytest.fixture
+def publisher(broker: str, cache: Cache) -> Publisher:
+    return create_publisher("my-topic", cache=Cache)
+
+
+@pytest.fixture
+def consumer(broker: str, clear_topics: None) -> Consumer:
+    return create_consumer("my-topic")
+
+
+async def drain_one(consumer: Consumer) -> Optional[Message]:
+    captured_messages: List[Message] = []
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+        raise StopConsumer(ack=True)
+
+    with anyio.move_on_after(0.1):
+        await consumer.run(handler)
+
+    return captured_messages[0] if captured_messages else None
+
+
+async def test_publishing_and_consuming_a_single_message(
+    publisher: Publisher, consumer: Consumer
+) -> None:
+    captured_messages: List[Message] = []
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+        raise StopConsumer(ack=True)
+
+    consumer_task = asyncio.create_task(consumer.run(handler))
+
+    try:
+        async with publisher as p:
+            await p.publish_data(b"hello, world", {"howdy": "partner"})
+    finally:
+        await consumer_task
+
+    assert len(captured_messages) == 1
+    (message,) = captured_messages
+    assert message.data == b"hello, world"
+    assert message.attributes == {"howdy": "partner"}
+
+    remaining_message = await drain_one(consumer)
+    assert not remaining_message
+
+
+async def test_stopping_consumer_without_acking(
+    publisher: Publisher, consumer: Consumer
+) -> None:
+    captured_messages: List[Message] = []
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+        raise StopConsumer(ack=False)
+
+    consumer_task = asyncio.create_task(consumer.run(handler))
+
+    try:
+        async with publisher as p:
+            await p.publish_data(b"hello, world", {"howdy": "partner"})
+    finally:
+        await consumer_task
+
+    assert len(captured_messages) == 1
+    (message,) = captured_messages
+    assert message.data == b"hello, world"
+    assert message.attributes == {"howdy": "partner"}
+
+    remaining_message = await drain_one(consumer)
+    assert remaining_message == message
+
+
+async def test_erroring_handler_does_not_ack(
+    publisher: Publisher, consumer: Consumer
+) -> None:
+    captured_messages: List[Message] = []
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+        if len(captured_messages) == 1:
+            raise ValueError("oops")
+        else:
+            raise StopConsumer(ack=True)
+
+    consumer_task = asyncio.create_task(consumer.run(handler))
+
+    try:
+        async with publisher as p:
+            await p.publish_data(b"hello, world", {"howdy": "partner"})
+    finally:
+        await consumer_task
+
+    assert len(captured_messages) == 2
+    (message1, message2) = captured_messages
+    assert message1 is message2
+
+    remaining_message = await drain_one(consumer)
+    assert not remaining_message
+
+
+@pytest.fixture
+def deduplicating_publisher(broker: str, cache: Cache) -> Publisher:
+    return create_publisher("my-topic", cache, deduplicate_by="my-message-id")
+
+
+async def test_publisher_will_avoid_sending_duplicate_messages_in_same_batch(
+    deduplicating_publisher: Publisher, consumer: Consumer
+):
+    captured_messages: List[Message] = []
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+        raise StopConsumer(ack=True)
+
+    consumer_task = asyncio.create_task(consumer.run(handler))
+
+    try:
+        async with deduplicating_publisher as p:
+            await p.publish_data(
+                b"hello, world", {"my-message-id": "A", "howdy": "partner"}
+            )
+            await p.publish_data(
+                b"hello, world", {"my-message-id": "A", "doesn't": "matter"}
+            )
+    finally:
+        await consumer_task
+
+    assert len(captured_messages) == 1
+    (message,) = captured_messages
+    assert message.data == b"hello, world"
+    assert message.attributes == {"my-message-id": "A", "howdy": "partner"}
+
+    remaining_message = await drain_one(consumer)
+    assert not remaining_message
+
+
+async def test_publisher_will_avoid_sending_duplicate_messages_in_different_batches(
+    deduplicating_publisher: Publisher, consumer: Consumer
+):
+    captured_messages: List[Message] = []
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+        raise StopConsumer(ack=True)
+
+    consumer_task = asyncio.create_task(consumer.run(handler))
+
+    try:
+        async with deduplicating_publisher as p:
+            await p.publish_data(
+                b"hello, world", {"my-message-id": "A", "howdy": "partner"}
+            )
+
+        async with deduplicating_publisher as p:
+            await p.publish_data(
+                b"hello, world", {"my-message-id": "A", "doesn't": "matter"}
+            )
+    finally:
+        await consumer_task
+
+    assert len(captured_messages) == 1
+    (message,) = captured_messages
+    assert message.data == b"hello, world"
+    assert message.attributes == {"my-message-id": "A", "howdy": "partner"}
+
+    remaining_message = await drain_one(consumer)
+    assert not remaining_message
+
+
+@pytest.fixture
+def break_topic() -> Callable[[], AsyncContextManager[AsyncMock]]:
+    @asynccontextmanager
+    async def break_topic(broker_name: str):
+        publishing_mock = AsyncMock(side_effect=ValueError("oops"))
+
+        if broker_name == "memory":
+            with mock.patch(
+                "prefect.server.utilities.messaging.memory.Topic.publish",
+                publishing_mock,
+            ):
+                yield publishing_mock
+        else:
+            raise NotImplementedError("Implement broken publishing for this broker")
+
+    return break_topic
+
+
+async def test_break_topic_fixture_raises_for_unknown_broker(
+    break_topic: Callable[[], AsyncContextManager[AsyncMock]],
+):
+    with pytest.raises(NotImplementedError, match="Implement broken publishing"):
+        context = break_topic("whodis?")
+        await context.__aenter__()
+
+
+async def test_broken_topic_reraises(
+    broker_name: str,
+    publisher: Publisher,
+    consumer: Consumer,
+    break_topic: Callable[[], AsyncContextManager[AsyncMock]],
+) -> None:
+    with pytest.raises(ValueError, match="oops"):
+        async with break_topic(broker_name):
+            async with publisher as p:
+                await p.publish_data(b"hello, world", {"howdy": "partner"})
+
+    remaining_message = await drain_one(consumer)
+    assert not remaining_message
+
+
+async def test_publisher_will_forget_duplicate_messages_on_error(
+    broker_name: str,
+    deduplicating_publisher: Publisher,
+    consumer: Consumer,
+    break_topic: Callable[[], AsyncContextManager[AsyncMock]],
+):
+    with pytest.raises(ValueError, match="oops"):
+        async with break_topic(broker_name):
+            async with deduplicating_publisher as p:
+                await p.publish_data(
+                    b"hello, world", {"my-message-id": "A", "howdy": "partner"}
+                )
+
+    # with the topic broken, the message won't be published
+    remaining_message = await drain_one(consumer)
+    assert not remaining_message
+
+    # but on a subsequent attempt, the message is published and not considered duplicate
+    captured_messages: List[Message] = []
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+        raise StopConsumer(ack=True)
+
+    consumer_task = asyncio.create_task(consumer.run(handler))
+
+    try:
+        async with deduplicating_publisher as p:
+            await p.publish_data(
+                b"hello, world", {"my-message-id": "A", "howdy": "partner"}
+            )
+    finally:
+        await consumer_task
+
+    assert len(captured_messages) == 1
+    (message,) = captured_messages
+    assert message.data == b"hello, world"
+    assert message.attributes == {"my-message-id": "A", "howdy": "partner"}
+
+    remaining_message = await drain_one(consumer)
+    assert not remaining_message
+
+
+async def test_publisher_does_not_interfere_with_duplicate_messages_without_id(
+    deduplicating_publisher: Publisher, consumer: Consumer
+):
+    captured_messages: List[Message] = []
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+        if len(captured_messages) == 2:
+            raise StopConsumer(ack=True)
+
+    consumer_task = asyncio.create_task(consumer.run(handler))
+
+    try:
+        async with deduplicating_publisher as p:
+            await p.publish_data(b"hello, world", {"howdy": "partner"})
+            await p.publish_data(b"hello, world", {"howdy": "partner"})
+    finally:
+        await consumer_task
+
+    assert len(captured_messages) == 2
+    (message1, message2) = captured_messages
+
+    assert message1 is not message2
+
+    assert message1.data == b"hello, world"
+    assert message1.attributes == {"howdy": "partner"}
+
+    assert message2.data == b"hello, world"
+    assert message2.attributes == {"howdy": "partner"}
+
+    remaining_message = await drain_one(consumer)
+    assert not remaining_message
+
+
+async def test_publisher_does_not_interfere_with_duplicate_messages_without_id_on_error(
+    broker_name: str,
+    deduplicating_publisher: Publisher,
+    consumer: Consumer,
+    break_topic: Callable[[], AsyncContextManager[AsyncMock]],
+):
+    with pytest.raises(ValueError, match="oops"):
+        async with break_topic(broker_name):
+            async with deduplicating_publisher as p:
+                await p.publish_data(b"hello, world", {"howdy": "partner"})
+
+    # with the topic broken, the message won't be published
+    remaining_message = await drain_one(consumer)
+    assert not remaining_message
+
+    # but on a subsequent attempt, the message is published
+    captured_messages: List[Message] = []
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+        raise StopConsumer(ack=True)
+
+    consumer_task = asyncio.create_task(consumer.run(handler))
+
+    try:
+        async with deduplicating_publisher as p:
+            await p.publish_data(b"hello, world", {"howdy": "partner"})
+    finally:
+        await consumer_task
+
+    assert len(captured_messages) == 1
+    (message,) = captured_messages
+
+    assert message.data == b"hello, world"
+    assert message.attributes == {"howdy": "partner"}
+
+    remaining_message = await drain_one(consumer)
+    assert not remaining_message
+
+
+async def test_ephemeral_subscription(broker: str, publisher: Publisher):
+    captured_messages: List[Message] = []
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+        raise StopConsumer(ack=True)
+
+    async with ephemeral_subscription("my-topic") as consumer_kwargs:
+        consumer = create_consumer(**consumer_kwargs)
+        consumer_task = asyncio.create_task(consumer.run(handler))
+
+        try:
+            async with publisher as p:
+                await p.publish_data(b"hello, world", {"howdy": "partner"})
+        finally:
+            await consumer_task
+
+        assert len(captured_messages) == 1
+        (message,) = captured_messages
+        assert message.data == b"hello, world"
+        assert message.attributes == {"howdy": "partner"}
+
+        remaining_message = await drain_one(consumer)
+        assert not remaining_message
+
+    # TODO: is there a way we can test that ephemeral subscriptions really have cleaned
+    # up after themselves after they have exited?  This will differ significantly by
+    # each broker implementation, so it's hard to write a generic test.


### PR DESCRIPTION
This introduces the abstract bases and the first in-memory implementation of
message publishers and consumers.  This generic base can form the foundation for
events, actions, and task run subscriptions.  The in-memory implementation is
based on distributing messages among `asyncio.Queue`s, and using an in-memory
`TTLCache` to keep track of duplicate messages.

The test suite here fully covers the in-memory implementation, but can stand
become a set of compatibility tests for any other implementations.  I have not
tried to address dynamically loading implementations from external collections,
but that could be addressed with minor adjustments to the `create_*` functions.

```
src/prefect/server/utilities/messaging/__init__.py           44      0      8      0   100%
src/prefect/server/utilities/messaging/memory.py            130      0     32      0   100%
tests/server/utilities/__init__.py                            0      0      0      0   100%
tests/server/utilities/test_messaging.py                    254      0     10      0   100%
```
