### PR TITLE
update lower bound for typer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ kubernetes >= 24.2.0, < 30.0.0
 pytz >= 2021.1, < 2025
 readchar >= 4.0.0, < 5.0.0
 sqlalchemy[asyncio] >= 1.4.22, != 1.4.33, < 3.0.0
-typer >= 0.4.2
+typer >= 0.10.0


### PR DESCRIPTION
on any version of typer below `0.10.0`, the current prefect CLI would break because of the changes described here

https://github.com/PrefectHQ/prefect/pull/12398