### PR TITLE
Implements the `call-webhook` action and adds all Action client-side schemata

### DIFF
--- a/src/prefect/events/actions.py
+++ b/src/prefect/events/actions.py
@@ -1,36 +1,66 @@
+import abc
 from typing import Any, Dict, Optional, Union
 from uuid import UUID
+
+from typing_extensions import Literal, TypeAlias
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 
 if HAS_PYDANTIC_V2:
-    from pydantic.v1 import Field
+    from pydantic.v1 import Field, root_validator
 else:
-    from pydantic import Field
-
-from typing_extensions import Literal
-
+    from pydantic import Field, root_validator
 from prefect._internal.schemas.bases import PrefectBaseModel
+from prefect.client.schemas.objects import StateType
 
 
-class Action(PrefectBaseModel):
+class Action(PrefectBaseModel, abc.ABC):
     """An Action that may be performed when an Automation is triggered"""
 
     type: str
 
 
 class DoNothing(Action):
-    """Do nothing, which may be helpful for testing automations"""
+    """Do nothing when an Automation is triggered"""
 
     type: Literal["do-nothing"] = "do-nothing"
 
 
-class RunDeployment(Action):
-    """Run the given deployment with the given parameters"""
+class DeploymentAction(Action):
+    """Base class for Actions that operate on Deployments and need to infer them from
+    events"""
+
+    source: Literal["selected", "inferred"] = Field(
+        "selected",
+        description=(
+            "Whether this Action applies to a specific selected "
+            "deployment (given by `deployment_id`), or to a deployment that is "
+            "inferred from the triggering event.  If the source is 'inferred', "
+            "the `deployment_id` may not be set.  If the source is 'selected', the "
+            "`deployment_id` must be set."
+        ),
+    )
+    deployment_id: Optional[UUID] = Field(
+        None, description="The identifier of the deployment"
+    )
+
+    @root_validator
+    def selected_deployment_requires_id(cls, values):
+        wants_selected_deployment = values.get("source") == "selected"
+        has_deployment_id = bool(values.get("deployment_id"))
+        if wants_selected_deployment != has_deployment_id:
+            raise ValueError(
+                "deployment_id is "
+                + ("not allowed" if has_deployment_id else "required")
+            )
+        return values
+
+
+class RunDeployment(DeploymentAction):
+    """Runs the given deployment with the given parameters"""
 
     type: Literal["run-deployment"] = "run-deployment"
 
-    source: Literal["selected"] = "selected"
     parameters: Optional[Dict[str, Any]] = Field(
         None,
         description=(
@@ -38,26 +68,223 @@ class RunDeployment(Action):
             "deployment's default parameters"
         ),
     )
-    deployment_id: UUID = Field(..., description="The identifier of the deployment")
     job_variables: Optional[Dict[str, Any]] = Field(
         None,
         description=(
-            "Job variables to pass to the run, or None to use the "
-            "deployment's default job variables"
+            "The job variables to pass to the created flow run, or None "
+            "to use the deployment's default job variables"
         ),
     )
 
 
+class PauseDeployment(DeploymentAction):
+    """Pauses the given Deployment"""
+
+    type: Literal["pause-deployment"] = "pause-deployment"
+
+
+class ResumeDeployment(DeploymentAction):
+    """Resumes the given Deployment"""
+
+    type: Literal["resume-deployment"] = "resume-deployment"
+
+
+class ChangeFlowRunState(Action):
+    """Changes the state of a flow run associated with the trigger"""
+
+    type: Literal["change-flow-run-state"] = "change-flow-run-state"
+
+    name: Optional[str] = Field(
+        None,
+        description="The name of the state to change the flow run to",
+    )
+    state: StateType = Field(
+        ...,
+        description="The type of the state to change the flow run to",
+    )
+    message: Optional[str] = Field(
+        None,
+        description="An optional message to associate with the state change",
+    )
+
+
+class CancelFlowRun(Action):
+    """Cancels a flow run associated with the trigger"""
+
+    type: Literal["cancel-flow-run"] = "cancel-flow-run"
+
+
+class SuspendFlowRun(Action):
+    """Suspends a flow run associated with the trigger"""
+
+    type: Literal["suspend-flow-run"] = "suspend-flow-run"
+
+
+class CallWebhook(Action):
+    """Call a webhook when an Automation is triggered."""
+
+    type: Literal["call-webhook"] = "call-webhook"
+    block_document_id: UUID = Field(
+        description="The identifier of the webhook block to use"
+    )
+    payload: str = Field(
+        default="",
+        description="An optional templatable payload to send when calling the webhook.",
+    )
+
+
 class SendNotification(Action):
