### PR TITLE
Backporting `POST /api/events` and the `/api/events/in` Websocket

### DIFF
--- a/src/prefect/server/api/__init__.py
+++ b/src/prefect/server/api/__init__.py
@@ -11,6 +11,7 @@ from . import (
     csrf_token,
     dependencies,
     deployments,
+    events,
     flow_run_notification_policies,
     flow_run_states,
     flow_runs,

--- a/src/prefect/server/api/events.py
+++ b/src/prefect/server/api/events.py
@@ -1,0 +1,37 @@
+from typing import List
+
+from prefect._vendor.fastapi import Response, WebSocket, status
+
+from prefect.logging import get_logger
+from prefect.server.events import messaging
+from prefect.server.events.schemas.events import Event
+from prefect.server.utilities import subscriptions
+from prefect.server.utilities.server import PrefectRouter
+
+logger = get_logger(__name__)
+
+
+router = PrefectRouter(prefix="/events", tags=["Events"])
+
+
+@router.post("", status_code=status.HTTP_204_NO_CONTENT, response_class=Response)
+async def create_events(events: List[Event]):
+    """Record a batch of Events"""
+    await messaging.publish([event.receive() for event in events])
+
+
+@router.websocket("/in")
+async def stream_events_in(websocket: WebSocket) -> None:
+    """Open a WebSocket to stream incoming Events"""
+
+    await websocket.accept()
+
+    try:
+        async with messaging.create_event_publisher() as publisher:
+            async for event_json in websocket.iter_text():
+                event = Event.parse_raw(event_json)
+                await publisher.publish_event(event.receive())
+    except subscriptions.NORMAL_DISCONNECT_EXCEPTIONS:  # pragma: no cover
+        pass  # it's fine if a client disconnects either normally or abnormally
+
+    return None

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -84,6 +84,7 @@ API_ROUTERS = (
     api.collections.router,
     api.variables.router,
     api.csrf_token.router,
+    api.events.router,
     api.ui.flow_runs.router,
     api.ui.schemas.router,
     api.ui.task_runs.router,

--- a/src/prefect/server/events/messaging.py
+++ b/src/prefect/server/events/messaging.py
@@ -1,0 +1,63 @@
+from typing import Iterable
+
+from prefect.logging import get_logger
+from prefect.server.events.schemas.events import ReceivedEvent
+from prefect.server.utilities.messaging import Publisher, create_publisher
+from prefect.settings import PREFECT_EVENTS_MAXIMUM_SIZE_BYTES
+
+logger = get_logger(__name__)
+
+
+async def publish(events: Iterable[ReceivedEvent]):
+    """Send the given events as a batch via the default publisher"""
+    async with create_event_publisher() as publisher:
+        for event in events:
+            await publisher.publish_event(event)
+
+
+class EventPublisher(Publisher):
+    _publisher: Publisher
+
+    def __init__(self, publisher: Publisher = None):
+        self._publisher = publisher
+
+    async def __aenter__(self):
+        await self._publisher.__aenter__()
+        return self
+
+    async def __aexit__(self, *args):
+        await self._publisher.__aexit__(*args)
+
+    async def publish_data(self, data: bytes, attributes: dict):
+        await self._publisher.publish_data(data, attributes)
+
+    async def publish_event(self, event: ReceivedEvent):
+        """
+        Publishes the given events
+
+        Args:
+            event: the event to publish
+        """
+        encoded = event.json().encode()
+        if len(encoded) > PREFECT_EVENTS_MAXIMUM_SIZE_BYTES.value():
+            logger.warning(
+                "Refusing to publish event of size %s",
+                extra={
+                    "event_id": str(event.id),
+                    "event": event.event[:100],
+                    "length": len(encoded),
+                },
+            )
+            return
+        await self.publish_data(
+            encoded,
+            {
+                "id": str(event.id),
+                "event": event.event,
+            },
+        )
+
+
+def create_event_publisher() -> EventPublisher:
+    publisher = create_publisher(topic="events", deduplicate_by="id")
+    return EventPublisher(publisher=publisher)

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1661,6 +1661,11 @@ PREFECT_EVENTS_MAXIMUM_RELATED_RESOURCES = Setting(int, default=500)
 The maximum number of related resources an Event may have.
 """
 
+PREFECT_EVENTS_MAXIMUM_SIZE_BYTES = Setting(int, default=1_500_000)
+"""
+The maximum size of an Event when serialized to JSON
+"""
+
 
 # Deprecated settings ------------------------------------------------------------------
 

--- a/tests/events/client/test_cloud_events_subscriber.py
+++ b/tests/events/client/test_cloud_events_subscriber.py
@@ -86,13 +86,12 @@ async def test_subscriber_specifying_negative_reconnects_gets_error(
     filter = EventFilter(event=EventNameFilter(name=["example.event"]))
 
     with pytest.raises(ValueError, match="non-negative"):
-        async with PrefectCloudEventSubscriber(
+        PrefectCloudEventSubscriber(
             events_api_url,
             "my-token",
             filter,
             reconnection_attempts=-1,
-        ):
-            pass  # pragma: no cover
+        )
 
     assert recorder.connections == 0
 
@@ -110,13 +109,13 @@ async def test_subscriber_raises_on_invalid_auth_with_soft_denial(
     filter = EventFilter(event=EventNameFilter(name=["example.event"]))
 
     with pytest.raises(Exception, match="Unable to authenticate"):
-        async with PrefectCloudEventSubscriber(
+        subscriber = PrefectCloudEventSubscriber(
             events_api_url,
             "bogus",
             filter,
             reconnection_attempts=0,
-        ):
-            pass  # pragma: no cover
+        )
+        await subscriber.__aenter__()
 
     assert recorder.connections == 1
     assert recorder.path == "/accounts/A/workspaces/W/events/out"
@@ -138,13 +137,13 @@ async def test_subscriber_raises_on_invalid_auth_with_hard_denial(
     filter = EventFilter(event=EventNameFilter(name=["example.event"]))
 
     with pytest.raises(Exception, match="Unable to authenticate"):
-        async with PrefectCloudEventSubscriber(
+        subscriber = PrefectCloudEventSubscriber(
             events_api_url,
             "bogus",
             filter,
             reconnection_attempts=0,
-        ):
-            pass  # pragma: no cover
+        )
+        await subscriber.__aenter__()
 
     assert recorder.connections == 1
     assert recorder.path == "/accounts/A/workspaces/W/events/out"

--- a/tests/events/server/conftest.py
+++ b/tests/events/server/conftest.py
@@ -1,0 +1,30 @@
+from typing import Optional, Union
+
+import pendulum
+import pytest
+from pendulum.tz.timezone import Timezone
+
+from prefect.server.events.schemas.events import ReceivedEvent
+from prefect.server.utilities.messaging import Message
+
+
+@pytest.fixture
+def frozen_time(monkeypatch: pytest.MonkeyPatch) -> pendulum.DateTime:
+    frozen = pendulum.now("UTC")
+
+    def frozen_time(tz: Optional[Union[str, Timezone]] = None):
+        if tz is None:
+            return frozen
+        return frozen.in_timezone(tz)
+
+    monkeypatch.setattr(pendulum, "now", frozen_time)
+    return frozen
+
+
+def assert_message_represents_event(message: Message, event: ReceivedEvent):
+    """Confirms that the message adequately represents the event"""
+    assert message.data
+    assert ReceivedEvent.parse_raw(message.data) == event
+    assert message.attributes
+    assert message.attributes["id"] == str(event.id)
+    assert message.attributes["event"] == event.event

--- a/tests/events/server/gateway/conftest.py
+++ b/tests/events/server/gateway/conftest.py
@@ -1,0 +1,42 @@
+from uuid import uuid4
+
+import pendulum
+import pytest
+from prefect._vendor.fastapi import FastAPI
+from prefect._vendor.fastapi.testclient import TestClient
+
+from prefect.server.events.schemas.events import Event, Resource
+
+
+@pytest.fixture
+def events_app(app: FastAPI) -> FastAPI:
+    return app
+
+
+@pytest.fixture
+def test_client(events_app: FastAPI) -> TestClient:
+    # We typically use the httpx.AsyncClient with an async ASGI transport for testing,
+    # but for tests that involve websockets, we need to use the FastAPI TestClient
+    return TestClient(events_app)
+
+
+@pytest.fixture
+def event1() -> Event:
+    return Event(
+        occurred=pendulum.now("UTC"),
+        event="was.radical",
+        resource=Resource(__root__={"prefect.resource.id": "my.resources"}),
+        payload={"hello": "world"},
+        id=uuid4(),
+    )
+
+
+@pytest.fixture
+def event2() -> Event:
+    return Event(
+        occurred=pendulum.now("UTC"),
+        event="was.super.awesome",
+        resource=Resource(__root__={"prefect.resource.id": "my.resources"}),
+        payload={"goodbye": "moon"},
+        id=uuid4(),
+    )

--- a/tests/events/server/gateway/test_gateway_in.py
+++ b/tests/events/server/gateway/test_gateway_in.py
@@ -1,0 +1,75 @@
+from typing import Tuple
+from unittest import mock
+
+import pendulum
+import pytest
+from prefect._vendor.fastapi.testclient import TestClient
+from prefect._vendor.starlette.testclient import WebSocketTestSession
+
+from prefect.server.events import messaging
+from prefect.server.events.schemas.events import Event
+
+
+@pytest.fixture(autouse=True)
+def publish(monkeypatch: pytest.MonkeyPatch) -> mock.AsyncMock:
+    mock_publish = mock.AsyncMock()
+    monkeypatch.setattr("prefect.server.events.messaging.publish", mock_publish)
+    return mock_publish
+
+
+@pytest.fixture
+async def stream_publish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Tuple[mock.MagicMock, mock.AsyncMock]:
+    mock_create_publisher = mock.MagicMock(spec=messaging.create_event_publisher)
+    mock_publish = mock.AsyncMock()
+    mock_create_publisher.return_value.__aenter__.return_value.publish_event = (
+        mock_publish
+    )
+
+    monkeypatch.setattr(
+        "prefect.server.events.messaging.create_event_publisher", mock_create_publisher
+    )
+
+    return mock_publish
+
+
+def test_stream_events_in(
+    test_client: TestClient,
+    frozen_time: pendulum.DateTime,
+    event1: Event,
+    event2: Event,
+    stream_publish: mock.AsyncMock,
+):
+    websocket: WebSocketTestSession
+    with test_client.websocket_connect("/api/events/in") as websocket:
+        websocket.send_text(event1.json())
+        websocket.send_text(event2.json())
+
+    server_events = [
+        event1.receive(received=frozen_time),
+        event2.receive(received=frozen_time),
+    ]
+    stream_publish.assert_has_awaits([mock.call(event) for event in server_events])
+
+
+def test_post_events(
+    test_client: TestClient,
+    frozen_time: pendulum.DateTime,
+    event1: Event,
+    event2: Event,
+    publish: mock.AsyncMock,
+):
+    response = test_client.post(
+        "/api/events",
+        json=[
+            event1.dict(json_compatible=True),
+            event2.dict(json_compatible=True),
+        ],
+    )
+    assert response.status_code == 204
+    server_events = [
+        event1.receive(received=frozen_time),
+        event2.receive(received=frozen_time),
+    ]
+    publish.assert_awaited_once_with(server_events)

--- a/tests/events/server/test_messaging.py
+++ b/tests/events/server/test_messaging.py
@@ -1,0 +1,127 @@
+from typing import Generator, Type
+from unittest import mock
+from uuid import uuid4
+
+import pendulum
+import pytest
+
+from prefect.server.events import messaging
+from prefect.server.events.messaging import create_event_publisher
+from prefect.server.events.schemas.events import ReceivedEvent, Resource
+from prefect.server.utilities.messaging import CapturingPublisher
+from prefect.settings import PREFECT_EVENTS_MAXIMUM_SIZE_BYTES, temporary_settings
+
+from .conftest import assert_message_represents_event
+
+
+@pytest.fixture
+def event1() -> ReceivedEvent:
+    return ReceivedEvent(
+        occurred=pendulum.now("UTC"),
+        event="was.tubular",
+        resource=Resource(__root__={"prefect.resource.id": "my.kickflip"}),
+        payload={"goodbye": "yellow brick road"},
+        id=uuid4(),
+    )
+
+
+@pytest.fixture
+def event2() -> ReceivedEvent:
+    return ReceivedEvent(
+        occurred=pendulum.now("UTC"),
+        event="was.super.gnarly",
+        resource=Resource(__root__={"prefect.resource.id": "my.ollie"}),
+        payload={"where": "the dogs of society howl"},
+        id=uuid4(),
+    )
+
+
+@pytest.fixture
+def event3() -> ReceivedEvent:
+    return ReceivedEvent(
+        occurred=pendulum.now("UTC"),
+        event="was.extra.spicy",
+        resource=Resource(__root__={"prefect.resource.id": "my.heelflip"}),
+        payload={"you": "can't plant me in your penthouse"},
+        id=uuid4(),
+    )
+
+
+@pytest.fixture
+def capturing_publisher() -> Generator[Type[CapturingPublisher], None, None]:
+    with mock.patch(
+        "prefect.server.events.messaging.create_publisher",
+        CapturingPublisher,
+    ):
+        CapturingPublisher.messages = []
+        yield CapturingPublisher
+        CapturingPublisher.messages = []
+
+
+async def test_publishing_events(
+    capturing_publisher: Type[CapturingPublisher],
+    event1: ReceivedEvent,
+    event2: ReceivedEvent,
+):
+    async with create_event_publisher() as publisher:
+        await publisher.publish_event(event1)
+        await publisher.publish_event(event2)
+
+    (one, two) = capturing_publisher.messages
+
+    assert_message_represents_event(one, event1)
+    assert_message_represents_event(two, event2)
+
+
+@pytest.fixture
+def tiny_event_size() -> Generator[int, None, None]:
+    with temporary_settings(updates={PREFECT_EVENTS_MAXIMUM_SIZE_BYTES: 10000}):
+        yield 10_000
+
+
+async def test_maximum_event_message_size(
+    capturing_publisher: Type[CapturingPublisher],
+    event1: ReceivedEvent,
+    event2: ReceivedEvent,
+    event3: ReceivedEvent,
+    caplog: pytest.LogCaptureFixture,
+    tiny_event_size: int,
+):
+    with caplog.at_level("WARN"):
+        async with create_event_publisher() as publisher:
+            await publisher.publish_event(event1)
+
+            # publish a bad one in the middle that will be quietly dropped
+            event2.payload = {"message": "foo" * tiny_event_size}
+            await publisher.publish_event(event2)
+
+            await publisher.publish_event(event3)
+
+    assert "Refusing to publish event" in caplog.text
+
+    (one, two) = capturing_publisher.messages
+
+    assert_message_represents_event(one, event1)
+    assert_message_represents_event(two, event3)
+
+
+async def test_will_not_publish_duplicate_messages(
+    capturing_publisher: Type[CapturingPublisher],
+    event1: ReceivedEvent,
+    event2: ReceivedEvent,
+    event3: ReceivedEvent,
+):
+    await messaging.publish([event1, event2])
+    # send event2 a few more times, in different batches to confirm that we aren't
+    # just deduping locally to each batch
+    await messaging.publish([event2])
+    await messaging.publish([event2])
+    await messaging.publish([event2])
+    # bookend it with event3 to make sure all the events come through
+    await messaging.publish([event1, event2, event3])
+
+    (one, two, three) = capturing_publisher.messages
+
+    assert_message_represents_event(one, event1)
+    assert_message_represents_event(two, event2)
+    assert_message_represents_event(three, event3)


### PR DESCRIPTION
This adds the events HTTP and websocket endpoints to act as the inbound gateway
for events, matching the interface and behavior of Prefect Cloud (apart from
authentication).  Based on the current implementation using the default
in-memory topics and subscriptions will essentially act as a `/dev/null` for any
events sent to them.
