### PR TITLE
Create integration tags on published release

### DIFF
--- a/.github/workflows/create-tags-for-changed-integrations.yaml
+++ b/.github/workflows/create-tags-for-changed-integrations.yaml
@@ -1,9 +1,8 @@
 name: Create tags for changed integrations
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/create-tags-for-changed-integrations.yaml
+++ b/.github/workflows/create-tags-for-changed-integrations.yaml
@@ -1,0 +1,38 @@
+name: Create tags for changed integrations
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create-integrations-tags:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -U packaging gh-util tomli
+
+      - name: Get previous tag
+        id: get-previous-tag
+        run: echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+
+      - name: Push tags for changed integrations
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREVIOUS_TAG: ${{ steps.get-previous-tag.outputs.tag }}
+          CURRENT_COMMIT: ${{ github.sha }}
+
+        run: python scripts/create_tags_for_changed_collections.py

--- a/.github/workflows/create-tags-for-changed-integrations.yaml
+++ b/.github/workflows/create-tags-for-changed-integrations.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -U packaging gh-util tomli
+          pip install -U packaging gh-util
 
       - name: Get previous tag
         id: get-previous-tag

--- a/.github/workflows/create-tags-for-changed-integrations.yaml
+++ b/.github/workflows/create-tags-for-changed-integrations.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   create-integrations-tags:

