### PR TITLE
Deployment status persistence and events

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -163,6 +163,7 @@ jobs:
           --publish 4200:4200
           ${{ matrix.extra_docker_run_options }}
           --env PREFECT_EXPERIMENTAL_EVENTS=True
+          --env PREFECT_LOGGING_SERVER_LEVEL=DEBUG
           prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
           ${{ matrix.server_command || 'prefect server start --analytics-off' }} --host 0.0.0.0
 
@@ -181,6 +182,11 @@ jobs:
           TEST_CLIENT_VERSION=$(python -c 'import prefect; print(prefect.__version__)')
           ./scripts/run-integration-flows.py flows/
 
+      - name: Show server@${{ matrix.prefect-version }} logs
+        if: always()
+        run: |
+          docker logs "prefect-server-${{ matrix.prefect-version }}" || echo "No logs available"
+
       - name: Turn off CSRF protection for older clients.
         if: ${{ matrix.server-disable-csrf }}
         run: |
@@ -190,6 +196,7 @@ jobs:
         env:
           PREFECT_API_URL: http://127.0.0.1:4200/api
           PREFECT_EXPERIMENTAL_EVENTS: True
+          PREFECT_LOGGING_SERVER_LEVEL: DEBUG
         run: |
           # First, we must stop the server container if it exists
           # TODO: Once we have `prefect server stop` we can run these tests first and the
@@ -197,7 +204,7 @@ jobs:
           #       https://github.com/PrefectHQ/prefect/issues/6989
           docker stop "prefect-server-${{ matrix.prefect-version }}" || echo "That's okay!"
 
-          prefect server start --analytics-off&
+          prefect server start --analytics-off > server-logs.txt 2>&1 &
           ./scripts/wait-for-server.py
 
       - name: Run integration flows with client@${{ matrix.prefect-version }}, server@dev
@@ -213,3 +220,8 @@ jobs:
           ${{ matrix.extra_docker_run_options }}
           prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
           /opt/prefect/integration/scripts/run-integration-flows.py /opt/prefect/integration/flows
+
+      - name: Show server@dev logs
+        if: always()
+        run: |
+          cat server-logs.txt || echo "No logs available"

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -9,6 +9,7 @@ from uuid import UUID
 import jsonschema.exceptions
 import pendulum
 from prefect._vendor.fastapi import Body, Depends, HTTPException, Path, Response, status
+from prefect._vendor.starlette.background import BackgroundTasks
 
 import prefect.server.api.dependencies as dependencies
 import prefect.server.models as models
@@ -18,6 +19,7 @@ from prefect.server.api.workers import WorkerLookups
 from prefect.server.database.dependencies import provide_database_interface
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.exceptions import MissingVariableError, ObjectNotFoundError
+from prefect.server.models.deployments import mark_deployments_ready
 from prefect.server.models.workers import DEFAULT_AGENT_WORK_POOL_NAME
 from prefect.server.utilities.schemas import DateTimeTZ
 from prefect.server.utilities.server import PrefectRouter
@@ -142,13 +144,11 @@ async def create_deployment(
                 )
 
         if deployment.storage_document_id is not None:
