### PR TITLE
Making sure that we explicitly install pydantic v2 in CI where we intend to

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -377,7 +377,7 @@ jobs:
         if: ${{ failure() }}
         id: create_failure_flag
         run: |
-          sanitized_name="pydantic-v2-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}"
+          sanitized_name="pydantic-v2-internals-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}"
           sanitized_name="${sanitized_name//:/-}"
           echo "Failure in $sanitized_name" > "${sanitized_name}-failure.txt"
           echo "artifact_name=${sanitized_name}-failure" >> $GITHUB_OUTPUT

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -441,10 +441,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev]
-
-      - name: Force install sqlalchemy for unit tests
-        run: uv pip install "sqlalchemy[asyncio]<2" --system
+          uv pip install --upgrade --system -e .[dev] 'sqlalchemy[asyncio]<2'
 
       - name: Start database container
         if: ${{ startsWith(matrix.database, 'postgres') }}
@@ -621,7 +618,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev]
+          uv pip install --upgrade --system -e .[dev] 'pydantic>=2,<3'
 
       - name: Start database container
         run: >
@@ -742,7 +739,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev]
+          uv pip install --upgrade --system -e .[dev] 'pydantic>=2,<3'
 
       - name: Start database container
         if: ${{ startsWith(matrix.database, 'postgres') }}

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -93,6 +93,7 @@ jobs:
         run: |
           python -m pip install -U uv
           uv pip install --upgrade --system -e .[dev]
+          uv pip install 'pydantic>=2,<3' --system
 
       - name: Start database container
         if: ${{ startsWith(matrix.database, 'postgres') }}
@@ -277,10 +278,10 @@ jobs:
           && docker container logs postgres
           || echo "Ignoring bad exit code"
 
-  run-pydantic-v2-tests:
+  run-pydantic-v2-internals-tests:
     runs-on:
       group: oss-larger-runners
-    name: pydantic v2, python:${{ matrix.python-version }}
+    name: pydantic v2 internals, python:${{ matrix.python-version }}
     strategy:
       matrix:
         database:
@@ -329,6 +330,7 @@ jobs:
         run: |
           python -m pip install -U uv
           uv pip install --upgrade --system -e .[dev]
+          uv pip install 'pydantic>=2,<3' --system
 
       - name: Set PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS env var
         run: echo "PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS=1" >> $GITHUB_ENV
@@ -380,7 +382,7 @@ jobs:
         if: ${{ failure() }}
         id: create_failure_flag
         run: |
-          sanitized_name="pydantic-v1-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}"
+          sanitized_name="pydantic-v2-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}"
           sanitized_name="${sanitized_name//:/-}"
           echo "Failure in $sanitized_name" > "${sanitized_name}-failure.txt"
           echo "artifact_name=${sanitized_name}-failure" >> $GITHUB_OUTPUT

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -92,8 +92,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev]
-          uv pip install 'pydantic>=2,<3' --system
+          uv pip install --upgrade --system -e .[dev] 'pydantic>=2,<3'
 
       - name: Start database container
         if: ${{ startsWith(matrix.database, 'postgres') }}
@@ -206,10 +205,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev]
-
-      - name: Force install pydantic for unit tests
-        run: uv pip install "pydantic<2" --system
+          uv pip install --upgrade --system -e .[dev] 'pydantic<2'
 
       - name: Start database container
         if: ${{ startsWith(matrix.database, 'postgres') }}
@@ -329,8 +325,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev]
-          uv pip install 'pydantic>=2,<3' --system
+          uv pip install --upgrade --system -e .[dev] 'pydantic>=2,<3'
 
       - name: Set PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS env var
         run: echo "PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS=1" >> $GITHUB_ENV

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev] 'pydantic>=2,<3'
+          uv pip install --upgrade --system -e .[dev] 'pydantic>=2.4,<3'
 
       - name: Start database container
         if: ${{ startsWith(matrix.database, 'postgres') }}
@@ -325,7 +325,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev] 'pydantic>=2,<3'
+          uv pip install --upgrade --system -e .[dev] 'pydantic>=2.4,<3'
 
       - name: Set PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS env var
         run: echo "PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS=1" >> $GITHUB_ENV
@@ -618,7 +618,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev] 'pydantic>=2,<3'
+          uv pip install --upgrade --system -e .[dev] 'pydantic>=2.4,<3'
 
       - name: Start database container
         run: >
@@ -739,7 +739,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev] 'pydantic>=2,<3'
+          uv pip install --upgrade --system -e .[dev] 'pydantic>=2.4,<3'
 
       - name: Start database container
         if: ${{ startsWith(matrix.database, 'postgres') }}

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -21,7 +21,7 @@ pendulum < 3.0; python_version < '3.12'
 pendulum >= 3.0.0, <4; python_version >= '3.12'
 # the version constraints for pydantic are merged with those from fastapi 0.103.2
 pydantic[email]>=1.10.0,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0
-pydantic_core >= 2.17.0, < 3.0.0
+pydantic_core >= 2.10.0, < 3.0.0
 python_dateutil >= 2.8.2, < 3.0.0
 python-slugify >= 5.0, < 9.0
 pyyaml >= 5.4.1, < 7.0.0


### PR DESCRIPTION
We were depending on `pip` to install the _latest_ version of pydantic, but with
recent `uv` changes, it looks as if it favors the cached lower version.  This
adds an explicit additional install to the tests where we expect pydantic v2.
