### PR TITLE
Introduces the server-side automations schema models

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ markers =
 env =
     # NOTE: Additional Prefect setting values are set dynamically in conftest.py
     PREFECT_TEST_MODE = 1
+    PREFECT_LOGGING_SERVER_LEVEL = DEBUG
 
 asyncio_mode = auto
 timeout = 90
@@ -128,4 +129,3 @@ eval_annotations = yes
 only_show_violations = yes
 targets = 3.8-
 exclusion_regex = ^src/prefect/_vendor/.*$|^src/prefect/utilities/compat\.py$
-

--- a/src/prefect/events/actions.py
+++ b/src/prefect/events/actions.py
@@ -19,10 +19,17 @@ class Action(PrefectBaseModel):
     type: str
 
 
+class DoNothing(Action):
+    """Do nothing, which may be helpful for testing automations"""
+
+    type: Literal["do-nothing"] = "do-nothing"
+
+
 class RunDeployment(Action):
     """Run the given deployment with the given parameters"""
 
     type: Literal["run-deployment"] = "run-deployment"
+
     source: Literal["selected"] = "selected"
     parameters: Optional[Dict[str, Any]] = Field(
         None,
@@ -45,6 +52,7 @@ class SendNotification(Action):
     """Send a notification with the given parameters"""
 
     type: Literal["send-notification"] = "send-notification"
+
     block_document_id: UUID = Field(
         ..., description="The identifier of the notification block"
     )
@@ -52,4 +60,4 @@ class SendNotification(Action):
     subject: Optional[str] = Field(None, description="Notification subject")
 
 
-ActionTypes = Union[RunDeployment, SendNotification]
+ActionTypes = Union[DoNothing, RunDeployment, SendNotification]

--- a/src/prefect/events/schemas/automations.py
+++ b/src/prefect/events/schemas/automations.py
@@ -294,6 +294,17 @@ class Automation(PrefectBaseModel, extra="ignore"):
         ...,
         description="The actions to perform when this Automation triggers",
     )
+
+    actions_on_trigger: List[ActionTypes] = Field(
+        default_factory=list,
+        description="The actions to perform when an Automation goes into a triggered state",
+    )
+
+    actions_on_resolve: List[ActionTypes] = Field(
+        default_factory=list,
+        description="The actions to perform when an Automation goes into a resolving state",
+    )
+
     owner_resource: Optional[str] = Field(
         default=None, description="The owning resource of this automation"
     )

