### PR TITLE
Flow run state change events

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -3143,9 +3143,7 @@ class PrefectClient:
         response.raise_for_status()
         return pydantic.parse_obj_as(List[Automation], response.json())
 
-    async def find_automation(
-        self, id_or_name: str, exit_if_not_found: bool = True
-    ) -> Optional[Automation]:
+    async def find_automation(self, id_or_name: str) -> Optional[Automation]:
         try:
             id = UUID(id_or_name)
         except ValueError:

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -115,7 +115,7 @@ async def create_deployment(
         elif deployment.work_queue_name:
             # If just a queue name was provided, ensure that the queue exists and
             # get its ID.
-            work_queue = await models.work_queues._ensure_work_queue_exists(
+            work_queue = await models.work_queues.ensure_work_queue_exists(
                 session=session, name=deployment.work_queue_name
             )
             deployment_dict["work_queue_id"] = work_queue.id

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -218,8 +218,8 @@ async def update_deployment(
     elif deployment.work_queue_name:
         # If just a queue name was provided, ensure the queue exists and
         # get its ID.
-        work_queue = await models.work_queues._ensure_work_queue_exists(
-            session=session, name=update_data["work_queue_name"], db=db
+        work_queue = await models.work_queues.ensure_work_queue_exists(
+            session=session, name=update_data["work_queue_name"]
         )
         update_data["work_queue_id"] = work_queue.id
 

--- a/src/prefect/server/models/events.py
+++ b/src/prefect/server/models/events.py
@@ -1,0 +1,287 @@
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, MutableMapping, Optional, Set, Union
+from uuid import UUID
+
+from cachetools import TTLCache
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from prefect.server import models, schemas
+from prefect.server.database.orm_models import (
+    ORMDeployment,
+    ORMFlow,
+    ORMFlowRun,
+    ORMFlowRunState,
+    ORMTaskRun,
+    ORMTaskRunState,
+    ORMWorkPool,
+    ORMWorkQueue,
+)
+from prefect.server.events.schemas.events import Event
+from prefect.server.models import deployments
+from prefect.settings import PREFECT_API_EVENTS_RELATED_RESOURCE_CACHE_TTL
+from prefect.utilities.text import truncated_to
+
+ResourceData = Dict[str, Dict[str, Any]]
+RelatedResourceList = List[Dict[str, str]]
+
+
+# Some users use state messages to convey error messages and large results; let's
+# truncate them so they don't blow out the size of a message
+TRUNCATE_STATE_MESSAGES_AT = 100_000
+
+
+_flow_run_resource_data_cache: MutableMapping[UUID, ResourceData] = TTLCache(
+    maxsize=1000,
+    ttl=PREFECT_API_EVENTS_RELATED_RESOURCE_CACHE_TTL.value().total_seconds(),
+)
+
+
+async def flow_run_state_change_event(
+    session: AsyncSession,
+    occurred: datetime,
+    flow_run: ORMFlowRun,
+    initial_state_id: Optional[UUID],
+    initial_state: Optional[schemas.states.State],
+    validated_state_id: Optional[UUID],
+    validated_state: schemas.states.State,
+) -> Event:
+    return Event(
+        occurred=occurred,
+        event=f"prefect.flow-run.{validated_state.name}",
+        resource={
+            "prefect.resource.id": f"prefect.flow-run.{flow_run.id}",
+            "prefect.resource.name": flow_run.name,
+            "prefect.state-message": truncated_to(
+                TRUNCATE_STATE_MESSAGES_AT, validated_state.message
+            ),
+            "prefect.state-name": validated_state.name or "",
+            "prefect.state-timestamp": (
+                validated_state.timestamp.isoformat()
+                if validated_state.timestamp
+                else None
+            ),
+            "prefect.state-type": validated_state.type.value,
+        },
+        related=await _flow_run_related_resources_from_orm(
+            session=session, flow_run=flow_run
+        ),
+        payload={
+            "intended": {
+                "from": _state_type(initial_state),
+                "to": _state_type(validated_state),
+            },
+            "initial_state": state_payload(initial_state),
+            "validated_state": state_payload(validated_state),
+        },
+        # Here we use the state's ID as the ID of the event as well, in order to
+        # establish the ordering of the state-change events
+        id=validated_state_id,
+        follows=initial_state_id if _timing_is_tight(occurred, initial_state) else None,
+    )
+
+
+async def _flow_run_related_resources_from_orm(
+    session: AsyncSession, flow_run: ORMFlowRun
+) -> RelatedResourceList:
+    resource_data = _flow_run_resource_data_cache.get(flow_run.id)
+    if not resource_data:
+        flow = await models.flows.read_flow(session=session, flow_id=flow_run.flow_id)
+        deployment: Optional[ORMDeployment] = None
+        if flow_run.deployment_id:
+            deployment = await deployments.read_deployment(
+                session, deployment_id=flow_run.deployment_id
+            )
+
+        work_queue = None
+        if flow_run.work_queue_id:
+            work_queue = await models.work_queues.read_work_queue(
+                session, work_queue_id=flow_run.work_queue_id
+            )
+
+        work_pool = work_queue.work_pool if work_queue is not None else None
+
+        task_run: Optional[ORMTaskRun] = None
+        if flow_run.parent_task_run_id:
+            task_run = await models.task_runs.read_task_run(
+                session,
+                task_run_id=flow_run.parent_task_run_id,
+            )
+
+        print(task_run)
+        if task_run:
+            print("events", task_run.id, task_run.tags)
+
+        resource_data = _as_resource_data(
+            flow_run, flow, deployment, work_queue, work_pool, task_run
+        )
+        _flow_run_resource_data_cache[flow_run.id] = resource_data
+
+    return _resource_data_as_related_resources(
+        resource_data,
+        excluded_kinds=["flow-run"],
+    ) + _provenance_as_related_resources(flow_run.created_by)
+
+
+def _as_resource_data(
+    flow_run: ORMFlowRun,
+    flow: Union[ORMFlow, schemas.core.Flow, None],
+    deployment: Union[ORMDeployment, schemas.responses.DeploymentResponse, None],
+    work_queue: Union[ORMWorkQueue, schemas.responses.WorkQueueResponse, None],
+    work_pool: Union[ORMWorkPool, schemas.core.WorkPool, None],
+    task_run: Union[ORMTaskRun, schemas.core.TaskRun, None] = None,
+) -> ResourceData:
+    return {
+        "flow-run": {
+            "id": str(flow_run.id),
+            "name": flow_run.name,
+            "tags": flow_run.tags if flow_run.tags else [],
+            "role": "flow-run",
+        },
+        "flow": (
+            {
+                "id": str(flow.id),
+                "name": flow.name,
+                "tags": flow.tags if flow.tags else [],
+                "role": "flow",
+            }
+            if flow
+            else {}
+        ),
+        "deployment": (
+            {
+                "id": str(deployment.id),
+                "name": deployment.name,
+                "tags": deployment.tags if deployment.tags else [],
+                "role": "deployment",
+            }
+            if deployment
+            else {}
+        ),
+        "work-queue": (
+            {
+                "id": str(work_queue.id),
+                "name": work_queue.name,
+                "tags": [],
+                "role": "work-queue",
+            }
+            if work_queue
+            else {}
+        ),
+        "work-pool": (
+            {
+                "id": str(work_pool.id),
+                "name": work_pool.name,
+                "tags": [],
+                "role": "work-pool",
+            }
+            if work_pool
+            else {}
+        ),
+        "task-run": (
+            {
+                "id": str(task_run.id),
+                "name": task_run.name,
+                "tags": task_run.tags if task_run.tags else [],
+                "role": "task-run",
+            }
+            if task_run
+            else {}
+        ),
+    }
+
+
+def _resource_data_as_related_resources(
+    resource_data: ResourceData,
+    excluded_kinds: Optional[List[str]] = None,
+) -> RelatedResourceList:
+    related = []
+    tags: Set[str] = set()
+
+    if excluded_kinds is None:
+        excluded_kinds = []
+
+    for kind, data in resource_data.items():
+        tags |= set(data.get("tags", []))
+
+        if kind in excluded_kinds or not data:
+            continue
+
+        related.append(
+            {
+                "prefect.resource.id": f"prefect.{kind}.{data['id']}",
+                "prefect.resource.role": data["role"],
+                "prefect.resource.name": data["name"],
+            }
+        )
+
+    related += [
+        {
+            "prefect.resource.id": f"prefect.tag.{tag}",
+            "prefect.resource.role": "tag",
+        }
+        for tag in sorted(tags)
+    ]
+
+    return related
+
+
+def _provenance_as_related_resources(
+    created_by: Optional[schemas.core.CreatedBy],
+) -> RelatedResourceList:
+    if not created_by:
+        return []
+
+    resource_id: str
+
+    if created_by.type == "DEPLOYMENT":
+        resource_id = f"prefect.deployment.{created_by.id}"
+    elif created_by.type == "AUTOMATION":
+        resource_id = f"prefect.automation.{created_by.id}"
+    else:
+        return []
+
+    related = {
+        "prefect.resource.id": resource_id,
+        "prefect.resource.role": "creator",
+    }
+    if created_by.display_value:
+        related["prefect.resource.name"] = created_by.display_value
+    return [related]
+
+
+def _state_type(
+    state: Union[ORMFlowRunState, ORMTaskRunState, Optional[schemas.states.State]],
+) -> Optional[str]:
+    return str(state.type.value) if state else None
+
+
+def state_payload(state: Optional[schemas.states.State]) -> Optional[Dict[str, str]]:
+    """Given a State, return the essential string parts of it for use in an
+    event payload"""
+    if not state:
+        return None
+    payload: Dict[str, str] = {"type": state.type.value}
+    if state.name:
+        payload["name"] = state.name
+    if state.message:
+        payload["message"] = truncated_to(TRUNCATE_STATE_MESSAGES_AT, state.message)
+    if state.is_paused():
+        payload["pause_reschedule"] = str(state.state_details.pause_reschedule).lower()
+    return payload
+
+
+def _timing_is_tight(
+    occurred: datetime,
+    initial_state: Union[
+        ORMFlowRunState, ORMTaskRunState, Optional[schemas.states.State]
+    ],
+) -> bool:
+    # Only connect events with event.follows if the timing here is tight, which will
+    # help us resolve the order of these events if they happen to be delivered out of
+    # order.  If the preceding state change happened a while back, don't worry about
+    # it because the order is very likely to be unambiguous.
+    TIGHT_TIMING = timedelta(minutes=5)
+    if initial_state and initial_state.timestamp:
+        return bool(-TIGHT_TIMING < (occurred - initial_state.timestamp) < TIGHT_TIMING)
+
+    return False

--- a/src/prefect/server/models/work_queues.py
+++ b/src/prefect/server/models/work_queues.py
@@ -4,11 +4,13 @@ Intended for internal use by the Prefect REST API.
 """
 
 import datetime
+from typing import Optional, Sequence
 from uuid import UUID
 
 import sqlalchemy as sa
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
+from prefect.server.database.orm_models import ORMFlowRun, ORMWorkQueue
 
 if HAS_PYDANTIC_V2:
     from pydantic.v1 import parse_obj_as
@@ -20,7 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import prefect.server.models as models
 import prefect.server.schemas as schemas
-from prefect.server.database.dependencies import inject_db
+from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.models.workers import (
@@ -30,12 +32,12 @@ from prefect.server.models.workers import (
 from prefect.server.schemas.states import StateType
 
 
-@inject_db
+@db_injector
 async def create_work_queue(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_queue: schemas.core.WorkQueue,
-    db: PrefectDBInterface,
-):
+) -> ORMWorkQueue:
     """
     Inserts a WorkQueue.
 
@@ -114,10 +116,10 @@ async def create_work_queue(
     return model
 
 
-@inject_db
+@db_injector
 async def read_work_queue(
-    session: AsyncSession, work_queue_id: UUID, db: PrefectDBInterface
-):
+    db: PrefectDBInterface, session: AsyncSession, work_queue_id: UUID
+) -> Optional[ORMWorkQueue]:
     """
     Reads a WorkQueue by id.
 
@@ -132,10 +134,10 @@ async def read_work_queue(
     return await session.get(db.WorkQueue, work_queue_id)
 
 
-@inject_db
+@db_injector
 async def read_work_queue_by_name(
-    session: AsyncSession, name: str, db: PrefectDBInterface
-):
+    db: PrefectDBInterface, session: AsyncSession, name: str
+) -> Optional[ORMWorkQueue]:
     """
     Reads a WorkQueue by id.
 
@@ -160,14 +162,14 @@ async def read_work_queue_by_name(
     return result.scalar()
 
 
-@inject_db
+@db_injector
 async def read_work_queues(
     db: PrefectDBInterface,
     session: AsyncSession,
     offset: int = None,
     limit: int = None,
     work_queue_filter: schemas.filters.WorkQueueFilter = None,
-):
+) -> Sequence[ORMWorkQueue]:
     """
     Read WorkQueues.
 
@@ -177,7 +179,7 @@ async def read_work_queues(
         limit: Query limit
         work_queue_filter: only select work queues matching these filters
     Returns:
-        List[db.WorkQueue]: WorkQueues
+        Sequence[db.WorkQueue]: WorkQueues
     """
 
     query = select(db.WorkQueue).order_by(db.WorkQueue.name)
@@ -193,12 +195,12 @@ async def read_work_queues(
     return result.scalars().unique().all()
 
 
-@inject_db
+@db_injector
 async def update_work_queue(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_queue_id: UUID,
     work_queue: schemas.actions.WorkQueueUpdate,
-    db: PrefectDBInterface,
 ) -> bool:
     """
     Update a WorkQueue by id.
@@ -225,9 +227,9 @@ async def update_work_queue(
     return result.rowcount > 0
 
 
-@inject_db
+@db_injector
 async def delete_work_queue(
-    session: AsyncSession, work_queue_id: UUID, db: PrefectDBInterface
+    db: PrefectDBInterface, session: AsyncSession, work_queue_id: UUID
 ) -> bool:
     """
     Delete a WorkQueue by id.
@@ -246,14 +248,14 @@ async def delete_work_queue(
     return result.rowcount > 0
 
 
-@inject_db
+@db_injector
 async def get_runs_in_work_queue(
+    db: PrefectDBInterface,
     session: AsyncSession,
     work_queue_id: UUID,
-    db: PrefectDBInterface,
     limit: int = None,
     scheduled_before: datetime.datetime = None,
-):
+) -> Sequence[ORMFlowRun]:
     """
     Get runs from a work queue.
 
@@ -286,20 +288,17 @@ async def get_runs_in_work_queue(
         return await _legacy_get_runs_in_work_queue(
             session=session,
             work_queue_id=work_queue_id,
-            db=db,
             scheduled_before=scheduled_before,
             limit=limit,
         )
 
 
-@inject_db
 async def _legacy_get_runs_in_work_queue(
     session: AsyncSession,
     work_queue_id: UUID,
-    db: PrefectDBInterface,
     scheduled_before: datetime.datetime = None,
     limit: int = None,
-):
+) -> Sequence[ORMFlowRun]:
     """
     DEPRECATED method for getting runs from a tag-based work queue
 
@@ -364,10 +363,7 @@ async def _legacy_get_runs_in_work_queue(
     )
 
 
-@inject_db
-async def _ensure_work_queue_exists(
-    session: AsyncSession, name: str, db: PrefectDBInterface
-):
+async def ensure_work_queue_exists(session: AsyncSession, name: str):
     """
     Checks if a work queue exists and creates it if it does not.
 
@@ -404,9 +400,8 @@ async def _ensure_work_queue_exists(
     return work_queue
 
 
-@inject_db
 async def read_work_queue_status(
-    session: AsyncSession, work_queue_id: UUID, db: PrefectDBInterface
+    session: AsyncSession, work_queue_id: UUID
 ) -> schemas.core.WorkQueueStatusDetail:
     """
     Get work queue status by id.

--- a/src/prefect/server/orchestration/instrumentation_policies.py
+++ b/src/prefect/server/orchestration/instrumentation_policies.py
@@ -1,0 +1,59 @@
+"""
+Orchestration rules related to instrumenting the orchestration engine for Prefect
+Observability
+"""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from prefect.server.events.clients import PrefectServerEventsClient
+from prefect.server.models.events import (
+    TRUNCATE_STATE_MESSAGES_AT,
+    flow_run_state_change_event,
+    truncated_to,
+)
+from prefect.server.orchestration.rules import (
+    BaseUniversalTransform,
+    FlowOrchestrationContext,
+    OrchestrationContext,
+)
+
+
+class InstrumentFlowRunStateTransitions(BaseUniversalTransform):
+    """When a Flow Run changes states, fire a Prefect Event for the state change"""
+
+    async def after_transition(self, context: OrchestrationContext) -> None:
+        if not context.proposed_state or not context.validated_state:
+            return
+
+        if not isinstance(context, FlowOrchestrationContext):
+            return
+
+        initial_state = context.initial_state.copy() if context.initial_state else None
+        validated_state = context.validated_state.copy()
+
+        # Guard against passing large state payloads to arq
+        if initial_state:
+            initial_state.timestamp = context.initial_state.timestamp
+            initial_state.message = truncated_to(
+                TRUNCATE_STATE_MESSAGES_AT, initial_state.message
+            )
+        if validated_state:
+            validated_state.timestamp = context.validated_state.timestamp
+            validated_state.message = truncated_to(
+                TRUNCATE_STATE_MESSAGES_AT, validated_state.message
+            )
+
+        assert isinstance(context.session, AsyncSession)
+
+        async with PrefectServerEventsClient() as events:
+            await events.emit(
+                await flow_run_state_change_event(
+                    session=context.session,
+                    occurred=validated_state.timestamp,
+                    flow_run=context.run,
+                    initial_state_id=initial_state.id if initial_state else None,
+                    initial_state=initial_state,
+                    validated_state_id=validated_state.id,
+                    validated_state=validated_state,
+                )
+            )

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1698,6 +1698,13 @@ PREFECT_API_EVENTS_STREAM_OUT_ENABLED = Setting(bool, default=True)
 Whether or not to allow streaming events out of via websockets.
 """
 
+PREFECT_API_EVENTS_RELATED_RESOURCE_CACHE_TTL = Setting(
+    timedelta, default=timedelta(minutes=5)
+)
+"""
+How long to cache related resource data for emitting server-side vents
+"""
+
 # Deprecated settings ------------------------------------------------------------------
 
 

--- a/tests/fixtures/events.py
+++ b/tests/fixtures/events.py
@@ -21,3 +21,7 @@ def workspace_events_client(
         "prefect.server.events.actions.PrefectServerEventsClient",
         AssertingEventsClient,
     )
+    monkeypatch.setattr(
+        "prefect.server.orchestration.instrumentation_policies.PrefectServerEventsClient",
+        AssertingEventsClient,
+    )

--- a/tests/server/orchestration/test_flow_run_instrumentation_policies.py
+++ b/tests/server/orchestration/test_flow_run_instrumentation_policies.py
@@ -1,0 +1,1069 @@
+from contextlib import AsyncExitStack
+from datetime import timedelta
+from typing import Any, Dict
+from unittest import mock
+from uuid import uuid4
+
+import httpx
+import pendulum
+import pytest
+from httpx import ASGITransport, AsyncClient
+from prefect._vendor.fastapi.applications import FastAPI
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from prefect.server import models
+from prefect.server.database.orm_models import (
+    ORMDeployment,
+    ORMFlow,
+    ORMFlowRun,
+    ORMTaskRun,
+    ORMWorkPool,
+    ORMWorkQueue,
+)
+from prefect.server.events.clients import AssertingEventsClient
+from prefect.server.events.schemas.events import RelatedResource, Resource
+from prefect.server.models import events, flow_run_states, flow_runs, workers
+from prefect.server.models.events import _flow_run_resource_data_cache
+from prefect.server.models.work_queues import create_work_queue
+from prefect.server.orchestration.instrumentation_policies import (
+    InstrumentFlowRunStateTransitions,
+)
+from prefect.server.orchestration.rules import (
+    ALL_ORCHESTRATION_STATES,
+    BaseOrchestrationRule,
+    FlowOrchestrationContext,
+    TaskOrchestrationContext,
+)
+from prefect.server.schemas.actions import WorkQueueCreate
+from prefect.server.schemas.core import CreatedBy, FlowRun
+from prefect.server.schemas.responses import FlowRunResponse
+from prefect.server.schemas.states import (
+    Cancelled,
+    Pending,
+    State,
+    StateDetails,
+    StateType,
+)
+from prefect.settings import PREFECT_EXPERIMENTAL_EVENTS, temporary_settings
+
+
+@pytest.fixture(autouse=True)
+def events_enabled():
+    with temporary_settings({PREFECT_EXPERIMENTAL_EVENTS: True}):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def cleared_resource_data_cache():
+    _flow_run_resource_data_cache.clear()
+
+
+@pytest.fixture
+async def orchestration_parameters() -> Dict[str, Any]:
+    return {}
+
+
+async def test_instrumenting_a_flow_run_state_change(
+    session: AsyncSession,
+    flow: ORMFlow,
+    flow_run: ORMFlowRun,
+    start_of_test: pendulum.DateTime,
+    orchestration_parameters: Dict[str, Any],
+):
+    transition = (StateType.PENDING, StateType.RUNNING)
+    context = FlowOrchestrationContext(
+        initial_state=State(type=transition[0]),
+        proposed_state=State(type=transition[1]),
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+
+    async with InstrumentFlowRunStateTransitions(context, *transition):
+        await context.validate_proposed_state()
+    await session.commit()
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    assert context.proposed_state
+    assert event.event == "prefect.flow-run.Running"
+    assert start_of_test <= event.occurred <= pendulum.now("UTC")
+
+    assert event.resource.dict() == Resource.parse_obj(
+        {
+            "prefect.resource.id": f"prefect.flow-run.{flow_run.id}",
+            "prefect.resource.name": flow_run.name,
+            "prefect.state-message": "",
+            "prefect.state-name": "Running",
+            "prefect.state-timestamp": context.proposed_state.timestamp.isoformat(),
+            "prefect.state-type": "RUNNING",
+        }
+    )
+    assert event.related == [
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": f"prefect.flow.{flow.id}",
+                "prefect.resource.role": "flow",
+                "prefect.resource.name": "my-flow",
+            }
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "created_by, resource_prefix",
+    [
+        (
+            CreatedBy(id=uuid4(), type="DEPLOYMENT", display_value="Deployjoy"),
+            "prefect.deployment",
+        ),
+        (
+            CreatedBy(id=uuid4(), type="AUTOMATION", display_value="I'm Triggered"),
+            "prefect.automation",
+        ),
+        (
+            CreatedBy(id=uuid4(), type="NEVERHOIDOFIT", display_value="anything"),
+            None,
+        ),
+    ],
+)
+async def test_capturing_flow_run_provenance_as_related_resource(
+    session: AsyncSession,
+    flow: ORMFlow,
+    flow_run: ORMFlowRun,
+    start_of_test: pendulum.DateTime,
+    orchestration_parameters: Dict[str, Any],
+    created_by: CreatedBy,
+    resource_prefix: str,
+):
+    flow_run.created_by = created_by
+    session.add(flow_run)
+    await session.commit()
+
+    transition = (StateType.PENDING, StateType.RUNNING)
+    context = FlowOrchestrationContext(
+        initial_state=State(type=transition[0]),
+        proposed_state=State(type=transition[1]),
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+
+    async with InstrumentFlowRunStateTransitions(context, *transition):
+        await context.validate_proposed_state()
+    await session.commit()
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    creators = [r for r in event.related if r.role == "creator"]
+    if resource_prefix is None:
+        assert not creators
+    else:
+        assert creators == [
+            RelatedResource.parse_obj(
+                {
+                    "prefect.resource.id": f"{resource_prefix}.{created_by.id}",
+                    "prefect.resource.role": "creator",
+                    "prefect.resource.name": created_by.display_value,
+                }
+            )
+        ]
+
+
+async def test_flow_run_state_change_events_capture_order_on_short_gaps(
+    session: AsyncSession,
+    flow: ORMFlow,
+    flow_run: ORMFlowRun,
+    start_of_test: pendulum.DateTime,
+    orchestration_parameters: Dict[str, Any],
+):
+    # send the pending state through orchestration so it is written to the DB
+    pending_state: State = State(
+        type=StateType.PENDING,
+        timestamp=start_of_test - timedelta(minutes=2),
+    )
+    pending_transition = (None, StateType.PENDING)
+    context = FlowOrchestrationContext(
+        initial_state=None,
+        proposed_state=pending_state,
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+
+    async with InstrumentFlowRunStateTransitions(context, *pending_transition):
+        await context.validate_proposed_state()
+    await session.commit()
+
+    from_db = await flow_run_states.read_flow_run_state(session, pending_state.id)
+    assert from_db
+    pending_state = State.from_orm(from_db)
+
+    # Now process the Pending->Running transition and confirm it sends an event
+    running_state: State = State(type=StateType.RUNNING)
+    running_transition = (pending_state.type, running_state.type)
+    context = FlowOrchestrationContext(
+        initial_state=pending_state,
+        proposed_state=running_state,
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+    async with InstrumentFlowRunStateTransitions(context, *running_transition):
+        await context.validate_proposed_state()
+    await session.commit()
+
+    assert len(AssertingEventsClient.all) == 2
+    all_events = {e.events[0].event for e in AssertingEventsClient.all}
+    assert all_events == {"prefect.flow-run.Pending", "prefect.flow-run.Running"}
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    assert event.event == "prefect.flow-run.Running"
+    assert event.id == running_state.id
+
+    # we _do_ track event.follows here because the events are close enough in time
+    # that we might need to disambiguate the ordering of them in downstream systems
+    assert event.follows == pending_state.id
+
+
+async def test_flow_run_state_change_events_do_not_capture_order_on_long_gaps(
+    session: AsyncSession,
+    flow: ORMFlow,
+    flow_run: ORMFlowRun,
+    start_of_test: pendulum.DateTime,
+    orchestration_parameters: Dict[str, Any],
+):
+    # send the pending state through orchestration so it is written to the DB
+    pending_state: State = State(
+        type=StateType.PENDING,
+        timestamp=start_of_test - timedelta(minutes=15),
+    )
+    pending_transition = (None, StateType.PENDING)
+    context = FlowOrchestrationContext(
+        initial_state=None,
+        proposed_state=pending_state,
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+
+    async with InstrumentFlowRunStateTransitions(context, *pending_transition):
+        await context.validate_proposed_state()
+    await session.commit()
+
+    from_db = await flow_run_states.read_flow_run_state(session, pending_state.id)
+    assert from_db
+    pending_state = State.from_orm(from_db)
+
+    # Now process the Pending->Running transition and confirm it sends an event
+    running_state: State = State(type=StateType.RUNNING)
+    running_transition = (pending_state.type, running_state.type)
+    context = FlowOrchestrationContext(
+        initial_state=pending_state,
+        proposed_state=running_state,
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+    async with InstrumentFlowRunStateTransitions(context, *running_transition):
+        await context.validate_proposed_state()
+    await session.commit()
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    assert event.event == "prefect.flow-run.Running"
+    assert event.id == running_state.id
+
+    # we _do not_ track event.follows here because the events are distant enough in time
+    # that we don't need to ensure their local ordering
+    assert event.follows is None
+
+
+async def test_flow_run_state_change_events_do_not_capture_order_on_initial_transition(
+    session: AsyncSession,
+    flow: ORMFlow,
+    flow_run: ORMFlowRun,
+    start_of_test: pendulum.DateTime,
+    orchestration_parameters: Dict[str, Any],
+):
+    pending_state: State = State(type=StateType.PENDING)
+    transition = (None, StateType.PENDING)
+    context = FlowOrchestrationContext(
+        initial_state=None,
+        proposed_state=pending_state,
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+
+    async with InstrumentFlowRunStateTransitions(context, *transition):
+        await context.validate_proposed_state()
+    await session.commit()
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    assert event.event == "prefect.flow-run.Pending"
+    assert event.id == pending_state.id
+    assert event.follows is None
+
+
+async def test_instrumenting_a_flow_run_with_no_flow(
+    session: AsyncSession,
+    flow: ORMFlow,
+    flow_run: ORMFlowRun,
+    start_of_test: pendulum.DateTime,
+    orchestration_parameters: Dict[str, Any],
+):
+    """Regression test for errors observed on 2023-02-01, where a flow run was found
+    but the associated flow was not.  Likely due to a race condition at the point of
+    emitting the event.  We can emit a barebones version of the event without the
+    typical related resources."""
+    transition = (StateType.PENDING, StateType.RUNNING)
+    context = FlowOrchestrationContext(
+        initial_state=State(type=transition[0]),
+        proposed_state=State(type=transition[1]),
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+
+    # emulate the race condition where a flow is deleted just after getting a flow_run
+    with mock.patch(
+        "prefect.server.models.events.models.flows.read_flow",
+        return_value=None,
+        spec=models.flows.read_flow,
+    ):
+        async with InstrumentFlowRunStateTransitions(context, *transition):
+            await context.validate_proposed_state()
+        await session.commit()
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    assert context.proposed_state
+    assert event.event == "prefect.flow-run.Running"
+    assert start_of_test <= event.occurred <= pendulum.now("UTC")
+
+    assert event.resource == Resource.parse_obj(
+        {
+            "prefect.resource.id": f"prefect.flow-run.{flow_run.id}",
+            "prefect.resource.name": flow_run.name,
+            "prefect.state-message": "",
+            "prefect.state-name": "Running",
+            "prefect.state-timestamp": context.proposed_state.timestamp.isoformat(),
+            "prefect.state-type": "RUNNING",
+        }
+    )
+    # flow runs without a flow won't be able to have any related resources
+    assert event.related == []
+
+
+async def test_instrumenting_a_flow_run_includes_state_in_payload(
+    session: AsyncSession,
+    flow_run,
+    orchestration_parameters: Dict[str, Any],
+):
+    transition = (None, StateType.RUNNING)
+    context = FlowOrchestrationContext(
+        initial_state=None,
+        proposed_state=State(type=transition[1], name="custom", message="foo"),
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+
+    async with InstrumentFlowRunStateTransitions(context, *transition):
+        await context.validate_proposed_state()
+    await session.commit()
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    assert event.payload == {
+        "intended": {"from": None, "to": "RUNNING"},
+        "initial_state": None,
+        "validated_state": {"type": "RUNNING", "name": "custom", "message": "foo"},
+    }
+
+
+async def test_instrumenting_a_deployed_flow_run_state_change(
+    session: AsyncSession,
+    flow: ORMFlow,
+    deployment: ORMDeployment,
+    flow_run: ORMFlowRun,
+    orchestration_parameters: Dict[str, Any],
+):
+    flow_run.deployment_id = deployment.id
+    session.add(flow_run)
+    await session.commit()
+
+    transition = (StateType.PENDING, StateType.RUNNING)
+    context = FlowOrchestrationContext(
+        initial_state=State(type=transition[0]),
+        proposed_state=State(type=transition[1]),
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+
+    async with InstrumentFlowRunStateTransitions(context, *transition):
+        await context.validate_proposed_state()
+    await session.commit()
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    assert event.related == [
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": f"prefect.flow.{flow.id}",
+                "prefect.resource.role": "flow",
+                "prefect.resource.name": "my-flow",
+            }
+        ),
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": f"prefect.deployment.{deployment.id}",
+                "prefect.resource.role": "deployment",
+                "prefect.resource.name": deployment.name,
+            }
+        ),
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": "prefect.tag.test",
+                "prefect.resource.role": "tag",
+            }
+        ),
+    ]
+
+
+async def test_instrumenting_a_flow_with_tags(
+    session: AsyncSession,
+    flow: ORMFlow,
+    deployment: ORMDeployment,
+    flow_run: ORMFlowRun,
+    start_of_test: pendulum.DateTime,
+    orchestration_parameters: Dict[str, Any],
+):
+    flow_run.tags = ["flow-run-one"]
+    flow.tags = ["flow-one", "common-one"]
+    deployment.tags = ["deployment-one", "common-one"]
+    flow_run.deployment_id = deployment.id
+    session.add_all(
+        [
+            flow_run,
+            flow,
+            deployment,
+            flow_run,
+        ]
+    )
+    await session.commit()
+
+    transition = (StateType.PENDING, StateType.RUNNING)
+    context = FlowOrchestrationContext(
+        initial_state=State(type=transition[0]),
+        proposed_state=State(type=transition[1]),
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+
+    async with InstrumentFlowRunStateTransitions(context, *transition):
+        await context.validate_proposed_state()
+    await session.commit()
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    assert len(event.related) == 6  # two of these are the flow and deployment
+
+    assert (
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": "prefect.tag.common-one",
+                "prefect.resource.role": "tag",
+            }
+        )
+        in event.related
+    )
+    assert (
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": "prefect.tag.deployment-one",
+                "prefect.resource.role": "tag",
+            }
+        )
+        in event.related
+    )
+    assert (
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": "prefect.tag.flow-run-one",
+                "prefect.resource.role": "tag",
+            }
+        )
+        in event.related
+    )
+    assert (
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": "prefect.tag.flow-one",
+                "prefect.resource.role": "tag",
+            }
+        )
+        in event.related
+    )
+
+
+@pytest.fixture
+async def work_queue(session: AsyncSession):
+    work_queue = await create_work_queue(
+        session=session,
+        work_queue=WorkQueueCreate(name="This is a queuey one"),
+    )
+    await session.commit()
+
+    return work_queue
+
+
+@pytest.fixture
+async def work_pool(session: AsyncSession, work_queue: ORMWorkQueue):
+    work_pool = await workers.read_work_pool(
+        session=session,
+        work_pool_id=work_queue.work_pool_id,
+    )
+
+    return work_pool
+
+
+async def test_instrumenting_a_flow_run_from_a_work_queue(
+    session: AsyncSession,
+    flow,
+    work_queue,
+    work_pool,
+    flow_run,
+    start_of_test: pendulum.DateTime,
+    orchestration_parameters: Dict[str, Any],
+):
+    flow_run.work_queue_id = work_queue.id
+    session.add(flow_run)
+    await session.commit()
+
+    transition = (StateType.PENDING, StateType.RUNNING)
+    context = FlowOrchestrationContext(
+        initial_state=State(type=transition[0]),
+        proposed_state=State(type=transition[1]),
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+
+    async with InstrumentFlowRunStateTransitions(context, *transition):
+        await context.validate_proposed_state()
+    await session.commit()
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    assert len(event.related) == 3  # the other one is the flow
+
+    assert (
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": f"prefect.work-queue.{work_queue.id}",
+                "prefect.resource.role": "work-queue",
+                "prefect.resource.name": "This is a queuey one",
+            }
+        )
+        in event.related
+    )
+
+    assert (
+        RelatedResource.parse_obj(
+            {
+                "prefect.resource.id": f"prefect.work-pool.{work_pool.id}",
+                "prefect.resource.role": "work-pool",
+                "prefect.resource.name": work_pool.name,
+            }
+        )
+        in event.related
+    )
+
+
+async def test_does_nothing_for_task_transitions(
+    session: AsyncSession,
+    task_run: ORMTaskRun,
+    orchestration_parameters: Dict[str, Any],
+):
+    transition = (StateType.PENDING, StateType.RUNNING)
+    context = TaskOrchestrationContext(
+        initial_state=State(type=transition[0]),
+        proposed_state=State(type=transition[1]),
+        run=task_run,
+        session=session,
+    )
+
+    async with InstrumentFlowRunStateTransitions(context, *transition):
+        await context.validate_proposed_state()
+    await session.commit()
+
+    # no events should have been emitted
+    assert not AssertingEventsClient.last
+
+
+async def test_still_instruments_rejected_state_transitions(
+    session: AsyncSession,
+    flow_run: ORMFlowRun,
+    orchestration_parameters: Dict[str, Any],
+):
+    transition = (StateType.PENDING, StateType.RUNNING)
+    context = FlowOrchestrationContext(
+        initial_state=State(type=transition[0]),
+        proposed_state=State(type=transition[1]),
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+
+    class FussyRule(BaseOrchestrationRule):
+        FROM_STATES = ALL_ORCHESTRATION_STATES
+        TO_STATES = ALL_ORCHESTRATION_STATES
+
+        async def before_transition(self, initial_state, proposed_state, context):
+            new_state = proposed_state.copy()
+            new_state.name = "Cancelled Fussily"
+            new_state.type = StateType.CANCELLED
+            await self.reject_transition(new_state, reason="I am fussy")
+
+        async def after_transition(self, initial_state, validated_state, context):
+            pass
+
+        async def cleanup(self, initial_state, validated_state, context):
+            pass
+
+    fussy_policy = [
+        InstrumentFlowRunStateTransitions,
+        FussyRule,
+    ]
+
+    async with AsyncExitStack() as stack:
+        for rule in fussy_policy:
+            context = await stack.enter_async_context(rule(context, *transition))
+        await context.validate_proposed_state()
+    await session.commit()
+
+    # The validated transition should be emitted
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    assert event.event == "prefect.flow-run.Cancelled Fussily"
+    assert event.resource["prefect.state-type"] == "CANCELLED"
+
+
+async def test_does_nothing_for_aborted_transitions(
+    session: AsyncSession,
+    flow_run,
+    orchestration_parameters: Dict[str, Any],
+):
+    transition = (StateType.PENDING, StateType.RUNNING)
+    context = FlowOrchestrationContext(
+        initial_state=State(type=transition[0]),
+        proposed_state=State(type=transition[1]),
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+
+    class UglyRule(BaseOrchestrationRule):
+        FROM_STATES = ALL_ORCHESTRATION_STATES
+        TO_STATES = ALL_ORCHESTRATION_STATES
+
+        async def before_transition(self, initial_state, proposed_state, context):
+            await self.abort_transition("I am just plain ugly")
+
+        async def after_transition(self, initial_state, validated_state, context):
+            pass
+
+        async def cleanup(self, initial_state, validated_state, context):
+            pass
+
+    ugly_policy = [
+        InstrumentFlowRunStateTransitions,
+        UglyRule,
+    ]
+
+    async with AsyncExitStack() as stack:
+        for rule in ugly_policy:
+            context = await stack.enter_async_context(rule(context, *transition))
+        await context.validate_proposed_state()
+    await session.commit()
+
+    # no events should have been emitted
+    assert not AssertingEventsClient.last
+
+
+async def test_does_nothing_for_delayed_transitions(
+    session: AsyncSession,
+    flow_run,
+    orchestration_parameters: Dict[str, Any],
+):
+    transition = (StateType.PENDING, StateType.RUNNING)
+    context = FlowOrchestrationContext(
+        initial_state=State(type=transition[0]),
+        proposed_state=State(type=transition[1]),
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+
+    class ProcrastinatingRule(BaseOrchestrationRule):
+        FROM_STATES = ALL_ORCHESTRATION_STATES
+        TO_STATES = ALL_ORCHESTRATION_STATES
+
+        async def before_transition(self, initial_state, proposed_state, context):
+            await self.delay_transition(10, "I'll get to it when I get to it")
+
+        async def after_transition(self, initial_state, validated_state, context):
+            pass
+
+        async def cleanup(self, initial_state, validated_state, context):
+            pass
+
+    Procrastinating_policy = [
+        InstrumentFlowRunStateTransitions,
+        ProcrastinatingRule,
+    ]
+
+    async with AsyncExitStack() as stack:
+        for rule in Procrastinating_policy:
+            context = await stack.enter_async_context(rule(context, *transition))
+        await context.validate_proposed_state()
+    await session.commit()
+
+    # no events should have been emitted
+    assert not AssertingEventsClient.last
+
+
+@pytest.fixture
+async def client(app: FastAPI):
+    # The automations tests assume that the client will not raise exceptions and will
+    # serve any server-side errors as HTTP responses.  This is different than some other
+    # parts of the general test suite, so we'll override the fixture here.
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://test/api"
+    ) as async_client:
+        yield async_client
+
+
+async def test_cancelling_to_cancelled_transitions(
+    session: AsyncSession,
+    client: AsyncClient,
+    flow_run: ORMFlowRun,
+    start_of_test: pendulum.DateTime,
+):
+    """Regression test for https://github.com/PrefectHQ/nebula/issues/2826, where
+    we observed that flow runs firing Cancelling events never end up firing Cancelled
+    events.  Uses the API for a more realistic reproduction case."""
+    await flow_runs.set_flow_run_state(
+        session=session,
+        flow_run_id=flow_run.id,
+        state=State(type=StateType.CANCELLED, name="Cancelling"),
+    )
+    await session.commit()
+
+    response = await client.post(
+        f"flow_runs/{flow_run.id}/set_state",
+        json={
+            "state": Cancelled().dict(json_compatible=True),
+            "force": True,  # the Agent uses force=True here, which caused the bug
+        },
+    )
+    assert response.status_code == 201, response.text
+
+    response = await client.get(
+        f"/flow_runs/{flow_run.id}",
+    )
+    assert response.status_code == 200
+
+    updated_flow_run = FlowRunResponse.parse_obj(response.json())
+    assert updated_flow_run.state
+
+    assert AssertingEventsClient.last
+    (event,) = AssertingEventsClient.last.events
+
+    assert event.event == "prefect.flow-run.Cancelled"
+    assert start_of_test <= event.occurred <= pendulum.now("UTC")
+
+    assert event.resource == Resource.parse_obj(
+        {
+            "prefect.resource.id": f"prefect.flow-run.{flow_run.id}",
+            "prefect.resource.name": flow_run.name,
+            "prefect.state-message": "",
+            "prefect.state-name": "Cancelled",
+            "prefect.state-timestamp": updated_flow_run.state.timestamp.isoformat(),
+            "prefect.state-type": "CANCELLED",
+        }
+    )
+
+
+async def test_caches_resource_data(
+    session: AsyncSession,
+    work_queue,
+    work_pool,
+    flow: ORMFlow,
+    flow_run: ORMFlowRun,
+    deployment: ORMDeployment,
+    orchestration_parameters: Dict[str, Any],
+):
+    flow_run.work_queue_id = work_queue.id
+    flow_run.tags = ["flow-run-one", "common-one"]
+    flow.tags = ["flow-one", "common-one"]
+    deployment.tags = ["deployment-one", "common-one"]
+    flow_run.deployment_id = deployment.id
+    session.add_all(
+        [
+            flow,
+            deployment,
+            flow_run,
+        ]
+    )
+
+    transition = (StateType.PENDING, StateType.RUNNING)
+    context = FlowOrchestrationContext(
+        initial_state=State(type=transition[0]),
+        proposed_state=State(type=transition[1]),
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+
+    async with InstrumentFlowRunStateTransitions(context, *transition):
+        await context.validate_proposed_state()
+    await session.commit()
+
+    assert AssertingEventsClient.last
+
+    related = _flow_run_resource_data_cache[flow_run.id]
+
+    assert related == {
+        "flow-run": {
+            "id": str(flow_run.id),
+            "name": flow_run.name,
+            "tags": ["flow-run-one", "common-one"],
+            "role": "flow-run",
+        },
+        "flow": {
+            "id": str(flow.id),
+            "name": flow.name,
+            "tags": ["flow-one", "common-one"],
+            "role": "flow",
+        },
+        "deployment": {
+            "id": str(deployment.id),
+            "name": deployment.name,
+            "tags": ["deployment-one", "common-one"],
+            "role": "deployment",
+        },
+        "work-queue": {
+            "id": str(work_queue.id),
+            "name": work_queue.name,
+            "tags": [],
+            "role": "work-queue",
+        },
+        "work-pool": {
+            "id": str(work_pool.id),
+            "name": work_pool.name,
+            "tags": [],
+            "role": "work-pool",
+        },
+        "task-run": {},
+    }
+
+
+async def test_caches_resource_data_for_subflow_runs(
+    session: AsyncSession,
+    work_queue: ORMWorkQueue,
+    work_pool: ORMWorkPool,
+    task_run: ORMTaskRun,
+    flow: ORMFlow,
+    orchestration_parameters: Dict[str, Any],
+):
+    task_run.tags = ["task-run-one", "common-one"]
+    await session.commit()
+
+    flow_run = await flow_runs.create_flow_run(
+        session=session,
+        flow_run=FlowRun(
+            flow_id=flow.id,
+            flow_version="1.0",
+            state=Pending(),
+            job_variables={"x": "y"},
+            parent_task_run_id=task_run.id,
+            work_queue_id=work_queue.id,
+            tags=["flow-run-one", "common-one"],
+        ),
+    )
+
+    session.add_all(
+        [
+            flow_run,
+            task_run,
+        ]
+    )
+    await session.commit()
+
+    transition = (StateType.PENDING, StateType.RUNNING)
+    context = FlowOrchestrationContext(
+        initial_state=State(type=transition[0]),
+        proposed_state=State(type=transition[1]),
+        run=flow_run,
+        session=session,
+        parameters=orchestration_parameters,
+    )
+
+    async with InstrumentFlowRunStateTransitions(context, *transition):
+        await context.validate_proposed_state()
+
+    await session.commit()
+
+    assert AssertingEventsClient.last
+
+    related = _flow_run_resource_data_cache[flow_run.id]
+
+    assert related == {
+        "flow-run": {
+            "id": str(flow_run.id),
+            "name": flow_run.name,
+            "tags": ["flow-run-one", "common-one"],
+            "role": "flow-run",
+        },
+        "deployment": {},
+        "flow": {
+            "id": str(flow.id),
+            "name": flow.name,
+            "tags": [],
+            "role": "flow",
+        },
+        "work-queue": {
+            "id": str(work_queue.id),
+            "name": work_queue.name,
+            "tags": [],
+            "role": "work-queue",
+        },
+        "work-pool": {
+            "id": str(work_pool.id),
+            "name": work_pool.name,
+            "tags": [],
+            "role": "work-pool",
+        },
+        "task-run": {
+            "id": str(task_run.id),
+            "name": task_run.name,
+            "tags": ["task-run-one", "common-one"],
+            "role": "task-run",
+        },
+    }
+
+
+@pytest.fixture
+def odd_truncation(monkeypatch: pytest.MonkeyPatch):
+    assert 50_000 < events.TRUNCATE_STATE_MESSAGES_AT < 1_000_000
+    monkeypatch.setattr(events, "TRUNCATE_STATE_MESSAGES_AT", 11)
+
+
+@pytest.mark.parametrize(
+    "message, expected",
+    [
+        (None, None),
+        ("", None),
+        ("a", "a"),
+        ("heyyy", "heyyy"),
+        ("12345678901", "12345678901"),
+        ("123456789012", "123456789012"),  # because let's not be silly
+        (
+            "12345xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxghijk",
+            "12345...39 additional characters...ghijk",
+        ),
+        (
+            "12345xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxghijk",
+            "12345...40 additional characters...ghijk",
+        ),
+    ],
+)
+def test_truncating_state_messages_at_odd_length(
+    odd_truncation: None,
+    message: str,
+    expected: str,
+):
+    payload = events.state_payload(
+        State(
+            type=StateType.PENDING,
+            name="Pending",
+            message=message,
+        )
+    )
+    assert payload
+    assert payload.get("message") == expected
+
+
+@pytest.fixture
+def even_truncation(monkeypatch: pytest.MonkeyPatch):
+    assert 50_000 < events.TRUNCATE_STATE_MESSAGES_AT < 1_000_000
+    monkeypatch.setattr(events, "TRUNCATE_STATE_MESSAGES_AT", 10)
+
+
+@pytest.mark.parametrize(
+    "message, expected",
+    [
+        (None, None),
+        ("", None),
+        ("a", "a"),
+        ("heyyy", "heyyy"),
+        ("12345678901", "12345678901"),
+        ("123456789012", "123456789012"),  # because let's not be silly
+        (
+            "12345xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxghijk",
+            "12345...39 additional characters...ghijk",
+        ),
+        (
+            "12345xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxghijk",
+            "12345...40 additional characters...ghijk",
+        ),
+    ],
+)
+def test_truncating_state_messages_at_even_length(
+    even_truncation: None,
+    message: str,
+    expected: str,
+):
+    payload = events.state_payload(
+        State(
+            type=StateType.PENDING,
+            name="Pending",
+            message=message,
+        )
+    )
+    assert payload
+    assert payload.get("message") == expected
+
+
+def test_state_payload_paused_state():
+    payload = events.state_payload(
+        State(
+            type=StateType.PAUSED,
+            name="Paused",
+            state_details=StateDetails(pause_reschedule=True),
+        )
+    )
+    assert payload
+    assert payload["pause_reschedule"] == "true"

--- a/tests/server/services/test_late_runs.py
+++ b/tests/server/services/test_late_runs.py
@@ -1,12 +1,25 @@
+from unittest import mock
+from uuid import UUID
+
 import pendulum
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server import models, schemas
+from prefect.server.database.orm_models import ORMFlowRun
+from prefect.server.events.clients import AssertingEventsClient
 from prefect.server.services.late_runs import MarkLateRuns
 from prefect.settings import (
     PREFECT_API_SERVICES_LATE_RUNS_AFTER_SECONDS,
+    PREFECT_EXPERIMENTAL_EVENTS,
     temporary_settings,
 )
+
+
+@pytest.fixture(autouse=True)
+def enable_events():
+    with temporary_settings({PREFECT_EXPERIMENTAL_EVENTS: True}):
+        yield
 
 
 @pytest.fixture
@@ -212,3 +225,49 @@ async def test_only_scheduled_runs_marked_late(
     )
     await session.refresh(pending_run)
     assert pending_run.state_name == "Pending"
+
+
+async def test_mark_late_runs_fires_flow_run_state_change_events(
+    late_run: ORMFlowRun, session: AsyncSession
+):
+    previous_state_id = late_run.state_id
+    assert isinstance(previous_state_id, UUID)
+
+    await MarkLateRuns(handle_signals=False).start(loops=1)
+
+    session.expunge_all()
+
+    updated_flow_run = await models.flow_runs.read_flow_run(session, late_run.id)
+    late_state_id = updated_flow_run.state_id
+    assert isinstance(late_state_id, UUID)
+    assert late_state_id != previous_state_id
+
+    assert AssertingEventsClient.last
+    assert len(AssertingEventsClient.last.events) == 1
+    (event,) = AssertingEventsClient.last.events
+
+    assert event.resource.id == f"prefect.flow-run.{late_run.id}"
+    assert event.event == "prefect.flow-run.Late"
+    assert event.resource["prefect.state-type"] == "SCHEDULED"
+    assert event.payload == {
+        "intended": {"from": "SCHEDULED", "to": "SCHEDULED"},
+        "initial_state": {"type": "SCHEDULED", "name": "Scheduled"},
+        "validated_state": {"type": "SCHEDULED", "name": "Late"},
+    }
+
+    # The events should use the state IDs to help track the ordering of events
+    assert event.id == late_state_id
+    assert event.follows == previous_state_id
+
+
+async def test_mark_late_runs_ignores_missing_runs(late_run: ORMFlowRun):
+    """Regression test for https://github.com/PrefectHQ/nebula/issues/2846"""
+    # Simulate another process deleting the flow run in the middle of the service loop
+    # Before the fix, this would have raised the ObjectNotFoundError
+    with mock.patch("prefect.server.models.flow_runs.read_flow_run", return_value=None):
+        service = MarkLateRuns(handle_signals=False)
+        await service._on_start()
+        try:
+            await service.run_once()
+        finally:
+            await service._on_stop()


### PR DESCRIPTION
This represents parity with Prefect Cloud for instrumenting flow run state
changes with events with an orchestration rule.  The events are emitted
synchronously during the request/response cycle.
