### PR TITLE
Raise a better error when deleting and inspecting blocks

### DIFF
--- a/src/prefect/cli/block.py
+++ b/src/prefect/cli/block.py
@@ -222,6 +222,10 @@ async def block_delete(
             except ObjectNotFound:
                 exit_with_error(f"Deployment {block_id!r} not found!")
         elif slug is not None:
+            if "/" not in slug:
+                exit_with_error(
+                    f"{slug!r} is not valid. Slug must contain a '/', e.g. 'json/my-json-block'"
+                )
             block_type_slug, block_document_name = slug.split("/")
             try:
                 block_document = await client.read_block_document_by_name(
@@ -289,6 +293,10 @@ async def block_inspect(
             except ObjectNotFound:
                 exit_with_error(f"Deployment {block_id!r} not found!")
         elif slug is not None:
+            if "/" not in slug:
+                exit_with_error(
+                    f"{slug!r} is not valid. Slug must contain a '/', e.g. 'json/my-json-block'"
+                )
             block_type_slug, block_document_name = slug.split("/")
             try:
                 block_document = await client.read_block_document_by_name(

--- a/tests/cli/test_block.py
+++ b/tests/cli/test_block.py
@@ -237,6 +237,14 @@ def test_inspecting_a_block():
     )
 
 
+def test_inspecting_a_block_malfomed_slug():
+    invoke_and_assert(
+        ["block", "inspect", "chonk-block"],
+        expected_code=1,
+        expected_output_contains="'chonk-block' is not valid. Slug must contain a '/'",
+    )
+
+
 def test_deleting_a_block():
     system.JSON(value="don't delete me please").save("pleasedonterase")
 
@@ -248,6 +256,14 @@ def test_deleting_a_block():
     invoke_and_assert(
         ["block", "inspect", "json/pleasedonterase"],
         expected_code=1,
+    )
+
+
+def test_deleting_a_block_malfomed_slug():
+    invoke_and_assert(
+        ["block", "delete", "chonk-block"],
+        expected_code=1,
+        expected_output_contains="'chonk-block' is not valid. Slug must contain a '/'",
     )
 
 

--- a/tests/cli/test_block.py
+++ b/tests/cli/test_block.py
@@ -237,7 +237,7 @@ def test_inspecting_a_block():
     )
 
 
-def test_inspecting_a_block_malfomed_slug():
+def test_inspecting_a_block_malformed_slug():
     invoke_and_assert(
         ["block", "inspect", "chonk-block"],
         expected_code=1,
@@ -259,7 +259,7 @@ def test_deleting_a_block():
     )
 
 
-def test_deleting_a_block_malfomed_slug():
+def test_deleting_a_block_malformed_slug():
     invoke_and_assert(
         ["block", "delete", "chonk-block"],
         expected_code=1,


### PR DESCRIPTION
Fix https://github.com/PrefectHQ/prefect/issues/6676


## Examples
```bash
❯ prefect block inspect my-block
'my-block' is not valid. Slug must contain a '/', e.g. 'json/my-json-block'
```

```bash
❯ prefect block delete my-block
'my-block' is not valid. Slug must contain a '/', e.g. 'json/my-json-block'
```
