### PR TITLE
Fix release notes integrations section generation

### DIFF
--- a/scripts/generate-release-notes.py
+++ b/scripts/generate-release-notes.py
@@ -34,7 +34,6 @@ import httpx
 REPO_ORG = "PrefectHQ"
 REPO_NAMES = [
     "prefect",
-    "prefect-ui-library",
     "prefect-azure",
     "prefect-aws",
     "prefect-gcp",

--- a/scripts/generate-release-notes.py
+++ b/scripts/generate-release-notes.py
@@ -105,6 +105,30 @@ def get_latest_repo_release_date(repo_org: str, repo_name: str) -> datetime:
     )
 
 
+def get_latest_and_previous_tags(
+    repo_org: str, repo_name: str, github_token: str
+) -> tuple:
+    """
+    Retrieves the latest and the previous release tags for the specified repository.
+    """
+    headers = {
+        "Authorization": f"Bearer {github_token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    response = httpx.get(
+        f"https://api.github.com/repos/{repo_org}/{repo_name}/tags", headers=headers
+    )
+    tags = response.json()
+    if not tags:
+        raise Exception(f"No tags found for {repo_name}")
+
+    # Assuming tags are sorted in reverse chronological order, which GitHub usually does by default.
+    latest_tag = tags[0]["name"]
+    previous_tag = tags[1]["name"] if len(tags) > 1 else None
+
+    return latest_tag, previous_tag
+
+
 def generate_release_notes(
     repo_org: str,
     repo_names: List[str],
@@ -129,6 +153,11 @@ def generate_release_notes(
             )
             if not repo_has_release_since_latest_prefect_release:
                 continue
+
+        if repo_name != "prefect":
+            tag_name, previous_tag = get_latest_and_previous_tags(
+                repo_org, repo_name, github_token
+            )
 
         request = {"tag_name": tag_name, "target_commitish": target_commit}
         if previous_tag:
@@ -184,7 +213,7 @@ def generate_release_notes(
         else:
             # Drop the first line of the release notes ("## What's Changed")
             # and drop the change preview and the contributors sections
-            release_notes = "\n".join(release_notes.splitlines()[1:-5])
+            release_notes = "\n".join(release_notes.splitlines()[1:])
             # Add newlines before all categories
             release_notes = release_notes.replace("\n###", "\n\n###")
             # Parse all entries
@@ -196,15 +225,28 @@ def generate_release_notes(
                 release_notes,
             )
 
-            integrations_section.append(release_notes)
+            # we won't include the full changelog and integrations contributors
+            search_strings = [
+                "## New Contributors",
+                "## Contributors",
+                "**Full Changelog**",
+            ]
+            indices = [release_notes.find(s) for s in search_strings]
+            indices = [i for i in indices if i != -1]
+
+            if indices:
+                split_index = min(indices)
+                changelog = release_notes[:split_index].strip()
+            else:
+                changelog = release_notes.strip()
+
+            integrations_section.append(changelog)
 
     if integrations_section != [""]:
         parts = prefect_release_notes.split("### Contributors")
         # ensure that Integrations section is before Contributors
         # Print all accumulated non-Prefect changes under "Integrations"
-        integrations_heading = (
-            "### Integrations" + "\n" + "\n\n".join(integrations_section)
-        )
+        integrations_heading = "### Integrations" + "\n".join(integrations_section)
 
         prefect_release_notes = (
             parts[0] + integrations_heading + "\n\n### Contributors" + parts[1]

--- a/scripts/generate-release-notes.py
+++ b/scripts/generate-release-notes.py
@@ -105,7 +105,7 @@ def get_latest_repo_release_date(repo_org: str, repo_name: str) -> datetime:
     )
 
 
-def get_latest_and_previous_tags(
+def get_latest_and_previous_releases(
     repo_org: str, repo_name: str, github_token: str
 ) -> tuple:
     """
@@ -128,8 +128,6 @@ def get_latest_and_previous_tags(
 
     latest_tag = releases[0]["tag_name"]
     previous_tag = releases[1]["tag_name"] if len(releases) > 1 else None
-
-    breakpoint()
 
     return latest_tag, previous_tag
 
@@ -154,13 +152,13 @@ def generate_release_notes(
             latest_repo_release_date = get_latest_repo_release_date(repo_org, repo_name)
 
             repo_has_release_since_latest_prefect_release = (
-                latest_repo_release_date <= latest_prefect_release_date
+                latest_repo_release_date >= latest_prefect_release_date
             )
             if not repo_has_release_since_latest_prefect_release:
                 continue
 
         if repo_name != "prefect":
-            tag_name, previous_tag = get_latest_and_previous_tags(
+            tag_name, previous_tag = get_latest_and_previous_releases(
                 repo_org, repo_name, github_token
             )
 

--- a/scripts/generate-release-notes.py
+++ b/scripts/generate-release-notes.py
@@ -119,7 +119,9 @@ def get_latest_and_previous_releases(
     response = httpx.get(
         f"https://api.github.com/repos/{repo_org}/{repo_name}/releases", headers=headers
     )
+    response.raise_for_status()
     releases = response.json()
+
     if not releases:
         raise Exception(f"No releases found for {repo_name}")
 

--- a/scripts/generate-release-notes.py
+++ b/scripts/generate-release-notes.py
@@ -118,6 +118,7 @@ def get_latest_and_previous_tags(
     response = httpx.get(
         f"https://api.github.com/repos/{repo_org}/{repo_name}/tags", headers=headers
     )
+    response.raise_for_status()
     tags = response.json()
     if not tags:
         raise Exception(f"No tags found for {repo_name}")

--- a/scripts/generate-release-notes.py
+++ b/scripts/generate-release-notes.py
@@ -129,6 +129,25 @@ def get_latest_and_previous_tags(
     return latest_tag, previous_tag
 
 
+def clean_integrations_changelog(release_notes: str) -> str:
+    # we won't include the full changelog and integrations contributors
+    search_strings = [
+        "## New Contributors",
+        "## Contributors",
+        "**Full Changelog**",
+    ]
+    indices = [release_notes.find(s) for s in search_strings]
+    indices = [i for i in indices if i != -1]
+
+    if indices:
+        split_index = min(indices)
+        changelog = release_notes[:split_index].strip()
+    else:
+        changelog = release_notes.strip()
+
+    return changelog
+
+
 def generate_release_notes(
     repo_org: str,
     repo_names: List[str],
@@ -225,21 +244,7 @@ def generate_release_notes(
                 release_notes,
             )
 
-            # we won't include the full changelog and integrations contributors
-            search_strings = [
-                "## New Contributors",
-                "## Contributors",
-                "**Full Changelog**",
-            ]
-            indices = [release_notes.find(s) for s in search_strings]
-            indices = [i for i in indices if i != -1]
-
-            if indices:
-                split_index = min(indices)
-                changelog = release_notes[:split_index].strip()
-            else:
-                changelog = release_notes.strip()
-
+            changelog = clean_integrations_changelog(release_notes)
             integrations_section.append(changelog)
 
     if integrations_section != [""]:


### PR DESCRIPTION
Ensures we can retrieve the latest release commits from integrations repos. 

- Add `get_latest_and_previous_tags` fn to correctly fetch and handle tags from GitHub
- Add `clean_integrations_changelog` fn to cleanup the integrations changelog

