### PR TITLE
Flow run input created events

### DIFF
--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -630,7 +630,7 @@ async def create_flow_run_input(
                     status_code=status.HTTP_404_NOT_FOUND, detail="Flow run not found"
                 )
 
-        if not PREFECT_EXPERIMENTAL_EVENTS:
+        if PREFECT_EXPERIMENTAL_EVENTS:
             async with PrefectServerEventsClient() as events:
                 event = await flow_run_input_created_event(
                     session, pendulum.now("UTC"), flow_run_id, key, value.decode()

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -628,11 +628,11 @@ async def create_flow_run_input(
                     status_code=status.HTTP_404_NOT_FOUND, detail="Flow run not found"
                 )
 
-    async with PrefectServerEventsClient() as events:
-        event = await flow_run_input_created_event(
-            session, pendulum.now("UTC"), flow_run_id, key, value.decode()
-        )
-        await events.emit(event)
+        async with PrefectServerEventsClient() as events:
+            event = await flow_run_input_created_event(
+                session, pendulum.now("UTC"), flow_run_id, key, value.decode()
+            )
+            await events.emit(event)
 
 
 @router.post("/{id}/input/filter")

--- a/tests/fixtures/events.py
+++ b/tests/fixtures/events.py
@@ -29,3 +29,7 @@ def workspace_events_client(
         "prefect.server.models.deployments.PrefectServerEventsClient",
         AssertingEventsClient,
     )
+    monkeypatch.setattr(
+        "prefect.server.api.flow_runs.PrefectServerEventsClient",
+        AssertingEventsClient,
+    )

--- a/tests/server/api/test_flow_runs.py
+++ b/tests/server/api/test_flow_runs.py
@@ -8,6 +8,8 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
+from prefect.server.events.clients import AssertingEventsClient
+from prefect.server.events.schemas.events import RelatedResource, Resource
 
 if HAS_PYDANTIC_V2:
     import pydantic.v1 as pydantic
@@ -1822,6 +1824,51 @@ class TestFlowRunInput:
         assert flow_run_input.flow_run_id == flow_run.id
         assert flow_run_input.key == "structured-key-1"
         assert flow_run_input.value == "really important stuff"
+
+    async def test_create_flow_run_input_sends_event(
+        self,
+        flow_run,
+        client: AsyncClient,
+        session: AsyncSession,
+        start_of_test: pendulum.DateTime,
+    ):
+        response = await client.post(
+            f"/flow_runs/{flow_run.id}/input",
+            json=dict(
+                key="structured-key-1",
+                value="really important stuff",
+            ),
+        )
+        assert response.status_code == 201
+
+        assert AssertingEventsClient.last
+        (event,) = AssertingEventsClient.last.events
+
+        assert event.event == "prefect.flow-run-input.created"
+        assert start_of_test <= event.occurred <= pendulum.now("UTC")
+        assert event.resource == Resource.parse_obj(
+            {
+                "prefect.resource.id": "prefect.flow-run-input.structured-key-1",
+                "prefect.resource.name": "structured-key-1",
+                "value": "really important stuff",
+            }
+        )
+        assert event.related == [
+            RelatedResource.parse_obj(
+                {
+                    "prefect.resource.id": f"prefect.flow-run.{flow_run.id}",
+                    "prefect.resource.role": "flow-run",
+                    "prefect.resource.name": flow_run.name,
+                }
+            ),
+            RelatedResource.parse_obj(
+                {
+                    "prefect.resource.id": f"prefect.flow.{flow_run.id}",
+                    "prefect.resource.role": "flow",
+                    "prefect.resource.name": flow_run.name,
+                }
+            ),
+        ]
 
     async def test_404_non_existent_flow_run(
         self, client: AsyncClient, session: AsyncSession

--- a/tests/server/api/test_flow_runs.py
+++ b/tests/server/api/test_flow_runs.py
@@ -1827,6 +1827,7 @@ class TestFlowRunInput:
 
     async def test_create_flow_run_input_sends_event(
         self,
+        flow,
         flow_run,
         client: AsyncClient,
         session: AsyncSession,
@@ -1863,9 +1864,9 @@ class TestFlowRunInput:
             ),
             RelatedResource.parse_obj(
                 {
-                    "prefect.resource.id": f"prefect.flow.{flow_run.id}",
+                    "prefect.resource.id": f"prefect.flow.{flow.id}",
                     "prefect.resource.role": "flow",
-                    "prefect.resource.name": flow_run.name,
+                    "prefect.resource.name": flow.name,
                 }
             ),
         ]


### PR DESCRIPTION
This PR adds server-side event emission for flow run inputs.

More specifically, on pause and resume of a flow run using `wait_for_input`, `prefect.flow-run-input.<key>` events should be emitted as the relevant flow-run-input objects are created:
1. `prefect.flow-run-input.paused-1-schema` - on pause/input-creation
2. `prefect.flow-run-input.paused-1-description` - _optionally_ created & emitted if `wait_for_input=SomeRunInput(with_initial_data(description=...))` is used
3. `prefect.flow-run-input.paused-1-response` - on response

As-is models directly to how these events are handled in prefect cloud today.

Closes #12906

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [x] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [x] This pull request includes helpful docstrings.
- [x] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
