### PR TITLE
Add support for using the "normal" Trigger classes for flow.serve and .deploy

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -7,8 +7,15 @@ from copy import deepcopy
 from datetime import timedelta
 from getpass import GetPassWarning
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 from uuid import UUID
+
+import typer
+import yaml
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from yaml.error import YAMLError
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 
@@ -17,12 +24,6 @@ if HAS_PYDANTIC_V2:
 else:
     import pydantic
 
-import typer
-import yaml
-from rich.console import Console
-from rich.panel import Panel
-from rich.table import Table
-from yaml.error import YAMLError
 
 import prefect
 from prefect._internal.compatibility.deprecated import (
@@ -62,7 +63,7 @@ from prefect.deployments.base import (
     _save_deployment_to_prefect_file,
 )
 from prefect.deployments.steps.core import run_steps
-from prefect.events import DeploymentTriggerTypes
+from prefect.events import DeploymentTriggerTypes, TriggerTypes
 from prefect.exceptions import ObjectNotFound
 from prefect.flows import load_flow_from_entrypoint
 from prefect.settings import (
@@ -1602,7 +1603,9 @@ def _initialize_deployment_triggers(
 
 
 async def _create_deployment_triggers(
-    client: PrefectClient, deployment_id: UUID, triggers: List[DeploymentTriggerTypes]
+    client: PrefectClient,
+    deployment_id: UUID,
+    triggers: List[Union[DeploymentTriggerTypes, TriggerTypes]],
 ):
     if client.server_type.supports_automations():
         # The triggers defined in the deployment spec are, essentially,

--- a/src/prefect/deployments/deployments.py
+++ b/src/prefect/deployments/deployments.py
@@ -16,6 +16,13 @@ import anyio
 import pendulum
 import yaml
 
+from prefect._internal.pydantic import HAS_PYDANTIC_V2
+
+if HAS_PYDANTIC_V2:
+    from pydantic.v1 import BaseModel, Field, parse_obj_as, root_validator, validator
+else:
+    from pydantic import BaseModel, Field, parse_obj_as, root_validator, validator
+
 from prefect._internal.compatibility.deprecated import (
     DeprecatedInfraOverridesField,
     deprecated_callable,
@@ -23,7 +30,6 @@ from prefect._internal.compatibility.deprecated import (
     deprecated_parameter,
     handle_deprecated_infra_overrides_parameter,
 )
-from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect._internal.schemas.validators import (
     handle_openapi_schema,
     infrastructure_must_have_capabilities,
@@ -32,16 +38,10 @@ from prefect._internal.schemas.validators import (
     validate_automation_names,
     validate_deprecated_schedule_fields,
 )
-from prefect.client.schemas.actions import DeploymentScheduleCreate
-
-if HAS_PYDANTIC_V2:
-    from pydantic.v1 import BaseModel, Field, parse_obj_as, root_validator, validator
-else:
-    from pydantic import BaseModel, Field, parse_obj_as, root_validator, validator
-
 from prefect.blocks.core import Block
 from prefect.blocks.fields import SecretDict
 from prefect.client.orchestration import PrefectClient, get_client
+from prefect.client.schemas.actions import DeploymentScheduleCreate
 from prefect.client.schemas.objects import (
     FlowRun,
     MinimalDeploymentSchedule,
@@ -53,7 +53,7 @@ from prefect.deployments.schedules import (
     FlexibleScheduleList,
 )
 from prefect.deployments.steps.core import run_steps
-from prefect.events import DeploymentTriggerTypes
+from prefect.events import DeploymentTriggerTypes, TriggerTypes
 from prefect.exceptions import (
     BlockMissingCapabilities,
     ObjectAlreadyExists,
@@ -609,7 +609,7 @@ class Deployment(DeprecatedInfraOverridesField, BaseModel):
         description="The parameter schema of the flow, including defaults.",
     )
     timestamp: datetime = Field(default_factory=partial(pendulum.now, "UTC"))
-    triggers: List[DeploymentTriggerTypes] = Field(
+    triggers: List[Union[DeploymentTriggerTypes, TriggerTypes]] = Field(
         default_factory=list,
         description="The triggers that should cause this deployment to run.",
     )

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -42,26 +42,19 @@ from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn, track
 from rich.table import Table
 
-from prefect._internal.concurrency.api import create_call, from_async
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
-from prefect._internal.schemas.validators import (
-    reconcile_paused_deployment,
-    reconcile_schedules_runner,
-    validate_automation_names,
-)
-from prefect.runner.storage import RunnerStorage
-from prefect.settings import (
-    PREFECT_DEFAULT_DOCKER_BUILD_NAMESPACE,
-    PREFECT_DEFAULT_WORK_POOL_NAME,
-    PREFECT_UI_URL,
-)
-from prefect.utilities.collections import get_from_dict, isiterable
 
 if HAS_PYDANTIC_V2:
     from pydantic.v1 import BaseModel, Field, PrivateAttr, root_validator, validator
 else:
     from pydantic import BaseModel, Field, PrivateAttr, root_validator, validator
 
+from prefect._internal.concurrency.api import create_call, from_async
+from prefect._internal.schemas.validators import (
+    reconcile_paused_deployment,
+    reconcile_schedules_runner,
+    validate_automation_names,
+)
 from prefect.client.orchestration import get_client
 from prefect.client.schemas.objects import MinimalDeploymentSchedule
 from prefect.client.schemas.schedules import (
@@ -72,13 +65,20 @@ from prefect.deployments.schedules import (
     FlexibleScheduleList,
     create_minimal_deployment_schedule,
 )
-from prefect.events import DeploymentTriggerTypes
+from prefect.events import DeploymentTriggerTypes, TriggerTypes
 from prefect.exceptions import (
     ObjectNotFound,
     PrefectHTTPStatusError,
 )
+from prefect.runner.storage import RunnerStorage
+from prefect.settings import (
+    PREFECT_DEFAULT_DOCKER_BUILD_NAMESPACE,
+    PREFECT_DEFAULT_WORK_POOL_NAME,
+    PREFECT_UI_URL,
+)
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.callables import ParameterSchema, parameter_schema
+from prefect.utilities.collections import get_from_dict, isiterable
 from prefect.utilities.dockerutils import (
     PushError,
     build_image,
@@ -179,7 +179,7 @@ class RunnerDeployment(BaseModel):
             "The path to the entrypoint for the workflow, relative to the `path`."
         ),
     )
-    triggers: List[DeploymentTriggerTypes] = Field(
+    triggers: List[Union[DeploymentTriggerTypes, TriggerTypes]] = Field(
         default_factory=list,
         description="The triggers that should cause this deployment to run.",
     )
@@ -446,7 +446,7 @@ class RunnerDeployment(BaseModel):
         schedule: Optional[SCHEDULE_TYPES] = None,
         is_schedule_active: Optional[bool] = None,
         parameters: Optional[dict] = None,
-        triggers: Optional[List[DeploymentTriggerTypes]] = None,
+        triggers: Optional[List[Union[DeploymentTriggerTypes, TriggerTypes]]] = None,
         description: Optional[str] = None,
         tags: Optional[List[str]] = None,
         version: Optional[str] = None,
@@ -582,7 +582,7 @@ class RunnerDeployment(BaseModel):
         schedule: Optional[SCHEDULE_TYPES] = None,
         is_schedule_active: Optional[bool] = None,
         parameters: Optional[dict] = None,
-        triggers: Optional[List[DeploymentTriggerTypes]] = None,
+        triggers: Optional[List[Union[DeploymentTriggerTypes, TriggerTypes]]] = None,
         description: Optional[str] = None,
         tags: Optional[List[str]] = None,
         version: Optional[str] = None,
@@ -680,7 +680,7 @@ class RunnerDeployment(BaseModel):
         schedule: Optional[SCHEDULE_TYPES] = None,
         is_schedule_active: Optional[bool] = None,
         parameters: Optional[dict] = None,
-        triggers: Optional[List[DeploymentTriggerTypes]] = None,
+        triggers: Optional[List[Union[DeploymentTriggerTypes, TriggerTypes]]] = None,
         description: Optional[str] = None,
         tags: Optional[List[str]] = None,
         version: Optional[str] = None,

--- a/src/prefect/events/schemas/automations.py
+++ b/src/prefect/events/schemas/automations.py
@@ -66,6 +66,8 @@ class Trigger(PrefectBaseModel, abc.ABC, extra="ignore"):
         return [
             RunDeployment(
                 deployment_id=self._deployment_id,
+                parameters=getattr(self, "parameters", None),
+                job_variables=getattr(self, "job_variables", None),
             )
         ]
 

--- a/src/prefect/events/schemas/deployment_triggers.py
+++ b/src/prefect/events/schemas/deployment_triggers.py
@@ -16,7 +16,6 @@ from typing import (
     Any,
     Dict,
     List,
-    Literal,
     Optional,
     Set,
     Union,
@@ -27,14 +26,11 @@ from typing_extensions import TypeAlias
 
 from prefect._internal.compatibility.deprecated import deprecated_class
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
-from prefect._internal.schemas.validators import validate_trigger_within
 
 if HAS_PYDANTIC_V2:
-    from pydantic.v1 import Field, PrivateAttr, root_validator, validator
-    from pydantic.v1.fields import ModelField
+    from pydantic.v1 import Field, PrivateAttr
 else:
-    from pydantic import Field, PrivateAttr, root_validator, validator
-    from pydantic.fields import ModelField
+    from pydantic import Field, PrivateAttr
 
 from prefect._internal.schemas.bases import PrefectBaseModel
 from prefect.events.actions import RunDeployment
@@ -47,8 +43,6 @@ from .automations import (
     MetricTriggerQuery,
     Posture,
     SequenceTrigger,
-    Trigger,
-    TriggerTypes,
 )
 from .events import ResourceSpecification
 
@@ -67,10 +61,6 @@ class BaseDeploymentTrigger(PrefectBaseModel, abc.ABC, extra="ignore"):
     description: str = Field("", description="A longer description of this automation")
     enabled: bool = Field(True, description="Whether this automation will be evaluated")
 
-    # Fields from Trigger
-
-    type: str
-
     # Fields from Deployment
 
     parameters: Optional[Dict[str, Any]] = Field(
@@ -87,60 +77,9 @@ class BaseDeploymentTrigger(PrefectBaseModel, abc.ABC, extra="ignore"):
             "deployment's default job variables"
         ),
     )
-    _deployment_id: Optional[UUID] = PrivateAttr(default=None)
-
-    def set_deployment_id(self, deployment_id: UUID):
-        self._deployment_id = deployment_id
-
-    def owner_resource(self) -> Optional[str]:
-        return f"prefect.deployment.{self._deployment_id}"
-
-    def actions(self) -> List[RunDeployment]:
-        assert self._deployment_id
-        return [
-            RunDeployment(
-                parameters=self.parameters,
-                deployment_id=self._deployment_id,
-                job_variables=self.job_variables,
-            )
-        ]
-
-    def as_automation(self) -> AutomationCore:
-        if not self.name:
-            raise ValueError("name is required")
-
-        return AutomationCore(
-            name=self.name,
-            description=self.description,
-            enabled=self.enabled,
-            trigger=self.as_trigger(),
-            actions=self.actions(),
-            owner_resource=self.owner_resource(),
-        )
-
-    @abc.abstractmethod
-    def as_trigger(self) -> Trigger:
-        ...
 
 
-class DeploymentResourceTrigger(BaseDeploymentTrigger, abc.ABC):
-    """
-    Base class for triggers that may filter by the labels of resources.
-    """
-
-    type: str
-
-    match: ResourceSpecification = Field(
-        default_factory=lambda: ResourceSpecification.parse_obj({}),
-        description="Labels for resources which this trigger will match.",
-    )
-    match_related: ResourceSpecification = Field(
-        default_factory=lambda: ResourceSpecification.parse_obj({}),
-        description="Labels for related resources which this trigger will match.",
-    )
-
-
-class DeploymentEventTrigger(DeploymentResourceTrigger):
+class DeploymentEventTrigger(BaseDeploymentTrigger, EventTrigger):
     """
     A trigger that fires based on the presence or absence of events within a given
     period of time.
@@ -148,183 +87,27 @@ class DeploymentEventTrigger(DeploymentResourceTrigger):
 
     trigger_type = EventTrigger
 
-    type: Literal["event"] = "event"
 
-    after: Set[str] = Field(
-        default_factory=set,
-        description=(
-            "The event(s) which must first been seen to fire this trigger.  If "
-            "empty, then fire this trigger immediately.  Events may include "
-            "trailing wildcards, like `prefect.flow-run.*`"
-        ),
-    )
-    expect: Set[str] = Field(
-        default_factory=set,
-        description=(
-            "The event(s) this trigger is expecting to see.  If empty, this "
-            "trigger will match any event.  Events may include trailing wildcards, "
-            "like `prefect.flow-run.*`"
-        ),
-    )
-
-    for_each: Set[str] = Field(
-        default_factory=set,
-        description=(
-            "Evaluate the trigger separately for each distinct value of these labels "
-            "on the resource.  By default, labels refer to the primary resource of the "
-            "triggering event.  You may also refer to labels from related "
-            "resources by specifying `related:<role>:<label>`.  This will use the "
-            "value of that label for the first related resource in that role.  For "
-            'example, `"for_each": ["related:flow:prefect.resource.id"]` would '
-            "evaluate the trigger for each flow."
-        ),
-    )
-    posture: Literal[Posture.Reactive, Posture.Proactive] = Field(  # type: ignore[valid-type]
-        Posture.Reactive,
-        description=(
-            "The posture of this trigger, either Reactive or Proactive.  Reactive "
-            "triggers respond to the _presence_ of the expected events, while "
-            "Proactive triggers respond to the _absence_ of those expected events."
-        ),
-    )
-    threshold: int = Field(
-        1,
-        description=(
-            "The number of events required for this trigger to fire (for "
-            "Reactive triggers), or the number of events expected (for Proactive "
-            "triggers)"
-        ),
-    )
-    within: timedelta = Field(
-        timedelta(0),
-        minimum=0.0,
-        exclusiveMinimum=False,
-        description=(
-            "The time period over which the events must occur.  For Reactive triggers, "
-            "this may be as low as 0 seconds, but must be at least 10 seconds for "
-            "Proactive triggers"
-        ),
-    )
-
-    @validator("within")
-    def enforce_minimum_within(
-        cls, value: timedelta, values, config, field: ModelField
-    ):
-        return validate_trigger_within(value, field)
-
-    @root_validator(skip_on_failure=True)
-    def enforce_minimum_within_for_proactive_triggers(cls, values: Dict[str, Any]):
-        posture: Optional[Posture] = values.get("posture")
-        within: Optional[timedelta] = values.get("within")
-
-        if posture == Posture.Proactive:
-            if not within or within == timedelta(0):
-                values["within"] = timedelta(seconds=10.0)
-            elif within < timedelta(seconds=10.0):
-                raise ValueError(
-                    "The minimum within for Proactive triggers is 10 seconds"
-                )
-
-        return values
-
-    def as_trigger(self) -> Trigger:
-        return self.trigger_type(
-            match=self.match,
-            match_related=self.match_related,
-            after=self.after,
-            expect=self.expect,
-            for_each=self.for_each,
-            posture=self.posture,
-            threshold=self.threshold,
-            within=self.within,
-        )
-
-
-class DeploymentMetricTrigger(DeploymentResourceTrigger):
+class DeploymentMetricTrigger(BaseDeploymentTrigger, MetricTrigger):
     """
     A trigger that fires based on the results of a metric query.
     """
 
     trigger_type = MetricTrigger
 
-    type: Literal["metric"] = "metric"
 
-    posture: Literal[Posture.Metric] = Field(  # type: ignore[valid-type]
-        Posture.Metric,
-        description="Periodically evaluate the configured metric query.",
-    )
-
-    metric: MetricTriggerQuery = Field(
-        ...,
-        description="The metric query to evaluate for this trigger. ",
-    )
-
-    def as_trigger(self) -> Trigger:
-        return self.trigger_type(
-            match=self.match,
-            match_related=self.match_related,
-            posture=self.posture,
-            metric=self.metric,
-            job_variables=self.job_variables,
-        )
-
-
-class DeploymentCompositeTrigger(BaseDeploymentTrigger, abc.ABC):
-    """
-    Requires some number of triggers to have fired within the given time period.
-    """
-
-    type: Literal["compound", "sequence"]
-    triggers: List["TriggerTypes"]
-    within: Optional[timedelta]
-
-
-class DeploymentCompoundTrigger(DeploymentCompositeTrigger):
+class DeploymentCompoundTrigger(BaseDeploymentTrigger, CompoundTrigger):
     """A composite trigger that requires some number of triggers to have
     fired within the given time period"""
 
     trigger_type = CompoundTrigger
 
-    type: Literal["compound"] = "compound"
-    require: Union[int, Literal["any", "all"]]
 
-    @root_validator
-    def validate_require(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        require = values.get("require")
-
-        if isinstance(require, int):
-            if require < 1:
-                raise ValueError("required must be at least 1")
-            if require > len(values["triggers"]):
-                raise ValueError(
-                    "required must be less than or equal to the number of triggers"
-                )
-
-        return values
-
-    def as_trigger(self) -> Trigger:
-        return self.trigger_type(
-            require=self.require,
-            triggers=self.triggers,
-            within=self.within,
-            job_variables=self.job_variables,
-        )
-
-
-class DeploymentSequenceTrigger(DeploymentCompositeTrigger):
+class DeploymentSequenceTrigger(BaseDeploymentTrigger, SequenceTrigger):
     """A composite trigger that requires some number of triggers to have fired
     within the given time period in a specific order"""
 
     trigger_type = SequenceTrigger
-
-    type: Literal["sequence"] = "sequence"
-
-    def as_trigger(self) -> Trigger:
-        return self.trigger_type(
-            triggers=self.triggers,
-            within=self.within,
-            job_variables=self.job_variables,
-        )
 
 
 # Concrete deployment trigger types

--- a/src/prefect/events/schemas/deployment_triggers.py
+++ b/src/prefect/events/schemas/deployment_triggers.py
@@ -61,7 +61,7 @@ class BaseDeploymentTrigger(PrefectBaseModel, abc.ABC, extra="ignore"):
     description: str = Field("", description="A longer description of this automation")
     enabled: bool = Field(True, description="Whether this automation will be evaluated")
 
-    # Fields from Deployment
+    # Fields from the RunDeployment action
 
     parameters: Optional[Dict[str, Any]] = Field(
         None,

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -34,20 +34,10 @@ from typing import (
 )
 from uuid import UUID
 
-from prefect._vendor.fastapi.encoders import jsonable_encoder
-from typing_extensions import Self
+from rich.console import Console
+from typing_extensions import Literal, ParamSpec, Self
 
-from prefect._internal.compatibility.deprecated import deprecated_parameter
-from prefect._internal.concurrency.api import create_call, from_async
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
-from prefect.client.orchestration import get_client
-from prefect.deployments.runner import DeploymentImage, EntrypointType, deploy
-from prefect.filesystems import ReadableDeploymentStorage
-from prefect.runner.storage import (
-    BlockStorageAdapter,
-    RunnerStorage,
-    create_storage_from_url,
-)
 
 if HAS_PYDANTIC_V2:
     import pydantic.v1 as pydantic
@@ -67,24 +57,33 @@ else:
 
     V2ValidationError = None
 
-from rich.console import Console
-from typing_extensions import Literal, ParamSpec
+from prefect._vendor.fastapi.encoders import jsonable_encoder
 
+from prefect._internal.compatibility.deprecated import deprecated_parameter
+from prefect._internal.concurrency.api import create_call, from_async
 from prefect._internal.schemas.validators import raise_on_name_with_banned_characters
+from prefect.client.orchestration import get_client
 from prefect.client.schemas.objects import Flow as FlowSchema
 from prefect.client.schemas.objects import FlowRun, MinimalDeploymentSchedule
 from prefect.client.schemas.schedules import SCHEDULE_TYPES
 from prefect.context import PrefectObjectRegistry, registry_from_script
-from prefect.events import DeploymentTriggerTypes
+from prefect.deployments.runner import DeploymentImage, EntrypointType, deploy
+from prefect.events import DeploymentTriggerTypes, TriggerTypes
 from prefect.exceptions import (
     MissingFlowError,
     ObjectNotFound,
     ParameterTypeError,
     UnspecifiedFlowError,
 )
+from prefect.filesystems import ReadableDeploymentStorage
 from prefect.futures import PrefectFuture
 from prefect.logging import get_logger
 from prefect.results import ResultSerializer, ResultStorage
+from prefect.runner.storage import (
+    BlockStorageAdapter,
+    RunnerStorage,
+    create_storage_from_url,
+)
 from prefect.settings import (
     PREFECT_DEFAULT_WORK_POOL_NAME,
     PREFECT_FLOW_DEFAULT_RETRIES,
@@ -618,7 +617,7 @@ class Flow(Generic[P, R]):
         schedule: Optional[SCHEDULE_TYPES] = None,
         is_schedule_active: Optional[bool] = None,
         parameters: Optional[dict] = None,
-        triggers: Optional[List[DeploymentTriggerTypes]] = None,
+        triggers: Optional[List[Union[DeploymentTriggerTypes, TriggerTypes]]] = None,
         description: Optional[str] = None,
         tags: Optional[List[str]] = None,
         version: Optional[str] = None,
@@ -748,7 +747,7 @@ class Flow(Generic[P, R]):
         schedules: Optional[List["FlexibleScheduleList"]] = None,
         schedule: Optional[SCHEDULE_TYPES] = None,
         is_schedule_active: Optional[bool] = None,
-        triggers: Optional[List[DeploymentTriggerTypes]] = None,
+        triggers: Optional[List[Union[DeploymentTriggerTypes, TriggerTypes]]] = None,
         parameters: Optional[dict] = None,
         description: Optional[str] = None,
         tags: Optional[List[str]] = None,
@@ -962,7 +961,7 @@ class Flow(Generic[P, R]):
         schedules: Optional[List[MinimalDeploymentSchedule]] = None,
         schedule: Optional[SCHEDULE_TYPES] = None,
         is_schedule_active: Optional[bool] = None,
-        triggers: Optional[List[DeploymentTriggerTypes]] = None,
+        triggers: Optional[List[Union[DeploymentTriggerTypes, TriggerTypes]]] = None,
         parameters: Optional[dict] = None,
         description: Optional[str] = None,
         tags: Optional[List[str]] = None,

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -29,6 +29,7 @@ Example:
     ```
 
 """
+
 import asyncio
 import datetime
 import inspect
@@ -80,7 +81,7 @@ from prefect.deployments.runner import (
 )
 from prefect.deployments.schedules import FlexibleScheduleList
 from prefect.engine import propose_state
-from prefect.events import DeploymentTriggerTypes
+from prefect.events import DeploymentTriggerTypes, TriggerTypes
 from prefect.exceptions import (
     Abort,
 )
@@ -232,7 +233,7 @@ class Runner:
         schedule: Optional[SCHEDULE_TYPES] = None,
         is_schedule_active: Optional[bool] = None,
         parameters: Optional[dict] = None,
-        triggers: Optional[List[DeploymentTriggerTypes]] = None,
+        triggers: Optional[List[Union[DeploymentTriggerTypes, TriggerTypes]]] = None,
         description: Optional[str] = None,
         tags: Optional[List[str]] = None,
         version: Optional[str] = None,

--- a/tests/events/client/test_deployment_trigger_schema.py
+++ b/tests/events/client/test_deployment_trigger_schema.py
@@ -47,14 +47,16 @@ def test_deployment_trigger_defaults_to_empty_reactive_trigger():
     assert automation.trigger.expect == set()
 
 
-def test_deployment_trigger_requires_name_but_can_have_it_set_later():
+def test_deployment_trigger_defaults_name_but_can_have_it_overridden():
     trigger = pydantic.parse_obj_as(DeploymentTriggerTypes, {})
     assert isinstance(trigger, DeploymentEventTrigger)
 
-    trigger.set_deployment_id(uuid4())
+    deployment_id = uuid4()
 
-    with pytest.raises(ValueError, match="name is required"):
-        trigger.as_automation()
+    trigger.set_deployment_id(deployment_id)
+
+    automation = trigger.as_automation()
+    assert automation.name == f"Automation for deployment {deployment_id}"
 
     trigger.name = "A deployment automation"
     automation = trigger.as_automation()

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -34,6 +34,7 @@ from prefect.client.orchestration import PrefectClient, get_client
 from prefect.context import FlowRunContext
 from prefect.deployments import Deployment, run_deployment
 from prefect.events import DeploymentTriggerTypes
+from prefect.events.schemas.deployment_triggers import DeploymentEventTrigger
 from prefect.exceptions import BlockMissingCapabilities
 from prefect.filesystems import S3, GitHub, LocalFileSystem
 from prefect.infrastructure import DockerContainer, Infrastructure, Process
@@ -1066,6 +1067,7 @@ class TestDeploymentApply:
         trigger = pydantic.parse_obj_as(
             DeploymentTriggerTypes, {"job_variables": {"foo": 123}}
         )
+        assert isinstance(trigger, DeploymentEventTrigger)
 
         deployment = Deployment(
             name="TEST",


### PR DESCRIPTION
The `Deployment*Trigger` classes help capture some additional information about
the automation to create (name, description, whether it's enabled, etc) or
about how to customize the `RunDeployment` action, which can be useful for
stored triggers in a `prefect.yaml`.  When serving flows dynamically or when we
don't need as much customization, we can also accept triggers from the "normal"
`Trigger` hierarchy.

This allows doing this:

```
from prefect import flow
from prefect.events import EventTrigger

@flow
def my_flow():
    pass

my_flow.serve(name="my-server", triggers=[EventTrigger(expect={"some.event"})])
```

This also makes the `Deployment*Trigger` classes subclasses of their respective
`Trigger` types to avoid duplicating fields and validations.
