### PR TITLE
better error on `prefect worker start -t bad-type`

### DIFF
--- a/src/prefect/cli/worker.py
+++ b/src/prefect/cli/worker.py
@@ -279,8 +279,14 @@ async def _find_package_for_worker_type(worker_type: str) -> Optional[str]:
         for worker_type in worker_dict
         if worker_type != "prefect-agent"
     }
-
-    return worker_types_with_packages[worker_type]
+    try:
+        return worker_types_with_packages[worker_type]
+    except KeyError:
+        app.console.print(
+            f"Could not find a package for worker type {worker_type!r}.",
+            style="yellow",
+        )
+        return None
 
 
 async def _get_worker_class(

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -359,6 +359,29 @@ async def test_worker_discovers_work_pool_type(
 
 
 @pytest.mark.usefixtures("use_hosted_api_server")
+async def test_worker_start_fails_informatively_with_bad_type(
+    process_work_pool, prefect_client: PrefectClient
+):
+    await run_sync_in_worker_thread(
+        invoke_and_assert,
+        command=[
+            "worker",
+            "start",
+            "-p",
+            process_work_pool.name,
+            "-t",
+            "not-a-real-type",
+        ],
+        expected_code=1,
+        expected_output_contains=[
+            "Could not find a package for worker type",
+            "Unable to start worker. Please ensure you have the necessary"
+            " dependencies installed to run your desired worker type.",
+        ],
+    )
+
+
+@pytest.mark.usefixtures("use_hosted_api_server")
 async def test_worker_does_not_run_with_push_pool(push_work_pool):
     await run_sync_in_worker_thread(
         invoke_and_assert,


### PR DESCRIPTION
previously, we'd raise a raw `KeyError` because we could not find a `package` for a bad worker `type`