### PR TITLE
Add serve docs script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: docs
+
+docs:
+	@if [ ! -x "./scripts/serve_docs" ]; then \
+		echo "Error: The 'serve_docs' script is not executable."; \
+		echo "Please make it executable by running:"; \
+		echo "  chmod +x \"./scripts/serve_docs\""; \
+		echo "Then, run 'make docs' again."; \
+		exit 1; \
+	fi
+	@./scripts/serve_docs

--- a/scripts/serve_docs
+++ b/scripts/serve_docs
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Setup a temporary directory for creating a virtual environment
+temp_dir=$(mktemp -d)
+echo "Using temporary directory: $temp_dir"
+
+cleanup() {
+  echo "Cleaning up..."
+  rm -rf "$temp_dir"
+  trap - INT EXIT
+  exit
+}
+
+trap cleanup INT EXIT
+
+command_exists() {
+  type "$1" &> /dev/null;
+}
+
+# Check if uv is installed, if not, install it
+if ! command_exists uv; then
+  echo "uv is not installed. Installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+
+# Navigate to the parent directory containing the prefect package
+cd "$(dirname "$0")/.."
+
+# Create a temporary virtual environment using uv
+uv venv "$temp_dir/.venv"
+source "$temp_dir/.venv/bin/activate"
+
+# Install the prefect package in editable mode
+uv pip install -e ".[dev]"
+
+# Install all integration libraries from src/integrations
+integration_packages=$(find src/integrations -name "pyproject.toml" -exec dirname {} \;)
+uv pip install $integration_packages
+
+# Build and serve the docs
+mkdocs serve -a localhost:8000

--- a/scripts/serve_docs
+++ b/scripts/serve_docs
@@ -30,12 +30,12 @@ cd "$(dirname "$0")/.."
 uv venv "$temp_dir/.venv"
 source "$temp_dir/.venv/bin/activate"
 
-# Install the prefect package in editable mode
-uv pip install -e ".[dev]"
-
 # Install all integration libraries from src/integrations
 integration_packages=$(find src/integrations -name "pyproject.toml" -exec dirname {} \;)
 uv pip install $integration_packages
+
+# Install the prefect package in editable mode
+uv pip install -e ".[dev]"
 
 # Build and serve the docs
 mkdocs serve -a localhost:8000


### PR DESCRIPTION
since serving the docs will require all integration libraries be installed (to build api refs from docstrings etc) this PR adds a script to handle that for us

`make docs` will:
- run `./scripts/serve_docs` if its executable, otherwise prompt the user to make it so and retry
- install all collection / core deps in a `uv` `venv` in a tmpdir
- start a hot-reloading `mkdocs serve` process

i tried messing with it to `open` the browser for you, but since
- `open` i dont think works for most linux
- `mkdocs serve` is blocking
- `mkdocs serve` gives you a link to the serve address anyways

it seemed more trouble than it was worth

___

this PR also introduces a `Makefile`, which @chrisguidry has mentioned we should do at some point