-            infrastructure_block = (
-                await models.block_documents.read_block_document_by_id(
-                    session=session,
-                    block_document_id=deployment.storage_document_id,
-                )
+            storage_block = await models.block_documents.read_block_document_by_id(
+                session=session,
+                block_document_id=deployment.storage_document_id,
             )
-            if not infrastructure_block:
+            if not storage_block:
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail=(
@@ -378,6 +378,7 @@ async def read_deployments(
 
 @router.post("/get_scheduled_flow_runs")
 async def get_scheduled_flow_runs_for_deployments(
+    background_tasks: BackgroundTasks,
     deployment_ids: List[UUID] = Body(
         default=..., description="The deployment IDs to get scheduled runs for"
     ),
@@ -415,12 +416,10 @@ async def get_scheduled_flow_runs_for_deployments(
             for orm_flow_run in orm_flow_runs
         ]
 
-    async with db.session_context(
-        begin_transaction=True, with_for_update=True
-    ) as session:
-        await models.deployments._update_deployment_last_polled(
-            session=session, deployment_ids=deployment_ids
-        )
+    background_tasks.add_task(
+        mark_deployments_ready,
+        deployment_ids=deployment_ids,
+    )
 
     return flow_run_responses
 

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -574,6 +574,9 @@ def create_app(
                 services.flow_run_notifications.FlowRunNotifications()
             )
 
+        if prefect.settings.PREFECT_API_SERVICES_FOREMAN_ENABLED.value():
+            service_instances.append(services.foreman.Foreman())
+
         if prefect.settings.PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING.value():
             service_instances.append(services.task_scheduling.TaskSchedulingTimeouts())
 

--- a/src/prefect/server/database/alembic_commands.py
+++ b/src/prefect/server/database/alembic_commands.py
@@ -2,7 +2,7 @@ from functools import wraps
 from pathlib import Path
 from threading import Lock
 
-import prefect
+import prefect.server
 
 ALEMBIC_LOCK = Lock()
 

--- a/src/prefect/server/database/migrations/versions/postgresql/2024_04_23_094748_7ae9e431e67a_work_status_fields.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2024_04_23_094748_7ae9e431e67a_work_status_fields.py
@@ -1,0 +1,72 @@
+"""Work status fields
+
+Revision ID: 7ae9e431e67a
+Revises: 15768c2ec702
+Create Date: 2024-04-23 09:47:48.344011
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "7ae9e431e67a"
+down_revision = "15768c2ec702"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    deployment_status = postgresql.ENUM("READY", "NOT_READY", name="deployment_status")
+    deployment_status.create(op.get_bind())
+
+    op.add_column(
+        "deployment",
+        sa.Column(
+            "status",
+            deployment_status,
+            nullable=False,
+            server_default="NOT_READY",
+        ),
+    )
+
+    work_pool_status = postgresql.ENUM(
+        "READY", "NOT_READY", "PAUSED", name="work_pool_status"
+    )
+    work_pool_status.create(op.get_bind())
+
+    op.add_column(
+        "work_pool",
+        sa.Column(
+            "status",
+            work_pool_status,
+            nullable=False,
+            server_default="NOT_READY",
+        ),
+    )
+
+    work_queue_status = postgresql.ENUM(
+        "READY", "NOT_READY", "PAUSED", name="work_queue_status"
+    )
+    work_queue_status.create(op.get_bind())
+
+    op.add_column(
+        "work_queue",
+        sa.Column(
+            "status",
+            work_queue_status,
+            nullable=False,
+            server_default="NOT_READY",
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("work_queue", "status")
+    op.drop_column("work_pool", "status")
+    op.drop_column("deployment", "status")
+
+    op.execute("DROP TYPE work_queue_status")
+    op.execute("DROP TYPE work_pool_status")
+    op.execute("DROP TYPE deployment_status")

--- a/src/prefect/server/database/migrations/versions/sqlite/2024_04_23_094701_75c8f17b8b51_work_status_fields.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2024_04_23_094701_75c8f17b8b51_work_status_fields.py
@@ -1,0 +1,59 @@
+"""Work status fields
+
+Revision ID: 75c8f17b8b51
+Revises: 824e9edafa60
+Create Date: 2024-04-23 09:47:01.931872
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "75c8f17b8b51"
+down_revision = "824e9edafa60"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "status",
+                sa.Enum("READY", "NOT_READY", name="deployment_status"),
+                nullable=False,
+                server_default="NOT_READY",
+            )
+        )
+
+    with op.batch_alter_table("work_pool", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "status",
+                sa.Enum("READY", "NOT_READY", "PAUSED", name="work_pool_status"),
+                nullable=False,
+                server_default="NOT_READY",
+            )
+        )
+
+    with op.batch_alter_table("work_queue", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "status",
+                sa.Enum("READY", "NOT_READY", "PAUSED", name="work_queue_status"),
+                nullable=False,
+                server_default="NOT_READY",
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("work_queue", schema=None) as batch_op:
+        batch_op.drop_column("status")
+
+    with op.batch_alter_table("work_pool", schema=None) as batch_op:
+        batch_op.drop_column("status")
+
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.drop_column("status")

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -26,6 +26,11 @@ from prefect.server.events.schemas.automations import (
     TriggerTypes,
 )
 from prefect.server.events.schemas.events import ReceivedEvent
+from prefect.server.schemas.statuses import (
+    DeploymentStatus,
+    WorkPoolStatus,
+    WorkQueueStatus,
+)
 from prefect.server.utilities.database import (
     JSON,
     UUID,
@@ -869,13 +874,17 @@ class ORMDeployment:
     description = sa.Column(sa.Text(), nullable=True)
     manifest_path = sa.Column(sa.String, nullable=True)
     work_queue_name = sa.Column(sa.String, nullable=True, index=True)
-    last_polled = sa.Column(
-        Timestamp(),
-        nullable=True,
-    )
     infra_overrides = sa.Column(JSON, server_default="{}", default=dict, nullable=False)
     path = sa.Column(sa.String, nullable=True)
     entrypoint = sa.Column(sa.String, nullable=True)
+
+    last_polled = sa.Column(Timestamp(), nullable=True)
+    status = sa.Column(
+        sa.Enum(DeploymentStatus, name="deployment_status"),
+        nullable=False,
+        default=DeploymentStatus.NOT_READY,
+        server_default="NOT_READY",
+    )
 
     @declared_attr
     def job_variables(self):
@@ -1238,9 +1247,13 @@ class ORMWorkQueue:
         nullable=True,
     )
     priority = sa.Column(sa.Integer, index=True, nullable=False)
-    last_polled = sa.Column(
-        Timestamp(),
-        nullable=True,
+
+    last_polled = sa.Column(Timestamp(), nullable=True)
+    status = sa.Column(
+        sa.Enum(WorkQueueStatus, name="work_queue_status"),
+        nullable=False,
+        default=WorkQueueStatus.NOT_READY,
+        server_default="NOT_READY",
     )
 
     @declared_attr
@@ -1278,6 +1291,13 @@ class ORMWorkPool:
     concurrency_limit = sa.Column(
         sa.Integer,
         nullable=True,
+    )
+
+    status = sa.Column(
+        sa.Enum(WorkPoolStatus, name="work_pool_status"),
+        nullable=False,
+        default=WorkPoolStatus.NOT_READY,
+        server_default="NOT_READY",
     )
 
     @declared_attr

--- a/src/prefect/server/events/models/composite_trigger_child_firing.py
+++ b/src/prefect/server/events/models/composite_trigger_child_firing.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 from uuid import UUID
 
 import pendulum
@@ -8,8 +8,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
-from prefect.server.database.orm_models import ORMCompositeTriggerChildFiring
 from prefect.server.events.schemas.automations import CompositeTrigger, Firing
+
+if TYPE_CHECKING:
+    from prefect.server.database.orm_models import ORMCompositeTriggerChildFiring
 
 
 @db_injector
@@ -65,7 +67,7 @@ async def get_child_firings(
     db: PrefectDBInterface,
     session: AsyncSession,
     trigger: CompositeTrigger,
-) -> Sequence[ORMCompositeTriggerChildFiring]:
+) -> Sequence["ORMCompositeTriggerChildFiring"]:
     result = await session.execute(
         sa.select(db.CompositeTriggerChildFiring).filter(
             db.CompositeTriggerChildFiring.automation_id == trigger.automation.id,

--- a/src/prefect/server/events/storage/database.py
+++ b/src/prefect/server/events/storage/database.py
@@ -1,14 +1,19 @@
-from typing import Any, Dict, Generator, List, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Generator, List, Sequence, Tuple
 
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
+
+if HAS_PYDANTIC_V2:
+    import pydantic.v1 as pydantic
+else:
+    import pydantic
+
 from prefect.logging.loggers import get_logger
 from prefect.server.database.dependencies import db_injector, provide_database_interface
 from prefect.server.database.interface import PrefectDBInterface
-from prefect.server.database.orm_models import ORMEvent
 from prefect.server.events.counting import Countable, TimeUnit
 from prefect.server.events.filters import EventFilter, EventOrder
 from prefect.server.events.schemas.events import EventCount, ReceivedEvent
@@ -21,10 +26,8 @@ from prefect.server.events.storage import (
 from prefect.server.utilities.database import get_dialect
 from prefect.settings import PREFECT_API_DATABASE_CONNECTION_URL
 
-if HAS_PYDANTIC_V2:
-    import pydantic.v1 as pydantic
-else:
-    import pydantic
+if TYPE_CHECKING:
+    from prefect.server.database.orm_models import ORMEvent
 
 logger = get_logger(__name__)
 
@@ -33,7 +36,7 @@ logger = get_logger(__name__)
 def build_distinct_queries(
     db: PrefectDBInterface,
     events_filter: EventFilter,
-) -> List[sa.Column[ORMEvent]]:
+) -> List[sa.Column["ORMEvent"]]:
     distinct_fields: List[str] = []
     if events_filter.resource and events_filter.resource.distinct:
         distinct_fields.append("resource_id")
@@ -129,7 +132,7 @@ async def read_events(
     events_filter: EventFilter,
     limit: "int | None" = None,
     offset: "int | None" = None,
-) -> Sequence[ORMEvent]:
+) -> Sequence["ORMEvent"]:
     """
     Read events from the Postgres database.
 

--- a/src/prefect/server/models/block_documents.py
+++ b/src/prefect/server/models/block_documents.py
@@ -4,7 +4,7 @@ Intended for internal use by the Prefect REST API.
 """
 
 from copy import copy
-from typing import Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 from uuid import UUID, uuid4
 
 import sqlalchemy as sa
@@ -14,7 +14,6 @@ import prefect.server.models as models
 from prefect.server import schemas
 from prefect.server.database.dependencies import inject_db
 from prefect.server.database.interface import PrefectDBInterface
-from prefect.server.database.orm_models import ORMBlockDocument
 from prefect.server.schemas.actions import BlockDocumentReferenceCreate
 from prefect.server.schemas.core import BlockDocument, BlockDocumentReference
 from prefect.server.schemas.filters import BlockSchemaFilter
@@ -22,6 +21,9 @@ from prefect.server.utilities.database import UUID as UUIDTypeDecorator
 from prefect.server.utilities.names import obfuscate_string
 from prefect.utilities.collections import dict_to_flatdict, flatdict_to_dict
 from prefect.utilities.names import obfuscate
+
+if TYPE_CHECKING:
+    from prefect.server.database.orm_models import ORMBlockDocument
 
 
 @inject_db
@@ -153,7 +155,7 @@ async def read_block_document_by_id(
 async def _construct_full_block_document(
     session: AsyncSession,
     block_documents_with_references: List[
-        Tuple[ORMBlockDocument, Optional[str], Optional[UUID]]
+        Tuple["ORMBlockDocument", Optional[str], Optional[UUID]]
     ],
     parent_block_document: Optional[BlockDocument] = None,
     include_secrets: bool = False,

--- a/src/prefect/server/models/block_types.py
+++ b/src/prefect/server/models/block_types.py
@@ -4,7 +4,7 @@ Intended for internal use by the Prefect REST API.
 """
 
 import html
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 from uuid import UUID
 
 import sqlalchemy as sa
@@ -12,7 +12,9 @@ import sqlalchemy as sa
 from prefect.server import schemas
 from prefect.server.database.dependencies import inject_db
 from prefect.server.database.interface import PrefectDBInterface
-from prefect.server.database.orm_models import ORMBlockType
+
+if TYPE_CHECKING:
+    from prefect.server.database.orm_models import ORMBlockType
 
 
 @inject_db
@@ -21,7 +23,7 @@ async def create_block_type(
     block_type: schemas.core.BlockType,
     db: PrefectDBInterface,
     override: bool = False,
-) -> ORMBlockType:
+) -> "ORMBlockType":
     """
     Create a new block type.
 

--- a/src/prefect/server/models/flow_runs.py
+++ b/src/prefect/server/models/flow_runs.py
@@ -6,7 +6,7 @@ Intended for internal use by the Prefect REST API.
 import contextlib
 import datetime
 from itertools import chain
-from typing import Any, Dict, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 from uuid import UUID
 
 import pendulum
@@ -19,7 +19,6 @@ import prefect.server.models as models
 import prefect.server.schemas as schemas
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
-from prefect.server.database.orm_models import ORMFlowRun
 from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.orchestration.core_policy import MinimalFlowPolicy
 from prefect.server.orchestration.global_policy import GlobalFlowPolicy
@@ -35,6 +34,9 @@ from prefect.settings import (
     PREFECT_API_MAX_FLOW_RUN_GRAPH_NODES,
 )
 
+if TYPE_CHECKING:
+    from prefect.server.database.orm_models import ORMFlowRun
+
 
 @db_injector
 async def create_flow_run(
@@ -42,7 +44,7 @@ async def create_flow_run(
     session: AsyncSession,
     flow_run: schemas.core.FlowRun,
     orchestration_parameters: Optional[dict] = None,
-) -> ORMFlowRun:
+) -> "ORMFlowRun":
     """Creates a new flow run.
 
     If the provided flow run has a state attached, it will also be created.
@@ -153,7 +155,7 @@ async def read_flow_run(
     session: AsyncSession,
     flow_run_id: UUID,
     for_update: bool = False,
-) -> Optional[ORMFlowRun]:
+) -> Optional["ORMFlowRun"]:
     """
     Reads a flow run by id.
 
@@ -261,7 +263,7 @@ async def read_flow_runs(
     offset: int = None,
     limit: int = None,
     sort: schemas.sorting.FlowRunSort = schemas.sorting.FlowRunSort.ID_DESC,
-) -> Sequence[ORMFlowRun]:
+) -> Sequence["ORMFlowRun"]:
     """
     Read flow runs.
 

--- a/src/prefect/server/models/flows.py
+++ b/src/prefect/server/models/flows.py
@@ -3,7 +3,7 @@ Functions for interacting with flow ORM objects.
 Intended for internal use by the Prefect REST API.
 """
 
-from typing import Optional, Sequence
+from typing import TYPE_CHECKING, Optional, Sequence
 from uuid import UUID
 
 import sqlalchemy as sa
@@ -13,13 +13,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import prefect.server.schemas as schemas
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
-from prefect.server.database.orm_models import ORMFlow
+
+if TYPE_CHECKING:
+    from prefect.server.database.orm_models import ORMFlow
 
 
 @db_injector
 async def create_flow(
     db: PrefectDBInterface, session: AsyncSession, flow: schemas.core.Flow
-) -> ORMFlow:
+) -> "ORMFlow":
     """
     Creates a new flow.
 
@@ -87,7 +89,7 @@ async def update_flow(
 @db_injector
 async def read_flow(
     db: PrefectDBInterface, session: AsyncSession, flow_id: UUID
-) -> Optional[ORMFlow]:
+) -> Optional["ORMFlow"]:
     """
     Reads a flow by id.
 
@@ -104,7 +106,7 @@ async def read_flow(
 @db_injector
 async def read_flow_by_name(
     db: PrefectDBInterface, session: AsyncSession, name: str
-) -> Optional[ORMFlow]:
+) -> Optional["ORMFlow"]:
     """
     Reads a flow by name.
 
@@ -187,7 +189,7 @@ async def read_flows(
     sort: schemas.sorting.FlowSort = schemas.sorting.FlowSort.NAME_ASC,
     offset: int = None,
     limit: int = None,
-) -> Sequence[ORMFlow]:
+) -> Sequence["ORMFlow"]:
     """
     Read multiple flows.
 

--- a/src/prefect/server/models/variables.py
+++ b/src/prefect/server/models/variables.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from typing import TYPE_CHECKING, Optional, Sequence
 from uuid import UUID
 
 import sqlalchemy as sa
@@ -6,9 +6,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
-from prefect.server.database.orm_models import ORMVariable
 from prefect.server.schemas import filters, sorting
 from prefect.server.schemas.actions import VariableCreate, VariableUpdate
+
+if TYPE_CHECKING:
+    from prefect.server.database.orm_models import ORMVariable
 
 
 @db_injector
@@ -16,7 +18,7 @@ async def create_variable(
     db: PrefectDBInterface,
     session: AsyncSession,
     variable: VariableCreate,
-) -> ORMVariable:
+) -> "ORMVariable":
     """
     Create a variable
 
@@ -39,7 +41,7 @@ async def read_variable(
     db: PrefectDBInterface,
     session: AsyncSession,
     variable_id: UUID,
-) -> Optional[ORMVariable]:
+) -> Optional["ORMVariable"]:
     """
     Reads a variable by id.
     """
@@ -55,7 +57,7 @@ async def read_variable_by_name(
     db: PrefectDBInterface,
     session: AsyncSession,
     name: str,
-) -> Optional[ORMVariable]:
+) -> Optional["ORMVariable"]:
     """
     Reads a variable by name.
     """
@@ -74,7 +76,7 @@ async def read_variables(
     sort: sorting.VariableSort = sorting.VariableSort.NAME_ASC,
     offset: int = None,
     limit: int = None,
-) -> Sequence[ORMVariable]:
+) -> Sequence["ORMVariable"]:
     """
     Read variables, applying filers.
     """

--- a/src/prefect/server/models/work_queues.py
+++ b/src/prefect/server/models/work_queues.py
@@ -4,13 +4,12 @@ Intended for internal use by the Prefect REST API.
 """
 
 import datetime
-from typing import Optional, Sequence
+from typing import TYPE_CHECKING, Optional, Sequence
 from uuid import UUID
 
 import sqlalchemy as sa
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
-from prefect.server.database.orm_models import ORMFlowRun, ORMWorkQueue
 
 if HAS_PYDANTIC_V2:
     from pydantic.v1 import parse_obj_as
@@ -31,13 +30,16 @@ from prefect.server.models.workers import (
 )
 from prefect.server.schemas.states import StateType
 
+if TYPE_CHECKING:
+    from prefect.server.database.orm_models import ORMFlowRun, ORMWorkQueue
+
 
 @db_injector
 async def create_work_queue(
     db: PrefectDBInterface,
     session: AsyncSession,
     work_queue: schemas.core.WorkQueue,
-) -> ORMWorkQueue:
+) -> "ORMWorkQueue":
     """
     Inserts a WorkQueue.
 
@@ -119,7 +121,7 @@ async def create_work_queue(
 @db_injector
 async def read_work_queue(
     db: PrefectDBInterface, session: AsyncSession, work_queue_id: UUID
-) -> Optional[ORMWorkQueue]:
+) -> Optional["ORMWorkQueue"]:
     """
     Reads a WorkQueue by id.
 
@@ -137,7 +139,7 @@ async def read_work_queue(
 @db_injector
 async def read_work_queue_by_name(
     db: PrefectDBInterface, session: AsyncSession, name: str
-) -> Optional[ORMWorkQueue]:
+) -> Optional["ORMWorkQueue"]:
     """
     Reads a WorkQueue by id.
 
@@ -169,7 +171,7 @@ async def read_work_queues(
     offset: int = None,
     limit: int = None,
     work_queue_filter: schemas.filters.WorkQueueFilter = None,
-) -> Sequence[ORMWorkQueue]:
+) -> Sequence["ORMWorkQueue"]:
     """
     Read WorkQueues.
 
@@ -255,7 +257,7 @@ async def get_runs_in_work_queue(
     work_queue_id: UUID,
     limit: int = None,
     scheduled_before: datetime.datetime = None,
-) -> Sequence[ORMFlowRun]:
+) -> Sequence["ORMFlowRun"]:
     """
     Get runs from a work queue.
 
@@ -298,7 +300,7 @@ async def _legacy_get_runs_in_work_queue(
     work_queue_id: UUID,
     scheduled_before: datetime.datetime = None,
     limit: int = None,
-) -> Sequence[ORMFlowRun]:
+) -> Sequence["ORMFlowRun"]:
     """
     DEPRECATED method for getting runs from a tag-based work queue
 

