### PR TITLE
support `mode="json"` when flag is off

### DIFF
--- a/src/prefect/_internal/pydantic/utilities/model_dump.py
+++ b/src/prefect/_internal/pydantic/utilities/model_dump.py
@@ -1,5 +1,6 @@
 import typing
 
+from pydantic_core import from_json
 from typing_extensions import Self
 
 from prefect._internal.pydantic._base_model import BaseModel
@@ -58,6 +59,18 @@ def model_dump(  # type: ignore[no-redef]
             warnings=warnings,
         )
     else:
+        if mode == "json":
+            return from_json(
+                model_instance.json(
+                    include=include,
+                    exclude=exclude,
+                    by_alias=by_alias,
+                    exclude_unset=exclude_unset,
+                    exclude_defaults=exclude_defaults,
+                    exclude_none=exclude_none,
+                )
+            )
+
         return getattr(model_instance, "dict")(
             include=include,
             exclude=exclude,

--- a/src/prefect/_internal/pydantic/utilities/model_dump.py
+++ b/src/prefect/_internal/pydantic/utilities/model_dump.py
@@ -1,4 +1,5 @@
 import typing
+import warnings as python_warnings
 
 from pydantic_core import from_json
 from typing_extensions import Self
@@ -60,16 +61,18 @@ def model_dump(  # type: ignore[no-redef]
         )
     else:
         if mode == "json":
-            return from_json(
-                model_instance.json(
-                    include=include,
-                    exclude=exclude,
-                    by_alias=by_alias,
-                    exclude_unset=exclude_unset,
-                    exclude_defaults=exclude_defaults,
-                    exclude_none=exclude_none,
+            with python_warnings.catch_warnings():
+                python_warnings.simplefilter("ignore")
+                return from_json(
+                    model_instance.json(
+                        include=include,
+                        exclude=exclude,
+                        by_alias=by_alias,
+                        exclude_unset=exclude_unset,
+                        exclude_defaults=exclude_defaults,
+                        exclude_none=exclude_none,
+                    )
                 )
-            )
 
         return getattr(model_instance, "dict")(
             include=include,

--- a/tests/_internal/pydantic/test_model_dump.py
+++ b/tests/_internal/pydantic/test_model_dump.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 from pydantic import BaseModel
 
@@ -47,3 +49,13 @@ def test_model_dump_with_flag_disabled():
 def test_model_dump_with_non_basemodel_raises():
     with pytest.raises(AttributeError):
         model_dump("not a model")  # type: ignore
+
+
+def test_model_dump_with_json_mode():
+    class TestModel(BaseModel):
+        a: int
+        time: datetime
+
+    model = TestModel(a=1, time=datetime.now())
+
+    assert model_dump(model, mode="json") == {"a": 1, "time": model.time.isoformat()}


### PR DESCRIPTION
with the flag off, we can still get `json_compatible` behavior

```python
In [1]: from datetime import datetime

In [2]: from prefect.pydantic import BaseModel

In [3]: class FooModel(BaseModel):
   ...:     d: datetime = datetime.now()
   ...:

In [4]: FooModel(x=42).model_dump(mode="json")
Out[4]: {'d': '2024-04-02T09:45:31.311534'}
```