### PR TITLE
Implementing the `run-deployment` automation action

### DIFF
--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -193,11 +193,18 @@ class PrefectHttpxClient(httpx.AsyncClient):
     [Configuring Cloudflare Rate Limiting](https://support.cloudflare.com/hc/en-us/articles/115001635128-Configuring-Rate-Limiting-from-UI)
     """
 
-    def __init__(self, *args, enable_csrf_support: bool = False, **kwargs):
+    def __init__(
+        self,
+        *args,
+        enable_csrf_support: bool = False,
+        raise_on_all_errors: bool = True,
+        **kwargs,
+    ):
         self.enable_csrf_support: bool = enable_csrf_support
         self.csrf_token: Optional[str] = None
         self.csrf_token_expiration: Optional[datetime] = None
         self.csrf_client_id: uuid.UUID = uuid.uuid4()
+        self.raise_on_all_errors: bool = raise_on_all_errors
 
         super().__init__(*args, **kwargs)
 
@@ -345,10 +352,8 @@ class PrefectHttpxClient(httpx.AsyncClient):
         # Convert to a Prefect response to add nicer errors messages
         response = PrefectResponse.from_httpx_response(response)
 
-        # Always raise bad responses
-        # NOTE: We may want to remove this and handle responses per route in the
-        #       `PrefectClient`
-        response.raise_for_status()
+        if self.raise_on_all_errors:
+            response.raise_for_status()
 
         return response
 

--- a/src/prefect/server/api/dependencies.py
+++ b/src/prefect/server/api/dependencies.py
@@ -1,11 +1,16 @@
 """
 Utilities for injecting FastAPI dependencies.
 """
+
 import logging
+from base64 import b64decode
+from typing import Optional
+from uuid import UUID
 
 from packaging.version import Version
 from prefect._vendor.fastapi import Body, Depends, Header, HTTPException, status
 
+from prefect.server import schemas
 from prefect.settings import PREFECT_API_DEFAULT_LIMIT
 
 
@@ -116,3 +121,41 @@ def LimitBody() -> Depends:
         return limit
 
     return Depends(get_limit)
+
+
+def get_created_by(
+    prefect_automation_id: Optional[UUID] = Header(None, include_in_schema=False),
+    prefect_automation_name: Optional[str] = Header(None, include_in_schema=False),
+) -> Optional[schemas.core.CreatedBy]:
+    """A dependency that returns the provenance information to use when creating objects
+    during this API call."""
+    if prefect_automation_id and prefect_automation_name:
+        try:
+            display_value = b64decode(prefect_automation_name.encode()).decode()
+        except Exception:
+            display_value = None
+
+        if display_value:
+            return schemas.core.CreatedBy(
+                id=prefect_automation_id,
+                type="AUTOMATION",
+                display_value=display_value,
+            )
+
+    return None
+
+
+def get_updated_by(
+    prefect_automation_id: Optional[UUID] = Header(None, include_in_schema=False),
+    prefect_automation_name: Optional[str] = Header(None, include_in_schema=False),
+) -> Optional[schemas.core.UpdatedBy]:
+    """A dependency that returns the provenance information to use when updating objects
+    during this API call."""
+    if prefect_automation_id and prefect_automation_name:
+        return schemas.core.UpdatedBy(
+            id=prefect_automation_id,
+            type="AUTOMATION",
+            display_value=prefect_automation_name,
+        )
+
+    return None

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -3,7 +3,7 @@ Routes for interacting with Deployment objects.
 """
 
 import datetime
-from typing import List
+from typing import List, Optional
 from uuid import UUID
 
 import jsonschema.exceptions
@@ -53,6 +53,8 @@ async def create_deployment(
     deployment: schemas.actions.DeploymentCreate,
     response: Response,
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
+    created_by: Optional[schemas.core.CreatedBy] = Depends(dependencies.get_created_by),
+    updated_by: Optional[schemas.core.UpdatedBy] = Depends(dependencies.get_updated_by),
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> schemas.responses.DeploymentResponse:
     """
@@ -64,6 +66,8 @@ async def create_deployment(
     """
 
     data = deployment.dict(exclude_unset=True)
+    data["created_by"] = created_by.dict() if created_by else None
+    data["updated_by"] = updated_by.dict() if created_by else None
 
     async with db.session_context(begin_transaction=True) as session:
         if (
@@ -584,6 +588,7 @@ async def set_schedule_inactive(
 async def create_flow_run_from_deployment(
     flow_run: schemas.actions.DeploymentFlowRunCreate,
     deployment_id: UUID = Path(..., description="The deployment id", alias="id"),
+    created_by: Optional[schemas.core.CreatedBy] = Depends(dependencies.get_created_by),
     db: PrefectDBInterface = Depends(provide_database_interface),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     response: Response = None,
@@ -680,6 +685,7 @@ async def create_flow_run_from_deployment(
             ),
             work_queue_name=work_queue_name,
             work_queue_id=work_queue_id,
+            created_by=created_by,
         )
 
         if not flow_run.state:

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -53,6 +53,7 @@ async def create_flow_run(
     flow_run: schemas.actions.FlowRunCreate,
     db: PrefectDBInterface = Depends(provide_database_interface),
     response: Response = None,
+    created_by: Optional[schemas.core.CreatedBy] = Depends(dependencies.get_created_by),
     orchestration_parameters: Dict[str, Any] = Depends(
         orchestration_dependencies.provide_flow_orchestration_parameters
     ),
@@ -65,7 +66,7 @@ async def create_flow_run(
     If no state is provided, the flow run will be created in a PENDING state.
     """
     # hydrate the input model into a full flow run / state model
-    flow_run = schemas.core.FlowRun(**flow_run.dict())
+    flow_run = schemas.core.FlowRun(**flow_run.dict(), created_by=created_by)
 
     # pass the request version to the orchestration engine to support compatibility code
     orchestration_parameters.update({"api-version": api_version})

--- a/src/prefect/server/events/jinja_filters.py
+++ b/src/prefect/server/events/jinja_filters.py
@@ -1,0 +1,102 @@
+import urllib.parse
+from typing import Any, Mapping, Optional
+
+from jinja2 import pass_context
+
+from prefect.server.schemas.core import (
+    Deployment,
+    Flow,
+    FlowRun,
+    TaskRun,
+    WorkPool,
+    WorkQueue,
+)
+from prefect.server.schemas.responses import WorkQueueWithStatus
+from prefect.server.utilities.schemas import ORMBaseModel
+from prefect.settings import PREFECT_UI_URL
+
+model_to_kind = {
+    Deployment: "prefect.deployment",
+    Flow: "prefect.flow",
+    FlowRun: "prefect.flow-run",
+    TaskRun: "prefect.task-run",
+    WorkQueue: "prefect.work-queue",
+    WorkQueueWithStatus: "prefect.work-queue",
+    WorkPool: "prefect.work-pool",
+}
+
+
+@pass_context
+def ui_url(ctx: Mapping[str, Any], obj: Any) -> Optional[str]:
+    """Return the UI URL for the given object.
+
+    Supports Automation, Resource, Deployment, Flow, FlowRun, TaskRun, and
+    WorkQueue objects. Within a Resource, deployment, flow, flow-run, task-run,
+    and work-queue are supported. If the given object is of a different type or
+    an unsupported Resource `None` is returned"""
+    from prefect.server.events.schemas.automations import Automation
+    from prefect.server.events.schemas.events import ReceivedEvent, Resource
+
+    url = None
+
+    url_formats = {
+        "prefect.deployment": "deployments/deployment/{id}",
+        "prefect.flow": "flows/flow/{id}",
+        "prefect.flow-run": "flow-runs/flow-run/{id}",
+        "prefect.task-run": "flow-runs/task-run/{id}",
+        "prefect.work-queue": "work-queues/work-queue/{id}",
+        "prefect.work-pool": "work-pools/work-pool/{name}",
+    }
+
+    if isinstance(obj, ReceivedEvent):
+        url = "/events/event/{obj.occurred.strftime('%Y-%m-%d')}/{obj.id}"
+    elif isinstance(obj, Automation):
+        url = f"/automations/automation/{obj.id}"
+    elif isinstance(obj, Resource):
+        kind, _, id = obj.id.rpartition(".")
+        url_format = url_formats.get(kind)
+        if url_format:
+            url = url_format.format(id=id)
+    elif isinstance(obj, ORMBaseModel):
+        url_format = url_formats.get(model_to_kind.get(type(obj)))  # type: ignore
+        if url_format:
+            url = url_format.format(id=obj.id, name=getattr(obj, "name", None))
+
+    if url:
+        return urllib.parse.urljoin(PREFECT_UI_URL.value(), url)
+    else:
+        return None
+
+
+@pass_context
+def ui_resource_events_url(ctx: Mapping[str, Any], obj: Any) -> Optional[str]:
+    """Given a Resource or Model, return a UI link to the events page
+    filtered for that resource. If an unsupported object is provided,
+    return `None`.
+
+    Currently supports Automation, Resource, Deployment, Flow, FlowRun, TaskRun, and
+    WorkQueue objects. Within a Resource, deployment, flow, flow-run, task-run,
+    and work-queue are supported."""
+    from prefect.server.events.schemas.automations import Automation
+    from prefect.server.events.schemas.events import Resource
+
+    url = None
+    url_format = "events?resource={resource_id}"
+
+    if isinstance(obj, Automation):
+        url = url_format.format(resource_id=f"prefect-cloud.automation.{obj.id}")
+    elif isinstance(obj, Resource):
+        kind, _, id = obj.id.rpartition(".")
+        url = url_format.format(resource_id=f"{kind}.{id}")
+    elif isinstance(obj, ORMBaseModel):
+        kind = model_to_kind.get(type(obj))  # type: ignore
+
+        if kind:
+            url = url_format.format(resource_id=f"{kind}.{obj.id}")
+    if url:
+        return urllib.parse.urljoin(PREFECT_UI_URL.value(), url)
+    else:
+        return None
+
+
+all_filters = {"ui_url": ui_url, "ui_resource_events_url": ui_resource_events_url}

--- a/src/prefect/server/schemas/responses.py
+++ b/src/prefect/server/schemas/responses.py
@@ -18,7 +18,12 @@ from typing_extensions import TYPE_CHECKING, Literal
 
 import prefect.server.models as models
 import prefect.server.schemas as schemas
-from prefect.server.schemas.core import CreatedBy, FlowRunPolicy, UpdatedBy
+from prefect.server.schemas.core import (
+    CreatedBy,
+    FlowRunPolicy,
+    UpdatedBy,
+    WorkQueueStatusDetail,
+)
 from prefect.server.utilities.schemas.bases import ORMBaseModel, PrefectBaseModel
 from prefect.server.utilities.schemas.fields import DateTimeTZ
 from prefect.utilities.collections import AutoEnum
@@ -496,6 +501,10 @@ class WorkQueueResponse(schemas.core.WorkQueue):
             else:
                 response.status = schemas.statuses.WorkQueueStatus.NOT_READY
         return response
+
+
+class WorkQueueWithStatus(WorkQueueResponse, WorkQueueStatusDetail):
+    """Combines a work queue and its status details into a single object"""
 
 
 class WorkPoolResponse(schemas.core.WorkPool):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,7 @@ from .fixtures.collections_registry import *
 from .fixtures.database import *
 from .fixtures.deprecation import *
 from .fixtures.docker import *
+from .fixtures.events import *
 from .fixtures.logging import *
 from .fixtures.storage import *
 from .fixtures.time import *

--- a/tests/events/server/actions/test_infinite_loops.py
+++ b/tests/events/server/actions/test_infinite_loops.py
@@ -1,0 +1,298 @@
+"""Tests for our heuristics about Automations that may contain infinite loops."""
+
+from datetime import timedelta
+from typing import Set
+from uuid import uuid4
+
+import pytest
+
+from prefect._internal.pydantic import HAS_PYDANTIC_V2
+
+if HAS_PYDANTIC_V2:
+    from pydantic.v1 import ValidationError
+else:
+    from pydantic import ValidationError
+
+from prefect.server.events.actions import RunDeployment
+from prefect.server.events.schemas.automations import (
+    AutomationCore,
+    EventTrigger,
+    Posture,
+)
+
+
+def test_running_inferred_deployment_on_all_flow_run_state_changes():
+    """It's never okay to run an inferred deployment from all flow run state changes."""
+    with pytest.raises(ValidationError) as exc_info:
+        AutomationCore(
+            name="Run inferred deployment on all flow run state changes",
+            trigger=EventTrigger(
+                match={"prefect.resource.id": "prefect.flow-run.*"},
+                for_each={"prefect.resource.id"},
+                expect={"prefect.flow-run.*"},
+                posture=Posture.Reactive,
+                threshold=1,
+                within=timedelta(seconds=0),
+            ),
+            actions=[RunDeployment(source="inferred")],
+        )
+
+    errors = exc_info.value.errors()
+
+    assert len(errors) == 1
+    (error,) = errors
+
+    assert error["loc"] == ("__root__",)
+    assert error["msg"].startswith("Running an inferred deployment from a flow run")
+
+
+def test_running_inferred_deployment_on_filtered_flow_run_state_changes():
+    """It's never okay to run an inferred deployment from a flow run state change,
+    even if there are filters on it (because it's inferred so the flow run will just
+    generate another flow run just like it)."""
+    with pytest.raises(ValidationError) as exc_info:
+        AutomationCore(
+            name="Run inferred deployment on some flow run state changes",
+            trigger=EventTrigger(
+                match={"prefect.resource.id": "prefect.flow-run.*", "some": "thing"},
+                for_each={"prefect.resource.id"},
+                expect={"prefect.flow-run.*"},
+                posture=Posture.Reactive,
+                threshold=1,
+                within=timedelta(seconds=0),
+            ),
+            actions=[RunDeployment(source="inferred")],
+        )
+
+    errors = exc_info.value.errors()
+
+    assert len(errors) == 1
+    (error,) = errors
+
+    assert error["loc"] == ("__root__",)
+    assert error["msg"].startswith("Running an inferred deployment from a flow run")
+
+
+def test_running_inferred_deployment_on_related_filtered_flow_run_state_changes():
+    """It's never okay to run an inferred deployment from a flow run state change,
+    even if there are filters on it (because it's inferred so the flow run will just
+    generate another flow run just like it)."""
+    with pytest.raises(ValidationError) as exc_info:
+        AutomationCore(
+            name="Run inferred deployment on some flow run state changes",
+            trigger=EventTrigger(
+                match={"prefect.resource.id": "prefect.flow-run.*"},
+                match_related={"some": "thing"},
+                for_each={"prefect.resource.id"},
+                expect={"prefect.flow-run.*"},
+                posture=Posture.Reactive,
+                threshold=1,
+                within=timedelta(seconds=0),
+            ),
+            actions=[RunDeployment(source="inferred")],
+        )
+
+    errors = exc_info.value.errors()
+
+    assert len(errors) == 1
+    (error,) = errors
+
+    assert error["loc"] == ("__root__",)
+    assert error["msg"].startswith("Running an inferred deployment from a flow run")
+
+
+def test_running_a_selected_deployment_on_unfiltered_flow_run_state_changes():
+    """It's never okay to run a selected deployment from an unfiltered flow run state
+    change, because nothing could filter out the new flow run."""
+    with pytest.raises(ValidationError) as exc_info:
+        AutomationCore(
+            name="Run selected deployment on all flow run state changes",
+            trigger=EventTrigger(
+                match={"prefect.resource.id": "prefect.flow-run.*"},
+                for_each={"prefect.resource.id"},
+                expect={"prefect.flow-run.*"},
+                posture=Posture.Reactive,
+                threshold=1,
+                within=timedelta(seconds=0),
+            ),
+            actions=[RunDeployment(source="selected", deployment_id=uuid4())],
+        )
+
+    errors = exc_info.value.errors()
+
+    assert len(errors) == 1
+    (error,) = errors
+
+    assert error["loc"] == ("__root__",)
+    assert error["msg"].startswith("Running a selected deployment from a flow run")
+
+
+def test_running_a_selected_deployment_on_filtered_flow_run_state_changes():
+    """While these can still produce infinite loops, it is okay to set up an automation
+    that runs a selected deployment on flow run state changes as long as there are
+    some kinds of filters in place (match, match_related)"""
+    AutomationCore(
+        name="Run selected deployment on some flow run state changes",
+        trigger=EventTrigger(
+            match={"prefect.resource.id": "prefect.flow-run.*", "some": "thing"},
+            for_each={"prefect.resource.id"},
+            expect={"prefect.flow-run.*"},
+            posture=Posture.Reactive,
+            threshold=1,
+            within=timedelta(seconds=0),
+        ),
+        actions=[RunDeployment(source="selected", deployment_id=uuid4())],
+    )
+
+    AutomationCore(
+        name="Run selected deployment on some flow run state changes",
+        trigger=EventTrigger(
+            match={"prefect.resource.id": "prefect.flow-run.*"},
+            match_related={"some": "thing"},
+            for_each={"prefect.resource.id"},
+            expect={"prefect.flow-run.*"},
+            posture=Posture.Reactive,
+            threshold=1,
+            within=timedelta(seconds=0),
+        ),
+        actions=[RunDeployment(source="selected", deployment_id=uuid4())],
+    )
+
+
+@pytest.mark.parametrize(
+    "allowed_events",
+    [
+        {"prefect.flow-run.Failed"},
+        {"prefect.flow-run.Crashed"},
+        {"prefect.flow-run.TimedOut"},
+        {
+            "prefect.flow-run.Failed",
+            "prefect.flow-run.Crashed",
+            "prefect.flow-run.TimedOut",
+        },
+    ],
+)
+def test_allowing_specialized_flow_run_events(allowed_events: Set[str]):
+    """Regression test for a bug the first time we released this: many people have
+    totally valid and encouraged automations to run deployments on flow run state
+    events liked TimedOut, Failed, or Crashed.  These should be accepted."""
+    AutomationCore(
+        name="Run inferred deployment on failure events",
+        trigger=EventTrigger(
+            match={"prefect.resource.id": "prefect.flow-run.*"},
+            for_each={"prefect.resource.id"},
+            expect=allowed_events,
+            posture=Posture.Reactive,
+            threshold=1,
+            within=timedelta(seconds=0),
+        ),
+        actions=[RunDeployment(source="inferred")],
+    )
+
+    AutomationCore(
+        name="Run selected deployment on failure events",
+        trigger=EventTrigger(
+            match={"prefect.resource.id": "prefect.flow-run.*"},
+            for_each={"prefect.resource.id"},
+            expect={
+                "prefect.flow-run.TimedOut",
+                "prefect.flow-run.Failed",
+                "prefect.flow-run.Crashed",
+            },
+            posture=Posture.Reactive,
+            threshold=1,
+            within=timedelta(seconds=0),
+        ),
+        actions=[RunDeployment(source="selected", deployment_id=uuid4())],
+    )
+
+
+@pytest.mark.parametrize(
+    "naughty_events",
+    [
+        {
+            "prefect.flow-run.Failed",
+            "prefect.flow-run.Crashed",
+            "prefect.flow-run.Scheduled",  # nope
+        },
+        {
+            "prefect.flow-run.Failed",
+            "prefect.flow-run.*",  # nope
+            "prefect.flow-run.Crashed",
+        },
+        {"prefect.flow-run.Pending"},  # nope
+        {"prefect.flow-run.Running"},  # nope
+        {"prefect.flow-run.Scheduled"},  # nope
+    ],
+)
+def test_blocking_inferred_on_universal_flow_run_events(naughty_events: Set[str]):
+    """Regression test for a bug the first time we released this: many people have
+    totally valid and encouraged automations to run deployments on flow run state
+    events liked TimedOut, Failed, or Crashed.  However, if they sneak in one of the
+    universal events, like Scheduled, Pending, Running, or *, they should be blocked."""
+    with pytest.raises(ValidationError) as exc_info:
+        AutomationCore(
+            name="Run inferred deployment on failure events",
+            trigger=EventTrigger(
+                match={"prefect.resource.id": "prefect.flow-run.*"},
+                for_each={"prefect.resource.id"},
+                expect=naughty_events,
+                posture=Posture.Reactive,
+                threshold=1,
+                within=timedelta(seconds=0),
+            ),
+            actions=[RunDeployment(source="inferred")],
+        )
+
+    errors = exc_info.value.errors()
+
+    assert len(errors) == 1
+    (error,) = errors
+
+    assert error["loc"] == ("__root__",)
+    assert error["msg"].startswith("Running an inferred deployment from a flow run")
+
+
+@pytest.mark.parametrize(
+    "naughty_events",
+    [
+        {
+            "prefect.flow-run.Failed",
+            "prefect.flow-run.Crashed",
+            "prefect.flow-run.Scheduled",  # nope
+        },
+        {
+            "prefect.flow-run.Failed",
+            "prefect.flow-run.*",  # nope
+            "prefect.flow-run.Crashed",
+        },
+        {"prefect.flow-run.Pending"},  # nope
+        {"prefect.flow-run.Running"},  # nope
+    ],
+)
+def test_blocking_selected_on_universal_flow_run_events(naughty_events: Set[str]):
+    """Regression test for a bug the first time we released this: many people have
+    totally valid and encouraged automations to run deployments on flow run state
+    events liked TimedOut, Failed, or Crashed.  However, if they sneak in one of the
+    universal events, like Scheduled, Pending, Running, or *, they should be blocked."""
+    with pytest.raises(ValidationError) as exc_info:
+        AutomationCore(
+            name="Run inferred deployment on failure events",
+            trigger=EventTrigger(
+                match={"prefect.resource.id": "prefect.flow-run.*"},
+                for_each={"prefect.resource.id"},
+                expect=naughty_events,
+                posture=Posture.Reactive,
+                threshold=1,
+                within=timedelta(seconds=0),
+            ),
+            actions=[RunDeployment(source="selected", deployment_id=uuid4())],
+        )
+
+    errors = exc_info.value.errors()
+
+    assert len(errors) == 1
+    (error,) = errors
+
+    assert error["loc"] == ("__root__",)
+    assert error["msg"].startswith("Running a selected deployment from a flow run")

--- a/tests/events/server/actions/test_jinja_templated_action.py
+++ b/tests/events/server/actions/test_jinja_templated_action.py
@@ -1,0 +1,1417 @@
+import copy
+from datetime import timedelta
+from typing import Dict, Generator, List, Literal
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pendulum
+import pytest
+from pendulum.datetime import DateTime
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from prefect._internal.pydantic import HAS_PYDANTIC_V2
+
+if HAS_PYDANTIC_V2:
+    from pydantic.v1 import Field, validator
+    from pydantic.v1.fields import ModelField
+else:
+    from pydantic import Field, validator
+    from pydantic.fields import ModelField
+
+from prefect.server.api.clients import OrchestrationClient
+from prefect.server.database.orm_models import (
+    ORMConcurrencyLimitV2,
+    ORMDeployment,
+    ORMFlow,
+    ORMFlowRun,
+    ORMTaskRun,
+    ORMWorkPool,
+    ORMWorkQueue,
+)
+from prefect.server.events import actions
+from prefect.server.events.schemas.automations import (
+    Automation,
+    EventTrigger,
+    Firing,
+    Posture,
+    ReceivedEvent,
+    TriggeredAction,
+    TriggerState,
+)
+from prefect.server.events.schemas.events import Event, Resource
+from prefect.server.models import (
+    deployments,
+    flow_runs,
+    flows,
+    task_runs,
+    variables,
+    work_queues,
+)
+from prefect.server.schemas.actions import (
+    VariableCreate,
+    WorkQueueCreate,
+    WorkQueueUpdate,
+)
+from prefect.server.schemas.core import Deployment, Flow, FlowRun, TaskRun, WorkQueue
+from prefect.server.schemas.responses import FlowRunResponse
+from prefect.server.schemas.states import State, StateType
+from prefect.settings import PREFECT_UI_URL, temporary_settings
+
+
+@pytest.fixture(autouse=True)
+def ui_url() -> Generator[str, None, None]:
+    with temporary_settings(set_defaults={PREFECT_UI_URL: "http://localhost:3000"}):
+        yield PREFECT_UI_URL.value()
+
+
+class DemoAction(actions.JinjaTemplateAction):
+    type: Literal["test-action"] = "test-action"
+    template: str = Field()
+
+    @validator("template")
+    def is_valid_template(cls, value: str, field: ModelField) -> str:
+        return actions.JinjaTemplateAction.validate_template(value, field.name)
+
+    async def act(self, triggered_action: TriggeredAction) -> None:
+        return None
+
+    async def render(self, triggered_action: TriggeredAction) -> List[str]:
+        return await self._render([self.template], triggered_action)
+
+
+@pytest.fixture
+async def orchestration_client() -> OrchestrationClient:
+    return OrchestrationClient()
+
+
+@pytest.fixture
+async def tell_me_about_the_culprit() -> Automation:
+    return Automation(
+        name="If my lilies get nibbled, tell me about it",
+        description="Send an email notification whenever the lillies are nibbled",
+        enabled=True,
+        trigger=EventTrigger(
+            expect={"animal.ingested"},
+            match_related={
+                "prefect.resource.role": "meal",
+                "genus": "Hemerocallis",
+                "species": "fulva",
+            },
+            posture=Posture.Reactive,
+            threshold=0,
+            within=timedelta(seconds=30),
+        ),
+        actions=[actions.DoNothing()],
+    )
+
+
+@pytest.fixture
+def woodchonk_triggered(
+    tell_me_about_the_culprit: Automation,
+    woodchonk_nibbled: ReceivedEvent,
+) -> TriggeredAction:
+    return TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        triggered=pendulum.now("UTC"),
+        triggering_labels={"i.am.so": "triggered"},
+        triggering_event=woodchonk_nibbled,
+        action=tell_me_about_the_culprit.actions[0],
+    )
+
+
+@pytest.fixture
+async def snap_a_pic(
+    session: AsyncSession,
+) -> ORMFlow:
+    flow = await flows.create_flow(
+        session=session,
+        flow=Flow(name="snap-a-pic"),
+    )
+    await session.commit()
+
+    return flow
+
+
+@pytest.fixture
+async def take_a_picture(
+    session: AsyncSession,
+    snap_a_pic,
+) -> ORMFlowRun:
+    now = pendulum.now("UTC")
+
+    flow_run = await flow_runs.create_flow_run(
+        session=session,
+        flow_run=FlowRun(
+            flow_id=snap_a_pic.id,
+            flow_version="1.0",
+        ),
+    )
+    scheduled_state: State = State(
+        type=StateType.RUNNING,
+        message="It's running!",
+        timestamp=now,
+    )
+    await flow_runs.set_flow_run_state(
+        session=session,
+        flow_run_id=flow_run.id,
+        state=scheduled_state,
+        force=True,
+    )
+    await session.commit()
+
+    return flow_run
+
+
+@pytest.fixture
+async def take_a_picture_task(
+    session: AsyncSession,
+    snap_a_pic,
+    take_a_picture,
+) -> ORMTaskRun:
+    now = pendulum.now("UTC")
+
+    task_run = await task_runs.create_task_run(
+        session=session,
+        task_run=TaskRun(
+            flow_run_id=take_a_picture.id,
+            name="the-task-run",
+            task_key="task-123",
+            dynamic_key="a",
+        ),
+    )
+    assert task_run
+    scheduled_state: State = State(
+        type=StateType.RUNNING,
+        message="It's running!",
+        timestamp=now,
+    )
+    await task_runs.set_task_run_state(
+        session=session,
+        task_run_id=task_run.id,
+        state=scheduled_state,
+        force=True,
+    )
+    await session.commit()
+
+    return task_run
+
+
+@pytest.fixture
+async def take_a_picture_deployment(
+    session: AsyncSession,
+    take_a_picture: FlowRun,
+) -> ORMDeployment:
+    deployment = await deployments.create_deployment(
+        session=session,
+        deployment=Deployment(
+            name="Take a picture on demand",
+            manifest_path="file.json",
+            flow_id=take_a_picture.flow_id,
+            is_schedule_active=True,
+            paused=False,
+        ),
+    )
+    await session.commit()
+
+    return deployment
+
+
+@pytest.fixture
+async def take_a_picture_work_queue(
+    session: AsyncSession,
+) -> ORMWorkQueue:
+    work_queue = await work_queues.create_work_queue(
+        session=session,
+        work_queue=WorkQueueCreate(name="camera-queue"),  # type: ignore
+    )
+    await session.commit()
+
+    return work_queue
+
+
+@pytest.fixture
+def picture_taken(
+    start_of_test: DateTime,
+    take_a_picture: FlowRun,
+    take_a_picture_deployment: Deployment,
+    take_a_picture_work_queue: WorkQueue,
+):
+    return ReceivedEvent(
+        occurred=start_of_test + timedelta(microseconds=2),
+        event="prefect.flow-run.completed",
+        resource={
+            "prefect.resource.id": f"prefect.flow-run.{take_a_picture.id}",
+            "prefect.state-message": "All states completed.",
+            "prefect.state-name": "Completed",
+            "prefect.state-timestamp": pendulum.now("UTC").isoformat(),
+            "prefect.state-type": "COMPLETED",
+        },
+        related=[
+            {
+                "prefect.resource.id": f"prefect.flow.{take_a_picture.flow_id}",
+                "prefect.resource.role": "flow",
+            },
+            {
+                "prefect.resource.id": f"prefect.deployment.{take_a_picture_deployment.id}",
+                "prefect.resource.role": "deployment",
+            },
+            {
+                "prefect.resource.id": f"prefect.work-queue.{take_a_picture_work_queue.id}",
+                "prefect.resource.role": "work-queue",
+            },
+        ],
+        id=uuid4(),
+    )
+
+
+@pytest.fixture
+def picture_taken_by_task(
+    start_of_test: DateTime,
+    take_a_picture: FlowRun,
+    take_a_picture_task: TaskRun,
+    take_a_picture_deployment: Deployment,
+    take_a_picture_work_queue: WorkQueue,
+):
+    return ReceivedEvent(
+        occurred=start_of_test + timedelta(microseconds=2),
+        event="prefect.task-run.completed",
+        resource={
+            "prefect.resource.id": f"prefect.task-run.{take_a_picture_task.id}",
+            "prefect.state-message": "All states completed.",
+            "prefect.state-name": "Completed",
+            "prefect.state-timestamp": pendulum.now("UTC").isoformat(),
+            "prefect.state-type": "COMPLETED",
+        },
+        related=[
+            {
+                "prefect.resource.id": f"prefect.flow-run.{take_a_picture.id}",
+                "prefect.resource.role": "flow",
+            },
+            {
+                "prefect.resource.id": f"prefect.flow.{take_a_picture.flow_id}",
+                "prefect.resource.role": "flow",
+            },
+            {
+                "prefect.resource.id": f"prefect.deployment.{take_a_picture_deployment.id}",
+                "prefect.resource.role": "deployment",
+            },
+            {
+                "prefect.resource.id": f"prefect.work-queue.{take_a_picture_work_queue.id}",
+                "prefect.resource.role": "work-queue",
+            },
+        ],
+        id=uuid4(),
+    )
+
+
+@pytest.fixture
+def took_a_picture(
+    tell_me_about_the_culprit: Automation,
+    picture_taken: ReceivedEvent,
+) -> TriggeredAction:
+    return TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        triggered=pendulum.now("UTC"),
+        triggering_labels={},
+        triggering_event=picture_taken,
+        action=tell_me_about_the_culprit.actions[0],
+    )
+
+
+@pytest.fixture
+def took_a_picture_by_task(
+    tell_me_about_the_culprit: Automation,
+    picture_taken_by_task: ReceivedEvent,
+) -> TriggeredAction:
+    return TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        triggered=pendulum.now("UTC"),
+        triggering_labels={},
+        triggering_event=picture_taken_by_task,
+        action=tell_me_about_the_culprit.actions[0],
+    )
+
+
+async def test_filters_are_available_to_templates(took_a_picture: TriggeredAction):
+    assert took_a_picture.triggering_event
+    action = DemoAction(template="{{ automation|ui_url }}")
+    rendered = await action.render(took_a_picture)
+    assert len(rendered) == 1
+    assert f"/automations/automation/{took_a_picture.automation.id}" in rendered[0]
+
+
+async def test_flow_is_available_to_templates(
+    snap_a_pic: ORMFlow, took_a_picture: TriggeredAction
+):
+    assert took_a_picture.triggering_event
+    action = DemoAction(template="{{ flow.name }}")
+    rendered = await action.render(took_a_picture)
+    assert len(rendered) == 1
+    assert rendered[0] == snap_a_pic.name
+
+
+async def test_flow_run_is_available_to_templates(
+    take_a_picture: FlowRun, took_a_picture: TriggeredAction
+):
+    assert took_a_picture.triggering_event
+    action = DemoAction(template="{{ flow_run.name }}")
+    rendered = await action.render(took_a_picture)
+    assert len(rendered) == 1
+    assert rendered[0] == take_a_picture.name
+
+
+async def test_flow_run_state_comes_from_event_resource(
+    took_a_picture: TriggeredAction,
+):
+    """Regression test for https://github.com/PrefectHQ/nebula/issues/3310,
+    where the state of the flow run fetched from the API was updated after the
+    state change that caused the automation to run and notifications that were
+    sent contained the incorrect state information"""
+
+    event = took_a_picture.triggering_event
+    assert event
+    action = DemoAction(
+        template=(
+            "{{ flow_run.state.message }} "
+            "{{ flow_run.state.name }} "
+            "{{ flow_run.state.timestamp.isoformat() }} "
+            "{{ flow_run.state.type.value }}"
+        )
+    )
+    rendered = await action.render(took_a_picture)
+
+    assert len(rendered) == 1
+    assert rendered[0] == " ".join(
+        [
+            event.resource["prefect.state-message"],
+            event.resource["prefect.state-name"],
+            event.resource["prefect.state-timestamp"],
+            event.resource["prefect.state-type"],
+        ]
+    )
+
+
+async def test_flow_run_state_event_missing_state_data_uses_api_state(
+    session: AsyncSession,
+    took_a_picture: TriggeredAction,
+    take_a_picture: FlowRun,
+):
+    """Regression test for https://github.com/PrefectHQ/nebula/issues/3310,
+    where the state of the flow run fetched from the API was updated after the
+    state change that caused the automation to run and notifications that were
+    sent contained the incorrect state information"""
+
+    event = took_a_picture.triggering_event
+    assert event
+
+    # Change the resource to one that does not have any of the state
+    # information.
+    event.resource = Resource.parse_obj(
+        {"prefect.resource.id": f"prefect.flow-run.{take_a_picture.id}"}
+    )
+
+    action = DemoAction(
+        template=(
+            "{{ flow_run.state.message }} "
+            "{{ flow_run.state.name }} "
+            "{{ flow_run.state.timestamp }} "
+            "{{ flow_run.state.type }}"
+        )
+    )
+    rendered = await action.render(took_a_picture)
+
+    flow_run = await flow_runs.read_flow_run(
+        session,
+        take_a_picture.id,
+    )
+
+    assert len(rendered) == 1
+    assert rendered[0] == " ".join(
+        [
+            flow_run.state.message,
+            flow_run.state.name,
+            str(flow_run.state.timestamp),
+            str(flow_run.state.type),
+        ]
+    )
+
+
+async def test_flow_run_state_event_malformed_uses_api_state(
+    session: AsyncSession,
+    took_a_picture: TriggeredAction,
+    take_a_picture: FlowRun,
+):
+    """Regression test for https://github.com/PrefectHQ/nebula/issues/3310,
+    where the state of the flow run fetched from the API was updated after the
+    state change that caused the automation to run and notifications that were
+    sent contained the incorrect state information"""
+
+    event = took_a_picture.triggering_event
+    assert event
+    assert take_a_picture.state
+
+    # Change the resource to one that has malformed state information.
+    event.resource = Resource.parse_obj(
+        {
+            "prefect.resource.id": f"prefect.flow-run.{take_a_picture.id}",
+            "prefect.state-message": "",
+            "prefect.state-name": "Buh-bye",
+            "prefect.state-timestamp": take_a_picture.state.timestamp.isoformat(),
+            "prefect.state-type": "ANNIHILATED",
+        }
+    )
+
+    action = DemoAction(
+        template=(
+            "{{ flow_run.state.message }} "
+            "{{ flow_run.state.name }} "
+            "{{ flow_run.state.timestamp }} "
+            "{{ flow_run.state.type }}"
+        )
+    )
+    rendered = await action.render(took_a_picture)
+
+    flow_run = await flow_runs.read_flow_run(
+        session,
+        take_a_picture.id,
+    )
+
+    assert len(rendered) == 1
+    assert rendered[0] == " ".join(
+        [
+            flow_run.state.message,
+            flow_run.state.name,
+            str(flow_run.state.timestamp),
+            str(flow_run.state.type),
+        ]
+    )
+
+
+async def test_flow_run_state_comes_from_event_resource_empty_message(
+    took_a_picture: TriggeredAction,
+    take_a_picture: FlowRun,
+):
+    """Regression test for https://github.com/PrefectHQ/prefect/issues/9230
+    where the flow run event had all of the correct state information but the
+    message, as is the case in many events, was empty causing the state to not
+    be rehydrated but instead use the state from the API"""
+
+    event = took_a_picture.triggering_event
+    assert event
+    assert take_a_picture.state
+
+    event.resource = Resource.parse_obj(
+        {
+            "prefect.resource.id": f"prefect.flow-run.{take_a_picture.id}",
+            "prefect.state-message": "",
+            "prefect.state-name": "Pending",
+            "prefect.state-timestamp": take_a_picture.state.timestamp.isoformat(),
+            "prefect.state-type": "PENDING",
+        }
+    )
+
+    action = DemoAction(
+        template=(
+            "{{ flow_run.state.message }} "
+            "{{ flow_run.state.name }} "
+            "{{ flow_run.state.timestamp }} "
+            "{{ flow_run.state.type.value }}"
+        )
+    )
+    rendered = await action.render(took_a_picture)
+
+    assert len(rendered) == 1
+    assert rendered[0] == " ".join(
+        [
+            "",
+            "Pending",
+            str(take_a_picture.state.timestamp),
+            "PENDING",
+        ]
+    )
+
+
+async def test_task_run_is_available_to_templates(
+    take_a_picture_task: TaskRun, took_a_picture_by_task: TriggeredAction
+):
+    assert took_a_picture_by_task.triggering_event
+    action = DemoAction(template="{{ task_run.name }}")
+    rendered = await action.render(took_a_picture_by_task)
+    assert len(rendered) == 1
+    assert rendered[0] == take_a_picture_task.name
+
+
+async def test_task_run_state_comes_from_event_resource(
+    took_a_picture_by_task: TriggeredAction,
+):
+    event = took_a_picture_by_task.triggering_event
+    assert event
+    action = DemoAction(
+        template=(
+            "{{ task_run.state.message }} "
+            "{{ task_run.state.name }} "
+            "{{ task_run.state.timestamp.isoformat() }} "
+            "{{ task_run.state.type.value }}"
+        )
+    )
+    rendered = await action.render(took_a_picture_by_task)
+
+    assert len(rendered) == 1
+    assert rendered[0] == " ".join(
+        [
+            event.resource["prefect.state-message"],
+            event.resource["prefect.state-name"],
+            event.resource["prefect.state-timestamp"],
+            event.resource["prefect.state-type"],
+        ]
+    )
+
+
+async def test_deployment_is_available_to_templates(
+    take_a_picture_deployment: Deployment, took_a_picture: TriggeredAction
+):
+    assert took_a_picture.triggering_event
+    action = DemoAction(template="{{ deployment.name }}")
+    rendered = await action.render(took_a_picture)
+    assert len(rendered) == 1
+    assert rendered[0] == take_a_picture_deployment.name
+
+
+async def test_work_queue_is_available_to_templates(
+    take_a_picture_work_queue: WorkQueue, took_a_picture: TriggeredAction
+):
+    assert took_a_picture.triggering_event
+    action = DemoAction(template="{{ work_queue.name }}")
+    rendered = await action.render(took_a_picture)
+    assert len(rendered) == 1
+    assert rendered[0] == take_a_picture_work_queue.name
+
+
+async def test_all_objects_in_template(
+    took_a_picture: TriggeredAction,
+    snap_a_pic: ORMFlow,
+    take_a_picture_deployment: Deployment,
+    take_a_picture_work_queue: WorkQueue,
+    take_a_picture: FlowRun,
+):
+    assert took_a_picture.triggering_event
+    action = DemoAction(
+        template="{{ flow.id }} {{ flow_run.id }} {{ deployment.id }} {{ work_queue.id }}"
+    )
+    rendered = await action.render(took_a_picture)
+    assert len(rendered) == 1
+    assert rendered[0] == " ".join(
+        [
+            str(snap_a_pic.id),
+            str(take_a_picture.id),
+            str(take_a_picture_deployment.id),
+            str(take_a_picture_work_queue.id),
+        ]
+    )
+
+
+async def test_caches_objects(
+    took_a_picture: TriggeredAction,
+    snap_a_pic: ORMFlow,
+):
+    assert took_a_picture.triggering_event
+
+    mock_get_object = AsyncMock()
+    mock_get_object.side_effect = [snap_a_pic]
+    with patch(
+        "prefect.server.events.actions.JinjaTemplateAction._get_object_from_prefect_api",
+        mock_get_object,
+    ):
+        action = DemoAction(template="{{ flow.id }}")
+
+        await action.render(took_a_picture)
+        assert mock_get_object.call_count == 1
+
+        mock_get_object.reset_mock()
+
+        await action.render(took_a_picture)
+        assert mock_get_object.call_count == 0
+
+
+async def test_retrieves_after_caching(
+    took_a_picture: TriggeredAction,
+    snap_a_pic: ORMFlow,
+    take_a_picture: FlowRun,
+    take_a_picture_deployment: Deployment,
+    take_a_picture_work_queue: WorkQueue,
+):
+    assert took_a_picture.triggering_event
+
+    def object_retriever(oriont_client, triggered_action, resource: Resource):
+        if "prefect.flow." in resource.id:
+            return snap_a_pic
+        elif "prefect.flow-run" in resource.id:
+            return take_a_picture
+        elif "prefect.deployment" in resource.id:
+            return take_a_picture_deployment
+        elif "prefect.work-queue" in resource.id:
+            return take_a_picture_work_queue
+
+    mock_get_object = AsyncMock()
+    mock_get_object.side_effect = object_retriever
+    with patch(
+        "prefect.server.events.actions.JinjaTemplateAction._get_object_from_prefect_api",
+        mock_get_object,
+    ):
+        action = DemoAction(template="")
+
+        rendered = await action._render(
+            ["{{ flow.id }} {{ flow_run.id}}"], took_a_picture
+        )
+        assert mock_get_object.call_count == 2
+        assert rendered[0] == f"{snap_a_pic.id} {take_a_picture.id}"
+
+        mock_get_object.reset_mock()
+        rendered = await action._render(
+            ["{{ flow.id }} {{ flow_run.id }} {{ deployment.id }} {{ work_queue.id }}"],
+            took_a_picture,
+        )
+        assert mock_get_object.call_count == 2
+        assert (
+            rendered[0]
+            == f"{snap_a_pic.id} {take_a_picture.id} {take_a_picture_deployment.id} {take_a_picture_work_queue.id}"
+        )
+
+        mock_get_object.reset_mock()
+        rendered = await action._render(
+            ["{{ flow.id }} {{ flow_run.id }} {{ deployment.id }} {{ work_queue.id }}"],
+            took_a_picture,
+        )
+        assert mock_get_object.call_count == 0
+        assert (
+            rendered[0]
+            == f"{snap_a_pic.id} {take_a_picture.id} {take_a_picture_deployment.id} {take_a_picture_work_queue.id}"
+        )
+
+
+async def test_lazy_objects_are_none_without_a_resource(
+    woodchonk_triggered: TriggeredAction,
+):
+    assert woodchonk_triggered.triggering_event
+    action = DemoAction(template="{{ flow_run.name }}")
+    rendered = await action.render(woodchonk_triggered)
+    assert len(rendered) == 1
+    assert rendered[0] == ""
+
+
+async def test_get_object_from_orion_null_resource(
+    orchestration_client: OrchestrationClient, woodchonk_triggered: TriggeredAction
+):
+    resource = None
+    action = DemoAction(template="")
+    assert (
+        await action._get_object_from_prefect_api(
+            orchestration_client, woodchonk_triggered, resource
+        )
+        is None
+    )
+
+
+async def test_get_object_from_orion_resource_with_invalid_uuid(
+    orchestration_client: OrchestrationClient, woodchonk_triggered: TriggeredAction
+):
+    resource = Resource.parse_obj({"prefect.resource.id": "prefect.flow-run.thing"})
+    action = DemoAction(template="")
+    assert (
+        await action._get_object_from_prefect_api(
+            orchestration_client, woodchonk_triggered, resource
+        )
+        is None
+    )
+
+
+async def test_get_object_from_orion_resource_with_unknown_kind(
+    orchestration_client: OrchestrationClient, woodchonk_triggered: TriggeredAction
+):
+    resource = Resource.parse_obj({"prefect.resource.id": "prefect.unknown.thing"})
+    action = DemoAction(template="")
+    assert (
+        await action._get_object_from_prefect_api(
+            orchestration_client, woodchonk_triggered, resource
+        )
+        is None
+    )
+
+
+async def test_get_object_from_orion_resource_missing_from_api(
+    orchestration_client: OrchestrationClient, woodchonk_triggered: TriggeredAction
+):
+    resource = Resource.parse_obj(
+        {"prefect.resource.id": f"prefect.flow-run.{uuid4()}"}
+    )
+    action = DemoAction(template="")
+    assert (
+        await action._get_object_from_prefect_api(
+            orchestration_client, woodchonk_triggered, resource
+        )
+        is None
+    )
+
+
+async def test_get_object_returns_object(
+    orchestration_client: OrchestrationClient,
+    take_a_picture: FlowRun,
+    woodchonk_triggered: TriggeredAction,
+):
+    resource = Resource.parse_obj(
+        {"prefect.resource.id": f"prefect.flow-run.{take_a_picture.id}"}
+    )
+    action = DemoAction(template="")
+    flow_run = await action._get_object_from_prefect_api(
+        orchestration_client, woodchonk_triggered, resource
+    )
+
+    assert isinstance(flow_run, FlowRunResponse)
+    assert flow_run.id == take_a_picture.id
+    assert flow_run.name == take_a_picture.name
+
+
+async def test_triggering_labels_may_be_accessed_as_object(
+    woodchonk_triggered: TriggeredAction,
+):
+    assert woodchonk_triggered.triggering_labels == {"i.am.so": "triggered"}
+    action = DemoAction(template="{{ labels.i.am.so }}")
+    rendered = await action.render(woodchonk_triggered)
+    assert len(rendered) == 1
+    assert rendered[0] == "triggered"
+
+
+async def test_triggering_labels_may_be_accessed_as_dict(
+    woodchonk_triggered: TriggeredAction,
+):
+    assert woodchonk_triggered.triggering_labels == {"i.am.so": "triggered"}
+    action = DemoAction(template="{{ labels['i.am.so'] }}")
+    rendered = await action.render(woodchonk_triggered)
+    assert len(rendered) == 1
+    assert rendered[0] == "triggered"
+
+
+async def test_resource_labels_may_be_accessed_as_object(
+    woodchonk_triggered: TriggeredAction,
+):
+    assert woodchonk_triggered.triggering_event
+    assert woodchonk_triggered.triggering_event.resource.id == "woodchonk"
+    assert woodchonk_triggered.triggering_event.resource["kingdom"] == "Animalia"
+
+    action = DemoAction(
+        template=(
+            "{{ event.resource.labels.prefect.resource.id }} - "
+            "{{ event.resource.labels.kingdom }}"
+        ),
+    )
+    rendered = await action.render(woodchonk_triggered)
+    assert len(rendered) == 1
+    assert rendered[0] == "woodchonk - Animalia"
+
+
+async def test_resource_labels_may_be_iterated(woodchonk_triggered: TriggeredAction):
+    action = DemoAction(
+        template=(
+            "{% for label, value in event.resource.labels %}"
+            "{{label}} - {{value}}\n"
+            "{% endfor %}"
+        ),
+    )
+    rendered = await action.render(woodchonk_triggered)
+    assert len(rendered) == 1
+    assert set(rendered[0].splitlines()) == {
+        "kingdom - Animalia",
+        "phylum - Chordata",
+        "class - Mammalia",
+        "order - Rodentia",
+        "family - Sciuridae",
+        "genus - Marmota",
+        "species - monax",
+        "prefect.resource.id - woodchonk",
+    }
+
+
+async def test_resource_labels_may_be_sorted(woodchonk_triggered: TriggeredAction):
+    action = DemoAction(
+        template=(
+            "{% for label, value in event.resource.labels|sort %}"
+            "{{label}} - {{value}}\n"
+            "{% endfor %}"
+        ),
+    )
+    rendered = await action.render(woodchonk_triggered)
+    assert len(rendered) == 1
+    assert rendered[0].splitlines() == [
+        "class - Mammalia",
+        "family - Sciuridae",
+        "genus - Marmota",
+        "kingdom - Animalia",
+        "order - Rodentia",
+        "phylum - Chordata",
+        "prefect.resource.id - woodchonk",
+        "species - monax",
+    ]
+
+
+async def test_related_labels_may_be_accessed_as_object(
+    woodchonk_triggered: TriggeredAction,
+):
+    assert woodchonk_triggered.triggering_event
+    assert len(woodchonk_triggered.triggering_event.related) == 2
+
+    first, second = woodchonk_triggered.triggering_event.related
+    assert first.role == "meal"
+    assert first["genus"] == "Hemerocallis"
+    assert second.role == "meal"
+    assert second["genus"] == "Tulipa"
+
+    action = DemoAction(
+        template=(
+            "{% for related in event.related %}"
+            "{{ related.labels.prefect.resource.role }} - {{ related.labels.genus }}, "
+            "{% endfor %}"
+        ),
+    )
+
+    rendered = await action.render(woodchonk_triggered)
+    assert len(rendered) == 1
+    assert rendered[0] == "meal - Hemerocallis, meal - Tulipa, "
+
+
+@pytest.fixture
+async def workspace_variables(
+    session: AsyncSession,
+) -> Dict[str, str]:
+    to_create = {"hello": "world!", "goodbye": "moon!"}
+    for name, value in to_create.items():
+        await variables.create_variable(
+            session,
+            VariableCreate(name=name, value=value),  # type: ignore[call-arg]
+        )
+    await session.commit()
+    return to_create
+
+
+async def test_workspace_variables_may_be_accessed_as_an_object(
+    workspace_variables: Dict[str, str],
+    woodchonk_triggered: TriggeredAction,
+):
+    action = DemoAction(template="{{ variables.hello }} {{ variables.goodbye }}")
+    (rendered,) = await action.render(woodchonk_triggered)
+    assert rendered == "world! moon!"
+
+
+async def test_workspace_variables_may_be_accessed_as_a_dict(
+    workspace_variables: Dict[str, str],
+    woodchonk_triggered: TriggeredAction,
+):
+    action = DemoAction(template="{{ variables['hello'] }}")
+    (rendered,) = await action.render(woodchonk_triggered)
+    assert rendered == "world!"
+
+
+async def test_environment_is_immutable(woodchonk_triggered: TriggeredAction):
+    # we're using the immutable sandbox, which disallows mutating collections and a
+    # few other things
+    template = "{{ event.related.append(42) }}"
+
+    before = copy.deepcopy(woodchonk_triggered)
+
+    action = DemoAction(template=template)
+    rendered = await action.render(woodchonk_triggered)
+    assert len(rendered) == 1
+    assert rendered[0] == (
+        "Failed to render template due to the following error: "
+        "SecurityError("
+        "\"access to attribute 'append' of 'list' object is unsafe.\""
+        ")\n"
+        "Template source:\n"
+        f"{template}"
+    )
+
+    assert woodchonk_triggered == before
+
+
+async def test_ranges_are_limited(woodchonk_triggered: TriggeredAction):
+    # we're limiting ranges to 100
+    template = "{% for i in range(101) %}{{ i }} {% endfor %}"
+    action = DemoAction(template=template)
+    rendered = await action.render(woodchonk_triggered)
+    assert len(rendered) == 1
+    assert rendered[0] == (
+        "Failed to render template due to the following error: "
+        "OverflowError("
+        "'Range too big. The sandbox blocks ranges larger than MAX_RANGE (100).'"
+        ")\n"
+        "Template source:\n"
+        f"{template}"
+    )
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        # You can't extend templates
+        "{% extends 'base.html' %}",
+        # You can't import other templates
+        "{% import 'anything.html' as forms %}",
+    ],
+)
+async def test_loading_templates_is_disabled(
+    woodchonk_triggered: TriggeredAction, template: str
+):
+    action = DemoAction(template=template)
+    rendered = await action.render(woodchonk_triggered)
+    assert len(rendered) == 1
+    assert rendered[0] == (
+        "Failed to render template due to the following error: "
+        "TypeError('no loader for this environment specified')\n"
+        "Template source:\n"
+        f"{template}"
+    )
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        # Accessing special attributes directly is prohibited
+        "{{ event.__type__ }}",
+        # Accessing special attributes via the attr() filter prohibited
+        "{{ event|attr('__type__') }}",
+    ],
+)
+async def test_unsafe_attribute_is_verboten(
+    woodchonk_triggered: TriggeredAction, template: str
+):
+    template = "I did not get this attribute: (" + template + "), no, Sir, I did not"
+
+    action = DemoAction(template=template)
+    rendered = await action.render(woodchonk_triggered)
+
+    assert len(rendered) == 1
+    assert rendered[0] == "I did not get this attribute: (), no, Sir, I did not"
+
+
+async def test_deeply_nested_for_loops_prohibited():
+    template = (
+        "{% for i in range(100) %}"
+        "{% for j in range(100) %}"
+        "{% for l in range(100) %}"
+        "{% endfor %}"
+        "{% endfor %}"
+        "{% endfor %}"
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="'template' is not a valid template: Contains nested for loops at a depth of 3. Templates can nest for loops no more than 2 loops deep.",
+    ):
+        DemoAction(template=template)
+
+
+async def test_many_loops_prohibited():
+    template = (
+        "{% for a in range(100) %}{% endfor %}"
+        "{% for b in range(100) %}{% endfor %}"
+        "{% for c in range(100) %}{% endfor %}"
+        "{% for d in range(100) %}{% endfor %}"
+        "{% for e in range(100) %}{% endfor %}"
+        "{% for f in range(100) %}{% endfor %}"
+        "{% for g in range(100) %}{% endfor %}"
+        "{% for h in range(100) %}{% endfor %}"
+        "{% for i in range(100) %}{% endfor %}"
+        "{% for j in range(100) %}{% endfor %}"
+        "{% for k in range(100) %}{% endfor %}"
+    )
+    with pytest.raises(
+        ValueError,
+        match="'template' is not a valid template: Contains 11 for loops. Templates can contain no more than 10 for loops.",
+    ):
+        DemoAction(template=template)
+
+
+async def test_complex_valid_template():
+    template = """
+    {% if flow_run %}
+        {% set n = 10 %}
+        {% for i in range(n) %}
+            {% if i % 2 == 0 %}
+                {% for j in range(n * 2) %}
+                    {{ j }}
+                {% endfor %}
+            {% else %}
+                {% for k in range(n * 3) %}
+                    {{ k }}
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+    {% else %}
+        {% for l in range(100) %}
+            {{ l }}
+        {% endfor %}
+    {% endif %}
+    """
+
+    DemoAction(template=template)
+
+
+async def test_complex_invalid_template():
+    # Complex template with a 3 deep nested for loop
+    template = """
+    {% if flow_run %}
+        {% set n = 10 %}
+        {% for i in range(n) %}
+            {% if i % 2 == 0 %}
+                {% for j in range(n * 2) %}
+                    {% for k in range(n * 2) %}
+                        {{ k }}
+                    {% endfor %}
+                {% endfor %}
+            {% else %}
+                {% for l in range(n * 3) %}
+                    {{ l }}
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+    {% else %}
+        {% for m in range(100) %}
+            {{ m }}
+        {% endfor %}
+    {% endif %}
+    """
+
+    with pytest.raises(
+        ValueError,
+        match="'template' is not a valid template: Contains nested for loops at a depth of 3. Templates can nest for loops no more than 2 loops deep.",
+    ):
+        DemoAction(template=template)
+
+
+async def test_work_queue_health_late_run_count(
+    session: AsyncSession,
+    tell_me_about_the_culprit: Automation,
+    take_a_picture_work_queue: WorkQueue,
+    start_of_test: DateTime,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression test for https://github.com/PrefectHQ/nebula/issues/3635, where
+    the late run count was not rendering in our work queue health template
+    """
+    await work_queues.update_work_queue(
+        session,
+        take_a_picture_work_queue.id,
+        work_queue=WorkQueueUpdate(
+            last_polled="2023-01-02T00:00:00.000000+00:00",  # type: ignore[call-arg]
+        ),
+    )
+    await session.commit()
+
+    # Just do the lazy thing and mock out the function which counts flow runs so that
+    # it always returns 42 (this will be the late run count below)
+    monkeypatch.setattr(
+        "prefect.server.models.flow_runs.count_flow_runs",
+        AsyncMock(return_value=42),
+    )
+
+    # This reflects our default template as of 2023-05-12
+    template = """
+    Name: {{ work_queue.name }}
+    Last polled: {{ work_queue.last_polled.isoformat() }}
+    Late run count: {{ work_queue.late_runs_count }}
+    URL: {{ work_queue|ui_url }}
+    """
+
+    triggered_action = TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        id=uuid4(),
+        triggered=start_of_test + timedelta(seconds=1),
+        triggering_event=Event(
+            occurred=start_of_test,
+            event="prefect.work-queue.healthy",
+            resource={
+                "prefect.resource.id": (
+                    f"prefect.work-queue.{take_a_picture_work_queue.id}"
+                )
+            },
+            id=uuid4(),
+        ).receive(),
+        triggering_labels={},
+        action=actions.DoNothing(),  # this doesn't matter for the test
+        action_index=0,
+    )
+
+    action = DemoAction(template=template)
+    (rendered,) = await action.render(triggered_action)
+    assert (
+        rendered
+        == f"""
+    Name: camera-queue
+    Last polled: 2023-01-02T00:00:00+00:00
+    Late run count: 42
+    URL: http://localhost:3000/work-queues/work-queue/{take_a_picture_work_queue.id}
+    """
+    )
+
+
+async def test_related_resource_by_role_in_templates(
+    work_pool: ORMWorkPool,
+    work_queue: ORMWorkQueue,
+    tell_me_about_the_culprit: Automation,
+    start_of_test: DateTime,
+):
+    """
+    Regression test for https://github.com/PrefectHQ/nebula/issues/5215, where we want
+    to add {{ work_pool }} as a template shortcut.  This is an alternative and more
+    general approach that can operate on just the event.
+    """
+    template = """
+    Name: {{ event.resource.name }}
+    Pool: {{ event.resource_in_role['work-pool'].name }}
+    Pools: {% for resource in event.resources_in_role['work-pool'] %}{{ resource.name }},{% endfor %}
+    """
+
+    triggered_action = TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        id=uuid4(),
+        triggered=start_of_test + timedelta(seconds=1),
+        triggering_event=Event(
+            occurred=start_of_test,
+            event="prefect.work-queue.healthy",
+            resource={
+                "prefect.resource.id": f"prefect.work-queue.{uuid4()}",
+                "prefect.resource.name": "some-queue",
+            },
+            related=[
+                {
+                    "prefect.resource.id": f"prefect.work-pool.{uuid4()}",
+                    "prefect.resource.role": "work-pool",
+                    "prefect.resource.name": "this-pool",
+                },
+                {
+                    "prefect.resource.id": f"prefect.work-pool.{uuid4()}",
+                    "prefect.resource.role": "work-pool",
+                    "prefect.resource.name": "that-pool",
+                },
+            ],
+            id=uuid4(),
+        ).receive(),
+        triggering_labels={},
+        action=actions.DoNothing(),  # this doesn't matter for the test
+        action_index=0,
+    )
+
+    action = DemoAction(template=template)
+    (rendered,) = await action.render(triggered_action)
+    assert (
+        rendered
+        == """
+    Name: some-queue
+    Pool: this-pool
+    Pools: this-pool,that-pool,
+    """
+    )
+
+
+async def test_work_pool_is_available_to_templates(
+    work_pool: ORMWorkPool,
+    work_queue: ORMWorkQueue,
+    tell_me_about_the_culprit: Automation,
+    start_of_test: DateTime,
+):
+    """
+    Regression test for https://github.com/PrefectHQ/nebula/issues/5215, where we want
+    to add {{ work_pool }} as a template shortcut
+    """
+    template = """
+    Name: {{ work_queue.name }}
+    Pool: {{ work_pool.name }}
+    """
+
+    triggered_action = TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        id=uuid4(),
+        triggered=start_of_test + timedelta(seconds=1),
+        triggering_event=Event(
+            occurred=start_of_test,
+            event="prefect.work-queue.healthy",
+            resource={"prefect.resource.id": f"prefect.work-queue.{work_queue.id}"},
+            related=[
+                {
+                    "prefect.resource.id": f"prefect.work-pool.{work_pool.id}",
+                    "prefect.resource.role": "work-pool",
+                    "prefect.resource.name": "test-pool",
+                }
+            ],
+            id=uuid4(),
+        ).receive(),
+        triggering_labels={},
+        action=actions.DoNothing(),  # this doesn't matter for the test
+        action_index=0,
+    )
+
+    action = DemoAction(template=template)
+    (rendered,) = await action.render(triggered_action)
+    assert (
+        rendered
+        == f"""
+    Name: { work_queue.name }
+    Pool: { work_pool.name }
+    """
+    )
+
+
+async def test_concurrency_limit_is_available_in_templates(
+    concurrency_limit_v2: ORMConcurrencyLimitV2,
+    tell_me_about_the_culprit: Automation,
+    start_of_test: DateTime,
+):
+    """
+    Regression test for https://github.com/PrefectHQ/nebula/issues/5120, where we want
+    to add {{ concurrency_limit }} as a template shortcut (for v2 limits)
+    """
+    template = """
+    Name: {{ concurrency_limit.name }}
+    Limit: {{ concurrency_limit.limit }}
+    """
+
+    triggered_action = TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        id=uuid4(),
+        triggered=start_of_test + timedelta(seconds=1),
+        triggering_event=Event(
+            occurred=start_of_test,
+            event="prefect.concurrency-limit.acquired",
+            resource={
+                "prefect.resource.id": f"prefect.concurrency-limit.{concurrency_limit_v2.id}",
+            },
+            id=uuid4(),
+        ).receive(),
+        triggering_labels={},
+        action=actions.DoNothing(),  # this doesn't matter for the test
+        action_index=0,
+    )
+
+    action = DemoAction(template=template)
+    (rendered,) = await action.render(triggered_action)
+    assert (
+        rendered
+        == """
+    Name: my-limit
+    Limit: 42
+    """
+    )
+
+
+async def test_composite_firings_are_available_in_templates(
+    tell_me_about_the_culprit: Automation,
+    start_of_test: DateTime,
+):
+    template = """
+    Firings: {{ firings|length }}
+    Outer: {{ firings[0].trigger.id }}
+    Child 1: {{ firings[1].trigger.id }}
+    Child 2: {{ firings[2].trigger.id }}
+    """
+
+    first_child = tell_me_about_the_culprit.trigger.copy(update={"id": uuid4()})
+    second_child = tell_me_about_the_culprit.trigger.copy(update={"id": uuid4()})
+
+    triggered_action = TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        id=uuid4(),
+        triggered=start_of_test + timedelta(seconds=1),
+        # we're not worried about how these get populated or that they're duplicates,
+        # just that they're available
+        firing=Firing(
+            trigger=tell_me_about_the_culprit.trigger,
+            trigger_states={TriggerState.Triggered},
+            triggered=start_of_test + timedelta(seconds=1),
+            triggering_firings=[
+                Firing(
+                    trigger=first_child,
+                    trigger_states={TriggerState.Triggered},
+                    triggered=start_of_test + timedelta(seconds=1),
+                ),
+                Firing(
+                    trigger=second_child,
+                    trigger_states={TriggerState.Triggered},
+                    triggered=start_of_test + timedelta(seconds=1),
+                ),
+            ],
+        ),
+        # none of these matter for the test
+        triggering_event=None,
+        triggering_labels={},
+        action=actions.DoNothing(),
+        action_index=0,
+    )
+
+    action = DemoAction(template=template)
+    (rendered,) = await action.render(triggered_action)
+    assert (
+        rendered
+        == f"""
+    Firings: 3
+    Outer: {tell_me_about_the_culprit.trigger.id}
+    Child 1: {first_child.id}
+    Child 2: {second_child.id}
+    """
+    )
+
+
+async def test_composite_triggering_events_are_available_in_templates(
+    picture_taken: ReceivedEvent,
+    tell_me_about_the_culprit: Automation,
+    start_of_test: DateTime,
+):
+    template = """
+    Events: {{ events|length }}
+    Event 1: {{ events[0].id }}
+    Event 2: {{ events[1].id }}
+    """
+
+    first_event = picture_taken.copy(update={"id": uuid4()})
+    second_event = picture_taken.copy(update={"id": uuid4()})
+
+    triggered_action = TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        id=uuid4(),
+        triggered=start_of_test + timedelta(seconds=1),
+        # we're not worried about how these get populated or that they're duplicates,
+        # just that they're available
+        firing=Firing(
+            trigger=tell_me_about_the_culprit.trigger,
+            trigger_states={TriggerState.Triggered},
+            triggered=start_of_test + timedelta(seconds=1),
+            triggering_firings=[
+                Firing(
+                    trigger=tell_me_about_the_culprit.trigger,
+                    trigger_states={TriggerState.Triggered},
+                    triggered=start_of_test + timedelta(seconds=1),
+                    triggering_event=first_event,
+                ),
+                Firing(
+                    trigger=tell_me_about_the_culprit.trigger,
+                    trigger_states={TriggerState.Triggered},
+                    triggered=start_of_test + timedelta(seconds=1),
+                    triggering_event=second_event,
+                ),
+            ],
+        ),
+        # none of these matter for the test
+        triggering_event=None,
+        triggering_labels={},
+        action=actions.DoNothing(),
+        action_index=0,
+    )
+
+    action = DemoAction(template=template)
+    (rendered,) = await action.render(triggered_action)
+    assert (
+        rendered
+        == f"""
+    Events: 2
+    Event 1: {first_event.id}
+    Event 2: {second_event.id}
+    """
+    )

--- a/tests/events/server/actions/test_running_deployment.py
+++ b/tests/events/server/actions/test_running_deployment.py
@@ -1,0 +1,527 @@
+from datetime import timedelta
+from uuid import uuid4
+
+import pendulum
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from prefect._internal.pydantic import HAS_PYDANTIC_V2
+
+if HAS_PYDANTIC_V2:
+    from pydantic.v1 import ValidationError
+else:
+    from pydantic import ValidationError
+
+from prefect.server import schemas
+from prefect.server.events import actions
+from prefect.server.events.clients import AssertingEventsClient
+from prefect.server.events.schemas.automations import (
+    Automation,
+    EventTrigger,
+    Posture,
+    TriggeredAction,
+)
+from prefect.server.events.schemas.events import ReceivedEvent, RelatedResource
+from prefect.server.models import deployments, flow_runs, flows, variables, workers
+from prefect.server.schemas.actions import VariableCreate, WorkPoolCreate
+from prefect.server.schemas.core import CreatedBy, Deployment, Flow
+
+
+async def test_action_can_omit_parameters():
+    """Regression test for https://github.com/PrefectHQ/nebula/issues/2857, where
+    `parameters` are omitted by the UI"""
+
+    action = actions.RunDeployment.parse_obj(
+        {
+            "type": "run-deployment",
+            "source": "inferred",
+        }
+    )
+    assert action.parameters is None
+
+    action = actions.RunDeployment.parse_obj(
+        {
+            "type": "run-deployment",
+            "source": "inferred",
+            "parameters": None,
+        }
+    )
+    assert action.parameters is None
+
+    action = actions.RunDeployment.parse_obj(
+        {
+            "type": "run-deployment",
+            "source": "inferred",
+            "parameters": {},
+        }
+    )
+    assert action.parameters == {}
+
+
+@pytest.fixture
+async def take_a_picture(session: AsyncSession) -> Deployment:
+    work_pool = await workers.create_work_pool(
+        session=session,
+        work_pool=WorkPoolCreate.construct(
+            _fields_set=schemas.actions.WorkPoolCreate.__fields_set__,
+            name="wp-1",
+            type="None",
+            description="None",
+            base_job_template={},
+        ),
+    )
+
+    snap_a_pic = await flows.create_flow(
+        session=session,
+        flow=Flow(name="snap-a-pic"),
+    )
+    await session.flush()
+
+    deployment = await deployments.create_deployment(
+        session=session,
+        deployment=Deployment(
+            name="Take a picture on demand",
+            manifest_path="file.json",
+            flow_id=snap_a_pic.id,
+            is_schedule_active=True,
+            paused=False,
+            work_queue_id=work_pool.default_queue_id,
+        ),
+    )
+    assert deployment
+    await session.commit()
+
+    return Deployment.from_orm(deployment)
+
+
+@pytest.fixture
+def take_a_picture_of_the_culprit(take_a_picture: Deployment) -> Automation:
+    return Automation(
+        name="If my lilies get nibbled, take a picture of the culprit",
+        trigger=EventTrigger(
+            expect={"animal.ingested"},
+            match_related={
+                "prefect.resource.role": "meal",
+                "genus": "Hemerocallis",
+                "species": "fulva",
+            },
+            posture=Posture.Reactive,
+            threshold=0,
+            within=timedelta(seconds=30),
+        ),
+        actions=[
+            actions.RunDeployment(
+                deployment_id=take_a_picture.id,
+                parameters={
+                    "camera": "back-yard",
+                    "focal_ratio": 1 / 6,
+                    "flash": False,
+                    "meta": {
+                        "automation": "{{ automation.name }}",
+                    },
+                },
+                job_variables={"resolution": "high", "mode": "color"},
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def snap_that_naughty_woodchuck(
+    take_a_picture_of_the_culprit: Automation,
+    woodchonk_nibbled: ReceivedEvent,
+) -> TriggeredAction:
+    return TriggeredAction(
+        automation=take_a_picture_of_the_culprit,
+        triggered=pendulum.now("UTC"),
+        triggering_labels={},
+        triggering_event=woodchonk_nibbled,
+        action=take_a_picture_of_the_culprit.actions[0],
+    )
+
+
+async def test_running_a_deployment(
+    snap_that_naughty_woodchuck: TriggeredAction,
+    take_a_picture: Deployment,
+    session: AsyncSession,
+):
+    action = snap_that_naughty_woodchuck.action
+
+    assert isinstance(action, actions.RunDeployment)
+    assert action.source == "selected"
+    assert action.deployment_id
+
+    await action.act(snap_that_naughty_woodchuck)
+
+    (run,) = await flow_runs.read_flow_runs(session)
+
+    assert run.state
+    assert run.state.name == "Scheduled"
+    assert run.deployment_id == take_a_picture.id
+
+    assert run.parameters == {
+        "camera": "back-yard",
+        "focal_ratio": 1 / 6,
+        "flash": False,
+        "meta": {
+            "automation": snap_that_naughty_woodchuck.automation.name,
+        },
+    }
+
+    assert run.created_by == CreatedBy(
+        id=snap_that_naughty_woodchuck.automation.id,
+        type="AUTOMATION",
+        display_value=snap_that_naughty_woodchuck.automation.name,
+    )
+
+    # Since the feature flag is off, the run should omit job_variables entirely
+    assert run.job_variables is None
+
+
+async def test_running_a_deployment_with_overrides_enabled(
+    snap_that_naughty_woodchuck: TriggeredAction,
+    session: AsyncSession,
+    enable_infra_overrides,
+):
+    action = snap_that_naughty_woodchuck.action
+
+    assert isinstance(action, actions.RunDeployment)
+    assert action.job_variables is not None
+
+    await action.act(snap_that_naughty_woodchuck)
+
+    *_, run = await flow_runs.read_flow_runs(session)
+    assert run.job_variables == {"resolution": "high", "mode": "color"}
+
+
+async def test_running_a_deployment_unicode_automation_name(
+    snap_that_naughty_woodchuck: TriggeredAction,
+    take_a_picture: Deployment,
+    session: AsyncSession,
+):
+    action = snap_that_naughty_woodchuck.action
+
+    snap_that_naughty_woodchuck.automation.name = "📸 Gotcha!"
+
+    assert isinstance(action, actions.RunDeployment)
+    assert action.source == "selected"
+    assert action.deployment_id
+
+    await action.act(snap_that_naughty_woodchuck)
+
+    (run,) = await flow_runs.read_flow_runs(session)
+
+    assert run.state
+    assert run.state.name == "Scheduled"
+    assert run.deployment_id == take_a_picture.id
+
+    assert run.parameters == {
+        "camera": "back-yard",
+        "focal_ratio": 1 / 6,
+        "flash": False,
+        "meta": {
+            "automation": snap_that_naughty_woodchuck.automation.name,
+        },
+    }
+
+    assert run.created_by == CreatedBy(
+        id=snap_that_naughty_woodchuck.automation.id,
+        type="AUTOMATION",
+        display_value="📸 Gotcha!",
+    )
+
+
+@pytest.fixture
+async def my_workspace_variable(
+    session: AsyncSession,
+) -> None:
+    await variables.create_variable(
+        session, VariableCreate(name="my_variable", value="my variable value")
+    )
+
+
+async def test_running_a_deployment_supports_schemas_v2(
+    snap_that_naughty_woodchuck: TriggeredAction,
+    take_a_picture: Deployment,
+    session: AsyncSession,
+    my_workspace_variable: None,
+):
+    action = snap_that_naughty_woodchuck.action
+
+    snap_that_naughty_woodchuck.automation.name = "📸 Gotcha!"
+
+    assert isinstance(action, actions.RunDeployment)
+    assert action.source == "selected"
+    assert action.deployment_id
+
+    action.parameters = {
+        "camera": "back-yard",
+        "focal_ratio": {"__prefect_kind": "whatevs", "value": 1 / 6},
+        "flash": {"__prefect_kind": "json", "value": "false"},
+        "meta": {
+            "__prefect_kind": "json",
+            "value": '{"one_thing": "hello", "another_thing": 5}',
+        },
+        "somefin": {
+            "__prefect_kind": "workspace_variable",
+            "variable_name": "my_variable",
+        },
+    }
+
+    await action.act(snap_that_naughty_woodchuck)
+
+    (run,) = await flow_runs.read_flow_runs(session)
+
+    assert run.state
+    assert run.state.name == "Scheduled"
+    assert run.deployment_id == take_a_picture.id
+
+    assert run.parameters == {
+        "camera": "back-yard",
+        "focal_ratio": 1 / 6,
+        "flash": False,
+        "meta": {"one_thing": "hello", "another_thing": 5},
+        "somefin": "my variable value",
+    }
+
+    assert run.created_by == CreatedBy(
+        id=snap_that_naughty_woodchuck.automation.id,
+        type="AUTOMATION",
+        display_value="📸 Gotcha!",
+    )
+
+
+async def test_run_deployment_parameter_validation_handles_workspace_variables(
+    snap_that_naughty_woodchuck: TriggeredAction,
+    my_workspace_variable: None,
+):
+    # regression test for https://github.com/PrefectHQ/nebula/issues/7425
+    # previously this would raise a `ValidationError` due to the workspace variable not being found
+    # and failing to hydrate.
+
+    actions.RunDeployment(
+        deployment_id=uuid4(),
+        parameters={
+            "my_string": {
+                "__prefect_kind": "workspace_variable",
+                "variable_name": "my_variable",
+            }
+        },
+    )
+
+
+async def test_run_deployment_parameter_validation_handles_top_level_hydration_error(
+    snap_that_naughty_woodchuck: TriggeredAction,
+):
+    # regression test for: https://github.com/PrefectHQ/prefect/issues/12585
+    # Model instantiation would fail with `AttributeError` instead of correctly raising a ValidationError
+
+    with pytest.raises(ValidationError) as exc:
+        actions.RunDeployment(
+            deployment_id=uuid4(),
+            parameters={"__prefect_kind": "json", "value": "{notajsonstring}"},
+        )
+    assert (
+        "Invalid JSON: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)"
+        in str(exc.value)
+    )
+
+
+async def test_running_a_deployment_handles_top_level_hydration_error(
+    snap_that_naughty_woodchuck: TriggeredAction,
+):
+    # regression test for: https://github.com/PrefectHQ/prefect/issues/12585
+    # The action would fail due to an `AttributeError` instead of `InvalidJSON`
+
+    action = snap_that_naughty_woodchuck.action
+    assert isinstance(action, actions.RunDeployment)
+    action.parameters = {
+        "__prefect_kind": "json",
+        "value": "{notvalidjson}",
+    }
+
+    with pytest.raises(
+        actions.ActionFailed,
+    ) as exc:
+        await action.act(snap_that_naughty_woodchuck)
+    assert "Unable to create flow run from deployment: InvalidJSON()" in str(exc.value)
+
+
+async def test_running_an_inferred_deployment(
+    snap_that_naughty_woodchuck: TriggeredAction,
+    take_a_picture: Deployment,
+    session: AsyncSession,
+):
+    action = snap_that_naughty_woodchuck.action
+
+    assert isinstance(action, actions.RunDeployment)
+    action.source = "inferred"
+    action.deployment_id = None
+
+    # add a related resource for finding the associated deployment
+    assert snap_that_naughty_woodchuck.triggering_event
+    snap_that_naughty_woodchuck.triggering_event.related.append(
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.role": "deployment",
+                "prefect.resource.id": f"prefect.deployment.{take_a_picture.id}",
+            }
+        )
+    )
+
+    await action.act(snap_that_naughty_woodchuck)
+
+    (run,) = await flow_runs.read_flow_runs(session)
+
+    assert run.state
+    assert run.state.name == "Scheduled"
+    assert run.deployment_id == take_a_picture.id
+
+    assert run.parameters == {
+        "camera": "back-yard",
+        "focal_ratio": 1 / 6,
+        "flash": False,
+        "meta": {
+            "automation": snap_that_naughty_woodchuck.automation.name,
+        },
+    }
+
+    assert run.created_by == CreatedBy(
+        id=snap_that_naughty_woodchuck.automation.id,
+        type="AUTOMATION",
+        display_value=snap_that_naughty_woodchuck.automation.name,
+    )
+
+
+async def test_orchestration_errors_are_reported_as_events(
+    snap_that_naughty_woodchuck: TriggeredAction,
+):
+    action = snap_that_naughty_woodchuck.action
+    assert isinstance(action, actions.RunDeployment)
+
+    action.deployment_id = uuid4()  # this doesn't exist
+
+    with pytest.raises(
+        actions.ActionFailed, match="Unexpected status from run-deployment action: 404"
+    ):
+        await action.act(snap_that_naughty_woodchuck)
+
+
+async def test_validates_templates_in_parameters(
+    take_a_picture: Deployment,
+):
+    expected_error = "bad_template: Invalid jinja: unexpected '}'"
+    with pytest.raises(ValueError, match=expected_error):
+        actions.RunDeployment(
+            deployment_id=take_a_picture.id,
+            parameters={
+                "bad_template": "This is an {{ invalid } template.",
+            },
+        )
+
+
+async def test_success_event(
+    snap_that_naughty_woodchuck: TriggeredAction,
+    take_a_picture: Deployment,
+    session: AsyncSession,
+):
+    action = snap_that_naughty_woodchuck.action
+
+    await action.act(snap_that_naughty_woodchuck)
+    await action.succeed(snap_that_naughty_woodchuck)
+
+    runs = await flow_runs.read_flow_runs(session)
+    (new_flow_run,) = runs
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.related == [
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": f"prefect.deployment.{take_a_picture.id}",
+                "prefect.resource.role": "target",
+            }
+        ),
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": f"prefect.flow-run.{new_flow_run.id}",
+                "prefect.resource.role": "flow-run",
+                "prefect.resource.name": f"{new_flow_run.name}",
+            }
+        ),
+    ]
+    assert event.payload == {
+        "action_index": 0,
+        "action_type": "run-deployment",
+        "invocation": str(snap_that_naughty_woodchuck.id),
+        "status_code": 201,
+    }
+
+
+async def test_running_a_deployment_action_succeeds_paramaters_too_large(
+    snap_that_naughty_woodchuck: TriggeredAction,
+    take_a_picture: Deployment,
+    session: AsyncSession,
+):
+    """In a significant difference from Prefect Cloud, we will not restrict the size of
+    parameters in the open-source Prefect API"""
+    action = snap_that_naughty_woodchuck.action
+
+    assert isinstance(action, actions.RunDeployment)
+    assert action.source == "selected"
+    assert action.deployment_id
+    assert action.parameters
+
+    action.parameters["camera"] = "testing" * 100000
+
+    await action.act(snap_that_naughty_woodchuck)
+
+
+async def test_deployment_action_accepts_job_variables():
+    action = actions.RunDeployment.parse_obj(
+        {
+            "type": "run-deployment",
+            "source": "inferred",
+        }
+    )
+    assert action.job_variables is None
+
+    action = actions.RunDeployment.parse_obj(
+        {
+            "type": "run-deployment",
+            "source": "inferred",
+            "job_variables": None,
+        }
+    )
+    assert action.job_variables is None
+
+    action = actions.RunDeployment.parse_obj(
+        {
+            "type": "run-deployment",
+            "source": "inferred",
+            "job_variables": {},
+        }
+    )
+    assert action.job_variables == {}
+
+    job_vars = {"foo": "bar"}
+    action = actions.RunDeployment.parse_obj(
+        {
+            "type": "run-deployment",
+            "source": "inferred",
+            "job_variables": job_vars,
+        }
+    )
+    assert action.job_variables == job_vars
+
+    job_vars = {"nested": {"vars": "ok"}}
+    action = actions.RunDeployment.parse_obj(
+        {
+            "type": "run-deployment",
+            "source": "inferred",
+            "job_variables": job_vars,
+        }
+    )
+    assert action.job_variables == job_vars

--- a/tests/events/server/actions/test_running_deployment.py
+++ b/tests/events/server/actions/test_running_deployment.py
@@ -238,6 +238,7 @@ async def my_workspace_variable(
     await variables.create_variable(
         session, VariableCreate(name="my_variable", value="my variable value")
     )
+    await session.commit()
 
 
 async def test_running_a_deployment_supports_schemas_v2(

--- a/tests/events/server/conftest.py
+++ b/tests/events/server/conftest.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
-from typing import Any, Dict, List, Sequence, Tuple
-from unittest import mock
+from typing import Any, Dict, Generator, List, Sequence, Tuple
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pendulum
@@ -11,6 +11,10 @@ from pendulum.datetime import DateTime
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES,
+    temporary_settings,
+)
 
 if HAS_PYDANTIC_V2:
     import pydantic.v1 as pydantic
@@ -30,8 +34,8 @@ from prefect.server.utilities.messaging import Message
 
 
 @pytest.fixture
-def act(monkeypatch: pytest.MonkeyPatch) -> mock.AsyncMock:
-    mock_act = mock.AsyncMock()
+def act(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    mock_act = AsyncMock()
     monkeypatch.setattr("prefect.server.events.triggers.act", mock_act)
     return mock_act
 
@@ -408,11 +412,19 @@ async def some_workspace_automations(
 
 
 @pytest.fixture
+def enable_infra_overrides() -> Generator[None, None, None]:
+    with temporary_settings(
+        updates={PREFECT_EXPERIMENTAL_ENABLE_FLOW_RUN_INFRA_OVERRIDES: True}
+    ):
+        yield
+
+
+@pytest.fixture
 def publish_mocks(
     monkeypatch: pytest.MonkeyPatch,
-) -> Tuple[mock.MagicMock, mock.AsyncMock]:
-    mock_create_publisher = mock.MagicMock(spec=messaging.create_event_publisher)
-    mock_publish = mock.AsyncMock()
+) -> Tuple[MagicMock, AsyncMock]:
+    mock_create_publisher = MagicMock(spec=messaging.create_event_publisher)
+    mock_publish = AsyncMock()
     mock_create_publisher.return_value.__aenter__.return_value.publish_data = (
         mock_publish
     )
@@ -425,14 +437,14 @@ def publish_mocks(
 
 
 @pytest.fixture
-def publish(publish_mocks: Tuple[mock.MagicMock, mock.AsyncMock]) -> mock.AsyncMock:
+def publish(publish_mocks: Tuple[MagicMock, AsyncMock]) -> AsyncMock:
     return publish_mocks[1]
 
 
 @pytest.fixture
 def create_publisher(
-    publish_mocks: Tuple[mock.MagicMock, mock.AsyncMock],
-) -> mock.MagicMock:
+    publish_mocks: Tuple[MagicMock, AsyncMock],
+) -> MagicMock:
     return publish_mocks[0]
 
 

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -23,11 +23,13 @@ from prefect.server.database.dependencies import (
     provide_database_interface,
 )
 from prefect.server.models.block_registration import run_block_auto_registration
+from prefect.server.models.concurrency_limits_v2 import create_concurrency_limit
 from prefect.server.orchestration.rules import (
     FlowOrchestrationContext,
     TaskOrchestrationContext,
 )
 from prefect.server.schemas import states
+from prefect.server.schemas.core import ConcurrencyLimitV2
 from prefect.utilities.callables import parameter_schema
 from prefect.workers.process import ProcessWorker
 
@@ -1198,3 +1200,18 @@ async def worker_deployment_wq_2(
     )
     await session.commit()
     return deployment
+
+
+@pytest.fixture
+async def concurrency_limit_v2(session: AsyncSession) -> ConcurrencyLimitV2:
+    concurrency_limit = await create_concurrency_limit(
+        session=session,
+        concurrency_limit=ConcurrencyLimitV2(
+            name="my-limit",
+            limit=42,
+        ),
+    )
+
+    await session.commit()
+
+    return ConcurrencyLimitV2.from_orm(concurrency_limit)

--- a/tests/fixtures/events.py
+++ b/tests/fixtures/events.py
@@ -1,0 +1,23 @@
+import pytest
+
+from prefect.server.events.clients import AssertingEventsClient
+
+
+@pytest.fixture
+def clean_asserting_events_client():
+    AssertingEventsClient.last = None
+    AssertingEventsClient.all.clear()
+
+
+@pytest.fixture(autouse=True)
+def workspace_events_client(
+    clean_asserting_events_client: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "prefect.server.events.clients.PrefectServerEventsClient",
+        AssertingEventsClient,
+    )
+    monkeypatch.setattr(
+        "prefect.server.events.actions.PrefectServerEventsClient",
+        AssertingEventsClient,
+    )

--- a/tests/server/utilities/test_database.py
+++ b/tests/server/utilities/test_database.py
@@ -1,7 +1,9 @@
 import datetime
 import enum
 import math
+import sqlite3
 from typing import List
+from unittest import mock
 
 import pendulum
 
@@ -511,18 +513,18 @@ class TestDateFunctions:
         assert result.scalar() == datetime.timedelta(days=3, minutes=48)
 
 
-async def test_error_thrown_if_sqlite_version_is_below_minimum(monkeypatch):
-    monkeypatch.setattr("sqlite3.sqlite_version_info", (3, 23, 9))
-    monkeypatch.setattr("sqlite3.sqlite_version", "3.23.9")
-    with pytest.raises(
-        RuntimeError,
-        match="Prefect requires sqlite >= 3.24.0 but we found version 3.23.9",
-    ):
-        db = PrefectDBInterface(
-            database_config=AioSqliteConfiguration(
-                connection_url="sqlite+aiosqlite:///file::memory",
-            ),
-            query_components=AioSqliteQueryComponents(),
-            orm=AioSqliteORMConfiguration(),
-        )
-        await db.engine()
+async def test_error_thrown_if_sqlite_version_is_below_minimum():
+    with mock.patch.object(sqlite3, "sqlite_version_info", (3, 23, 9)):
+        with mock.patch.object(sqlite3, "sqlite_version", "3.23.9"):
+            with pytest.raises(
+                RuntimeError,
+                match="Prefect requires sqlite >= 3.24.0 but we found version 3.23.9",
+            ):
+                db = PrefectDBInterface(
+                    database_config=AioSqliteConfiguration(
+                        connection_url="sqlite+aiosqlite:///file::memory",
+                    ),
+                    query_components=AioSqliteQueryComponents(),
+                    orm=AioSqliteORMConfiguration(),
+                )
+                await db.engine()


### PR DESCRIPTION
This brings the `run-deployment` action to parity with Prefect Cloud, which
required bringing quite a few additional things along.

First, we needed to bring the Jinja2 base `Action` and refresh the open-source
version of schema hydration to include Jinja2 support.  This will aid with
several upcoming `Action`s as well.

Second, we needed the support for `created_by`, which was stubbed in for OSS,
but had a fuller implementation in Prefect Cloud.  I've ported the automations
part of that to OSS.

I'm also removing a long-standing TODO to allow some configuration of whether
our custom client will always raise on HTTP errors or not.  The actions template
system expected to get raw responses (and test for 404s, etc).  Making this an
argument to the Prefect HTTP client allows us to change this behavior.
