### PR TITLE
Enable `EventsWorker` to emit events to Prefect servers

### DIFF
--- a/src/prefect/events/utilities.py
+++ b/src/prefect/events/utilities.py
@@ -12,7 +12,7 @@ from .clients import (
     PrefectEventsClient,
 )
 from .schemas.events import Event, RelatedResource
-from .worker import EventsWorker, emit_events
+from .worker import EventsWorker, should_emit_events
 
 TIGHT_TIMING = timedelta(minutes=5)
 
@@ -46,7 +46,7 @@ def emit_event(
         The event that was emitted if worker is using a client that emit
         events, otherwise None
     """
-    if not emit_events():
+    if not should_emit_events():
         return None
 
     operational_clients = [

--- a/src/prefect/events/utilities.py
+++ b/src/prefect/events/utilities.py
@@ -6,9 +6,13 @@ import pendulum
 
 from prefect._internal.schemas.fields import DateTimeTZ
 
-from .clients import AssertingEventsClient, PrefectCloudEventsClient
+from .clients import (
+    AssertingEventsClient,
+    PrefectCloudEventsClient,
+    PrefectEventsClient,
+)
 from .schemas.events import Event, RelatedResource
-from .worker import EventsWorker, emit_events_to_cloud
+from .worker import EventsWorker, emit_events
 
 TIGHT_TIMING = timedelta(minutes=5)
 
@@ -42,10 +46,14 @@ def emit_event(
         The event that was emitted if worker is using a client that emit
         events, otherwise None
     """
-    if not emit_events_to_cloud():
+    if not emit_events():
         return None
 
-    operational_clients = [AssertingEventsClient, PrefectCloudEventsClient]
+    operational_clients = [
+        AssertingEventsClient,
+        PrefectCloudEventsClient,
+        PrefectEventsClient,
+    ]
     worker_instance = EventsWorker.instance()
 
     if worker_instance.client_type not in operational_clients:

--- a/src/prefect/events/worker.py
+++ b/src/prefect/events/worker.py
@@ -23,6 +23,10 @@ from .related import related_resources_from_run_context
 from .schemas.events import Event
 
 
+def emit_events() -> bool:
+    return emit_events_to_cloud() or emit_events_to_running_server()
+
+
 def emit_events_to_cloud() -> bool:
     api = PREFECT_API_URL.value()
     return api and api.startswith(PREFECT_CLOUD_API_URL.value())

--- a/src/prefect/events/worker.py
+++ b/src/prefect/events/worker.py
@@ -23,8 +23,8 @@ from .related import related_resources_from_run_context
 from .schemas.events import Event
 
 
-def emit_events() -> bool:
-    return emit_events_to_cloud() or emit_events_to_running_server()
+def should_emit_events() -> bool:
+    return emit_events_to_cloud() or should_emit_events_to_running_server()
 
 
 def emit_events_to_cloud() -> bool:
@@ -34,7 +34,7 @@ def emit_events_to_cloud() -> bool:
     )
 
 
-def emit_events_to_running_server() -> bool:
+def should_emit_events_to_running_server() -> bool:
     api_url = PREFECT_API_URL.value()
     return isinstance(api_url, str) and PREFECT_EXPERIMENTAL_EVENTS
 
@@ -83,7 +83,7 @@ class EventsWorker(QueueService[Event]):
                     "api_url": PREFECT_API_URL.value(),
                     "api_key": PREFECT_API_KEY.value(),
                 }
-            elif emit_events_to_running_server():
+            elif should_emit_events_to_running_server():
                 client_type = PrefectEventsClient
 
             else:

--- a/src/prefect/events/worker.py
+++ b/src/prefect/events/worker.py
@@ -28,13 +28,15 @@ def emit_events() -> bool:
 
 
 def emit_events_to_cloud() -> bool:
-    api = PREFECT_API_URL.value()
-    return api and api.startswith(PREFECT_CLOUD_API_URL.value())
+    api_url = PREFECT_API_URL.value()
+    return isinstance(api_url, str) and api_url.startswith(
+        PREFECT_CLOUD_API_URL.value()
+    )
 
 
 def emit_events_to_running_server() -> bool:
