### PR TITLE
replicate `custom_pydantic_encoder`

### DIFF
--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -18,14 +18,13 @@ from prefect._internal.pydantic import HAS_PYDANTIC_V2
 if HAS_PYDANTIC_V2:
     import pydantic.v1 as pydantic
     from pydantic.v1 import BaseModel, Field, SecretField
-    from pydantic.v1.json import custom_pydantic_encoder
 else:
     import pydantic
     from pydantic import BaseModel, Field, SecretField
-    from pydantic.json import custom_pydantic_encoder
 
 from prefect._internal.schemas.fields import DateTimeTZ
 from prefect._internal.schemas.serializers import orjson_dumps_extra_compatible
+from prefect.utilities.pydantic import custom_pydantic_encoder
 
 T = TypeVar("T")
 

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -14,14 +14,13 @@ from prefect._internal.pydantic import HAS_PYDANTIC_V2
 if HAS_PYDANTIC_V2:
     import pydantic.v1 as pydantic
     from pydantic.v1 import BaseModel, Field, SecretField
-    from pydantic.v1.json import custom_pydantic_encoder
 else:
     import pydantic
     from pydantic import BaseModel, Field, SecretField
-    from pydantic.json import custom_pydantic_encoder
 
 from prefect.server.utilities.schemas.fields import DateTimeTZ
 from prefect.server.utilities.schemas.serializers import orjson_dumps_extra_compatible
+from prefect.utilities.pydantic import custom_pydantic_encoder
 
 T = TypeVar("T")
 B = TypeVar("B", bound=BaseModel)

--- a/tests/utilities/test_pydantic.py
+++ b/tests/utilities/test_pydantic.py
@@ -25,15 +25,6 @@ from prefect.utilities.pydantic import (
 )
 
 
-class BaseClass:
-    def __init__(self, value):
-        self.value = value
-
-
-class DerivedClass(BaseClass):
-    pass
-
-
 class SimplePydantic(pydantic.BaseModel):
     x: int
     y: int


### PR DESCRIPTION
removes a dependency on `pydantic.v1.custom_pydantic_encoder` by implementing it using `to_jsonable_python` from `pydantic_core`

the new signature / behavior should be exactly the same as the old