### PR TITLE
exclude job_variables when exclude=None

### DIFF
--- a/src/prefect/_internal/compatibility/deprecated.py
+++ b/src/prefect/_internal/compatibility/deprecated.py
@@ -344,6 +344,8 @@ class DeprecatedInfraOverridesField(BaseModel):
             exclude.add("job_variables")
         elif exclude_type is dict:
             exclude["job_variables"] = True
+        else:
+            exclude = {"job_variables"}
         kwargs["exclude"] = exclude
 
         return super().dict(**kwargs)

--- a/tests/_internal/compatibility/test_deprecated.py
+++ b/tests/_internal/compatibility/test_deprecated.py
@@ -320,3 +320,15 @@ class TestDeprecatedInfraOverridesField:
             )
 
         assert MyModel.schema()["description"] == "Hey mom"
+
+    def test_excludes_job_variables_if_excludes_is_none(self):
+        class MyModel(DeprecatedInfraOverridesField, pydantic.BaseModel):
+            name: str
+            job_variables: Optional[Dict[str, Any]] = pydantic.Field(
+                default_factory=dict,
+                description="Overrides to apply to my deployment infrastructure at runtime.",
+            )
+
+        serialized = MyModel(name="hey").dict(exclude=None)
+        assert "job_variables" not in serialized
+        assert serialized["infra_overrides"] == {}


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

When we use `DeprecatedInfraOverridesField`, we always want serialized forms of the object to exclude `job_variables`. Currently, if `exclude=None` when `dict()` is called, we will fail to exclude `job_variables`. This PR fixes that.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