--- a/src/prefect/server/models/workers.py
+++ b/src/prefect/server/models/workers.py
@@ -4,7 +4,7 @@ Intended for internal use by the Prefect REST API.
 """
 
 import datetime
-from typing import Dict, List, Optional, Sequence
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence
 from uuid import UUID
 
 import pendulum
@@ -15,7 +15,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import prefect.server.schemas as schemas
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
-from prefect.server.database.orm_models import ORMWorker, ORMWorkPool, ORMWorkQueue
+
+if TYPE_CHECKING:
+    from prefect.server.database.orm_models import ORMWorker, ORMWorkPool, ORMWorkQueue
 
 DEFAULT_AGENT_WORK_POOL_NAME = "default-agent-pool"
 
@@ -33,7 +35,7 @@ async def create_work_pool(
     db: PrefectDBInterface,
     session: AsyncSession,
     work_pool: schemas.core.WorkPool,
-) -> ORMWorkPool:
+) -> "ORMWorkPool":
     """
     Creates a work pool.
 
@@ -69,7 +71,7 @@ async def create_work_pool(
 @db_injector
 async def read_work_pool(
     db: PrefectDBInterface, session: AsyncSession, work_pool_id: UUID
-) -> Optional[ORMWorkPool]:
+) -> Optional["ORMWorkPool"]:
     """
     Reads a WorkPool by id.
 
@@ -88,7 +90,7 @@ async def read_work_pool(
 @db_injector
 async def read_work_pool_by_name(
     db: PrefectDBInterface, session: AsyncSession, work_pool_name: str
-) -> Optional[ORMWorkPool]:
+) -> Optional["ORMWorkPool"]:
     """
     Reads a WorkPool by name.
 
