### PR TITLE
Fix import syntax in `variables.Variable` example

### DIFF
--- a/docs/guides/variables.md
+++ b/docs/guides/variables.md
@@ -57,7 +57,7 @@ In addition to the UI and API, variables can be referenced in code and in certai
 You can access any variable via the Python SDK via the `Variable.get()` method. If you attempt to reference a variable that does not exist, the method will return `None`. You can create variables via the Python SDK with the `Variable.set()` method. Note that if a variable of the same name exists, you'll need to pass `overwrite=True`.
 
 ```python
-from prefect import variables.Variable
+from prefect.variables import Variable
 
 # setting the variable
 variable = Variable.set(name="the_answer", value="42")

--- a/src/prefect/variables.py
+++ b/src/prefect/variables.py
@@ -30,11 +30,11 @@ class Variable(VariableRequest):
         """
         Sets a new variable. If one exists with the same name, user must pass `overwrite=True`
         ```
-            from prefect import variables
+            from prefect.variables import Variable
 
             @flow
             def my_flow():
-                var = variables.Variable.set(name="my_var",value="test_value", tags=["hi", "there"], overwrite=True)
+                var = Variable.set(name="my_var",value="test_value", tags=["hi", "there"], overwrite=True)
         ```
         or
         ```
@@ -69,11 +69,11 @@ class Variable(VariableRequest):
         """
         Get a variable by name. If doesn't exist return the default.
         ```
-            from prefect import variables
+            from prefect.variables import Variable
 
             @flow
             def my_flow():
-                var = variables.Variable.get("my_var")
+                var = Variable.get("my_var")
         ```
         or
         ```


### PR DESCRIPTION
```python
In [1]: from prefect import variables.Variable
  Cell In[1], line 1
    from prefect import variables.Variable
                                 ^
SyntaxError: invalid syntax
```