--- a/src/prefect/server/events/actions.py
+++ b/src/prefect/server/events/actions.py
@@ -1,0 +1,172 @@
+import abc
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from uuid import UUID, uuid4
+
+import pendulum
+
+from prefect._internal.pydantic import HAS_PYDANTIC_V2
+
+if HAS_PYDANTIC_V2:
+    from pydantic.v1 import Field
+else:
+    from pydantic import Field
+
+from typing_extensions import Literal
+
+from prefect._internal.schemas.bases import PrefectBaseModel
+from prefect.logging import get_logger
+from prefect.server.events.schemas.events import Event
+
+if TYPE_CHECKING:  # pragma: no cover
+    from prefect.server.events.clients import PrefectServerEventsClient
+    from prefect.server.events.schemas.automations import TriggeredAction
+
+logger = get_logger(__name__)
+
+
+class Action(PrefectBaseModel):
+    """An Action that may be performed when an Automation is triggered"""
+
+    type: str
+
+    @abc.abstractmethod
+    async def act(self, triggered_action: "TriggeredAction") -> None:
+        """Perform the requested Action"""
+
+    async def fail(self, triggered_action: "TriggeredAction", reason: str) -> None:
+        from prefect.server.events.schemas.automations import EventTrigger
+
+        automation = triggered_action.automation
+        action = triggered_action.action
+        action_index = triggered_action.action_index
+
+        automation_resource_id = f"prefect.automation.{automation.id}"
+
+        async with PrefectServerEventsClient() as events:
+            logger.warning(
+                "Action failed: %r",
+                reason,
+                extra={**self.logging_context(triggered_action)},
+            )
+            event = Event(
+                occurred=pendulum.now("UTC"),
+                event="prefect.automation.action.failed",
+                resource={
+                    "prefect.resource.id": automation_resource_id,
+                    "prefect.resource.name": automation.name,
+                    "prefect.trigger-type": automation.trigger.type,
+                },
+                related=self._resulting_related_resources,
+                payload={
+                    "action_index": action_index,
+                    "action_type": action.type,
+                    "invocation": str(triggered_action.id),
+                    "reason": reason,
+                    **self._result_details,
+                },
+                id=uuid4(),
+            )
+            if isinstance(automation.trigger, EventTrigger):
+                event.resource["prefect.posture"] = automation.trigger.posture
+            await events.emit(event)
+
+    async def succeed(self, triggered_action: "TriggeredAction") -> None:
+        from prefect.server.events.schemas.automations import EventTrigger
+
+        automation = triggered_action.automation
+        action = triggered_action.action
+        action_index = triggered_action.action_index
+
+        automation_resource_id = f"prefect.automation.{automation.id}"
+
+        async with PrefectServerEventsClient() as events:
+            event = Event(
+                occurred=pendulum.now("UTC"),
+                event="prefect.automation.action.executed",
+                resource={
+                    "prefect.resource.id": automation_resource_id,
+                    "prefect.resource.name": automation.name,
+                    "prefect.trigger-type": automation.trigger.type,
+                },
+                related=self._resulting_related_resources,
+                payload={
+                    "action_index": action_index,
+                    "action_type": action.type,
+                    "invocation": str(triggered_action.id),
+                    **self._result_details,
+                },
+                id=uuid4(),
+            )
+            if isinstance(automation.trigger, EventTrigger):
+                event.resource["prefect.posture"] = automation.trigger.posture
+            await events.emit(event)
+
+    def logging_context(self, triggered_action: "TriggeredAction") -> Dict[str, Any]:
+        """Common logging context for all actions"""
+        return {
+            "automation": str(triggered_action.automation.id),
+            "action": self.dict(json_compatible=True),
+            "triggering_event": (
+                {
+                    "id": triggered_action.triggering_event.id,
+                    "event": triggered_action.triggering_event.event,
+                }
+                if triggered_action.triggering_event
+                else None
+            ),
+            "triggering_labels": triggered_action.triggering_labels,
+        }
+
+
+class DoNothing(Action):
+    """Do nothing when an Automation is triggered"""
+
+    type: Literal["do-nothing"] = "do-nothing"
+
+    async def act(self, triggered_action: "TriggeredAction") -> None:
+        logger.info(
+            "Doing nothing",
+            extra={**self.logging_context(triggered_action)},
+        )
+
+
+class RunDeployment(Action):
+    """Run the given deployment with the given parameters"""
+
+    type: Literal["run-deployment"] = "run-deployment"
+    source: Literal["selected"] = "selected"
+    parameters: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "The parameters to pass to the deployment, or None to use the "
+            "deployment's default parameters"
+        ),
+    )
+    deployment_id: UUID = Field(..., description="The identifier of the deployment")
+    job_variables: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "Job variables to pass to the run, or None to use the "
+            "deployment's default job variables"
+        ),
+    )
+
+    async def act(self, triggered_action: "TriggeredAction") -> None:
+        raise NotImplementedError()
+
+
+class SendNotification(Action):
+    """Send a notification with the given parameters"""
+
+    type: Literal["send-notification"] = "send-notification"
+    block_document_id: UUID = Field(
+        ..., description="The identifier of the notification block"
+    )
+    body: str = Field(..., description="Notification body")
+    subject: Optional[str] = Field(None, description="Notification subject")
+
+    async def act(self, triggered_action: "TriggeredAction") -> None:
+        raise NotImplementedError()
+
+
+ActionTypes = Union[DoNothing, RunDeployment, SendNotification]

