### PR TITLE
Implement flow retries in new flow engine

### DIFF
--- a/src/prefect/new_flow_engine.py
+++ b/src/prefect/new_flow_engine.py
@@ -91,7 +91,7 @@ class FlowRunEngine(Generic[P, R]):
         await self.set_subflow_state(state)
         return state
 
-    async def result(self, raise_on_failure: bool = True) -> R | State | None:
+    async def result(self, raise_on_failure: bool = True) -> "R | State | None":
         return await self.state.result(raise_on_failure=raise_on_failure, fetch=True)
 
     async def handle_success(self, result: R) -> R:
@@ -138,7 +138,7 @@ class FlowRunEngine(Generic[P, R]):
 
     async def get_most_recent_flow_run_for_parent_task_run(
         self, client: PrefectClient, parent_task_run: TaskRun
-    ) -> FlowRun:
+    ) -> "FlowRun | None":
         """
         Get the most recent flow run associated with the provided parent task run.
 
@@ -267,7 +267,7 @@ async def run_flow(
     parameters: Optional[Dict[str, Any]] = None,
     wait_for: Optional[Iterable[PrefectFuture[A, Async]]] = None,
     return_type: Literal["state", "result"] = "result",
-) -> R | None:
+) -> "R | None":
     """
     Runs a flow against the API.
 

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -194,7 +194,7 @@ class TaskRunEngine(Generic[P, R]):
             await self._run_hooks(new_state)
         return new_state
 
-    async def result(self, raise_on_failure: bool = True) -> R | State | None:
+    async def result(self, raise_on_failure: bool = True) -> "R | State | None":
         return await self.state.result(raise_on_failure=raise_on_failure)
 
     async def handle_success(self, result: R) -> R:
