### PR TITLE
Giving the Prefect HTTP client an informative `User-Agent`

### DIFF
--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -27,6 +27,8 @@ from httpx import HTTPStatusError, Request, Response
 from prefect._vendor.starlette import status
 from typing_extensions import Self
 
+import prefect
+from prefect.client import constants
 from prefect.client.schemas.objects import CsrfToken
 from prefect.exceptions import PrefectHTTPStatusError
 from prefect.logging import get_logger
@@ -198,6 +200,11 @@ class PrefectHttpxClient(httpx.AsyncClient):
         self.csrf_client_id: uuid.UUID = uuid.uuid4()
 
         super().__init__(*args, **kwargs)
+
+        user_agent = (
+            f"prefect/{prefect.__version__} (API {constants.SERVER_API_VERSION})"
+        )
+        self.headers["User-Agent"] = user_agent
 
     async def _send_with_retry(
         self,


### PR DESCRIPTION
We've been sending the default `python-httpx/x.y.z` `User-Agent` header, but
we're missing out on an opportunity for better observability.  This change sets
a Prefect-specific `User-Agent` header for all HTTP requests.

Closes #12539
