### PR TITLE
Fix subflow handling in new engine

### DIFF
--- a/src/prefect/new_flow_engine.py
+++ b/src/prefect/new_flow_engine.py
@@ -50,7 +50,6 @@ class FlowRunEngine(Generic[P, R]):
     flow: Flow[P, Coroutine[Any, Any, R]]
     parameters: Optional[Dict[str, Any]] = None
     flow_run: Optional[FlowRun] = None
-    is_subflow: bool = False
     _is_started: bool = False
     _client: Optional[PrefectClient] = None
     short_circuit: bool = False
@@ -193,8 +192,6 @@ class FlowRunEngine(Generic[P, R]):
 
         # this is a subflow run
         if flow_run_ctx:
-            self.is_subflow = True
-
             # get the parent task run
             parent_task_run = await self.create_subflow_task_run(
                 client=client, context=flow_run_ctx

--- a/src/prefect/new_flow_engine.py
+++ b/src/prefect/new_flow_engine.py
@@ -149,15 +149,16 @@ class FlowRunEngine(Generic[P, R]):
         if parent_task_run.state.is_final() and not (
             rerunning and not parent_task_run.state.is_completed()
         ):
-            # If the parent task run already completed, return the last flow run
-            # associated with the parent task run. This prevents rerunning a completed
-            # flow run when the parent task run is rerun.
-            if most_recent_flow_run := (
-                await self.get_most_recent_flow_run_for_parent_task_run(
-                    client=client, parent_task_run=parent_task_run
-                )
-            ):
-                return most_recent_flow_run
+            # return the most recent flow run, if it exists
+            flow_runs = await client.read_flow_runs(
+                flow_run_filter=FlowRunFilter(
+                    parent_task_run_id={"any_": [parent_task_run.id]}
+                ),
+                sort=FlowRunSort.EXPECTED_START_TIME_ASC,
+                limit=1,
+            )
+            if flow_runs:
+                return flow_runs[-1]
 
     async def create_subflow_task_run(
         self, client: PrefectClient, context: FlowRunContext
@@ -184,28 +185,6 @@ class FlowRunEngine(Generic[P, R]):
             state=Pending(),
         )
         return parent_task_run
-
-    async def get_most_recent_flow_run_for_parent_task_run(
-        self, client: PrefectClient, parent_task_run: TaskRun
-    ) -> "Union[FlowRun, None]":
-        """
-        Get the most recent flow run associated with the provided parent task run.
-
-        Args:
-            - An orchestration client
-            - The parent task run to get the most recent flow run for
-
-        Returns:
-            The most recent flow run associated with the parent task run or `None` if
-            no flow runs are found
-        """
-        flow_runs = await client.read_flow_runs(
-            flow_run_filter=FlowRunFilter(
-                parent_task_run_id={"any_": [parent_task_run.id]}
-            ),
-            sort=FlowRunSort.EXPECTED_START_TIME_ASC,
-        )
-        return flow_runs[-1] if flow_runs else None
 
     async def create_flow_run(self, client: PrefectClient) -> FlowRun:
         flow_run_ctx = FlowRunContext.get()

--- a/src/prefect/utilities/asyncutils.py
+++ b/src/prefect/utilities/asyncutils.py
@@ -9,6 +9,7 @@ import threading
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
+from contextvars import copy_context
 from functools import partial, wraps
 from threading import Thread
 from typing import (
@@ -103,16 +104,18 @@ def run_sync(coroutine: Coroutine[Any, Any, T]) -> T:
         run_sync(my_async_function(1))
         ```
     """
+    # ensure context variables are properly copied to the async frame
+    context = copy_context()
     try:
         loop = asyncio.get_running_loop()
         if loop.is_running():
             with ThreadPoolExecutor() as executor:
-                future = executor.submit(asyncio.run, coroutine)
+                future = executor.submit(context.run, asyncio.run, coroutine)
                 return future.result()
         else:
-            return asyncio.run(coroutine)
+            return context.run(asyncio.run, coroutine)
     except RuntimeError:
-        return asyncio.run(coroutine)
+        return context.run(asyncio.run, coroutine)
 
 
 async def run_sync_in_worker_thread(

--- a/src/prefect/utilities/asyncutils.py
+++ b/src/prefect/utilities/asyncutils.py
@@ -83,11 +83,10 @@ def is_async_gen_fn(func):
 
 def run_sync(coroutine: Coroutine[Any, Any, T]) -> T:
     """
-    Runs a coroutine from a synchronous context, either in the current event
-    loop or in a new one if there is no event loop running. The coroutine will
-    block until it is done. A thread will be spawned to run the event loop if
-    necessary, which allows coroutines to run in environments like Jupyter
-    notebooks where the event loop runs on the main thread.
+    Runs a coroutine from a synchronous context. A thread will be spawned
+    to run the event loop if necessary, which allows coroutines to run in
+    environments like Jupyter notebooks where the event loop runs on the main
+    thread.
 
     Args:
         coroutine: The coroutine to run.
@@ -108,13 +107,14 @@ def run_sync(coroutine: Coroutine[Any, Any, T]) -> T:
     context = copy_context()
     try:
         loop = asyncio.get_running_loop()
-        if loop.is_running():
-            with ThreadPoolExecutor() as executor:
-                future = executor.submit(context.run, asyncio.run, coroutine)
-                return future.result()
-        else:
-            return context.run(asyncio.run, coroutine)
     except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        with ThreadPoolExecutor() as executor:
+            future = executor.submit(context.run, asyncio.run, coroutine)
+            return future.result()
+    else:
         return context.run(asyncio.run, coroutine)
 
 

--- a/tests/utilities/test_asyncutils.py
+++ b/tests/utilities/test_asyncutils.py
@@ -3,11 +3,13 @@ import threading
 import time
 import uuid
 from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
 from functools import partial, wraps
 
 import anyio
 import pytest
 
+from prefect.context import ContextModel
 from prefect.utilities.asyncutils import (
     GatherIncomplete,
     LazySemaphore,
@@ -20,6 +22,7 @@ from prefect.utilities.asyncutils import (
     is_async_gen_fn,
     run_async_from_worker_thread,
     run_async_in_new_loop,
+    run_sync,
     run_sync_in_interruptible_worker_thread,
     run_sync_in_worker_thread,
     sync_compatible,
@@ -453,3 +456,27 @@ async def test_lazy_semaphore_initialization():
         assert lazy_semaphore._semaphore._value == initial_value - 1
 
     assert lazy_semaphore._semaphore._value == initial_value
+
+
+class MyVar(ContextModel):
+    __var__ = ContextVar("my_var")
+    x: int = 1
+
+
+class TestRunSyncContextVars:
+    def test_context_carries_to_async_frame(self):
+        """
+        Ensures that ContextVars set in a parent scope of `run_sync` are automatically
+        carried over to the async frame.
+        """
+
+        async def load_var():
+            return MyVar.get().x
+
+        async def parent():
+            with MyVar(x=42):
+                return run_sync(load_var())
+
+        # this has to be run via asyncio.run because
+        # otherwise the context is maintained automatically
+        assert asyncio.run(parent()) == 42


### PR DESCRIPTION
One of my favorite things about the new engine (there are many) is that it eliminates the separate execution branches and logic for subflow runs. Now there is only a small amount of bookkeeping that has to be done. 

This PR stems from an odd behavior observed in the tests for https://github.com/PrefectHQ/prefect/pull/12889, in which a test that is currently passing on main started failing without clear catalyst. 

[This test](https://github.com/PrefectHQ/prefect/blob/ebb42b0fe328c8c3486344c43fb227d28563a483/tests/test_new_flow_engine.py#L568-L603) is currently passing on `main`, but is actually doing the right thing for the wrong reason. As written it is a synchronous flow and synchronous subflow, but if you switch both flows to async (on `main`) the test will fail. 

The test is supposed to check that subflow runs reset their run count when their parent run retries. The async version of the unit test fails because of a [conditional check](https://github.com/PrefectHQ/prefect/compare/subflow-engine?expand=1#diff-0e5512aa7886dfe75949ae57bd9c990397c07a2b264b48036d62ab1cbe39e35bR149-R151) that needed to be added to the new engine to ensure that subflows do not always load their previous states. Specifically, this check ensures that if the parent run is rerunning, a new subflow run is generated. Without it, the old subflow run is reloaded, which has already exhausted its retries, and so the engine does not allow the subflow to run (failing the test).

The reason the sync version of the test was passing is that flow run information is stored in a `ContextVar`, which are (by Python design) not carried over to new async frames, such as those created by `run_sync`. So when the subflow run was invoked the second time, it actually *didn't know it was a subflow* since the context wasn't copied over, and happily reran, satisfying the test. To fix this, `run_sync` has been updated to propagate contextvars appropriately.