### PR TITLE
Typing for several models modules

### DIFF
--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -574,7 +574,6 @@ async def set_schedule_inactive(
         await models.deployments._delete_scheduled_runs(
             session=session,
             deployment_id=deployment_id,
-            db=db,
             auto_scheduled_only=True,
         )
 
@@ -802,7 +801,6 @@ async def update_deployment_schedule(
         await models.deployments._delete_scheduled_runs(
             session=session,
             deployment_id=deployment_id,
-            db=db,
             auto_scheduled_only=True,
         )
 
@@ -835,6 +833,5 @@ async def delete_deployment_schedule(
         await models.deployments._delete_scheduled_runs(
             session=session,
             deployment_id=deployment_id,
-            db=db,
             auto_scheduled_only=True,
         )

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -4,7 +4,7 @@ Intended for internal use by the Prefect REST API.
 """
 
 import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence
 from uuid import UUID, uuid4
 
 import pendulum
@@ -14,8 +14,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server import models, schemas
 from prefect.server.api.workers import WorkerLookups
-from prefect.server.database.dependencies import inject_db
+from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
+from prefect.server.database.orm_models import ORMDeployment
 from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.utilities.database import json_contains
 from prefect.settings import (
@@ -26,11 +27,11 @@ from prefect.settings import (
 )
 
 
-@inject_db
+@db_injector
 async def _delete_scheduled_runs(
-    session: sa.orm.Session,
-    deployment_id: UUID,
     db: PrefectDBInterface,
+    session: AsyncSession,
+    deployment_id: UUID,
     auto_scheduled_only: bool = False,
 ):
     """
@@ -55,12 +56,12 @@ async def _delete_scheduled_runs(
     await session.execute(delete_query)
 
 
-@inject_db
+@db_injector
 async def create_deployment(
+    db: PrefectDBInterface,
     session: AsyncSession,
     deployment: schemas.core.Deployment,
-    db: PrefectDBInterface,
-):
+) -> Optional[ORMDeployment]:
     """Upserts a deployment.
 
     Args:
@@ -117,7 +118,7 @@ async def create_deployment(
     # schedules and any runs from the old deployment.
 
     await _delete_scheduled_runs(
-        session=session, deployment_id=deployment_id, db=db, auto_scheduled_only=True
+        session=session, deployment_id=deployment_id, auto_scheduled_only=True
     )
 
     await delete_schedules_for_deployment(session=session, deployment_id=deployment_id)
@@ -149,12 +150,12 @@ async def create_deployment(
     return result.scalar()
 
 
-@inject_db
+@db_injector
 async def update_deployment(
-    session: sa.orm.Session,
+    db: PrefectDBInterface,
+    session: AsyncSession,
     deployment_id: UUID,
     deployment: schemas.actions.DeploymentUpdate,
-    db: PrefectDBInterface,
 ) -> bool:
     """Updates a deployment.
 
@@ -220,7 +221,7 @@ async def update_deployment(
 
     # delete any auto scheduled runs that would have reflected the old deployment config
     await _delete_scheduled_runs(
-        session=session, deployment_id=deployment_id, db=db, auto_scheduled_only=True
+        session=session, deployment_id=deployment_id, auto_scheduled_only=True
     )
 
     if should_update_schedules:
@@ -244,10 +245,10 @@ async def update_deployment(
     return result.rowcount > 0
 
 
-@inject_db
+@db_injector
 async def read_deployment(
-    session: sa.orm.Session, deployment_id: UUID, db: PrefectDBInterface
-):
+    db: PrefectDBInterface, session: AsyncSession, deployment_id: UUID
+) -> Optional[ORMDeployment]:
     """Reads a deployment by id.
 
     Args:
@@ -261,10 +262,10 @@ async def read_deployment(
     return await session.get(db.Deployment, deployment_id)
 
 
-@inject_db
+@db_injector
 async def read_deployment_by_name(
-    session: sa.orm.Session, name: str, flow_name: str, db: PrefectDBInterface
-):
+    db: PrefectDBInterface, session: AsyncSession, name: str, flow_name: str
+) -> Optional[ORMDeployment]:
     """Reads a deployment by name.
 
     Args:
@@ -290,10 +291,10 @@ async def read_deployment_by_name(
     return result.scalar()
 
 
-@inject_db
+@db_injector
 async def _apply_deployment_filters(
-    query,
     db: PrefectDBInterface,
+    query,
     flow_filter: schemas.filters.FlowFilter = None,
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
@@ -349,10 +350,10 @@ async def _apply_deployment_filters(
     return query
 
 
-@inject_db
+@db_injector
 async def read_deployments(
-    session: sa.orm.Session,
     db: PrefectDBInterface,
+    session: AsyncSession,
     offset: int = None,
     limit: int = None,
     flow_filter: schemas.filters.FlowFilter = None,
@@ -362,7 +363,7 @@ async def read_deployments(
     work_pool_filter: schemas.filters.WorkPoolFilter = None,
     work_queue_filter: schemas.filters.WorkQueueFilter = None,
     sort: schemas.sorting.DeploymentSort = schemas.sorting.DeploymentSort.NAME_ASC,
-):
+) -> Sequence[ORMDeployment]:
     """
     Read deployments.
 
@@ -404,10 +405,10 @@ async def read_deployments(
     return result.scalars().unique().all()
 
 
-@inject_db
+@db_injector
 async def count_deployments(
-    session: sa.orm.Session,
     db: PrefectDBInterface,
+    session: AsyncSession,
     flow_filter: schemas.filters.FlowFilter = None,
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
@@ -448,9 +449,9 @@ async def count_deployments(
     return result.scalar()
 
 
-@inject_db
+@db_injector
 async def delete_deployment(
-    session: sa.orm.Session, deployment_id: UUID, db: PrefectDBInterface
+    db: PrefectDBInterface, session: AsyncSession, deployment_id: UUID
 ) -> bool:
     """
     Delete a deployment by id.
@@ -475,7 +476,7 @@ async def delete_deployment(
 
 
 async def schedule_runs(
-    session: sa.orm.Session,
+    session: AsyncSession,
     deployment_id: UUID,
     start_time: datetime.datetime = None,
     end_time: datetime.datetime = None,
@@ -538,16 +539,16 @@ async def schedule_runs(
     return await _insert_scheduled_flow_runs(session=session, runs=runs)
 
 
-@inject_db
+@db_injector
 async def _generate_scheduled_flow_runs(
-    session: sa.orm.Session,
+    db: PrefectDBInterface,
+    session: AsyncSession,
     deployment_id: UUID,
     start_time: datetime.datetime,
     end_time: datetime.datetime,
     min_time: datetime.timedelta,
     min_runs: int,
     max_runs: int,
-    db: PrefectDBInterface,
     auto_scheduled: bool = True,
 ) -> List[Dict]:
     """
@@ -641,10 +642,10 @@ async def _generate_scheduled_flow_runs(
     return runs
 
 
-@inject_db
+@db_injector
 async def _insert_scheduled_flow_runs(
-    session: sa.orm.Session, runs: List[Dict], db: PrefectDBInterface
-) -> List[UUID]:
+    db: PrefectDBInterface, session: AsyncSession, runs: List[Dict]
+) -> Sequence[UUID]:
     """
     Given a list of flow runs to schedule, as generated by `_generate_scheduled_flow_runs`,
     inserts them into the database. Note this is a separate method to facilitate batch
@@ -711,9 +712,9 @@ async def _insert_scheduled_flow_runs(
     return inserted_flow_run_ids
 
 
-@inject_db
+@db_injector
 async def check_work_queues_for_deployment(
-    db: PrefectDBInterface, session: sa.orm.Session, deployment_id: UUID
+    db: PrefectDBInterface, session: AsyncSession, deployment_id: UUID
 ) -> List[schemas.core.WorkQueue]:
     """
     Get work queues that can pick up the specified deployment.
@@ -768,9 +769,9 @@ async def check_work_queues_for_deployment(
     return result.scalars().unique().all()
 
 
-@inject_db
+@db_injector
 async def _update_deployment_last_polled(
-    db: PrefectDBInterface, session: sa.orm.Session, deployment_ids: List[UUID]
+    db: PrefectDBInterface, session: AsyncSession, deployment_ids: List[UUID]
 ) -> None:
     """
     Update the last_polled for a list of deployment ids
@@ -783,7 +784,7 @@ async def _update_deployment_last_polled(
     await session.execute(query)
 
 
-@inject_db
+@db_injector
 async def create_deployment_schedules(
     db: PrefectDBInterface,
     session: AsyncSession,
@@ -814,7 +815,7 @@ async def create_deployment_schedules(
     return [schemas.core.DeploymentSchedule.from_orm(m) for m in models]
 
 
-@inject_db
+@db_injector
 async def read_deployment_schedules(
     db: PrefectDBInterface,
     session: AsyncSession,
@@ -848,7 +849,7 @@ async def read_deployment_schedules(
     return [schemas.core.DeploymentSchedule.from_orm(s) for s in result.scalars().all()]
 
 
-@inject_db
+@db_injector
 async def update_deployment_schedule(
     db: PrefectDBInterface,
     session: AsyncSession,
@@ -879,7 +880,7 @@ async def update_deployment_schedule(
     return result.rowcount > 0
 
 
-@inject_db
+@db_injector
 async def delete_schedules_for_deployment(
     db: PrefectDBInterface, session: AsyncSession, deployment_id: UUID
 ) -> bool:
@@ -900,7 +901,7 @@ async def delete_schedules_for_deployment(
     return result.rowcount > 0
 
 
-@inject_db
+@db_injector
 async def delete_deployment_schedule(
     db: PrefectDBInterface,
     session: AsyncSession,

--- a/src/prefect/server/models/flow_runs.py
+++ b/src/prefect/server/models/flow_runs.py
@@ -6,7 +6,7 @@ Intended for internal use by the Prefect REST API.
 import contextlib
 import datetime
 from itertools import chain
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 from uuid import UUID
 
 import pendulum
@@ -17,8 +17,9 @@ from sqlalchemy.orm import load_only, selectinload
 
 import prefect.server.models as models
 import prefect.server.schemas as schemas
-from prefect.server.database.dependencies import inject_db
+from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
+from prefect.server.database.orm_models import ORMFlowRun
 from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.orchestration.core_policy import MinimalFlowPolicy
 from prefect.server.orchestration.global_policy import GlobalFlowPolicy
@@ -35,13 +36,13 @@ from prefect.settings import (
 )
 
 
-@inject_db
+@db_injector
 async def create_flow_run(
+    db: PrefectDBInterface,
     session: AsyncSession,
     flow_run: schemas.core.FlowRun,
-    db: PrefectDBInterface,
     orchestration_parameters: Optional[dict] = None,
-):
+) -> ORMFlowRun:
     """Creates a new flow run.
 
     If the provided flow run has a state attached, it will also be created.
@@ -117,12 +118,12 @@ async def create_flow_run(
     return model
 
 
-@inject_db
+@db_injector
 async def update_flow_run(
+    db: PrefectDBInterface,
     session: AsyncSession,
     flow_run_id: UUID,
     flow_run: schemas.actions.FlowRunUpdate,
-    db: PrefectDBInterface,
 ) -> bool:
     """
     Updates a flow run.
@@ -146,13 +147,13 @@ async def update_flow_run(
     return result.rowcount > 0
 
 
-@inject_db
+@db_injector
 async def read_flow_run(
+    db: PrefectDBInterface,
     session: AsyncSession,
     flow_run_id: UUID,
-    db: PrefectDBInterface,
     for_update: bool = False,
-):
+) -> Optional[ORMFlowRun]:
     """
     Reads a flow run by id.
 
@@ -178,10 +179,10 @@ async def read_flow_run(
     return result.scalar()
 
 
-@inject_db
+@db_injector
 async def _apply_flow_run_filters(
-    query,
     db: PrefectDBInterface,
+    query,
     flow_filter: schemas.filters.FlowFilter = None,
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
@@ -246,10 +247,10 @@ async def _apply_flow_run_filters(
     return query
 
 
-@inject_db
+@db_injector
 async def read_flow_runs(
-    session: AsyncSession,
     db: PrefectDBInterface,
+    session: AsyncSession,
     columns: List = None,
     flow_filter: schemas.filters.FlowFilter = None,
     flow_run_filter: schemas.filters.FlowRunFilter = None,
@@ -260,7 +261,7 @@ async def read_flow_runs(
     offset: int = None,
     limit: int = None,
     sort: schemas.sorting.FlowRunSort = schemas.sorting.FlowRunSort.ID_DESC,
-):
+) -> Sequence[ORMFlowRun]:
     """
     Read flow runs.
 
@@ -370,10 +371,10 @@ async def read_task_run_dependencies(
     return dependency_graph
 
 
-@inject_db
+@db_injector
 async def count_flow_runs(
-    session: AsyncSession,
     db: PrefectDBInterface,
+    session: AsyncSession,
     flow_filter: schemas.filters.FlowFilter = None,
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
@@ -412,9 +413,9 @@ async def count_flow_runs(
     return result.scalar()
 
 
-@inject_db
+@db_injector
 async def delete_flow_run(
-    session: AsyncSession, flow_run_id: UUID, db: PrefectDBInterface
+    db: PrefectDBInterface, session: AsyncSession, flow_run_id: UUID
 ) -> bool:
     """
     Delete a flow run by flow_run_id.
@@ -527,7 +528,7 @@ async def set_flow_run_state(
     return result
 
 
-@inject_db
+@db_injector
 async def read_flow_run_graph(
     db: PrefectDBInterface,
     session: AsyncSession,

--- a/src/prefect/server/models/flows.py
+++ b/src/prefect/server/models/flows.py
@@ -3,20 +3,23 @@ Functions for interacting with flow ORM objects.
 Intended for internal use by the Prefect REST API.
 """
 
+from typing import Optional, Sequence
 from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 import prefect.server.schemas as schemas
-from prefect.server.database.dependencies import inject_db
+from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
+from prefect.server.database.orm_models import ORMFlow
 
 
-@inject_db
+@db_injector
 async def create_flow(
-    session: sa.orm.Session, flow: schemas.core.Flow, db: PrefectDBInterface
-):
+    db: PrefectDBInterface, session: AsyncSession, flow: schemas.core.Flow
+) -> ORMFlow:
     """
     Creates a new flow.
 
@@ -52,13 +55,13 @@ async def create_flow(
     return model
 
 
-@inject_db
+@db_injector
 async def update_flow(
-    session: sa.orm.Session,
+    db: PrefectDBInterface,
+    session: AsyncSession,
     flow_id: UUID,
     flow: schemas.actions.FlowUpdate,
-    db: PrefectDBInterface,
-):
+) -> bool:
     """
     Updates a flow.
 
@@ -81,8 +84,10 @@ async def update_flow(
     return result.rowcount > 0
 
 
-@inject_db
-async def read_flow(session: sa.orm.Session, flow_id: UUID, db: PrefectDBInterface):
+@db_injector
+async def read_flow(
+    db: PrefectDBInterface, session: AsyncSession, flow_id: UUID
+) -> Optional[ORMFlow]:
     """
     Reads a flow by id.
 
@@ -96,8 +101,10 @@ async def read_flow(session: sa.orm.Session, flow_id: UUID, db: PrefectDBInterfa
     return await session.get(db.Flow, flow_id)
 
 
-@inject_db
-async def read_flow_by_name(session: sa.orm.Session, name: str, db: PrefectDBInterface):
+@db_injector
+async def read_flow_by_name(
+    db: PrefectDBInterface, session: AsyncSession, name: str
+) -> Optional[ORMFlow]:
     """
     Reads a flow by name.
 
@@ -113,10 +120,10 @@ async def read_flow_by_name(session: sa.orm.Session, name: str, db: PrefectDBInt
     return result.scalar()
 
 
-@inject_db
+@db_injector
 async def _apply_flow_filters(
-    query,
     db: PrefectDBInterface,
+    query,
     flow_filter: schemas.filters.FlowFilter = None,
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
@@ -168,10 +175,10 @@ async def _apply_flow_filters(
     return query
 
 
-@inject_db
+@db_injector
 async def read_flows(
-    session: sa.orm.Session,
     db: PrefectDBInterface,
+    session: AsyncSession,
     flow_filter: schemas.filters.FlowFilter = None,
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
@@ -180,7 +187,7 @@ async def read_flows(
     sort: schemas.sorting.FlowSort = schemas.sorting.FlowSort.NAME_ASC,
     offset: int = None,
     limit: int = None,
-):
+) -> Sequence[ORMFlow]:
     """
     Read multiple flows.
 
@@ -220,10 +227,10 @@ async def read_flows(
     return result.scalars().unique().all()
 
 
-@inject_db
+@db_injector
 async def count_flows(
-    session: sa.orm.Session,
     db: PrefectDBInterface,
+    session: AsyncSession,
     flow_filter: schemas.filters.FlowFilter = None,
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
@@ -261,9 +268,9 @@ async def count_flows(
     return result.scalar()
 
 
-@inject_db
+@db_injector
 async def delete_flow(
-    session: sa.orm.Session, flow_id: UUID, db: PrefectDBInterface
+    db: PrefectDBInterface, session: AsyncSession, flow_id: UUID
 ) -> bool:
     """
     Delete a flow by id.

--- a/src/prefect/server/models/variables.py
+++ b/src/prefect/server/models/variables.py
@@ -1,21 +1,22 @@
-from typing import Optional
+from typing import Optional, Sequence
 from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from prefect.server.database.dependencies import inject_db
+from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
+from prefect.server.database.orm_models import ORMVariable
 from prefect.server.schemas import filters, sorting
 from prefect.server.schemas.actions import VariableCreate, VariableUpdate
 
 
-@inject_db
+@db_injector
 async def create_variable(
+    db: PrefectDBInterface,
     session: AsyncSession,
     variable: VariableCreate,
-    db: PrefectDBInterface,
-):
+) -> ORMVariable:
     """
     Create a variable
 
@@ -33,12 +34,12 @@ async def create_variable(
     return model
 
 
-@inject_db
+@db_injector
 async def read_variable(
+    db: PrefectDBInterface,
     session: AsyncSession,
     variable_id: UUID,
-    db: PrefectDBInterface,
-):
+) -> Optional[ORMVariable]:
     """
     Reads a variable by id.
     """
@@ -49,12 +50,12 @@ async def read_variable(
     return result.scalar()
 
 
-@inject_db
+@db_injector
 async def read_variable_by_name(
+    db: PrefectDBInterface,
     session: AsyncSession,
     name: str,
-    db: PrefectDBInterface,
-):
+) -> Optional[ORMVariable]:
     """
     Reads a variable by name.
     """
@@ -65,15 +66,15 @@ async def read_variable_by_name(
     return result.scalar()
 
 
-@inject_db
+@db_injector
 async def read_variables(
-    session: AsyncSession,
     db: PrefectDBInterface,
+    session: AsyncSession,
     variable_filter: Optional[filters.VariableFilter] = None,
     sort: sorting.VariableSort = sorting.VariableSort.NAME_ASC,
     offset: int = None,
     limit: int = None,
-):
+) -> Sequence[ORMVariable]:
     """
     Read variables, applying filers.
     """
@@ -91,10 +92,10 @@ async def read_variables(
     return result.scalars().unique().all()
 
 
-@inject_db
+@db_injector
 async def count_variables(
-    session: AsyncSession,
     db: PrefectDBInterface,
+    session: AsyncSession,
     variable_filter: Optional[filters.VariableFilter] = None,
 ) -> int:
     """
@@ -110,12 +111,12 @@ async def count_variables(
     return result.scalar()
 
 
-@inject_db
+@db_injector
 async def update_variable(
+    db: PrefectDBInterface,
     session: AsyncSession,
     variable_id: UUID,
     variable: VariableUpdate,
-    db: PrefectDBInterface,
 ) -> bool:
     """
     Updates a variable by id.
@@ -130,12 +131,12 @@ async def update_variable(
     return result.rowcount > 0
 
 
-@inject_db
+@db_injector
 async def update_variable_by_name(
+    db: PrefectDBInterface,
     session: AsyncSession,
     name: str,
     variable: VariableUpdate,
-    db: PrefectDBInterface,
 ) -> bool:
     """
     Updates a variable by name.
@@ -150,11 +151,11 @@ async def update_variable_by_name(
     return result.rowcount > 0
 
 
-@inject_db
+@db_injector
 async def delete_variable(
+    db: PrefectDBInterface,
     session: AsyncSession,
     variable_id: UUID,
-    db: PrefectDBInterface,
 ) -> bool:
     """
     Delete a variable by id.
@@ -166,11 +167,11 @@ async def delete_variable(
     return result.rowcount > 0
 
 
-@inject_db
+@db_injector
 async def delete_variable_by_name(
+    db: PrefectDBInterface,
     session: AsyncSession,
     name: str,
-    db: PrefectDBInterface,
 ) -> bool:
     """
     Delete a variable by name.

--- a/src/prefect/server/models/workers.py
+++ b/src/prefect/server/models/workers.py
@@ -4,7 +4,7 @@ Intended for internal use by the Prefect REST API.
 """
 
 import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence
 from uuid import UUID
 
 import pendulum
@@ -13,7 +13,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import prefect.server.schemas as schemas
-from prefect.server.database.dependencies import inject_db
+from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.database.orm_models import ORMWorker, ORMWorkPool, ORMWorkQueue
 
@@ -28,11 +28,11 @@ DEFAULT_AGENT_WORK_POOL_NAME = "default-agent-pool"
 # -----------------------------------------------------
 
 
-@inject_db
+@db_injector
 async def create_work_pool(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool: schemas.core.WorkPool,
-    db: PrefectDBInterface,
 ) -> ORMWorkPool:
     """
     Creates a work pool.
@@ -66,10 +66,10 @@ async def create_work_pool(
     return pool
 
 
-@inject_db
+@db_injector
 async def read_work_pool(
-    session: AsyncSession, work_pool_id: UUID, db: PrefectDBInterface
-) -> ORMWorkPool:
+    db: PrefectDBInterface, session: AsyncSession, work_pool_id: UUID
+) -> Optional[ORMWorkPool]:
     """
     Reads a WorkPool by id.
 
@@ -85,10 +85,10 @@ async def read_work_pool(
     return result.scalar()
 
 
-@inject_db
+@db_injector
 async def read_work_pool_by_name(
-    session: AsyncSession, work_pool_name: str, db: PrefectDBInterface
-) -> ORMWorkPool:
+    db: PrefectDBInterface, session: AsyncSession, work_pool_name: str
+) -> Optional[ORMWorkPool]:
     """
     Reads a WorkPool by name.
 
@@ -104,14 +104,14 @@ async def read_work_pool_by_name(
     return result.scalar()
 
 
-@inject_db
+@db_injector
 async def read_work_pools(
     db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_filter: schemas.filters.WorkPoolFilter = None,
     offset: int = None,
     limit: int = None,
-) -> List[ORMWorkPool]:
+) -> Sequence[ORMWorkPool]:
     """
     Read worker configs.
 
@@ -136,7 +136,7 @@ async def read_work_pools(
     return result.scalars().unique().all()
 
 
-@inject_db
+@db_injector
 async def count_work_pools(
     db: PrefectDBInterface,
     session: AsyncSession,
@@ -161,12 +161,12 @@ async def count_work_pools(
     return result.scalar()
 
 
-@inject_db
+@db_injector
 async def update_work_pool(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_id: UUID,
     work_pool: schemas.actions.WorkPoolUpdate,
-    db: PrefectDBInterface,
 ) -> bool:
     """
     Update a WorkPool by id.
@@ -192,9 +192,9 @@ async def update_work_pool(
     return result.rowcount > 0
 
 
-@inject_db
+@db_injector
 async def delete_work_pool(
-    session: AsyncSession, work_pool_id: UUID, db: PrefectDBInterface
+    db: PrefectDBInterface, session: AsyncSession, work_pool_id: UUID
 ) -> bool:
     """
     Delete a WorkPool by id.
@@ -213,8 +213,9 @@ async def delete_work_pool(
     return result.rowcount > 0
 
 
-@inject_db
+@db_injector
 async def get_scheduled_flow_runs(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_ids: List[UUID] = None,
     work_queue_ids: List[UUID] = None,
@@ -222,8 +223,7 @@ async def get_scheduled_flow_runs(
     scheduled_after: datetime.datetime = None,
     limit: int = None,
     respect_queue_priorities: bool = None,
-    db: PrefectDBInterface = None,
-) -> List[schemas.responses.WorkerFlowRunResponse]:
+) -> Sequence[schemas.responses.WorkerFlowRunResponse]:
     """
     Get runs from queues in a specific work pool.
 
@@ -266,12 +266,12 @@ async def get_scheduled_flow_runs(
 # -----------------------------------------------------
 
 
-@inject_db
+@db_injector
 async def create_work_queue(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_id: UUID,
     work_queue: schemas.actions.WorkQueueCreate,
-    db: PrefectDBInterface,
 ) -> ORMWorkQueue:
     """
     Creates a work pool queue.
@@ -324,13 +324,13 @@ async def create_work_queue(
     return model
 
 
-@inject_db
+@db_injector
 async def bulk_update_work_queue_priorities(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_id: UUID,
     new_priorities: Dict[UUID, int],
-    db: PrefectDBInterface,
-):
+) -> None:
     """
     This is a brute force update of all work pool queue priorities for a given work
     pool.
@@ -390,15 +390,15 @@ async def bulk_update_work_queue_priorities(
     await session.flush()
 
 
-@inject_db
+@db_injector
 async def read_work_queues(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_id: UUID,
-    db: PrefectDBInterface,
     work_queue_filter: Optional[schemas.filters.WorkQueueFilter] = None,
     offset: Optional[int] = None,
     limit: Optional[int] = None,
-) -> List[ORMWorkQueue]:
+) -> Sequence[ORMWorkQueue]:
     """
     Read all work pool queues for a work pool. Results are ordered by ascending priority.
 
@@ -431,12 +431,12 @@ async def read_work_queues(
     return result.scalars().unique().all()
 
 
-@inject_db
+@db_injector
 async def read_work_queue(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_queue_id: UUID,
-    db: PrefectDBInterface,
-) -> ORMWorkQueue:
+) -> Optional[ORMWorkQueue]:
     """
     Read a specific work pool queue.
 
@@ -451,13 +451,13 @@ async def read_work_queue(
     return await session.get(db.WorkQueue, work_queue_id)
 
 
-@inject_db
+@db_injector
 async def read_work_queue_by_name(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_name: str,
     work_queue_name: str,
-    db: PrefectDBInterface,
-) -> ORMWorkQueue:
+) -> Optional[ORMWorkQueue]:
     """
     Reads a WorkQueue by name.
 
@@ -482,12 +482,12 @@ async def read_work_queue_by_name(
     return result.scalar()
 
 
-@inject_db
+@db_injector
 async def update_work_queue(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_queue_id: UUID,
     work_queue: schemas.actions.WorkQueueUpdate,
-    db: PrefectDBInterface,
 ) -> bool:
     """
     Update a work pool queue.
@@ -519,11 +519,11 @@ async def update_work_queue(
     return result.rowcount > 0
 
 
-@inject_db
+@db_injector
 async def delete_work_queue(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_queue_id: UUID,
-    db: PrefectDBInterface,
 ) -> bool:
     """
     Delete a work pool queue.
@@ -567,15 +567,15 @@ async def delete_work_queue(
 # -----------------------------------------------------
 
 
-@inject_db
+@db_injector
 async def read_workers(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_id: UUID,
     worker_filter: schemas.filters.WorkerFilter = None,
     limit: int = None,
     offset: int = None,
-    db: PrefectDBInterface = None,
-) -> List[ORMWorker]:
+) -> Sequence[ORMWorker]:
     query = (
         sa.select(db.Worker)
         .where(db.Worker.work_pool_id == work_pool_id)
@@ -596,12 +596,12 @@ async def read_workers(
     return result.scalars().all()
 
 
-@inject_db
+@db_injector
 async def worker_heartbeat(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_id: UUID,
     worker_name: str,
-    db: PrefectDBInterface,
     heartbeat_interval_seconds: Optional[int] = None,
 ) -> bool:
     """
@@ -645,12 +645,12 @@ async def worker_heartbeat(
     return result.rowcount > 0
 
 
-@inject_db
+@db_injector
 async def delete_worker(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_id: UUID,
     worker_name: str,
-    db: PrefectDBInterface,
 ) -> bool:
     """
     Delete a work pool's worker.


### PR DESCRIPTION
This improves the typing for the deployments, flow_runs, flows, variables and
workers model functions, in advance of porting the `run-deployment` automation
action.

The general pattern here is:
* use `@db_injector` and put the `db` argument first
* specify single object returns as `ORMModel` or `Optional[ORMModel]`
* specify multi-object returns as `Sequence[ORMModel]`
