### PR TITLE
stop trying to cache docker layers

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -614,8 +614,6 @@ jobs:
             PREFECT_EXTRAS=[dev]
           tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}
           outputs: type=docker,dest=/tmp/image.tar
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Test Docker image
         run: |

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -737,8 +737,6 @@ jobs:
             PREFECT_EXTRAS=[dev]
           tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}
           outputs: type=docker,dest=/tmp/image.tar
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Test Docker image
         run: |


### PR DESCRIPTION
Trying to cache our docker images results in trying to build and export to the cache, which seems to takes all of the time.
This PR removes caching when trying to build images during our tests. When caching is working in a normal manner this seems to only save us around 10s total. For now lets remove caching entirely to avoid running into 15min image build times and we can revisit it.

Additionally we've exceed our GHA cache by 200GB (the limit is allegedly 10GB). Clearing this might provide a more reliable experience.
 
![Screenshot 2024-03-29 at 6 04 09 PM](https://github.com/PrefectHQ/prefect/assets/40362401/3af9388e-4179-41fc-b8b6-c2330af7f609)

without it this step takes under 2 minutes:
![Screenshot 2024-03-29 at 6 04 55 PM](https://github.com/PrefectHQ/prefect/assets/40362401/80a3aa80-e25f-473f-8462-468db63c9634)
