### PR TITLE
Add myself as a CODEOWNER for the events subsystem while it's being ported

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,12 @@ mkdocs.yml                           @PrefectHQ/docs
 mkdocs.insiders.yml                  @PrefectHQ/docs
 
 # orchestration rules / policies
-/src/prefect/server/orchestration     @PrefectHQ/open-source 
+/src/prefect/server/orchestration     @PrefectHQ/open-source
 
 # database configuration / models
 /src/prefect/server/database          @PrefectHQ/open-source
+
+# the events subsystem, while it's being ported
+/src/prefect/events                   @chrisguidry
+/src/prefect/server/events            @chrisguidry
+/tests/events                         @chrisguidry


### PR DESCRIPTION
It's important that I keep the OSS and Prefect Cloud implementations in concert
with one another.  While we're in the process of porting it to
`PrefectHQ/prefect`, I'd like to see any proposed changes so I can relay them
to Cloud.
