### PR TITLE
Fix writing events for SQLite + SQLAlchemy<2

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -405,6 +405,7 @@ jobs:
       matrix:
         database:
           - "postgres:14"
+          - "sqlite"
         python-version:
           - "3.8"
           - "3.12"

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -400,7 +400,7 @@ jobs:
   run-sqlalchemy-v1-tests:
     runs-on:
       group: oss-larger-runners
-    name: sqlalchemy v1, python:${{ matrix.python-version }}
+    name: sqlalchemy v1, ${{ matrix.database }} python:${{ matrix.python-version }}
     strategy:
       matrix:
         database:

--- a/src/prefect/server/utilities/database.py
+++ b/src/prefect/server/utilities/database.py
@@ -622,7 +622,7 @@ def get_dialect(
         from prefect.server.utilities.database import get_dialect
 
         dialect = get_dialect(PREFECT_API_DATABASE_CONNECTION_URL.value())
-        if dialect == "sqlite":
+        if dialect.name == "sqlite":
             print("Using SQLite!")
         else:
             print("Using Postgres!")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Updates `write_events` to check for existing events before inserting when using a SQLite database because SQLite doesn't support the `RETURNING` clause when used with SQLAlchemy 1.x.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