-    """Send a notification with the given parameters"""
+    """Send a notification when an Automation is triggered"""
 
     type: Literal["send-notification"] = "send-notification"
-
     block_document_id: UUID = Field(
-        ..., description="The identifier of the notification block"
+        description="The identifier of the notification block to use"
     )
-    body: str = Field(..., description="Notification body")
-    subject: Optional[str] = Field(None, description="Notification subject")
+    subject: str = Field("Prefect automated notification")
+    body: str = Field(description="The text of the notification to send")
 
 
-ActionTypes = Union[DoNothing, RunDeployment, SendNotification]
+class WorkPoolAction(Action):
+    """Base class for Actions that operate on Work Pools and need to infer them from
+    events"""
+
+    source: Literal["selected", "inferred"] = Field(
+        "selected",
+        description=(
+            "Whether this Action applies to a specific selected "
+            "work pool (given by `work_pool_id`), or to a work pool that is "
+            "inferred from the triggering event.  If the source is 'inferred', "
+            "the `work_pool_id` may not be set.  If the source is 'selected', the "
+            "`work_pool_id` must be set."
+        ),
+    )
+    work_pool_id: Optional[UUID] = Field(
+        None,
+        description="The identifier of the work pool to pause",
+    )
+
+
+class PauseWorkPool(WorkPoolAction):
+    """Pauses a Work Pool"""
+
+    type: Literal["pause-work-pool"] = "pause-work-pool"
+
+
+class ResumeWorkPool(WorkPoolAction):
+    """Resumes a Work Pool"""
+
+    type: Literal["resume-work-pool"] = "resume-work-pool"
+
+
+class WorkQueueAction(Action):
+    """Base class for Actions that operate on Work Queues and need to infer them from
+    events"""
+
+    source: Literal["selected", "inferred"] = Field(
+        "selected",
+        description=(
+            "Whether this Action applies to a specific selected "
+            "work queue (given by `work_queue_id`), or to a work queue that is "
+            "inferred from the triggering event.  If the source is 'inferred', "
+            "the `work_queue_id` may not be set.  If the source is 'selected', the "
+            "`work_queue_id` must be set."
+        ),
+    )
+    work_queue_id: Optional[UUID] = Field(
+        None, description="The identifier of the work queue to pause"
+    )
+
+    @root_validator
+    def selected_work_queue_requires_id(cls, values):
+        wants_selected_work_queue = values.get("source") == "selected"
+        has_work_queue_id = bool(values.get("work_queue_id"))
+        if wants_selected_work_queue != has_work_queue_id:
+            raise ValueError(
+                "work_queue_id is "
+                + ("not allowed" if has_work_queue_id else "required")
+            )
+        return values
+
+
+class PauseWorkQueue(WorkQueueAction):
+    """Pauses a Work Queue"""
+
+    type: Literal["pause-work-queue"] = "pause-work-queue"
+
+
+class ResumeWorkQueue(WorkQueueAction):
+    """Resumes a Work Queue"""
+
+    type: Literal["resume-work-queue"] = "resume-work-queue"
+
+
+class AutomationAction(Action):
+    """Base class for Actions that operate on Automations and need to infer them from
+    events"""
+
+    source: Literal["selected", "inferred"] = Field(
+        "selected",
+        description=(
+            "Whether this Action applies to a specific selected "
+            "automation (given by `automation_id`), or to an automation that is "
+            "inferred from the triggering event.  If the source is 'inferred', "
+            "the `automation_id` may not be set.  If the source is 'selected', the "
+            "`automation_id` must be set."
+        ),
+    )
+    automation_id: Optional[UUID] = Field(
+        None, description="The identifier of the automation to act on"
+    )
+
+    @root_validator
+    def selected_automation_requires_id(cls, values):
+        wants_selected_automation = values.get("source") == "selected"
+        has_automation_id = bool(values.get("automation_id"))
+        if wants_selected_automation != has_automation_id:
+            raise ValueError(
+                "automation_id is "
+                + ("not allowed" if has_automation_id else "required")
+            )
+        return values
+
+
+class PauseAutomation(AutomationAction):
+    """Pauses a Work Queue"""
+
+    type: Literal["pause-automation"] = "pause-automation"
+
+
+class ResumeAutomation(AutomationAction):
+    """Resumes a Work Queue"""
+
+    type: Literal["resume-automation"] = "resume-automation"
+
+
+class DeclareIncident(Action):
+    """Declares an incident for the triggering event.  Only available on Prefect Cloud"""
+
+    type: Literal["declare-incident"] = "declare-incident"
+
+
+# The actual action types that we support.  It's important to update this
+# Union when adding new subclasses of Action so that they are available for clients
+# and in the OpenAPI docs
+ActionTypes: TypeAlias = Union[
+    DoNothing,
+    RunDeployment,
+    PauseDeployment,
+    ResumeDeployment,
+    CancelFlowRun,
+    ChangeFlowRunState,
+    PauseWorkQueue,
+    ResumeWorkQueue,
+    SendNotification,
+    CallWebhook,
+    PauseAutomation,
+    ResumeAutomation,
+    SuspendFlowRun,
+    PauseWorkPool,
+    ResumeWorkPool,
+    # Prefect Cloud only
+    DeclareIncident,
+]