@@ -111,7 +113,7 @@ async def read_work_pools(
     work_pool_filter: schemas.filters.WorkPoolFilter = None,
     offset: int = None,
     limit: int = None,
-) -> Sequence[ORMWorkPool]:
+) -> Sequence["ORMWorkPool"]:
     """
     Read worker configs.
 
@@ -272,7 +274,7 @@ async def create_work_queue(
     session: AsyncSession,
     work_pool_id: UUID,
     work_queue: schemas.actions.WorkQueueCreate,
-) -> ORMWorkQueue:
+) -> "ORMWorkQueue":
     """
     Creates a work pool queue.
 
@@ -397,7 +399,7 @@ async def read_work_queues(
     work_queue_filter: Optional[schemas.filters.WorkQueueFilter] = None,
     offset: Optional[int] = None,
     limit: Optional[int] = None,
-) -> Sequence[ORMWorkQueue]:
+) -> Sequence["ORMWorkQueue"]:
     """
     Read all work pool queues for a work pool. Results are ordered by ascending priority.
 
@@ -435,7 +437,7 @@ async def read_work_queue(
     db: PrefectDBInterface,
     session: AsyncSession,
     work_queue_id: UUID,
-) -> Optional[ORMWorkQueue]:
+) -> Optional["ORMWorkQueue"]:
     """
     Read a specific work pool queue.
 
@@ -456,7 +458,7 @@ async def read_work_queue_by_name(
     session: AsyncSession,
     work_pool_name: str,
     work_queue_name: str,
-) -> Optional[ORMWorkQueue]:
+) -> Optional["ORMWorkQueue"]:
     """
     Reads a WorkQueue by name.
 
@@ -574,7 +576,7 @@ async def read_workers(
     worker_filter: schemas.filters.WorkerFilter = None,
     limit: int = None,
     offset: int = None,
-) -> Sequence[ORMWorker]:
+) -> Sequence["ORMWorker"]:
     query = (
         sa.select(db.Worker)
         .where(db.Worker.work_pool_id == work_pool_id)

--- a/src/prefect/server/schemas/statuses.py
+++ b/src/prefect/server/schemas/statuses.py
@@ -8,6 +8,9 @@ class WorkPoolStatus(AutoEnum):
     NOT_READY = AutoEnum.auto()
     PAUSED = AutoEnum.auto()
 
+    def in_kebab_case(self) -> str:
+        return self.value.lower().replace("_", "-")
+
 
 class WorkerStatus(AutoEnum):
     """Enumeration of worker statuses."""
@@ -22,6 +25,9 @@ class DeploymentStatus(AutoEnum):
     READY = AutoEnum.auto()
     NOT_READY = AutoEnum.auto()
 
+    def in_kebab_case(self) -> str:
+        return self.value.lower().replace("_", "-")
+
 
 class WorkQueueStatus(AutoEnum):
     """Enumeration of work queue statuses."""
@@ -29,3 +35,6 @@ class WorkQueueStatus(AutoEnum):
     READY = AutoEnum.auto()
     NOT_READY = AutoEnum.auto()
     PAUSED = AutoEnum.auto()
+
+    def in_kebab_case(self) -> str:
+        return self.value.lower().replace("_", "-")

--- a/src/prefect/server/services/__init__.py
+++ b/src/prefect/server/services/__init__.py
@@ -1,5 +1,6 @@
 import prefect.server.services.cancellation_cleanup
 import prefect.server.services.flow_run_notifications
+import prefect.server.services.foreman
 import prefect.server.services.late_runs
 import prefect.server.services.pause_expirations
 import prefect.server.services.scheduler

--- a/src/prefect/server/services/foreman.py
+++ b/src/prefect/server/services/foreman.py
@@ -1,0 +1,104 @@
+"""
+Foreman is a loop service designed to monitor workers.
+"""
+
+from datetime import timedelta
+from typing import Optional
+
+import pendulum
+import sqlalchemy as sa
+
+from prefect.server.database.dependencies import db_injector
+from prefect.server.database.interface import PrefectDBInterface
+from prefect.server.models.deployments import mark_deployments_not_ready
+from prefect.server.schemas.statuses import DeploymentStatus
+from prefect.server.services.loop_service import LoopService
+from prefect.settings import (
+    PREFECT_API_SERVICES_FOREMAN_DEPLOYMENT_LAST_POLLED_TIMEOUT_SECONDS,
+    PREFECT_API_SERVICES_FOREMAN_LOOP_SECONDS,
+)
+
+
+class Foreman(LoopService):
+    """
+    A loop service responsible for monitoring the status of workers.
+
+    Handles updating the status of workers and their associated work pools.
+    """
+
+    def __init__(
+        self,
+        loop_seconds: Optional[float] = None,
+        deployment_last_polled_timeout_seconds: Optional[int] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            loop_seconds=loop_seconds
+            or PREFECT_API_SERVICES_FOREMAN_LOOP_SECONDS.value(),
+            **kwargs,
+        )
+        self._deployment_last_polled_timeout_seconds = (
+            PREFECT_API_SERVICES_FOREMAN_DEPLOYMENT_LAST_POLLED_TIMEOUT_SECONDS.value()
+            if deployment_last_polled_timeout_seconds is None
+            else deployment_last_polled_timeout_seconds
+        )
+
+    @db_injector
+    async def run_once(db: PrefectDBInterface, self) -> None:
+        """
+        Iterate over workers current marked as online. Mark workers as offline
+        if they have an old last_heartbeat_time. Marks work pools as not ready
+        if they do not have any online workers and are currently marked as ready.
+        Mark deployments as not ready if they have a last_polled time that is
+        older than the configured deployment last polled timeout.
+        """
+        await self._mark_deployments_as_not_ready()
+
+    @db_injector
+    async def _mark_deployments_as_not_ready(
+        db: PrefectDBInterface,
+        self,
+    ):
+        """
+        Marks a deployment as NOT_READY and emits a deployment status event.
+        Emits an event and updates any bookkeeping fields on the deployment.
+        Args:
+            session (AsyncSession): The session to use for the database operation.
+        """
+        async with db.session_context(begin_transaction=True) as session:
+            deployment_status_timeout_threshold = pendulum.now("UTC") - timedelta(
+                seconds=self._deployment_last_polled_timeout_seconds
+            )
+            deployment_id_select_stmt = (
+                sa.select(db.Deployment.id)
+                .outerjoin(db.WorkQueue, db.WorkQueue.id == db.Deployment.work_queue_id)
+                .filter(db.Deployment.status == DeploymentStatus.READY)
+                .filter(db.Deployment.last_polled.isnot(None))
+                .filter(
+                    sa.or_(
+                        # if work_queue.last_polled doesn't exist, use only deployment's
+                        # last_polled
+                        sa.and_(
+                            db.WorkQueue.last_polled.is_(None),
+                            db.Deployment.last_polled
+                            < deployment_status_timeout_threshold,
+                        ),
+                        # if work_queue.last_polled exists, both times should be less than
+                        # the threshold
+                        sa.and_(
+                            db.WorkQueue.last_polled.isnot(None),
+                            db.Deployment.last_polled
+                            < deployment_status_timeout_threshold,
+                            db.WorkQueue.last_polled
+                            < deployment_status_timeout_threshold,
+                        ),
+                    )
+                )
+            )
+            result = await session.execute(deployment_id_select_stmt)
+
+            deployment_ids_to_mark_unready = result.scalars().all()
+
+        await mark_deployments_not_ready(
+            deployment_ids=deployment_ids_to_mark_unready,
+        )

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1214,6 +1214,20 @@ PREFECT_API_SERVICES_CANCELLATION_CLEANUP_LOOP_SECONDS = Setting(
 this often. Defaults to `20`.
 """
 
+PREFECT_API_SERVICES_FOREMAN_ENABLED = Setting(bool, default=True)
+"""Whether or not to start the Foreman service in the server application."""
+
+PREFECT_API_SERVICES_FOREMAN_LOOP_SECONDS = Setting(float, default=15)
+"""The number of seconds to wait between each iteration of the Foreman loop which checks
+for offline workers and updates work pool status."""
+
+PREFECT_API_SERVICES_FOREMAN_DEPLOYMENT_LAST_POLLED_TIMEOUT_SECONDS = Setting(
+    int, default=60
+)
+"""The number of seconds before a deployment is marked as not ready if it has not been
+polled."""
+
+
 PREFECT_API_DEFAULT_LIMIT = Setting(
     int,
     default=200,

--- a/tests/agent/test_agent_run_submission.py
+++ b/tests/agent/test_agent_run_submission.py
@@ -519,6 +519,9 @@ class TestInfrastructureIntegration:
         ) as agent:
             await agent.get_and_submit_flow_runs()
 