--- a/scripts/create_tags_for_changed_collections.py
+++ b/scripts/create_tags_for_changed_collections.py
@@ -38,11 +38,11 @@ async def get_changed_integrations(
     for file_path in modified_integrations_files:
         path = Path(file_path)
         integration_name = path.parent.name
-        current_version = await fetch_latest_repo_tag(
-            OWNER, REPO, f"{integration_name}-*"
+        latest_ref = await fetch_latest_repo_tag(
+            OWNER, REPO, pattern=f"{integration_name}-*"
         )
         changed_integrations[integration_name] = increment_patch_version(
-            current_version
+            latest_ref.ref.replace("refs/tags/", "")
         )
     return changed_integrations
 

--- a/scripts/create_tags_for_changed_collections.py
+++ b/scripts/create_tags_for_changed_collections.py
@@ -6,14 +6,12 @@ import sys
 from pathlib import Path
 from typing import Dict, List
 
-import tomli
-from gh_util.functions import (
-    create_repo_tag,  # pip install gh-util, set GITHUB_TOKEN env var
-)
+from gh_util.functions import create_repo_tag
 from packaging.version import Version
 
 INTEGRATIONS_BASEPATH = "src/integrations"
-INTEGRATIONS_VERSIONS_FILE = "src/integrations/versions.toml"
+OWNER = "prefecthq"
+REPO = "prefect"
 
 
 def get_changed_files(previous_tag: str, current_commit: str) -> List[str]:
@@ -27,13 +25,24 @@ def increment_patch_version(version: str) -> str:
     return f"{v.major}.{v.minor}.{v.micro + 1}"
 
 
+def get_latest_tag_version(integration_name: str) -> str:
+    cmd = (
+        f"git tag --list '*-{integration_name}' "
+        "--sort=-v:refname --format='%(refname:short)' | head -n1"
+    )
+    output = subprocess.check_output(cmd, shell=True, text=True)
+    tag_name = output.strip()
+    if tag_name:
+        return tag_name.split("-")[-1]
+
+    raise ValueError(f"Tag not found for {integration_name}")
+
+
 def get_changed_integrations(
     changed_files: List[str], glob_pattern: str
 ) -> Dict[str, str]:
     integrations_base_path = Path(INTEGRATIONS_BASEPATH)
     changed_integrations = {}
-    with open(INTEGRATIONS_VERSIONS_FILE, "rb") as f:
-        versions: Dict[str, str] = tomli.load(f).get("integrations", {})
     modified_integrations_files = [
         file_path
         for file_path in changed_files
@@ -43,18 +52,18 @@ def get_changed_integrations(
     for file_path in modified_integrations_files:
         path = Path(file_path)
         integration_name = path.parent.name
-        if integration_name in versions:
-            current_version = versions[integration_name]
-            next_version = increment_patch_version(current_version)
-            changed_integrations[integration_name] = next_version
+        current_version = get_latest_tag_version(integration_name)
+        changed_integrations[integration_name] = increment_patch_version(
+            current_version
+        )
     return changed_integrations
 
 
 async def create_tags(changed_integrations: Dict[str, str]) -> None:
     for integration_name, version in changed_integrations.items():
         await create_repo_tag(
-            owner="zzstoatzz",
-            repo="integration-monorepo",
+            owner=OWNER,
+            repo=REPO,
             tag_name=f"{integration_name}-{version}",
             commit_sha=os.environ.get("CURRENT_COMMIT", ""),
             message=f"Release {integration_name} {version}",

--- a/scripts/create_tags_for_changed_collections.py
+++ b/scripts/create_tags_for_changed_collections.py
@@ -39,7 +39,7 @@ async def get_changed_integrations(
         path = Path(file_path)
         integration_name = path.parent.name
         current_version = await fetch_latest_repo_tag(
-            OWNER, REPO, f"*-{integration_name}"
+            OWNER, REPO, f"{integration_name}-*"
         )
         changed_integrations[integration_name] = increment_patch_version(
             current_version

--- a/scripts/create_tags_for_changed_collections.py
+++ b/scripts/create_tags_for_changed_collections.py
@@ -1,0 +1,86 @@
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+import tomli
+from gh_util.functions import (
+    create_repo_tag,  # pip install gh-util, set GITHUB_TOKEN env var
+)
+from packaging.version import Version
+
+INTEGRATIONS_BASEPATH = "src/integrations"
+INTEGRATIONS_VERSIONS_FILE = "src/integrations/versions.toml"
+
+
+def get_changed_files(previous_tag: str, current_commit: str) -> List[str]:
+    cmd = f"git diff --name-only {previous_tag}..{current_commit}"
+    output = subprocess.check_output(cmd, shell=True, text=True)
+    return output.strip().split("\n")
+
+
+def increment_patch_version(version: str) -> str:
+    v = Version(version)
+    return f"{v.major}.{v.minor}.{v.micro + 1}"
+
+
+def get_changed_integrations(
+    changed_files: List[str], glob_pattern: str
+) -> Dict[str, str]:
+    integrations_base_path = Path(INTEGRATIONS_BASEPATH)
+    changed_integrations = {}
+    with open(INTEGRATIONS_VERSIONS_FILE, "rb") as f:
+        versions: Dict[str, str] = tomli.load(f).get("integrations", {})
+    modified_integrations_files = [
+        file_path
+        for file_path in changed_files
+        if Path(file_path).match(glob_pattern)
+        and integrations_base_path in Path(file_path).parents
+    ]
+    for file_path in modified_integrations_files:
+        path = Path(file_path)
+        integration_name = path.parent.name
+        if integration_name in versions:
+            current_version = versions[integration_name]
+            next_version = increment_patch_version(current_version)
+            changed_integrations[integration_name] = next_version
+    return changed_integrations
+
+
+async def create_tags(changed_integrations: Dict[str, str]) -> None:
+    for integration_name, version in changed_integrations.items():
+        await create_repo_tag(
+            owner="zzstoatzz",
+            repo="integration-monorepo",
+            tag_name=f"{integration_name}-{version}",
+            commit_sha=os.environ.get("CURRENT_COMMIT", ""),
+            message=f"Release {integration_name} {version}",
+        )
+
+
+async def main(glob_pattern: str = "**/*.py"):
+    previous_tag = os.environ.get("PREVIOUS_TAG", "")
+    current_commit = os.environ.get("CURRENT_COMMIT", "")
+
+    if not previous_tag or not current_commit:
+        print(
+            "Error: `PREVIOUS_TAG` or `CURRENT_COMMIT` environment variable is missing."
+        )
+        return
+
+    changed_files = get_changed_files(previous_tag, current_commit)
+    changed_integrations = get_changed_integrations(changed_files, glob_pattern)
+    print(json.dumps(changed_integrations))
+
+    if changed_integrations:
+        await create_tags(changed_integrations)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        asyncio.run(main(sys.argv[1]))
+    else:
+        asyncio.run(main())


### PR DESCRIPTION
this PR adds:
- a script that creates new GitHub tags for each changed collection given a current commit and previous tag
- a github action to trigger this script on published release of prefect core, or workflow dispatch

when we release prefect core or trigger via `workflow_dispatch`, we will:
- discover all modified collections
- fetch the latest tag for each such collection
- create and push a new tag for each such collection, a PATCH bump is assumed for now

 tested [here](https://github.com/zzstoatzz/integration-monorepo/tags)
<details>

```python
» PREVIOUS_TAG=0.1.0 CURRENT_COMMIT=d811e10e7de8fba01f490aeb1a35c05f60a97dab python scripts/create_tags_for_changed_collections.py
[04/19/24 13:44:45] INFO     gh_util.client: AUTH: Using token from env vars `GITHUB_TOKEN`                                                                                   logging.py:86
                    INFO     gh_util.client: AUTH: Using token from env vars `GITHUB_TOKEN`                                                                                   logging.py:86
                    INFO     gh_util.client: AUTH: Using token from env vars `GITHUB_TOKEN`                                                                                   logging.py:86
                    INFO     gh_util.client: AUTH: Using token from env vars `GITHUB_TOKEN`                                                                                   logging.py:86
[04/19/24 13:44:46] INFO     gh_util.functions: Tag created: Created tag 'bar-0.1.1' at 'd811e10e7de8fba01f490aeb1a35c05f60a97dab' in repository                              logging.py:86
                             'zzstoatzz/integration-monorepo'
                    INFO     gh_util.client: AUTH: Using token from env vars `GITHUB_TOKEN`                                                                                   logging.py:86
                    INFO     gh_util.functions: Tag created: Created tag 'foo-0.1.1' at 'd811e10e7de8fba01f490aeb1a35c05f60a97dab' in repository                              logging.py:86
                             'zzstoatzz/integration-monorepo'
```
</details>