### PR TITLE
Fix improper context access for nested async task outside of flow

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -1410,7 +1410,9 @@ def enter_task_run_engine(
         task_runner=task_runner,
     )
 
-    if task.isasync and flow_run_context.flow.isasync:
+    if task.isasync and (
+        flow_run_context.flow is None or flow_run_context.flow.isasync
+    ):
         # return a coro for the user to await if an async task in an async flow
         return from_async.wait_for_call_in_loop_thread(begin_run)
     else:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -4085,3 +4085,15 @@ class TestNestedTasks:
         result = my_flow()
         assert result == "Failed"
         assert count == 4
+
+    async def test_nested_async_task_without_parent_flow(self):
+        @task
+        async def inner_task():
+            return 42
+
+        @task
+        async def outer_task():
+            return await inner_task()
+
+        result = await outer_task()
+        assert result == 42


### PR DESCRIPTION
fixing another improper assumption of having an attr (`flow` in this case) on `FlowRunContext` in a nested task outside of flow situation