### PR TITLE
better flow validation error

### DIFF
--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -178,7 +178,7 @@ class ParameterTypeError(PrefectException):
 
     @classmethod
     def from_validation_error(cls, exc: ValidationError) -> Self:
-        bad_params = [f'{err["loc"]}: {err["msg"]}' for err in exc.errors()]
+        bad_params = [f'{".".join(err["loc"])}: {err["msg"]}' for err in exc.errors()]
         msg = "Flow run received invalid parameters:\n - " + "\n - ".join(bad_params)
         return cls(msg)
 

--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -178,7 +178,7 @@ class ParameterTypeError(PrefectException):
 
     @classmethod
     def from_validation_error(cls, exc: ValidationError) -> Self:
-        bad_params = [f'{err["loc"][0]}: {err["msg"]}' for err in exc.errors()]
+        bad_params = [f'{err["loc"]}: {err["msg"]}' for err in exc.errors()]
         msg = "Flow run received invalid parameters:\n - " + "\n - ".join(bad_params)
         return cls(msg)
 


### PR DESCRIPTION
taking the following example
```python
from typing import Annotated

from prefect import flow
from pydantic import BaseModel, Field

NonNegativeInt = Annotated[int, Field(ge=0)]

class User(BaseModel):
    name: str
    age: NonNegativeInt

class FlowInput(BaseModel):
    user: User
    other_user: User

@flow
def process_input(flow_input: FlowInput):
    pass

if __name__ == "__main__":
    process_user(dict(user=dict(name="John", age=-1)))
```

previously surfaced validation errors would not display the field(s) that actually failed validation
```python
prefect.exceptions.ParameterTypeError: Flow run received invalid parameters:
 - flow_input: Input should be greater than or equal to 0
 - flow_input: Field required
 ```
 
 this PR includes the whole `loc` part of the error, such that we can see which field(s) failed validation
 
```python
prefect.exceptions.ParameterTypeError: Flow run received invalid parameters:
 - flow_input.user.age: Input should be greater than or equal to 0
 - flow_input.other_user: Field required
 ```
