### PR TITLE
Deprecate `KubernetesCusterConfig` block

### DIFF
--- a/src/prefect/blocks/kubernetes.py
+++ b/src/prefect/blocks/kubernetes.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Dict, Type
 
 import yaml
 
+from prefect._internal.compatibility.deprecated import deprecated_class
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 
 if HAS_PYDANTIC_V2:
@@ -23,6 +24,10 @@ else:
     kubernetes = lazy_import("kubernetes")
 
 
+@deprecated_class(
+    start_date="Mar 2024",
+    help="Use the KubernetesClusterConfig block from prefect-kubernetes instead.",
+)
 class KubernetesClusterConfig(Block):
     """
     Stores configuration for interaction with Kubernetes clusters.

--- a/tests/blocks/test_kubernetes_block.py
+++ b/tests/blocks/test_kubernetes_block.py
@@ -3,6 +3,7 @@ import re
 from pathlib import Path
 from typing import Dict
 
+from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 
 if HAS_PYDANTIC_V2:
@@ -49,6 +50,11 @@ def config_file(tmp_path) -> Path:
     config_file.write_text(CONFIG_CONTENT)
 
     return config_file
+
+
+async def test_raises_deprecation_warning():
+    with pytest.warns(PrefectDeprecationWarning):
+        KubernetesClusterConfig(config=CONFIG_CONTENT, context_name="docker-desktop")
 
 
 async def test_instantiation_from_file(config_file):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
This PR adds a deprecation I missed when deprecating classes related to agent deprecation.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.