-    api = PREFECT_API_URL.value()
-    return api and PREFECT_EXPERIMENTAL_EVENTS
+    api_url = PREFECT_API_URL.value()
+    return isinstance(api_url, str) and PREFECT_EXPERIMENTAL_EVENTS
 
 
 class EventsWorker(QueueService[Event]):

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -325,10 +325,10 @@ def events_cloud_api_url(events_server: WebSocketServer, unused_tcp_port: int) -
 
 
 @pytest.fixture
-def mock_emit_events(monkeypatch) -> mock.Mock:
+def mock_should_emit_events(monkeypatch) -> mock.Mock:
     m = mock.Mock()
     m.return_value = True
-    monkeypatch.setattr("prefect.events.utilities.emit_events", m)
+    monkeypatch.setattr("prefect.events.utilities.should_emit_events", m)
     return m
 
 

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -325,10 +325,10 @@ def events_cloud_api_url(events_server: WebSocketServer, unused_tcp_port: int) -
 
 
 @pytest.fixture
-def mock_emit_events_to_cloud(monkeypatch) -> mock.Mock:
+def mock_emit_events(monkeypatch) -> mock.Mock:
     m = mock.Mock()
     m.return_value = True
-    monkeypatch.setattr("prefect.events.utilities.emit_events_to_cloud", m)
+    monkeypatch.setattr("prefect.events.utilities.emit_events", m)
     return m
 
 

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -316,6 +316,11 @@ async def events_server(
 
 @pytest.fixture
 def events_api_url(events_server: WebSocketServer, unused_tcp_port: int) -> str:
+    return f"http://localhost:{unused_tcp_port}"
+
+
+@pytest.fixture
+def events_cloud_api_url(events_server: WebSocketServer, unused_tcp_port: int) -> str:
     return f"http://localhost:{unused_tcp_port}/accounts/A/workspaces/W"
 
 

--- a/tests/concurrency/test_concurrency_asyncio.py
+++ b/tests/concurrency/test_concurrency_asyncio.py
@@ -94,7 +94,7 @@ async def test_concurrency_emits_events(
     concurrency_limit: ConcurrencyLimitV2,
     other_concurrency_limit: ConcurrencyLimitV2,
     asserting_events_worker: EventsWorker,
-    mock_emit_events_to_cloud,
+    mock_emit_events,
     reset_worker_events,
 ):
     executed = False
@@ -248,7 +248,7 @@ async def test_rate_limit_emits_events(
     concurrency_limit_with_decay: ConcurrencyLimitV2,
     other_concurrency_limit_with_decay: ConcurrencyLimitV2,
     asserting_events_worker: EventsWorker,
-    mock_emit_events_to_cloud,
+    mock_emit_events,
     reset_worker_events,
 ):
     async def resource_heavy():

--- a/tests/concurrency/test_concurrency_asyncio.py
+++ b/tests/concurrency/test_concurrency_asyncio.py
@@ -94,7 +94,7 @@ async def test_concurrency_emits_events(
     concurrency_limit: ConcurrencyLimitV2,
     other_concurrency_limit: ConcurrencyLimitV2,
     asserting_events_worker: EventsWorker,
-    mock_emit_events,
+    mock_should_emit_events,
     reset_worker_events,
 ):
     executed = False
@@ -248,7 +248,7 @@ async def test_rate_limit_emits_events(
     concurrency_limit_with_decay: ConcurrencyLimitV2,
     other_concurrency_limit_with_decay: ConcurrencyLimitV2,
     asserting_events_worker: EventsWorker,
-    mock_emit_events,
+    mock_should_emit_events,
     reset_worker_events,
 ):
     async def resource_heavy():

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -49,7 +49,7 @@ def test_concurrency_emits_events(
     concurrency_limit: ConcurrencyLimitV2,
     other_concurrency_limit: ConcurrencyLimitV2,
     asserting_events_worker: EventsWorker,
-    mock_emit_events,
+    mock_should_emit_events,
     reset_worker_events,
 ):
     def resource_heavy():
@@ -241,7 +241,7 @@ def test_rate_limit_emits_events(
     concurrency_limit_with_decay: ConcurrencyLimitV2,
     other_concurrency_limit_with_decay: ConcurrencyLimitV2,
     asserting_events_worker: EventsWorker,
-    mock_emit_events,
+    mock_should_emit_events,
     reset_worker_events,
 ):
     def resource_heavy():

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -49,7 +49,7 @@ def test_concurrency_emits_events(
     concurrency_limit: ConcurrencyLimitV2,
     other_concurrency_limit: ConcurrencyLimitV2,
     asserting_events_worker: EventsWorker,
-    mock_emit_events_to_cloud,
+    mock_emit_events,
     reset_worker_events,
 ):
     def resource_heavy():
@@ -241,7 +241,7 @@ def test_rate_limit_emits_events(
     concurrency_limit_with_decay: ConcurrencyLimitV2,
     other_concurrency_limit_with_decay: ConcurrencyLimitV2,
     asserting_events_worker: EventsWorker,
-    mock_emit_events_to_cloud,
+    mock_emit_events,
     reset_worker_events,
 ):
     def resource_heavy():

--- a/tests/events/client/conftest.py
+++ b/tests/events/client/conftest.py
@@ -10,8 +10,8 @@ def reset_asserting_events_client():
 
 
 @pytest.fixture(autouse=True)
-def mock_emit_events(mock_emit_events):
-    yield mock_emit_events
+def mock_should_emit_events(mock_should_emit_events):
+    yield mock_should_emit_events
 
 
 @pytest.fixture

--- a/tests/events/client/conftest.py
+++ b/tests/events/client/conftest.py
@@ -10,8 +10,8 @@ def reset_asserting_events_client():
 
 
 @pytest.fixture(autouse=True)
-def mock_emit_events_to_cloud(mock_emit_events_to_cloud):
-    yield mock_emit_events_to_cloud
+def mock_emit_events(mock_emit_events):
+    yield mock_emit_events
 
 
 @pytest.fixture

--- a/tests/events/client/test_cloud_events_subscriber.py
+++ b/tests/events/client/test_cloud_events_subscriber.py
@@ -9,14 +9,14 @@ from prefect.testing.fixtures import Puppeteer, Recorder
 
 
 async def test_subscriber_can_connect_with_defaults(
-    events_api_url: str,
+    events_cloud_api_url: str,
     example_event_1: Event,
     example_event_2: Event,
     recorder: Recorder,
     puppeteer: Puppeteer,
 ):
     with temporary_settings(
-        updates={PREFECT_API_KEY: "my-token", PREFECT_API_URL: events_api_url}
+        updates={PREFECT_API_KEY: "my-token", PREFECT_API_URL: events_cloud_api_url}
     ):
         puppeteer.token = "my-token"
         puppeteer.outgoing_events = [example_event_1, example_event_2]
@@ -34,7 +34,7 @@ async def test_subscriber_can_connect_with_defaults(
 
 
 async def test_subscriber_complains_without_api_url_and_key(
-    events_api_url: str,
+    events_cloud_api_url: str,
     example_event_1: Event,
     example_event_2: Event,
     recorder: Recorder,
@@ -46,7 +46,7 @@ async def test_subscriber_complains_without_api_url_and_key(
 
 
 async def test_subscriber_can_connect_and_receive_one_event(
-    events_api_url: str,
+    events_cloud_api_url: str,
     example_event_1: Event,
     example_event_2: Event,
     recorder: Recorder,
@@ -58,7 +58,7 @@ async def test_subscriber_can_connect_and_receive_one_event(
     filter = EventFilter(event=EventNameFilter(name=["example.event"]))
 
     async with PrefectCloudEventSubscriber(
-        events_api_url,
+        events_cloud_api_url,
         "my-token",
         filter,
         reconnection_attempts=0,
@@ -74,7 +74,7 @@ async def test_subscriber_can_connect_and_receive_one_event(
 
 
 async def test_subscriber_specifying_negative_reconnects_gets_error(
-    events_api_url: str,
+    events_cloud_api_url: str,
     example_event_1: Event,
     example_event_2: Event,
     recorder: Recorder,
@@ -87,7 +87,7 @@ async def test_subscriber_specifying_negative_reconnects_gets_error(
 
     with pytest.raises(ValueError, match="non-negative"):
         PrefectCloudEventSubscriber(
-            events_api_url,
+            events_cloud_api_url,
             "my-token",
             filter,
             reconnection_attempts=-1,
@@ -97,7 +97,7 @@ async def test_subscriber_specifying_negative_reconnects_gets_error(
 
 
 async def test_subscriber_raises_on_invalid_auth_with_soft_denial(
-    events_api_url: str,
+    events_cloud_api_url: str,
     example_event_1: Event,
     example_event_2: Event,
     recorder: Recorder,
@@ -110,7 +110,7 @@ async def test_subscriber_raises_on_invalid_auth_with_soft_denial(
 
     with pytest.raises(Exception, match="Unable to authenticate"):
         subscriber = PrefectCloudEventSubscriber(
-            events_api_url,
+            events_cloud_api_url,
             "bogus",
             filter,
             reconnection_attempts=0,
@@ -124,7 +124,7 @@ async def test_subscriber_raises_on_invalid_auth_with_soft_denial(
 
 
 async def test_subscriber_raises_on_invalid_auth_with_hard_denial(
-    events_api_url: str,
+    events_cloud_api_url: str,
     example_event_1: Event,
     example_event_2: Event,
     recorder: Recorder,
@@ -138,7 +138,7 @@ async def test_subscriber_raises_on_invalid_auth_with_hard_denial(
 
     with pytest.raises(Exception, match="Unable to authenticate"):
         subscriber = PrefectCloudEventSubscriber(
-            events_api_url,
+            events_cloud_api_url,
             "bogus",
             filter,
             reconnection_attempts=0,
@@ -152,7 +152,7 @@ async def test_subscriber_raises_on_invalid_auth_with_hard_denial(
 
 
 async def test_subscriber_reconnects_on_hard_disconnects(
-    events_api_url: str,
+    events_cloud_api_url: str,
     example_event_1: Event,
     example_event_2: Event,
     recorder: Recorder,
@@ -165,7 +165,7 @@ async def test_subscriber_reconnects_on_hard_disconnects(
     filter = EventFilter(event=EventNameFilter(name=["example.event"]))
 
     async with PrefectCloudEventSubscriber(
-        events_api_url,
+        events_cloud_api_url,
         "my-token",
         filter,
         reconnection_attempts=2,
@@ -178,7 +178,7 @@ async def test_subscriber_reconnects_on_hard_disconnects(
 
 
 async def test_subscriber_gives_up_after_so_many_attempts(
-    events_api_url: str,
+    events_cloud_api_url: str,
     example_event_1: Event,
     example_event_2: Event,
     recorder: Recorder,
@@ -192,7 +192,7 @@ async def test_subscriber_gives_up_after_so_many_attempts(
 
     with pytest.raises(ConnectionClosedError):
         async with PrefectCloudEventSubscriber(
-            events_api_url,
+            events_cloud_api_url,
             "my-token",
             filter,
             reconnection_attempts=4,
@@ -205,7 +205,7 @@ async def test_subscriber_gives_up_after_so_many_attempts(
 
 
 async def test_subscriber_skips_duplicate_events(
-    events_api_url: str,
+    events_cloud_api_url: str,
     example_event_1: Event,
     example_event_2: Event,
     recorder: Recorder,
@@ -217,7 +217,7 @@ async def test_subscriber_skips_duplicate_events(
     filter = EventFilter(event=EventNameFilter(name=["example.event"]))
 
     async with PrefectCloudEventSubscriber(
-        events_api_url,
+        events_cloud_api_url,
         "my-token",
         filter,
     ) as subscriber:

--- a/tests/events/client/test_events_emit_event.py
+++ b/tests/events/client/test_events_emit_event.py
@@ -123,9 +123,9 @@ def test_noop_with_null_events_client():
         )
 
 
-def test_noop_with_non_cloud_client(mock_emit_events: mock.Mock):
+def test_noop_with_non_cloud_client(mock_should_emit_events: mock.Mock):
     with temporary_settings(updates={PREFECT_API_URL: "http://localhost:4242"}):
-        mock_emit_events.return_value = None
+        mock_should_emit_events.return_value = None
 
         assert (
             emit_event(

--- a/tests/events/client/test_events_emit_event.py
+++ b/tests/events/client/test_events_emit_event.py
@@ -123,9 +123,9 @@ def test_noop_with_null_events_client():
         )
 
 
-def test_noop_with_non_cloud_client(mock_emit_events_to_cloud: mock.Mock):
+def test_noop_with_non_cloud_client(mock_emit_events: mock.Mock):
     with temporary_settings(updates={PREFECT_API_URL: "http://localhost:4242"}):
-        mock_emit_events_to_cloud.return_value = None
+        mock_emit_events.return_value = None
 
         assert (
             emit_event(

--- a/tests/events/client/test_events_worker.py
+++ b/tests/events/client/test_events_worker.py
@@ -7,10 +7,12 @@ from prefect.events import Event
 from prefect.events.clients import (
     AssertingEventsClient,
     NullEventsClient,
+    PrefectEventsClient,
 )
 from prefect.events.worker import EventsWorker
 from prefect.settings import (
     PREFECT_API_URL,
+    PREFECT_EXPERIMENTAL_EVENTS,
     temporary_settings,
 )
 
@@ -42,6 +44,17 @@ def test_worker_instance_null_client_non_cloud_api_url():
     with temporary_settings(updates={PREFECT_API_URL: "http://localhost:8080/api"}):
         worker = EventsWorker.instance()
         assert worker.client_type == NullEventsClient
+
+
+def test_worker_instance_null_client_non_cloud_api_url_events_enabled():
+    with temporary_settings(
+        updates={
+            PREFECT_API_URL: "http://localhost:8080/api",
+            PREFECT_EXPERIMENTAL_EVENTS: True,
+        }
+    ):
+        worker = EventsWorker.instance()
+        assert worker.client_type == PrefectEventsClient
 
 
 async def test_includes_related_resources_from_run_context(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Adds a `PrefectEventsClient` that enables event emission to OSS Prefect servers. The existing `PrefectCloudEventsClient` inherits from this new client because emitting events to Prefect Cloud requires authentication.

Note that this PR requires a long-running Prefect server. Emitting events via the ephemeral API will be handled in a subsequent PR.

Closes https://github.com/PrefectHQ/prefect/issues/12631

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
1. Update the following settings in your Prefect profile:
```
PREFECT_API_SERVICES_EVENT_LOGGER_ENABLED='True'
PREFECT_API_URL='http://localhost:4200/api'
PREFECT_EXPERIMENTAL_EVENTS='True'
```
2. Start a Prefect server:
```
prefect server start
```
3. Run the following code:
```
>>> from prefect.events import emit_event
>>>
>>> def some_function(name: str="kiki") -> None:
...     print(f"hi {name}!")
...     emit_event(event=f"{name}.sent.event!", resource={"prefect.resource.id": f"coder{name}"})
...
>>> some_function()
hi kiki!
>>> some_function("alex")
hi alex!
```
4. You should see events in your Prefect server logs:
```
Event: 05b9977a 2024-04-09T21:46:59.839805+00:00  ( -0.07) [kiki.sent.event!]
coder.kiki
Event: 02c01cc1 2024-04-09T21:47:08.559323+00:00  ( -0.00) [alex.sent.event!]
coder.alex
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.