### PR TITLE
Run `compat-tests` as part of CI

### DIFF
--- a/.github/workflows/api-compatibility-tests.yaml
+++ b/.github/workflows/api-compatibility-tests.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Create OSS OpenAPI JSON
         working-directory: compat-tests
-        run: python scripts/generate_oss_openapi_schema.py
+        run: python ../scripts/generate_oss_openapi_schema.py
 
       - name: Run API compatibility tests
         working-directory: compat-tests

--- a/.github/workflows/api-compatibility-tests.yaml
+++ b/.github/workflows/api-compatibility-tests.yaml
@@ -62,14 +62,13 @@ jobs:
           uv pip install --upgrade --system -e .[dev] 'pydantic>=2.4,<3'
 
       - name: Create Cloud OpenAPI JSON
-        run: |
-          curl https://api.prefect.cloud/api/openapi.json > cloud_schema.json
+        working-directory: compat-tests
+        run: curl https://api.prefect.cloud/api/openapi.json > cloud_schema.json
 
       - name: Create OSS OpenAPI JSON
-        run: |
-          python scripts/generate_oss_openapi_schema.py
+        working-directory: compat-tests
+        run: python scripts/generate_oss_openapi_schema.py
 
       - name: Run API compatibility tests
-        run: |
-          cd compat-tests
-          pytest -vv
+        working-directory: compat-tests
+        run: pytest -vv

--- a/.github/workflows/api-compatibility-tests.yaml
+++ b/.github/workflows/api-compatibility-tests.yaml
@@ -1,0 +1,75 @@
+---
+name: Cloud API Compatibility
+on:
+  pull_request:
+    paths:
+      - .github/workflows/api-compatibility-tests.yaml
+      - "**/*.py"
+      - requirements*.txt
+      - setup.cfg
+      - compat-tests
+  push:
+    branches:
+      - main
+
+# Limit concurrency by workflow/branch combination.
+#
+# For pull request builds, pushing additional changes to the
+# branch will cancel prior in-progress and pending builds.
+#
+# For builds triggered on a branch push, additional changes
+# will wait for prior builds to complete before starting.
+#
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  compatibility-tests:
+
+    timeout-minutes: 10
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Versioneer only generates correct versions with a full fetch
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        id: setup_python
+        with:
+          python-version: 3.12
+
+      - name: UV Cache
+        # Manually cache the uv cache directory
+        # until setup-python supports it:
+        # https://github.com/actions/setup-python/issues/822
+        uses: actions/cache@v4
+        id: cache-uv
+        with:
+          path: ~/.cache/uv
+          key: uvcache-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-client.txt', 'requirements.txt', 'requirements-dev.txt') }}
+
+      - name: Install packages
+        run: |
+          python -m pip install -U uv
+          uv pip install --upgrade --system -e .[dev] 'pydantic>=2.4,<3'
+
+      - name: Create Cloud OpenAPI JSON
+        run: |
+          curl https://api.prefect.cloud/api/openapi.json > cloud_schema.json
+
+      - name: Create OSS OpenAPI JSON
+        run: |
+          python scripts/generate_oss_openapi_schema.py
+
+      - name: Run API compatibility tests
+        run: |
+          cd compat-tests
+          pytest -vv

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "compat-tests"]
+	path = compat-tests
+	url = https://github.com/PrefectHQ/compat-tests.git

--- a/scripts/generate_oss_openapi_schema.py
+++ b/scripts/generate_oss_openapi_schema.py
@@ -1,0 +1,9 @@
+import json
+
+from prefect.server.api.server import create_app
+
+app = create_app()
+openapi_schema = app.openapi()
+
+with open("oss_schema.json", "w") as f:
+    json.dump(openapi_schema, f)

--- a/scripts/run-compatibility-tests
+++ b/scripts/run-compatibility-tests
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd compat-tests
+curl https://api.prefect.cloud/api/openapi.json > cloud_schema.json
+python ../scripts/generate_oss_openapi_schema.py
+pytest -vv test_oss_cloud_api_compatibility.py


### PR DESCRIPTION
Our [`compat-tests`](https://github.com/PrefectHQ/compat-tests) have been
running with every Prefect Cloud CI build for some time now.  Here, we also
start running them with every `PrefectHQ/prefect` pull request as well.  This
will help to catch incompatibilities earlier and prevent the scenario where an
addition in OSS will cause the _next_ Prefect Cloud build to fail.

Part of PrefectHQ/compat-tests#16
