### PR TITLE
Remove `version` from `docker-compose.yml`, as it is now deprecated

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   test-db:
     image: postgres:14


### PR DESCRIPTION
Compose v2 doesn't require or use the `version` field, and now prints a warning
about it being obsolete:

https://docs.docker.com/compose/compose-file/04-version-and-name/