--- a/src/prefect/server/events/schemas/automations.py
+++ b/src/prefect/server/events/schemas/automations.py
@@ -1,0 +1,756 @@
+from __future__ import annotations
+
+import abc
+import re
+import weakref
+from datetime import timedelta
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
+from uuid import UUID, uuid4
+
+from typing_extensions import TypeAlias
+
+from prefect._internal.pydantic import HAS_PYDANTIC_V2
+
+if HAS_PYDANTIC_V2:
+    from pydantic.v1 import Field, PrivateAttr, root_validator, validator
+    from pydantic.v1.fields import ModelField
+else:
+    from pydantic import Field, PrivateAttr, root_validator, validator
+    from pydantic.fields import ModelField
+
+
+from prefect.logging import get_logger
+from prefect.server.events.actions import ActionTypes
+from prefect.server.events.schemas.events import (
+    ReceivedEvent,
+    RelatedResource,
+    Resource,
+    ResourceSpecification,
+    matches,
+)
+from prefect.server.schemas.actions import ActionBaseModel
+from prefect.server.utilities.schemas import DateTimeTZ, ORMBaseModel, PrefectBaseModel
+from prefect.utilities.collections import AutoEnum
+
+logger = get_logger(__name__)
+
+
+class Posture(AutoEnum):
+    Reactive = "Reactive"
+    Proactive = "Proactive"
+    Metric = "Metric"
+
+
+class TriggerState(AutoEnum):
+    Triggered = "Triggered"
+    Resolved = "Resolved"
+
+
+class Trigger(PrefectBaseModel, abc.ABC):
+    """
+    Base class describing a set of criteria that must be satisfied in order to trigger
+    an automation.
+    """
+
+    __slots__ = ("__weakref__",)
+
+    type: str
+
+    id: UUID = Field(default_factory=uuid4, description="The unique ID of this trigger")
+
+    _automation: Optional[weakref.ref] = PrivateAttr(None)
+    _parent: Optional[weakref.ref] = PrivateAttr(None)
+
+    @property
+    def automation(self) -> "Automation":
+        assert self._automation is not None, "Trigger._automation has not been set"
+        value = self._automation()
+        assert value is not None, "Trigger._automation has been garbage collected"
+        return value
+
+    @property
+    def parent(self) -> "Union[Trigger, Automation]":
+        assert self._parent is not None, "Trigger._parent has not been set"
+        value = self._parent()
+        assert value is not None, "Trigger._parent has been garbage collected"
+        return value
+
+    def _set_parent(self, value: "Union[Trigger, Automation]"):
+        if isinstance(value, Automation):
+            self._automation = weakref.ref(value)
+            self._parent = self._automation
+        elif isinstance(value, Trigger):
+            self._parent = weakref.ref(value)
+            self._automation = value._automation
+        else:  # pragma: no cover
+            raise ValueError("parent must be an Automation or a Trigger")
+
+    def reset_ids(self) -> None:
+        """Resets the ID of this trigger and all of its children"""
+        self.id = uuid4()
+        for trigger in self.all_triggers():
+            trigger.id = uuid4()
+
+    def all_triggers(self) -> Sequence[Trigger]:
+        """Returns all triggers within this trigger"""
+        return [self]
+
+    @abc.abstractmethod
+    def create_automation_state_change_event(
+        self, firing: "Firing", trigger_state: TriggerState
+    ) -> ReceivedEvent:
+        ...
+
+
+class CompositeTrigger(Trigger, abc.ABC):
+    """
+    Requires some number of triggers to have fired within the given time period.
+    """
+
+    type: Literal["compound", "sequence"]
+    triggers: List["TriggerTypes"]
+    within: Optional[timedelta]
+
+    def create_automation_state_change_event(
+        self, firing: Firing, trigger_state: TriggerState
+    ) -> ReceivedEvent:
+        """Returns a ReceivedEvent for an automation state change
+        into a triggered or resolved state."""
+        automation = firing.trigger.automation
+        triggering_event = firing.triggering_event
+        return ReceivedEvent(
+            occurred=firing.triggered,
+            event=f"prefect.automation.{trigger_state.value.lower()}",
+            resource={
+                "prefect.resource.id": f"prefect.automation.{automation.id}",
+                "prefect.resource.name": automation.name,
+            },
+            related=(
+                [
+                    {
+                        "prefect.resource.id": f"prefect.event.{triggering_event.id}",
+                        "prefect.resource.role": "triggering-event",
+                    }
+                ]
+                if triggering_event
+                else []
+            ),
+            payload={
+                "triggering_labels": firing.triggering_labels,
+                "triggering_event": (
+                    triggering_event.dict(json_compatible=True)
+                    if triggering_event
+                    else None
+                ),
+            },
+            id=uuid4(),
+        )
+
+    def _set_parent(self, value: "Union[Trigger , Automation]"):
+        super()._set_parent(value)
+        for trigger in self.triggers:
+            trigger._set_parent(self)
+
+    def all_triggers(self) -> Sequence[Trigger]:
+        return [self] + [t for child in self.triggers for t in child.all_triggers()]
+
+    @property
+    def child_trigger_ids(self) -> List[UUID]:
+        return [trigger.id for trigger in self.triggers]
+
+    @property
+    def num_expected_firings(self) -> int:
+        return len(self.triggers)
+
+    @abc.abstractmethod
+    def ready_to_fire(self, firings: Sequence["Firing"]) -> bool:
+        ...
+
+
+class CompoundTrigger(CompositeTrigger):
+    """A composite trigger that requires some number of triggers to have
+    fired within the given time period"""
+
+    type: Literal["compound"] = "compound"
+    require: Union[int, Literal["any", "all"]]
+
+    @property
+    def num_expected_firings(self) -> int:
+        if self.require == "any":
+            return 1
+        elif self.require == "all":
+            return len(self.triggers)
+        else:
+            return int(self.require)
+
+    def ready_to_fire(self, firings: Sequence["Firing"]) -> bool:
+        return len(firings) >= self.num_expected_firings
+
+    @root_validator
+    def validate_require(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        require = values.get("require")
+
+        if isinstance(require, int):
+            if require < 1:
+                raise ValueError("required must be at least 1")
+            if require > len(values["triggers"]):
+                raise ValueError(
+                    "required must be less than or equal to the number of triggers"
+                )
+
+        return values
+
+
+class SequenceTrigger(CompositeTrigger):
+    """A composite trigger that requires some number of triggers to have fired
+    within the given time period in a specific order"""
+
+    type: Literal["sequence"] = "sequence"
+
+    @property
+    def expected_firing_order(self) -> List[UUID]:
+        return [trigger.id for trigger in self.triggers]
+
+    def ready_to_fire(self, firings: Sequence["Firing"]) -> bool:
+        actual_firing_order = [
+            f.trigger.id for f in sorted(firings, key=lambda f: f.triggered)
+        ]
+        return actual_firing_order == self.expected_firing_order
+
+
+class ResourceTrigger(Trigger, abc.ABC):
+    """
+    Base class for triggers that may filter by the labels of resources.
+    """
+
+    type: str
+
+    match: ResourceSpecification = Field(
+        default_factory=lambda: ResourceSpecification(__root__={}),
+        description="Labels for resources which this trigger will match.",
+    )
+    match_related: ResourceSpecification = Field(
+        default_factory=lambda: ResourceSpecification(__root__={}),
+        description="Labels for related resources which this trigger will match.",
+    )
+
+    def covers_resources(
+        self, resource: Resource, related: Sequence[RelatedResource]
+    ) -> bool:
+        if not self.match.includes([resource]):
+            return False
+
+        if not self.match_related.includes(related):
+            return False
+
+        return True
+
+
+class EventTrigger(ResourceTrigger):
+    """
+    A trigger that fires based on the presence or absence of events within a given
+    period of time.
+    """
+
+    type: Literal["event"] = "event"
+
+    after: Set[str] = Field(
+        default_factory=set,
+        description=(
+            "The event(s) which must first been seen to fire this trigger.  If "
+            "empty, then fire this trigger immediately.  Events may include "
+            "trailing wildcards, like `prefect.flow-run.*`"
+        ),
+    )
+    expect: Set[str] = Field(
+        default_factory=set,
+        description=(
+            "The event(s) this trigger is expecting to see.  If empty, this "
+            "trigger will match any event.  Events may include trailing wildcards, "
+            "like `prefect.flow-run.*`"
+        ),
+    )
+
+    for_each: Set[str] = Field(
+        default_factory=set,
+        description=(
+            "Evaluate the trigger separately for each distinct value of these labels "
+            "on the resource.  By default, labels refer to the primary resource of the "
+            "triggering event.  You may also refer to labels from related "
+            "resources by specifying `related:<role>:<label>`.  This will use the "
+            "value of that label for the first related resource in that role.  For "
+            'example, `"for_each": ["related:flow:prefect.resource.id"]` would '
+            "evaluate the trigger for each flow."
+        ),
+    )
+    posture: Literal[Posture.Reactive, Posture.Proactive] = Field(  # type: ignore[valid-type]
+        ...,
+        description=(
+            "The posture of this trigger, either Reactive or Proactive.  Reactive "
+            "triggers respond to the _presence_ of the expected events, while "
+            "Proactive triggers respond to the _absence_ of those expected events."
+        ),
+    )
+    threshold: int = Field(
+        1,
+        description=(
+            "The number of events required for this trigger to fire (for "
+            "Reactive triggers), or the number of events expected (for Proactive "
+            "triggers)"
+        ),
+    )
+    within: timedelta = Field(
+        timedelta(0),
+        minimum=0.0,
+        exclusiveMinimum=False,
+        description=(
+            "The time period over which the events must occur.  For Reactive triggers, "
+            "this may be as low as 0 seconds, but must be at least 10 seconds for "
+            "Proactive triggers"
+        ),
+    )
+
+    @validator("within")
+    def enforce_minimum_within(
+        cls, value: timedelta, values, config, field: ModelField
+    ):
+        minimum = field.field_info.extra["minimum"]
+        if value.total_seconds() < minimum:
+            raise ValueError("The minimum within is 0 seconds")
+        return value
+
+    @root_validator(skip_on_failure=True)
+    def enforce_minimum_within_for_proactive_triggers(cls, values: Dict[str, Any]):
+        posture: Optional[Posture] = values.get("posture")
+        within: Optional[timedelta] = values.get("within")
+
+        if posture == Posture.Proactive:
+            if not within or within == timedelta(0):
+                values["within"] = timedelta(seconds=10.0)
+            elif within < timedelta(seconds=10.0):
+                raise ValueError(
+                    "The minimum within for Proactive triggers is 10 seconds"
+                )
+
+        return values
+
+    def covers(self, event: ReceivedEvent):
+        if not self.covers_resources(event.resource, event.related):
+            return False
+
+        if not self.event_pattern.match(event.event):
+            return False
+
+        return True
+
+    @property
+    def immediate(self) -> bool:
+        """Does this reactive trigger fire immediately for all events?"""
+        return self.posture == Posture.Reactive and self.within == timedelta(0)
+
+    _event_pattern: Optional[re.Pattern] = PrivateAttr(None)
+
+    @property
+    def event_pattern(self) -> re.Pattern:
+        """A regular expression which may be evaluated against any event string to
+        determine if this trigger would be interested in the event"""
+        if self._event_pattern:
+            return self._event_pattern
+
+        if not self.expect:
+            # This preserves the trivial match for `expect`, and matches the behavior
+            # of expects() below
+            self._event_pattern = re.compile(".+")
+        else:
+            patterns = [
+                # escape each pattern, then translate wildcards ('*' -> r'.+')
+                re.escape(e).replace("\\*", ".+")
+                for e in self.expect | self.after
+            ]
+            self._event_pattern = re.compile("|".join(patterns))
+
+        return self._event_pattern
+
+    def starts_after(self, event: str) -> bool:
+        # Warning: Previously we returned 'True' if there was trivial 'after' criteria.
+        # Although this is not wrong, it led to automations processing more events
+        # than they should have.
+        if not self.after:
+            return False
+
+        for candidate in self.after:
+            if matches(candidate, event):
+                return True
+        return False
+
+    def expects(self, event: str) -> bool:
+        if not self.expect:
+            return True
+
+        for candidate in self.expect:
+            if matches(candidate, event):
+                return True
+        return False
+
+    def bucketing_key(self, event: ReceivedEvent) -> Tuple[str, ...]:
+        return tuple(
+            event.find_resource_label(label) or "" for label in sorted(self.for_each)
+        )
+
+    def meets_threshold(self, event_count: int) -> bool:
+        if self.posture == Posture.Reactive and event_count >= self.threshold:
+            return True
+
+        if self.posture == Posture.Proactive and event_count < self.threshold:
+            return True
+
+        return False
+
+    def create_automation_state_change_event(
+        self, firing: Firing, trigger_state: TriggerState
+    ) -> ReceivedEvent:
+        """Returns a ReceivedEvent for an automation state change
+        into a triggered or resolved state."""
+        automation = firing.trigger.automation
+        triggering_event = firing.triggering_event
+
+        resource_data = {
+            "prefect.resource.id": f"prefect.automation.{automation.id}",
+            "prefect.resource.name": automation.name,
+        }
+
+        if self.posture.value:
+            resource_data["prefect.posture"] = self.posture.value
+
+        return ReceivedEvent(
+            occurred=firing.triggered,
+            event=f"prefect.automation.{trigger_state.value.lower()}",
+            resource=resource_data,
+            related=(
+                [
+                    {
+                        "prefect.resource.id": f"prefect.event.{triggering_event.id}",
+                        "prefect.resource.role": "triggering-event",
+                    }
+                ]
+                if triggering_event
+                else []
+            ),
+            payload={
+                "triggering_labels": firing.triggering_labels,
+                "triggering_event": (
+                    triggering_event.dict(json_compatible=True)
+                    if triggering_event
+                    else None
+                ),
+            },
+            id=uuid4(),
+        )
+
+
+TriggerTypes: TypeAlias = Union[EventTrigger, CompoundTrigger, SequenceTrigger]
+"""The union of all concrete trigger types that a user may actually create"""
+
+T = TypeVar("T", bound=Trigger)
+
+
+class AutomationCore(PrefectBaseModel, extra="ignore"):
+    """Defines an action a user wants to take when a certain number of events
+    do or don't happen to the matching resources"""
+
+    name: str = Field(..., description="The name of this automation")
+    description: str = Field("", description="A longer description of this automation")
+
+    enabled: bool = Field(True, description="Whether this automation will be evaluated")
+
+    trigger: TriggerTypes = Field(
+        ...,
+        description=(
+            "The criteria for which events this Automation covers and how it will "
+            "respond to the presence or absence of those events"
+        ),
+    )
+
+    actions: List[ActionTypes] = Field(
+        ...,
+        description="The actions to perform when this Automation triggers",
+    )
+
+    actions_on_trigger: List[ActionTypes] = Field(
+        default_factory=list,
+        description="The actions to perform when an Automation goes into a triggered state",
+    )
+
+    actions_on_resolve: List[ActionTypes] = Field(
+        default_factory=list,
+        description="The actions to perform when an Automation goes into a resolving state",
+    )
+
+    def triggers(self) -> Sequence[Trigger]:
+        """Returns all triggers within this automation"""
+        return self.trigger.all_triggers()
+
+    def triggers_of_type(self, trigger_type: Type[T]) -> Sequence[T]:
+        """Returns all triggers of the specified type within this automation"""
+        return [t for t in self.triggers() if isinstance(t, trigger_type)]
+
+    def trigger_by_id(self, trigger_id: UUID) -> Optional[Trigger]:
+        """Returns the trigger with the given ID, or None if no such trigger exists"""
+        for trigger in self.triggers():
+            if trigger.id == trigger_id:
+                return trigger
+        return None
+
+    @root_validator
+    def prevent_run_deployment_loops(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        """Detects potential infinite loops in automations with RunDeployment actions"""
+        from prefect.server.events.actions import RunDeployment
+
+        if any(values.get(key) is None for key in ("enabled", "trigger", "actions")):
+            # This automation is invalid anyway, so don't proceed with validation
+            return values
+
+        enabled: bool = values["enabled"]
+        if not enabled:
+            # Disabled automations can't cause problems
+            return values
+
+        trigger: Optional[TriggerTypes] = values["trigger"]
+        if (
+            not trigger
+            or not isinstance(trigger, EventTrigger)
+            or trigger.posture != Posture.Reactive
+        ):
+            # Only reactive automations can cause infinite amplification
+            return values
+
+        if not any(e.startswith("prefect.flow-run.") for e in trigger.expect):
+            # Only flow run events can cause infinite amplification
+            return values
+
+        # Every flow run created by a Deployment goes through these states
+        problematic_events = {
+            "prefect.flow-run.Scheduled",
+            "prefect.flow-run.Pending",
+            "prefect.flow-run.Running",
+            "prefect.flow-run.*",
+        }
+        if not problematic_events.intersection(trigger.expect):
+            return values
+
+        actions = [a for a in values["actions"] if isinstance(a, RunDeployment)]
+        for action in actions:
+            if action.source == "inferred":
+                # Inferred deployments for flow run state change events will always
+                # cause infinite loops, because no matter what filters we place on the
+                # flow run, we're inferring the deployment from it, so we'll always
+                # produce a new flow run that matches those filters.
+                raise ValueError(
+                    "Running an inferred deployment from a flow run state change event "
+                    "will lead to an infinite loop of flow runs.  Please choose a "
+                    "specific deployment and add additional filtering labels to the "
+                    "match or match_related for this automation's trigger."
+                )
+
+            if action.source == "selected":
+                # Selected deployments for flow run state changes can cause infinite
+                # loops if there aren't enough filtering labels on the trigger's match
+                # or match_related.  While it's still possible to have infinite loops
+                # with additional filters, it's less likely.
+                if trigger.match.matches_every_resource_of_kind(
+                    "prefect.flow-run"
+                ) and trigger.match_related.matches_every_resource_of_kind(
+                    "prefect.flow-run"
+                ):
+                    raise ValueError(
+                        "Running a selected deployment from a flow run state change "
+                        "event may lead to an infinite loop of flow runs.  Please "
+                        "include additional filtering labels on either match or "
+                        "match_related to narrow down which flow runs will trigger "
+                        "this automation to exclude flow runs from the deployment "
+                        "you've selected."
+                    )
+
+        return values
+
+
+class Automation(ORMBaseModel, AutomationCore, extra="ignore"):
+    __slots__ = ("__weakref__",)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.trigger._set_parent(self)
+
+    @classmethod
+    def from_orm(cls: Type["Automation"], obj: Any) -> "Automation":
+        automation = super().from_orm(obj)
+        automation.trigger._set_parent(automation)
+        return automation
+
+
+class AutomationCreate(AutomationCore, ActionBaseModel, extra="forbid"):
+    owner_resource: Optional[str] = Field(
+        default=None, description="The resource to which this automation belongs"
+    )
+
+
+class AutomationUpdate(AutomationCore, ActionBaseModel, extra="forbid"):
+    pass
+
+
+class AutomationPartialUpdate(ActionBaseModel, extra="forbid"):
+    enabled: bool = Field(True, description="Whether this automation will be evaluated")
+
+
+class AutomationSort(AutoEnum):
+    """Defines automations sorting options."""
+
+    CREATED_DESC = "CREATED_DESC"
+    UPDATED_DESC = "UPDATED_DESC"
+    NAME_ASC = "NAME_ASC"
+    NAME_DESC = "NAME_DESC"
+
+
+class Firing(PrefectBaseModel):
+    """Represents one instance of a trigger firing"""
+
+    id: UUID = Field(default_factory=uuid4)
+
+    trigger: TriggerTypes = Field(..., description="The trigger that is firing")
+    trigger_states: Set[TriggerState] = Field(
+        ...,
+        description="The state changes represented by this Firing",
+    )
+    triggered: DateTimeTZ = Field(
+        ...,
+        description=(
+            "The time at which this trigger fired, which may differ from the "
+            "occurred time of the associated event (as events processing may always "
+            "be slightly delayed)."
+        ),
+    )
+    triggering_labels: Dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "The labels associated with this Firing, derived from the underlying "
+            "for_each values of the trigger.  Only used in the context "
+            "of EventTriggers."
+        ),
+    )
+    triggering_firings: List[Firing] = Field(
+        default_factory=list,
+        description=(
+            "The firings of the triggers that caused this trigger to fire.  Only used "
+            "in the context of CompoundTriggers."
+        ),
+    )
+    triggering_event: Optional[ReceivedEvent] = Field(
+        None,
+        description=(
+            "The most recent event associated with this Firing.  This may be the "
+            "event that caused the trigger to fire (for Reactive triggers), or the "
+            "last event to match the trigger (for Proactive triggers), or the state "
+            "change event (for a Metric trigger)."
+        ),
+    )
+    triggering_value: Any = Field(
+        None,
+        description=(
+            "A value associated with this firing of a trigger.  Maybe used to "
+            "convey additional information at the point of firing, like the value of "
+            "the last query for a MetricTrigger"
+        ),
+    )
+
+    @validator("trigger_states")
+    def validate_trigger_states(cls, value: Set[TriggerState]):
+        if not value:
+            raise ValueError("At least one trigger state must be provided")
+        return value
+
+    def all_firings(self) -> Sequence[Firing]:
+        return [self] + [
+            f for child in self.triggering_firings for f in child.all_firings()
+        ]
+
+    def all_events(self) -> Sequence[ReceivedEvent]:
+        events = [self.triggering_event] if self.triggering_event else []
+        return events + [
+            e for child in self.triggering_firings for e in child.all_events()
+        ]
+
+
+class TriggeredAction(PrefectBaseModel):
+    """An action caused as the result of an automation"""
+
+    automation: Automation = Field(
+        ..., description="The Automation that caused this action"
+    )
+
+    id: UUID = Field(
+        default_factory=uuid4,
+        description="A unique key representing a single triggering of an action",
+    )
+
+    firing: Optional[Firing] = Field(
+        None, description="The Firing that prompted this action"
+    )
+
+    triggered: DateTimeTZ = Field(..., description="When this action was triggered")
+    triggering_labels: Dict[str, str] = Field(
+        ...,
+        description=(
+            "The subset of labels of the Event that triggered this action, "
+            "corresponding to the Automation's for_each.  If no for_each is specified, "
+            "this will be an empty set of labels"
+        ),
+    )
+    triggering_event: Optional[ReceivedEvent] = Field(
+        ...,
+        description=(
+            "The last Event to trigger this automation, if applicable.  For reactive "
+            "triggers, this will be the event that caused the trigger to fire.  For "
+            "proactive triggers, this will be the last event to match the automation, "
+            "if there was one."
+        ),
+    )
+    action: ActionTypes = Field(
+        ...,
+        description="The action to perform",
+    )
+    action_index: int = Field(
+        0,
+        description="The index of the action within the automation",
+    )
+
+    def idempotency_key(self) -> str:
+        """Produce a human-friendly idempotency key for this action"""
+        return ", ".join(
+            [
+                f"automation {self.automation.id}",
+                f"action {self.action_index}",
+                f"invocation {self.id}",
+            ]
+        )
+
+    def all_firings(self) -> Sequence[Firing]:
+        return self.firing.all_firings() if self.firing else []
+
+    def all_events(self) -> Sequence[ReceivedEvent]:
+        return self.firing.all_events() if self.firing else []
+
+
+CompoundTrigger.update_forward_refs()
+SequenceTrigger.update_forward_refs()

