### PR TITLE
Renaming `prefect-cloud.*` events and labels to `prefect.*`

### DIFF
--- a/src/prefect/server/events/actions.py
+++ b/src/prefect/server/events/actions.py
@@ -130,7 +130,7 @@ class Action(PrefectBaseModel, abc.ABC):
         action = triggered_action.action
         action_index = triggered_action.action_index
 
-        automation_resource_id = f"prefect-cloud.automation.{automation.id}"
+        automation_resource_id = f"prefect.automation.{automation.id}"
 
         logger.warning(
             "Action failed: %r",
@@ -139,11 +139,11 @@ class Action(PrefectBaseModel, abc.ABC):
         )
         event = Event(
             occurred=pendulum.now("UTC"),
-            event="prefect-cloud.automation.action.failed",
+            event="prefect.automation.action.failed",
             resource={
                 "prefect.resource.id": automation_resource_id,
                 "prefect.resource.name": automation.name,
-                "prefect-cloud.trigger-type": automation.trigger.type,
+                "prefect.trigger-type": automation.trigger.type,
             },
             related=self._resulting_related_resources,
             payload={
@@ -156,7 +156,7 @@ class Action(PrefectBaseModel, abc.ABC):
             id=uuid4(),
         )
         if isinstance(automation.trigger, EventTrigger):
-            event.resource["prefect-cloud.posture"] = automation.trigger.posture
+            event.resource["prefect.posture"] = automation.trigger.posture
 
         async with PrefectServerEventsClient() as events:
             await events.emit(event)
@@ -168,15 +168,15 @@ class Action(PrefectBaseModel, abc.ABC):
         action = triggered_action.action
         action_index = triggered_action.action_index
 
-        automation_resource_id = f"prefect-cloud.automation.{automation.id}"
+        automation_resource_id = f"prefect.automation.{automation.id}"
 
         event = Event(
             occurred=pendulum.now("UTC"),
-            event="prefect-cloud.automation.action.executed",
+            event="prefect.automation.action.executed",
             resource={
                 "prefect.resource.id": automation_resource_id,
                 "prefect.resource.name": automation.name,
-                "prefect-cloud.trigger-type": automation.trigger.type,
+                "prefect.trigger-type": automation.trigger.type,
             },
             related=self._resulting_related_resources,
             payload={
@@ -188,7 +188,7 @@ class Action(PrefectBaseModel, abc.ABC):
             id=uuid4(),
         )
         if isinstance(automation.trigger, EventTrigger):
-            event.resource["prefect-cloud.posture"] = automation.trigger.posture
+            event.resource["prefect.posture"] = automation.trigger.posture
 
         async with PrefectServerEventsClient() as events:
             await events.emit(event)
@@ -1468,7 +1468,7 @@ class AutomationAction(Action):
             raise ActionFailed("No event to infer the automation")
 
         assert event
-        if id := _id_of_first_resource_of_kind(event, "prefect-cloud.automation"):
+        if id := _id_of_first_resource_of_kind(event, "prefect.automation"):
             return id
 
         raise ActionFailed("No automation could be inferred")
@@ -1483,7 +1483,7 @@ class AutomationCommandAction(AutomationAction, ExternalDataAction):
         self._resulting_related_resources += [
             RelatedResource.parse_obj(
                 {
-                    "prefect.resource.id": f"prefect-cloud.automation.{automation_id}",
+                    "prefect.resource.id": f"prefect.automation.{automation_id}",
                     "prefect.resource.role": "target",
                 }
             )

--- a/src/prefect/server/events/jinja_filters.py
+++ b/src/prefect/server/events/jinja_filters.py
@@ -84,7 +84,7 @@ def ui_resource_events_url(ctx: Mapping[str, Any], obj: Any) -> Optional[str]:
     url_format = "events?resource={resource_id}"
 
     if isinstance(obj, Automation):
-        url = url_format.format(resource_id=f"prefect-cloud.automation.{obj.id}")
+        url = url_format.format(resource_id=f"prefect.automation.{obj.id}")
     elif isinstance(obj, Resource):
         kind, _, id = obj.id.rpartition(".")
         url = url_format.format(resource_id=f"{kind}.{id}")

--- a/tests/events/server/actions/test_actions_service.py
+++ b/tests/events/server/actions/test_actions_service.py
@@ -98,9 +98,9 @@ async def test_successes_emit_events(
     automation_id = email_me_when_that_dang_spider_comes.automation.id
 
     assert start_of_test <= event.occurred <= pendulum.now("UTC")
-    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.event == "prefect.automation.action.executed"
 
-    assert event.resource.id == f"prefect-cloud.automation.{automation_id}"
+    assert event.resource.id == f"prefect.automation.{automation_id}"
     assert event.resource["prefect.resource.name"] == "React immediately to spiders"
 
     assert not event.related
@@ -133,8 +133,8 @@ async def test_failures_emit_events(
     automation_id = email_me_when_that_dang_spider_comes.automation.id
 
     assert start_of_test <= event.occurred <= pendulum.now("UTC")
-    assert event.event == "prefect-cloud.automation.action.failed"
-    assert event.resource.id == f"prefect-cloud.automation.{automation_id}"
+    assert event.event == "prefect.automation.action.failed"
+    assert event.resource.id == f"prefect.automation.{automation_id}"
     assert event.resource["prefect.resource.name"] == "React immediately to spiders"
 
     assert not event.related

--- a/tests/events/server/actions/test_calling_webhook.py
+++ b/tests/events/server/actions/test_calling_webhook.py
@@ -367,7 +367,7 @@ async def test_success_event(
     assert AssertingEventsClient.last
     (event,) = AssertingEventsClient.last.events
 
-    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.event == "prefect.automation.action.executed"
     assert event.related == [
         RelatedResource.parse_obj(
             {

--- a/tests/events/server/actions/test_cancelling_flow_run.py
+++ b/tests/events/server/actions/test_cancelling_flow_run.py
@@ -220,7 +220,7 @@ async def test_success_event(
     assert AssertingEventsClient.last
     (event,) = AssertingEventsClient.last.events
 
-    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.event == "prefect.automation.action.executed"
     assert event.related == [
         RelatedResource.parse_obj(
             {

--- a/tests/events/server/actions/test_changing_flow_run_state.py
+++ b/tests/events/server/actions/test_changing_flow_run_state.py
@@ -292,7 +292,7 @@ async def test_success_event(
     assert AssertingEventsClient.last
     (event,) = AssertingEventsClient.last.events
 
-    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.event == "prefect.automation.action.executed"
     assert event.related == [
         RelatedResource.parse_obj(
             {

--- a/tests/events/server/actions/test_pausing_resuming_automation.py
+++ b/tests/events/server/actions/test_pausing_resuming_automation.py
@@ -313,7 +313,7 @@ def the_sprinklers_stopped(
             List[RelatedResource],
             [
                 {
-                    "prefect.resource.id": f"prefect-cloud.automation.{self_managing_sprinkler_automation.id}",
+                    "prefect.resource.id": f"prefect.automation.{self_managing_sprinkler_automation.id}",
                     "prefect.resource.role": "i-automated-it",
                 }
             ],
@@ -446,7 +446,7 @@ async def test_inferring_automation_requires_recognizable_resource_id(
         [
             {
                 "prefect.resource.role": "i-automated-it",
-                "prefect.resource.id": "prefect-cloud.automation.nope",  # not a uuid
+                "prefect.resource.id": "prefect.automation.nope",  # not a uuid
             },
             {
                 "prefect.resource.role": "i-automated-it",

--- a/tests/events/server/actions/test_pausing_resuming_deployment.py
+++ b/tests/events/server/actions/test_pausing_resuming_deployment.py
@@ -461,7 +461,7 @@ async def test_pausing_success_event(
     assert AssertingEventsClient.last
     (event,) = AssertingEventsClient.last.events
 
-    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.event == "prefect.automation.action.executed"
     assert event.related == [
         RelatedResource.parse_obj(
             {
@@ -490,7 +490,7 @@ async def test_resuming_success_event(
     assert AssertingEventsClient.last
     (event,) = AssertingEventsClient.last.events
 
-    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.event == "prefect.automation.action.executed"
     assert event.related == [
         RelatedResource.parse_obj(
             {

--- a/tests/events/server/actions/test_pausing_resuming_work_pool.py
+++ b/tests/events/server/actions/test_pausing_resuming_work_pool.py
@@ -279,7 +279,7 @@ async def test_pausing_publishes_success_event(
     assert AssertingEventsClient.last
     (event,) = AssertingEventsClient.last.events
 
-    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.event == "prefect.automation.action.executed"
     assert event.related == [
         RelatedResource.parse_obj(
             {
@@ -497,7 +497,7 @@ async def test_resuming_publishes_success_event(
     assert AssertingEventsClient.last
     (event,) = AssertingEventsClient.last.events
 
-    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.event == "prefect.automation.action.executed"
     assert event.related == [
         RelatedResource.parse_obj(
             {

--- a/tests/events/server/actions/test_pausing_resuming_work_queue.py
+++ b/tests/events/server/actions/test_pausing_resuming_work_queue.py
@@ -443,7 +443,7 @@ async def test_pausing_success_event(
     assert AssertingEventsClient.last
     (event,) = AssertingEventsClient.last.events
 
-    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.event == "prefect.automation.action.executed"
     assert event.related == [
         RelatedResource.parse_obj(
             {
@@ -472,7 +472,7 @@ async def test_resuming_success_event(
     assert AssertingEventsClient.last
     (event,) = AssertingEventsClient.last.events
 
-    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.event == "prefect.automation.action.executed"
     assert event.related == [
         RelatedResource.parse_obj(
             {

--- a/tests/events/server/actions/test_running_deployment.py
+++ b/tests/events/server/actions/test_running_deployment.py
@@ -446,7 +446,7 @@ async def test_success_event(
     assert AssertingEventsClient.last
     (event,) = AssertingEventsClient.last.events
 
-    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.event == "prefect.automation.action.executed"
     assert event.related == [
         RelatedResource.parse_obj(
             {

--- a/tests/events/server/actions/test_sending_notification.py
+++ b/tests/events/server/actions/test_sending_notification.py
@@ -207,7 +207,7 @@ async def test_success_event(
     assert AssertingEventsClient.last
     (event,) = AssertingEventsClient.last.events
 
-    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.event == "prefect.automation.action.executed"
     assert event.related == [
         RelatedResource.parse_obj(
             {
@@ -250,7 +250,7 @@ async def test_captures_notification_failures(
     assert AssertingEventsClient.last
     (event,) = AssertingEventsClient.last.events
 
-    assert event.event == "prefect-cloud.automation.action.failed"
+    assert event.event == "prefect.automation.action.failed"
     assert event.related == [
         RelatedResource.parse_obj(
             {

--- a/tests/events/server/actions/test_suspending_flow_run.py
+++ b/tests/events/server/actions/test_suspending_flow_run.py
@@ -216,7 +216,7 @@ async def test_success_event(
     assert AssertingEventsClient.last
     (event,) = AssertingEventsClient.last.events
 
-    assert event.event == "prefect-cloud.automation.action.executed"
+    assert event.event == "prefect.automation.action.executed"
     assert event.related == [
         RelatedResource.parse_obj(
             {


### PR DESCRIPTION
While introducing automations to open-source, we want to be consistent with the
naming of events, since all orchestration domain concepts use events and labels
like `prefect.*`.  While automations started life in Prefect Cloud, they are
now going to be considered orchestration domain objects.  This will break a
conceptual compatibility for the near term: if you're triggering on
`prefect.automation.*` events in OSS, you'll need to change that to
`prefect-cloud.automation.*` in order to deploy that to Prefect Cloud.  We're
good with that tradeoff until we can get the concepts in Prefect Cloud renamed
as well.
