### PR TITLE
Add `prompts_and_responses` support to `invoke_and_assert`

### DIFF
--- a/src/prefect/testing/cli.py
+++ b/src/prefect/testing/cli.py
@@ -1,8 +1,10 @@
 import contextlib
+import re
 import textwrap
-from typing import Iterable, List, Union
+from typing import Iterable, List, Tuple, Union
 
-from typer.testing import CliRunner, Result
+import readchar
+from typer.testing import CliRunner, Result  # type: ignore
 
 from prefect.cli import app
 from prefect.utilities.asyncutils import in_async_main_thread
@@ -44,15 +46,16 @@ def check_contains(cli_result: Result, content: str, should_contain: bool):
 
 
 def invoke_and_assert(
-    command: List[str],
-    user_input: str = None,
-    expected_output: str = None,
-    expected_output_contains: Union[str, Iterable[str]] = None,
-    expected_output_does_not_contain: Union[str, Iterable[str]] = None,
-    expected_line_count: int = None,
+    command: Union[str, List[str]],
+    user_input: Union[str, None] = None,
+    prompts_and_responses: List[Union[Tuple[str, str], Tuple[str, str, str]]] = [],
+    expected_output: Union[str, None] = None,
+    expected_output_contains: Union[str, Iterable[str], None] = None,
+    expected_output_does_not_contain: Union[str, Iterable[str], None] = None,
+    expected_line_count: Union[int, None] = None,
     expected_code: int = 0,
     echo: bool = True,
-    temp_dir: str = None,
+    temp_dir: Union[str, None] = None,
 ) -> Result:
     """
     Test utility for the Prefect CLI application, asserts exact match with CLI output.
@@ -95,6 +98,16 @@ def invoke_and_assert(
     else:
         ctx = contextlib.nullcontext()
 
+    if user_input and prompts_and_responses:
+        raise ValueError("Cannot provide both user_input and prompts_and_responses")
+
+    if prompts_and_responses:
+        user_input = (
+            ("\n".join(response for (_, response, *_) in prompts_and_responses) + "\n")
+            .replace("↓", readchar.key.DOWN)
+            .replace("↑", readchar.key.UP)
+        )
+
     with ctx:
         result = runner.invoke(app, command, catch_exceptions=False, input=user_input)
 
@@ -123,6 +136,34 @@ def invoke_and_assert(
             "------ end ------\n"
         )
         assert output == expected_output, compare_string
+
+    if prompts_and_responses:
+        output = result.stdout.strip()
+        cursor = 0
+
+        for item in prompts_and_responses:
+            prompt = item[0]
+            selected_option = item[2] if len(item) == 3 else None
+
+            prompt_re = rf"{re.escape(prompt)}.*?"
+            if not selected_option:
+                # If we're not prompting for a table, then expect that the
+                # prompt ends with a colon.
+                prompt_re += ":"
+
+            match = re.search(prompt_re, output[cursor:])
+            if not match:
+                raise AssertionError(f"Prompt '{prompt}' not found in CLI output")
+            cursor = cursor + match.end()
+
+            if selected_option:
+                option_re = re.escape(f"│ >  │ {selected_option}")
+                match = re.search(option_re, output[cursor:])
+                if not match:
+                    raise AssertionError(
+                        f"Option '{selected_option}' not found after prompt '{prompt}'"
+                    )
+                cursor = cursor + match.end()
 
     if expected_output_contains is not None:
         if isinstance(expected_output_contains, str):

--- a/tests/cli/test_artifact.py
+++ b/tests/cli/test_artifact.py
@@ -208,7 +208,9 @@ def test_inspecting_artifact_with_limit(artifacts):
 def test_deleting_artifact_by_key_succeeds(artifacts):
     invoke_and_assert(
         ["artifact", "delete", str(artifacts[0].key)],
-        user_input="y",
+        prompts_and_responses=[
+            ("Are you sure you want to delete 2 artifact(s) with key 'voltaic'?", "y"),
+        ],
         expected_output_contains="Deleted 2 artifact(s) with key 'voltaic'.",
         expected_code=0,
     )

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -4749,37 +4749,18 @@ class TestSaveUserInputs:
     def test_save_user_inputs_with_interval_schedule(self):
         invoke_and_assert(
             command="deploy flows/hello.py:my_flow",
-            user_input=(
-                # Accept default deployment name
-                readchar.key.ENTER
-                +
-                # accept schedule
-                readchar.key.ENTER
-                +
-                # select interval schedule
-                readchar.key.ENTER
-                +
-                # enter interval schedule
-                "3600"
-                + readchar.key.ENTER
-                # accept schedule being active
-                + readchar.key.ENTER
-                # decline adding another schedule
-                + readchar.key.ENTER
-                +
-                # accept create work pool
-                readchar.key.ENTER
-                +
-                # choose process work pool
-                readchar.key.ENTER
-                +
-                # enter work pool name
-                "inflatable"
-                + readchar.key.ENTER
-                # accept save user inputs
-                + "y"
-                + readchar.key.ENTER
-            ),
+            prompts_and_responses=[
+                ("? Deployment name (default)", ""),
+                ("Would you like to configure schedules for this deployment?", ""),
+                ("What type of schedule would you like to use?", "", "Interval"),
+                ("Seconds between scheduled runs", "3600"),
+                ("Would you like to activate this schedule?", "y"),
+                ("Would you like to add another schedule?", "n"),
+                ("you don't have any work pools", "y"),
+                ("What infrastructure type", "", "process"),
+                ("Work pool name", "inflatable"),
+                ("Would you like to save configuration", "y"),
+            ],
             expected_code=0,
             expected_output_contains=[
                 (
@@ -4807,36 +4788,19 @@ class TestSaveUserInputs:
     def test_save_user_inputs_with_cron_schedule(self):
         invoke_and_assert(
             command="deploy flows/hello.py:my_flow",
-            user_input=(
-                # Accept default deployment name
-                readchar.key.ENTER
-                +
-                # accept schedule
-                readchar.key.ENTER
-                +
-                # select cron schedule
-                readchar.key.DOWN
-                + readchar.key.ENTER
-                # enter cron schedule
-                + "* * * * *"
-                + readchar.key.ENTER
-                # accept default timezone
-                + readchar.key.ENTER
-                # accept schedule being active
-                + readchar.key.ENTER
-                # decline adding another schedule
-                + readchar.key.ENTER
-                # accept create work pool
-                + readchar.key.ENTER
-                # choose process work pool
-                + readchar.key.ENTER
-                # enter work pool name
-                + "inflatable"
-                + readchar.key.ENTER
-                # accept save user inputs
-                + "y"
-                + readchar.key.ENTER
-            ),
+            prompts_and_responses=[
+                ("? Deployment name (default)", ""),
+                ("Would you like to configure schedules for this deployment?", ""),
+                ("What type of schedule would you like to use?", "↓", "Cron"),
+                ("Cron string (0 0 * * *)", "* * * * *"),
+                ("Timezone (UTC)", ""),
+                ("Would you like to activate this schedule?", "y"),
+                ("Would you like to add another schedule?", "n"),
+                ("you don't have any work pools", "y"),
+                ("What infrastructure type", "", "process"),
+                ("Work pool name", "inflatable"),
+                ("Would you like to save configuration", "y"),
+            ],
             expected_code=0,
             expected_output_contains=[
                 (
@@ -4867,40 +4831,19 @@ class TestSaveUserInputs:
         # Set up initial deployment deployment
         invoke_and_assert(
             command="deploy flows/hello.py:my_flow",
-            user_input=(
-                # enter deployment name
-                "existing-deployment"
-                + readchar.key.ENTER
-                # accept create schedule
-                + "y"
-                + readchar.key.ENTER
-                # select cron schedule
-                + readchar.key.DOWN
-                + readchar.key.ENTER
-                # enter cron schedule
-                + "* * * * *"
-                # accept schedule being active
-                + readchar.key.ENTER
-                # decline adding another schedule
-                + readchar.key.ENTER
-                # accept default timezone
-                + readchar.key.ENTER
-                # accept schedule being active
-                + readchar.key.ENTER
-                +
-                # accept create work pool
-                readchar.key.ENTER
-                +
-                # choose process work pool
-                readchar.key.ENTER
-                +
-                # enter work pool name
-                "inflatable"
-                + readchar.key.ENTER
-                # accept save user inputs
-                + "y"
-                + readchar.key.ENTER
-            ),
+            prompts_and_responses=[
+                ("? Deployment name (default)", "existing-deployment"),
+                ("Would you like to configure schedules for this deployment?", ""),
+                ("What type of schedule would you like to use?", "↓", "Cron"),
+                ("Cron string (0 0 * * *)", "* * * * *"),
+                ("Timezone (UTC)", ""),
+                ("Would you like to activate this schedule?", "y"),
+                ("Would you like to add another schedule?", "n"),
+                ("you don't have any work pools", "y"),
+                ("What infrastructure type", "", "process"),
+                ("Work pool name", "inflatable"),
+                ("Would you like to save configuration", "y"),
+            ],
             expected_code=0,
             expected_output_contains=[
                 (
@@ -4929,18 +4872,10 @@ class TestSaveUserInputs:
 
         invoke_and_assert(
             command="deploy -n existing-deployment --cron '* * * * *'",
-            user_input=(
-                # decline remote storage
-                "n"
-                + readchar.key.ENTER
-                # accept create work pool
-                + readchar.key.ENTER
-                # choose process work pool
-                + readchar.key.ENTER
-                # enter work pool name
-                + "inflatable"
-                + readchar.key.ENTER
-            ),
+            prompts_and_responses=[
+                ("Would you like to save configuration", "y"),
+                ("Would you like to overwrite that entry?", "y"),
+            ],
             expected_code=0,
             expected_output_does_not_contain=[
                 (


### PR DESCRIPTION
This adds a new concept of `prompts_and_responses` to `invoke_and_assert`. `prompts_and_responses` let's you define the prompts you expect and the response that should be given, and includes support for navigating tables with up/down arrows. `invoke_and_assert` will grab all of the 'responses' and use those as input for the command, and then it will assert that all of the prompts are in the output, and in the expected order. It will also assert that the correct option is selected in the table. 

I've updated several tests with this new pattern, but wanted to get feedback before going further.