+        # Read the deployment back because it will have been updated by polling
+        deployment = await prefect_client.read_deployment(deployment.id)
+
         mock_infrastructure_run.assert_called_once_with(
             infrastructure.prepare_for_flow_run(
                 flow_run, deployment=deployment, flow=flow
@@ -538,6 +541,9 @@ class TestInfrastructureIntegration:
         ) as agent:
             await agent.get_and_submit_flow_runs()
 
+        # Read the deployment back because it will have been updated by polling
+        deployment = await prefect_client.read_deployment(deployment.id)
+
         flow_run = await prefect_client.read_flow_run(flow_run.id)
         assert flow_run.state.is_pending()
         mock_infrastructure_run.assert_called_once()
@@ -554,6 +560,9 @@ class TestInfrastructureIntegration:
             work_queues=[deployment.work_queue_name], prefetch_seconds=10
         ) as agent:
             await agent.get_and_submit_flow_runs()
+
+        # Read the deployment back because it will have been updated by polling
+        deployment = await prefect_client.read_deployment(deployment.id)
 
         flow_run = await prefect_client.read_flow_run(flow_run.id)
         assert flow_run.infrastructure_pid == "id-1234"
@@ -735,6 +744,9 @@ class TestInfrastructureIntegration:
             agent.logger = MagicMock()
             await agent.get_and_submit_flow_runs()
 
