### PR TITLE
Adding helper functions for creating an events client or subscriber

### DIFF
--- a/flows/automation-assessments.py
+++ b/flows/automation-assessments.py
@@ -12,18 +12,18 @@ from packaging.version import Version
 
 import prefect
 from prefect import flow, get_client, get_run_logger
-from prefect.events import Event
-from prefect.events.filters import (
-    EventFilter,
-    EventNameFilter,
-    EventOccurredFilter,
-    EventResourceFilter,
-)
 
 try:
+    from prefect.events import Event
     from prefect.events.clients import get_events_client, get_events_subscriber
+    from prefect.events.filters import (
+        EventFilter,
+        EventNameFilter,
+        EventOccurredFilter,
+        EventResourceFilter,
+    )
 except ImportError:
-    # These were introduced in 2.17.1+ and are not available in older versions
+    # These were introduced in ~2.17.1+ and are not available in older versions
     sys.exit(0)
 
 

--- a/flows/automation-assessments.py
+++ b/flows/automation-assessments.py
@@ -1,0 +1,286 @@
+import asyncio
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from typing import Any, AsyncGenerator, Dict
+from uuid import uuid4
+
+import anyio
+import pendulum
+
+from prefect import flow, get_client, get_run_logger
+from prefect.events import Event
+from prefect.events.clients import get_events_client, get_events_subscriber
+from prefect.events.filters import (
+    EventFilter,
+    EventNameFilter,
+    EventOccurredFilter,
+    EventResourceFilter,
+)
+
+
+@asynccontextmanager
+async def create_or_replace_automation(
+    automation: Dict[str, Any],
+) -> AsyncGenerator[Dict[str, Any], None]:
+    logger = get_run_logger()
+
+    async with get_client() as prefect:
+        # Clean up any older automations with the same name prefix
+        response = await prefect._client.post("/automations/filter")
+        response.raise_for_status()
+        for existing in response.json():
+            name = str(existing["name"])
+            if name.startswith(automation["name"]):
+                age = pendulum.now("UTC") - pendulum.parse(existing["created"])
+                assert isinstance(age, timedelta)
+                if age > timedelta(minutes=10):
+                    logger.info(
+                        "Deleting old automation %s (%s)",
+                        existing["name"],
+                        existing["id"],
+                    )
+                await prefect._client.delete(f"/automations/{existing['id']}")
+
+        automation["name"] = f"{automation['name']}:{uuid4()}"
+
+        response = await prefect._client.post("/automations", json=automation)
+        response.raise_for_status()
+
+        automation = response.json()
+        logger.info("Created automation %s (%s)", automation["name"], automation["id"])
+
+        logger.info("Waiting 5s for the automation to be loaded the triggers services")
+        await asyncio.sleep(5)
+
+        try:
+            yield automation
+        finally:
+            response = await prefect._client.delete(f"/automations/{automation['id']}")
+            response.raise_for_status()
+
+
+async def wait_for_event(event: str, resource_id: str) -> Event:
+    logger = get_run_logger()
+
+    filter = EventFilter(
+        occurred=EventOccurredFilter(since=pendulum.now("UTC")),
+        event=EventNameFilter(name=[]),
+        resource=EventResourceFilter(id=[resource_id]),
+    )
+    async with get_events_subscriber(filter=filter) as subscriber:
+        async for event in subscriber:
+            logger.info(event)
+            return event
+
+    raise Exception("Disconnected without an event")
+
+
+@flow
+async def assess_reactive_automation():
+    expected_resource = {"prefect.resource.id": f"integration:reactive:{uuid4()}"}
+    async with create_or_replace_automation(
+        {
+            "name": "reactive-automation",
+            "trigger": {
+                "posture": "Reactive",
+                "expect": ["integration.example.event"],
+                "match": expected_resource,
+                "threshold": 5,
+                "within": 60,
+            },
+            "actions": [{"type": "do-nothing"}],
+        }
+    ) as automation:
+        listener = asyncio.create_task(
+            wait_for_event(
+                "prefect.automation.triggered",
+                f"prefect.automation.{automation['id']}",
+            )
+        )
+
+        async with get_events_client() as events:
+            for i in range(5):
+                await events.emit(
+                    Event(
+                        event="integration.example.event",
+                        resource=expected_resource,
+                        payload={"iteration": i},
+                    )
+                )
+
+        # Wait until we see the automation triggered event, or fail if it takes longer
+        # than 60 seconds.  The reactive trigger should fire almost immediately.
+        with anyio.fail_after(60):
+            await listener
+
+
+@flow
+async def assess_proactive_automation():
+    expected_resource = {"prefect.resource.id": f"integration:proactive:{uuid4()}"}
+    async with create_or_replace_automation(
+        {
+            "name": "proactive-automation",
+            "trigger": {
+                "posture": "Proactive",
+                "expect": ["integration.example.event"],
+                # Doing it for_each resource ID should prevent it from firing endlessly
+                # while the integration tests are _not_ running
+                "for_each": ["prefect.resource.id"],
+                "match": expected_resource,
+                "threshold": 5,
+                "within": 15,
+            },
+            "actions": [{"type": "do-nothing"}],
+        }
+    ) as automation:
+        listener = asyncio.create_task(
+            wait_for_event(
+                "prefect.automation.triggered",
+                f"prefect.automation.{automation['id']}",
+            )
+        )
+
+        async with get_events_client() as events:
+            for i in range(2):  # not enough events to close the automation
+                await events.emit(
+                    Event(
+                        event="integration.example.event",
+                        resource=expected_resource,
+                        payload={"iteration": i},
+                    )
+                )
+
+        # Wait until we see the automation triggered event, or fail if it takes longer
+        # than 60 seconds.  The proactive trigger should take a little over 15s to fire.
+        with anyio.fail_after(60):
+            await listener
+
+
+@flow
+async def assess_compound_automation():
+    expected_resource = {"prefect.resource.id": f"integration:compound:{uuid4()}"}
+    async with create_or_replace_automation(
+        {
+            "name": "compound-automation",
+            "trigger": {
+                "type": "compound",
+                "require": "all",
+                "within": 60,
+                "triggers": [
+                    {
+                        "posture": "Reactive",
+                        "expect": ["integration.example.event.A"],
+                        "match": expected_resource,
+                        "threshold": 1,
+                        "within": 0,
+                    },
+                    {
+                        "posture": "Reactive",
+                        "expect": ["integration.example.event.B"],
+                        "match": expected_resource,
+                        "threshold": 1,
+                        "within": 0,
+                    },
+                ],
+            },
+            "actions": [{"type": "do-nothing"}],
+        }
+    ) as automation:
+        listener = asyncio.create_task(
+            wait_for_event(
+                "prefect.automation.triggered",
+                f"prefect.automation.{automation['id']}",
+            )
+        )
+
+        async with get_events_client() as events:
+            await events.emit(
+                Event(
+                    event="integration.example.event.A",
+                    resource=expected_resource,
+                )
+            )
+            await events.emit(
+                Event(
+                    event="integration.example.event.B",
+                    resource=expected_resource,
+                )
+            )
+
+        # Wait until we see the automation triggered event, or fail if it takes longer
+        # than 60 seconds.  The compound trigger should fire almost immediately.
+        with anyio.fail_after(60):
+            await listener
+
+
+@flow
+async def assess_sequence_automation():
+    expected_resource = {"prefect.resource.id": f"integration:sequence:{uuid4()}"}
+    async with create_or_replace_automation(
+        {
+            "name": "sequence-automation",
+            "trigger": {
+                "type": "sequence",
+                "within": 60,
+                "triggers": [
+                    {
+                        "posture": "Reactive",
+                        "expect": ["integration.example.event.A"],
+                        "match": expected_resource,
+                        "threshold": 1,
+                        "within": 0,
+                    },
+                    {
+                        "posture": "Reactive",
+                        "expect": ["integration.example.event.B"],
+                        "match": expected_resource,
+                        "threshold": 1,
+                        "within": 0,
+                    },
+                ],
+            },
+            "actions": [{"type": "do-nothing"}],
+        }
+    ) as automation:
+        listener = asyncio.create_task(
+            wait_for_event(
+                "prefect.automation.triggered",
+                f"prefect.automation.{automation['id']}",
+            )
+        )
+
+        first = uuid4()
+        second = uuid4()
+        async with get_events_client() as events:
+            await events.emit(
+                Event(
+                    id=first,
+                    event="integration.example.event.A",
+                    resource=expected_resource,
+                )
+            )
+
+        get_run_logger().info("Waiting 1s to make sure the sequence is unambiguous")
+        await asyncio.sleep(1)
+
+        async with get_events_client() as events:
+            await events.emit(
+                Event(
+                    id=second,
+                    follows=first,
+                    event="integration.example.event.B",
+                    resource=expected_resource,
+                )
+            )
+
+        # Wait until we see the automation triggered event, or fail if it takes longer
+        # than 60 seconds.  The compound trigger should fire almost immediately.
+        with anyio.fail_after(60):
+            await listener
+
+
+if __name__ == "__main__":
+    asyncio.run(assess_reactive_automation())
+    asyncio.run(assess_proactive_automation())
+    asyncio.run(assess_compound_automation())
+    asyncio.run(assess_sequence_automation())

