### PR TITLE
allow flows in standalone tasks

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -163,7 +163,6 @@ from prefect.logging.loggers import (
 from prefect.results import ResultFactory, UnknownResult
 from prefect.settings import (
     PREFECT_DEBUG_MODE,
-    PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
     PREFECT_TASK_INTROSPECTION_WARN_THRESHOLD,
     PREFECT_TASKS_REFRESH_CACHE,
     PREFECT_UI_URL,
@@ -617,13 +616,21 @@ async def create_and_begin_subflow_run(
     if wait_for:
         task_inputs["wait_for"] = await collect_task_run_inputs(wait_for)
 
-    rerunning = parent_flow_run_context.flow_run.run_count > 1
+    rerunning = (
+        parent_flow_run_context.flow_run.run_count > 1
+        if getattr(parent_flow_run_context, "flow_run", None)
+        else False
+    )
 
     # Generate a task in the parent flow run to represent the result of the subflow run
     dummy_task = Task(name=flow.name, fn=flow.fn, version=flow.version)
     parent_task_run = await client.create_task_run(
         task=dummy_task,
-        flow_run_id=parent_flow_run_context.flow_run.id,
+        flow_run_id=(
+            parent_flow_run_context.flow_run.id
+            if getattr(parent_flow_run_context, "flow_run", None)
+            else None
+        ),
         dynamic_key=_dynamic_key_for_task_run(parent_flow_run_context, dummy_task),
         task_inputs=task_inputs,
         state=Pending(),
@@ -851,7 +858,7 @@ async def orchestrate_flow_run(
                 if parent_call and (
                     not parent_flow_run_context
                     or (
-                        parent_flow_run_context
+                        getattr(parent_flow_run_context, "flow", None)
                         and parent_flow_run_context.flow.isasync == flow.isasync
                     )
                 ):
@@ -1372,17 +1379,11 @@ def enter_task_run_engine(
     flow_run_context = FlowRunContext.get()
 
     if not flow_run_context:
-        if (
-            not PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING.value()
-            or return_type == "future"
-            or mapped
-        ):
+        if return_type == "future" or mapped:
             raise RuntimeError(
-                "Tasks cannot be run outside of a flow by default."
-                " If you meant to submit an autonomous task, you need to set"
+                " If you meant to submit an background task, you need to set"
                 " `prefect config set PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING=true`"
                 " and use `your_task.submit()` instead of `your_task()`."
-                " Mapping autonomous tasks is not yet supported."
             )
         from prefect.task_engine import submit_autonomous_task_run_to_engine
 

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1381,7 +1381,7 @@ def enter_task_run_engine(
     if not flow_run_context:
         if return_type == "future" or mapped:
             raise RuntimeError(
-                " If you meant to submit an background task, you need to set"
+                " If you meant to submit a background task, you need to set"
                 " `prefect config set PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING=true`"
                 " and use `your_task.submit()` instead of `your_task()`."
             )

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -173,7 +173,6 @@ async def test_background_task_state_changes(
     assert [e.event for e in events] == [
         "prefect.task-run.Scheduled",
         "prefect.task-run.Pending",
-        # "prefect.block.local-file-system.save.called",
         "prefect.task-run.Running",
         "prefect.task-run.Completed",
     ]

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -3,6 +3,7 @@ import pytest
 from prefect import flow, task
 from prefect.events.clients import AssertingEventsClient
 from prefect.events.worker import EventsWorker
+from prefect.filesystems import LocalFileSystem
 from prefect.settings import (
     PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
     temporary_settings,
@@ -150,7 +151,10 @@ async def test_background_task_state_changes(
     prefect_client,
     enable_task_scheduling,
 ):
-    @task
+    storage = LocalFileSystem(basepath="/tmp/prefect")
+    storage.save("test")
+
+    @task(result_storage=storage)
     def foo():
         pass
 
@@ -164,14 +168,12 @@ async def test_background_task_state_changes(
 
     events = sorted(asserting_events_worker._client.events, key=lambda e: e.occurred)
 
-    assert len(events) == 5  # 4 state changes + 1 block save
-
-    assert len(task_run_states) == 4
+    assert len(task_run_states) == len(events) == 4
 
     assert [e.event for e in events] == [
         "prefect.task-run.Scheduled",
         "prefect.task-run.Pending",
-        "prefect.block.local-file-system.save.called",
+        # "prefect.block.local-file-system.save.called",
         "prefect.task-run.Running",
         "prefect.task-run.Completed",
     ]

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -95,12 +95,6 @@ def async_foo_task_with_result_storage(async_foo_task, local_filesystem):
     return async_foo_task.with_options(result_storage=local_filesystem)
 
 
-def test_task_submission_fails_when_experimental_flag_off(foo_task):
-    with temporary_settings({PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING: False}):
-        with pytest.raises(RuntimeError, match="Tasks cannot be run outside of a flow"):
-            foo_task.submit(42)
-
-
 def test_task_submission_with_parameters_uses_default_storage(foo_task):
     foo_task_without_result_storage = foo_task.with_options(result_storage=None)
     task_run = foo_task_without_result_storage.submit(42)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -163,14 +163,6 @@ class TestTaskRunName:
 
 
 class TestTaskCall:
-    def test_task_called_outside_flow_raises(self):
-        @task
-        def foo():
-            pass
-
-        with pytest.raises(RuntimeError, match="Tasks cannot be run outside of a flow"):
-            foo()
-
     def test_sync_task_called_inside_sync_flow(self):
         @task
         def foo(x):
@@ -331,14 +323,6 @@ class TestTaskCall:
 
 
 class TestTaskRun:
-    def test_task_run_outside_flow_raises(self):
-        @task
-        def foo():
-            pass
-
-        with pytest.raises(RuntimeError, match="Tasks cannot be run outside of a flow"):
-            foo()
-
     def test_sync_task_run_inside_sync_flow(self):
         @task
         def foo(x):
@@ -430,14 +414,6 @@ class TestTaskRun:
 
 
 class TestTaskSubmit:
-    def test_task_submitted_outside_flow_raises(self):
-        @task
-        def foo():
-            pass
-
-        with pytest.raises(RuntimeError, match="Tasks cannot be run outside of a flow"):
-            foo()
-
     def test_sync_task_submitted_inside_sync_flow(self):
         @task
         def foo(x):


### PR DESCRIPTION
fixes #12605 

also removes the somewhat arbitrary restriction that you must have the `PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING` flag on to run a task outside of a flow