### PR TITLE
Do not use the mixin docstring for the schema

### DIFF
--- a/src/prefect/_internal/compatibility/deprecated.py
+++ b/src/prefect/_internal/compatibility/deprecated.py
@@ -15,6 +15,7 @@ import warnings
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 
 import pendulum
+from pydantic.v1.schema import default_ref_template
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 
@@ -345,6 +346,21 @@ class DeprecatedInfraOverridesField(BaseModel):
         kwargs["exclude"] = exclude
 
         return super().dict(**kwargs)
+
+    @classmethod
+    def schema(
+        cls, by_alias: bool = True, ref_template: str = default_ref_template
+    ) -> Dict[str, Any]:
+        """
+        Don't use the mixin docstring as the description if this class is missing a
+        docstring.
+        """
+        schema = super().schema(by_alias=by_alias, ref_template=ref_template)
+
+        if not cls.__doc__:
+            schema.pop("description", None)
+
+        return schema
 
 
 def handle_deprecated_infra_overrides_parameter(

--- a/src/prefect/_internal/compatibility/deprecated.py
+++ b/src/prefect/_internal/compatibility/deprecated.py
@@ -15,14 +15,15 @@ import warnings
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 
 import pendulum
-from pydantic.v1.schema import default_ref_template
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 
 if HAS_PYDANTIC_V2:
     from pydantic.v1 import BaseModel, Field, root_validator
+    from pydantic.v1.schema import default_ref_template
 else:
     from pydantic import BaseModel, Field, root_validator
+    from pydantic.schema import default_ref_template
 
 from prefect.utilities.callables import get_call_parameters
 from prefect.utilities.importtools import (

--- a/tests/_internal/compatibility/test_deprecated.py
+++ b/tests/_internal/compatibility/test_deprecated.py
@@ -305,3 +305,18 @@ class TestDeprecatedInfraOverridesField:
         json_dict = my_deployment.dict()
         assert "job_variables" not in json_dict
         assert json_dict["infra_overrides"] is None
+
+    def test_does_not_override_description_if_none_set(self, my_deployment_model):
+        assert "description" not in my_deployment_model.schema()
+
+    def test_preserves_description_if_present(self):
+        class MyModel(DeprecatedInfraOverridesField, pydantic.BaseModel):
+            """Hey mom"""
+
+            name: str
+            job_variables: Optional[Dict[str, Any]] = pydantic.Field(
+                default_factory=dict,
+                description="Overrides to apply to my deployment infrastructure at runtime.",
+            )
+
+        assert MyModel.schema()["description"] == "Hey mom"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

Pydantic uses a class's docstring for the "description" field in its generated JSON schema. If the subclass that includes this mixin does not specify a docstring, Pydantic will use the mixin's docstring where previously the schema would not have included a description. This mixin's description shouldn't appear in a schema, so if that case arises, we preserve the previous behavior.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
