### PR TITLE
set loop debug off

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -578,6 +578,14 @@ PREFECT_UNIT_TEST_MODE = Setting(
 This variable only exists to facilitate unit testing. If `True`,
 code is executing in a unit test context. Defaults to `False`.
 """
+PREFECT_UNIT_TEST_LOOP_DEBUG = Setting(
+    bool,
+    default=False,
+)
+"""
+If `True` turns on debug mode for the unit testing event loop.
+Defaults to `False`.
+"""
 
 PREFECT_TEST_SETTING = Setting(
     Any,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,7 +229,6 @@ def event_loop(request):
     asyncio_logger = logging.getLogger("asyncio")
     asyncio_logger.setLevel("WARNING")
     asyncio_logger.addHandler(logging.StreamHandler())
-    # loop.set_debug(True)
     loop.slow_callback_duration = 0.25
 
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,7 +229,7 @@ def event_loop(request):
     asyncio_logger = logging.getLogger("asyncio")
     asyncio_logger.setLevel("WARNING")
     asyncio_logger.addHandler(logging.StreamHandler())
-    loop.set_debug(True)
+    # loop.set_debug(True)
     loop.slow_callback_duration = 0.25
 
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,8 +63,8 @@ from prefect.settings import (
     PREFECT_PROFILES_PATH,
     PREFECT_SERVER_ANALYTICS_ENABLED,
     PREFECT_SERVER_CSRF_PROTECTION_ENABLED,
-    PREFECT_UNIT_TEST_MODE,
     PREFECT_UNIT_TEST_LOOP_DEBUG,
+    PREFECT_UNIT_TEST_MODE,
 )
 from prefect.utilities.dispatch import get_registry_for_type
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,7 @@ from prefect.settings import (
     PREFECT_SERVER_ANALYTICS_ENABLED,
     PREFECT_SERVER_CSRF_PROTECTION_ENABLED,
     PREFECT_UNIT_TEST_MODE,
+    PREFECT_UNIT_TEST_LOOP_DEBUG,
 )
 from prefect.utilities.dispatch import get_registry_for_type
 
@@ -229,6 +230,10 @@ def event_loop(request):
     asyncio_logger = logging.getLogger("asyncio")
     asyncio_logger.setLevel("WARNING")
     asyncio_logger.addHandler(logging.StreamHandler())
+
+    if PREFECT_UNIT_TEST_LOOP_DEBUG.value():
+        loop.set_debug(True)
+
     loop.slow_callback_duration = 0.25
 
     try:

--- a/tests/server/models/test_orm.py
+++ b/tests/server/models/test_orm.py
@@ -605,7 +605,11 @@ class TestExpectedStartTimeDelta:
         result = await session.execute(
             sa.select(db.FlowRun.estimated_start_time_delta).filter_by(id=fr.id)
         )
-        assert lateness <= result.scalar() <= (pendulum.now() - dt)
+        estimated_start_time_delta = result.scalar()
+
+        # allow for some wiggle room in the time delta
+        assert (estimated_start_time_delta - lateness) <= pendulum.duration(seconds=1)
+        assert (pendulum.now() - dt - lateness) <= pendulum.duration(seconds=1)
 
     async def test_flow_run_lateness_when_pending(self, session, flow, db):
         lateness = pendulum.duration(seconds=60)
@@ -631,7 +635,11 @@ class TestExpectedStartTimeDelta:
         result = await session.execute(
             sa.select(db.FlowRun.estimated_start_time_delta).filter_by(id=fr.id)
         )
-        assert lateness <= result.scalar() <= (pendulum.now() - dt)
+        estimated_start_time_delta = result.scalar()
+
+        # allow for some wiggle room in the time delta
+        assert (estimated_start_time_delta - lateness) <= pendulum.duration(seconds=1)
+        assert (pendulum.now() - dt - lateness) <= pendulum.duration(seconds=1)
 
     async def test_flow_run_lateness_when_running(self, session, flow, db):
         dt = pendulum.now("UTC").subtract(minutes=1)


### PR DESCRIPTION
Setting the test event loop to `loop.set_debug(True)` makes things way slower during our tests.

Removing this cuts the sqlite test suite by about 3 minutes and the postgres test suite by about 1 minute.

## SQLITE:
### then:
![Screenshot 2024-03-29 at 7 02 25 PM](https://github.com/PrefectHQ/prefect/assets/40362401/5b757b4b-e99d-4db2-9892-f69004b85a82)
### Now
![Screenshot 2024-03-29 at 7 02 08 PM](https://github.com/PrefectHQ/prefect/assets/40362401/f0e5e259-2821-4ceb-96be-22f775ba83e8)

## Postgres
### Then:
![Screenshot 2024-03-29 at 7 05 58 PM](https://github.com/PrefectHQ/prefect/assets/40362401/39b4fd42-be1d-4cc7-97ce-de416f720a77)
### Now:
![Screenshot 2024-03-29 at 7 05 51 PM](https://github.com/PrefectHQ/prefect/assets/40362401/f3ea74e4-afc7-4463-bba4-70e20f2dba83)
