### PR TITLE
Clarify deployment trigger examples

### DIFF
--- a/docs/concepts/automations.md
+++ b/docs/concepts/automations.md
@@ -635,11 +635,11 @@ if __name__=="__main__":
     )
 ```
 
-As with prior examples, composite triggers must be supplied with a list of underlying triggers:
+As with prior examples, composite triggers must be supplied with a list of underlying triggers. Note that only the outer trigger type needs to be prefixed with `Deployment` since the underlying triggers don't interface directly with the linked deployment or create separate automations:
 
 ```python
 from prefect import flow
-from prefect.events import DeploymentEventTrigger, DeploymentCompoundTrigger
+from prefect.events import DeploymentCompoundTrigger, EventTrigger
 
 
 @flow(log_prints=True)
@@ -650,17 +650,17 @@ def decorated_fn(param_1: str):
 if __name__=="__main__":
     decorated_fn.deploy(
         name="my-deployment",
-        image="prefecthq/prefect:2-latest"
+        image="my-image-registry/my-image:my-tag"
         triggers=[
             DeploymentCompoundTrigger(
                 name="my-compound-trigger",
                 require="all",
                 triggers=[
-                    DeploymentEventTrigger(
+                    EventTrigger(
                       match={"prefect.resource.id": "my.external.resource"},
                       expect=["external.resource.pinged"],
                     ),
-                    DeploymentEventTrigger(
+                    EventTrigger(
                       match={"prefect.resource.id": "my.external.resource"},
                       expect=["external.resource.replied"],
                     ),

--- a/docs/concepts/automations.md
+++ b/docs/concepts/automations.md
@@ -639,7 +639,7 @@ As with prior examples, composite triggers must be supplied with a list of under
 
 ```python
 from prefect import flow
-from prefect.events import DeploymentCompoundTrigger, EventTrigger
+from prefect.events import DeploymentCompoundTrigger
 
 
 @flow(log_prints=True)

--- a/docs/concepts/automations.md
+++ b/docs/concepts/automations.md
@@ -635,7 +635,7 @@ if __name__=="__main__":
     )
 ```
 
-As with prior examples, composite triggers must be supplied with a list of underlying triggers. Note that only the outer trigger type needs to be prefixed with `Deployment` since the underlying triggers don't interface directly with the linked deployment or create separate automations:
+As with prior examples, composite triggers must be supplied with a list of underlying triggers:
 
 ```python
 from prefect import flow
@@ -653,17 +653,20 @@ if __name__=="__main__":
         image="my-image-registry/my-image:my-tag"
         triggers=[
             DeploymentCompoundTrigger(
+                enabled=True,
                 name="my-compound-trigger",
                 require="all",
                 triggers=[
-                    EventTrigger(
-                      match={"prefect.resource.id": "my.external.resource"},
-                      expect=["external.resource.pinged"],
-                    ),
-                    EventTrigger(
-                      match={"prefect.resource.id": "my.external.resource"},
-                      expect=["external.resource.replied"],
-                    ),
+                    {
+                      "type": "event",
+                      "match": {"prefect.resource.id": "my.external.resource"},
+                      "expect": ["external.resource.pinged"],
+                    },
+                    {
+                      "type": "event",
+                      "match": {"prefect.resource.id": "my.external.resource"},
+                      "expect": ["external.resource.replied"],
+                    },
                 ],
                 parameters={
                     "param_1": "{{ event }}",


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

Changes the Python composite trigger example to use a dictionary for each inner trigger to keep user-facing classes to a minimum and align with the other examples.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
