### PR TITLE
pin `uv==0.1.29` for now

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Install packages
         run: |
-          python -m pip install -U uv
+          python -m pip install -U 'uv==0.1.29'
           uv pip install --upgrade --system -e .[dev] 'pydantic>=2.4,<3'
 
       - name: Start database container
@@ -204,7 +204,7 @@ jobs:
 
       - name: Install packages
         run: |
-          python -m pip install -U uv
+          python -m pip install -U 'uv==0.1.29'
           uv pip install --upgrade --system -e .[dev] 'pydantic<2'
 
       - name: Start database container
@@ -324,7 +324,7 @@ jobs:
 
       - name: Install packages
         run: |
-          python -m pip install -U uv
+          python -m pip install -U 'uv==0.1.29'
           uv pip install --upgrade --system -e .[dev] 'pydantic>=2.4,<3'
 
       - name: Set PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS env var
@@ -440,7 +440,7 @@ jobs:
 
       - name: Install packages
         run: |
-          python -m pip install -U uv
+          python -m pip install -U 'uv==0.1.29'
           uv pip install --upgrade --system -e .[dev] 'sqlalchemy[asyncio]<2'
 
       - name: Start database container
@@ -617,7 +617,7 @@ jobs:
 
       - name: Install packages
         run: |
-          python -m pip install -U uv
+          python -m pip install -U 'uv==0.1.29'
           uv pip install --upgrade --system -e .[dev] 'pydantic>=2.4,<3'
 
       - name: Start database container
@@ -738,7 +738,7 @@ jobs:
 
       - name: Install packages
         run: |
-          python -m pip install -U uv
+          python -m pip install -U 'uv==0.1.29'
           uv pip install --upgrade --system -e .[dev] 'pydantic>=2.4,<3'
 
       - name: Start database container


### PR DESCRIPTION
`uv==0.1.30` ([release](https://github.com/astral-sh/uv/releases/tag/0.1.30)) seems to break our dep installs in CI

[example](https://github.com/PrefectHQ/prefect/actions/runs/8620086419/job/23626392040?pr=12629)