### PR TITLE
Implements the `send-notification` action

### DIFF
--- a/src/prefect/blocks/abstract.py
+++ b/src/prefect/blocks/abstract.py
@@ -48,6 +48,13 @@ class CredentialsBlock(Block, ABC):
         """
 
 
+class NotificationError(Exception):
+    """Raised if a notification block fails to send a notification."""
+
+    def __init__(self, log: str) -> None:
+        self.log = log
+
+
 class NotificationBlock(Block, ABC):
     """
     Block that represents a resource in an external system that is able to send notifications.
@@ -55,6 +62,8 @@ class NotificationBlock(Block, ABC):
 
     _block_schema_capabilities = ["notify"]
     _events_excluded_methods = Block._events_excluded_methods + ["notify"]
+
+    raise_on_failure: bool = False
 
     @property
     def logger(self) -> Logger:

--- a/src/prefect/blocks/abstract.py
+++ b/src/prefect/blocks/abstract.py
@@ -1,7 +1,19 @@
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from logging import Logger
 from pathlib import Path
-from typing import Any, BinaryIO, Dict, Generic, List, Optional, Tuple, TypeVar, Union
+from typing import (
+    Any,
+    BinaryIO,
+    Dict,
+    Generator,
+    Generic,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 from typing_extensions import Self
 
@@ -63,8 +75,6 @@ class NotificationBlock(Block, ABC):
     _block_schema_capabilities = ["notify"]
     _events_excluded_methods = Block._events_excluded_methods + ["notify"]
 
-    raise_on_failure: bool = False
-
     @property
     def logger(self) -> Logger:
         """
@@ -90,6 +100,20 @@ class NotificationBlock(Block, ABC):
             body: The body of the notification.
             subject: The subject of the notification.
         """
+
+    _raise_on_failure: bool = False
+
+    @contextmanager
+    def raise_on_failure(self) -> Generator[None, None, None]:
+        """
+        Context manager that, while active, causes the block to raise errors if it
+        encounters a failure sending notifications.
+        """
+        self._raise_on_failure = True
+        try:
+            yield
+        finally:
+            self._raise_on_failure = False
 
 
 class JobRun(ABC, Generic[T]):  # not a block

--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -3,7 +3,7 @@ from abc import ABC
 from typing import Dict, List, Optional
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
-from prefect.logging.loggers import LogEavesdropper
+from prefect.logging import LogEavesdropper
 
 if HAS_PYDANTIC_V2:
     from pydantic.v1 import AnyHttpUrl, Field, SecretStr

--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -72,7 +72,7 @@ class AbstractAppriseNotificationBlock(NotificationBlock, ABC):
             result = await self._apprise_client.async_notify(
                 body=body, title=subject, notify_type=self.notify_type
             )
-        if not result and self.raise_on_failure:
+        if not result and self._raise_on_failure:
             raise NotificationError(log=eavesdropper.text())
 
 

--- a/src/prefect/logging/__init__.py
+++ b/src/prefect/logging/__init__.py
@@ -1,3 +1,3 @@
-from .loggers import disable_run_logger, get_logger, get_run_logger
+from .loggers import disable_run_logger, get_logger, get_run_logger, LogEavesdropper
 
-__all__ = ["get_logger", "get_run_logger"]
+__all__ = ["get_logger", "get_run_logger", "LogEavesdropper"]

--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -5,7 +5,10 @@ import warnings
 from builtins import print
 from contextlib import contextmanager
 from functools import lru_cache
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from logging import LogRecord
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
+
+from typing_extensions import Self
 
 import prefect
 from prefect.exceptions import MissingContextError
@@ -295,3 +298,36 @@ def patch_print():
         yield
     finally:
         builtins.print = original
+
+
+class LogEavesdropper(logging.Handler):
+    """A context manager that collects logs for the duration of the context"""
+
+    _target_logger: logging.Logger
+    _lines: List[str]
+
+    def __init__(self, eavesdrop_on: str, level: int = logging.NOTSET):
+        super().__init__(level=level)
+        self.eavesdrop_on = eavesdrop_on
+        self._target_logger = None
+
+        # It's important that we use a very minimalistic formatter for use cases where
+        # we may present these logs back to the user.  We shouldn't leak filenames,
+        # versions, or other environmental information.
+        self.formatter = logging.Formatter("[%(levelname)s]: %(message)s")
+
+    def __enter__(self) -> Self:
+        self._target_logger = logging.getLogger(self.eavesdrop_on)
+        self._target_logger.addHandler(self)
+        self._lines = []
+        return self
+
+    def __exit__(self, *_):
+        if self._target_logger:
+            self._target_logger.removeHandler(self)
+
+    def emit(self, record: LogRecord) -> None:
+        self._lines.append(self.format(record))
+
+    def text(self) -> str:
+        return "\n".join(self._lines)

--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -301,12 +301,34 @@ def patch_print():
 
 
 class LogEavesdropper(logging.Handler):
-    """A context manager that collects logs for the duration of the context"""
+    """A context manager that collects logs for the duration of the context
+
+    Example:
+
+        ```python
+        import logging
+        from prefect.logging import LogEavesdropper
+
+        with LogEavesdropper("my_logger") as eavesdropper:
+            logging.getLogger("my_logger").info("Hello, world!")
+            logging.getLogger("my_logger.child_module").info("Another one!")
+
+        print(eavesdropper.text())
+
+        # Outputs: "Hello, world!\nAnother one!"
+    """
 
     _target_logger: logging.Logger
     _lines: List[str]
 
     def __init__(self, eavesdrop_on: str, level: int = logging.NOTSET):
+        """
+        Args:
+            eavesdrop_on (str): the name of the logger to eavesdrop on
+            level (int): the minimum log level to eavesdrop on; if omitted, all levels
+                are captured
+        """
+
         super().__init__(level=level)
         self.eavesdrop_on = eavesdrop_on
         self._target_logger = None
@@ -318,6 +340,8 @@ class LogEavesdropper(logging.Handler):
 
     def __enter__(self) -> Self:
         self._target_logger = logging.getLogger(self.eavesdrop_on)
+        self._original_level = self._target_logger.level
+        self._target_logger.level = self.level
         self._target_logger.addHandler(self)
         self._lines = []
         return self
@@ -325,9 +349,12 @@ class LogEavesdropper(logging.Handler):
     def __exit__(self, *_):
         if self._target_logger:
             self._target_logger.removeHandler(self)
+            self._target_logger.level = self._original_level
 
     def emit(self, record: LogRecord) -> None:
+        """The logging.Handler implementation, not intended to be called directly."""
         self._lines.append(self.format(record))
 
     def text(self) -> str:
+        """Return the collected logs as a single newline-delimited string"""
         return "\n".join(self._lines)

--- a/src/prefect/server/events/actions.py
+++ b/src/prefect/server/events/actions.py
@@ -1070,12 +1070,12 @@ class SendNotification(JinjaTemplateAction):
 
         subject, body = await self.render(triggered_action)
 
-        block.raise_on_failure = True
-        try:
-            await block.notify(subject=subject, body=body)
-        except NotificationError as e:
-            self._result_details["notification_log"] = e.log
-            raise ActionFailed("Notification failed")
+        with block.raise_on_failure():
+            try:
+                await block.notify(subject=subject, body=body)
+            except NotificationError as e:
+                self._result_details["notification_log"] = e.log
+                raise ActionFailed("Notification failed")
 
     async def render(self, triggered_action: "TriggeredAction") -> List[str]:
         return await self._render([self.subject, self.body], triggered_action)

--- a/src/prefect/server/events/actions.py
+++ b/src/prefect/server/events/actions.py
@@ -21,6 +21,7 @@ from typing import (
     Tuple,
     Type,
     Union,
+    cast,
 )
 from uuid import UUID, uuid4
 
@@ -31,6 +32,7 @@ from httpx import Response
 from typing_extensions import TypeAlias
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
+from prefect.blocks.core import Block
 
 if HAS_PYDANTIC_V2:
     from pydantic.v1 import Field, PrivateAttr, root_validator, validator
@@ -39,6 +41,7 @@ else:
     from pydantic import Field, PrivateAttr, root_validator, validator
     from pydantic.fields import ModelField
 
+from prefect.blocks.abstract import NotificationBlock, NotificationError
 from prefect.logging import get_logger
 from prefect.server.events.clients import (
     PrefectServerEventsAPIClient,
@@ -49,6 +52,7 @@ from prefect.server.events.schemas.events import Event, RelatedResource, Resourc
 from prefect.server.events.schemas.labelling import LabelDiver
 from prefect.server.schemas.actions import DeploymentFlowRunCreate, StateCreate
 from prefect.server.schemas.core import (
+    BlockDocument,
     ConcurrencyLimitV2,
     Flow,
     TaskRun,
@@ -1026,8 +1030,52 @@ class SendNotification(JinjaTemplateAction):
     def is_valid_template(cls, value: str, field: ModelField) -> str:
         return cls.validate_template(value, field.name)
 
+    async def _get_notification_block(
+        self, triggered_action: "TriggeredAction"
+    ) -> NotificationBlock:
+        async with await self.orchestration_client(triggered_action) as orion:
+            response = await orion.read_block_document_raw(self.block_document_id)
+            if response.status_code >= 300:
+                raise ActionFailed(self.reason_from_response(response))
+
+            try:
+                block_document = BlockDocument.parse_obj(response.json())
+                block = Block._from_block_document(block_document)
+            except Exception as e:
+                raise ActionFailed(f"The notification block was invalid: {e!r}")
+
+            if "notify" not in block.get_block_capabilities():
+                raise ActionFailed("The referenced block was not a notification block")
+
+            self._resulting_related_resources += [
+                RelatedResource.parse_obj(
+                    {
+                        "prefect.resource.id": f"prefect.block-document.{self.block_document_id}",
+                        "prefect.resource.role": "block",
+                        "prefect.resource.name": block_document.name,
+                    }
+                ),
+                RelatedResource.parse_obj(
+                    {
+                        "prefect.resource.id": f"prefect.block-type.{block.get_block_type_slug()}",
+                        "prefect.resource.role": "block-type",
+                    }
+                ),
+            ]
+
+            return cast(NotificationBlock, block)
+
     async def act(self, triggered_action: "TriggeredAction") -> None:
-        raise NotImplementedError("TODO: coming in a future automations update")
+        block = await self._get_notification_block(triggered_action=triggered_action)
+
+        subject, body = await self.render(triggered_action)
+
+        block.raise_on_failure = True
+        try:
+            await block.notify(subject=subject, body=body)
+        except NotificationError as e:
+            self._result_details["notification_log"] = e.log
+            raise ActionFailed("Notification failed")
 
     async def render(self, triggered_action: "TriggeredAction") -> List[str]:
         return await self._render([self.subject, self.body], triggered_action)

--- a/tests/events/server/actions/test_sending_notification.py
+++ b/tests/events/server/actions/test_sending_notification.py
@@ -1,0 +1,257 @@
+import re
+from datetime import timedelta
+from typing import Type
+from unittest import mock
+from uuid import UUID, uuid4
+
+import pendulum
+import pytest
+
+from prefect.blocks.abstract import NotificationBlock
+from prefect.blocks.core import Block
+from prefect.blocks.notifications import NotificationError
+from prefect.server.events import actions
+from prefect.server.events.clients import AssertingEventsClient
+from prefect.server.events.schemas.automations import (
+    Automation,
+    EventTrigger,
+    Posture,
+    TriggeredAction,
+)
+from prefect.server.events.schemas.events import ReceivedEvent, RelatedResource
+
+
+@pytest.fixture
+def TestNotificationBlock(
+    DebugPrintNotification: Type[NotificationBlock],
+) -> Type[NotificationBlock]:
+    return DebugPrintNotification
+
+
+@pytest.fixture
+async def email_me_block_id(notifier_block: NotificationBlock) -> UUID:
+    return notifier_block._block_document_id
+
+
+@pytest.fixture
+async def tell_me_about_the_culprit(
+    email_me_block_id: UUID,
+) -> Automation:
+    return Automation(
+        name="If my lilies get nibbled, tell me about it",
+        description="Send an email notification whenever the lillies are nibbled",
+        enabled=True,
+        trigger=EventTrigger(
+            expect={"animal.ingested"},
+            match_related={
+                "prefect.resource.role": "meal",
+                "genus": "Hemerocallis",
+                "species": "fulva",
+            },
+            posture=Posture.Reactive,
+            threshold=0,
+            within=timedelta(seconds=30),
+        ),
+        actions=[
+            actions.SendNotification(
+                block_document_id=email_me_block_id,
+                body="{{ automation.name }}",
+            ),
+            actions.SendNotification(
+                block_document_id=uuid4(),
+                body="Invalid block id",
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def notify_me(
+    tell_me_about_the_culprit: Automation,
+    woodchonk_nibbled: ReceivedEvent,
+) -> TriggeredAction:
+    return TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        triggered=pendulum.now("UTC"),
+        triggering_labels={"i.am.so": "triggered"},
+        triggering_event=woodchonk_nibbled,
+        action=tell_me_about_the_culprit.actions[0],
+    )
+
+
+@pytest.fixture
+def invalid_block_id(
+    tell_me_about_the_culprit: Automation,
+    woodchonk_nibbled: ReceivedEvent,
+) -> TriggeredAction:
+    return TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        triggered=pendulum.now("UTC"),
+        triggering_labels={},
+        triggering_event=woodchonk_nibbled,
+        action=tell_me_about_the_culprit.actions[1],
+    )
+
+
+async def test_sending_notification(
+    TestNotificationBlock: Type[NotificationBlock], notify_me: TriggeredAction
+):
+    action = notify_me.action
+
+    with mock.patch.object(TestNotificationBlock, "notify") as notify:
+        assert isinstance(action, actions.SendNotification)
+        await action.act(notify_me)
+
+    notify.assert_called_once_with(
+        body="If my lilies get nibbled, tell me about it",
+        subject="Prefect automated notification",
+    )
+
+
+async def test_invalid_block_id(invalid_block_id: TriggeredAction):
+    action = invalid_block_id.action
+    assert isinstance(action, actions.SendNotification)
+    with pytest.raises(actions.ActionFailed):
+        await action.act(invalid_block_id)
+
+
+async def test_validation_error_loading_block(notify_me: TriggeredAction):
+    """If there is a ValidationError loading the NotificationBlock, handle it and
+    fail the action.  This is a regression test for an alert we got about a Slack
+    webhook missing its URL in production."""
+    action = notify_me.action
+    assert isinstance(action, actions.SendNotification)
+    error = ValueError("woops")
+    expected_reason = re.escape(
+        "The notification block was invalid: ValueError('woops')"
+    )
+    with mock.patch.object(Block, "_from_block_document", side_effect=error):
+        with pytest.raises(actions.ActionFailed, match=expected_reason):
+            await action.act(notify_me)
+
+
+async def test_action_validates_body_as_template(email_me_block_id: UUID):
+    with pytest.raises(
+        ValueError, match="'body' is not a valid template: unexpected '}'"
+    ):
+        actions.SendNotification(
+            block_document_id=email_me_block_id,
+            subject="This is fine",
+            body="This is an {{ invalid } template.",
+        )
+
+
+async def test_action_validates_subject_as_template(email_me_block_id: UUID):
+    with pytest.raises(
+        ValueError, match="'subject' is not a valid template: unexpected '}'"
+    ):
+        actions.SendNotification(
+            block_document_id=email_me_block_id,
+            subject="This is an {{ invalid } template.",
+            body="This is fine",
+        )
+
+
+async def test_subject_is_rendered(notify_me: TriggeredAction):
+    assert notify_me.triggering_event
+    action = actions.SendNotification(
+        block_document_id=uuid4(),
+        subject="{{ event.id }}",
+        body="",
+    )
+    subject, _ = await action.render(notify_me)
+    assert subject == str(notify_me.triggering_event.id)
+
+
+async def test_body_is_rendered(notify_me: TriggeredAction):
+    assert notify_me.triggering_event
+    action = actions.SendNotification(
+        block_document_id=uuid4(),
+        subject="",
+        body="{{ event.id }}",
+    )
+    _, body = await action.render(notify_me)
+    assert body == str(notify_me.triggering_event.id)
+
+
+async def test_success_event(
+    TestNotificationBlock: Type[NotificationBlock],
+    notify_me: TriggeredAction,
+    email_me_block_id: UUID,
+):
+    action = notify_me.action
+
+    with mock.patch.object(TestNotificationBlock, "notify"):
+        await action.act(notify_me)
+
+    await action.succeed(notify_me)
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.related == [
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": f"prefect.block-document.{email_me_block_id}",
+                "prefect.resource.role": "block",
+                "prefect.resource.name": "debug-print-notification",
+            }
+        ),
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": "prefect.block-type.debug-print-notification",
+                "prefect.resource.role": "block-type",
+            }
+        ),
+    ]
+    assert event.payload == {
+        "action_index": 0,
+        "action_type": "send-notification",
+        "invocation": str(notify_me.id),
+    }
+
+
+async def test_captures_notification_failures(
+    TestNotificationBlock: Type[NotificationBlock],
+    notify_me: TriggeredAction,
+    email_me_block_id: UUID,
+):
+    action = notify_me.action
+
+    with mock.patch.object(
+        TestNotificationBlock,
+        "notify",
+        side_effect=NotificationError(log="bad\nthings\nhappened\n"),
+    ):
+        with pytest.raises(actions.ActionFailed) as captured:
+            await action.act(notify_me)
+
+    await action.fail(notify_me, captured.value.reason)
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    assert event.event == "prefect-cloud.automation.action.failed"
+    assert event.related == [
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": f"prefect.block-document.{email_me_block_id}",
+                "prefect.resource.role": "block",
+                "prefect.resource.name": "debug-print-notification",
+            }
+        ),
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": "prefect.block-type.debug-print-notification",
+                "prefect.resource.role": "block-type",
+            }
+        ),
+    ]
+    assert event.payload == {
+        "action_index": 0,
+        "action_type": "send-notification",
+        "invocation": str(notify_me.id),
+        "reason": "Notification failed",
+        "notification_log": "bad\nthings\nhappened\n",
+    }

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -4,7 +4,7 @@ import gc
 import uuid
 import warnings
 from contextlib import asynccontextmanager
