### PR TITLE
Making `TriggeredAction.firing` required

### DIFF
--- a/src/prefect/server/events/schemas/automations.py
+++ b/src/prefect/server/events/schemas/automations.py
@@ -704,9 +704,7 @@ class TriggeredAction(PrefectBaseModel):
         description="A unique key representing a single triggering of an action",
     )
 
-    firing: Optional[Firing] = Field(
-        None, description="The Firing that prompted this action"
-    )
+    firing: Firing = Field(None, description="The Firing that prompted this action")
 
     triggered: DateTimeTZ = Field(..., description="When this action was triggered")
     triggering_labels: Dict[str, str] = Field(

--- a/tests/events/server/actions/test_jinja_templated_action.py
+++ b/tests/events/server/actions/test_jinja_templated_action.py
@@ -110,11 +110,19 @@ def woodchonk_triggered(
     tell_me_about_the_culprit: Automation,
     woodchonk_nibbled: ReceivedEvent,
 ) -> TriggeredAction:
-    return TriggeredAction(
-        automation=tell_me_about_the_culprit,
+    firing = Firing(
+        trigger=tell_me_about_the_culprit.trigger,
+        trigger_states={TriggerState.Triggered},
         triggered=pendulum.now("UTC"),
         triggering_labels={"i.am.so": "triggered"},
         triggering_event=woodchonk_nibbled,
+    )
+    return TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        firing=firing,
+        triggered=firing.triggered,
+        triggering_labels=firing.triggering_labels,
+        triggering_event=firing.triggering_event,
         action=tell_me_about_the_culprit.actions[0],
     )
 
@@ -309,11 +317,19 @@ def took_a_picture(
     tell_me_about_the_culprit: Automation,
     picture_taken: ReceivedEvent,
 ) -> TriggeredAction:
-    return TriggeredAction(
-        automation=tell_me_about_the_culprit,
+    firing = Firing(
+        trigger=tell_me_about_the_culprit.trigger,
+        trigger_states={TriggerState.Triggered},
         triggered=pendulum.now("UTC"),
         triggering_labels={},
         triggering_event=picture_taken,
+    )
+    return TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        firing=firing,
+        triggered=firing.triggered,
+        triggering_labels=firing.triggering_labels,
+        triggering_event=firing.triggering_event,
         action=tell_me_about_the_culprit.actions[0],
     )
 
@@ -323,11 +339,19 @@ def took_a_picture_by_task(
     tell_me_about_the_culprit: Automation,
     picture_taken_by_task: ReceivedEvent,
 ) -> TriggeredAction:
-    return TriggeredAction(
-        automation=tell_me_about_the_culprit,
+    firing = Firing(
+        trigger=tell_me_about_the_culprit.trigger,
+        trigger_states={TriggerState.Triggered},
         triggered=pendulum.now("UTC"),
         triggering_labels={},
         triggering_event=picture_taken_by_task,
+    )
+    return TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        firing=firing,
+        triggered=firing.triggered,
+        triggering_labels=firing.triggering_labels,
+        triggering_event=firing.triggering_event,
         action=tell_me_about_the_culprit.actions[0],
     )
 
@@ -1121,9 +1145,9 @@ async def test_work_queue_health_late_run_count(
     URL: {{ work_queue|ui_url }}
     """
 
-    triggered_action = TriggeredAction(
-        automation=tell_me_about_the_culprit,
-        id=uuid4(),
+    firing = Firing(
+        trigger=tell_me_about_the_culprit.trigger,
+        trigger_states={TriggerState.Triggered},
         triggered=start_of_test + timedelta(seconds=1),
         triggering_event=Event(
             occurred=start_of_test,
@@ -1136,6 +1160,14 @@ async def test_work_queue_health_late_run_count(
             id=uuid4(),
         ).receive(),
         triggering_labels={},
+    )
+    triggered_action = TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        id=uuid4(),
+        firing=firing,
+        triggered=firing.triggered,
+        triggering_labels=firing.triggering_labels,
+        triggering_event=firing.triggering_event,
         action=actions.DoNothing(),  # this doesn't matter for the test
         action_index=0,
     )
@@ -1170,9 +1202,9 @@ async def test_related_resource_by_role_in_templates(
     Pools: {% for resource in event.resources_in_role['work-pool'] %}{{ resource.name }},{% endfor %}
     """
 
-    triggered_action = TriggeredAction(
-        automation=tell_me_about_the_culprit,
-        id=uuid4(),
+    firing = Firing(
+        trigger=tell_me_about_the_culprit.trigger,
+        trigger_states={TriggerState.Triggered},
         triggered=start_of_test + timedelta(seconds=1),
         triggering_event=Event(
             occurred=start_of_test,
@@ -1196,6 +1228,14 @@ async def test_related_resource_by_role_in_templates(
             id=uuid4(),
         ).receive(),
         triggering_labels={},
+    )
+    triggered_action = TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        id=uuid4(),
+        firing=firing,
+        triggered=firing.triggered,
+        triggering_labels=firing.triggering_labels,
+        triggering_event=firing.triggering_event,
         action=actions.DoNothing(),  # this doesn't matter for the test
         action_index=0,
     )
@@ -1227,9 +1267,9 @@ async def test_work_pool_is_available_to_templates(
     Pool: {{ work_pool.name }}
     """
 
-    triggered_action = TriggeredAction(
-        automation=tell_me_about_the_culprit,
-        id=uuid4(),
+    firing = Firing(
+        trigger=tell_me_about_the_culprit.trigger,
+        trigger_states={TriggerState.Triggered},
         triggered=start_of_test + timedelta(seconds=1),
         triggering_event=Event(
             occurred=start_of_test,
@@ -1245,6 +1285,14 @@ async def test_work_pool_is_available_to_templates(
             id=uuid4(),
         ).receive(),
         triggering_labels={},
+    )
+    triggered_action = TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        id=uuid4(),
+        firing=firing,
+        triggered=firing.triggered,
+        triggering_labels=firing.triggering_labels,
+        triggering_event=firing.triggering_event,
         action=actions.DoNothing(),  # this doesn't matter for the test
         action_index=0,
     )
@@ -1274,9 +1322,9 @@ async def test_concurrency_limit_is_available_in_templates(
     Limit: {{ concurrency_limit.limit }}
     """
 
-    triggered_action = TriggeredAction(
-        automation=tell_me_about_the_culprit,
-        id=uuid4(),
+    firing = Firing(
+        trigger=tell_me_about_the_culprit.trigger,
+        trigger_states={TriggerState.Triggered},
         triggered=start_of_test + timedelta(seconds=1),
         triggering_event=Event(
             occurred=start_of_test,
@@ -1287,6 +1335,15 @@ async def test_concurrency_limit_is_available_in_templates(
             id=uuid4(),
         ).receive(),
         triggering_labels={},
+    )
+
+    triggered_action = TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        id=uuid4(),
+        firing=firing,
+        triggered=firing.triggered,
+        triggering_labels=firing.triggering_labels,
+        triggering_event=firing.triggering_event,
         action=actions.DoNothing(),  # this doesn't matter for the test
         action_index=0,
     )

--- a/tests/events/server/actions/test_running_deployment.py
+++ b/tests/events/server/actions/test_running_deployment.py
@@ -18,8 +18,10 @@ from prefect.server.events.clients import AssertingEventsClient
 from prefect.server.events.schemas.automations import (
     Automation,
     EventTrigger,
+    Firing,
     Posture,
     TriggeredAction,
+    TriggerState,
 )
 from prefect.server.events.schemas.events import ReceivedEvent, RelatedResource
 from prefect.server.models import deployments, flow_runs, flows, variables, workers
@@ -131,11 +133,18 @@ def snap_that_naughty_woodchuck(
     take_a_picture_of_the_culprit: Automation,
     woodchonk_nibbled: ReceivedEvent,
 ) -> TriggeredAction:
-    return TriggeredAction(
-        automation=take_a_picture_of_the_culprit,
+    firing = Firing(
+        trigger=take_a_picture_of_the_culprit.trigger,
+        trigger_states={TriggerState.Triggered},
         triggered=pendulum.now("UTC"),
         triggering_labels={},
         triggering_event=woodchonk_nibbled,
+    )
+    return TriggeredAction(
+        automation=take_a_picture_of_the_culprit,
+        triggered=firing.triggered,
+        triggering_labels=firing.triggering_labels,
+        triggering_event=firing.triggering_event,
         action=take_a_picture_of_the_culprit.actions[0],
     )
 

--- a/tests/events/server/actions/test_sending_notification.py
+++ b/tests/events/server/actions/test_sending_notification.py
@@ -15,8 +15,10 @@ from prefect.server.events.clients import AssertingEventsClient
 from prefect.server.events.schemas.automations import (
     Automation,
     EventTrigger,
+    Firing,
     Posture,
     TriggeredAction,
+    TriggerState,
 )
 from prefect.server.events.schemas.events import ReceivedEvent, RelatedResource
 
@@ -70,11 +72,19 @@ def notify_me(
     tell_me_about_the_culprit: Automation,
     woodchonk_nibbled: ReceivedEvent,
 ) -> TriggeredAction:
-    return TriggeredAction(
-        automation=tell_me_about_the_culprit,
+    firing = Firing(
+        trigger=tell_me_about_the_culprit.trigger,
+        trigger_states={TriggerState.Triggered},
         triggered=pendulum.now("UTC"),
         triggering_labels={"i.am.so": "triggered"},
         triggering_event=woodchonk_nibbled,
+    )
+    return TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        firing=firing,
+        triggered=firing.triggered,
+        triggering_labels=firing.triggering_labels,
+        triggering_event=firing.triggering_event,
         action=tell_me_about_the_culprit.actions[0],
     )
 
@@ -84,11 +94,19 @@ def invalid_block_id(
     tell_me_about_the_culprit: Automation,
     woodchonk_nibbled: ReceivedEvent,
 ) -> TriggeredAction:
-    return TriggeredAction(
-        automation=tell_me_about_the_culprit,
+    firing = Firing(
+        trigger=tell_me_about_the_culprit.trigger,
+        trigger_states={TriggerState.Triggered},
         triggered=pendulum.now("UTC"),
         triggering_labels={},
         triggering_event=woodchonk_nibbled,
+    )
+    return TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        firing=firing,
+        triggered=firing.triggered,
+        triggering_labels=firing.triggering_labels,
+        triggering_event=firing.triggering_event,
         action=tell_me_about_the_culprit.actions[1],
     )
 

--- a/tests/events/server/conftest.py
+++ b/tests/events/server/conftest.py
@@ -26,8 +26,10 @@ from prefect.server.events import ResourceSpecification, actions, messaging
 from prefect.server.events.schemas.automations import (
     Automation,
     EventTrigger,
+    Firing,
     Posture,
     TriggeredAction,
+    TriggerState,
 )
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.utilities.messaging import Message
@@ -356,11 +358,19 @@ def email_me_when_that_dang_spider_comes(
     arachnophobia: Automation,
     daddy_long_legs_walked: ReceivedEvent,
 ) -> TriggeredAction:
-    return TriggeredAction(
-        automation=arachnophobia,
+    firing = Firing(
+        trigger=arachnophobia.trigger,
+        trigger_states={TriggerState.Triggered},
         triggered=pendulum.now("UTC"),
         triggering_labels={"hello": "world"},
         triggering_event=daddy_long_legs_walked,
+    )
+    return TriggeredAction(
+        automation=arachnophobia,
+        firing=firing,
+        triggered=firing.triggered,
+        triggering_labels=firing.triggering_labels,
+        triggering_event=firing.triggering_event,
         action=arachnophobia.actions[0],
     )
 


### PR DESCRIPTION
This matches a comparable change in Prefect Cloud, and it was always intended
that the `firing` would be required for any triggered action.  Prefect Cloud had
it as optional for temporary compatibility but that's been corrected now.