--- a/src/prefect/server/utilities/http.py
+++ b/src/prefect/server/utilities/http.py
@@ -1,0 +1,20 @@
+def should_redact_header(key: str) -> bool:
+    """Indicates whether an HTTP header is sensitive or noisy and should be redacted
+    from events and templates."""
+    key = key.lower()
+    if key in {"authorization", "traceparent", "via"}:
+        return True
+    if key.startswith("x-forwarded"):
+        return True
+    if key.startswith("x-b3"):
+        return True
+    if key.startswith("x-cloud-trace"):
+        return True
+    if key.startswith("x-envoy"):
+        return True
+    if key.startswith("x-nebula"):
+        return True
+    if key.startswith("x-prefect"):
+        return True
+
+    return False

--- a/tests/events/server/actions/test_calling_webhook.py
+++ b/tests/events/server/actions/test_calling_webhook.py
@@ -1,0 +1,436 @@
+import re
+from datetime import timedelta
+from unittest import mock
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import orjson
+import pendulum
+import pydantic
+import pytest
+from httpx import Response
+from pendulum.datetime import DateTime
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from prefect._internal.pydantic import HAS_PYDANTIC_V2
+
+if HAS_PYDANTIC_V2:
+    import pydantic.v1 as pydantic
+else:
+    import pydantic
+
+from prefect.blocks.core import Block
+from prefect.blocks.webhook import Webhook
+from prefect.server.database.orm_models import (
+    ORMDeployment,
+    ORMFlow,
+    ORMFlowRun,
+    ORMWorkQueue,
+)
+from prefect.server.events import actions
+from prefect.server.events.actions import ActionFailed
+from prefect.server.events.clients import AssertingEventsClient
+from prefect.server.events.schemas.automations import (
+    Automation,
+    EventTrigger,
+    Firing,
+    Posture,
+    TriggeredAction,
+    TriggerState,
+)
+from prefect.server.events.schemas.events import ReceivedEvent, RelatedResource
+from prefect.server.models import deployments, flow_runs, flows, work_queues
+from prefect.server.schemas.actions import WorkQueueCreate
+from prefect.server.schemas.core import Deployment, Flow, FlowRun, WorkQueue
+
+
+@pytest.fixture
+async def snap_a_pic(
+    session: AsyncSession,
+) -> ORMFlow:
+    flow = await flows.create_flow(
+        session=session,
+        flow=Flow(name="snap-a-pic"),
+    )
+    await session.commit()
+    return flow
+
+
+@pytest.fixture
+async def take_a_picture(
+    session: AsyncSession,
+    snap_a_pic: ORMFlow,
+) -> ORMFlowRun:
+    flow_run = await flow_runs.create_flow_run(
+        session=session,
+        flow_run=FlowRun(flow_id=snap_a_pic.id, flow_version="1.0"),
+    )
+    await session.commit()
+    return flow_run
+
+
+@pytest.fixture
+async def take_a_picture_deployment(
+    session: AsyncSession,
+    take_a_picture: FlowRun,
+) -> ORMDeployment:
+    deployment = await deployments.create_deployment(
+        session=session,
+        deployment=Deployment(
+            name="Take a picture on demand",
+            manifest_path="file.json",
+            flow_id=take_a_picture.flow_id,
+            is_schedule_active=True,
+            paused=False,
+        ),
+    )
+    await session.commit()
+    return deployment
+
+
+@pytest.fixture
+async def take_a_picture_work_queue(
+    session: AsyncSession,
+) -> ORMWorkQueue:
+    work_queue = await work_queues.create_work_queue(
+        session=session,
+        work_queue=WorkQueueCreate(name="camera-queue"),
+    )
+    await session.commit()
+    return work_queue
+
+
+@pytest.fixture
+async def webhook_block_id() -> UUID:
+    block = Webhook(method="POST", url="https://example.com", headers={"foo": "bar"})
+    return await block.save(name="webhook-test")
+
+
+@pytest.fixture
+def picture_taken(
+    start_of_test: DateTime,
+    take_a_picture: FlowRun,
+    take_a_picture_deployment: Deployment,
+    take_a_picture_work_queue: WorkQueue,
+):
+    return ReceivedEvent(
+        occurred=start_of_test + timedelta(microseconds=2),
+        event="prefect.flow-run.completed",
+        resource={"prefect.resource.id": f"prefect.flow-run.{take_a_picture.id}"},
+        related=[
+            {
+                "prefect.resource.id": f"prefect.flow.{take_a_picture.flow_id}",
+                "prefect.resource.role": "flow",
+            },
+            {
+                "prefect.resource.id": f"prefect.deployment.{take_a_picture_deployment.id}",
+                "prefect.resource.role": "deployment",
+            },
+            {
+                "prefect.resource.id": f"prefect.work-queue.{take_a_picture_work_queue.id}",
+                "prefect.resource.role": "work-queue",
+            },
+        ],
+        id=uuid4(),
+    )
+
+
+@pytest.fixture
+async def tell_me_about_the_culprit(
+    webhook_block_id: UUID,
+) -> Automation:
+    return Automation(
+        name="If my lilies get nibbled, tell me about it",
+        description="Send a webhook whenever the lillies are nibbled",
+        enabled=True,
+        trigger=EventTrigger(
+            expect={"animal.ingested"},
+            match_related={
+                "prefect.resource.role": "meal",
+                "genus": "Hemerocallis",
+                "species": "fulva",
+            },
+            posture=Posture.Reactive,
+            threshold=0,
+            within=timedelta(seconds=30),
+        ),
+        actions=[
+            actions.CallWebhook(
+                block_document_id=webhook_block_id,
+            ),
+            actions.CallWebhook(
+                block_document_id=uuid4(),
+            ),
+            actions.CallWebhook(
+                block_document_id=webhook_block_id,
+                payload={
+                    "automation": "{{ automation.name }}",
+                },
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def call_webhook(
+    tell_me_about_the_culprit: Automation,
+    woodchonk_nibbled: ReceivedEvent,
+) -> TriggeredAction:
+    firing = Firing(
+        trigger=tell_me_about_the_culprit.trigger,
+        trigger_states={TriggerState.Triggered},
+        triggered=pendulum.now("UTC"),
+        triggering_labels={"i.am.so": "triggered"},
+        triggering_event=woodchonk_nibbled,
+    )
+    return TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        firing=firing,
+        triggered=firing.triggered,
+        triggering_labels=firing.triggering_labels,
+        triggering_event=firing.triggering_event,
+        action=tell_me_about_the_culprit.actions[0],
+    )
+
+
+@pytest.fixture
+def call_webhook_with_templated_payload(
+    tell_me_about_the_culprit: Automation,
+    woodchonk_nibbled: ReceivedEvent,
+) -> TriggeredAction:
+    firing = Firing(
+        trigger=tell_me_about_the_culprit.trigger,
+        trigger_states={TriggerState.Triggered},
+        triggered=pendulum.now("UTC"),
+        triggering_labels={"i.am.so": "triggered"},
+        triggering_event=woodchonk_nibbled,
+    )
+    return TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        firing=firing,
+        triggered=firing.triggered,
+        triggering_labels=firing.triggering_labels,
+        triggering_event=firing.triggering_event,
+        action=tell_me_about_the_culprit.actions[2],
+    )
+
+
+@pytest.fixture
+def invalid_block_id(
+    tell_me_about_the_culprit: Automation,
+    woodchonk_nibbled: ReceivedEvent,
+) -> TriggeredAction:
+    firing = Firing(
+        trigger=tell_me_about_the_culprit.trigger,
+        trigger_states={TriggerState.Triggered},
+        triggered=pendulum.now("UTC"),
+        triggering_labels={"i.am.so": "triggered"},
+        triggering_event=woodchonk_nibbled,
+    )
+    return TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        firing=firing,
+        triggered=firing.triggered,
+        triggering_labels=firing.triggering_labels,
+        triggering_event=firing.triggering_event,
+        action=tell_me_about_the_culprit.actions[1],
+    )
+
+
+@pytest.fixture
+def took_a_picture(
+    tell_me_about_the_culprit: Automation,
+    picture_taken: ReceivedEvent,
+) -> TriggeredAction:
+    firing = Firing(
+        trigger=tell_me_about_the_culprit.trigger,
+        trigger_states={TriggerState.Triggered},
+        triggered=picture_taken.occurred,
+        triggering_labels={},
+        triggering_event=picture_taken,
+    )
+    return TriggeredAction(
+        automation=tell_me_about_the_culprit,
+        firing=firing,
+        triggered=firing.triggered,
+        triggering_labels=firing.triggering_labels,
+        triggering_event=firing.triggering_event,
+        action=tell_me_about_the_culprit.actions[0],
+    )
+
+
+async def test_sending_webhook(
+    call_webhook: TriggeredAction, monkeypatch: pytest.MonkeyPatch
+):
+    action = call_webhook.action
+
+    call = AsyncMock()
+    call.return_value = Response(status_code=200)
+    monkeypatch.setattr("prefect.blocks.webhook.Webhook.call", call)
+
+    assert isinstance(action, actions.CallWebhook)
+    await action.act(call_webhook)
+    assert call_webhook.triggering_event
+
+    assert call_webhook.triggering_event
+    call.assert_called_once_with(payload="")
+
+
+async def test_sending_webhook_with_payload(
+    call_webhook_with_templated_payload: TriggeredAction,
+    tell_me_about_the_culprit: Automation,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    action = call_webhook_with_templated_payload.action
+
+    call = AsyncMock()
+    call.return_value = Response(
+        status_code=200,
+        headers={
+            "foo": "bar",
+            "Authorization": "trust me bro",
+            "via": "the interwebs",
+        },
+        text="Booped the snoot!",
+    )
+    monkeypatch.setattr("prefect.blocks.webhook.Webhook.call", call)
+
+    assert isinstance(action, actions.CallWebhook)
+    await action.act(call_webhook_with_templated_payload)
+
+    assert call_webhook_with_templated_payload.triggering_event
+    call.assert_called_once_with(
+        payload=orjson.dumps(
+            {
+                "automation": tell_me_about_the_culprit.name,
+            },
+            option=orjson.OPT_INDENT_2,
+        ).decode()
+    )
+    assert action._result_details["status_code"] == 200
+    response_headers = action._result_details["response_headers"]
+    assert response_headers.get("foo") == "bar"
+    assert response_headers.get("Authorization") is None
+    assert response_headers.get("via") is None
+    assert action._result_details.get("response_body") == "Booped the snoot!"
+
+
+async def test_error_calling_webhook(
+    call_webhook_with_templated_payload: TriggeredAction,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    action = call_webhook_with_templated_payload.action
+
+    call = AsyncMock(side_effect=ValueError("woops!"))
+    monkeypatch.setattr("prefect.blocks.webhook.Webhook.call", call)
+
+    assert isinstance(action, actions.CallWebhook)
+
+    with pytest.raises(ActionFailed, match="woops!"):
+        await action.act(call_webhook_with_templated_payload)
+
+
+async def test_invalid_block_id(invalid_block_id: TriggeredAction):
+    action = invalid_block_id.action
+    assert isinstance(action, actions.CallWebhook)
+    with pytest.raises(actions.ActionFailed):
+        await action.act(invalid_block_id)
+
+
+async def test_validation_error_loading_block(took_a_picture: TriggeredAction):
+    """If there is a ValidationError loading the Webhook Block, handle it and
+    fail the action.  This is a regression test for an alert we got about a Slack
+    webhook missing its URL in production."""
+    action = took_a_picture.action
+    assert isinstance(action, actions.CallWebhook)
+    error = ValueError("woops")
+    expected_reason = re.escape("The webhook block was invalid: ValueError('woops')")
+    with mock.patch.object(Block, "_from_block_document", side_effect=error):
+        with pytest.raises(actions.ActionFailed, match=expected_reason):
+            await action.act(took_a_picture)
+
+
+async def test_success_event(
+    call_webhook: TriggeredAction,
+    monkeypatch: pytest.MonkeyPatch,
+    webhook_block_id: UUID,
+):
+    action = call_webhook.action
+
+    webhook_call = AsyncMock()
+    webhook_call.return_value = Response(status_code=200, text="🦊")
+    monkeypatch.setattr("prefect.blocks.webhook.Webhook.call", webhook_call)
+
+    await action.act(call_webhook)
+    await action.succeed(call_webhook)
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.related == [
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": f"prefect.block-document.{webhook_block_id}",
+                "prefect.resource.role": "block",
+                "prefect.resource.name": "webhook-test",
+            }
+        ),
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": "prefect.block-type.webhook",
+                "prefect.resource.role": "block-type",
+            }
+        ),
+    ]
+    assert event.payload == {
+        "action_index": 0,
+        "action_type": "call-webhook",
+        "invocation": str(call_webhook.id),
+        "status_code": webhook_call.return_value.status_code,
+        "response_headers": {
+            "content-length": "4",
+            "content-type": "text/plain; charset=utf-8",
+        },
+        "response_body": "🦊",
+    }
+
+
+async def test_migrating_to_templates():
+    """Confirms that our plan to migrate `payload` from dict[str, Any] to str will
+    parse payloads from both the database and the UI."""
+
+    action = actions.CallWebhook(
+        block_document_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        payload={"message": "hello world"},
+    )
+    assert isinstance(action.payload, str)
+    assert action.payload == '{\n  "message": "hello world"\n}'
+
+    # The form it will be when read from the database
+    action = pydantic.parse_obj_as(
+        actions.ActionTypes,
+        {
+            "type": "call-webhook",
+            "block_document_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "payload": {"message": "hello world"},
+        },
+    )
+    assert isinstance(action, actions.CallWebhook)
+    assert isinstance(action.payload, str)
+    assert action.payload == '{\n  "message": "hello world"\n}'
+
+    # The form it will be when read from an API body
+    action = pydantic.parse_raw_as(
+        actions.ActionTypes,
+        """
+        {
+            "type" : "call-webhook",
+            "block_document_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "payload": {"message": "hello world"}
+        }
+        """,
+    )
+    assert isinstance(action, actions.CallWebhook)
+    assert isinstance(action.payload, str)
+    assert action.payload == '{\n  "message": "hello world"\n}'


### PR DESCRIPTION
Adds the `CallWebhook` action to use a invoke a configured Webhook block. This
also adds client-side schemata for all supported Action types on both OSS
and Prefect Cloud.