@@ -334,7 +334,7 @@ async def run_task(
     parameters: Optional[Dict[str, Any]] = None,
     wait_for: Optional[Iterable[PrefectFuture[A, Async]]] = None,
     return_type: Literal["state", "result"] = "result",
-) -> R | State | None:
+) -> "R | State | None":
     """
     Runs a task against the API.
 

--- a/tests/test_new_flow_engine.py
+++ b/tests/test_new_flow_engine.py
@@ -433,7 +433,7 @@ class TestFlowRetries:
         flow_run_count = 0
 
         @task
-        def child_task():
+        async def child_task():
             nonlocal child_task_run_count
             child_task_run_count += 1
 
@@ -444,21 +444,21 @@ class TestFlowRetries:
             return "hello"
 
         @flow
-        def child_flow():
+        async def child_flow():
             nonlocal child_flow_run_count
             child_flow_run_count += 1
-            return child_task()
+            return await child_task()
 
         @flow(retries=1)
-        def parent_flow():
+        async def parent_flow():
             nonlocal flow_run_count
             flow_run_count += 1
 
-            state = child_flow()
+            state = await child_flow()
 
             return state
 
-        assert parent_flow() == "hello"
+        assert await parent_flow() == "hello"
         assert flow_run_count == 2
         assert child_flow_run_count == 2, "Child flow should run again"
         assert child_task_run_count == 2, "Child tasks should run again with child flow"

--- a/tests/test_new_flow_engine.py
+++ b/tests/test_new_flow_engine.py
@@ -91,7 +91,9 @@ class TestFlowRuns:
         state = await run_flow(bar, parameters=parameters, return_type="state")
 
         assert state.is_failed()
-        with pytest.raises(ParameterTypeError, match="is not a valid integer"):
+        with pytest.raises(
+            ParameterTypeError, match="Flow run received invalid parameters"
+        ):
             await state.result()
 
     async def test_flow_run_name(self, prefect_client):
@@ -192,24 +194,24 @@ class TestFlowRetries:
         flow_run_count = 0
 
         @task
-        def my_task():
+        async def my_task():
             nonlocal task_run_count
             task_run_count += 1
             return "hello"
 
         @flow(retries=1)
-        def foo():
+        async def foo():
             nonlocal flow_run_count
             flow_run_count += 1
 
-            state = my_task(return_state=True)
+            state = await my_task(return_state=True)
 
             if flow_run_count == 1:
                 raise ValueError()
 
-            return state.result()
+            return await state.result()
 
-        assert foo() == "hello"
+        assert await foo() == "hello"
         assert flow_run_count == 2
         assert task_run_count == 1
 
@@ -314,7 +316,7 @@ class TestFlowRetries:
         flow_run_count = 0
 
         @flow
-        def child_flow():
+        async def child_flow():
             nonlocal child_run_count
             child_run_count += 1
 
@@ -325,12 +327,12 @@ class TestFlowRetries:
             return "hello"
 
         @flow(retries=1)
-        def parent_flow():
+        async def parent_flow():
             nonlocal flow_run_count
             flow_run_count += 1
-            return child_flow()
+            return await child_flow()
 
-        state = parent_flow._run()
+        state = await parent_flow._run()
         assert await state.result() == "hello"
         assert flow_run_count == 2
         assert child_run_count == 2, "Child flow should be reset and run again"
@@ -352,16 +354,16 @@ class TestFlowRetries:
         flow_run_count = 0
 
         @flow
-        def child_flow():
+        async def child_flow():
             nonlocal child_run_count
             child_run_count += 1
             return "hello"
 
         @flow(retries=1)
-        def parent_flow():
+        async def parent_flow():
             nonlocal flow_run_count
             flow_run_count += 1
-            child_result = child_flow()
+            child_result = await child_flow()
 
             # Fail on the first flow run but not the retry
             if flow_run_count == 1:
@@ -369,7 +371,7 @@ class TestFlowRetries:
 
             return child_result
 
-        assert parent_flow() == "hello"
+        assert await parent_flow() == "hello"
         assert flow_run_count == 2
         assert child_run_count == 1, "Child flow should not run again"
 
@@ -502,24 +504,24 @@ class TestFlowRetries:
         assert flow_run_count == 2
         assert task_run_count == 4, "Task should use all of its retries every time"
 
-    def test_flow_retry_with_error_in_flow_and_one_failed_task_with_retries_cannot_exceed_retries(
+    async def test_flow_retry_with_error_in_flow_and_one_failed_task_with_retries_cannot_exceed_retries(
         self,
     ):
         task_run_count = 0
         flow_run_count = 0
 
         @task(retries=2)
-        def my_task():
+        async def my_task():
             nonlocal task_run_count
             task_run_count += 1
             raise ValueError("This task always fails")
 
         @flow(retries=1)
-        def my_flow():
+        async def my_flow():
             nonlocal flow_run_count
             flow_run_count += 1
 
-            fut = my_task()
+            fut = await my_task()
 
             # It is important that the flow run fails after the task run is created
             if flow_run_count == 1:
@@ -528,7 +530,9 @@ class TestFlowRetries:
             return fut
 
         with pytest.raises(ValueError, match="This task always fails"):
-            my_flow().result().result()
+            fut = await my_flow()
+            flow_result = await fut.result()
+            await flow_result.result()
 
         assert flow_run_count == 2
         assert task_run_count == 6, "Task should use all of its retries every time"

--- a/tests/test_new_task_engine.py
+++ b/tests/test_new_task_engine.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 from unittest.mock import MagicMock
 from uuid import UUID
 
@@ -272,9 +273,10 @@ class TestTaskRetries:
 
         @flow
         async def test_flow():
-            return await flaky_function(return_state=True)
+            # return a tuple to avoid unpacking the state which would raise
+            return await flaky_function(return_state=True), ...
 
-        task_run_state = await test_flow()
+        task_run_state, _ = await test_flow()
         task_run_id = task_run_state.state_details.task_run_id
 
         if always_fail:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Adds flow run retries in the new flow engine. Also updates a couple of tests to use async flows and tasks so that they'll pass and refactors the flow run engine to look more like the task run engine.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
