### PR TITLE
Add more documentation for Pydantic V2 compatibility and utilities

### DIFF
--- a/src/prefect/_internal/pydantic/_base_model.py
+++ b/src/prefect/_internal/pydantic/_base_model.py
@@ -1,3 +1,6 @@
+"""
+This file introduces a conditional import of `BaseModel` from Pydantic, depending on the Pydantic version available. If Pydantic V2 is not used, it falls back to importing `BaseModel` from Pydantic V1. This is to ensure compatibility with different versions of Pydantic.
+"""
 import typing
 
 from prefect._internal.pydantic._flags import (

--- a/src/prefect/_internal/pydantic/_compat.py
+++ b/src/prefect/_internal/pydantic/_compat.py
@@ -1,3 +1,7 @@
+"""
+Functions within this module check for Pydantic V2 compatibility and provide mechanisms for copying,
+ dumping, and validating models in a way that is agnostic to the underlying Pydantic version.
+"""
 import typing
 
 from ._base_model import BaseModel as PydanticBaseModel

--- a/src/prefect/_internal/pydantic/_flags.py
+++ b/src/prefect/_internal/pydantic/_flags.py
@@ -1,3 +1,6 @@
+"""
+This file defines flags that determine whether Pydantic V2 is available and whether its features should be used.
+"""
 import os
 
 # Retrieve current version of Pydantic installed in environment

--- a/src/prefect/_internal/pydantic/utilities/field_validator.py
+++ b/src/prefect/_internal/pydantic/utilities/field_validator.py
@@ -95,7 +95,9 @@ def field_validator(
                 field, *fields, mode=mode, check_fields=check_fields
             )(validate_func)
         elif HAS_PYDANTIC_V2:
-            from pydantic.v1 import BaseModel, validator  # type: ignore
+            from pydantic.v1 import validator  # type: ignore
+
+            from prefect.pydantic import BaseModel
         else:
             from pydantic import BaseModel, validator
 

--- a/src/prefect/pydantic/__init__.py
+++ b/src/prefect/pydantic/__init__.py
@@ -1,3 +1,6 @@
+"""
+This initialization file makes the `BaseModel` and `PrefectBaseModel` classes available for import from the pydantic module within Prefect. This setup allows other parts of the Prefect codebase to use these models without needing to understand the underlying compatibility layer.
+"""
 import typing
 from prefect._internal.pydantic._flags import HAS_PYDANTIC_V2, USE_PYDANTIC_V2
 

--- a/src/prefect/pydantic/main.py
+++ b/src/prefect/pydantic/main.py
@@ -1,3 +1,6 @@
+"""
+This file defines a `PrefectBaseModel` class that extends the `BaseModel` (imported from the internal compatibility layer).
+"""
 import typing
 
 from prefect._internal.pydantic._compat import (

--- a/tests/_internal/pydantic/test_field_validator.py
+++ b/tests/_internal/pydantic/test_field_validator.py
@@ -1,19 +1,30 @@
 import pytest
-from pydantic import BaseModel, Field, ValidationError
 from typing_extensions import Annotated
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect._internal.pydantic._flags import USE_V2_MODELS
 from prefect._internal.pydantic.utilities.field_validator import field_validator
 
-if USE_V2_MODELS:
-    from pydantic import ValidationInfo
-elif not HAS_PYDANTIC_V2:
-    from pydantic.errors import ConfigError
+if not HAS_PYDANTIC_V2:
+    # v1v1
+    from pydantic import BaseModel, ConfigError, Field, ValidationError
+elif HAS_PYDANTIC_V2 and not USE_V2_MODELS:
+    # v2v1
+    from pydantic.v1 import ConfigError
+
+    from prefect.pydantic import BaseModel, Field, ValidationError
+else:
+    # v2v2
+    from pydantic import (  # type: ignore
+        BaseModel,
+        Field,
+        ValidationError,
+        ValidationInfo,
+    )
 
 
 @pytest.mark.skipif(
-    HAS_PYDANTIC_V2,
+    USE_V2_MODELS,
     reason="These tests are only valid when compatibility layer is disabled and/or V1 is installed",
 )
 class TestFieldValidatorV1:


### PR DESCRIPTION
In alignment with our efforts to support Pydantic V2 while maintaining backward compatibility, this PR introduces docstrings across several modules.