--- a/tests/events/server/actions/test_doing_nothing.py
+++ b/tests/events/server/actions/test_doing_nothing.py
@@ -1,0 +1,16 @@
+import pytest
+
+from prefect.server.events import actions
+from prefect.server.events.schemas.automations import TriggeredAction
+
+
+async def test_doing_nothing(
+    caplog: pytest.LogCaptureFixture,
+    email_me_when_that_dang_spider_comes: TriggeredAction,
+):
+    action = actions.DoNothing()
+
+    with caplog.at_level("INFO"):
+        await action.act(email_me_when_that_dang_spider_comes)
+
+    assert "Doing nothing" in caplog.text

--- a/tests/events/server/conftest.py
+++ b/tests/events/server/conftest.py
@@ -1,9 +1,19 @@
+from datetime import timedelta
 from typing import Optional, Union
+from uuid import uuid4
 
 import pendulum
 import pytest
+from pendulum.datetime import DateTime
 from pendulum.tz.timezone import Timezone
 
+from prefect.server.events import actions
+from prefect.server.events.schemas.automations import (
+    Automation,
+    EventTrigger,
+    Posture,
+    TriggeredAction,
+)
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.utilities.messaging import Message
 
@@ -19,6 +29,56 @@ def frozen_time(monkeypatch: pytest.MonkeyPatch) -> pendulum.DateTime:
 
     monkeypatch.setattr(pendulum, "now", frozen_time)
     return frozen
