### PR TITLE
`mypy` coverage for the rest of client-side events

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,3 +38,4 @@ respx
 
 # type stubs
 types-cachetools
+types-PyYAML

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,9 +81,13 @@ filterwarnings =
     ignore::pytest.PytestUnraisableExceptionWarning
     ignore::pluggy.PluggyTeardownRaisedWarning
 
-
 [mypy]
-files = ./src/prefect/input/*.py,./src/prefect/events/*.py
+plugins=
+    pydantic.mypy
+
+files =
+    src/prefect/events/,
+    src/prefect/input/
 
 [mypy-ruamel]
 ignore_missing_imports = True

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -996,7 +996,7 @@ class Block(BaseModel, ABC):
         return self._block_document_id
 
     @sync_compatible
-    @instrument_instance_method_call()
+    @instrument_instance_method_call
     async def save(
         self,
         name: Optional[str] = None,

--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -62,7 +62,7 @@ class AbstractAppriseNotificationBlock(NotificationBlock, ABC):
         self._start_apprise_client(self.url)
 
     @sync_compatible
-    @instrument_instance_method_call()
+    @instrument_instance_method_call
     async def notify(
         self,
         body: str,
@@ -717,7 +717,7 @@ class CustomWebhookNotificationBlock(NotificationBlock):
                     raise KeyError(f"{name}/{placeholder}")
 
     @sync_compatible
-    @instrument_instance_method_call()
+    @instrument_instance_method_call
     async def notify(self, body: str, subject: Optional[str] = None):
         import httpx
 

--- a/src/prefect/cli/_types.py
+++ b/src/prefect/cli/_types.py
@@ -7,10 +7,12 @@ import sys
 from typing import List, Optional
 
 import typer
+from rich.console import Console
+from rich.theme import Theme
 
 from prefect._internal.compatibility.deprecated import generate_deprecation_message
 from prefect.cli._utilities import with_cli_exception_handling
-from prefect.settings import Setting
+from prefect.settings import PREFECT_CLI_COLORS, PREFECT_CLI_WRAP_LINES, Setting
 from prefect.utilities.asyncutils import is_async_fn, sync_compatible
 
 
@@ -59,6 +61,8 @@ class PrefectTyper(typer.Typer):
     Wraps commands created by `Typer` to support async functions and handle errors.
     """
 
+    console: Console
+
     def __init__(
         self,
         *args,
@@ -79,6 +83,14 @@ class PrefectTyper(typer.Typer):
                 start_date=deprecated_start_date,
                 help=deprecated_help,
             )
+
+        self.console = Console(
+            highlight=False,
+            color_system="auto" if PREFECT_CLI_COLORS else None,
+            theme=Theme({"prompt.choices": "bold blue"}),
+            # `soft_wrap` disables wrapping when `True`
+            soft_wrap=not PREFECT_CLI_WRAP_LINES.value(),
+        )
 
     def add_typer(
         self,

--- a/src/prefect/cli/_types.py
+++ b/src/prefect/cli/_types.py
@@ -12,7 +12,7 @@ from rich.theme import Theme
 
 from prefect._internal.compatibility.deprecated import generate_deprecation_message
 from prefect.cli._utilities import with_cli_exception_handling
-from prefect.settings import Setting
+from prefect.settings import PREFECT_CLI_COLORS, Setting
 from prefect.utilities.asyncutils import is_async_fn, sync_compatible
 
 
@@ -87,6 +87,7 @@ class PrefectTyper(typer.Typer):
         self.console = Console(
             highlight=False,
             theme=Theme({"prompt.choices": "bold blue"}),
+            color_system="auto" if PREFECT_CLI_COLORS else None,
         )
 
     def add_typer(

--- a/src/prefect/cli/_types.py
+++ b/src/prefect/cli/_types.py
@@ -12,7 +12,7 @@ from rich.theme import Theme
 
 from prefect._internal.compatibility.deprecated import generate_deprecation_message
 from prefect.cli._utilities import with_cli_exception_handling
-from prefect.settings import PREFECT_CLI_COLORS, PREFECT_CLI_WRAP_LINES, Setting
+from prefect.settings import Setting
 from prefect.utilities.asyncutils import is_async_fn, sync_compatible
 
 
@@ -86,10 +86,7 @@ class PrefectTyper(typer.Typer):
 
         self.console = Console(
             highlight=False,
-            color_system="auto" if PREFECT_CLI_COLORS else None,
             theme=Theme({"prompt.choices": "bold blue"}),
-            # `soft_wrap` disables wrapping when `True`
-            soft_wrap=not PREFECT_CLI_WRAP_LINES.value(),
         )
 
     def add_typer(

--- a/src/prefect/cli/dev.py
+++ b/src/prefect/cli/dev.py
@@ -1,6 +1,7 @@
 """
 Command line interface for working with Prefect Server
 """
+
 import json
 import os
 import platform
@@ -23,8 +24,6 @@ from prefect.cli.agent import start as start_agent
 from prefect.cli.root import app
 from prefect.settings import (
     PREFECT_API_URL,
-    PREFECT_CLI_COLORS,
-    PREFECT_CLI_WRAP_LINES,
     PREFECT_SERVER_API_HOST,
     PREFECT_SERVER_API_PORT,
 )
@@ -65,8 +64,6 @@ def agent_process_entrypoint(**kwargs):
     """
     import inspect
 
-    import rich
-
     # import locally so only the `dev` command breaks if Typer internals change
     from typer.models import ParameterInfo
 
@@ -91,18 +88,6 @@ def agent_process_entrypoint(**kwargs):
             # Some defaults are Prefect `SettingsOption.value` methods
             # that must be called to get the actual value.
             kwargs[name] = default() if callable(default) else default
-
-    # add a console, because calling the agent start function directly
-    # instead of via CLI call means `app` has no `console` attached.
-    app.console = (
-        rich.console.Console(
-            highlight=False,
-            color_system="auto" if PREFECT_CLI_COLORS else None,
-            soft_wrap=not PREFECT_CLI_WRAP_LINES.value(),
-        )
-        if not getattr(app, "console", None)
-        else app.console
-    )
 
     try:
         start_agent(**kwargs)  # type: ignore

--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -18,7 +18,6 @@ from prefect.client.constants import SERVER_API_VERSION
 from prefect.client.orchestration import ServerType
 from prefect.logging.configuration import setup_logging
 from prefect.settings import (
-    PREFECT_CLI_COLORS,
     PREFECT_CLI_WRAP_LINES,
     PREFECT_TEST_MODE,
 )
@@ -78,7 +77,6 @@ def main(
 
     app.console.is_interactive = prompt
     app.console.soft_wrap = not PREFECT_CLI_WRAP_LINES.value()
-    app.console.color_system = "auto" if PREFECT_CLI_COLORS else None
 
     if not PREFECT_TEST_MODE:
         # When testing, this entrypoint can be called multiple times per process which

--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -18,6 +18,8 @@ from prefect.client.constants import SERVER_API_VERSION
 from prefect.client.orchestration import ServerType
 from prefect.logging.configuration import setup_logging
 from prefect.settings import (
+    PREFECT_CLI_COLORS,
+    PREFECT_CLI_WRAP_LINES,
     PREFECT_TEST_MODE,
 )
 
@@ -75,6 +77,8 @@ def main(
     # Configure the output console after loading the profile
 
     app.console.is_interactive = prompt
+    app.console.soft_wrap = not PREFECT_CLI_WRAP_LINES.value()
+    app.console.color_system = "auto" if PREFECT_CLI_COLORS else None
 
     if not PREFECT_TEST_MODE:
         # When testing, this entrypoint can be called multiple times per process which

--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -7,9 +7,7 @@ import platform
 import sys
 
 import pendulum
-import rich.console
 import typer
-from rich.theme import Theme
 
 import prefect
 import prefect.context
@@ -20,8 +18,6 @@ from prefect.client.constants import SERVER_API_VERSION
 from prefect.client.orchestration import ServerType
 from prefect.logging.configuration import setup_logging
 from prefect.settings import (
-    PREFECT_CLI_COLORS,
-    PREFECT_CLI_WRAP_LINES,
     PREFECT_TEST_MODE,
 )
 
@@ -78,14 +74,7 @@ def main(
 
     # Configure the output console after loading the profile
 
-    app.console = rich.console.Console(
-        highlight=False,
-        color_system="auto" if PREFECT_CLI_COLORS else None,
-        theme=Theme({"prompt.choices": "bold blue"}),
-        # `soft_wrap` disables wrapping when `True`
-        soft_wrap=not PREFECT_CLI_WRAP_LINES.value(),
-        force_interactive=prompt,
-    )
+    app.console.is_interactive = prompt
 
     if not PREFECT_TEST_MODE:
         # When testing, this entrypoint can be called multiple times per process which

--- a/src/prefect/events/instrument.py
+++ b/src/prefect/events/instrument.py
@@ -10,7 +10,9 @@ from typing import (
     Set,
     Tuple,
     Type,
+    TypeVar,
     Union,
+    cast,
 )
 
 from prefect.events import emit_event
@@ -41,45 +43,45 @@ def emit_instance_method_called_event(
     )
 
 
-def instrument_instance_method_call():
-    def instrument(function):
-        if is_instrumented(function):
-            return function
+F = TypeVar("F", bound=Callable)
 
-        if inspect.iscoroutinefunction(function):
 
-            @functools.wraps(function)
-            async def inner(self, *args, **kwargs):
-                success = True
-                try:
-                    return await function(self, *args, **kwargs)
-                except Exception as exc:
-                    success = False
-                    raise exc
-                finally:
-                    emit_instance_method_called_event(
-                        instance=self, method_name=function.__name__, successful=success
-                    )
+def instrument_instance_method_call(function: F) -> F:
+    if is_instrumented(function):
+        return function
 
-        else:
+    if inspect.iscoroutinefunction(function):
 
-            @functools.wraps(function)
-            def inner(self, *args, **kwargs):
-                success = True
-                try:
-                    return function(self, *args, **kwargs)
-                except Exception as exc:
-                    success = False
-                    raise exc
-                finally:
-                    emit_instance_method_called_event(
-                        instance=self, method_name=function.__name__, successful=success
-                    )
+        @functools.wraps(function)
+        async def inner(self, *args, **kwargs):
+            success = True
+            try:
+                return await function(self, *args, **kwargs)
+            except Exception as exc:
+                success = False
+                raise exc
+            finally:
+                emit_instance_method_called_event(
+                    instance=self, method_name=function.__name__, successful=success
+                )
 
-        setattr(inner, "__events_instrumented__", True)
-        return inner
+    else:
 
-    return instrument
+        @functools.wraps(function)
+        def inner(self, *args, **kwargs):
+            success = True
+            try:
+                return function(self, *args, **kwargs)
+            except Exception as exc:
+                success = False
+                raise exc
+            finally:
+                emit_instance_method_called_event(
+                    instance=self, method_name=function.__name__, successful=success
+                )
+
+    setattr(inner, "__events_instrumented__", True)
+    return cast(F, inner)
 
 
 def is_instrumented(function: Callable) -> bool:
@@ -125,11 +127,9 @@ def instrument_method_calls_on_class_instances(cls: Type) -> Type:
                 f"Unable to instrument class {cls}. Class must define {method_name!r}."
             )
 
-    decorator = instrument_instance_method_call()
-
     for method_name, method in instrumentable_methods(
         cls,
         exclude_methods=getattr(cls, "_events_excluded_methods", []),
     ):
-        setattr(cls, method_name, decorator(method))
+        setattr(cls, method_name, instrument_instance_method_call(method))
     return cls

--- a/src/prefect/events/schemas/events.py
+++ b/src/prefect/events/schemas/events.py
@@ -15,9 +15,14 @@ from typing import (
 from uuid import UUID, uuid4
 
 import pendulum
-from pydantic import Field, root_validator, validator
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
+
+if HAS_PYDANTIC_V2:
+    from pydantic.v1 import Field, root_validator, validator
+else:
+    from pydantic import Field, root_validator, validator  # type: ignore
+
 from prefect._internal.schemas.bases import PrefectBaseModel
 from prefect._internal.schemas.fields import DateTimeTZ
 from prefect.logging import get_logger
@@ -25,11 +30,6 @@ from prefect.settings import (
     PREFECT_EVENTS_MAXIMUM_LABELS_PER_RESOURCE,
     PREFECT_EVENTS_MAXIMUM_RELATED_RESOURCES,
 )
-
-if HAS_PYDANTIC_V2:
-    from pydantic.v1 import Field, root_validator, validator
-else:
-    from pydantic import Field, root_validator, validator
 
 from .labelling import Labelled
 
@@ -128,7 +128,7 @@ class Event(PrefectBaseModel):
         description="The client-provided identifier of this event",
     )
     follows: Optional[UUID] = Field(
-        None,
+        default=None,
         description=(
             "The ID of an event that is known to have occurred prior to this one. "
             "If set, this may be used to establish a more precise ordering of causally-"

--- a/tests/events/client/cli/test_automations.py
+++ b/tests/events/client/cli/test_automations.py
@@ -12,8 +12,10 @@ from prefect.events.schemas.automations import (
     Automation,
     EventTrigger,
     MetricTrigger,
+    MetricTriggerOperator,
     MetricTriggerQuery,
     Posture,
+    PrefectMetric,
 )
 from prefect.settings import PREFECT_EXPERIMENTAL_EVENTS, temporary_settings
 from prefect.testing.cli import invoke_and_assert
@@ -81,7 +83,9 @@ def various_automations(read_automations: mock.AsyncMock) -> List[Automation]:
             name="A Metric one",
             trigger=MetricTrigger(
                 metric=MetricTriggerQuery(
-                    name="successes", operator="<", threshold=0.78
+                    name=PrefectMetric.successes,
+                    operator=MetricTriggerOperator.LT,
+                    threshold=0.78,
                 )
             ),
             actions=[CancelFlowRun()],

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -1,6 +1,8 @@
 import pytest
 
 from prefect import flow, task
+from prefect.client.orchestration import PrefectClient
+from prefect.client.schemas.objects import State
 from prefect.events.clients import AssertingEventsClient
 from prefect.events.worker import EventsWorker
 from prefect.filesystems import LocalFileSystem
@@ -19,8 +21,8 @@ def enable_task_scheduling():
 
 async def test_task_state_change_happy_path(
     asserting_events_worker: EventsWorker,
-    reset_worker_events,
-    prefect_client,
+    reset_worker_events: None,
+    prefect_client: PrefectClient,
 ):
     @task
     def happy_little_tree():
@@ -30,9 +32,9 @@ async def test_task_state_change_happy_path(
     def happy_path():
         return happy_little_tree._run()
 
-    flow_state = happy_path._run()
+    flow_state: State[State[str]] = happy_path._run()
 
-    task_state = await flow_state.result()
+    task_state: State[str] = await flow_state.result()
     task_run_id = task_state.state_details.task_run_id
     task_run = await prefect_client.read_task_run(task_run_id)
     task_run_states = await prefect_client.read_task_run_states(task_run_id)

--- a/tests/events/client/test_automations_server_compatibility.py
+++ b/tests/events/client/test_automations_server_compatibility.py
@@ -33,6 +33,7 @@ from prefect.events.schemas.automations import (
     CompoundTrigger,
     EventTrigger,
     MetricTrigger,
+    Posture,
     SequenceTrigger,
 )
 from prefect.events.schemas.deployment_triggers import (
@@ -42,17 +43,16 @@ from prefect.events.schemas.deployment_triggers import (
     DeploymentSequenceTrigger,
     DeploymentTriggerTypes,
 )
-from prefect.server.events.schemas.automations import Posture
 from prefect.settings import (
     PREFECT_API_SERVICES_TRIGGERS_ENABLED,
     PREFECT_EXPERIMENTAL_EVENTS,
     temporary_settings,
 )
 
-CLIENT_TRIGGER_TYPES: List[Type[Trigger]] = list(TriggerTypes.__args__)
+CLIENT_TRIGGER_TYPES: List[Type[Trigger]] = list(TriggerTypes.__args__)  # type: ignore[attr-defined]
 CLOUD_ONLY_TRIGGER_TYPES: Set[Type[Trigger]] = {MetricTrigger}
 
-EXAMPLE_TRIGGERS: List[Trigger] = [
+EXAMPLE_TRIGGERS: List[TriggerTypes] = [
     EventTrigger(),
     EventTrigger(posture=Posture.Reactive),
     EventTrigger(posture=Posture.Proactive),
@@ -147,7 +147,7 @@ def test_all_triggers_represented():
 
 
 @pytest.mark.parametrize("trigger", EXAMPLE_TRIGGERS)
-async def test_trigger_round_tripping(trigger: Trigger):
+async def test_trigger_round_tripping(trigger: TriggerTypes):
     """Tests that any of the example client triggers can be round-tripped to the
     Prefect server"""
     async with get_client() as client:
@@ -166,11 +166,11 @@ async def test_trigger_round_tripping(trigger: Trigger):
     assert sent == returned
 
 
-DEPLOYMENT_TRIGGER_TYPES: List[Type[Trigger]] = list(DeploymentTriggerTypes.__args__)
+DEPLOYMENT_TRIGGER_TYPES: List[Type[Trigger]] = list(DeploymentTriggerTypes.__args__)  # type: ignore[attr-defined]
 CLOUD_ONLY_DEPLOYMENT_TRIGGER_TYPES: Set[Type[Trigger]] = {DeploymentMetricTrigger}
 
 
-EXAMPLE_DEPLOYMENT_TRIGGERS = [
+EXAMPLE_DEPLOYMENT_TRIGGERS: List[DeploymentTriggerTypes] = [
     DeploymentEventTrigger(),
     DeploymentEventTrigger(posture=Posture.Reactive),
     DeploymentEventTrigger(posture=Posture.Proactive),
@@ -274,11 +274,11 @@ def test_trigger_serialization(deployment_trigger: DeploymentTriggerTypes):
     assert trigger.dict() == serialized
 
 
-CLIENT_ACTION_TYPES: List[Type[Action]] = list(ActionTypes.__args__)
+CLIENT_ACTION_TYPES: List[Type[Action]] = list(ActionTypes.__args__)  # type: ignore[attr-defined]
 CLOUD_ONLY_ACTION_TYPES: Set[Type[Action]] = {DeclareIncident}
 
 
-EXAMPLE_ACTIONS = [
+EXAMPLE_ACTIONS: List[ActionTypes] = [
     DoNothing(),
     RunDeployment(source="inferred"),
     RunDeployment(source="selected", deployment_id=uuid4()),
@@ -315,7 +315,7 @@ def test_all_actions_represented():
 
 
 @pytest.mark.parametrize("action", EXAMPLE_ACTIONS)
-async def test_action_round_tripping(action: Action):
+async def test_action_round_tripping(action: ActionTypes):
     """Tests that any of the example client triggers can be round-tripped to the
     Prefect server"""
     async with get_client() as client:

--- a/tests/events/client/test_deployment_trigger_schema.py
+++ b/tests/events/client/test_deployment_trigger_schema.py
@@ -8,7 +8,7 @@ from prefect._internal.pydantic import HAS_PYDANTIC_V2
 if HAS_PYDANTIC_V2:
     import pydantic.v1 as pydantic
 else:
-    import pydantic
+    import pydantic  # type: ignore
 
 from prefect.events import (
     AutomationCore,

--- a/tests/events/client/test_events_emit_event.py
+++ b/tests/events/client/test_events_emit_event.py
@@ -77,12 +77,14 @@ def test_sets_follows_tight_timing(
         event="planet.destroyed",
         resource={"prefect.resource.id": "milky-way.sol.earth"},
     )
+    assert destroyed_event
 
     read_event = emit_event(
         event="vogon.poetry.read",
         resource={"prefect.resource.id": "vogon.poem.oh-freddled-gruntbuggly"},
         follows=destroyed_event,
     )
+    assert read_event
 
     asserting_events_worker.drain()
     assert read_event.follows == destroyed_event.id
@@ -96,6 +98,7 @@ def test_does_not_set_follows_not_tight_timing(
         occurred=pendulum.now("UTC") - timedelta(minutes=10),
         resource={"prefect.resource.id": "milky-way.sol.earth"},
     )
+    assert destroyed_event
 
     # These events are more than 5m apart so the `follows` property of the
     # emitted event shouldn't be set.
@@ -104,6 +107,7 @@ def test_does_not_set_follows_not_tight_timing(
         resource={"prefect.resource.id": "vogon.poem.oh-freddled-gruntbuggly"},
         follows=destroyed_event,
     )
+    assert read_event
 
     asserting_events_worker.drain()
     assert read_event.follows is None

--- a/tests/events/client/test_resource_schema.py
+++ b/tests/events/client/test_resource_schema.py
@@ -15,7 +15,7 @@ from prefect.settings import (
 if HAS_PYDANTIC_V2:
     from pydantic.v1 import ValidationError
 else:
-    from pydantic import ValidationError
+    from pydantic import ValidationError  # type: ignore
 
 from prefect.events import Event, RelatedResource, Resource, ResourceSpecification
 from prefect.events.schemas.labelling import LabelDiver

--- a/tests/events/client/test_v1_triggers_deserialization.py
+++ b/tests/events/client/test_v1_triggers_deserialization.py
@@ -20,8 +20,8 @@ if HAS_PYDANTIC_V2:
     import pydantic.v1 as pydantic
     from pydantic.v1 import Field
 else:
-    import pydantic
-    from pydantic import Field
+    import pydantic  # type: ignore
+    from pydantic import Field  # type: ignore
 
 from prefect.events.schemas.automations import (
     EventTrigger,

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import AsyncGenerator, Dict
 
 import pytest
 
@@ -9,13 +9,17 @@ from prefect.settings import PREFECT_CLOUD_API_URL
 
 
 @pytest.fixture
-async def prefect_client(test_database_connection_url):
+async def prefect_client(
+    test_database_connection_url: str,
+) -> AsyncGenerator[PrefectClient, None]:
     async with get_client() as client:
         yield client
 
 
 @pytest.fixture
-async def cloud_client(prefect_client):
+async def cloud_client(
+    prefect_client: PrefectClient,
+) -> AsyncGenerator[PrefectClient, None]:
     async with PrefectClient(PREFECT_CLOUD_API_URL.value()) as cloud_client:
         yield cloud_client
 


### PR DESCRIPTION
The original mypy file selector was excluding files in deeper directories.  This
simplifies it to just include the directories we're able to check types on.

I also took a pass through all the low-hanging fruit in `tests/events/client`,
but we'll need to do some more work on the fundamentals first.