--- a/flows/automation-assessments.py
+++ b/flows/automation-assessments.py
@@ -1,299 +1,301 @@
-import asyncio
 import os
-import sys
-from contextlib import asynccontextmanager
-from datetime import timedelta
-from typing import Any, AsyncGenerator, Dict
-from uuid import uuid4
 
-import anyio
-import pendulum
 from packaging.version import Version
 
 import prefect
-from prefect import flow, get_client, get_run_logger
 
-try:
-    from prefect.events import Event
-    from prefect.events.clients import get_events_client, get_events_subscriber
-    from prefect.events.filters import (
-        EventFilter,
-        EventNameFilter,
-        EventOccurredFilter,
-        EventResourceFilter,
-    )
-except ImportError:
-    # These were introduced in ~2.17.1+ and are not available in older versions
-    sys.exit(0)
+TEST_SERVER_VERSION = os.environ.get("TEST_SERVER_VERSION", prefect.__version__)
 
+if Version(TEST_SERVER_VERSION) >= Version("2.17.1"):
+    import asyncio
+    import sys
+    from contextlib import asynccontextmanager
+    from datetime import timedelta
+    from typing import Any, AsyncGenerator, Dict
+    from uuid import uuid4
 
-@asynccontextmanager
-async def create_or_replace_automation(
-    automation: Dict[str, Any],
-) -> AsyncGenerator[Dict[str, Any], None]:
-    logger = get_run_logger()
+    import anyio
+    import pendulum
 
-    async with get_client() as prefect:
-        # Clean up any older automations with the same name prefix
-        response = await prefect._client.post("/automations/filter")
-        response.raise_for_status()
-        for existing in response.json():
-            name = str(existing["name"])
-            if name.startswith(automation["name"]):
-                age = pendulum.now("UTC") - pendulum.parse(existing["created"])
-                assert isinstance(age, timedelta)
-                if age > timedelta(minutes=10):
-                    logger.info(
-                        "Deleting old automation %s (%s)",
-                        existing["name"],
-                        existing["id"],
-                    )
-                await prefect._client.delete(f"/automations/{existing['id']}")
+    import prefect
+    from prefect import flow, get_client, get_run_logger
 