+
+
+@pytest.fixture
+def arachnophobia() -> Automation:
+    return Automation(
+        name="React immediately to spiders",
+        trigger=EventTrigger(
+            expect={"animal.walked"},
+            match={
+                "class": "Arachnida",
+                "order": "Araneae",
+            },
+            posture=Posture.Reactive,
+            threshold=1,
+        ),
+        actions=[actions.DoNothing()],
+    )
+
+
+@pytest.fixture
+def daddy_long_legs_walked(start_of_test: DateTime) -> ReceivedEvent:
+    return ReceivedEvent(
+        occurred=start_of_test + timedelta(microseconds=1),
+        event="animal.walked",
+        resource={
+            "kingdom": "Animalia",
+            "phylum": "Arthropoda",
+            "class": "Arachnida",
+            "order": "Araneae",
+            "family": "Pholcidae",
+            "genus": "Pholcus",
+            "species": "phalangioides",
+            "prefect.resource.id": "daddy-long-legs",
+        },
+        id=uuid4(),
+    )
+
+
+@pytest.fixture
+def email_me_when_that_dang_spider_comes(
+    arachnophobia: Automation,
+    daddy_long_legs_walked: ReceivedEvent,
+) -> TriggeredAction:
+    return TriggeredAction(
+        automation=arachnophobia,
+        triggered=pendulum.now("UTC"),
+        triggering_labels={"hello": "world"},
+        triggering_event=daddy_long_legs_walked,
+        action=arachnophobia.actions[0],
+    )
 
 
 def assert_message_represents_event(message: Message, event: ReceivedEvent):

