### PR TITLE
update handling where definitions falsy

### DIFF
--- a/src/prefect/utilities/schema_tools/validation.py
+++ b/src/prefect/utilities/schema_tools/validation.py
@@ -232,7 +232,7 @@ def preprocess_schema(schema):
         process_properties(schema["properties"], required_fields)
 
     if "definitions" in schema:  # Also process definitions for reused models
-        for definition in schema["definitions"].values():
+        for definition in (schema["definitions"] or {}).values():
             if "properties" in definition:
                 required_fields = definition.get("required", [])
                 process_properties(definition["properties"], required_fields)


### PR DESCRIPTION
if a `definitions` value is falsy, we should not try to call `.values()` on it