### PR TITLE
revert mixin strategy and copy schemas to remove `copy_model_fields`

### DIFF
--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -68,34 +68,31 @@ class StateCreate(ActionBaseModel):
     )
 
 
-class FlowCreate(ActionBaseModel, objects.FlowMixin):
+@copy_model_fields
+class FlowCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a flow."""
 
-    ...
+    name: str = FieldFrom(objects.Flow)
+    tags: List[str] = FieldFrom(objects.Flow)
 
 
-class FlowUpdate(ActionBaseModel, objects.FlowMixin):
+@copy_model_fields
+class FlowUpdate(ActionBaseModel):
     """Data used by the Prefect REST API to update a flow."""
 
-    ...
+    tags: List[str] = FieldFrom(objects.Flow)
 
 
-class DeploymentScheduleCreate(ActionBaseModel, objects.MinimalDeploymentSchedule):
-    """Data used by the Prefect REST API to create a deployment schedule."""
+@copy_model_fields
+class DeploymentScheduleCreate(ActionBaseModel):
+    active: bool = FieldFrom(objects.DeploymentSchedule)
+    schedule: SCHEDULE_TYPES = FieldFrom(objects.DeploymentSchedule)
 
-    ...
 
-
-class DeploymentScheduleUpdate(ActionBaseModel, objects.MinimalDeploymentSchedule):
-    """Data used by the Prefect REST API to update a deployment schedule."""
-
-    deployment_id: Optional[UUID] = Field(
-        description="The ID of the deployment to associate with the schedule."
-    )
-
-    schedule: Optional[SCHEDULE_TYPES] = Field(
-        description="The schedule for the deployment.",
-    )
+@copy_model_fields
+class DeploymentScheduleUpdate(ActionBaseModel):
+    active: bool = FieldFrom(objects.DeploymentSchedule)
+    schedule: SCHEDULE_TYPES = FieldFrom(objects.DeploymentSchedule)
 
 
 @experimental_field(
@@ -200,7 +197,6 @@ class DeploymentCreate(ActionBaseModel):
     group="work_pools",
     when=lambda x: x is not None,
 )
-@copy_model_fields
 class DeploymentUpdate(ActionBaseModel):
     """Data used by the Prefect REST API to update a deployment."""
 
@@ -241,27 +237,27 @@ class DeploymentUpdate(ActionBaseModel):
     def validate_none_schedule(cls, v):
         return return_none_schedule(v)
 
-    version: Optional[str] = FieldFrom(objects.Deployment)
-    schedule: Optional[SCHEDULE_TYPES] = FieldFrom(objects.Deployment)
-    description: Optional[str] = FieldFrom(objects.Deployment)
-    is_schedule_active: bool = FieldFrom(objects.Deployment)
+    version: Optional[str] = Field(None)
+    schedule: Optional[SCHEDULE_TYPES] = Field(None)
+    description: Optional[str] = Field(None)
+    is_schedule_active: bool = Field(None)
     parameters: Optional[Dict[str, Any]] = Field(
         default=None,
         description="Parameters for flow runs scheduled by the deployment.",
     )
-    tags: List[str] = FieldFrom(objects.Deployment)
-    work_queue_name: Optional[str] = FieldFrom(objects.Deployment)
+    tags: List[str] = Field(default_factory=list)
+    work_queue_name: Optional[str] = Field(None)
     work_pool_name: Optional[str] = Field(
         default=None,
         description="The name of the deployment's work pool.",
         example="my-work-pool",
     )
-    path: Optional[str] = FieldFrom(objects.Deployment)
-    infra_overrides: Optional[Dict[str, Any]] = FieldFrom(objects.Deployment)
-    entrypoint: Optional[str] = FieldFrom(objects.Deployment)
-    manifest_path: Optional[str] = FieldFrom(objects.Deployment)
-    storage_document_id: Optional[UUID] = FieldFrom(objects.Deployment)
-    infrastructure_document_id: Optional[UUID] = FieldFrom(objects.Deployment)
+    path: Optional[str] = Field(None)
+    infra_overrides: Optional[Dict[str, Any]] = Field(None)
+    entrypoint: Optional[str] = Field(None)
+    manifest_path: Optional[str] = Field(None)
+    storage_document_id: Optional[UUID] = Field(None)
+    infrastructure_document_id: Optional[UUID] = Field(None)
     enforce_parameter_schema: Optional[bool] = Field(
         default=None,
         description=(
@@ -290,17 +286,18 @@ class DeploymentUpdate(ActionBaseModel):
             jsonschema.validate(self.infra_overrides, variables_schema)
 
 
-@copy_model_fields
 class FlowRunUpdate(ActionBaseModel):
     """Data used by the Prefect REST API to update a flow run."""
 
-    name: Optional[str] = FieldFrom(objects.FlowRun)
-    flow_version: Optional[str] = FieldFrom(objects.FlowRun)
-    parameters: dict = FieldFrom(objects.FlowRun)
-    empirical_policy: objects.FlowRunPolicy = FieldFrom(objects.FlowRun)
-    tags: List[str] = FieldFrom(objects.FlowRun)
-    infrastructure_pid: Optional[str] = FieldFrom(objects.FlowRun)
-    job_variables: Optional[dict] = FieldFrom(objects.FlowRun)
+    name: Optional[str] = Field(None)
+    flow_version: Optional[str] = Field(None)
+    parameters: Optional[Dict[str, Any]] = Field(None)
+    empirical_policy: objects.FlowRunPolicy = Field(
+        default_factory=objects.FlowRunPolicy
+    )
+    tags: List[str] = Field(default_factory=list)
+    infrastructure_pid: Optional[str] = Field(None)
+    job_variables: Optional[Dict[str, Any]] = Field(None)
 
 
 @copy_model_fields

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -897,8 +897,8 @@ class BlockDocument(ObjectBaseModel):
         return values
 
 
-class FlowMixin(PrefectBaseModel):
-    """Base model for a Flow"""
+class Flow(ObjectBaseModel):
+    """An ORM representation of flow data."""
 
     name: str = Field(
         default=..., description="The name of the flow", example="my-flow"
@@ -914,12 +914,6 @@ class FlowMixin(PrefectBaseModel):
         return raise_on_name_with_banned_characters(v)
 
 
-class Flow(ObjectBaseModel, FlowMixin):
-    """An ORM representation of flow data."""
-
-    ...
-
-
 class MinimalDeploymentSchedule(PrefectBaseModel):
     schedule: SCHEDULE_TYPES = Field(
         default=..., description="The schedule for the deployment."
@@ -929,10 +923,16 @@ class MinimalDeploymentSchedule(PrefectBaseModel):
     )
 
 
-class DeploymentSchedule(ObjectBaseModel, MinimalDeploymentSchedule):
+class DeploymentSchedule(ObjectBaseModel):
     deployment_id: Optional[UUID] = Field(
         default=None,
         description="The deployment id associated with this schedule.",
+    )
+    schedule: SCHEDULE_TYPES = Field(
+        default=..., description="The schedule for the deployment."
+    )
+    active: bool = Field(
+        default=True, description="Whether or not the schedule is active."
     )
 
 

--- a/src/prefect/client/schemas/responses.py
+++ b/src/prefect/client/schemas/responses.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import List, Optional, TypeVar, Union
+from typing import Any, Dict, List, Optional, TypeVar, Union
 from uuid import UUID
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
@@ -12,9 +12,11 @@ else:
 from typing_extensions import Literal
 
 import prefect.client.schemas.objects as objects
-from prefect._internal.schemas.bases import PrefectBaseModel
-from prefect._internal.schemas.fields import DateTimeTZ
+from prefect._internal.schemas.bases import ObjectBaseModel, PrefectBaseModel
+from prefect._internal.schemas.fields import CreatedBy, DateTimeTZ, UpdatedBy
+from prefect.client.schemas.schedules import SCHEDULE_TYPES
 from prefect.utilities.collections import AutoEnum
+from prefect.utilities.names import generate_slug
 
 R = TypeVar("R")
 
@@ -152,11 +154,258 @@ class WorkerFlowRunResponse(PrefectBaseModel):
     flow_run: objects.FlowRun
 
 
-class FlowRunResponse(objects.FlowRun):
-    ...
+class FlowRunResponse(ObjectBaseModel):
+    name: str = Field(
+        default_factory=lambda: generate_slug(2),
+        description=(
+            "The name of the flow run. Defaults to a random slug if not specified."
+        ),
+        example="my-flow-run",
+    )
+    flow_id: UUID = Field(default=..., description="The id of the flow being run.")
+    state_id: Optional[UUID] = Field(
+        default=None, description="The id of the flow run's current state."
+    )
+    deployment_id: Optional[UUID] = Field(
+        default=None,
+        description=(
+            "The id of the deployment associated with this flow run, if available."
+        ),
+    )
+    work_queue_name: Optional[str] = Field(
+        default=None, description="The work queue that handled this flow run."
+    )
+    flow_version: Optional[str] = Field(
+        default=None,
+        description="The version of the flow executed in this flow run.",
+        example="1.0",
+    )
+    parameters: dict = Field(
+        default_factory=dict, description="Parameters for the flow run."
+    )
+    idempotency_key: Optional[str] = Field(
+        default=None,
+        description=(
+            "An optional idempotency key for the flow run. Used to ensure the same flow"
+            " run is not created multiple times."
+        ),
+    )
+    context: dict = Field(
+        default_factory=dict,
+        description="Additional context for the flow run.",
+        example={"my_var": "my_val"},
+    )
+    empirical_policy: objects.FlowRunPolicy = Field(
+        default_factory=objects.FlowRunPolicy,
+    )
+    tags: List[str] = Field(
+        default_factory=list,
+        description="A list of tags on the flow run",
+        example=["tag-1", "tag-2"],
+    )
+    parent_task_run_id: Optional[UUID] = Field(
+        default=None,
+        description=(
+            "If the flow run is a subflow, the id of the 'dummy' task in the parent"
+            " flow used to track subflow state."
+        ),
+    )
+    run_count: int = Field(
+        default=0, description="The number of times the flow run was executed."
+    )
+    expected_start_time: Optional[DateTimeTZ] = Field(
+        default=None,
+        description="The flow run's expected start time.",
+    )
+    next_scheduled_start_time: Optional[DateTimeTZ] = Field(
+        default=None,
+        description="The next time the flow run is scheduled to start.",
+    )
+    start_time: Optional[DateTimeTZ] = Field(
+        default=None, description="The actual start time."
+    )
+    end_time: Optional[DateTimeTZ] = Field(
+        default=None, description="The actual end time."
+    )
+    total_run_time: datetime.timedelta = Field(
+        default=datetime.timedelta(0),
+        description=(
+            "Total run time. If the flow run was executed multiple times, the time of"
+            " each run will be summed."
+        ),
+    )
+    estimated_run_time: datetime.timedelta = Field(
+        default=datetime.timedelta(0),
+        description="A real-time estimate of the total run time.",
+    )
+    estimated_start_time_delta: datetime.timedelta = Field(
+        default=datetime.timedelta(0),
+        description="The difference between actual and expected start time.",
+    )
+    auto_scheduled: bool = Field(
+        default=False,
+        description="Whether or not the flow run was automatically scheduled.",
+    )
+    infrastructure_document_id: Optional[UUID] = Field(
+        default=None,
+        description="The block document defining infrastructure to use this flow run.",
+    )
+    infrastructure_pid: Optional[str] = Field(
+        default=None,
+        description="The id of the flow run as returned by an infrastructure block.",
+    )
+    created_by: Optional[CreatedBy] = Field(
+        default=None,
+        description="Optional information about the creator of this flow run.",
+    )
+    work_queue_id: Optional[UUID] = Field(
+        default=None, description="The id of the run's work pool queue."
+    )
+
+    work_pool_id: Optional[UUID] = Field(
+        description="The work pool with which the queue is associated."
+    )
+    work_pool_name: Optional[str] = Field(
+        default=None,
+        description="The name of the flow run's work pool.",
+        example="my-work-pool",
+    )
+    state: Optional[objects.State] = Field(
+        default=None,
+        description="The state of the flow run.",
+        example=objects.State(type=objects.StateType.COMPLETED),
+    )
+    job_variables: Optional[dict] = Field(
+        default=None, description="Job variables for the flow run."
+    )
+
+    # These are server-side optimizations and should not be present on client models
+    # TODO: Deprecate these fields
+
+    state_type: Optional[objects.StateType] = Field(
+        default=None, description="The type of the current flow run state."
+    )
+    state_name: Optional[str] = Field(
+        default=None, description="The name of the current flow run state."
+    )
+
+    def __eq__(self, other: Any) -> bool:
+        """
+        Check for "equality" to another flow run schema
+
+        Estimates times are rolling and will always change with repeated queries for
+        a flow run so we ignore them during equality checks.
+        """
+        if isinstance(other, objects.FlowRun):
+            exclude_fields = {"estimated_run_time", "estimated_start_time_delta"}
+            return self.dict(exclude=exclude_fields) == other.dict(
+                exclude=exclude_fields
+            )
+        return super().__eq__(other)
 
 
-class DeploymentResponse(objects.Deployment):
+class DeploymentResponse(ObjectBaseModel):
+    name: str = Field(default=..., description="The name of the deployment.")
+    version: Optional[str] = Field(
+        default=None, description="An optional version for the deployment."
+    )
+    description: Optional[str] = Field(
+        default=None, description="A description for the deployment."
+    )
+    flow_id: UUID = Field(
+        default=..., description="The flow id associated with the deployment."
+    )
+    schedule: Optional[SCHEDULE_TYPES] = Field(
+        default=None, description="A schedule for the deployment."
+    )
+    is_schedule_active: bool = Field(
+        default=True, description="Whether or not the deployment schedule is active."
+    )
+    paused: bool = Field(
+        default=False, description="Whether or not the deployment is paused."
+    )
+    schedules: List[objects.DeploymentSchedule] = Field(
+        default_factory=list, description="A list of schedules for the deployment."
+    )
+    infra_overrides: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Overrides to apply to the base infrastructure block at runtime.",
+    )
+    parameters: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Parameters for flow runs scheduled by the deployment.",
+    )
+    pull_steps: Optional[List[dict]] = Field(
+        default=None,
+        description="Pull steps for cloning and running this deployment.",
+    )
+    tags: List[str] = Field(
+        default_factory=list,
+        description="A list of tags for the deployment",
+        example=["tag-1", "tag-2"],
+    )
+    work_queue_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "The work queue for the deployment. If no work queue is set, work will not"
+            " be scheduled."
+        ),
+    )
+    last_polled: Optional[DateTimeTZ] = Field(
+        default=None,
+        description="The last time the deployment was polled for status updates.",
+    )
+    parameter_openapi_schema: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="The parameter schema of the flow, including defaults.",
+    )
+    path: Optional[str] = Field(
+        default=None,
+        description=(
+            "The path to the working directory for the workflow, relative to remote"
+            " storage or an absolute path."
+        ),
+    )
+    entrypoint: Optional[str] = Field(
+        default=None,
+        description=(
+            "The path to the entrypoint for the workflow, relative to the `path`."
+        ),
+    )
+    manifest_path: Optional[str] = Field(
+        default=None,
+        description=(
+            "The path to the flow's manifest file, relative to the chosen storage."
+        ),
+    )
+    storage_document_id: Optional[UUID] = Field(
+        default=None,
+        description="The block document defining storage used for this flow.",
+    )
+    infrastructure_document_id: Optional[UUID] = Field(
+        default=None,
+        description="The block document defining infrastructure to use for flow runs.",
+    )
+    created_by: Optional[CreatedBy] = Field(
+        default=None,
+        description="Optional information about the creator of this deployment.",
+    )
+    updated_by: Optional[UpdatedBy] = Field(
+        default=None,
+        description="Optional information about the updater of this deployment.",
+    )
+    work_queue_id: UUID = Field(
+        default=None,
+        description=(
+            "The id of the work pool queue to which this deployment is assigned."
+        ),
+    )
+    enforce_parameter_schema: bool = Field(
+        default=False,
+        description=(
+            "Whether or not the deployment should enforce the parameter schema."
+        ),
+    )
     work_pool_name: Optional[str] = Field(
         default=None,
         description="The name of the deployment's work pool.",


### PR DESCRIPTION
continuing #12475

we are no longer doing the `Mixin` because its complex and mypy gets angry, so we are now duplicating schemas

---

#### more context
the `class SomeModel(ActionModel, SomeModelMixin):` strategy is seeming a bit complex, especially because mypy (we hope someday to pass its muster) does not let you override type annotations on base model, so even if you have a true intersection of `Field` objects that can live on the mixin, you can't really be safe with types (which sort of defeats the purpose of the this effort to remove `copy_model_fields`)
so, the plan is to just do the dead simplest thing, which is to duplicate the ORM and action schemas so we can be explicit on each with typing.

The claim is that even though this creates multiple places you need to update a schema if one changes:
- it is much easier to reason about
- you can correctly annotate model field types for the model, i.e. SomeModelUpdate will have more Optional fields than SomeModelCreate
- schemas wont change _that_ often