### PR TITLE
Fix: Remove Misleading Deprecated *Comment*

### DIFF
--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -341,8 +341,6 @@ class StateCreate(ActionBaseModel):
         description="The details of the state to create",
     )
 
-    # DEPRECATED
-
     timestamp: Optional[DateTimeTZ] = Field(
         default=None,
         repr=False,


### PR DESCRIPTION
A stray comment makes the StateCreate model fields

```python
    timestamp: Optional[DateTimeTZ] = Field(
        default=None,
        repr=False,
        ignored=True,
    )
    id: Optional[UUID] = Field(default=None, repr=False, ignored=True)
```

appear deprecated when, they are in fact, not. 