### PR TITLE
Preparing to introduce `mypy` checking, starting with client-side events

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ mkdocstrings-python
 mike
 mock; python_version < '3.8'
 moto >= 5
-mypy
+mypy >= 1.9.0
 numpy
 pillow
 pre-commit
@@ -35,3 +35,6 @@ vermin
 virtualenv
 watchfiles
 respx
+
+# type stubs
+types-cachetools

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,21 +83,10 @@ filterwarnings =
 
 
 [mypy]
-# TODO: We will allow definitions to be untyped for now; in the future we will want to
-#       toggle these back to True to enforce type checks.
-disallow_untyped_defs = False
-check_untyped_defs = False
+files = ./src/prefect/input/*.py,./src/prefect/events/*.py
 
-# Empty `mypy` will run on the prefect module
-files = ./src/prefect/**/*.py
-
-[mypy-prefect.flows]
-# mypy does not support ParamSpec which is used to preserve parameter types
-ignore_errors = True
-
-[mypy-prefect.tasks]
-# mypy does not support ParamSpec which is used to preserve parameter types
-ignore_errors = True
+[mypy-ruamel]
+ignore_missing_imports = True
 
 [versioneer]
 VCS = git

--- a/src/prefect/_internal/schemas/fields.py
+++ b/src/prefect/_internal/schemas/fields.py
@@ -3,6 +3,7 @@ from typing import Optional
 from uuid import UUID
 
 import pendulum
+from typing_extensions import TypeAlias
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 
@@ -12,19 +13,37 @@ else:
     from pydantic import BaseModel, Field
 
 
-class DateTimeTZ(pendulum.DateTime):
-    @classmethod
-    def __get_validators__(cls):
-        yield cls.validate
+# Rather than subclassing pendulum.DateTime to add our pydantic-specific validation,
+# which will lead to a lot of funky typing issues, we'll just monkeypatch the pydantic
+# validators onto the class.  Retaining this type alias means that we can still use it
+# as we have been in class definitions, also guaranteeing that we'll be applying these
+# validators by importing this module.
 
-    @classmethod
-    def validate(cls, v):
-        if isinstance(v, str):
-            return pendulum.parse(v)
-        elif isinstance(v, datetime.datetime):
-            return pendulum.instance(v)
-        else:
-            raise ValueError("Unrecognized datetime.")
+DateTimeTZ: TypeAlias = pendulum.DateTime
+
+
+def _datetime_patched_classmethod(function):
+    if hasattr(DateTimeTZ, function.__name__):
+        return function
+    setattr(DateTimeTZ, function.__name__, classmethod(function))
+    return function
+
+
+@_datetime_patched_classmethod
+def __get_validators__(cls):
+    yield getattr(cls, "validate")
+
+
+@_datetime_patched_classmethod
+def validate(cls, v) -> pendulum.DateTime:
+    if isinstance(v, str):
+        parsed = pendulum.parse(v)
+        assert isinstance(parsed, pendulum.DateTime)
+        return parsed
+    elif isinstance(v, datetime.datetime):
+        return pendulum.instance(v)
+    else:
+        raise ValueError("Unrecognized datetime.")
 
 
 class CreatedBy(BaseModel):

--- a/src/prefect/blocks/system.py
+++ b/src/prefect/blocks/system.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-import pendulum
-
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 
 if HAS_PYDANTIC_V2:
@@ -9,6 +7,7 @@ if HAS_PYDANTIC_V2:
 else:
     from pydantic import Field, SecretStr
 
+from prefect._internal.schemas.fields import DateTimeTZ
 from prefect.blocks.core import Block
 
 
@@ -76,7 +75,7 @@ class DateTime(Block):
     _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/8b3da9a6621e92108b8e6a75b82e15374e170ff7-48x48.png"
     _documentation_url = "https://docs.prefect.io/api-ref/prefect/blocks/system/#prefect.blocks.system.DateTime"
 