--- a/tests/events/server/schemas/test_automations.py
+++ b/tests/events/server/schemas/test_automations.py
@@ -1,0 +1,64 @@
+from datetime import timedelta
+
+import pytest
+
+from prefect.server.events.schemas.automations import (
+    CompoundTrigger,
+    EventTrigger,
+    Posture,
+)
+
+
+async def test_compound_trigger_requires_too_small():
+    with pytest.raises(ValueError, match="required must be at least 1"):
+        CompoundTrigger(
+            triggers=[
+                EventTrigger(
+                    expect={"dragon.seen"},
+                    match={
+                        "color": "red",
+                    },
+                    posture=Posture.Reactive,
+                    threshold=1,
+                ),
+                EventTrigger(
+                    expect={"dragon.seen"},
+                    match={
+                        "color": "green",
+                    },
+                    posture=Posture.Reactive,
+                    threshold=1,
+                ),
+            ],
+            require=0,
+            within=timedelta(seconds=10),
+        )
+
+
+async def test_compound_trigger_requires_too_big():
+    with pytest.raises(
+        ValueError,
+        match="required must be less than or equal to the number of triggers",
+    ):
+        CompoundTrigger(
+            triggers=[
+                EventTrigger(
+                    expect={"dragon.seen"},
+                    match={
+                        "color": "red",
+                    },
+                    posture=Posture.Reactive,
+                    threshold=1,
+                ),
+                EventTrigger(
+                    expect={"dragon.seen"},
+                    match={
+                        "color": "green",
+                    },
+                    posture=Posture.Reactive,
+                    threshold=1,
+                ),
+            ],
+            require=3,
+            within=timedelta(seconds=10),
+        )


### PR DESCRIPTION
This introduces just the models, including the instance methods, but doesn't
add much in the way of new tests because most of this code is tested as part of
the triggers services.  I need the schema models available so I can build out
the ORM and CRUD APIs.

I debated whether to cut these instance methods for better coverage or to keep
them in and accept the coverage drop.  Keeping them in means less churn when we
do add the triggers system, so I'm good with that.
