### PR TITLE
update `httpcore` dep

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -7,7 +7,7 @@ croniter >= 1.0.12, < 3.0.0
 fsspec >= 2022.5.0
 graphviz >= 0.20.1
 griffe >= 0.20.0
-httpcore >=0.15.0, < 2.0.0
+httpcore >=1.0.5, < 2.0.0
 httpx[http2] >= 0.23, != 0.23.2
 importlib_metadata >= 4.4; python_version < '3.10'
 importlib-resources >= 6.1.3, < 6.2.0


### PR DESCRIPTION
httpcore released an upstream fix for a bug that is common for our users, as long as this doesn't seem like too restrictive a lower bound, this should circumvent the problem without forcing manual upgrades for containerized runtimes


see https://github.com/PrefectHQ/prefect/issues/11660 and https://github.com/encode/httpcore/releases/tag/1.0.5
