### PR TITLE
`example` --> `examples`

### DIFF
--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -77,7 +77,7 @@ class AppriseNotificationBlock(AbstractAppriseNotificationBlock, ABC):
         default=...,
         title="Webhook URL",
         description="Incoming webhook URL used to send notifications.",
-        example="https://hooks.example.com/XXX",
+        examples=["https://hooks.example.com/XXX"],
     )
 
 
@@ -105,7 +105,7 @@ class SlackWebhook(AppriseNotificationBlock):
         default=...,
         title="Webhook URL",
         description="Slack incoming webhook URL used to send notifications.",
-        example="https://hooks.slack.com/XXX",
+        examples=["https://hooks.slack.com/XXX"],
     )
 
 
@@ -131,9 +131,9 @@ class MicrosoftTeamsWebhook(AppriseNotificationBlock):
         ...,
         title="Webhook URL",
         description="The Teams incoming webhook URL used to send notifications.",
-        example=(
+        examples=[
             "https://your-org.webhook.office.com/webhookb2/XXX/IncomingWebhook/YYY/ZZZ"
-        ),
+        ],
     )
 
 
@@ -222,7 +222,7 @@ class PagerDutyWebHook(AbstractAppriseNotificationBlock):
     custom_details: Optional[Dict[str, str]] = Field(
         default=None,
         description="Additional details to include as part of the payload.",
-        example='{"disk_space_left": "145GB"}',
+        examples=['{"disk_space_left": "145GB"}'],
     )
 
     def block_initialization(self) -> None:
@@ -283,14 +283,14 @@ class TwilioSMS(AbstractAppriseNotificationBlock):
     from_phone_number: str = Field(
         default=...,
         description="The valid Twilio phone number to send the message from.",
-        example="18001234567",
+        examples=["18001234567"],
     )
 
     to_phone_numbers: List[str] = Field(
         default=...,
         description="A list of valid Twilio phone number(s) to send the message to.",
         # not wrapped in brackets because of the way UI displays examples; in code should be ["18004242424"]
-        example="18004242424",
+        examples=["18004242424"],
     )
 
     def block_initialization(self) -> None:
@@ -366,7 +366,7 @@ class OpsgenieWebhook(AbstractAppriseNotificationBlock):
             "A comma-separated list of tags you can associate with your Opsgenie"
             " message."
         ),
-        example='["tag1", "tag2"]',
+        examples=['["tag1", "tag2"]'],
     )
 
     priority: Optional[str] = Field(
@@ -388,7 +388,7 @@ class OpsgenieWebhook(AbstractAppriseNotificationBlock):
     details: Optional[Dict[str, str]] = Field(
         default=None,
         description="Additional details composed of key/values pairs.",
-        example='{"key1": "value1", "key2": "value2"}',
+        examples=['{"key1": "value1", "key2": "value2"}'],
     )
 
     def block_initialization(self) -> None:
@@ -445,7 +445,7 @@ class MattermostWebhook(AbstractAppriseNotificationBlock):
     hostname: str = Field(
         default=...,
         description="The hostname of your Mattermost server.",
-        example="Mattermost.example.com",
+        examples=["Mattermost.example.com"],
     )
 
     token: SecretStr = Field(
@@ -617,7 +617,7 @@ class CustomWebhookNotificationBlock(NotificationBlock):
     url: str = Field(
         title="Webhook URL",
         description="The webhook URL.",
-        example="https://hooks.slack.com/XXX",
+        examples=["https://hooks.slack.com/XXX"],
     )
 
     method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"] = Field(
@@ -631,10 +631,10 @@ class CustomWebhookNotificationBlock(NotificationBlock):
         default=None,
         title="JSON Data",
         description="Send json data as payload.",
-        example=(
+        examples=[
             '{"text": "{{subject}}\\n{{body}}", "title": "{{name}}", "token":'
             ' "{{tokenFromSecrets}}"}'
-        ),
+        ],
     )
     form_data: Optional[Dict[str, str]] = Field(
         default=None,
@@ -642,10 +642,10 @@ class CustomWebhookNotificationBlock(NotificationBlock):
         description=(
             "Send form data as payload. Should not be used together with _JSON Data_."
         ),
-        example=(
+        examples=[
             '{"text": "{{subject}}\\n{{body}}", "title": "{{name}}", "token":'
             ' "{{tokenFromSecrets}}"}'
-        ),
+        ],
     )
 
     headers: Optional[Dict[str, str]] = Field(None, description="Custom headers.")
@@ -659,7 +659,7 @@ class CustomWebhookNotificationBlock(NotificationBlock):
         default_factory=lambda: SecretDict(dict()),
         title="Custom Secret Values",
         description="A dictionary of secret values to be substituted in other configs.",
-        example='{"tokenFromSecrets":"SomeSecretToken"}',
+        examples=['{"tokenFromSecrets":"SomeSecretToken"}'],
     )
 
     def _build_request_args(self, body: str, subject: Optional[str]):
@@ -753,14 +753,14 @@ class SendgridEmail(AbstractAppriseNotificationBlock):
     sender_email: str = Field(
         title="Sender email id",
         description="The sender email id.",
-        example="test-support@gmail.com",
+        examples=["test-support@gmail.com"],
     )
 
     to_emails: List[str] = Field(
         default=...,
         title="Recipient emails",
         description="Email ids of all recipients.",
-        example='"recipient1@gmail.com"',
+        examples=['"recipient1@gmail.com"'],
     )
 
     def block_initialization(self) -> None:

--- a/src/prefect/blocks/webhook.py
+++ b/src/prefect/blocks/webhook.py
@@ -36,7 +36,7 @@ class Webhook(Block):
         default=...,
         title="Webhook URL",
         description="The webhook URL.",
