### PR TITLE
Avoid running the `prefect-client` build all the time

### DIFF
--- a/.github/workflows/prefect-client.yaml
+++ b/.github/workflows/prefect-client.yaml
@@ -2,6 +2,8 @@ name: Verify prefect-client build
 
 on:
   pull_request:
+    branches:
+      - main
     paths:
       - "**/*.py"
       - requirements.txt
@@ -10,6 +12,11 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "**/*.py"
+      - requirements.txt
+      - requirements-client.txt
+      - setup.cfg
   workflow_call:
     inputs:
       upload-artifacts:

--- a/.github/workflows/prefect-client.yaml
+++ b/.github/workflows/prefect-client.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - "src/prefect/**/*.py"
+      - src/prefect/**/*.py
       - requirements.txt
       - requirements-client.txt
       - setup.cfg
@@ -13,7 +13,7 @@ on:
     branches:
       - main
     paths:
-      - "src/prefect/**/*.py"
+      - src/prefect/**/*.py
       - requirements.txt
       - requirements-client.txt
       - setup.cfg

--- a/.github/workflows/prefect-client.yaml
+++ b/.github/workflows/prefect-client.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - "**/*.py"
+      - "src/prefect/**/*.py"
       - requirements.txt
       - requirements-client.txt
       - setup.cfg
@@ -13,7 +13,7 @@ on:
     branches:
       - main
     paths:
-      - "**/*.py"
+      - "src/prefect/**/*.py"
       - requirements.txt
       - requirements-client.txt
       - setup.cfg


### PR DESCRIPTION
previously was running on every `push` to `main`, which does not seem necessary at all