-from typing import AsyncContextManager, AsyncGenerator, Callable
+from typing import AsyncContextManager, AsyncGenerator, Callable, Type
 
 import aiosqlite
 import asyncpg
@@ -1093,10 +1093,7 @@ def initialize_orchestration(flow):
 
 
 @pytest.fixture
-async def notifier_block(prefect_client):
-    # Ignore warnings from block reuse in fixture
-    warnings.filterwarnings("ignore", category=UserWarning)
-
+def DebugPrintNotification() -> Type[NotificationBlock]:
     class DebugPrintNotification(NotificationBlock):
         """
         Notification block that prints a message, useful for debugging.
@@ -1108,6 +1105,14 @@ async def notifier_block(prefect_client):
 
         async def notify(self, subject: str, body: str):
             print(body)
+
+    return DebugPrintNotification
+
+
+@pytest.fixture
+async def notifier_block(DebugPrintNotification: Type[NotificationBlock]):
+    # Ignore warnings from block reuse in fixture
+    warnings.filterwarnings("ignore", category=UserWarning)
 
     block = DebugPrintNotification()
     await block.save("debug-print-notification")


### PR DESCRIPTION
Building on the `JinjaTemplatedAction` in previous PRs, this ports the
`SendNotification` action and associated machinery.  During this process, I
introduced the ability for notification blocks to raise custom errors when they
fail, so that block subclasses can share more details when they fail.
