### PR TITLE
Bump pydantic-core min version

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -21,7 +21,7 @@ pendulum < 3.0; python_version < '3.12'
 pendulum >= 3.0.0, <4; python_version >= '3.12'
 # the version constraints for pydantic are merged with those from fastapi 0.103.2
 pydantic[email]>=1.10.0,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0
-pydantic_core >= 2.10.0, < 3.0.0
+pydantic_core >= 2.12.0, < 3.0.0
 python_dateutil >= 2.8.2, < 3.0.0
 python-slugify >= 5.0, < 9.0
 pyyaml >= 5.4.1, < 7.0.0


### PR DESCRIPTION
We use `from pydantic_core import from_json` which was introduced after our current min version 