### PR TITLE
Update `automation pause` and `automation resume` to handle automations with same name

### DIFF
--- a/src/prefect/events/cli/automations.py
+++ b/src/prefect/events/cli/automations.py
@@ -218,7 +218,7 @@ async def pause(
             for a in automation:
                 await client.pause_automation(a.id)
             exit_with_success(
-                f"Paused automation(s) with name {name!r} and id(s) {', '.join([repr(str(a.id)) for a in automation])}"
+                f"Paused automation(s) with name {name!r} and id(s) {', '.join([repr(str(a.id)) for a in automation])}."
             )
 
     elif id:

--- a/src/prefect/events/cli/automations.py
+++ b/src/prefect/events/cli/automations.py
@@ -17,6 +17,7 @@ from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error, exit_with_success
 from prefect.cli.root import app
 from prefect.client.orchestration import get_client
+from prefect.events.schemas.automations import Automation
 from prefect.exceptions import PrefectHTTPStatusError
 
 automations_app = PrefectTyper(
@@ -149,7 +150,7 @@ async def inspect(
     if yaml or json:
         if isinstance(automation, list):
             automation = [a.dict(json_compatible=True) for a in automation]
-        elif isinstance(automation, dict):
+        elif isinstance(automation, Automation):
             automation = automation.dict(json_compatible=True)
         if yaml:
             app.console.print(pyyaml.dump(automation, sort_keys=False))

--- a/src/prefect/events/cli/automations.py
+++ b/src/prefect/events/cli/automations.py
@@ -191,7 +191,9 @@ async def pause(
         async with get_client() as client:
             automation = await client.read_automations_by_name(name=name)
             if not automation:
-                exit_with_error(f"Automation {name!r} not found.")
+                exit_with_error(
+                    f"Automation with name {name!r} not found. You can also specify an id with the `--id` flag."
+                )
             if len(automation) > 1:
                 if not typer.confirm(
                     f"Multiple automations found with name {name!r}. Do you want to pause all of them?",
@@ -213,7 +215,7 @@ async def pause(
             except (PrefectHTTPStatusError, ValueError):
                 exit_with_error(f"Automation with id {id!r} not found.")
             await client.pause_automation(automation.id)
-            exit_with_success(f"Paused automation with id {str(automation.id)!r}")
+            exit_with_success(f"Paused automation with id {str(automation.id)!r}.")
 
 
 @automations_app.command()

--- a/src/prefect/events/cli/automations.py
+++ b/src/prefect/events/cli/automations.py
@@ -183,7 +183,21 @@ async def pause(
     name: Optional[str] = typer.Argument(None, help="An automation's name"),
     id: Optional[str] = typer.Option(None, "--id", help="An automation's id"),
 ):
-    """Pause an automation."""
+    """
+    Pause an automation.
+
+    Arguments:
+
+            name: the name of the automation to pause
+
+            id: the id of the automation to pause
+
+    Examples:
+
+        $ prefect automation pause "my-automation"
+
+        $ prefect automation pause --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    """
     if not id and not name:
         exit_with_error("Please provide either a name or an id.")
 

--- a/src/prefect/events/cli/automations.py
+++ b/src/prefect/events/cli/automations.py
@@ -164,17 +164,57 @@ async def inspect(
 
 @automations_app.command(aliases=["enable"])
 @requires_automations
-async def resume(id_or_name: str):
-    """Resume an automation."""
-    async with get_client() as client:
-        automation = await client.find_automation(id_or_name)
-        if not automation:
-            exit_with_error(f"Automation {id_or_name!r} not found.")
+async def resume(
+    name: Optional[str] = typer.Argument(None, help="An automation's name"),
+    id: Optional[str] = typer.Option(None, "--id", help="An automation's id"),
+):
+    """
+    Resume an automation.
 
-    async with get_client() as client:
-        await client.resume_automation(automation.id)
+    Arguments:
 
-    exit_with_success(f"Resumed automation {automation.name!r} ({automation.id})")
+            name: the name of the automation to resume
+
+            id: the id of the automation to resume
+
+    Examples:
+
+            $ prefect automation resume "my-automation"
+
+            $ prefect automation resume --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    """
+    if not id and not name:
+        exit_with_error("Please provide either a name or an id.")
+
+    if name:
+        async with get_client() as client:
+            automation = await client.read_automations_by_name(name=name)
+            if not automation:
+                exit_with_error(
+                    f"Automation with name {name!r} not found. You can also specify an id with the `--id` flag."
+                )
+            if len(automation) > 1:
+                if not typer.confirm(
+                    f"Multiple automations found with name {name!r}. Do you want to resume all of them?",
+                    default=False,
+                ):
+                    exit_with_error("Resume aborted.")
+
+            for a in automation:
+                await client.resume_automation(a.id)
+            exit_with_success(
+                f"Resumed automation(s) with name {name!r} and id(s) {', '.join([repr(str(a.id)) for a in automation])}."
+            )
+
+    elif id:
+        async with get_client() as client:
+            try:
+                uuid_id = UUID(id)
+                automation = await client.read_automation(uuid_id)
+            except (PrefectHTTPStatusError, ValueError):
+                exit_with_error(f"Automation with id {id!r} not found.")
+            await client.resume_automation(automation.id)
+            exit_with_success(f"Resumed automation with id {str(automation.id)!r}.")
 
 
 @automations_app.command(aliases=["disable"])

--- a/tests/events/client/cli/test_automations.py
+++ b/tests/events/client/cli/test_automations.py
@@ -334,6 +334,22 @@ def test_pausing_by_id(
     )
 
 
+def test_pausing_by_id_not_found(
+    pause_automation: mock.AsyncMock,
+    read_automation: mock.AsyncMock,
+):
+    read_automation.return_value = None
+    invoke_and_assert(
+        ["automations", "pause", "--id", "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz"],
+        expected_code=1,
+        expected_output_contains=[
+            "Automation with id 'zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz' not found"
+        ],
+    )
+
+    pause_automation.assert_not_awaited()
+
+
 @pytest.fixture
 def resume_automation() -> Generator[mock.AsyncMock, None, None]:
     with mock.patch(

--- a/tests/events/client/cli/test_automations.py
+++ b/tests/events/client/cli/test_automations.py
@@ -211,7 +211,7 @@ def test_inspecting_by_name_not_found(
     )
 
 
-def test_inspecting_in_json(
+def test_inspecting_by_name_in_json(
     various_automations: List[Automation], read_automations_by_name: mock.AsyncMock
 ):
     read_automations_by_name.return_value = [various_automations[0]]
@@ -223,7 +223,26 @@ def test_inspecting_in_json(
     assert loaded[0]["id"] == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 
 
-def test_inspecting_in_yaml(
+def test_inspecting_by_id_in_json(
+    various_automations: List[Automation], read_automation: mock.AsyncMock
+):
+    read_automation.return_value = various_automations[1]
+    result = invoke_and_assert(
+        [
+            "automations",
+            "inspect",
+            "--id",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "--json",
+        ],
+        expected_code=0,
+    )
+    loaded = orjson.loads(result.output)
+    assert loaded["name"] == "My Other Reactive Automation"
+    assert loaded["id"] == "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+
+def test_inspecting_by_name_in_yaml(
     various_automations: List[Automation], read_automations_by_name: mock.AsyncMock
 ):
     read_automations_by_name.return_value = [various_automations[0]]
@@ -233,6 +252,25 @@ def test_inspecting_in_yaml(
     loaded = yaml.safe_load(result.output)
     assert loaded[0]["name"] == "My First Reactive"
     assert loaded[0]["id"] == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+
+def test_inspecting_by_id_in_yaml(
+    various_automations: List[Automation], read_automation: mock.AsyncMock
+):
+    read_automation.return_value = various_automations[1]
+    result = invoke_and_assert(
+        [
+            "automations",
+            "inspect",
+            "--id",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "--yaml",
+        ],
+        expected_code=0,
+    )
+    loaded = yaml.safe_load(result.output)
+    assert loaded["name"] == "My Other Reactive Automation"
+    assert loaded["id"] == "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 
 
 @pytest.fixture

--- a/tests/events/client/cli/test_automations.py
+++ b/tests/events/client/cli/test_automations.py
@@ -282,12 +282,17 @@ def pause_automation() -> Generator[mock.AsyncMock, None, None]:
 
 
 def test_pausing_by_name(
-    pause_automation: mock.AsyncMock, various_automations: List[Automation]
+    pause_automation: mock.AsyncMock,
+    various_automations: List[Automation],
+    read_automations_by_name: mock.AsyncMock,
 ):
+    read_automations_by_name.return_value = [various_automations[0]]
     invoke_and_assert(
         ["automations", "pause", "My First Reactive"],
         expected_code=0,
-        expected_output_contains=["Paused automation 'My First Reactive'"],
+        expected_output_contains=[
+            "Paused automation(s) with name 'My First Reactive' and id(s) 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'"
+        ],
     )
 
     pause_automation.assert_awaited_once_with(
@@ -295,9 +300,12 @@ def test_pausing_by_name(
     )
 
 
-def test_pausing_not_found(
-    pause_automation: mock.AsyncMock, various_automations: List[Automation]
+def test_pausing_by_name_not_found(
+    pause_automation: mock.AsyncMock,
+    various_automations: List[Automation],
+    read_automations_by_name: mock.AsyncMock,
 ):
+    read_automations_by_name.return_value = None
     invoke_and_assert(
         ["automations", "pause", "Wha?"],
         expected_code=1,
@@ -305,6 +313,25 @@ def test_pausing_not_found(
     )
 
     pause_automation.assert_not_awaited()
+
+
+def test_pausing_by_id(
+    pause_automation: mock.AsyncMock,
+    various_automations: List[Automation],
+    read_automation: mock.AsyncMock,
+):
+    read_automation.return_value = various_automations[0]
+    invoke_and_assert(
+        ["automations", "pause", "--id", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"],
+        expected_code=0,
+        expected_output_contains=[
+            "Paused automation with id 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'"
+        ],
+    )
+
+    pause_automation.assert_awaited_once_with(
+        mock.ANY, UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    )
 
 
 @pytest.fixture

--- a/tests/events/client/cli/test_automations.py
+++ b/tests/events/client/cli/test_automations.py
@@ -309,7 +309,7 @@ def test_pausing_by_name_not_found(
     invoke_and_assert(
         ["automations", "pause", "Wha?"],
         expected_code=1,
-        expected_output_contains=["Automation 'Wha?' not found"],
+        expected_output_contains=["Automation with name 'Wha?' not found"],
     )
 
     pause_automation.assert_not_awaited()


### PR DESCRIPTION
- Previously, the `automation pause` and `resume` cmds accepted a single parameter `id_or_name`, which could be either an ID or a name. These functions have been refactored to separate these inputs into two distinct optional parameters: `name` and `id`, consistent with `automation delete`, `automation inspect`, etc.
- The logic in the `pause` and `resume` functions have been updated to ensure that either a name or an ID is provided.
- Added handling for cases where multiple automations are found when using the `name` parameter.
- The updated code includes more detailed comments and revised documentation strings that clarify the purpose and usage of each parameter and function.


## Examples
### Pause
```bash
❯ prefect automation pause --help
                                                                                                                                                                                                                                                                                                    
 Usage: prefect automation pause [OPTIONS] [NAME]                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                    
 Pause an automation.                                                                                                                                                                                                                                                                               
 Arguments:                                                                                                                                                                                                                                                                                         
 name: the name of the automation to pause                                                                                                                                                                                                                                                          
 id: the id of the automation to pause                                                                                                                                                                                                                                                              
 Examples:                                                                                                                                                                                                                                                                                          
 $ prefect automation pause "my-automation"                                                                                                                                                                                                                                                         
 $ prefect automation pause --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                    
╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│   name      [NAME]  An automation's name [default: None]                                                                                                                                                                                                                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --id          TEXT  An automation's id [default: None]                                                                                                                                                                                                                                           │
│ --help              Show this message and exit.                                                                                                                                                                                                                                                  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
```bash
❯ prefect automation pause
Please provide either a name or an id.
```
```bash
❯ prefect automation pause nonexistent-name
Automation 'nonexistent-name' not found.
```
```bash
❯ prefect automation pause --id nonexistent-name
Automation with id 'nonexistent-name' not found.
```
```bash
❯ prefect automation pause 8ad13e23-1584-4a14-a657-ac3e5724f339
Automation '8ad13e23-1584-4a14-a657-ac3e5724f339' not found.
```
```bash
❯ prefect automation pause 8ad13e23-1584-4a14-a657-ac3e5724f339
Automation with name '8ad13e23-1584-4a14-a657-ac3e5724f339' not found. You can also specify an id with the `--id` flag.
```
```bash
❯ prefect automation pause --id 8ad13e23-1584-4a14-a657-ac3e5724f339
Paused automation with id '8ad13e23-1584-4a14-a657-ac3e5724f339'
```
#### Pausing multiple automations with the same name

```bash
❯ prefect automation pause my-fave-automation
Multiple automations found with name 'my-fave-automation'. Do you want to pause all of them? [y/N]: n
Pause aborted.
```
```bash
❯ prefect automation pause my-fave-automation
Multiple automations found with name 'my-fave-automation'. Do you want to pause all of them? [y/N]: y
Paused automation(s) with name 'my-fave-automation' and id(s) '6d222a09-3c68-42d4-b019-bd331a3abb88', '291ba287-2149-4379-825e-52b1d266f114'
```
### Resume
```bash
❯ prefect automation resume
Please provide either a name or an id.
```
```bash
❯ prefect automation resume --help
                                                                                                                                                                                                                                                                                                    
 Usage: prefect automation resume [OPTIONS] [NAME]                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                    
 Resume an automation.                                                                                                                                                                                                                                                                              
 Arguments:                                                                                                                                                                                                                                                                                         
 name: the name of the automation to resume                                                                                                                                                                                                                                                         
 id: the id of the automation to resume                                                                                                                                                                                                                                                             
 Examples:                                                                                                                                                                                                                                                                                          
 $ prefect automation resume "my-automation"                                                                                                                                                                                                                                                        
 $ prefect automation resume --id "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                    
╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│   name      [NAME]  An automation's name [default: None]                                                                                                                                                                                                                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --id          TEXT  An automation's id [default: None]                                                                                                                                                                                                                                           │
│ --help              Show this message and exit.                                                                                                                                                                                                                                                  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
```bash
❯ prefect automation resume email-me-if-high-priority-wq-ready
Resumed automation(s) with name 'email-me-if-high-priority-wq-ready' and id(s) '8ad13e23-1584-4a14-a657-ac3e5724f339'.
```
```bash
❯ prefect automation resume nonexistent-name
Automation with name 'nonexistent-name' not found. You can also specify an id with the `--id` flag.
```

```bash
❯ prefect automation resume --id fsdh
Automation with id 'fsdh' not found.
```
```bash
❯ prefect automation resume --id 291ba287-2149-4379-825e-52b1d266f114
Resumed automation with id '291ba287-2149-4379-825e-52b1d266f114'.
```
#### Resuming multiple automations with the same name
```bash
❯ prefect automation resume my-fave-automation
Multiple automations found with name 'my-fave-automation'. Do you want to resume all of them? [y/N]: y
Resumed automation(s) with name 'my-fave-automation' and id(s) '291ba287-2149-4379-825e-52b1d266f114', 
'6d222a09-3c68-42d4-b019-bd331a3abb88'.
```