### PR TITLE
Add `EventPersister` service to store received events

### DIFF
--- a/scripts/events-coverage
+++ b/scripts/events-coverage
@@ -10,4 +10,5 @@ pytest \
     --cov-branch \
     --cov-report=term-missing \
     tests/events/ \
+    tests/server/events/ \
     $@

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -37,6 +37,7 @@ from prefect.logging import get_logger
 from prefect.server.api.dependencies import EnforceMinimumAPIVersion
 from prefect.server.events.services.actions import ActionLogger
 from prefect.server.events.services.event_logger import EventLogger
+from prefect.server.events.services.event_persister import EventPersister
 from prefect.server.events.services.triggers import ProactiveTriggers, ReactiveTriggers
 from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.utilities.database import get_dialect
@@ -588,6 +589,12 @@ def create_app(
             service_instances.append(ReactiveTriggers())
             service_instances.append(ProactiveTriggers())
             service_instances.append(ActionLogger())
+
+        if (
+            prefect.settings.PREFECT_EXPERIMENTAL_EVENTS
+            and prefect.settings.PREFECT_API_SERVICES_EVENT_PERSISTER_ENABLED
+        ):
+            service_instances.append(EventPersister())
 
         loop = asyncio.get_running_loop()
 

--- a/src/prefect/server/events/schemas/events.py
+++ b/src/prefect/server/events/schemas/events.py
@@ -179,12 +179,9 @@ class Event(PrefectBaseModel):
         return self.resource.get(label)
 
 
-class ReceivedEvent(Event):
+class ReceivedEvent(Event, extra="ignore", orm_mode=True):
     """The server-side view of an event that has happened to a Resource after it has
     been received by the server"""
-
-    class Config:
-        orm_mode = True
 
     received: DateTimeTZ = Field(
         default_factory=lambda: pendulum.now("UTC"),

--- a/src/prefect/server/events/services/event_persister.py
+++ b/src/prefect/server/events/services/event_persister.py
@@ -29,11 +29,9 @@ class EventPersister:
     consumer_task: Optional[asyncio.Task] = None
     started_event: Optional[asyncio.Event] = asyncio.Event()
 
-    async def start(self, started_event: Optional[asyncio.Event] = None):
+    async def start(self):
         assert self.consumer_task is None, "Event persister already started"
         self.consumer = create_consumer("events")
-        if started_event:
-            self.started_event = started_event
 
         async with create_handler(
             batch_size=PREFECT_API_SERVICES_EVENT_PERSISTER_BATCH_SIZE.value(),

--- a/src/prefect/server/events/services/event_persister.py
+++ b/src/prefect/server/events/services/event_persister.py
@@ -16,6 +16,8 @@ from prefect.server.utilities.messaging import Message, MessageHandler, create_c
 
 logger = get_logger(__name__)
 
+_event_persister_started = asyncio.Event()
+
 
 class EventPersister:
     """A service that persists events to the database as they arrive."""
@@ -31,6 +33,7 @@ class EventPersister:
         async with create_handler() as handler:
             self.consumer_task = asyncio.create_task(self.consumer.run(handler))
             logger.debug("Event persister started")
+            _event_persister_started.set()
 
             try:
                 await self.consumer_task
@@ -46,6 +49,7 @@ class EventPersister:
             pass
         finally:
             self.consumer_task = None
+            _event_persister_started.clear()
         logger.debug("Event persister stopped")
 
 

--- a/src/prefect/server/events/services/event_persister.py
+++ b/src/prefect/server/events/services/event_persister.py
@@ -1,0 +1,103 @@
+"""
+The event persister moves event messages from the event bus to storage
+storage as fast as it can.  Never gets tired.
+"""
+
+import asyncio
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from typing import AsyncGenerator, List, Optional
+
+from prefect.logging import get_logger
+from prefect.server.database.dependencies import provide_database_interface
+from prefect.server.events.schemas.events import ReceivedEvent
+from prefect.server.events.storage.database import write_events
+from prefect.server.utilities.messaging import Message, MessageHandler, create_consumer
+
+logger = get_logger(__name__)
+
+
+class EventPersister:
+    """A service that persists events to the database as they arrive."""
+
+    name: str = "EventLogger"
+
+    consumer_task: Optional[asyncio.Task] = None
+
+    async def start(self):
+        assert self.consumer_task is None, "Event persister already started"
+        self.consumer = create_consumer("events")
+
+        async with create_handler() as handler:
+            self.consumer_task = asyncio.create_task(self.consumer.run(handler))
+            logger.debug("Event persister started")
+
+            try:
+                await self.consumer_task
+            except asyncio.CancelledError:
+                pass
+
+    async def stop(self):
+        assert self.consumer_task is not None, "Event persister not started"
+        self.consumer_task.cancel()
+        try:
+            await self.consumer_task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self.consumer_task = None
+        logger.debug("Event persister stopped")
+
+
+@asynccontextmanager
+async def create_handler(
+    batch_size: int = 20,
+    flush_every: timedelta = timedelta(seconds=5),
+) -> AsyncGenerator[MessageHandler, None]:
+    """
+    Set up a message handler that will accumulate and send events to
+    the database every `batch_size` messages, or every `flush_every` interval to flush
+    any remaining messages
+    """
+    db = provide_database_interface()
+
+    queue: asyncio.Queue[ReceivedEvent] = asyncio.Queue()
+
+    async def flush() -> None:
+        logger.debug(f"Persisting {queue.qsize()} events...")
+
+        batch: List[ReceivedEvent] = []
+
+        while queue.qsize() > 0:
+            batch.append(await queue.get())
+
+        async with await db.session() as session:
+            await write_events(session=session, events=batch)
+            await session.commit()
+
+        logger.debug("Finished persisting events.")
+
+    async def flush_periodically():
+        while True:
+            await asyncio.sleep(flush_every.total_seconds())
+            if queue.qsize():
+                await flush()
+
+    async def message_handler(message: Message):
+        if not message.data:
+            return
+
+        event = ReceivedEvent.parse_raw(message.data)
+        await queue.put(event)
+
+        if queue.qsize() >= batch_size:
+            await flush()
+
+    periodic_task = asyncio.create_task(flush_periodically())
+
+    try:
+        yield message_handler
+    finally:
+        periodic_task.cancel()
+        if queue.qsize():
+            await flush()

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1691,6 +1691,16 @@ PREFECT_API_SERVICES_EVENT_PERSISTER_ENABLED = Setting(bool, default=True)
 Whether or not to start the event persister service in the server application.
 """
 
+PREFECT_API_SERVICES_EVENT_PERSISTER_BATCH_SIZE = Setting(int, default=20, gt=0)
+"""
+The number of events the event persister will attempt to insert in one batch.
+"""
+
+PREFECT_API_SERVICES_EVENT_PERSISTER_FLUSH_INTERVAL = Setting(float, default=5, gt=0.0)
+"""
+The maximum number of seconds between flushes of the event persister.
+"""
+
 
 # Deprecated settings ------------------------------------------------------------------
 

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1686,6 +1686,12 @@ PREFECT_EVENTS_PROACTIVE_GRANULARITY = Setting(timedelta, default=timedelta(seco
 How frequently proactive automations are evaluated
 """
 
+PREFECT_API_SERVICES_EVENT_PERSISTER_ENABLED = Setting(bool, default=True)
+"""
+Whether or not to start the event persister service in the server application.
+"""
+
+
 # Deprecated settings ------------------------------------------------------------------
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,7 @@ from .fixtures.deprecation import *
 from .fixtures.docker import *
 from .fixtures.logging import *
 from .fixtures.storage import *
+from .fixtures.time import *
 
 
 def pytest_addoption(parser):

--- a/tests/events/server/conftest.py
+++ b/tests/events/server/conftest.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Sequence, Tuple
 from unittest import mock
 from uuid import uuid4
 
@@ -8,7 +8,6 @@ import pydantic
 import pytest
 import sqlalchemy as sa
 from pendulum.datetime import DateTime
-from pendulum.tz.timezone import Timezone
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
@@ -28,19 +27,6 @@ from prefect.server.events.schemas.automations import (
 )
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.utilities.messaging import Message
-
-
-@pytest.fixture
-def frozen_time(monkeypatch: pytest.MonkeyPatch) -> pendulum.DateTime:
-    frozen = pendulum.now("UTC")
-
-    def frozen_time(tz: Optional[Union[str, Timezone]] = None):
-        if tz is None:
-            return frozen
-        return frozen.in_timezone(tz)
-
-    monkeypatch.setattr(pendulum, "now", frozen_time)
-    return frozen
 
 
 @pytest.fixture

--- a/tests/fixtures/time.py
+++ b/tests/fixtures/time.py
@@ -1,0 +1,18 @@
+from typing import Optional, Union
+
+import pendulum
+import pytest
+from pendulum.tz.timezone import Timezone
+
+
+@pytest.fixture
+def frozen_time(monkeypatch: pytest.MonkeyPatch) -> pendulum.DateTime:
+    frozen = pendulum.now("UTC")
+
+    def frozen_time(tz: Optional[Union[str, Timezone]] = None):
+        if tz is None:
+            return frozen
+        return frozen.in_timezone(tz)
+
+    monkeypatch.setattr(pendulum, "now", frozen_time)
+    return frozen

--- a/tests/server/events/services/test_event_persister.py
+++ b/tests/server/events/services/test_event_persister.py
@@ -102,7 +102,7 @@ async def test_start_and_stop_service():
     service = event_persister.EventPersister()
     service_task = asyncio.create_task(service.start())
 
-    await event_persister._event_persister_started.wait()
+    await service.started_event.wait()
     assert service.consumer_task is not None
 
     await service.stop()

--- a/tests/server/events/services/test_event_persister.py
+++ b/tests/server/events/services/test_event_persister.py
@@ -101,6 +101,7 @@ def message(event: ReceivedEvent) -> Message:
 async def test_start_and_stop_service():
     service = event_persister.EventPersister()
     service_task = asyncio.create_task(service.start())
+    service.started_event = asyncio.Event()
 
     await service.started_event.wait()
     assert service.consumer_task is not None

--- a/tests/server/events/services/test_event_persister.py
+++ b/tests/server/events/services/test_event_persister.py
@@ -23,7 +23,7 @@ else:
     from pydantic.v1 import ValidationError
 
 
-async def get_event(session: AsyncSession, id: UUID) -> ReceivedEvent | None:
+async def get_event(session: AsyncSession, id: UUID) -> "ReceivedEvent | None":
     result = await session.execute(
         sa.text("SELECT * FROM events WHERE id = :id"),
         params={"id": id},

--- a/tests/server/events/services/test_event_persister.py
+++ b/tests/server/events/services/test_event_persister.py
@@ -1,0 +1,295 @@
+import asyncio
+from datetime import timedelta
+from typing import AsyncGenerator, Sequence
+from uuid import UUID, uuid4
+
+import pendulum
+import pytest
+import sqlalchemy as sa
+from pendulum.datetime import DateTime
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+from tests._internal.pydantic.test_dynamic_imports import HAS_PYDANTIC_V1
+
+from prefect.server.database.interface import PrefectDBInterface
+from prefect.server.database.orm_models import ORMEventResource
+from prefect.server.events.schemas.events import ReceivedEvent
+from prefect.server.events.services import event_persister
+from prefect.server.utilities.messaging import CapturedMessage, Message, MessageHandler
+
+if HAS_PYDANTIC_V1:
+    from pydantic import ValidationError
+else:
+    from pydantic.v1 import ValidationError
+
+
+async def get_event(session: AsyncSession, id: UUID) -> ReceivedEvent | None:
+    result = await session.execute(
+        sa.text("SELECT * FROM events WHERE id = :id"),
+        params={"id": id},
+    )
+    event = result.mappings().fetchone()
+    if not event:
+        return None
+
+    return ReceivedEvent.parse_obj(event)
+
+
+async def get_resources(
+    session: AsyncSession, id: UUID, db: PrefectDBInterface
+) -> Sequence[ORMEventResource]:
+    result = await session.execute(
+        sa.select(db.EventResource)
+        .where(db.EventResource.event_id == id)
+        .order_by(db.EventResource.resource_id)
+    )
+    return result.scalars().all()
+
+
+async def get_event_count(session: AsyncSession) -> int:
+    result = await session.execute(sa.text("SELECT COUNT(*) FROM events"))
+    return result.scalar() or 0
+
+
+@pytest.fixture
+async def event_persister_handler() -> AsyncGenerator[MessageHandler, None]:
+    async with event_persister.create_handler(batch_size=1) as handler:
+        yield handler
+
+
+@pytest.fixture
+def event() -> ReceivedEvent:
+    return ReceivedEvent(
+        occurred=pendulum.now("UTC"),
+        event="hello",
+        resource={"prefect.resource.id": "my.resource.id", "label-1": "value-1"},
+        related=[
+            {
+                "prefect.resource.id": "related-1",
+                "prefect.resource.role": "role-1",
+                "label-1": "value-1",
+                "label-2": "value-2",
+            },
+            {
+                "prefect.resource.id": "related-2",
+                "prefect.resource.role": "role-1",
+                "label-1": "value-3",
+                "label-2": "value-4",
+            },
+            {
+                "prefect.resource.id": "related-3",
+                "prefect.resource.role": "role-2",
+                "label-1": "value-5",
+                "label-2": "value-6",
+            },
+        ],
+        payload={"hello": "world"},
+        received=pendulum.datetime(2022, 2, 3, 4, 5, 6, 7, "UTC"),
+        id=uuid4(),
+        follows=UUID("ffffffff-ffff-ffff-ffff-ffffffffffff"),
+    )
+
+
+@pytest.fixture
+def message(event: ReceivedEvent) -> Message:
+    return CapturedMessage(
+        data=event.json().encode(),
+        attributes={},
+    )
+
+
+async def test_start_and_stop_service():
+    service = event_persister.EventPersister()
+    service_task = asyncio.create_task(service.start())
+
+    await event_persister._event_persister_started.wait()
+    assert service.consumer_task is not None
+
+    await service.stop()
+    assert service.consumer_task is None
+
+    await service_task
+
+
+async def test_handling_message_writes_event(
+    frozen_time: DateTime,
+    event_persister_handler: MessageHandler,
+    message: Message,
+    session: AsyncSession,
+    event: ReceivedEvent,
+):
+    await event_persister_handler(message)
+
+    stored_event = await get_event(session, event.id)
+    assert stored_event
+    assert stored_event == ReceivedEvent(
+        occurred=pendulum.now("UTC"),
+        event="hello",
+        resource={"prefect.resource.id": "my.resource.id", "label-1": "value-1"},
+        related=[
+            {
+                "prefect.resource.id": "related-1",
+                "prefect.resource.role": "role-1",
+                "label-1": "value-1",
+                "label-2": "value-2",
+            },
+            {
+                "prefect.resource.id": "related-2",
+                "prefect.resource.role": "role-1",
+                "label-1": "value-3",
+                "label-2": "value-4",
+            },
+            {
+                "prefect.resource.id": "related-3",
+                "prefect.resource.role": "role-2",
+                "label-1": "value-5",
+                "label-2": "value-6",
+            },
+        ],
+        payload={"hello": "world"},
+        received=pendulum.datetime(2022, 2, 3, 4, 5, 6, 7, "UTC"),
+        id=event.id,
+        follows=UUID("ffffffff-ffff-ffff-ffff-ffffffffffff"),
+    )
+
+
+async def test_handling_message_writes_event_resources(
+    frozen_time: DateTime,
+    db: PrefectDBInterface,
+    event_persister_handler: MessageHandler,
+    message: Message,
+    session: AsyncSession,
+    event: ReceivedEvent,
+):
+    await event_persister_handler(message)
+
+    resources = await get_resources(session, event.id, db)
+    primary, related_1, related_2, related_3 = resources
+
+    for resource in resources:
+        assert resource.occurred == event.occurred
+        assert resource.event_id == event.id
+
+    # Note: we're expecting the resource values to _not_ include the id and role, this
+    # is to conserve space, since those are unpacked to columns for all resources
+
+    assert primary.resource_id == "my.resource.id"
+    assert primary.resource_role == ""
+    assert primary.resource == {"label-1": "value-1"}
+
+    assert related_1.resource_id == "related-1"
+    assert related_1.resource_role == "role-1"
+    assert related_1.resource == {"label-1": "value-1", "label-2": "value-2"}
+
+    assert related_2.resource_id == "related-2"
+    assert related_2.resource_role == "role-1"
+    assert related_2.resource == {"label-1": "value-3", "label-2": "value-4"}
+
+    assert related_3.resource_id == "related-3"
+    assert related_3.resource_role == "role-2"
+    assert related_3.resource == {"label-1": "value-5", "label-2": "value-6"}
+
+
+@pytest.fixture
+def empty_message() -> Message:
+    return CapturedMessage(
+        data=None,
+        attributes={},
+    )
+
+
+async def test_skips_empty_messages(
+    event_persister_handler: MessageHandler,
+    empty_message: Message,
+    session: AsyncSession,
+):
+    before = await get_event_count(session)
+
+    await event_persister_handler(empty_message)
+
+    assert (await get_event_count(session)) == before
+
+
+@pytest.fixture
+def non_json_message() -> Message:
+    return CapturedMessage(
+        data=b"this ain't even JSON, y'all",
+        attributes={},
+    )
+
+
+async def test_raises_for_non_json_messages(
+    event_persister_handler: MessageHandler,
+    non_json_message: Message,
+    session: AsyncSession,
+):
+    before = await get_event_count(session)
+
+    with pytest.raises(ValidationError):
+        await event_persister_handler(non_json_message)
+
+    assert (await get_event_count(session)) == before
+
+
+@pytest.fixture
+def non_event_message() -> Message:
+    return CapturedMessage(
+        data=b'{"something": "else"}',
+        attributes={},
+    )
+
+
+async def test_raises_for_non_events(
+    event_persister_handler: MessageHandler,
+    non_event_message: Message,
+    session: AsyncSession,
+):
+    before = await get_event_count(session)
+
+    with pytest.raises(ValidationError):
+        await event_persister_handler(non_event_message)
+
+    assert (await get_event_count(session)) == before
+
+
+async def test_sends_remaining_messages(
+    event: ReceivedEvent,
+    session: AsyncSession,
+):
+    async with event_persister.create_handler(
+        batch_size=4,
+        flush_every=timedelta(days=100),
+    ) as handler:
+        for _ in range(10):
+            event.id = uuid4()
+            message = CapturedMessage(
+                data=event.json().encode(),
+                attributes={},
+            )
+            await handler(message)
+
+    # The two remaining messages should get flushed when the service stops
+    assert (await get_event_count(session)) == 10
+
+
+async def test_flushes_messages_periodically(
+    event: ReceivedEvent,
+    session: AsyncSession,
+):
+    async with event_persister.create_handler(
+        batch_size=5,
+        flush_every=timedelta(seconds=0.001),
+    ) as handler:
+        for _ in range(9):
+            event.id = uuid4()
+            message = CapturedMessage(
+                data=event.json().encode(),
+                attributes={},
+            )
+            await handler(message)
+
+        await asyncio.sleep(0.1)  # this is 100x the time necessary
+
+        # no matter how many batches this ended up being distributed over due to the
+        # periodic flushes, we should definitely have flushed all of the records by here
+        assert (await get_event_count(session)) == 9


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Adds an `EventPersister` service to store received events in the Prefect server's configured database. The service will write to the DB in batches with periodic flushes. The batch size and flush interval can be configured with the `PREFECT_API_SERVICES_EVENT_PERSISTER_BATCH_SIZE` and `PREFECT_API_SERVICES_EVENT_PERSISTER_FLUSH_INTERVAL` settings, respectively.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.