-    value: pendulum.DateTime = Field(
+    value: DateTimeTZ = Field(
         default=...,
         description="An ISO 8601-compatible datetime value.",
     )

--- a/src/prefect/events/actions.py
+++ b/src/prefect/events/actions.py
@@ -9,7 +9,8 @@ from prefect._internal.pydantic import HAS_PYDANTIC_V2
 if HAS_PYDANTIC_V2:
     from pydantic.v1 import Field, root_validator
 else:
-    from pydantic import Field, root_validator
+    from pydantic import Field, root_validator  # type: ignore
+
 from prefect._internal.schemas.bases import PrefectBaseModel
 from prefect.client.schemas.objects import StateType
 

--- a/src/prefect/events/filters.py
+++ b/src/prefect/events/filters.py
@@ -13,7 +13,7 @@ from .schemas.events import Event, Resource, ResourceSpecification
 if HAS_PYDANTIC_V2:
     from pydantic.v1 import Field, PrivateAttr
 else:
-    from pydantic import Field, PrivateAttr
+    from pydantic import Field, PrivateAttr  # type: ignore
 
 
 class EventDataFilter(PrefectBaseModel, extra="forbid"):
@@ -219,9 +219,8 @@ class EventFilter(EventDataFilter):
     related: Optional[EventRelatedFilter] = Field(
         None, description="Filter criteria for the related resources of the event"
     )
-    id: EventIDFilter = Field(
-        default_factory=EventIDFilter,
-        description="Filter criteria for the events' ID",
+    id: Optional[EventIDFilter] = Field(
+        None, description="Filter criteria for the events' ID"
     )
 
     order: EventOrder = Field(

--- a/src/prefect/events/filters.py
+++ b/src/prefect/events/filters.py
@@ -203,7 +203,7 @@ class EventOrder(AutoEnum):
 
 class EventFilter(EventDataFilter):
     occurred: EventOccurredFilter = Field(
-        default_factory=EventOccurredFilter,
+        default_factory=lambda: EventOccurredFilter(),
         description="Filter criteria for when the events occurred",
     )
     event: Optional[EventNameFilter] = Field(
@@ -219,8 +219,9 @@ class EventFilter(EventDataFilter):
     related: Optional[EventRelatedFilter] = Field(
         None, description="Filter criteria for the related resources of the event"
     )
-    id: Optional[EventIDFilter] = Field(
-        None, description="Filter criteria for the events' ID"
+    id: EventIDFilter = Field(
+        default_factory=lambda: EventIDFilter(id=[]),
+        description="Filter criteria for the events' ID",
     )
 
     order: EventOrder = Field(

--- a/src/prefect/events/instrument.py
+++ b/src/prefect/events/instrument.py
@@ -119,17 +119,17 @@ def instrument_method_calls_on_class_instances(cls: Type) -> Type:
     """
 
     required_events_methods = ["_event_kind", "_event_method_called_resources"]
-    for method in required_events_methods:
-        if not hasattr(cls, method):
+    for method_name in required_events_methods:
+        if not hasattr(cls, method_name):
             raise RuntimeError(
-                f"Unable to instrument class {cls}. Class must define {method!r}."
+                f"Unable to instrument class {cls}. Class must define {method_name!r}."
             )
 
     decorator = instrument_instance_method_call()
 
-    for name, method in instrumentable_methods(
+    for method_name, method in instrumentable_methods(
         cls,
         exclude_methods=getattr(cls, "_events_excluded_methods", []),
     ):
-        setattr(cls, name, decorator(method))
+        setattr(cls, method_name, decorator(method))
     return cls

--- a/src/prefect/events/related.py
+++ b/src/prefect/events/related.py
@@ -57,6 +57,7 @@ async def related_resources_from_run_context(
     exclude: Optional[Set[str]] = None,
 ) -> List[RelatedResource]:
     from prefect.client.orchestration import get_client
+    from prefect.client.schemas.objects import FlowRun
     from prefect.context import FlowRunContext, TaskRunContext
 
     if exclude is None:
@@ -111,7 +112,7 @@ async def related_resources_from_run_context(
 
         flow_run = related_objects[0]["object"]
 
-        if flow_run:
+        if isinstance(flow_run, FlowRun):
             related_objects += list(
                 await asyncio.gather(
                     _get_and_cache_related_object(

--- a/src/prefect/events/utilities.py
+++ b/src/prefect/events/utilities.py
@@ -61,7 +61,7 @@ def emit_event(
     if worker_instance.client_type not in operational_clients:
         return None
 
-    event_kwargs = {
+    event_kwargs: Dict[str, Any] = {
         "event": event,
         "resource": resource,
     }

--- a/src/prefect/events/worker.py
+++ b/src/prefect/events/worker.py
@@ -56,7 +56,7 @@ class EventsWorker(QueueService[Event]):
         self.client_type = client_type
         self.client_options = client_options
         self._client: EventsClient
-        self._context_cache: Dict[Event, Context]
+        self._context_cache: Dict[Event, Context] = {}
 
     @asynccontextmanager
     async def _lifespan(self):

--- a/src/prefect/server/events/filters.py
+++ b/src/prefect/server/events/filters.py
@@ -533,10 +533,7 @@ class EventFilter(EventDataFilter):
     related: Optional[EventRelatedFilter] = Field(
         None, description="Filter criteria for the related resources of the event"
     )
-    id: EventIDFilter = Field(
-        default_factory=EventIDFilter,
-        description="Filter criteria for the events' ID",
-    )
+    id: EventIDFilter = Field(None, description="Filter criteria for the events' ID")
 
     order: EventOrder = Field(
         EventOrder.DESC,

--- a/src/prefect/server/events/filters.py
+++ b/src/prefect/server/events/filters.py
@@ -517,7 +517,7 @@ class EventOrder(AutoEnum):
 
 class EventFilter(EventDataFilter):
     occurred: EventOccurredFilter = Field(
-        default_factory=EventOccurredFilter,
+        default_factory=lambda: EventOccurredFilter(),
         description="Filter criteria for when the events occurred",
     )
     event: Optional[EventNameFilter] = Field(
@@ -533,7 +533,10 @@ class EventFilter(EventDataFilter):
     related: Optional[EventRelatedFilter] = Field(
         None, description="Filter criteria for the related resources of the event"
     )
-    id: EventIDFilter = Field(None, description="Filter criteria for the events' ID")
+    id: EventIDFilter = Field(
+        default_factory=lambda: EventIDFilter(),
+        description="Filter criteria for the events' ID",
+    )
 
     order: EventOrder = Field(
         EventOrder.DESC,

--- a/src/prefect/server/utilities/schemas/fields.py
+++ b/src/prefect/server/utilities/schemas/fields.py
@@ -1,18 +1,36 @@
 import datetime
 
 import pendulum
+from typing_extensions import TypeAlias
+
+# Rather than subclassing pendulum.DateTime to add our pydantic-specific validation,
+# which will lead to a lot of funky typing issues, we'll just monkeypatch the pydantic
+# validators onto the class.  Retaining this type alias means that we can still use it
+# as we have been in class definitions, also guaranteeing that we'll be applying these
+# validators by importing this module.
+
+DateTimeTZ: TypeAlias = pendulum.DateTime
 
 
-class DateTimeTZ(pendulum.DateTime):
-    @classmethod
-    def __get_validators__(cls):
-        yield cls.validate
+def _datetime_patched_classmethod(function):
+    if hasattr(DateTimeTZ, function.__name__):
+        return function
+    setattr(DateTimeTZ, function.__name__, classmethod(function))
+    return function
 
-    @classmethod
-    def validate(cls, v):
-        if isinstance(v, str):
-            return pendulum.parse(v)
-        elif isinstance(v, datetime.datetime):
-            return pendulum.instance(v)
-        else:
-            raise ValueError("Unrecognized datetime.")
+
+@_datetime_patched_classmethod
+def __get_validators__(cls):
+    yield getattr(cls, "validate")
+
+
+@_datetime_patched_classmethod
+def validate(cls, v) -> pendulum.DateTime:
+    if isinstance(v, str):
+        parsed = pendulum.parse(v)
+        assert isinstance(parsed, pendulum.DateTime)
+        return parsed
+    elif isinstance(v, datetime.datetime):
+        return pendulum.instance(v)
+    else:
+        raise ValueError("Unrecognized datetime.")

--- a/tests/server/utilities/test_schemas.py
+++ b/tests/server/utilities/test_schemas.py
@@ -245,7 +245,7 @@ class TestDatetimeTZ:
         )
 
         assert model.dt.tzinfo is None
-        assert model.dtp.tzinfo is None
+        assert model.dtp.tzinfo.name == "UTC"
         assert model.dttz.tzinfo.name == "UTC"
 
     async def test_tz_is_pydantic_object(self):
@@ -255,6 +255,5 @@ class TestDatetimeTZ:
             dttz=datetime.datetime(2022, 1, 1),
         )
         assert not isinstance(model.dt, pendulum.DateTime)
-        # typing as pendulum datetime doesn't result in pendulum datetime
-        assert not isinstance(model.dtp, pendulum.DateTime)
+        assert isinstance(model.dtp, pendulum.DateTime)
         assert isinstance(model.dttz, pendulum.DateTime)

--- a/tests/utilities/test_templating.py
+++ b/tests/utilities/test_templating.py
@@ -386,7 +386,7 @@ class TestResolveBlockDocumentReferences:
         assert result == {
             "json": {"key": "value"},
             "secret": "N1nj4C0d3rP@ssw0rd!",
-            "datetime": "2020-01-01T00:00:00",
+            "datetime": "2020-01-01T00:00:00+00:00",
             "string": "hello",
         }
 


### PR DESCRIPTION
We have a long-term goal to have the entire Prefect library pass mypy in strict
mode, and the journey of a thousand miles starts with a single step.  This
resets the `mypy` configuration we had and starts with a couple of modules we've
identified to tackle today.  This includes the client-side events code.

Probably the most controversial thing I'm doing here is making `DateTimeTZ` just
an alias to `DateTime` and then dynamically adding the appropriate `pydantic`
validator functions to it.  This allows us to avoid a giant swath of typing
errors where it looks like we're downcasting a `DateTime` to a `DateTimeTZ`.

This change has been in effect on Prefect Cloud for some time now, so I'm pretty
confident that it is a drop-in replacement for what we were doing before.
