### PR TITLE
add `pydantic_core` to client deps

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -21,6 +21,7 @@ pendulum < 3.0; python_version < '3.12'
 pendulum >= 3.0.0, <4; python_version >= '3.12'
 # the version constraints for pydantic are merged with those from fastapi 0.103.2
 pydantic[email]>=1.10.0,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0
+pydantic_core >= 2.17.0, < 3.0.0
 python_dateutil >= 2.8.2, < 3.0.0
 python-slugify >= 5.0, < 9.0
 pyyaml >= 5.4.1, < 7.0.0


### PR DESCRIPTION
this install should not affect ongoing pydantic compatibility

short term:
- fix nebula compat

long term:
- v1 / v2 independent utils, for example `from_json` as an efficient version of `json.loads`