### PR TITLE
Adding a diagnostic service which consumes events and prints a summary of them

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -35,6 +35,7 @@ from prefect._internal.compatibility.experimental import enabled_experiments
 from prefect.client.constants import SERVER_API_VERSION
 from prefect.logging import get_logger
 from prefect.server.api.dependencies import EnforceMinimumAPIVersion
+from prefect.server.events.services.event_logger import EventLogger
 from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.utilities.database import get_dialect
 from prefect.server.utilities.server import method_paths_from_routes
@@ -569,6 +570,12 @@ def create_app(
 
         if prefect.settings.PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING.value():
             service_instances.append(services.task_scheduling.TaskSchedulingTimeouts())
+
+        if (
+            prefect.settings.PREFECT_EXPERIMENTAL_EVENTS.value()
+            and prefect.settings.PREFECT_API_SERVICES_EVENT_LOGGER_ENABLED.value()
+        ):
+            service_instances.append(EventLogger())
 
         loop = asyncio.get_running_loop()
 

--- a/src/prefect/server/events/services/event_logger.py
+++ b/src/prefect/server/events/services/event_logger.py
@@ -1,0 +1,57 @@
+import asyncio
+from typing import Optional
+
+import pendulum
+import rich
+
+from prefect.logging import get_logger
+from prefect.server.events.schemas.events import ReceivedEvent
+from prefect.server.utilities.messaging import Message, create_consumer
+
+logger = get_logger(__name__)
+
+
+class EventLogger:
+    """A debugging service that logs events to the console as they arrive."""
+
+    name: str = "EventLogger"
+
+    consumer_task: Optional[asyncio.Task] = None
+
+    async def start(self):
+        logger.debug("Event logger started")
+        assert self.consumer_task is None, "Logger already started"
+        self.consumer = create_consumer("events")
+
+        console = rich.console.Console()
+
+        async def handler(message: Message):
+            now = pendulum.now("UTC")
+            event: ReceivedEvent = ReceivedEvent.parse_raw(message.data)
+
+            console.print(
+                "Event:",
+                str(event.id).partition("-")[0],
+                f"{event.occurred.isoformat()}",
+                f" ({(event.occurred - now).total_seconds():>6,.2f})",
+                f"\\[[bold green]{event.event}[/]]",
+                event.resource.id,
+            )
+            console.file.flush()
+
+        self.consumer_task = asyncio.create_task(self.consumer.run(handler))
+        try:
+            await self.consumer_task
+        except asyncio.CancelledError:
+            pass
+
+    async def stop(self):
+        logger.debug("Event logger stopped")
+        assert self.consumer_task is not None, "Logger not started"
+        self.consumer_task.cancel()
+        try:
+            await self.consumer_task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self.consumer_task = None

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1666,6 +1666,10 @@ PREFECT_EVENTS_MAXIMUM_SIZE_BYTES = Setting(int, default=1_500_000)
 The maximum size of an Event when serialized to JSON
 """
 
+PREFECT_API_SERVICES_EVENT_LOGGER_ENABLED = Setting(bool, default=True)
+"""
+Whether or not to start the event debug logger service in the server application.
+"""
 
 # Deprecated settings ------------------------------------------------------------------
 


### PR DESCRIPTION
This enables an end-to-end test of event colleciton, from the API to
distribution to consumers.  It can be enabled at startup to print every event
received on the event bus.  I'm not including an additional test suite for this
service because it's not likely to stay with us long-term.
