### PR TITLE
Fix work pool volumes example which should be an array

### DIFF
--- a/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
+++ b/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
@@ -812,7 +812,7 @@
               "title": "Volumes",
               "description": "A list of volume to mount into created containers.",
               "example": [
-                "/my/local/path:/path/in/container"
+                "[\"/my/local/path:/path/in/container\"]"
               ],
               "type": "array",
               "items": {


### PR DESCRIPTION
# Description
Updates the example value when editing a work pool to show an array of volumes rather than a single volume. If a string is used flows will fail. 

![image](https://github.com/PrefectHQ/prefect/assets/6200442/4124939d-3c78-464e-849b-51012aa858d5)

[Slack thread](https://prefect-community.slack.com/archives/C0192RWGJQH/p1713299728768779)