-        automation["name"] = f"{automation['name']}:{uuid4()}"
-
-        response = await prefect._client.post("/automations", json=automation)
-        response.raise_for_status()
-
-        automation = response.json()
-        logger.info("Created automation %s (%s)", automation["name"], automation["id"])
-
-        logger.info("Waiting 5s for the automation to be loaded the triggers services")
-        await asyncio.sleep(5)
-
-        try:
-            yield automation
-        finally:
-            response = await prefect._client.delete(f"/automations/{automation['id']}")
-            response.raise_for_status()
-
-
-async def wait_for_event(event: str, resource_id: str) -> Event:
-    logger = get_run_logger()
-
-    filter = EventFilter(
-        occurred=EventOccurredFilter(since=pendulum.now("UTC")),
-        event=EventNameFilter(name=[]),
-        resource=EventResourceFilter(id=[resource_id]),
-    )
-    async with get_events_subscriber(filter=filter) as subscriber:
-        async for event in subscriber:
-            logger.info(event)
-            return event
-
-    raise Exception("Disconnected without an event")
-
-
-@flow
-async def assess_reactive_automation():
-    expected_resource = {"prefect.resource.id": f"integration:reactive:{uuid4()}"}
-    async with create_or_replace_automation(
-        {
-            "name": "reactive-automation",
-            "trigger": {
-                "posture": "Reactive",
-                "expect": ["integration.example.event"],
-                "match": expected_resource,
-                "threshold": 5,
-                "within": 60,
-            },
-            "actions": [{"type": "do-nothing"}],
-        }
-    ) as automation:
-        listener = asyncio.create_task(
-            wait_for_event(
-                "prefect.automation.triggered",
-                f"prefect.automation.{automation['id']}",
-            )
+    try:
+        from prefect.events import Event
+        from prefect.events.clients import get_events_client, get_events_subscriber
+        from prefect.events.filters import (
+            EventFilter,
+            EventNameFilter,
+            EventOccurredFilter,
+            EventResourceFilter,
         )
-
-        async with get_events_client() as events:
-            for i in range(5):
-                await events.emit(
-                    Event(
-                        event="integration.example.event",
-                        resource=expected_resource,
-                        payload={"iteration": i},
-                    )
-                )
-
-        # Wait until we see the automation triggered event, or fail if it takes longer
-        # than 60 seconds.  The reactive trigger should fire almost immediately.
-        with anyio.fail_after(60):
-            await listener
-
-
-@flow
-async def assess_proactive_automation():
-    expected_resource = {"prefect.resource.id": f"integration:proactive:{uuid4()}"}
-    async with create_or_replace_automation(
-        {
-            "name": "proactive-automation",
-            "trigger": {
-                "posture": "Proactive",
-                "expect": ["integration.example.event"],
-                # Doing it for_each resource ID should prevent it from firing endlessly
-                # while the integration tests are _not_ running
-                "for_each": ["prefect.resource.id"],
-                "match": expected_resource,
-                "threshold": 5,
-                "within": 15,
-            },
-            "actions": [{"type": "do-nothing"}],
-        }
-    ) as automation:
-        listener = asyncio.create_task(
-            wait_for_event(
-                "prefect.automation.triggered",
-                f"prefect.automation.{automation['id']}",
-            )
-        )
-
-        async with get_events_client() as events:
-            for i in range(2):  # not enough events to close the automation
-                await events.emit(
-                    Event(
-                        event="integration.example.event",
-                        resource=expected_resource,
-                        payload={"iteration": i},
-                    )
-                )
-
-        # Wait until we see the automation triggered event, or fail if it takes longer
-        # than 60 seconds.  The proactive trigger should take a little over 15s to fire.
-        with anyio.fail_after(60):
-            await listener
-
-
-@flow
-async def assess_compound_automation():
-    expected_resource = {"prefect.resource.id": f"integration:compound:{uuid4()}"}
-    async with create_or_replace_automation(
-        {
-            "name": "compound-automation",
-            "trigger": {
-                "type": "compound",
-                "require": "all",
-                "within": 60,
-                "triggers": [
-                    {
-                        "posture": "Reactive",
-                        "expect": ["integration.example.event.A"],
-                        "match": expected_resource,
-                        "threshold": 1,
-                        "within": 0,
-                    },
-                    {
-                        "posture": "Reactive",
-                        "expect": ["integration.example.event.B"],
-                        "match": expected_resource,
-                        "threshold": 1,
-                        "within": 0,
-                    },
-                ],
-            },
-            "actions": [{"type": "do-nothing"}],
-        }
-    ) as automation:
-        listener = asyncio.create_task(
-            wait_for_event(
-                "prefect.automation.triggered",
-                f"prefect.automation.{automation['id']}",
-            )
-        )
-
-        async with get_events_client() as events:
-            await events.emit(
-                Event(
-                    event="integration.example.event.A",
-                    resource=expected_resource,
-                )
-            )
-            await events.emit(
-                Event(
-                    event="integration.example.event.B",
-                    resource=expected_resource,
-                )
-            )
-
-        # Wait until we see the automation triggered event, or fail if it takes longer
-        # than 60 seconds.  The compound trigger should fire almost immediately.
-        with anyio.fail_after(60):
-            await listener
-
-
-@flow
-async def assess_sequence_automation():
-    expected_resource = {"prefect.resource.id": f"integration:sequence:{uuid4()}"}
-    async with create_or_replace_automation(
-        {
-            "name": "sequence-automation",
-            "trigger": {
-                "type": "sequence",
-                "within": 60,
-                "triggers": [
-                    {
-                        "posture": "Reactive",
-                        "expect": ["integration.example.event.A"],
-                        "match": expected_resource,
-                        "threshold": 1,
-                        "within": 0,
-                    },
-                    {
-                        "posture": "Reactive",
-                        "expect": ["integration.example.event.B"],
-                        "match": expected_resource,
-                        "threshold": 1,
-                        "within": 0,
-                    },
-                ],
-            },
-            "actions": [{"type": "do-nothing"}],
-        }
-    ) as automation:
-        listener = asyncio.create_task(
-            wait_for_event(
-                "prefect.automation.triggered",
-                f"prefect.automation.{automation['id']}",
-            )
-        )
-
-        first = uuid4()
-        second = uuid4()
-        async with get_events_client() as events:
-            await events.emit(
-                Event(
-                    id=first,
-                    event="integration.example.event.A",
-                    resource=expected_resource,
-                )
-            )
-
-        get_run_logger().info("Waiting 1s to make sure the sequence is unambiguous")
-        await asyncio.sleep(1)
-
-        async with get_events_client() as events:
-            await events.emit(
-                Event(
-                    id=second,
-                    follows=first,
-                    event="integration.example.event.B",
-                    resource=expected_resource,
-                )
-            )
-
-        # Wait until we see the automation triggered event, or fail if it takes longer
-        # than 60 seconds.  The compound trigger should fire almost immediately.
-        with anyio.fail_after(60):
-            await listener
-
-
-if __name__ == "__main__":
-    TEST_SERVER_VERSION = os.environ.get("TEST_SERVER_VERSION", prefect.__version__)
-    if Version(TEST_SERVER_VERSION) < Version("2.17.1"):
+    except ImportError:
+        # These were introduced in ~2.17.1+ and are not available in older versions
         sys.exit(0)
 
-    asyncio.run(assess_reactive_automation())
-    asyncio.run(assess_proactive_automation())
-    asyncio.run(assess_compound_automation())
-    asyncio.run(assess_sequence_automation())
+    @asynccontextmanager
+    async def create_or_replace_automation(
+        automation: Dict[str, Any],
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        logger = get_run_logger()
+
+        async with get_client() as prefect:
+            # Clean up any older automations with the same name prefix
+            response = await prefect._client.post("/automations/filter")
+            response.raise_for_status()
+            for existing in response.json():
+                name = str(existing["name"])
+                if name.startswith(automation["name"]):
+                    age = pendulum.now("UTC") - pendulum.parse(existing["created"])
+                    assert isinstance(age, timedelta)
+                    if age > timedelta(minutes=10):
+                        logger.info(
+                            "Deleting old automation %s (%s)",
+                            existing["name"],
+                            existing["id"],
+                        )
+                    await prefect._client.delete(f"/automations/{existing['id']}")
+
+            automation["name"] = f"{automation['name']}:{uuid4()}"
+
+            response = await prefect._client.post("/automations", json=automation)
+            response.raise_for_status()
+
+            automation = response.json()
+            logger.info(
+                "Created automation %s (%s)", automation["name"], automation["id"]
+            )
+
+            logger.info(
+                "Waiting 5s for the automation to be loaded the triggers services"
+            )
+            await asyncio.sleep(5)
+
+            try:
+                yield automation
+            finally:
+                response = await prefect._client.delete(
+                    f"/automations/{automation['id']}"
+                )
+                response.raise_for_status()
+
+    async def wait_for_event(event: str, resource_id: str) -> Event:
+        logger = get_run_logger()
+
+        filter = EventFilter(
+            occurred=EventOccurredFilter(since=pendulum.now("UTC")),
+            event=EventNameFilter(name=[]),
+            resource=EventResourceFilter(id=[resource_id]),
+        )
+        async with get_events_subscriber(filter=filter) as subscriber:
+            async for event in subscriber:
+                logger.info(event)
+                return event
+
+        raise Exception("Disconnected without an event")
+
+    @flow
+    async def assess_reactive_automation():
+        expected_resource = {"prefect.resource.id": f"integration:reactive:{uuid4()}"}
+        async with create_or_replace_automation(
+            {
+                "name": "reactive-automation",
+                "trigger": {
+                    "posture": "Reactive",
+                    "expect": ["integration.example.event"],
+                    "match": expected_resource,
+                    "threshold": 5,
+                    "within": 60,
+                },
+                "actions": [{"type": "do-nothing"}],
+            }
+        ) as automation:
+            listener = asyncio.create_task(
+                wait_for_event(
+                    "prefect.automation.triggered",
+                    f"prefect.automation.{automation['id']}",
+                )
+            )
+
+            async with get_events_client() as events:
+                for i in range(5):
+                    await events.emit(
+                        Event(
+                            event="integration.example.event",
+                            resource=expected_resource,
+                            payload={"iteration": i},
+                        )
+                    )
+
+            # Wait until we see the automation triggered event, or fail if it takes longer
+            # than 60 seconds.  The reactive trigger should fire almost immediately.
+            with anyio.fail_after(60):
+                await listener
+
+    @flow
+    async def assess_proactive_automation():
+        expected_resource = {"prefect.resource.id": f"integration:proactive:{uuid4()}"}
+        async with create_or_replace_automation(
+            {
+                "name": "proactive-automation",
+                "trigger": {
+                    "posture": "Proactive",
+                    "expect": ["integration.example.event"],
+                    # Doing it for_each resource ID should prevent it from firing endlessly
+                    # while the integration tests are _not_ running
+                    "for_each": ["prefect.resource.id"],
+                    "match": expected_resource,
+                    "threshold": 5,
+                    "within": 15,
+                },
+                "actions": [{"type": "do-nothing"}],
+            }
+        ) as automation:
+            listener = asyncio.create_task(
+                wait_for_event(
+                    "prefect.automation.triggered",
+                    f"prefect.automation.{automation['id']}",
+                )
+            )
+
+            async with get_events_client() as events:
+                for i in range(2):  # not enough events to close the automation
+                    await events.emit(
+                        Event(
+                            event="integration.example.event",
+                            resource=expected_resource,
+                            payload={"iteration": i},
+                        )
+                    )
+
+            # Wait until we see the automation triggered event, or fail if it takes longer
+            # than 60 seconds.  The proactive trigger should take a little over 15s to fire.
+            with anyio.fail_after(60):
+                await listener
+
+    @flow
+    async def assess_compound_automation():
+        expected_resource = {"prefect.resource.id": f"integration:compound:{uuid4()}"}
+        async with create_or_replace_automation(
+            {
+                "name": "compound-automation",
+                "trigger": {
+                    "type": "compound",
+                    "require": "all",
+                    "within": 60,
+                    "triggers": [
+                        {
+                            "posture": "Reactive",
+                            "expect": ["integration.example.event.A"],
+                            "match": expected_resource,
+                            "threshold": 1,
+                            "within": 0,
+                        },
+                        {
+                            "posture": "Reactive",
+                            "expect": ["integration.example.event.B"],
+                            "match": expected_resource,
+                            "threshold": 1,
+                            "within": 0,
+                        },
+                    ],
+                },
+                "actions": [{"type": "do-nothing"}],
+            }
+        ) as automation:
+            listener = asyncio.create_task(
+                wait_for_event(
+                    "prefect.automation.triggered",
+                    f"prefect.automation.{automation['id']}",
+                )
+            )
+
+            async with get_events_client() as events:
+                await events.emit(
+                    Event(
+                        event="integration.example.event.A",
+                        resource=expected_resource,
+                    )
+                )
+                await events.emit(
+                    Event(
+                        event="integration.example.event.B",
+                        resource=expected_resource,
+                    )
+                )
+
+            # Wait until we see the automation triggered event, or fail if it takes longer
+            # than 60 seconds.  The compound trigger should fire almost immediately.
+            with anyio.fail_after(60):
+                await listener
+
+    @flow
+    async def assess_sequence_automation():
+        expected_resource = {"prefect.resource.id": f"integration:sequence:{uuid4()}"}
+        async with create_or_replace_automation(
+            {
+                "name": "sequence-automation",
+                "trigger": {
+                    "type": "sequence",
+                    "within": 60,
+                    "triggers": [
+                        {
+                            "posture": "Reactive",
+                            "expect": ["integration.example.event.A"],
+                            "match": expected_resource,
+                            "threshold": 1,
+                            "within": 0,
+                        },
+                        {
+                            "posture": "Reactive",
+                            "expect": ["integration.example.event.B"],
+                            "match": expected_resource,
+                            "threshold": 1,
+                            "within": 0,
+                        },
+                    ],
+                },
+                "actions": [{"type": "do-nothing"}],
+            }
+        ) as automation:
+            listener = asyncio.create_task(
+                wait_for_event(
+                    "prefect.automation.triggered",
+                    f"prefect.automation.{automation['id']}",
+                )
+            )
+
+            first = uuid4()
+            second = uuid4()
+            async with get_events_client() as events:
+                await events.emit(
+                    Event(
+                        id=first,
+                        event="integration.example.event.A",
+                        resource=expected_resource,
+                    )
+                )
+
+            get_run_logger().info("Waiting 1s to make sure the sequence is unambiguous")
+            await asyncio.sleep(1)
+
+            async with get_events_client() as events:
+                await events.emit(
+                    Event(
+                        id=second,
+                        follows=first,
+                        event="integration.example.event.B",
+                        resource=expected_resource,
+                    )
+                )
+
+            # Wait until we see the automation triggered event, or fail if it takes longer
+            # than 60 seconds.  The compound trigger should fire almost immediately.
+            with anyio.fail_after(60):
+                await listener
+
+    if __name__ == "__main__":
+        asyncio.run(assess_reactive_automation())
+        asyncio.run(assess_proactive_automation())
+        asyncio.run(assess_compound_automation())
+        asyncio.run(assess_sequence_automation())

--- a/flows/automation-assessments.py
+++ b/flows/automation-assessments.py
@@ -13,7 +13,7 @@ import prefect
 
 TEST_SERVER_VERSION = os.environ.get("TEST_SERVER_VERSION", prefect.__version__)
 
-if Version(TEST_SERVER_VERSION) < Version("2.17"):
+if Version(TEST_SERVER_VERSION) < Version("2.17.2"):
     raise NotImplementedError()
 
 try:

--- a/flows/automation-assessments.py
+++ b/flows/automation-assessments.py
@@ -290,7 +290,7 @@ async def assess_sequence_automation():
 
 if __name__ == "__main__":
     TEST_SERVER_VERSION = os.environ.get("TEST_SERVER_VERSION", prefect.__version__)
-    if Version(prefect.__version__) < Version("2.17.1"):
+    if Version(TEST_SERVER_VERSION) < Version("2.17.1"):
         sys.exit(0)
 
     asyncio.run(assess_reactive_automation())

--- a/flows/automation-assessments.py
+++ b/flows/automation-assessments.py
@@ -13,7 +13,7 @@ import prefect
 
 TEST_SERVER_VERSION = os.environ.get("TEST_SERVER_VERSION", prefect.__version__)
 
-if Version(TEST_SERVER_VERSION) < Version("2.17.1"):
+if Version(TEST_SERVER_VERSION) < Version("2.17"):
     raise NotImplementedError()
 
 try:

--- a/flows/automation-assessments.py
+++ b/flows/automation-assessments.py
@@ -13,13 +13,18 @@ from packaging.version import Version
 import prefect
 from prefect import flow, get_client, get_run_logger
 from prefect.events import Event
-from prefect.events.clients import get_events_client, get_events_subscriber
 from prefect.events.filters import (
     EventFilter,
     EventNameFilter,
     EventOccurredFilter,
     EventResourceFilter,
 )
+
+try:
+    from prefect.events.clients import get_events_client, get_events_subscriber
+except ImportError:
+    # These were introduced in 2.17.1+ and are not available in older versions
+    sys.exit(0)
 
 
 @asynccontextmanager

--- a/flows/automation-assessments.py
+++ b/flows/automation-assessments.py
@@ -1,301 +1,298 @@
+import asyncio
 import os
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from typing import Any, AsyncGenerator, Dict
+from uuid import uuid4
 
+import anyio
+import pendulum
 from packaging.version import Version
 
 import prefect
 
 TEST_SERVER_VERSION = os.environ.get("TEST_SERVER_VERSION", prefect.__version__)
 
-if Version(TEST_SERVER_VERSION) >= Version("2.17.1"):
-    import asyncio
-    import sys
-    from contextlib import asynccontextmanager
-    from datetime import timedelta
-    from typing import Any, AsyncGenerator, Dict
-    from uuid import uuid4
+if Version(TEST_SERVER_VERSION) < Version("2.17.1"):
+    raise NotImplementedError()
 
-    import anyio
-    import pendulum
-
-    import prefect
+try:
     from prefect import flow, get_client, get_run_logger
+    from prefect.events import Event
+    from prefect.events.clients import get_events_client, get_events_subscriber
+    from prefect.events.filters import (
+        EventFilter,
+        EventNameFilter,
+        EventOccurredFilter,
+        EventResourceFilter,
+    )
+except ImportError:
+    raise NotImplementedError()
 
-    try:
-        from prefect.events import Event
-        from prefect.events.clients import get_events_client, get_events_subscriber
-        from prefect.events.filters import (
-            EventFilter,
-            EventNameFilter,
-            EventOccurredFilter,
-            EventResourceFilter,
-        )
-    except ImportError:
-        # These were introduced in ~2.17.1+ and are not available in older versions
-        sys.exit(0)
 
-    @asynccontextmanager
-    async def create_or_replace_automation(
-        automation: Dict[str, Any],
-    ) -> AsyncGenerator[Dict[str, Any], None]:
-        logger = get_run_logger()
+@asynccontextmanager
+async def create_or_replace_automation(
+    automation: Dict[str, Any],
+) -> AsyncGenerator[Dict[str, Any], None]:
+    logger = get_run_logger()
 
-        async with get_client() as prefect:
-            # Clean up any older automations with the same name prefix
-            response = await prefect._client.post("/automations/filter")
+    async with get_client() as prefect:
+        # Clean up any older automations with the same name prefix
+        response = await prefect._client.post("/automations/filter")
+        response.raise_for_status()
+        for existing in response.json():
+            name = str(existing["name"])
+            if name.startswith(automation["name"]):
+                age = pendulum.now("UTC") - pendulum.parse(existing["created"])
+                assert isinstance(age, timedelta)
+                if age > timedelta(minutes=10):
+                    logger.info(
+                        "Deleting old automation %s (%s)",
+                        existing["name"],
+                        existing["id"],
+                    )
+                await prefect._client.delete(f"/automations/{existing['id']}")
+
+        automation["name"] = f"{automation['name']}:{uuid4()}"
+
+        response = await prefect._client.post("/automations", json=automation)
+        response.raise_for_status()
+
+        automation = response.json()
+        logger.info("Created automation %s (%s)", automation["name"], automation["id"])
+
+        logger.info("Waiting 5s for the automation to be loaded the triggers services")
+        await asyncio.sleep(5)
+
+        try:
+            yield automation
+        finally:
+            response = await prefect._client.delete(f"/automations/{automation['id']}")
             response.raise_for_status()
-            for existing in response.json():
-                name = str(existing["name"])
-                if name.startswith(automation["name"]):
-                    age = pendulum.now("UTC") - pendulum.parse(existing["created"])
-                    assert isinstance(age, timedelta)
-                    if age > timedelta(minutes=10):
-                        logger.info(
-                            "Deleting old automation %s (%s)",
-                            existing["name"],
-                            existing["id"],
-                        )
-                    await prefect._client.delete(f"/automations/{existing['id']}")
 
-            automation["name"] = f"{automation['name']}:{uuid4()}"
 
-            response = await prefect._client.post("/automations", json=automation)
-            response.raise_for_status()
+async def wait_for_event(event: str, resource_id: str) -> Event:
+    logger = get_run_logger()
 
-            automation = response.json()
-            logger.info(
-                "Created automation %s (%s)", automation["name"], automation["id"]
+    filter = EventFilter(
+        occurred=EventOccurredFilter(since=pendulum.now("UTC")),
+        event=EventNameFilter(name=[]),
+        resource=EventResourceFilter(id=[resource_id]),
+    )
+    async with get_events_subscriber(filter=filter) as subscriber:
+        async for event in subscriber:
+            logger.info(event)
+            return event
+
+    raise Exception("Disconnected without an event")
+
+
+@flow
+async def assess_reactive_automation():
+    expected_resource = {"prefect.resource.id": f"integration:reactive:{uuid4()}"}
+    async with create_or_replace_automation(
+        {
+            "name": "reactive-automation",
+            "trigger": {
+                "posture": "Reactive",
+                "expect": ["integration.example.event"],
+                "match": expected_resource,
+                "threshold": 5,
+                "within": 60,
+            },
+            "actions": [{"type": "do-nothing"}],
+        }
+    ) as automation:
+        listener = asyncio.create_task(
+            wait_for_event(
+                "prefect.automation.triggered",
+                f"prefect.automation.{automation['id']}",
             )
-
-            logger.info(
-                "Waiting 5s for the automation to be loaded the triggers services"
-            )
-            await asyncio.sleep(5)
-
-            try:
-                yield automation
-            finally:
-                response = await prefect._client.delete(
-                    f"/automations/{automation['id']}"
-                )
-                response.raise_for_status()
-
-    async def wait_for_event(event: str, resource_id: str) -> Event:
-        logger = get_run_logger()
-
-        filter = EventFilter(
-            occurred=EventOccurredFilter(since=pendulum.now("UTC")),
-            event=EventNameFilter(name=[]),
-            resource=EventResourceFilter(id=[resource_id]),
         )
-        async with get_events_subscriber(filter=filter) as subscriber:
-            async for event in subscriber:
-                logger.info(event)
-                return event
 
-        raise Exception("Disconnected without an event")
+        async with get_events_client() as events:
+            for i in range(5):
+                await events.emit(
+                    Event(
+                        event="integration.example.event",
+                        resource=expected_resource,
+                        payload={"iteration": i},
+                    )
+                )
 
-    @flow
-    async def assess_reactive_automation():
-        expected_resource = {"prefect.resource.id": f"integration:reactive:{uuid4()}"}
-        async with create_or_replace_automation(
-            {
-                "name": "reactive-automation",
-                "trigger": {
-                    "posture": "Reactive",
-                    "expect": ["integration.example.event"],
-                    "match": expected_resource,
-                    "threshold": 5,
-                    "within": 60,
-                },
-                "actions": [{"type": "do-nothing"}],
-            }
-        ) as automation:
-            listener = asyncio.create_task(
-                wait_for_event(
-                    "prefect.automation.triggered",
-                    f"prefect.automation.{automation['id']}",
+        # Wait until we see the automation triggered event, or fail if it takes longer
+        # than 60 seconds.  The reactive trigger should fire almost immediately.
+        with anyio.fail_after(60):
+            await listener
+
+
+@flow
+async def assess_proactive_automation():
+    expected_resource = {"prefect.resource.id": f"integration:proactive:{uuid4()}"}
+    async with create_or_replace_automation(
+        {
+            "name": "proactive-automation",
+            "trigger": {
+                "posture": "Proactive",
+                "expect": ["integration.example.event"],
+                # Doing it for_each resource ID should prevent it from firing endlessly
+                # while the integration tests are _not_ running
+                "for_each": ["prefect.resource.id"],
+                "match": expected_resource,
+                "threshold": 5,
+                "within": 15,
+            },
+            "actions": [{"type": "do-nothing"}],
+        }
+    ) as automation:
+        listener = asyncio.create_task(
+            wait_for_event(
+                "prefect.automation.triggered",
+                f"prefect.automation.{automation['id']}",
+            )
+        )
+
+        async with get_events_client() as events:
+            for i in range(2):  # not enough events to close the automation
+                await events.emit(
+                    Event(
+                        event="integration.example.event",
+                        resource=expected_resource,
+                        payload={"iteration": i},
+                    )
+                )
+
+        # Wait until we see the automation triggered event, or fail if it takes longer
+        # than 60 seconds.  The proactive trigger should take a little over 15s to fire.
+        with anyio.fail_after(60):
+            await listener
+
+
+@flow
+async def assess_compound_automation():
+    expected_resource = {"prefect.resource.id": f"integration:compound:{uuid4()}"}
+    async with create_or_replace_automation(
+        {
+            "name": "compound-automation",
+            "trigger": {
+                "type": "compound",
+                "require": "all",
+                "within": 60,
+                "triggers": [
+                    {
+                        "posture": "Reactive",
+                        "expect": ["integration.example.event.A"],
+                        "match": expected_resource,
+                        "threshold": 1,
+                        "within": 0,
+                    },
+                    {
+                        "posture": "Reactive",
+                        "expect": ["integration.example.event.B"],
+                        "match": expected_resource,
+                        "threshold": 1,
+                        "within": 0,
+                    },
+                ],
+            },
+            "actions": [{"type": "do-nothing"}],
+        }
+    ) as automation:
+        listener = asyncio.create_task(
+            wait_for_event(
+                "prefect.automation.triggered",
+                f"prefect.automation.{automation['id']}",
+            )
+        )
+
+        async with get_events_client() as events:
+            await events.emit(
+                Event(
+                    event="integration.example.event.A",
+                    resource=expected_resource,
+                )
+            )
+            await events.emit(
+                Event(
+                    event="integration.example.event.B",
+                    resource=expected_resource,
                 )
             )
 
-            async with get_events_client() as events:
-                for i in range(5):
-                    await events.emit(
-                        Event(
-                            event="integration.example.event",
-                            resource=expected_resource,
-                            payload={"iteration": i},
-                        )
-                    )
+        # Wait until we see the automation triggered event, or fail if it takes longer
+        # than 60 seconds.  The compound trigger should fire almost immediately.
+        with anyio.fail_after(60):
+            await listener
 
-            # Wait until we see the automation triggered event, or fail if it takes longer
-            # than 60 seconds.  The reactive trigger should fire almost immediately.
-            with anyio.fail_after(60):
-                await listener
 
-    @flow
-    async def assess_proactive_automation():
-        expected_resource = {"prefect.resource.id": f"integration:proactive:{uuid4()}"}
-        async with create_or_replace_automation(
-            {
-                "name": "proactive-automation",
-                "trigger": {
-                    "posture": "Proactive",
-                    "expect": ["integration.example.event"],
-                    # Doing it for_each resource ID should prevent it from firing endlessly
-                    # while the integration tests are _not_ running
-                    "for_each": ["prefect.resource.id"],
-                    "match": expected_resource,
-                    "threshold": 5,
-                    "within": 15,
-                },
-                "actions": [{"type": "do-nothing"}],
-            }
-        ) as automation:
-            listener = asyncio.create_task(
-                wait_for_event(
-                    "prefect.automation.triggered",
-                    f"prefect.automation.{automation['id']}",
+@flow
+async def assess_sequence_automation():
+    expected_resource = {"prefect.resource.id": f"integration:sequence:{uuid4()}"}
+    async with create_or_replace_automation(
+        {
+            "name": "sequence-automation",
+            "trigger": {
+                "type": "sequence",
+                "within": 60,
+                "triggers": [
+                    {
+                        "posture": "Reactive",
+                        "expect": ["integration.example.event.A"],
+                        "match": expected_resource,
+                        "threshold": 1,
+                        "within": 0,
+                    },
+                    {
+                        "posture": "Reactive",
+                        "expect": ["integration.example.event.B"],
+                        "match": expected_resource,
+                        "threshold": 1,
+                        "within": 0,
+                    },
+                ],
+            },
+            "actions": [{"type": "do-nothing"}],
+        }
+    ) as automation:
+        listener = asyncio.create_task(
+            wait_for_event(
+                "prefect.automation.triggered",
+                f"prefect.automation.{automation['id']}",
+            )
+        )
+
+        first = uuid4()
+        second = uuid4()
+        async with get_events_client() as events:
+            await events.emit(
+                Event(
+                    id=first,
+                    event="integration.example.event.A",
+                    resource=expected_resource,
                 )
             )
 
-            async with get_events_client() as events:
-                for i in range(2):  # not enough events to close the automation
-                    await events.emit(
-                        Event(
-                            event="integration.example.event",
-                            resource=expected_resource,
-                            payload={"iteration": i},
-                        )
-                    )
+        get_run_logger().info("Waiting 1s to make sure the sequence is unambiguous")
+        await asyncio.sleep(1)
 
-            # Wait until we see the automation triggered event, or fail if it takes longer
-            # than 60 seconds.  The proactive trigger should take a little over 15s to fire.
-            with anyio.fail_after(60):
-                await listener
-
-    @flow
-    async def assess_compound_automation():
-        expected_resource = {"prefect.resource.id": f"integration:compound:{uuid4()}"}
-        async with create_or_replace_automation(
-            {
-                "name": "compound-automation",
-                "trigger": {
-                    "type": "compound",
-                    "require": "all",
-                    "within": 60,
-                    "triggers": [
-                        {
-                            "posture": "Reactive",
-                            "expect": ["integration.example.event.A"],
-                            "match": expected_resource,
-                            "threshold": 1,
-                            "within": 0,
-                        },
-                        {
-                            "posture": "Reactive",
-                            "expect": ["integration.example.event.B"],
-                            "match": expected_resource,
-                            "threshold": 1,
-                            "within": 0,
-                        },
-                    ],
-                },
-                "actions": [{"type": "do-nothing"}],
-            }
-        ) as automation:
-            listener = asyncio.create_task(
-                wait_for_event(
-                    "prefect.automation.triggered",
-                    f"prefect.automation.{automation['id']}",
+        async with get_events_client() as events:
+            await events.emit(
+                Event(
+                    id=second,
+                    follows=first,
+                    event="integration.example.event.B",
+                    resource=expected_resource,
                 )
             )
 
-            async with get_events_client() as events:
-                await events.emit(
-                    Event(
-                        event="integration.example.event.A",
-                        resource=expected_resource,
-                    )
-                )
-                await events.emit(
-                    Event(
-                        event="integration.example.event.B",
-                        resource=expected_resource,
-                    )
-                )
+        # Wait until we see the automation triggered event, or fail if it takes longer
+        # than 60 seconds.  The compound trigger should fire almost immediately.
+        with anyio.fail_after(60):
+            await listener
 
-            # Wait until we see the automation triggered event, or fail if it takes longer
-            # than 60 seconds.  The compound trigger should fire almost immediately.
-            with anyio.fail_after(60):
-                await listener
 
-    @flow
-    async def assess_sequence_automation():
-        expected_resource = {"prefect.resource.id": f"integration:sequence:{uuid4()}"}
-        async with create_or_replace_automation(
-            {
-                "name": "sequence-automation",
-                "trigger": {
-                    "type": "sequence",
-                    "within": 60,
-                    "triggers": [
-                        {
-                            "posture": "Reactive",
-                            "expect": ["integration.example.event.A"],
-                            "match": expected_resource,
-                            "threshold": 1,
-                            "within": 0,
-                        },
-                        {
-                            "posture": "Reactive",
-                            "expect": ["integration.example.event.B"],
-                            "match": expected_resource,
-                            "threshold": 1,
-                            "within": 0,
-                        },
-                    ],
-                },
-                "actions": [{"type": "do-nothing"}],
-            }
-        ) as automation:
-            listener = asyncio.create_task(
-                wait_for_event(
-                    "prefect.automation.triggered",
-                    f"prefect.automation.{automation['id']}",
-                )
-            )
-
-            first = uuid4()
-            second = uuid4()
-            async with get_events_client() as events:
-                await events.emit(
-                    Event(
-                        id=first,
-                        event="integration.example.event.A",
-                        resource=expected_resource,
-                    )
-                )
-
-            get_run_logger().info("Waiting 1s to make sure the sequence is unambiguous")
-            await asyncio.sleep(1)
-
-            async with get_events_client() as events:
-                await events.emit(
-                    Event(
-                        id=second,
-                        follows=first,
-                        event="integration.example.event.B",
-                        resource=expected_resource,
-                    )
-                )
-
-            # Wait until we see the automation triggered event, or fail if it takes longer
-            # than 60 seconds.  The compound trigger should fire almost immediately.
-            with anyio.fail_after(60):
-                await listener
-
-    if __name__ == "__main__":
-        asyncio.run(assess_reactive_automation())
-        asyncio.run(assess_proactive_automation())
-        asyncio.run(assess_compound_automation())
-        asyncio.run(assess_sequence_automation())
+if __name__ == "__main__":
+    asyncio.run(assess_reactive_automation())
+    asyncio.run(assess_proactive_automation())
+    asyncio.run(assess_compound_automation())
+    asyncio.run(assess_sequence_automation())

--- a/flows/automation-assessments.py
+++ b/flows/automation-assessments.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import sys
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import Any, AsyncGenerator, Dict
@@ -6,7 +8,9 @@ from uuid import uuid4
 
 import anyio
 import pendulum
+from packaging.version import Version
 
+import prefect
 from prefect import flow, get_client, get_run_logger
 from prefect.events import Event
 from prefect.events.clients import get_events_client, get_events_subscriber
@@ -280,6 +284,10 @@ async def assess_sequence_automation():
 
 
 if __name__ == "__main__":
+    TEST_SERVER_VERSION = os.environ.get("TEST_SERVER_VERSION", prefect.__version__)
+    if Version(prefect.__version__) < Version("2.17.1"):
+        sys.exit(0)
+
     asyncio.run(assess_reactive_automation())
     asyncio.run(assess_proactive_automation())
     asyncio.run(assess_compound_automation())

--- a/flows/client_context_lifespan.py
+++ b/flows/client_context_lifespan.py
@@ -1,12 +1,10 @@
-import sys
-
 from packaging.version import Version
 
 import prefect
 
 # Only run these tests if the version is at least 2.13.0
 if Version(prefect.__version__) < Version("2.13.0"):
-    sys.exit(0)
+    raise NotImplementedError()
 
 import asyncio
 import random

--- a/flows/deployment_run.py
+++ b/flows/deployment_run.py
@@ -13,7 +13,7 @@ SUPPORTED_VERSION = "2.6.0"
 
 
 if Version(prefect.__version__) < Version(SUPPORTED_VERSION):
-    sys.exit(0)
+    raise NotImplementedError()
 
 
 @prefect.flow

--- a/flows/deployment_storage.py
+++ b/flows/deployment_storage.py
@@ -15,7 +15,7 @@ SUPPORTED_VERSION = "2.6.0"
 
 
 if Version(prefect.__version__) < Version(SUPPORTED_VERSION):
-    sys.exit(0)
+    raise NotImplementedError()
 
 
 @prefect.flow

--- a/flows/flow_pauses.py
+++ b/flows/flow_pauses.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import threading
 import time
 from concurrent.futures import Future
@@ -15,7 +14,7 @@ SERVER_VERSION = os.getenv("TEST_SERVER_VERSION")
 if Version(prefect.__version__) < PAUSE_VERSION or (
     SERVER_VERSION and Version(SERVER_VERSION) < PAUSE_VERSION
 ):
-    sys.exit(0)
+    raise NotImplementedError()
 else:
     from prefect import flow, pause_flow_run, resume_flow_run, task
     from prefect.context import get_run_context

--- a/scripts/run-integration-flows.py
+++ b/scripts/run-integration-flows.py
@@ -12,6 +12,7 @@ Example:
 
     PREFECT_API_URL="http://localhost:4200" ./scripts/run-integration-flows.py
 """
+
 import os
 import runpy
 import sys
@@ -39,7 +40,10 @@ def run_flows(search_path: Union[str, Path]):
 
     for file in sorted(Path(search_path).glob("*.py")):
         print(f" {file.relative_to(search_path)} ".center(90, "-"), flush=True)
-        runpy.run_path(file, run_name="__main__")
+        try:
+            runpy.run_path(file, run_name="__main__")
+        except NotImplementedError:
+            print(f"Skipping {file}: not supported by this version of Prefect")
         print("".center(90, "-") + "\n", flush=True)
         count += 1
 

--- a/src/prefect/events/__init__.py
+++ b/src/prefect/events/__init__.py
@@ -1,6 +1,7 @@
 from .schemas.events import Event, ReceivedEvent
 from .schemas.events import Resource, RelatedResource, ResourceSpecification
 from .schemas.automations import (
+    Automation,
     AutomationCore,
     Posture,
     Trigger,
@@ -20,6 +21,7 @@ from .schemas.deployment_triggers import (
     DeploymentCompoundTrigger,
     DeploymentSequenceTrigger,
 )
+from .clients import get_events_client, get_events_subscriber
 from .utilities import emit_event
 
 __all__ = [
@@ -28,6 +30,7 @@ __all__ = [
     "Resource",
     "RelatedResource",
     "ResourceSpecification",
+    "Automation",
     "AutomationCore",
     "Posture",
     "Trigger",
@@ -45,4 +48,6 @@ __all__ = [
     "DeploymentCompoundTrigger",
     "DeploymentSequenceTrigger",
     "emit_event",
+    "get_events_client",
+    "get_events_subscriber",
 ]

--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -52,11 +52,14 @@ def get_events_client(
             reconnection_attempts=reconnection_attempts,
             checkpoint_every=checkpoint_every,
         )
-    elif not PREFECT_EXPERIMENTAL_EVENTS:
-        return PrefectEventsClient(
-            reconnection_attempts=reconnection_attempts,
-            checkpoint_every=checkpoint_every,
-        )
+    elif PREFECT_EXPERIMENTAL_EVENTS:
+        if PREFECT_API_URL:
+            return PrefectEventsClient(
+                reconnection_attempts=reconnection_attempts,
+                checkpoint_every=checkpoint_every,
+            )
+        else:
+            return PrefectEphemeralEventsClient()
 
     raise RuntimeError(
         "The current server and client configuration does not support "
@@ -74,7 +77,7 @@ def get_events_subscriber(
         return PrefectCloudEventSubscriber(
             filter=filter, reconnection_attempts=reconnection_attempts
         )
-    elif not PREFECT_EXPERIMENTAL_EVENTS:
+    elif PREFECT_EXPERIMENTAL_EVENTS:
         return PrefectEventSubscriber(
             filter=filter, reconnection_attempts=reconnection_attempts
         )

--- a/src/prefect/server/api/events.py
+++ b/src/prefect/server/api/events.py
@@ -20,6 +20,7 @@ from prefect.server.events.counting import (
     TimeUnit,
 )
 from prefect.server.events.filters import EventFilter
+from prefect.server.events.models.automations import automations_session
 from prefect.server.events.schemas.events import Event, EventCount, EventPage
 from prefect.server.events.storage import (
     INTERACTIVE_PAGE_SIZE,
@@ -102,10 +103,12 @@ async def stream_workspace_events_out(
         async with stream.events(filter) as event_stream:
             # ...then if the user wants, backfill up to the last 1k events...
             if wants_backfill:
-                backfill, _, _ = await database.query_events(
-                    filter=filter,
-                    page_size=1000,
-                )
+                async with automations_session() as session:
+                    backfill, _, _ = await database.query_events(
+                        session=session,
+                        filter=filter,
+                        page_size=1000,
+                    )
 
                 backfilled_ids = set()
 

--- a/tests/events/client/test_events_client.py
+++ b/tests/events/client/test_events_client.py
@@ -21,17 +21,23 @@ from prefect.settings import (
 from prefect.testing.fixtures import Puppeteer, Recorder
 
 
-def test_constructs_server_client():
+@pytest.fixture
+def server_settings():
     with temporary_settings(
         {
             PREFECT_API_URL: "https://locally/api",
             PREFECT_CLOUD_API_URL: "https://cloudy/api",
         }
     ):
-        assert isinstance(get_events_client(), PrefectEventsClient)
+        yield
 
 
-def test_constructs_cloud_client():
+async def test_constructs_server_client(server_settings):
+    assert isinstance(get_events_client(), PrefectEventsClient)
+
+
+@pytest.fixture
+def cloud_settings():
     with temporary_settings(
         {
             PREFECT_API_URL: "https://cloudy/api/accounts/1/workspaces/2",
@@ -39,7 +45,11 @@ def test_constructs_cloud_client():
             PREFECT_API_KEY: "howdy-doody",
         }
     ):
-        assert isinstance(get_events_client(), PrefectCloudEventsClient)
+        yield
+
+
+async def test_constructs_cloud_client(cloud_settings):
+    assert isinstance(get_events_client(), PrefectCloudEventsClient)
 
 
 async def test_ephemeral_events_client_can_emit(

--- a/tests/events/client/test_events_subscriber.py
+++ b/tests/events/client/test_events_subscriber.py
@@ -10,9 +10,27 @@ from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
+    PREFECT_EXPERIMENTAL_EVENTS,
     temporary_settings,
 )
 from prefect.testing.fixtures import Puppeteer, Recorder
+
+
+@pytest.fixture
+def no_viable_settings():
+    with temporary_settings(
+        {
+            PREFECT_API_URL: "https://locally/api",
+            PREFECT_CLOUD_API_URL: "https://cloudy/api",
+            PREFECT_EXPERIMENTAL_EVENTS: False,
+        }
+    ):
+        yield
+
+
+async def test_raises_when_no_viable_client(no_viable_settings):
+    with pytest.raises(RuntimeError, match="does not support events"):
+        get_events_subscriber()
 
 
 @pytest.fixture
@@ -21,6 +39,7 @@ def server_settings():
         {
             PREFECT_API_URL: "https://locally/api",
             PREFECT_CLOUD_API_URL: "https://cloudy/api",
+            PREFECT_EXPERIMENTAL_EVENTS: True,
         }
     ):
         yield
@@ -37,6 +56,7 @@ def cloud_settings():
             PREFECT_API_URL: "https://cloudy/api/accounts/1/workspaces/2",
             PREFECT_CLOUD_API_URL: "https://cloudy/api",
             PREFECT_API_KEY: "howdy-doody",
+            PREFECT_EXPERIMENTAL_EVENTS: False,
         }
     ):
         yield

--- a/tests/events/client/test_events_subscriber.py
+++ b/tests/events/client/test_events_subscriber.py
@@ -1,39 +1,86 @@
+from typing import Type
+
 import pytest
 from websockets.exceptions import ConnectionClosedError
 
-from prefect.events import Event
-from prefect.events.clients import PrefectCloudEventSubscriber
+from prefect.events import Event, get_events_subscriber
+from prefect.events.clients import PrefectCloudEventSubscriber, PrefectEventSubscriber
 from prefect.events.filters import EventFilter, EventNameFilter
-from prefect.settings import PREFECT_API_KEY, PREFECT_API_URL, temporary_settings
+from prefect.settings import (
+    PREFECT_API_KEY,
+    PREFECT_API_URL,
+    PREFECT_CLOUD_API_URL,
+    temporary_settings,
+)
 from prefect.testing.fixtures import Puppeteer, Recorder
 
 
+def test_constructs_server_subscriber():
+    with temporary_settings(
+        {
+            PREFECT_API_URL: "https://locally/api",
+            PREFECT_CLOUD_API_URL: "https://cloudy/api",
+        }
+    ):
+        assert isinstance(get_events_subscriber(), PrefectEventSubscriber)
+
+
+def test_constructs_cloud_subscriber():
+    with temporary_settings(
+        {
+            PREFECT_API_URL: "https://cloudy/api/accounts/1/workspaces/2",
+            PREFECT_CLOUD_API_URL: "https://cloudy/api",
+            PREFECT_API_KEY: "howdy-doody",
+        }
+    ):
+        assert isinstance(get_events_subscriber(), PrefectCloudEventSubscriber)
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc):
+    fixtures = set(metafunc.fixturenames)
+
+    if "Subscriber" in fixtures:
+        metafunc.parametrize(
+            "Subscriber",
+            [PrefectEventSubscriber, PrefectCloudEventSubscriber],
+        )
+
+
+@pytest.fixture(autouse=True)
+def api_setup(events_cloud_api_url: str):
+    with temporary_settings(
+        updates={
+            PREFECT_API_URL: events_cloud_api_url,
+            PREFECT_API_KEY: "my-token",
+        }
+    ):
+        yield
+
+
 async def test_subscriber_can_connect_with_defaults(
+    Subscriber: Type[PrefectEventSubscriber],
     events_cloud_api_url: str,
     example_event_1: Event,
     example_event_2: Event,
     recorder: Recorder,
     puppeteer: Puppeteer,
 ):
-    with temporary_settings(
-        updates={PREFECT_API_KEY: "my-token", PREFECT_API_URL: events_cloud_api_url}
-    ):
-        puppeteer.token = "my-token"
-        puppeteer.outgoing_events = [example_event_1, example_event_2]
+    puppeteer.token = "my-token" if Subscriber == PrefectCloudEventSubscriber else None
+    puppeteer.outgoing_events = [example_event_1, example_event_2]
 
-        async with PrefectCloudEventSubscriber() as subscriber:
-            async for event in subscriber:
-                recorder.events.append(event)
+    async with Subscriber() as subscriber:
+        async for event in subscriber:
+            recorder.events.append(event)
 
-        assert recorder.connections == 1
-        assert recorder.path == "/accounts/A/workspaces/W/events/out"
-        assert recorder.events == [example_event_1, example_event_2]
-        assert recorder.token == "my-token"
-        assert subscriber._filter
-        assert recorder.filter == subscriber._filter
+    assert recorder.connections == 1
+    assert recorder.path == "/accounts/A/workspaces/W/events/out"
+    assert recorder.events == [example_event_1, example_event_2]
+    assert recorder.token == puppeteer.token
+    assert subscriber._filter
+    assert recorder.filter == subscriber._filter
 
 
-async def test_subscriber_complains_without_api_url_and_key(
+async def test_cloud_subscriber_complains_without_api_url_and_key(
     events_cloud_api_url: str,
     example_event_1: Event,
     example_event_2: Event,
@@ -46,21 +93,20 @@ async def test_subscriber_complains_without_api_url_and_key(
 
 
 async def test_subscriber_can_connect_and_receive_one_event(
+    Subscriber: Type[PrefectEventSubscriber],
     events_cloud_api_url: str,
     example_event_1: Event,
     example_event_2: Event,
     recorder: Recorder,
     puppeteer: Puppeteer,
 ):
-    puppeteer.token = "my-token"
+    puppeteer.token = "my-token" if Subscriber == PrefectCloudEventSubscriber else None
     puppeteer.outgoing_events = [example_event_1, example_event_2]
 
     filter = EventFilter(event=EventNameFilter(name=["example.event"]))
 
-    async with PrefectCloudEventSubscriber(
-        events_cloud_api_url,
-        "my-token",
-        filter,
+    async with Subscriber(
+        filter=filter,
         reconnection_attempts=0,
     ) as subscriber:
         async for event in subscriber:
@@ -69,27 +115,26 @@ async def test_subscriber_can_connect_and_receive_one_event(
     assert recorder.connections == 1
     assert recorder.path == "/accounts/A/workspaces/W/events/out"
     assert recorder.events == [example_event_1, example_event_2]
-    assert recorder.token == "my-token"
+    assert recorder.token == puppeteer.token
     assert recorder.filter == filter
 
 
 async def test_subscriber_specifying_negative_reconnects_gets_error(
+    Subscriber: Type[PrefectEventSubscriber],
     events_cloud_api_url: str,
     example_event_1: Event,
     example_event_2: Event,
     recorder: Recorder,
     puppeteer: Puppeteer,
 ):
-    puppeteer.token = "my-token"
+    puppeteer.token = "my-token" if Subscriber == PrefectCloudEventSubscriber else None
     puppeteer.outgoing_events = [example_event_1, example_event_2]
 
     filter = EventFilter(event=EventNameFilter(name=["example.event"]))
 
     with pytest.raises(ValueError, match="non-negative"):
-        PrefectCloudEventSubscriber(
-            events_cloud_api_url,
-            "my-token",
-            filter,
+        Subscriber(
+            filter=filter,
             reconnection_attempts=-1,
         )
 
@@ -112,7 +157,7 @@ async def test_subscriber_raises_on_invalid_auth_with_soft_denial(
         subscriber = PrefectCloudEventSubscriber(
             events_cloud_api_url,
             "bogus",
-            filter,
+            filter=filter,
             reconnection_attempts=0,
         )
         await subscriber.__aenter__()
@@ -123,7 +168,7 @@ async def test_subscriber_raises_on_invalid_auth_with_soft_denial(
     assert recorder.events == []
 
 
-async def test_subscriber_raises_on_invalid_auth_with_hard_denial(
+async def test_cloud_subscriber_raises_on_invalid_auth_with_hard_denial(
     events_cloud_api_url: str,
     example_event_1: Event,
     example_event_2: Event,
@@ -140,7 +185,7 @@ async def test_subscriber_raises_on_invalid_auth_with_hard_denial(
         subscriber = PrefectCloudEventSubscriber(
             events_cloud_api_url,
             "bogus",
-            filter,
+            filter=filter,
             reconnection_attempts=0,
         )
         await subscriber.__aenter__()
@@ -152,22 +197,20 @@ async def test_subscriber_raises_on_invalid_auth_with_hard_denial(
 
 
 async def test_subscriber_reconnects_on_hard_disconnects(
-    events_cloud_api_url: str,
+    Subscriber: Type[PrefectEventSubscriber],
     example_event_1: Event,
     example_event_2: Event,
     recorder: Recorder,
     puppeteer: Puppeteer,
 ):
-    puppeteer.token = "my-token"
+    puppeteer.token = "my-token" if Subscriber == PrefectCloudEventSubscriber else None
     puppeteer.outgoing_events = [example_event_1, example_event_2]
     puppeteer.hard_disconnect_after = example_event_1.id
 
     filter = EventFilter(event=EventNameFilter(name=["example.event"]))
 
-    async with PrefectCloudEventSubscriber(
-        events_cloud_api_url,
-        "my-token",
-        filter,
+    async with Subscriber(
+        filter=filter,
         reconnection_attempts=2,
     ) as subscriber:
         async for event in subscriber:
@@ -178,23 +221,21 @@ async def test_subscriber_reconnects_on_hard_disconnects(
 
 
 async def test_subscriber_gives_up_after_so_many_attempts(
-    events_cloud_api_url: str,
+    Subscriber: Type[PrefectEventSubscriber],
     example_event_1: Event,
     example_event_2: Event,
     recorder: Recorder,
     puppeteer: Puppeteer,
 ):
-    puppeteer.token = "my-token"
+    puppeteer.token = "my-token" if Subscriber == PrefectCloudEventSubscriber else None
     puppeteer.outgoing_events = [example_event_1, example_event_2]
     puppeteer.hard_disconnect_after = example_event_1.id
 
     filter = EventFilter(event=EventNameFilter(name=["example.event"]))
 
     with pytest.raises(ConnectionClosedError):
-        async with PrefectCloudEventSubscriber(
-            events_cloud_api_url,
-            "my-token",
-            filter,
+        async with Subscriber(
+            filter=filter,
             reconnection_attempts=4,
         ) as subscriber:
             async for event in subscriber:
@@ -205,21 +246,19 @@ async def test_subscriber_gives_up_after_so_many_attempts(
 
 
 async def test_subscriber_skips_duplicate_events(
-    events_cloud_api_url: str,
+    Subscriber: Type[PrefectEventSubscriber],
     example_event_1: Event,
     example_event_2: Event,
     recorder: Recorder,
     puppeteer: Puppeteer,
 ):
-    puppeteer.token = "my-token"
+    puppeteer.token = "my-token" if Subscriber == PrefectCloudEventSubscriber else None
     puppeteer.outgoing_events = [example_event_1, example_event_1, example_event_2]
 
     filter = EventFilter(event=EventNameFilter(name=["example.event"]))
 
-    async with PrefectCloudEventSubscriber(
-        events_cloud_api_url,
-        "my-token",
-        filter,
+    async with Subscriber(
+        filter=filter,
     ) as subscriber:
         async for event in subscriber:
             recorder.events.append(event)

--- a/tests/events/client/test_events_subscriber.py
+++ b/tests/events/client/test_events_subscriber.py
@@ -15,17 +15,23 @@ from prefect.settings import (
 from prefect.testing.fixtures import Puppeteer, Recorder
 
 
-def test_constructs_server_subscriber():
+@pytest.fixture
+def server_settings():
     with temporary_settings(
         {
             PREFECT_API_URL: "https://locally/api",
             PREFECT_CLOUD_API_URL: "https://cloudy/api",
         }
     ):
-        assert isinstance(get_events_subscriber(), PrefectEventSubscriber)
+        yield
 
 
-def test_constructs_cloud_subscriber():
+async def test_constructs_server_client(server_settings):
+    assert isinstance(get_events_subscriber(), PrefectEventSubscriber)
+
+
+@pytest.fixture
+def cloud_settings():
     with temporary_settings(
         {
             PREFECT_API_URL: "https://cloudy/api/accounts/1/workspaces/2",
@@ -33,7 +39,11 @@ def test_constructs_cloud_subscriber():
             PREFECT_API_KEY: "howdy-doody",
         }
     ):
-        assert isinstance(get_events_subscriber(), PrefectCloudEventSubscriber)
+        yield
+
+
+async def test_constructs_cloud_client(cloud_settings):
+    assert isinstance(get_events_subscriber(), PrefectCloudEventSubscriber)
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc):

--- a/tests/events/server/gateway/test_gateway_out.py
+++ b/tests/events/server/gateway/test_gateway_out.py
@@ -9,6 +9,7 @@ from prefect._vendor.starlette.status import (
 )
 from prefect._vendor.starlette.testclient import TestClient
 from prefect._vendor.starlette.websockets import WebSocketDisconnect
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server.events.filters import (
     EventFilter,
@@ -52,7 +53,7 @@ def backfill_mock(
         filter: EventFilter,
         page_size: int = 0,
     ) -> Tuple[List[ReceivedEvent], Any, Any]:
-        assert session is None
+        assert isinstance(session, AsyncSession)
 
         assert isinstance(filter, EventFilter)
 


### PR DESCRIPTION
This gives us two top-level functions that will choose the correct
implementation subclasses for event clients and subscribers, depending on
your `PREFECT_API_URL`.  This also parametrizes most of the tests to check all
four client types.

Note: this is also sprawling into an attempt to correct the integration tests,
which were silently exiting the process when they weren't compatible with the
current server version.