-        example="https://hooks.slack.com/XXX",
+        examples=["https://hooks.slack.com/XXX"],
     )
 
     headers: SecretDict = Field(

--- a/src/prefect/cli/cloud/__init__.py
+++ b/src/prefect/cli/cloud/__init__.py
@@ -1,6 +1,7 @@
 """
 Command line interface for interacting with Prefect Cloud
 """
+
 import signal
 import traceback
 import uuid
@@ -17,12 +18,7 @@ import uvicorn
 from prefect._vendor.fastapi import FastAPI
 from prefect._vendor.fastapi.middleware.cors import CORSMiddleware
 
-from prefect._internal.pydantic import HAS_PYDANTIC_V2
-
-if HAS_PYDANTIC_V2:
-    from pydantic.v1 import BaseModel
-else:
-    from pydantic import BaseModel
+from prefect.pydantic import BaseModel
 
 from rich.live import Live
 from rich.table import Table

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -62,7 +62,7 @@ class StateCreate(ActionBaseModel):
 
     type: StateType
     name: Optional[str] = Field(default=None)
-    message: Optional[str] = Field(default=None, example="Run started")
+    message: Optional[str] = Field(default=None, examples=["Run started"])
     state_details: StateDetails = Field(default_factory=StateDetails)
     data: Union["BaseResult[R]", "DataDocument[R]", Any] = Field(
         default=None,
@@ -73,12 +73,12 @@ class FlowCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a flow."""
 
     name: str = Field(
-        default=..., description="The name of the flow", example="my-flow"
+        default=..., description="The name of the flow", examples=["my-flow"]
     )
     tags: List[str] = Field(
         default_factory=list,
         description="A list of flow tags",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
 
 
@@ -88,7 +88,7 @@ class FlowUpdate(ActionBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of flow tags",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
 
 
@@ -144,7 +144,7 @@ class DeploymentCreate(ActionBaseModel):
     work_pool_name: Optional[str] = Field(
         default=None,
         description="The name of the deployment's work pool.",
-        example="my-work-pool",
+        examples=["my-work-pool"],
     )
     storage_document_id: Optional[UUID] = Field(None)
     infrastructure_document_id: Optional[UUID] = Field(None)
@@ -199,7 +199,7 @@ class DeploymentUpdate(ActionBaseModel):
     work_pool_name: Optional[str] = Field(
         default=None,
         description="The name of the deployment's work pool.",
-        example="my-work-pool",
+        examples=["my-work-pool"],
     )
     path: Optional[str] = Field(None)
     infra_overrides: Optional[Dict[str, Any]] = Field(None)
@@ -605,10 +605,10 @@ class FlowRunNotificationPolicyCreate(ActionBaseModel):
             " Valid variables include:"
             f" {listrepr(sorted(objects.FLOW_RUN_NOTIFICATION_TEMPLATE_KWARGS), sep=', ')}"
         ),
-        example=(
+        examples=[
             "Flow run {flow_run_name} with id {flow_run_id} entered state"
             " {flow_run_state_name}."
-        ),
+        ],
     )
 
     @validator("message_template")
@@ -656,13 +656,13 @@ class VariableCreate(ActionBaseModel):
     name: str = Field(
         default=...,
         description="The name of the variable",
-        example="my_variable",
+        examples=["my_variable"],
         max_length=objects.MAX_VARIABLE_NAME_LENGTH,
     )
     value: str = Field(
         default=...,
         description="The value of the variable",
-        example="my-value",
+        examples=["my-value"],
         max_length=objects.MAX_VARIABLE_VALUE_LENGTH,
     )
     tags: Optional[List[str]] = Field(default=None)
@@ -677,13 +677,13 @@ class VariableUpdate(ActionBaseModel):
     name: Optional[str] = Field(
         default=None,
         description="The name of the variable",
-        example="my_variable",
+        examples=["my_variable"],
         max_length=objects.MAX_VARIABLE_NAME_LENGTH,
     )
     value: Optional[str] = Field(
         default=None,
         description="The value of the variable",
-        example="my-value",
+        examples=["my-value"],
         max_length=objects.MAX_VARIABLE_NAME_LENGTH,
     )
     tags: Optional[List[str]] = Field(default=None)

--- a/src/prefect/client/schemas/filters.py
+++ b/src/prefect/client/schemas/filters.py
@@ -48,7 +48,7 @@ class FlowFilterName(PrefectBaseModel):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of flow names to include",
-        example=["my-flow-1", "my-flow-2"],
+        examples=[["my-flow-1", "my-flow-2"]],
     )
 
     like_: Optional[str] = Field(
@@ -58,7 +58,7 @@ class FlowFilterName(PrefectBaseModel):
             " passing 'marvin' will match "
             "'marvin', 'sad-Marvin', and 'marvin-robot'."
         ),
-        example="marvin",
+        examples=["marvin"],
     )
 
 
@@ -67,7 +67,7 @@ class FlowFilterTags(PrefectBaseModel, OperatorMixin):
 
     all_: Optional[List[str]] = Field(
         default=None,
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
         description=(
             "A list of tags. Flows will be returned only if their tags are a superset"
             " of the list"
@@ -109,7 +109,7 @@ class FlowRunFilterName(PrefectBaseModel):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of flow run names to include",
-        example=["my-flow-run-1", "my-flow-run-2"],
+        examples=[["my-flow-run-1", "my-flow-run-2"]],
     )
 
     like_: Optional[str] = Field(
@@ -119,7 +119,7 @@ class FlowRunFilterName(PrefectBaseModel):
             " passing 'marvin' will match "
             "'marvin', 'sad-Marvin', and 'marvin-robot'."
         ),
-        example="marvin",
+        examples=["marvin"],
     )
 
 
@@ -128,7 +128,7 @@ class FlowRunFilterTags(PrefectBaseModel, OperatorMixin):
 
     all_: Optional[List[str]] = Field(
         default=None,
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
         description=(
             "A list of tags. Flow runs will be returned only if their tags are a"
             " superset of the list"
@@ -157,7 +157,7 @@ class FlowRunFilterWorkQueueName(PrefectBaseModel, OperatorMixin):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of work queue names to include",
-        example=["work_queue_1", "work_queue_2"],
+        examples=[["work_queue_1", "work_queue_2"]],
     )
     is_null_: Optional[bool] = Field(
         default=None,
@@ -343,7 +343,7 @@ class TaskRunFilterName(PrefectBaseModel):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of task run names to include",
-        example=["my-task-run-1", "my-task-run-2"],
+        examples=[["my-task-run-1", "my-task-run-2"]],
     )
 
     like_: Optional[str] = Field(
@@ -353,7 +353,7 @@ class TaskRunFilterName(PrefectBaseModel):
             " passing 'marvin' will match "
             "'marvin', 'sad-Marvin', and 'marvin-robot'."
         ),
-        example="marvin",
+        examples=["marvin"],
     )
 
 
@@ -362,7 +362,7 @@ class TaskRunFilterTags(PrefectBaseModel, OperatorMixin):
 
     all_: Optional[List[str]] = Field(
         default=None,
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
         description=(
             "A list of tags. Task runs will be returned only if their tags are a"
             " superset of the list"
@@ -460,7 +460,7 @@ class DeploymentFilterName(PrefectBaseModel):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of deployment names to include",
-        example=["my-deployment-1", "my-deployment-2"],
+        examples=[["my-deployment-1", "my-deployment-2"]],
     )
 
     like_: Optional[str] = Field(
@@ -470,7 +470,7 @@ class DeploymentFilterName(PrefectBaseModel):
             " passing 'marvin' will match "
             "'marvin', 'sad-Marvin', and 'marvin-robot'."
         ),
-        example="marvin",
+        examples=["marvin"],
     )
 
 
@@ -480,7 +480,7 @@ class DeploymentFilterWorkQueueName(PrefectBaseModel):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of work queue names to include",
-        example=["work_queue_1", "work_queue_2"],
+        examples=[["work_queue_1", "work_queue_2"]],
     )
 
 
@@ -498,7 +498,7 @@ class DeploymentFilterTags(PrefectBaseModel, OperatorMixin):
 
     all_: Optional[List[str]] = Field(
         default=None,
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
         description=(
             "A list of tags. Deployments will be returned only if their tags are a"
             " superset of the list"
@@ -535,7 +535,7 @@ class LogFilterName(PrefectBaseModel):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of log names to include",
-        example=["prefect.logger.flow_runs", "prefect.logger.task_runs"],
+        examples=[["prefect.logger.flow_runs", "prefect.logger.task_runs"]],
     )
 
 
@@ -545,13 +545,13 @@ class LogFilterLevel(PrefectBaseModel):
     ge_: Optional[int] = Field(
         default=None,
         description="Include logs with a level greater than or equal to this level",
-        example=20,
+        examples=[20],
     )
 
     le_: Optional[int] = Field(
         default=None,
         description="Include logs with a level less than or equal to this level",
-        example=50,
+        examples=[50],
     )
 
 
@@ -629,7 +629,7 @@ class BlockTypeFilterName(PrefectBaseModel):
             " passing 'marvin' will match "
             "'marvin', 'sad-Marvin', and 'marvin-robot'."
         ),
-        example="marvin",
+        examples=["marvin"],
     )
 
 
@@ -674,7 +674,7 @@ class BlockSchemaFilterCapabilities(PrefectBaseModel):
 
     all_: Optional[List[str]] = Field(
         default=None,
-        example=["write-storage", "read-storage"],
+        examples=[["write-storage", "read-storage"]],
         description=(
             "A list of block capabilities. Block entities will be returned only if an"
             " associated block schema has a superset of the defined capabilities."
@@ -687,7 +687,7 @@ class BlockSchemaFilterVersion(PrefectBaseModel):
 
     any_: Optional[List[str]] = Field(
         default=None,
-        example=["2.0.0", "2.1.0"],
+        examples=[["2.0.0", "2.1.0"]],
         description="A list of block schema versions.",
     )
 
@@ -748,7 +748,7 @@ class BlockDocumentFilterName(PrefectBaseModel):
             "A string to match block names against. This can include "
             "SQL wildcard characters like `%` and `_`."
         ),
-        example="my-block%",
+        examples=["my-block%"],
     )
 
 
@@ -809,7 +809,7 @@ class WorkQueueFilterName(PrefectBaseModel):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of work queue names to include",
-        example=["wq-1", "wq-2"],
+        examples=[["wq-1", "wq-2"]],
     )
 
     startswith_: Optional[List[str]] = Field(
@@ -819,7 +819,7 @@ class WorkQueueFilterName(PrefectBaseModel):
             " passing 'marvin' will match "
             "'marvin', and 'Marvin-robot', but not 'sad-marvin'."
         ),
-        example=["marvin", "Marvin-robot"],
+        examples=[["marvin", "Marvin-robot"]],
     )
 
 
@@ -929,7 +929,7 @@ class ArtifactFilterKey(PrefectBaseModel):
             "A string to match artifact keys against. This can include "
             "SQL wildcard characters like `%` and `_`."
         ),
-        example="my-artifact-%",
+        examples=["my-artifact-%"],
     )
 
     exists_: Optional[bool] = Field(
@@ -1009,7 +1009,7 @@ class ArtifactCollectionFilterKey(PrefectBaseModel):
             "A string to match artifact keys against. This can include "
             "SQL wildcard characters like `%` and `_`."
         ),
-        example="my-artifact-%",
+        examples=["my-artifact-%"],
     )
 
     exists_: Optional[bool] = Field(
@@ -1089,7 +1089,7 @@ class VariableFilterName(PrefectBaseModel):
             "A string to match variable names against. This can include "
             "SQL wildcard characters like `%` and `_`."
         ),
-        example="my_variable_%",
+        examples=["my_variable_%"],
     )
 
 
@@ -1105,7 +1105,7 @@ class VariableFilterValue(PrefectBaseModel):
             "A string to match variable value against. This can include "
             "SQL wildcard characters like `%` and `_`."
         ),
-        example="my-value-%",
+        examples=["my-value-%"],
     )
 
 
@@ -1114,7 +1114,7 @@ class VariableFilterTags(PrefectBaseModel, OperatorMixin):
 
     all_: Optional[List[str]] = Field(
         default=None,
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
         description=(
             "A list of tags. Variables will be returned only if their tags are a"
             " superset of the list"

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -142,7 +142,7 @@ class State(ObjectBaseModel, Generic[R]):
     type: StateType
     name: Optional[str] = Field(default=None)
     timestamp: DateTimeTZ = Field(default_factory=lambda: pendulum.now("UTC"))
-    message: Optional[str] = Field(default=None, example="Run started")
+    message: Optional[str] = Field(default=None, examples=["Run started"])
     state_details: StateDetails = Field(default_factory=StateDetails)
     data: Union["BaseResult[R]", "DataDocument[R]", Any] = Field(
         default=None,
@@ -410,7 +410,7 @@ class FlowRun(ObjectBaseModel):
         description=(
             "The name of the flow run. Defaults to a random slug if not specified."
         ),
-        example="my-flow-run",
+        examples=["my-flow-run"],
     )
     flow_id: UUID = Field(default=..., description="The id of the flow being run.")
     state_id: Optional[UUID] = Field(
@@ -425,7 +425,7 @@ class FlowRun(ObjectBaseModel):
     deployment_version: Optional[str] = Field(
         default=None,
         description="The version of the deployment associated with this flow run.",
-        example="1.0",
+        examples=["1.0"],
     )
     work_queue_name: Optional[str] = Field(
         default=None, description="The work queue that handled this flow run."
@@ -433,7 +433,7 @@ class FlowRun(ObjectBaseModel):
     flow_version: Optional[str] = Field(
         default=None,
         description="The version of the flow executed in this flow run.",
-        example="1.0",
+        examples=["1.0"],
     )
     parameters: Dict[str, Any] = Field(
         default_factory=dict, description="Parameters for the flow run."
@@ -448,7 +448,7 @@ class FlowRun(ObjectBaseModel):
     context: Dict[str, Any] = Field(
         default_factory=dict,
         description="Additional context for the flow run.",
-        example={"my_var": "my_val"},
+        examples=[{"my_var": "my_val"}],
     )
     empirical_policy: FlowRunPolicy = Field(
         default_factory=FlowRunPolicy,
@@ -456,7 +456,7 @@ class FlowRun(ObjectBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of tags on the flow run",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
     parent_task_run_id: Optional[UUID] = Field(
         default=None,
@@ -523,12 +523,12 @@ class FlowRun(ObjectBaseModel):
     work_pool_name: Optional[str] = Field(
         default=None,
         description="The name of the flow run's work pool.",
-        example="my-work-pool",
+        examples=["my-work-pool"],
     )
     state: Optional[State] = Field(
         default=None,
         description="The state of the flow run.",
-        example=State(type=StateType.COMPLETED),
+        examples=[State(type=StateType.COMPLETED)],
     )
     job_variables: Optional[dict] = Field(
         default=None, description="Job variables for the flow run."
@@ -639,7 +639,9 @@ class Constant(TaskRunInput):
 
 
 class TaskRun(ObjectBaseModel):
-    name: str = Field(default_factory=lambda: generate_slug(2), example="my-task-run")
+    name: str = Field(
+        default_factory=lambda: generate_slug(2), examples=["my-task-run"]
+    )
     flow_run_id: Optional[UUID] = Field(
         default=None, description="The flow run id of the task run."
     )
@@ -673,7 +675,7 @@ class TaskRun(ObjectBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of tags for the task run.",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
     state_id: Optional[UUID] = Field(
         default=None, description="The id of the current task run state."
@@ -736,7 +738,7 @@ class TaskRun(ObjectBaseModel):
     state: Optional[State] = Field(
         default=None,
         description="The state of the flow run.",
-        example=State(type=StateType.COMPLETED),
+        examples=[State(type=StateType.COMPLETED)],
     )
 
     @validator("name", pre=True)
@@ -889,12 +891,12 @@ class Flow(ObjectBaseModel):
     """An ORM representation of flow data."""
 
     name: str = Field(
-        default=..., description="The name of the flow", example="my-flow"
+        default=..., description="The name of the flow", examples=["my-flow"]
     )
     tags: List[str] = Field(
         default_factory=list,
         description="A list of flow tags",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
 
     @validator("name", check_fields=False)
@@ -964,7 +966,7 @@ class Deployment(ObjectBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of tags for the deployment",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
     work_queue_name: Optional[str] = Field(
         default=None,
@@ -1300,10 +1302,10 @@ class FlowRunNotificationPolicy(ObjectBaseModel):
             " Valid variables include:"
             f" {listrepr(sorted(FLOW_RUN_NOTIFICATION_TEMPLATE_KWARGS), sep=', ')}"
         ),
-        example=(
+        examples=[
             "Flow run {flow_run_name} with id {flow_run_id} entered state"
             " {flow_run_state_name}."
-        ),
+        ],
     )
 
     @validator("message_template")
@@ -1484,19 +1486,19 @@ class Variable(ObjectBaseModel):
     name: str = Field(
         default=...,
         description="The name of the variable",
-        example="my_variable",
+        examples=["my_variable"],
         max_length=MAX_VARIABLE_NAME_LENGTH,
     )
     value: str = Field(
         default=...,
         description="The value of the variable",
-        example="my-value",
+        examples=["my_value"],
         max_length=MAX_VARIABLE_VALUE_LENGTH,
     )
     tags: List[str] = Field(
         default_factory=list,
         description="A list of variable tags",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
 
 

--- a/src/prefect/client/schemas/responses.py
+++ b/src/prefect/client/schemas/responses.py
@@ -160,7 +160,7 @@ class FlowRunResponse(ObjectBaseModel):
         description=(
             "The name of the flow run. Defaults to a random slug if not specified."
         ),
-        example="my-flow-run",
+        examples=["my-flow-run"],
     )
     flow_id: UUID = Field(default=..., description="The id of the flow being run.")
     state_id: Optional[UUID] = Field(
@@ -175,7 +175,7 @@ class FlowRunResponse(ObjectBaseModel):
     deployment_version: Optional[str] = Field(
         default=None,
         description="The version of the deployment associated with this flow run.",
-        example="1.0",
+        examples=["1.0"],
     )
     work_queue_name: Optional[str] = Field(
         default=None, description="The work queue that handled this flow run."
@@ -183,7 +183,7 @@ class FlowRunResponse(ObjectBaseModel):
     flow_version: Optional[str] = Field(
         default=None,
         description="The version of the flow executed in this flow run.",
-        example="1.0",
+        examples=["1.0"],
     )
     parameters: Dict[str, Any] = Field(
         default_factory=dict, description="Parameters for the flow run."
@@ -198,7 +198,7 @@ class FlowRunResponse(ObjectBaseModel):
     context: Dict[str, Any] = Field(
         default_factory=dict,
         description="Additional context for the flow run.",
-        example={"my_var": "my_val"},
+        examples=[{"my_var": "my_val"}],
     )
     empirical_policy: objects.FlowRunPolicy = Field(
         default_factory=objects.FlowRunPolicy,
@@ -206,7 +206,7 @@ class FlowRunResponse(ObjectBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of tags on the flow run",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
     parent_task_run_id: Optional[UUID] = Field(
         default=None,
@@ -273,12 +273,12 @@ class FlowRunResponse(ObjectBaseModel):
     work_pool_name: Optional[str] = Field(
         default=None,
         description="The name of the flow run's work pool.",
-        example="my-work-pool",
+        examples=["my-work-pool"],
     )
     state: Optional[objects.State] = Field(
         default=None,
         description="The state of the flow run.",
-        example=objects.State(type=objects.StateType.COMPLETED),
+        examples=[objects.State(type=objects.StateType.COMPLETED)],
     )
     job_variables: Optional[dict] = Field(
         default=None, description="Job variables for the flow run."
@@ -347,7 +347,7 @@ class DeploymentResponse(ObjectBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of tags for the deployment",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
     work_queue_name: Optional[str] = Field(
         default=None,

--- a/src/prefect/client/schemas/schedules.py
+++ b/src/prefect/client/schemas/schedules.py
@@ -9,7 +9,7 @@ import dateutil
 import dateutil.rrule
 import pendulum
 
-from prefect._internal.pydantic import HAS_PYDANTIC_V2
+from prefect._internal.schemas.fields import DateTimeTZ
 from prefect._internal.schemas.validators import (
     default_anchor_date,
     default_timezone,
@@ -18,15 +18,7 @@ from prefect._internal.schemas.validators import (
     validate_rrule_string,
     validate_rrule_timezone,
 )
-
-if HAS_PYDANTIC_V2:
-    from pydantic.v1 import Field, validator
-else:
-    from pydantic import Field, validator
-
-
-from prefect._internal.schemas.bases import PrefectBaseModel
-from prefect._internal.schemas.fields import DateTimeTZ
+from prefect.pydantic import Field, PrefectBaseModel, field_validator
 
 MAX_ITERATIONS = 1000
 # approx. 1 years worth of RDATEs + buffer
@@ -68,17 +60,17 @@ class IntervalSchedule(PrefectBaseModel):
 
     interval: datetime.timedelta
     anchor_date: DateTimeTZ = None
-    timezone: Optional[str] = Field(default=None, example="America/New_York")
+    timezone: Optional[str] = Field(default=None, examples=["America/New_York"])
 
-    @validator("interval")
+    @field_validator("interval")
     def validate_interval_schedule(cls, v):
         return interval_schedule_must_be_positive(v)
 
-    @validator("anchor_date", always=True)
+    @field_validator("anchor_date", always=True)
     def validate_anchor_date(cls, v):
         return default_anchor_date(v)
 
-    @validator("timezone", always=True)
+    @field_validator("timezone", always=True)
     def validate_default_timezone(cls, v, values):
         return default_timezone(v, values=values)
 
@@ -111,8 +103,8 @@ class CronSchedule(PrefectBaseModel):
     class Config:
         extra = "forbid"
 
-    cron: str = Field(default=..., example="0 0 * * *")
-    timezone: Optional[str] = Field(default=None, example="America/New_York")
+    cron: str = Field(default=..., examples=["0 0 * * *"])
+    timezone: Optional[str] = Field(default=None, examples=["America/New_York"])
     day_or: bool = Field(
         default=True,
         description=(
@@ -120,11 +112,11 @@ class CronSchedule(PrefectBaseModel):
         ),
     )
 
-    @validator("timezone")
+    @field_validator("timezone")
     def valid_timezone(cls, v):
         return default_timezone(v)
 
-    @validator("cron")
+    @field_validator("cron")
     def valid_cron_string(cls, v):
         return validate_cron_string(v)
 
@@ -156,9 +148,9 @@ class RRuleSchedule(PrefectBaseModel):
         extra = "forbid"
 
     rrule: str
-    timezone: Optional[str] = Field(default=None, example="America/New_York")
+    timezone: Optional[str] = Field(default=None, examples=["America/New_York"])
 
-    @validator("rrule")
+    @field_validator("rrule")
     def validate_rrule_str(cls, v):
         return validate_rrule_string(v)
 
@@ -265,7 +257,7 @@ class RRuleSchedule(PrefectBaseModel):
 
             return rrule
 
-    @validator("timezone", always=True)
+    @field_validator("timezone", always=True)
     def valid_timezone(cls, v):
         return validate_rrule_timezone(v)
 

--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -270,7 +270,7 @@ class RemoteFileSystem(WritableFileSystem, WritableDeploymentStorage):
     basepath: str = Field(
         default=...,
         description="Default path for this block to write to.",
-        example="s3://my-bucket/my-folder/",
+        examples=["s3://my-bucket/my-folder/"],
     )
     settings: Dict[str, Any] = Field(
         default_factory=dict,
@@ -451,19 +451,19 @@ class S3(WritableFileSystem, WritableDeploymentStorage):
     bucket_path: str = Field(
         default=...,
         description="An S3 bucket path.",
-        example="my-bucket/a-directory-within",
+        examples=["my-bucket/a-directory-within"],
     )
     aws_access_key_id: Optional[SecretStr] = Field(
         default=None,
         title="AWS Access Key ID",
         description="Equivalent to the AWS_ACCESS_KEY_ID environment variable.",
-        example="AKIAIOSFODNN7EXAMPLE",
+        examples=["AKIAIOSFODNN7EXAMPLE"],
     )
     aws_secret_access_key: Optional[SecretStr] = Field(
         default=None,
         title="AWS Secret Access Key",
         description="Equivalent to the AWS_SECRET_ACCESS_KEY environment variable.",
-        example="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        examples=["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"],
     )
 
     _remote_file_system: RemoteFileSystem = None
@@ -549,7 +549,7 @@ class GCS(WritableFileSystem, WritableDeploymentStorage):
     bucket_path: str = Field(
         default=...,
         description="A GCS bucket path.",
-        example="my-bucket/a-directory-within",
+        examples=["my-bucket/a-directory-within"],
     )
     service_account_info: Optional[SecretStr] = Field(
         default=None,
@@ -653,7 +653,7 @@ class Azure(WritableFileSystem, WritableDeploymentStorage):
     bucket_path: str = Field(
         default=...,
         description="An Azure storage bucket path.",
-        example="my-bucket/a-directory-within",
+        examples=["my-bucket/a-directory-within"],
     )
     azure_storage_connection_string: Optional[SecretStr] = Field(
         default=None,
@@ -804,7 +804,7 @@ class SMB(WritableFileSystem, WritableDeploymentStorage):
     share_path: str = Field(
         default=...,
         description="SMB target (requires <SHARE>, followed by <PATH>).",
-        example="/SHARE/dir/subdir",
+        examples=["/SHARE/dir/subdir"],
     )
     smb_username: Optional[SecretStr] = Field(
         default=None,

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -90,12 +90,12 @@ class FlowCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a flow."""
 
     name: str = Field(
-        default=..., description="The name of the flow", example="my-flow"
+        default=..., description="The name of the flow", examples=["my-flow"]
     )
     tags: List[str] = Field(
         default_factory=list,
         description="A list of flow tags",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
 
     @validator("name", check_fields=False)
@@ -109,7 +109,7 @@ class FlowUpdate(ActionBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of flow tags",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
 
     @validator("name", check_fields=False)
@@ -147,7 +147,9 @@ class DeploymentCreate(ActionBaseModel):
         return remove_old_deployment_fields(values)
 
     name: str = Field(
-        default=..., description="The name of the deployment.", example="my-deployment"
+        default=...,
+        description="The name of the deployment.",
+        examples=["my-deployment"],
     )
     flow_id: UUID = Field(
         default=..., description="The ID of the flow associated with the deployment."
@@ -179,7 +181,7 @@ class DeploymentCreate(ActionBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of deployment tags.",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
     pull_steps: Optional[List[dict]] = Field(None)
 
@@ -188,7 +190,7 @@ class DeploymentCreate(ActionBaseModel):
     work_pool_name: Optional[str] = Field(
         default=None,
         description="The name of the deployment's work pool.",
-        example="my-work-pool",
+        examples=["my-work-pool"],
     )
     storage_document_id: Optional[UUID] = Field(None)
     infrastructure_document_id: Optional[UUID] = Field(None)
@@ -261,13 +263,13 @@ class DeploymentUpdate(ActionBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of deployment tags.",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
     work_queue_name: Optional[str] = Field(None)
     work_pool_name: Optional[str] = Field(
         default=None,
         description="The name of the deployment's work pool.",
-        example="my-work-pool",
+        examples=["my-work-pool"],
     )
     path: Optional[str] = Field(None)
     infra_overrides: Optional[Dict[str, Any]] = Field(None)
@@ -365,7 +367,9 @@ class TaskRunCreate(ActionBaseModel):
         default=None, description="The state of the task run to create"
     )
 
-    name: str = Field(default_factory=lambda: generate_slug(2), example="my-task-run")
+    name: str = Field(
+        default_factory=lambda: generate_slug(2), examples=["my-task-run"]
+    )
     flow_run_id: Optional[UUID] = Field(
         default=None, description="The flow run id of the task run."
     )
@@ -399,7 +403,7 @@ class TaskRunCreate(ActionBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of tags for the task run.",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
     task_inputs: Dict[
         str,
@@ -427,7 +431,9 @@ class TaskRunCreate(ActionBaseModel):
 class TaskRunUpdate(ActionBaseModel):
     """Data used by the Prefect REST API to update a task run"""
 
-    name: str = Field(default_factory=lambda: generate_slug(2), example="my-task-run")
+    name: str = Field(
+        default_factory=lambda: generate_slug(2), examples=["my-task-run"]
+    )
 
     @validator("name", pre=True)
     def set_name(cls, name):
@@ -447,7 +453,7 @@ class FlowRunCreate(ActionBaseModel):
         description=(
             "The name of the flow run. Defaults to a random slug if not specified."
         ),
-        example="my-flow-run",
+        examples=["my-flow-run"],
     )
     flow_id: UUID = Field(default=..., description="The id of the flow being run.")
     flow_version: Optional[str] = Field(
@@ -469,7 +475,7 @@ class FlowRunCreate(ActionBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of tags for the flow run.",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
     idempotency_key: Optional[str] = Field(
         None,
@@ -511,7 +517,7 @@ class DeploymentFlowRunCreate(ActionBaseModel):
         description=(
             "The name of the flow run. Defaults to a random slug if not specified."
         ),
-        example="my-flow-run",
+        examples=["my-flow-run"],
     )
     parameters: Dict[str, Any] = Field(default_factory=dict)
     context: Dict[str, Any] = Field(default_factory=dict)
@@ -523,7 +529,7 @@ class DeploymentFlowRunCreate(ActionBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of tags for the flow run.",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
     idempotency_key: Optional[str] = Field(
         None,
@@ -879,10 +885,10 @@ class FlowRunNotificationPolicyCreate(ActionBaseModel):
             " Valid variables include:"
             f" {listrepr(sorted(schemas.core.FLOW_RUN_NOTIFICATION_TEMPLATE_KWARGS), sep=', ')}"
         ),
-        example=(
+        examples=[
             "Flow run {flow_run_name} with id {flow_run_id} entered state"
             " {flow_run_state_name}."
-        ),
+        ],
     )
 
     @validator("message_template")
@@ -984,19 +990,19 @@ class VariableCreate(ActionBaseModel):
     name: str = Field(
         default=...,
         description="The name of the variable",
-        example="my_variable",
+        examples=["my-variable"],
         max_length=schemas.core.MAX_VARIABLE_NAME_LENGTH,
     )
     value: str = Field(
         default=...,
         description="The value of the variable",
-        example="my-value",
+        examples=["my-value"],
         max_length=schemas.core.MAX_VARIABLE_VALUE_LENGTH,
     )
     tags: List[str] = Field(
         default_factory=list,
         description="A list of variable tags",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
 
     # validators
@@ -1009,19 +1015,19 @@ class VariableUpdate(ActionBaseModel):
     name: Optional[str] = Field(
         default=None,
         description="The name of the variable",
-        example="my_variable",
+        examples=["my-variable"],
         max_length=schemas.core.MAX_VARIABLE_NAME_LENGTH,
     )
     value: Optional[str] = Field(
         default=None,
         description="The value of the variable",
-        example="my-value",
+        examples=["my-value"],
         max_length=schemas.core.MAX_VARIABLE_VALUE_LENGTH,
     )
     tags: Optional[List[str]] = Field(
         default=None,
         description="A list of variable tags",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
 
     # validators

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -65,12 +65,12 @@ class Flow(ORMBaseModel):
     """An ORM representation of flow data."""
 
     name: str = Field(
-        default=..., description="The name of the flow", example="my-flow"
+        default=..., description="The name of the flow", examples=["my-flow"]
     )
     tags: List[str] = Field(
         default_factory=list,
         description="A list of flow tags",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
 
     @validator("name", check_fields=False)
@@ -147,7 +147,7 @@ class FlowRun(ORMBaseModel):
         description=(
             "The name of the flow run. Defaults to a random slug if not specified."
         ),
-        example="my-flow-run",
+        examples=["my-flow-run"],
     )
     flow_id: UUID = Field(default=..., description="The id of the flow being run.")
     state_id: Optional[UUID] = Field(
@@ -162,7 +162,7 @@ class FlowRun(ORMBaseModel):
     deployment_version: Optional[str] = Field(
         default=None,
         description="The version of the deployment associated with this flow run.",
-        example="1.0",
+        examples=["1.0"],
     )
     work_queue_name: Optional[str] = Field(
         default=None, description="The work queue that handled this flow run."
@@ -170,7 +170,7 @@ class FlowRun(ORMBaseModel):
     flow_version: Optional[str] = Field(
         default=None,
         description="The version of the flow executed in this flow run.",
-        example="1.0",
+        examples=["1.0"],
     )
     parameters: Dict[str, Any] = Field(
         default_factory=dict, description="Parameters for the flow run."
@@ -185,7 +185,7 @@ class FlowRun(ORMBaseModel):
     context: Dict[str, Any] = Field(
         default_factory=dict,
         description="Additional context for the flow run.",
-        example={"my_var": "my_val"},
+        examples=[{"my_var": "my_value"}],
     )
     empirical_policy: FlowRunPolicy = Field(
         default_factory=FlowRunPolicy,
@@ -193,7 +193,7 @@ class FlowRun(ORMBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of tags on the flow run",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
     parent_task_run_id: Optional[UUID] = Field(
         default=None,
@@ -371,7 +371,9 @@ class Constant(TaskRunInput):
 class TaskRun(ORMBaseModel):
     """An ORM representation of task run data."""
 
-    name: str = Field(default_factory=lambda: generate_slug(2), example="my-task-run")
+    name: str = Field(
+        default_factory=lambda: generate_slug(2), examples=["my-task-run"]
+    )
     flow_run_id: Optional[UUID] = Field(
         default=None, description="The flow run id of the task run."
     )
@@ -405,7 +407,7 @@ class TaskRun(ORMBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of tags for the task run.",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
     state_id: Optional[UUID] = Field(
         default=None, description="The id of the current task run state."
@@ -534,7 +536,7 @@ class Deployment(ORMBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of tags for the deployment",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
     work_queue_name: Optional[str] = Field(
         default=None,
@@ -1010,10 +1012,10 @@ class FlowRunNotificationPolicy(ORMBaseModel):
             " Valid variables include:"
             f" {listrepr(sorted(FLOW_RUN_NOTIFICATION_TEMPLATE_KWARGS), sep=', ')}"
         ),
-        example=(
+        examples=[
             "Flow run {flow_run_name} with id {flow_run_id} entered state"
             " {flow_run_state_name}."
-        ),
+        ],
     )
 
     @validator("message_template")
@@ -1196,19 +1198,19 @@ class Variable(ORMBaseModel):
     name: str = Field(
         default=...,
         description="The name of the variable",
-        example="my_variable",
+        examples=["my-variable"],
         max_length=MAX_VARIABLE_NAME_LENGTH,
     )
     value: str = Field(
         default=...,
         description="The value of the variable",
-        example="my-value",
+        examples=["my-value"],
         max_length=MAX_VARIABLE_VALUE_LENGTH,
     )
     tags: List[str] = Field(
         default_factory=list,
         description="A list of variable tags",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
 
 

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -120,7 +120,7 @@ class FlowFilterName(PrefectFilterBaseModel):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of flow names to include",
-        example=["my-flow-1", "my-flow-2"],
+        examples=[["my-flow-1", "my-flow-2"]],
     )
 
     like_: Optional[str] = Field(
@@ -130,7 +130,7 @@ class FlowFilterName(PrefectFilterBaseModel):
             " passing 'marvin' will match "
             "'marvin', 'sad-Marvin', and 'marvin-robot'."
         ),
-        example="marvin",
+        examples=["marvin"],
     )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
@@ -147,7 +147,7 @@ class FlowFilterTags(PrefectOperatorFilterBaseModel):
 
     all_: Optional[List[str]] = Field(
         default=None,
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
         description=(
             "A list of tags. Flows will be returned only if their tags are a superset"
             " of the list"
@@ -224,7 +224,7 @@ class FlowRunFilterName(PrefectFilterBaseModel):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of flow run names to include",
-        example=["my-flow-run-1", "my-flow-run-2"],
+        examples=[["my-flow-run-1", "my-flow-run-2"]],
     )
 
     like_: Optional[str] = Field(
@@ -234,7 +234,7 @@ class FlowRunFilterName(PrefectFilterBaseModel):
             " passing 'marvin' will match "
             "'marvin', 'sad-Marvin', and 'marvin-robot'."
         ),
-        example="marvin",
+        examples=["marvin"],
     )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
@@ -251,7 +251,7 @@ class FlowRunFilterTags(PrefectOperatorFilterBaseModel):
 
     all_: Optional[List[str]] = Field(
         default=None,
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
         description=(
             "A list of tags. Flow runs will be returned only if their tags are a"
             " superset of the list"
@@ -304,7 +304,7 @@ class FlowRunFilterWorkQueueName(PrefectOperatorFilterBaseModel):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of work queue names to include",
-        example=["work_queue_1", "work_queue_2"],
+        examples=[["work_queue_1", "work_queue_2"]],
     )
     is_null_: Optional[bool] = Field(
         default=None,
@@ -667,7 +667,7 @@ class TaskRunFilterName(PrefectFilterBaseModel):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of task run names to include",
-        example=["my-task-run-1", "my-task-run-2"],
+        examples=[["my-task-run-1", "my-task-run-2"]],
     )
 
     like_: Optional[str] = Field(
@@ -677,7 +677,7 @@ class TaskRunFilterName(PrefectFilterBaseModel):
             " passing 'marvin' will match "
             "'marvin', 'sad-Marvin', and 'marvin-robot'."
         ),
-        example="marvin",
+        examples=["marvin"],
     )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
@@ -694,7 +694,7 @@ class TaskRunFilterTags(PrefectOperatorFilterBaseModel):
 
     all_: Optional[List[str]] = Field(
         default=None,
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
         description=(
             "A list of tags. Task runs will be returned only if their tags are a"
             " superset of the list"
@@ -876,7 +876,7 @@ class DeploymentFilterName(PrefectFilterBaseModel):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of deployment names to include",
-        example=["my-deployment-1", "my-deployment-2"],
+        examples=[["my-deployment-1", "my-deployment-2"]],
     )
 
     like_: Optional[str] = Field(
@@ -886,7 +886,7 @@ class DeploymentFilterName(PrefectFilterBaseModel):
             " passing 'marvin' will match "
             "'marvin', 'sad-Marvin', and 'marvin-robot'."
         ),
-        example="marvin",
+        examples=["marvin"],
     )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
@@ -919,7 +919,7 @@ class DeploymentFilterWorkQueueName(PrefectFilterBaseModel):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of work queue names to include",
-        example=["work_queue_1", "work_queue_2"],
+        examples=[["work_queue_1", "work_queue_2"]],
     )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
@@ -950,7 +950,7 @@ class DeploymentFilterTags(PrefectOperatorFilterBaseModel):
 
     all_: Optional[List[str]] = Field(
         default=None,
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
         description=(
             "A list of tags. Deployments will be returned only if their tags are a"
             " superset of the list"
@@ -1051,7 +1051,7 @@ class LogFilterName(PrefectFilterBaseModel):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of log names to include",
-        example=["prefect.logger.flow_runs", "prefect.logger.task_runs"],
+        examples=[["prefect.logger.flow_runs", "prefect.logger.task_runs"]],
     )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
@@ -1067,13 +1067,13 @@ class LogFilterLevel(PrefectFilterBaseModel):
     ge_: Optional[int] = Field(
         default=None,
         description="Include logs with a level greater than or equal to this level",
-        example=20,
+        examples=[20],
     )
 
     le_: Optional[int] = Field(
         default=None,
         description="Include logs with a level less than or equal to this level",
-        example=50,
+        examples=[50],
     )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
@@ -1193,7 +1193,7 @@ class BlockTypeFilterName(PrefectFilterBaseModel):
             " passing 'marvin' will match "
             "'marvin', 'sad-Marvin', and 'marvin-robot'."
         ),
-        example="marvin",
+        examples=["marvin"],
     )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
@@ -1273,7 +1273,7 @@ class BlockSchemaFilterCapabilities(PrefectFilterBaseModel):
 
     all_: Optional[List[str]] = Field(
         default=None,
-        example=["write-storage", "read-storage"],
+        examples=[["write-storage", "read-storage"]],
         description=(
             "A list of block capabilities. Block entities will be returned only if an"
             " associated block schema has a superset of the defined capabilities."
@@ -1294,7 +1294,7 @@ class BlockSchemaFilterVersion(PrefectFilterBaseModel):
 
     any_: Optional[List[str]] = Field(
         default=None,
-        example=["2.0.0", "2.1.0"],
+        examples=[["2.0.0", "2.1.0"]],
         description="A list of block schema versions.",
     )
 
@@ -1395,7 +1395,7 @@ class BlockDocumentFilterName(PrefectFilterBaseModel):
             "A string to match block names against. This can include "
             "SQL wildcard characters like `%` and `_`."
         ),
-        example="my-block%",
+        examples=["my-block%"],
     )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
@@ -1495,7 +1495,7 @@ class WorkQueueFilterName(PrefectFilterBaseModel):
     any_: Optional[List[str]] = Field(
         default=None,
         description="A list of work queue names to include",
-        example=["wq-1", "wq-2"],
+        examples=[["wq-1", "wq-2"]],
     )
 
     startswith_: Optional[List[str]] = Field(
@@ -1505,7 +1505,7 @@ class WorkQueueFilterName(PrefectFilterBaseModel):
             " passing 'marvin' will match "
             "'marvin', and 'Marvin-robot', but not 'sad-marvin'."
         ),
-        example=["marvin", "Marvin-robot"],
+        examples=[["marvin", "Marvin-robot"]],
     )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
@@ -1699,7 +1699,7 @@ class ArtifactFilterKey(PrefectFilterBaseModel):
             "A string to match artifact keys against. This can include "
             "SQL wildcard characters like `%` and `_`."
         ),
-        example="my-artifact-%",
+        examples=["my-artifact-%"],
     )
 
     exists_: Optional[bool] = Field(
@@ -1835,7 +1835,7 @@ class ArtifactCollectionFilterKey(PrefectFilterBaseModel):
             "A string to match artifact keys against. This can include "
             "SQL wildcard characters like `%` and `_`."
         ),
-        example="my-artifact-%",
+        examples=["my-artifact-%"],
     )
 
     exists_: Optional[bool] = Field(
@@ -1971,7 +1971,7 @@ class VariableFilterName(PrefectFilterBaseModel):
             "A string to match variable names against. This can include "
             "SQL wildcard characters like `%` and `_`."
         ),
-        example="my_variable_%",
+        examples=["my_variable_%"],
     )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
@@ -1995,7 +1995,7 @@ class VariableFilterValue(PrefectFilterBaseModel):
             "A string to match variable value against. This can include "
             "SQL wildcard characters like `%` and `_`."
         ),
-        example="my-value-%",
+        examples=["my-value-%"],
     )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:
@@ -2012,7 +2012,7 @@ class VariableFilterTags(PrefectOperatorFilterBaseModel):
 
     all_: Optional[List[str]] = Field(
         default=None,
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
         description=(
             "A list of tags. Variables will be returned only if their tags are a"
             " superset of the list"

--- a/src/prefect/server/schemas/responses.py
+++ b/src/prefect/server/schemas/responses.py
@@ -171,7 +171,7 @@ class FlowRunResponse(ORMBaseModel):
         description=(
             "The name of the flow run. Defaults to a random slug if not specified."
         ),
-        example="my-flow-run",
+        examples=["my-flow-run"],
     )
     flow_id: UUID = Field(default=..., description="The id of the flow being run.")
     state_id: Optional[UUID] = Field(
@@ -186,7 +186,7 @@ class FlowRunResponse(ORMBaseModel):
     deployment_version: Optional[str] = Field(
         default=None,
         description="The version of the deployment associated with this flow run.",
-        example="1.0",
+        examples=["1.0"],
     )
     work_queue_id: Optional[UUID] = Field(
         default=None, description="The id of the run's work pool queue."
@@ -197,7 +197,7 @@ class FlowRunResponse(ORMBaseModel):
     flow_version: Optional[str] = Field(
         default=None,
         description="The version of the flow executed in this flow run.",
-        example="1.0",
+        examples=["1.0"],
     )
     parameters: Dict[str, Any] = Field(
         default_factory=dict, description="Parameters for the flow run."
@@ -212,7 +212,7 @@ class FlowRunResponse(ORMBaseModel):
     context: Dict[str, Any] = Field(
         default_factory=dict,
         description="Additional context for the flow run.",
-        example={"my_var": "my_val"},
+        examples=[{"my_var": "my_val"}],
     )
     empirical_policy: FlowRunPolicy = Field(
         default_factory=FlowRunPolicy,
@@ -220,7 +220,7 @@ class FlowRunResponse(ORMBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of tags on the flow run",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
     parent_task_run_id: Optional[UUID] = Field(
         default=None,
@@ -290,7 +290,7 @@ class FlowRunResponse(ORMBaseModel):
     work_pool_name: Optional[str] = Field(
         default=None,
         description="The name of the flow run's work pool.",
-        example="my-work-pool",
+        examples=["my-work-pool"],
     )
     state: Optional[schemas.states.State] = Field(
         default=None, description="The current state of the flow run."
@@ -361,7 +361,7 @@ class DeploymentResponse(ORMBaseModel):
     tags: List[str] = Field(
         default_factory=list,
         description="A list of tags for the deployment",
-        example=["tag-1", "tag-2"],
+        examples=[["tag-1", "tag-2"]],
     )
     work_queue_name: Optional[str] = Field(
         default=None,

--- a/src/prefect/server/schemas/schedules.py
+++ b/src/prefect/server/schemas/schedules.py
@@ -83,7 +83,7 @@ class IntervalSchedule(PrefectBaseModel):
 
     interval: datetime.timedelta
     anchor_date: DateTimeTZ = None
-    timezone: Optional[str] = Field(default=None, example="America/New_York")
+    timezone: Optional[str] = Field(default=None, examples=["America/New_York"])
 
     @validator("interval")
     def validate_interval_schedule(cls, v):
@@ -224,8 +224,8 @@ class CronSchedule(PrefectBaseModel):
     class Config:
         extra = "forbid"
 
-    cron: str = Field(default=..., example="0 0 * * *")
-    timezone: Optional[str] = Field(default=None, example="America/New_York")
+    cron: str = Field(default=..., examples=["0 0 * * *"])
+    timezone: Optional[str] = Field(default=None, examples=["America/New_York"])
     day_or: bool = Field(
         default=True,
         description=(
@@ -378,7 +378,7 @@ class RRuleSchedule(PrefectBaseModel):
         extra = "forbid"
 
     rrule: str
-    timezone: Optional[str] = Field(default=None, example="America/New_York")
+    timezone: Optional[str] = Field(default=None, examples=["America/New_York"])
 
     @validator("rrule")
     def validate_rrule_str(cls, v):

--- a/src/prefect/server/schemas/states.py
+++ b/src/prefect/server/schemas/states.py
@@ -122,7 +122,7 @@ class State(StateBaseModel, Generic[R]):
     type: StateType
     name: Optional[str] = Field(default=None)
     timestamp: DateTimeTZ = Field(default_factory=lambda: pendulum.now("UTC"))
-    message: Optional[str] = Field(default=None, example="Run started")
+    message: Optional[str] = Field(default=None, examples=["Run started"])
     data: Optional[Any] = Field(
         default=None,
         description=(


### PR DESCRIPTION
in pydantic 2, `example` is no longer a first class `Field` kwarg - its been superseded by `examples`

```python
In [1]: from pydantic import Field

In [2]: Field(..., example=[1, 2])
Out[2]: FieldInfo(annotation=NoneType, required=True, json_schema_extra={'example': [1, 2]})

In [3]: Field(..., examples=[1, 2])
Out[3]: FieldInfo(annotation=NoneType, required=True, examples=[1, 2])
```

so to avoid unnecessary customization of `Field` to cater to our use of `example`, this PR switches our use to `examples` pre-emptively