+        # Read the deployment back because it will have been updated by polling
+        deployment = await prefect_client.read_deployment(deployment.id)
+
         mock_infrastructure_run.assert_called_once_with(
             infrastructure.prepare_for_flow_run(
                 flow_run, deployment=deployment, flow=flow
@@ -779,6 +791,9 @@ class TestInfrastructureIntegration:
             agent.logger = MagicMock()
             await agent.get_and_submit_flow_runs()
 
+        # Read the deployment back because it will have been updated by polling
+        deployment = await prefect_client.read_deployment(deployment.id)
+
         mock_infrastructure_run.assert_called_once_with(
             infrastructure.prepare_for_flow_run(
                 flow_run, deployment=deployment, flow=flow
@@ -812,6 +827,9 @@ class TestInfrastructureIntegration:
             agent.logger = MagicMock()
             await agent.get_and_submit_flow_runs()
 
+        # Read the deployment back because it will have been updated by polling
+        deployment = await prefect_client.read_deployment(deployment.id)
+
         agent.logger.error.assert_called_once_with(
             f"Infrastructure returned without reporting flow run '{flow_run.id}' "
             "as started or raising an error. This behavior is not expected and "
@@ -838,6 +856,9 @@ class TestInfrastructureIntegration:
             [deployment.work_queue_name], prefetch_seconds=10
         ) as agent:
             await agent.get_and_submit_flow_runs()
+
+        # Read the deployment back because it will have been updated by polling
+        deployment = await prefect_client.read_deployment(deployment.id)
 
         mock_infrastructure_run.assert_called_once_with(
             infrastructure.prepare_for_flow_run(
@@ -888,6 +909,9 @@ class TestInfrastructureIntegration:
             [deployment.work_queue_name], prefetch_seconds=10
         ) as agent:
             await agent.get_and_submit_flow_runs()
+
+        # Read the deployment back because it will have been updated by polling
+        deployment = await prefect_client.read_deployment(deployment.id)
 
         mock_infrastructure_run.assert_called_once_with(
             infrastructure.prepare_for_flow_run(

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -5270,7 +5270,9 @@ class TestDeploymentTrigger:
                 triggers[0].as_automation()
             )
 
-        async def test_create_deployment_triggers_not_cloud_noop(self):
+        async def test_create_deployment_triggers_events_disabled_noop(
+            self, events_disabled
+        ):
             client = AsyncMock()
             client.server_type = ServerType.SERVER
 

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -2070,8 +2070,8 @@ class TestAutomations:
             actions=[],
         )
 
-    async def test_create_not_cloud_runtime_error(
-        self, prefect_client, automation: AutomationCore
+    async def test_create_not_enabled_runtime_error(
+        self, events_disabled, prefect_client, automation: AutomationCore
     ):
         with pytest.raises(
             RuntimeError,
@@ -2166,8 +2166,8 @@ class TestAutomations:
 
             assert nonexistent_automation is None
 
-    async def test_delete_owned_automations_not_cloud_runtime_error(
-        self, prefect_client
+    async def test_delete_owned_automations_not_enabled_runtime_error(
+        self, events_disabled, prefect_client
     ):
         with pytest.raises(
             RuntimeError,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,9 @@ from prefect.settings import (
     PREFECT_API_BLOCKS_REGISTER_ON_START,
     PREFECT_API_DATABASE_CONNECTION_URL,
     PREFECT_API_SERVICES_CANCELLATION_CLEANUP_ENABLED,
+    PREFECT_API_SERVICES_EVENT_PERSISTER_ENABLED,
     PREFECT_API_SERVICES_FLOW_RUN_NOTIFICATIONS_ENABLED,
+    PREFECT_API_SERVICES_FOREMAN_ENABLED,
     PREFECT_API_SERVICES_LATE_RUNS_ENABLED,
     PREFECT_API_SERVICES_PAUSE_EXPIRATIONS_ENABLED,
     PREFECT_API_SERVICES_SCHEDULER_ENABLED,
@@ -52,12 +54,14 @@ from prefect.settings import (
     PREFECT_CLI_WRAP_LINES,
     PREFECT_EXPERIMENTAL_ENABLE_ENHANCED_CANCELLATION,
     PREFECT_EXPERIMENTAL_ENABLE_WORKERS,
+    PREFECT_EXPERIMENTAL_EVENTS,
     PREFECT_EXPERIMENTAL_WARN_ENHANCED_CANCELLATION,
     PREFECT_EXPERIMENTAL_WARN_WORKERS,
     PREFECT_HOME,
     PREFECT_LOCAL_STORAGE_PATH,
     PREFECT_LOGGING_INTERNAL_LEVEL,
     PREFECT_LOGGING_LEVEL,
+    PREFECT_LOGGING_SERVER_LEVEL,
     PREFECT_LOGGING_TO_API_ENABLED,
     PREFECT_MEMOIZE_BLOCK_AUTO_REGISTRATION,
     PREFECT_PROFILES_PATH,
@@ -319,6 +323,7 @@ def pytest_sessionstart(session):
             # Enable debug logging
             PREFECT_LOGGING_LEVEL: "DEBUG",
             PREFECT_LOGGING_INTERNAL_LEVEL: "DEBUG",
+            PREFECT_LOGGING_SERVER_LEVEL: "DEBUG",
             # Disable shipping logs to the API;
             # can be enabled by the `enable_api_log_handler` mark
             PREFECT_LOGGING_TO_API_ENABLED: False,
@@ -329,12 +334,17 @@ def pytest_sessionstart(session):
             PREFECT_API_SERVICES_FLOW_RUN_NOTIFICATIONS_ENABLED: False,
             PREFECT_API_SERVICES_PAUSE_EXPIRATIONS_ENABLED: False,
             PREFECT_API_SERVICES_CANCELLATION_CLEANUP_ENABLED: False,
+            PREFECT_API_SERVICES_FOREMAN_ENABLED: False,
             # Disable block auto-registration memoization
             PREFECT_MEMOIZE_BLOCK_AUTO_REGISTRATION: False,
             # Disable auto-registration of block types as they can conflict
             PREFECT_API_BLOCKS_REGISTER_ON_START: False,
             # Code is being executed in a unit test context
             PREFECT_UNIT_TEST_MODE: True,
+            # Events: disable the event persister, which may lock the DB during
+            # tests while writing events
+            PREFECT_EXPERIMENTAL_EVENTS: True,
+            PREFECT_API_SERVICES_EVENT_PERSISTER_ENABLED: False,
         },
         source=__file__,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -572,6 +572,12 @@ def disable_enhanced_cancellation():
 
 
 @pytest.fixture
+def events_disabled():
+    with temporary_settings({PREFECT_EXPERIMENTAL_EVENTS: False}):
+        yield
+
+
+@pytest.fixture
 def start_of_test() -> pendulum.DateTime:
     return pendulum.now("UTC")
 

--- a/tests/events/client/cli/test_automations.py
+++ b/tests/events/client/cli/test_automations.py
@@ -17,14 +17,7 @@ from prefect.events.schemas.automations import (
     Posture,
     PrefectMetric,
 )
-from prefect.settings import PREFECT_EXPERIMENTAL_EVENTS, temporary_settings
 from prefect.testing.cli import invoke_and_assert
-
-
-@pytest.fixture(autouse=True, scope="module")
-def enable_events():
-    with temporary_settings({PREFECT_EXPERIMENTAL_EVENTS: True}):
-        yield
 
 
 @pytest.fixture

--- a/tests/events/client/test_events_client.py
+++ b/tests/events/client/test_events_client.py
@@ -22,7 +22,7 @@ from prefect.testing.fixtures import Puppeteer, Recorder
 
 
 @pytest.fixture
-def no_viable_settings():
+def no_viable_settings(events_disabled):
     with temporary_settings(
         {
             PREFECT_API_URL: "https://locally/api",

--- a/tests/events/client/test_events_emit_event.py
+++ b/tests/events/client/test_events_emit_event.py
@@ -8,7 +8,11 @@ from prefect.events import emit_event
 from prefect.events.clients import AssertingEventsClient, NullEventsClient
 from prefect.events.worker import EventsWorker
 from prefect.server.utilities.schemas import DateTimeTZ
-from prefect.settings import PREFECT_API_URL, temporary_settings
+from prefect.settings import (
+    PREFECT_API_URL,
+    PREFECT_EXPERIMENTAL_EVENTS,
+    temporary_settings,
+)
 
 
 def test_emits_simple_event(asserting_events_worker: EventsWorker, reset_worker_events):
@@ -114,7 +118,7 @@ def test_does_not_set_follows_not_tight_timing(
 
 
 def test_noop_with_null_events_client():
-    with temporary_settings(updates={PREFECT_API_URL: None}):
+    with temporary_settings(updates={PREFECT_EXPERIMENTAL_EVENTS: False}):
         worker = EventsWorker.instance()
         assert worker.client_type == NullEventsClient
 

--- a/tests/events/client/test_events_worker.py
+++ b/tests/events/client/test_events_worker.py
@@ -36,37 +36,38 @@ def test_emits_event_via_client(asserting_events_worker: EventsWorker, event: Ev
     assert asserting_events_worker._client.events == [event]
 
 
-def test_worker_instance_null_client_no_api_url():
+def test_worker_instance_null_client_events_disabled():
+    with temporary_settings(
+        updates={
+            PREFECT_API_URL: None,
+            PREFECT_EXPERIMENTAL_EVENTS: False,
+        }
+    ):
+        worker = EventsWorker.instance()
+        assert worker.client_type == NullEventsClient
+
+
+def test_worker_instance_ephemeral_client_no_api_url():
     with temporary_settings(updates={PREFECT_API_URL: None}):
         worker = EventsWorker.instance()
-        assert worker.client_type == NullEventsClient
+        assert worker.client_type == PrefectEphemeralEventsClient
 
 
-def test_worker_instance_null_client_non_cloud_api_url():
+def test_worker_instance_server_client_non_cloud_api_url():
     with temporary_settings(updates={PREFECT_API_URL: "http://localhost:8080/api"}):
         worker = EventsWorker.instance()
-        assert worker.client_type == NullEventsClient
+        assert worker.client_type == PrefectEventsClient
 
 
 def test_worker_instance_client_non_cloud_api_url_events_enabled():
-    with temporary_settings(
-        updates={
-            PREFECT_API_URL: "http://localhost:8080/api",
-            PREFECT_EXPERIMENTAL_EVENTS: True,
-        }
-    ):
+    with temporary_settings(updates={PREFECT_API_URL: "http://localhost:8080/api"}):
         worker = EventsWorker.instance()
         assert worker.client_type == PrefectEventsClient
 
 
 def test_worker_instance_ephemeral_prefect_events_client():
-    with temporary_settings(
-        updates={
-            PREFECT_EXPERIMENTAL_EVENTS: True,
-        }
-    ):
-        worker = EventsWorker.instance()
-        assert worker.client_type == PrefectEphemeralEventsClient
+    worker = EventsWorker.instance()
+    assert worker.client_type == PrefectEphemeralEventsClient
 
 
 async def test_includes_related_resources_from_run_context(

--- a/tests/events/server/gateway/test_gateway_in.py
+++ b/tests/events/server/gateway/test_gateway_in.py
@@ -10,13 +10,6 @@ from prefect._vendor.starlette.testclient import WebSocketTestSession
 from prefect.server.events import messaging
 from prefect.server.events.schemas.events import Event
 from prefect.server.events.storage import database
-from prefect.settings import PREFECT_EXPERIMENTAL_EVENTS, temporary_settings
-
-
-@pytest.fixture(autouse=True)
-def enable_events():
-    with temporary_settings({PREFECT_EXPERIMENTAL_EVENTS: True}):
-        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/events/server/gateway/test_gateway_out.py
+++ b/tests/events/server/gateway/test_gateway_out.py
@@ -17,13 +17,6 @@ from prefect.server.events.filters import (
 )
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.events.storage import database
-from prefect.settings import PREFECT_EXPERIMENTAL_EVENTS, temporary_settings
-
-
-@pytest.fixture(autouse=True)
-def enable_events():
-    with temporary_settings({PREFECT_EXPERIMENTAL_EVENTS: True}):
-        yield
 
 
 @pytest.fixture

--- a/tests/events/server/storage/test_event_persister.py
+++ b/tests/events/server/storage/test_event_persister.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from datetime import timedelta
-from typing import AsyncGenerator, Sequence
+from typing import TYPE_CHECKING, AsyncGenerator, Sequence
 from uuid import UUID, uuid4
 
 import pendulum
@@ -14,7 +14,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
-from prefect.server.database.orm_models import ORMEventResource
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.events.services import event_persister
 from prefect.server.utilities.messaging import CapturedMessage, Message, MessageHandler
@@ -23,6 +22,9 @@ if HAS_PYDANTIC_V2:
     from pydantic.v1 import ValidationError
 else:
     from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from prefect.server.database.orm_models import ORMEventResource
 
 
 @db_injector
@@ -47,7 +49,7 @@ async def get_event(db: PrefectDBInterface, id: UUID) -> "ReceivedEvent | None":
 
 async def get_resources(
     session: AsyncSession, id: UUID, db: PrefectDBInterface
-) -> Sequence[ORMEventResource]:
+) -> Sequence["ORMEventResource"]:
     result = await session.execute(
         sa.select(db.EventResource)
         .where(db.EventResource.event_id == id)

--- a/tests/events/server/test_events_api.py
+++ b/tests/events/server/test_events_api.py
@@ -31,12 +31,6 @@ else:
     import pydantic
 
 
-@pytest.fixture(autouse=True)
-def enable_events():
-    with temporary_settings({PREFECT_EXPERIMENTAL_EVENTS: True}):
-        yield
-
-
 @pytest.fixture
 def filter(frozen_time: DateTime) -> EventFilter:
     return EventFilter(

--- a/tests/events/server/test_events_api.py
+++ b/tests/events/server/test_events_api.py
@@ -23,7 +23,6 @@ from prefect.server.events.schemas.events import (
     Resource,
 )
 from prefect.server.events.storage import INTERACTIVE_PAGE_SIZE, InvalidTokenError
-from prefect.settings import PREFECT_EXPERIMENTAL_EVENTS, temporary_settings
 
 if HAS_PYDANTIC_V2:
     import pydantic.v1 as pydantic
@@ -117,12 +116,13 @@ def last_events_page(
         yield query_next_page
 
 
-async def test_returns_404_when_events_are_disabled(client: AsyncClient):
-    with temporary_settings({PREFECT_EXPERIMENTAL_EVENTS: False}):
-        response = await client.post(
-            "http://test/api/events/filter",
-            json={"filter": {}},
-        )
+async def test_returns_404_when_events_are_disabled(
+    client: AsyncClient, events_disabled: None
+):
+    response = await client.post(
+        "http://test/api/events/filter",
+        json={"filter": {}},
+    )
 
     assert response.status_code == 404, response.content
 

--- a/tests/fixtures/events.py
+++ b/tests/fixtures/events.py
@@ -25,3 +25,7 @@ def workspace_events_client(
         "prefect.server.orchestration.instrumentation_policies.PrefectServerEventsClient",
         AssertingEventsClient,
     )
+    monkeypatch.setattr(
+        "prefect.server.models.deployments.PrefectServerEventsClient",
+        AssertingEventsClient,
+    )

--- a/tests/server/api/test_clients.py
+++ b/tests/server/api/test_clients.py
@@ -3,7 +3,7 @@ Tests for the server-side orchestration API client, used by server-side services
 interact with the Prefect API.
 """
 
-from typing import AsyncGenerator, List
+from typing import TYPE_CHECKING, AsyncGenerator, List
 from unittest import mock
 from uuid import uuid4
 
@@ -12,10 +12,12 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server.api.clients import OrchestrationClient
-from prefect.server.database.orm_models import ORMDeployment, ORMVariable
 from prefect.server.models.variables import create_variable
 from prefect.server.schemas.actions import VariableCreate
 from prefect.server.schemas.responses import DeploymentResponse
+
+if TYPE_CHECKING:
+    from prefect.server.database.orm_models import ORMDeployment, ORMVariable
 
 
 @pytest.fixture
@@ -25,7 +27,7 @@ async def orchestration_client() -> AsyncGenerator[OrchestrationClient, None]:
 
 
 async def test_read_deployment(
-    deployment: ORMDeployment, orchestration_client: OrchestrationClient
+    deployment: "ORMDeployment", orchestration_client: OrchestrationClient
 ):
     from_api = await orchestration_client.read_deployment(deployment.id)
     assert isinstance(from_api, DeploymentResponse)
@@ -68,7 +70,7 @@ async def variables(
 
 
 async def test_read_variables(
-    variables: List[ORMVariable],
+    variables: List["ORMVariable"],
     orchestration_client: OrchestrationClient,
 ):
     from_api = await orchestration_client.read_workspace_variables()
@@ -81,7 +83,7 @@ async def test_read_variables(
 
 
 async def test_read_variables_across_pages(
-    variables: List[ORMVariable],
+    variables: List["ORMVariable"],
     orchestration_client: OrchestrationClient,
 ):
     orchestration_client.VARIABLE_PAGE_SIZE = 3
@@ -95,7 +97,7 @@ async def test_read_variables_across_pages(
 
 
 async def test_read_variables_subset(
-    variables: List[ORMVariable],
+    variables: List["ORMVariable"],
     orchestration_client: OrchestrationClient,
 ):
     orchestration_client.VARIABLE_PAGE_SIZE = 3
@@ -116,7 +118,7 @@ async def test_read_variables_empty(
 
 
 async def test_read_variables_subset_none_requested(
-    variables: List[ORMVariable],
+    variables: List["ORMVariable"],
     orchestration_client: OrchestrationClient,
 ):
     from_api = await orchestration_client.read_workspace_variables(names=[])

--- a/tests/server/api/test_deployments.py
+++ b/tests/server/api/test_deployments.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import List
 from uuid import uuid4
 
 import pendulum
@@ -8,6 +9,7 @@ from prefect._vendor.starlette import status
 
 from prefect.client.schemas.responses import DeploymentResponse
 from prefect.server import models, schemas
+from prefect.server.events.clients import AssertingEventsClient
 from prefect.server.schemas.actions import DeploymentCreate, DeploymentUpdate
 from prefect.server.utilities.database import get_dialect
 from prefect.settings import (
@@ -15,6 +17,22 @@ from prefect.settings import (
     PREFECT_API_SERVICES_SCHEDULER_MAX_SCHEDULED_TIME,
     PREFECT_API_SERVICES_SCHEDULER_MIN_RUNS,
 )
+
+
+def assert_status_events(deployment_name: str, events: List[str]):
+    deployment_specific_events = [
+        event
+        for item in AssertingEventsClient.all
+        for event in item.events
+        if event.resource.name == deployment_name
+    ]
+
+    assert len(events) == len(
+        deployment_specific_events
+    ), f"Expected events {events}, but found {deployment_specific_events}"
+
+    for i, event in enumerate(events):
+        assert event == deployment_specific_events[i].event
 
 
 class TestCreateDeployment:
@@ -1893,6 +1911,8 @@ class TestGetScheduledFlowRuns:
             str(flow_run.id) for flow_run in flow_runs[:2]
         }
 
+        assert_status_events(deployment_1.name, ["prefect.deployment.ready"])
+
     async def test_get_scheduled_runs_for_multiple_deployments(
         self,
         client,
@@ -1908,6 +1928,9 @@ class TestGetScheduledFlowRuns:
         assert {res["id"] for res in response.json()} == {
             str(flow_run.id) for flow_run in flow_runs
         }
+
+        assert_status_events(deployment_1.name, ["prefect.deployment.ready"])
+        assert_status_events(deployment_2.name, ["prefect.deployment.ready"])
 
     async def test_get_scheduled_runs_respects_limit(
         self,

--- a/tests/server/models/test_deployments.py
+++ b/tests/server/models/test_deployments.py
@@ -1139,26 +1139,6 @@ class TestUpdateDeployment:
         assert wq.work_pool == work_pool
 
 
-class TestUpdateDeploymentLastPolled:
-    async def test_updated_deployments_have_last_polled_of_now(
-        self, session, deployment
-    ):
-        current_deployment = await models.deployments.read_deployment(
-            session=session, deployment_id=deployment.id
-        )
-        assert current_deployment.last_polled is None
-
-        await models.deployments._update_deployment_last_polled(
-            session=session, deployment_ids=[deployment.id]
-        )
-
-        updated_deployment = await models.deployments.read_deployment(
-            session=session, deployment_id=deployment.id
-        )
-        assert updated_deployment.last_polled is not None
-        assert updated_deployment.last_polled > pendulum.now("UTC").subtract(minutes=1)
-
-
 @pytest.fixture
 async def deployment_schedules(
     session: AsyncSession,

--- a/tests/server/orchestration/test_flow_run_instrumentation_policies.py
+++ b/tests/server/orchestration/test_flow_run_instrumentation_policies.py
@@ -44,13 +44,6 @@ from prefect.server.schemas.states import (
     StateDetails,
     StateType,
 )
-from prefect.settings import PREFECT_EXPERIMENTAL_EVENTS, temporary_settings
-
-
-@pytest.fixture(autouse=True)
-def events_enabled():
-    with temporary_settings({PREFECT_EXPERIMENTAL_EVENTS: True}):
-        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/server/services/test_foreman.py
+++ b/tests/server/services/test_foreman.py
@@ -1,0 +1,242 @@
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+import pendulum
+import sqlalchemy as sa
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from prefect.server import models, schemas
+from prefect.server.database.dependencies import db_injector
+from prefect.server.database.interface import PrefectDBInterface
+from prefect.server.events.clients import AssertingEventsClient
+from prefect.server.schemas.statuses import DeploymentStatus
+from prefect.server.services.foreman import Foreman
+
+if TYPE_CHECKING:
+    from prefect.server.database.orm_models import ORMDeployment
+
+
+@db_injector
+async def create_deployment_with_old_last_polled_time(
+    db: PrefectDBInterface,
+    session: AsyncSession,
+    suffix: str = "",
+) -> "ORMDeployment":
+    flow_1 = await models.flows.create_flow(
+        session=session,
+        flow=schemas.core.Flow(
+            name=f"test-flow-{suffix}",
+        ),
+    )
+    assert flow_1
+
+    await session.commit()
+
+    work_pool = await models.workers.create_work_pool(
+        session=session,
+        work_pool=schemas.actions.WorkPoolCreate(
+            name=f"test-wp-{suffix}",
+        ),
+    )
+
+    work_pool_id = work_pool.id
+
+    values = dict(name=f"test-wq-{suffix}", work_pool_id=str(work_pool_id))
+
+    insert_stmt = sa.insert(db.WorkQueue).values(**values)
+
+    await session.execute(insert_stmt)
+
+    await session.commit()
+
+    work_queue = await models.workers.read_work_queue_by_name(
+        session=session,
+        work_queue_name=f"test-wq-{suffix}",
+        work_pool_name=f"test-wp-{suffix}",
+    )
+
+    assert work_queue
+    work_queue_id = work_queue.id
+
+    deployment_name = f"deployment-with-old-last-polled-time-{suffix}"
+
+    last_polled = pendulum.now("UTC") - timedelta(60)
+    values = dict(
+        name=deployment_name,
+        flow_id=str(flow_1.id),
+        work_queue_name=f"test-wq-{suffix}",
+        work_queue_id=str(work_queue_id),
+        last_polled=last_polled,
+        status=DeploymentStatus.READY,
+    )
+
+    insert_stmt = sa.insert(db.Deployment).values(**values)
+    await session.execute(insert_stmt)
+    await session.commit()
+
+    deployment = await models.deployments.read_deployment_by_name(
+        session=session,
+        name=deployment_name,
+        flow_name=f"test-flow-{suffix}",
+    )
+    assert deployment
+    return deployment
+
+
+@db_injector
+async def create_deployment_with_new_last_polled_time(
+    db: PrefectDBInterface, session: AsyncSession
+) -> "ORMDeployment":
+    flow_2 = await models.flows.create_flow(
+        session=session,
+        flow=schemas.core.Flow(
+            name="test-flow-1",
+        ),
+    )
+    assert flow_2
+
+    await session.commit()
+
+    deployment_name = "deployment-with-new-last-polled-time"
+
+    last_polled = pendulum.now("UTC")
+
+    deployment_values = dict(
+        name=deployment_name,
+        flow_id=str(flow_2.id),
+        last_polled=last_polled,
+        status=schemas.statuses.DeploymentStatus.READY,
+    )
+
+    insert_stmt = sa.insert(db.Deployment).values(**deployment_values)
+    await session.execute(insert_stmt)
+    await session.commit()
+
+    deployment = await models.deployments.read_deployment_by_name(
+        session=session,
+        name=deployment_name,
+        flow_name=f"{flow_2.name}",
+    )
+    assert deployment
+    return deployment
+
+
+class TestForeman:
+    async def test_status_update_when_deployment_has_old_last_polled_time(
+        self,
+        session: AsyncSession,
+        client: AsyncClient,
+    ):
+        deployment = await create_deployment_with_old_last_polled_time(session=session)
+        assert deployment
+        assert deployment.status == "READY"
+
+        await Foreman().run_once()
+
+        # Check deployment is marked not_ready
+        response = await client.get(f"/deployments/{deployment.id}")
+        assert response.status_code == 200
+        assert response.json()["status"] == "NOT_READY"
+
+        assert AssertingEventsClient.last
+        events = [event for item in AssertingEventsClient.all for event in item.events]
+        assert len(events) == 1
+
+        event = events[0]
+        assert event.event == "prefect.deployment.not-ready"
+        assert event.resource.id == f"prefect.deployment.{deployment.id}"
+
+        assert event.resource.name == deployment.name
+        assert (
+            event.related[0]["prefect.resource.id"]
+            == f"prefect.flow.{deployment.flow_id}"
+        )
+        flow_response = await client.get(f"/flows/{deployment.flow_id}")
+        assert flow_response.status_code == 200
+        flow = flow_response.json()
+        assert event.related[0]["prefect.resource.name"] == flow["name"]
+        assert event.related[0]["prefect.resource.role"] == "flow"
+
+        assert (
+            event.related[1]["prefect.resource.id"]
+            == f"prefect.work-queue.{deployment.work_queue_id}"
+        )
+        assert event.related[1]["prefect.resource.name"] == deployment.work_queue_name
+        assert event.related[1]["prefect.resource.role"] == "work-queue"
+
+        work_queue_response = await client.get(
+            f"/work_queues/{deployment.work_queue_id}"
+        )
+        assert work_queue_response.status_code == 200
+        work_queue = response.json()
+        work_pool_name = work_queue["work_pool_name"]
+
+        assert event.related[2]["prefect.resource.name"] == work_pool_name
+        assert event.related[2]["prefect.resource.role"] == "work-pool"
+
+    async def test_status_update_when_deployment_has_new_last_polled_time(
+        self,
+        session: AsyncSession,
+        client: AsyncClient,
+    ):
+        deployment = await create_deployment_with_new_last_polled_time(session=session)
+
+        assert deployment
+        assert deployment.status == "READY"
+
+        await Foreman().run_once()
+
+        # Check deployment remains ready
+        response = await client.get(f"/deployments/{deployment.id}")
+        assert response.status_code == 200
+        assert response.json()["status"] == "READY"
+
+        events = [event for item in AssertingEventsClient.all for event in item.events]
+        assert len(events) == 0
+
+    async def test_foreman_with_no_deployments_to_update(self):
+        """
+        Foreman should not retrieve more than the batch size of work pools and
+        deployments at a time.
+        """
+
+        await Foreman().run_once()
+
+        assert not AssertingEventsClient.last
+
+    async def test_foreman_does_not_mark_deployments_with_recently_polled_work_queue(
+        self, session: AsyncSession
+    ):
+        """
+        Tests deployments with old last_polled time are not marked as not_ready
+        if the work_queue has been polled recently. Handles cases where there are
+        hoards of deployments on the same work queue.
+        """
+        deployment = await create_deployment_with_old_last_polled_time(session)
+        assert deployment
+        assert deployment.status == DeploymentStatus.READY
+        assert deployment.last_polled is not None
+        assert deployment.last_polled < (
+            pendulum.now("UTC")
+            - timedelta(seconds=Foreman()._deployment_last_polled_timeout_seconds)
+        )
+
+        await models.work_queues.update_work_queue(
+            session=session,
+            work_queue_id=deployment.work_queue_id,
+            work_queue=schemas.actions.WorkQueueUpdate(last_polled=pendulum.now("UTC")),
+        )
+
+        await session.commit()
+
+        await Foreman().run_once()
+
+        assert not AssertingEventsClient.last
+
+        deployment = await models.deployments.read_deployment(
+            session=session,
+            deployment_id=deployment.id,
+        )
+        assert deployment is not None
+        assert deployment.status == DeploymentStatus.READY

--- a/tests/server/services/test_late_runs.py
+++ b/tests/server/services/test_late_runs.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING
 from unittest import mock
 from uuid import UUID
 
@@ -6,20 +7,15 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server import models, schemas
-from prefect.server.database.orm_models import ORMFlowRun
 from prefect.server.events.clients import AssertingEventsClient
 from prefect.server.services.late_runs import MarkLateRuns
 from prefect.settings import (
     PREFECT_API_SERVICES_LATE_RUNS_AFTER_SECONDS,
-    PREFECT_EXPERIMENTAL_EVENTS,
     temporary_settings,
 )
 
-
-@pytest.fixture(autouse=True)
-def enable_events():
-    with temporary_settings({PREFECT_EXPERIMENTAL_EVENTS: True}):
-        yield
+if TYPE_CHECKING:
+    from prefect.server.database.orm_models import ORMFlowRun
 
 
 @pytest.fixture
@@ -228,7 +224,7 @@ async def test_only_scheduled_runs_marked_late(
 
 
 async def test_mark_late_runs_fires_flow_run_state_change_events(
-    late_run: ORMFlowRun, session: AsyncSession
+    late_run: "ORMFlowRun", session: AsyncSession
 ):
     previous_state_id = late_run.state_id
     assert isinstance(previous_state_id, UUID)
@@ -260,7 +256,7 @@ async def test_mark_late_runs_fires_flow_run_state_change_events(
     assert event.follows == previous_state_id
 
 
-async def test_mark_late_runs_ignores_missing_runs(late_run: ORMFlowRun):
+async def test_mark_late_runs_ignores_missing_runs(late_run: "ORMFlowRun"):
     """Regression test for https://github.com/PrefectHQ/nebula/issues/2846"""
     # Simulate another process deleting the flow run in the middle of the service loop
     # Before the fix, this would have raised the ObjectNotFoundError

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -1013,6 +1013,7 @@ class TestDeploymentApply:
 
     async def test_deployment_apply_does_not_sync_triggers_to_prefect_api_when_off(
         self,
+        events_disabled,
         patch_import,
         tmp_path,
     ):
@@ -1032,29 +1033,28 @@ class TestDeploymentApply:
 
         created_deployment_id = str(uuid4())
 
-        with temporary_settings(updates={PREFECT_EXPERIMENTAL_EVENTS: False}):
-            assert not get_client().server_type.supports_automations()
+        assert not get_client().server_type.supports_automations()
 
-            with respx.mock(
-                base_url=PREFECT_API_URL.value(), assert_all_called=False
-            ) as router:
-                router.post("/flows/").mock(
-                    return_value=httpx.Response(201, json={"id": str(uuid4())})
-                )
-                router.post("/deployments/").mock(
-                    return_value=httpx.Response(201, json={"id": created_deployment_id})
-                )
-                delete_route = router.delete(
-                    f"/automations/owned-by/prefect.deployment.{created_deployment_id}"
-                ).mock(return_value=httpx.Response(204))
-                create_route = router.post("/automations/").mock(
-                    return_value=httpx.Response(201, json={"id": str(uuid4())})
-                )
+        with respx.mock(
+            base_url=PREFECT_API_URL.value(), assert_all_called=False
+        ) as router:
+            router.post("/flows/").mock(
+                return_value=httpx.Response(201, json={"id": str(uuid4())})
+            )
+            router.post("/deployments/").mock(
+                return_value=httpx.Response(201, json={"id": created_deployment_id})
+            )
+            delete_route = router.delete(
+                f"/automations/owned-by/prefect.deployment.{created_deployment_id}"
+            ).mock(return_value=httpx.Response(204))
+            create_route = router.post("/automations/").mock(
+                return_value=httpx.Response(201, json={"id": str(uuid4())})
+            )
 
-                await deployment.apply()
+            await deployment.apply()
 
-                assert not delete_route.called
-                assert not create_route.called
+            assert not delete_route.called
+            assert not create_route.called
 
     async def test_trigger_job_vars(
         self,


### PR DESCRIPTION
This adds the emission of `prefect.deployment.ready`/`.not-ready` events and the
persistence of deployment status to the DB.  In order to timeout deployments
that haven't polled in a period of time, this introduces the `Foreman` loop
service from Prefect Cloud, stripped down to just operate on deployments for
the first version.

This also adds the status fields for work pools and queues in advance of the
next stage of work.

There is some additional typing/import churn here, because my recent use of the
`ORM*` classes for type hints created the conditions to easily be caught in
a long circular import chain.  I've moved all of those into `TYPE_CHECKING`
guards, and similarly broke a couple of other delicate import chains.
