### PR TITLE
Remove Deprecated Fields from StateCreate

### DIFF
--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -341,15 +341,6 @@ class StateCreate(ActionBaseModel):
         description="The details of the state to create",
     )
 
-    # DEPRECATED
-
-    timestamp: Optional[DateTimeTZ] = Field(
-        default=None,
-        repr=False,
-        ignored=True,
-    )
-    id: Optional[UUID] = Field(default=None, repr=False, ignored=True)
-
     @validator("name", always=True)
     def default_name_from_type(cls, v, *, values, **kwargs):
         return get_or_create_state_name(v, values)


### PR DESCRIPTION
Removing `timestamp` and `id` from `StateCreate`, the only two fields in prefect that use `ignored=True` as Field metadata. Removing these would eliminate some boilerplate from PrefectBaseModel I don't feel like reproducing, so 🤞 being marked as "Deprecated" means they're actually deprecated. 

<img width="656" alt="Screenshot 2024-04-10 at 12 39 07 PM" src="https://github.com/PrefectHQ/prefect/assets/33043305/4d88374e-2829-4255-bcfa-a37343023ff5">
