### PR TITLE
Vertex AI performance pass

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/aiplatform.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/aiplatform.py
@@ -383,7 +383,7 @@ class VertexAICustomTrainingJob(Infrastructure):
         )
         return job_spec
 
-    async def _create_and_begin_job(
+    def _create_and_begin_job(
         self, job_spec: "CustomJobSpec", job_service_client: "JobServiceClient"
     ) -> "CustomJob":
         """
@@ -398,8 +398,8 @@ class VertexAICustomTrainingJob(Infrastructure):
 
         # run job
         self.logger.info(
-            f"{self._log_prefix}: Job {self.job_name!r} starting to run "
-            f"the command {' '.join(self.command)!r} in region "
+            f"{self._log_prefix}: Creating job {self.job_name!r} "
+            f"with command {' '.join(self.command)!r} in region "
             f"{self.region!r} using image {self.image!r}"
         )
 
@@ -410,20 +410,22 @@ class VertexAICustomTrainingJob(Infrastructure):
             stop=stop_after_attempt(3), wait=wait_fixed(1) + wait_random(0, 3)
         )
 
-        custom_job_run = await run_sync_in_worker_thread(
-            retry_policy(job_service_client.create_custom_job),
+        create_custom_job_with_retries = retry_policy(
+            job_service_client.create_custom_job
+        )
+        custom_job_run = create_custom_job_with_retries(
             parent=resource_name,
             custom_job=custom_job,
         )
 
         self.logger.info(
-            f"{self._log_prefix}: Job {self.job_name!r} has successfully started; "
-            f"the full job name is {custom_job_run.name!r}"
+            f"{self._log_prefix}: Job {self.job_name!r} created. "
+            f"The full job name is {custom_job_run.name!r}"
         )
 
         return custom_job_run
 
-    async def _watch_job_run(
+    def _watch_job_run(
         self,
         full_job_name: str,  # different from self.job_name
         job_service_client: "JobServiceClient",
@@ -433,14 +435,19 @@ class VertexAICustomTrainingJob(Infrastructure):
     ) -> "CustomJob":
         """
         Polls job run to see if status changed.
+
+        State changes reported by the Vertex AI API may sometimes be inaccurate
+        immediately upon startup, but should eventually report a correct running
+        and then terminal state. The minimum training duration for a custom job is
+        30 seconds, so short-lived jobs may be marked as successful some time
+        after a flow run has completed.
         """
         state = JobState.JOB_STATE_UNSPECIFIED
         last_state = current_state
         t0 = time.time()
 
         while state not in until_states:
-            job_run = await run_sync_in_worker_thread(
-                job_service_client.get_custom_job,
+            job_run = job_service_client.get_custom_job(
                 name=full_job_name,
             )
             state = job_run.state
@@ -451,7 +458,7 @@ class VertexAICustomTrainingJob(Infrastructure):
                     .replace("state", "state is now:")
                 )
                 # results in "New job state is now: succeeded"
-                self.logger.info(
+                self.logger.debug(
                     f"{self._log_prefix}: {self.job_name} has new {state_label}"
                 )
                 last_state = state
@@ -488,26 +495,31 @@ class VertexAICustomTrainingJob(Infrastructure):
         )
 
         job_spec = self._build_job_spec()
-        with self.gcp_credentials.get_job_service_client(
+        job_service_client = self.gcp_credentials.get_job_service_client(
             client_options=client_options
-        ) as job_service_client:
-            job_run = await self._create_and_begin_job(job_spec, job_service_client)
+        )
+        job_run = await run_sync_in_worker_thread(
+            self._create_and_begin_job,
+            job_spec,
+            job_service_client,
+        )
 
-            if task_status:
-                task_status.started(self.job_name)
+        if task_status:
+            task_status.started(self.job_name)
 
-            final_job_run = await self._watch_job_run(
-                full_job_name=job_run.name,
-                job_service_client=job_service_client,
-                current_state=job_run.state,
-                until_states=(
-                    JobState.JOB_STATE_SUCCEEDED,
-                    JobState.JOB_STATE_FAILED,
-                    JobState.JOB_STATE_CANCELLED,
-                    JobState.JOB_STATE_EXPIRED,
-                ),
-                timeout=self.maximum_run_time.total_seconds(),
-            )
+        final_job_run = await run_sync_in_worker_thread(
+            self._watch_job_run,
+            full_job_name=job_run.name,
+            job_service_client=job_service_client,
+            current_state=job_run.state,
+            until_states=(
+                JobState.JOB_STATE_SUCCEEDED,
+                JobState.JOB_STATE_FAILED,
+                JobState.JOB_STATE_CANCELLED,
+                JobState.JOB_STATE_EXPIRED,
+            ),
+            timeout=self.maximum_run_time.total_seconds(),
+        )
 
         error_msg = final_job_run.error.message
         if error_msg:
@@ -534,15 +546,15 @@ class VertexAICustomTrainingJob(Infrastructure):
         client_options = ClientOptions(
             api_endpoint=f"{self.region}-aiplatform.googleapis.com"
         )
-        with self.gcp_credentials.get_job_service_client(
+        job_service_client = self.gcp_credentials.get_job_service_client(
             client_options=client_options
-        ) as job_service_client:
-            await run_sync_in_worker_thread(
-                self._kill_job,
-                job_service_client=job_service_client,
-                full_job_name=identifier,
-            )
-            self.logger.info(f"Requested to cancel {identifier}...")
+        )
+        await run_sync_in_worker_thread(
+            self._kill_job,
+            job_service_client=job_service_client,
+            full_job_name=identifier,
+        )
+        self.logger.info(f"Requested to cancel {identifier}...")
 
     def _kill_job(
         self, job_service_client: "JobServiceClient", full_job_name: str

--- a/src/integrations/prefect-gcp/prefect_gcp/aiplatform.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/aiplatform.py
@@ -54,7 +54,7 @@ Examples:
     job.preview()
     ```
 """  # noqa
-
+import asyncio
 import datetime
 import re
 import shlex
@@ -68,7 +68,7 @@ from pydantic import VERSION as PYDANTIC_VERSION
 from prefect._internal.compatibility.deprecated import deprecated_class
 from prefect.exceptions import InfrastructureNotFound
 from prefect.infrastructure import Infrastructure, InfrastructureResult
-from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
+from prefect.utilities.asyncutils import sync_compatible
 
 if PYDANTIC_VERSION.startswith("2."):
     from pydantic.v1 import Field
@@ -82,7 +82,7 @@ from typing_extensions import Literal
 # if google-cloud-aiplatform is not installed
 try:
     from google.api_core.client_options import ClientOptions
-    from google.cloud.aiplatform.gapic import JobServiceClient
+    from google.cloud.aiplatform.gapic import JobServiceAsyncClient
     from google.cloud.aiplatform_v1.types.custom_job import (
         ContainerSpec,
         CustomJob,
@@ -383,8 +383,10 @@ class VertexAICustomTrainingJob(Infrastructure):
         )
         return job_spec
 
-    def _create_and_begin_job(
-        self, job_spec: "CustomJobSpec", job_service_client: "JobServiceClient"
+    async def _create_and_begin_job(
+        self,
+        job_spec: "CustomJobSpec",
+        job_service_async_client: "JobServiceAsyncClient",
     ) -> "CustomJob":
         """
         Builds a custom job and begins running it.
@@ -411,9 +413,9 @@ class VertexAICustomTrainingJob(Infrastructure):
         )
 
         create_custom_job_with_retries = retry_policy(
-            job_service_client.create_custom_job
+            job_service_async_client.create_custom_job
         )
-        custom_job_run = create_custom_job_with_retries(
+        custom_job_run = await create_custom_job_with_retries(
             parent=resource_name,
             custom_job=custom_job,
         )
@@ -425,10 +427,10 @@ class VertexAICustomTrainingJob(Infrastructure):
 
         return custom_job_run
 
-    def _watch_job_run(
+    async def _watch_job_run(
         self,
         full_job_name: str,  # different from self.job_name
-        job_service_client: "JobServiceClient",
+        job_service_async_client: "JobServiceAsyncClient",
         current_state: "JobState",
         until_states: Tuple["JobState"],
         timeout: int = None,
@@ -447,7 +449,7 @@ class VertexAICustomTrainingJob(Infrastructure):
         t0 = time.time()
 
         while state not in until_states:
-            job_run = job_service_client.get_custom_job(
+            job_run = await job_service_async_client.get_custom_job(
                 name=full_job_name,
             )
             state = job_run.state
@@ -473,7 +475,7 @@ class VertexAICustomTrainingJob(Infrastructure):
                     f"Timed out after {elapsed_time}s while watching job for states "
                     "{until_states!r}"
                 )
-            time.sleep(self.job_watch_poll_interval)
+            await asyncio.sleep(self.job_watch_poll_interval)
 
         return job_run
 
@@ -495,22 +497,20 @@ class VertexAICustomTrainingJob(Infrastructure):
         )
 
         job_spec = self._build_job_spec()
-        job_service_client = self.gcp_credentials.get_job_service_client(
+        job_service_async_client = self.gcp_credentials.get_job_service_async_client(
             client_options=client_options
         )
-        job_run = await run_sync_in_worker_thread(
-            self._create_and_begin_job,
+        job_run = await self._create_and_begin_job(
             job_spec,
-            job_service_client,
+            job_service_async_client,
         )
 
         if task_status:
             task_status.started(self.job_name)
 
-        final_job_run = await run_sync_in_worker_thread(
-            self._watch_job_run,
+        final_job_run = await self._watch_job_run(
             full_job_name=job_run.name,
-            job_service_client=job_service_client,
+            job_service_async_client=job_service_async_client,
             current_state=job_run.state,
             until_states=(
                 JobState.JOB_STATE_SUCCEEDED,
@@ -546,18 +546,17 @@ class VertexAICustomTrainingJob(Infrastructure):
         client_options = ClientOptions(
             api_endpoint=f"{self.region}-aiplatform.googleapis.com"
         )
-        job_service_client = self.gcp_credentials.get_job_service_client(
+        job_service_async_client = self.gcp_credentials.get_job_service_async_client(
             client_options=client_options
         )
-        await run_sync_in_worker_thread(
-            self._kill_job,
-            job_service_client=job_service_client,
+        await self._kill_job(
+            job_service_async_client=job_service_async_client,
             full_job_name=identifier,
         )
         self.logger.info(f"Requested to cancel {identifier}...")
 
-    def _kill_job(
-        self, job_service_client: "JobServiceClient", full_job_name: str
+    async def _kill_job(
+        self, job_service_async_client: "JobServiceAsyncClient", full_job_name: str
     ) -> None:
         """
         Thin wrapper around Job.delete, wrapping a try/except since
@@ -566,7 +565,7 @@ class VertexAICustomTrainingJob(Infrastructure):
         """
         cancel_custom_job_request = CancelCustomJobRequest(name=full_job_name)
         try:
-            job_service_client.cancel_custom_job(
+            await job_service_async_client.cancel_custom_job(
                 request=cancel_custom_job_request,
             )
         except Exception as exc:

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -18,6 +18,7 @@ prefect worker start --pool 'my-vertex-pool'
 Read more about configuring work pools
 [here](https://docs.prefect.io/latest/concepts/work-pools/#work-pool-overview).
 """
+import asyncio
 import datetime
 import re
 import shlex
@@ -30,7 +31,6 @@ from pydantic import VERSION as PYDANTIC_VERSION
 
 from prefect.exceptions import InfrastructureNotFound
 from prefect.logging.loggers import PrefectLogAdapter
-from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.pydantic import JsonPatch
 from prefect.workers.base import (
     BaseJobConfiguration,
@@ -52,7 +52,7 @@ from prefect_gcp.credentials import GcpCredentials
 # if google-cloud-aiplatform is not installed
 try:
     from google.api_core.client_options import ClientOptions
-    from google.cloud.aiplatform.gapic import JobServiceClient
+    from google.cloud.aiplatform.gapic import JobServiceAsyncClient
     from google.cloud.aiplatform_v1.types.custom_job import (
         ContainerSpec,
         CustomJob,
@@ -409,15 +409,16 @@ class VertexAIWorker(BaseWorker):
         job_name = configuration.job_name
 
         job_spec = self._build_job_spec(configuration)
-        job_service_client = configuration.credentials.get_job_service_client(
-            client_options=client_options
+        job_service_async_client = (
+            configuration.credentials.get_job_service_async_client(
+                client_options=client_options
+            )
         )
 
-        job_run = await run_sync_in_worker_thread(
-            self._create_and_begin_job,
+        job_run = await self._create_and_begin_job(
             job_name,
             job_spec,
-            job_service_client,
+            job_service_async_client,
             configuration,
             logger,
         )
@@ -425,11 +426,10 @@ class VertexAIWorker(BaseWorker):
         if task_status:
             task_status.started(job_run.name)
 
-        final_job_run = await run_sync_in_worker_thread(
-            self._watch_job_run,
+        final_job_run = await self._watch_job_run(
             job_name=job_name,
             full_job_name=job_run.name,
-            job_service_client=job_service_client,
+            job_service_async_client=job_service_async_client,
             current_state=job_run.state,
             until_states=(
                 JobState.JOB_STATE_SUCCEEDED,
@@ -492,11 +492,11 @@ class VertexAIWorker(BaseWorker):
         )
         return job_spec
 
-    def _create_and_begin_job(
+    async def _create_and_begin_job(
         self,
         job_name: str,
         job_spec: "CustomJobSpec",
-        job_service_client: "JobServiceClient",
+        job_service_async_client: "JobServiceAsyncClient",
         configuration: VertexAIWorkerJobConfiguration,
         logger: PrefectLogAdapter,
     ) -> "CustomJob":
@@ -521,9 +521,9 @@ class VertexAIWorker(BaseWorker):
         )
 
         create_custom_job_with_retries = retry_policy(
-            job_service_client.create_custom_job
+            job_service_async_client.create_custom_job
         )
-        custom_job_run = create_custom_job_with_retries(
+        custom_job_run = await create_custom_job_with_retries(
             parent=resource_name,
             custom_job=custom_job,
         )
@@ -535,11 +535,11 @@ class VertexAIWorker(BaseWorker):
 
         return custom_job_run
 
-    def _watch_job_run(
+    async def _watch_job_run(
         self,
         job_name: str,
         full_job_name: str,  # different from job_name
-        job_service_client: "JobServiceClient",
+        job_service_async_client: "JobServiceAsyncClient",
         current_state: "JobState",
         until_states: Tuple["JobState"],
         configuration: VertexAIWorkerJobConfiguration,
@@ -560,7 +560,7 @@ class VertexAIWorker(BaseWorker):
         t0 = time.time()
 
         while state not in until_states:
-            job_run = job_service_client.get_custom_job(
+            job_run = await job_service_async_client.get_custom_job(
                 name=full_job_name,
             )
             state = job_run.state
@@ -584,7 +584,7 @@ class VertexAIWorker(BaseWorker):
                     f"Timed out after {elapsed_time}s while watching job for states "
                     "{until_states!r}"
                 )
-            time.sleep(configuration.job_watch_poll_interval)
+            await asyncio.sleep(configuration.job_watch_poll_interval)
 
         return job_run
 
@@ -635,22 +635,23 @@ class VertexAIWorker(BaseWorker):
         client_options = ClientOptions(
             api_endpoint=f"{configuration.region}-aiplatform.googleapis.com"
         )
-        job_service_client = configuration.credentials.get_job_service_client(
-            client_options=client_options
+        job_service_async_client = (
+            configuration.credentials.get_job_service_async_client(
+                client_options=client_options
+            )
         )
-        await run_sync_in_worker_thread(
-            self._stop_job,
-            client=job_service_client,
+        await self._stop_job(
+            client=job_service_async_client,
             vertex_job_name=infrastructure_pid,
         )
 
-    def _stop_job(self, client: "JobServiceClient", vertex_job_name: str):
+    async def _stop_job(self, client: "JobServiceAsyncClient", vertex_job_name: str):
         """
         Calls the `cancel_custom_job` method on the Vertex AI Job Service Client.
         """
         cancel_custom_job_request = CancelCustomJobRequest(name=vertex_job_name)
         try:
-            client.cancel_custom_job(
+            await client.cancel_custom_job(
                 request=cancel_custom_job_request,
             )
         except Exception as exc:

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -64,7 +64,7 @@ try:
     from google.cloud.aiplatform_v1.types.job_state import JobState
     from google.cloud.aiplatform_v1.types.machine_resources import DiskSpec, MachineSpec
     from google.protobuf.duration_pb2 import Duration
-    from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
+    from tenacity import AsyncRetrying, stop_after_attempt, wait_fixed, wait_random
 except ModuleNotFoundError:
     pass
 
@@ -516,17 +516,14 @@ class VertexAIWorker(BaseWorker):
         project = configuration.project
         resource_name = f"projects/{project}/locations/{configuration.region}"
 
-        retry_policy = retry(
+        async for attempt in AsyncRetrying(
             stop=stop_after_attempt(3), wait=wait_fixed(1) + wait_random(0, 3)
-        )
-
-        create_custom_job_with_retries = retry_policy(
-            job_service_async_client.create_custom_job
-        )
-        custom_job_run = await create_custom_job_with_retries(
-            parent=resource_name,
-            custom_job=custom_job,
-        )
+        ):
+            with attempt:
+                custom_job_run = await job_service_async_client.create_custom_job(
+                    parent=resource_name,
+                    custom_job=custom_job,
+                )
 
         logger.info(
             f"Job {job_name!r} created. "

--- a/src/integrations/prefect-gcp/tests/conftest.py
+++ b/src/integrations/prefect-gcp/tests/conftest.py
@@ -276,18 +276,21 @@ def job_service_client():
 
 @pytest.fixture
 def job_service_async_client():
-    job_service_client_async_mock = AsyncMock()
-    custom_run = AsyncMock(name="mock_name")
-    job_service_client_async_mock.create_custom_job.return_value = custom_run
+    job_service_client_async_mock = MagicMock()
+    custom_run = MagicMock(name="mock_name")
+    job_service_client_async_mock.create_custom_job = AsyncMock(return_value=custom_run)
 
     error = MagicMock(message="")
-    custom_run_final = AsyncMock(
+    custom_run_final = MagicMock(
         name="mock_name",
         state=JobState.JOB_STATE_SUCCEEDED,
         error=error,
         display_name="mock_display_name",
     )
-    job_service_client_async_mock.get_custom_job.return_value = custom_run_final
+    job_service_client_async_mock.get_custom_job = AsyncMock(
+        return_value=custom_run_final
+    )
+    job_service_client_async_mock.cancel_custom_job = AsyncMock()
     return job_service_client_async_mock
 
 

--- a/src/integrations/prefect-gcp/tests/test_aiplatform.py
+++ b/src/integrations/prefect-gcp/tests/test_aiplatform.py
@@ -113,8 +113,8 @@ class TestVertexAICustomTrainingJob:
     ):
         identifier = "projects/1234/locations/us-east1/customJobs/12345"
         gcp_credentials = vertex_ai_custom_training_job.gcp_credentials
-        job_service_client = gcp_credentials.job_service_client
-        job_service_client.cancel_custom_job.side_effect = self.raise_not_found
+        job_service_async_client = gcp_credentials.job_service_async_client
+        job_service_async_client.cancel_custom_job.side_effect = self.raise_not_found
         with pytest.raises(
             InfrastructureNotFound, match="Cannot stop Vertex AI job; the job name"
         ):
@@ -128,8 +128,8 @@ class TestVertexAICustomTrainingJob:
     ):
         identifier = "projects/1234/locations/us-east1/customJobs/12345"
         gcp_credentials = vertex_ai_custom_training_job.gcp_credentials
-        job_service_client = gcp_credentials.job_service_client
-        job_service_client.cancel_custom_job.side_effect = self.raise_random_error
+        job_service_async_client = gcp_credentials.job_service_async_client
+        job_service_async_client.cancel_custom_job.side_effect = self.raise_random_error
         with pytest.raises(RuntimeError, match="Random error"):
             vertex_ai_custom_training_job.kill(identifier)
 
@@ -149,7 +149,7 @@ class TestVertexAICustomTrainingJob:
             display_name="mock_display_name",
         )
         gcp_credentials = vertex_ai_custom_training_job.gcp_credentials
-        gcp_credentials.job_service_client.get_custom_job.return_value = (
+        gcp_credentials.job_service_async_client.get_custom_job.return_value = (
             failed_run_final
         )
         with pytest.raises(RuntimeError, match="my error msg"):
@@ -159,13 +159,15 @@ class TestVertexAICustomTrainingJob:
         self, vertex_ai_custom_training_job: VertexAICustomTrainingJob
     ):
         gcp_credentials = vertex_ai_custom_training_job.gcp_credentials
-        gcp_credentials.job_service_client.create_custom_job.side_effect = (
+        gcp_credentials.job_service_async_client.create_custom_job.side_effect = (
             RuntimeError()
         )
 
         with pytest.raises(RetryError):
             vertex_ai_custom_training_job.run()
-        assert gcp_credentials.job_service_client.create_custom_job.call_count == 3
+        assert (
+            gcp_credentials.job_service_async_client.create_custom_job.call_count == 3
+        )
 
     def test_machine_spec(
         self, vertex_ai_custom_training_job: VertexAICustomTrainingJob

--- a/src/integrations/prefect-gcp/tests/test_credentials.py
+++ b/src/integrations/prefect-gcp/tests/test_credentials.py
@@ -157,8 +157,7 @@ def test_get_job_service_client(service_account_info, oauth2_credentials):
     test_flow()
 
 
-@pytest.mark.asyncio
-def test_get_job_service_async_client(service_account_info, oauth2_credentials):
+async def test_get_job_service_async_client(service_account_info, oauth2_credentials):
     @flow
     def test_flow():
         project = "test_project"
@@ -172,8 +171,9 @@ def test_get_job_service_async_client(service_account_info, oauth2_credentials):
     test_flow()
 
 
-@pytest.mark.asyncio
-def test_get_job_service_async_client_cached(service_account_info, oauth2_credentials):
+async def test_get_job_service_async_client_cached(
+    service_account_info, oauth2_credentials
+):
     """
     Test to ensure that _get_job_service_async_client_cached function returns the same instance
     for multiple calls with the same parameters and properly utilizes lru_cache.

--- a/src/integrations/prefect-gcp/tests/test_credentials.py
+++ b/src/integrations/prefect-gcp/tests/test_credentials.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from google.cloud.aiplatform.gapic import JobServiceClient
 from prefect_gcp import GcpCredentials
-from prefect_gcp.credentials import ClientType
+from prefect_gcp.credentials import ClientType, _get_job_service_client_cached
 
 from prefect import flow, task
 from prefect.blocks.core import Block
@@ -155,6 +155,31 @@ def test_get_job_service_client(service_account_info, oauth2_credentials):
         assert isinstance(client, JobServiceClient)
 
     test_flow()
+
+
+def test_get_job_service_client_cached(service_account_info, oauth2_credentials):
+    """
+    Test to ensure that _get_job_service_client_cached function returns the same instance
+    for multiple calls with the same parameters and properly utilizes lru_cache.
+    """
+    _get_job_service_client_cached.cache_clear()
+
+    project = "test_project"
+    credentials = GcpCredentials(
+        service_account_info=service_account_info,
+        project=project,
+    )
+
+    assert (
+        _get_job_service_client_cached.cache_info().hits == 0
+    ), "Initial call count should be 0"
+
+    credentials.get_job_service_client(client_options={})
+    credentials.get_job_service_client(client_options={})
+    credentials.get_job_service_client(client_options={})
+
+    assert _get_job_service_client_cached.cache_info().misses == 1
+    assert _get_job_service_client_cached.cache_info().hits == 2
 
 
 class MockTargetConfigs(Block):

--- a/src/integrations/prefect-gcp/tests/test_vertex_worker.py
+++ b/src/integrations/prefect-gcp/tests/test_vertex_worker.py
@@ -261,7 +261,6 @@ class TestVertexAIWorker:
             else:
                 raise AssertionError("Expected message not found.")
 
-    @pytest.mark.asyncio
     async def test_kill_infrastructure_not_found(self, job_config):
         async with VertexAIWorker("test-pool") as worker:
             job_config.credentials.job_service_async_client.cancel_custom_job.side_effect = Exception(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

Closes #12875 

- Clarifies logging
- Changes confusing/delayed logs about job state changes to debug level
- Fixes blocking sync sleep causing slow job submission by switching to `JobServiceAsyncClient`
- Caches Vertex job service client for stable high volume concurrent job monitoring

# Threading
While trying to test performance for concurrent job submission, I noticed that simultaneously submitted jobs were beginning very slowly. When submitting 3 jobs for example, the time between the flow run being picked up by the agent/worker and the job being created on Vertex for the third job was 10 seconds. This was due to the sync sleep during Vertex job state change polling not happening in its own thread. Switching to the `JobServiceAsyncClient`  eliminates the needs for thread management and uses async sleeps.

## Submission speed
Depending on the volume of job submissions and length of job runs, the blocking nature of the issue causes compounding delays in agent/worker handling of jobs. Here are a few tests I conducted.

### Before

Submitting 10 30-second training jobs:
**First run picked up by agent**: 3:29:22 PM
**Final training job marked as succeeded**: 3:34:11 PM
**Duration**: 4 minutes and 49 seconds

Submitting 50 30-second training jobs:
**First run picked up by agent**: 4:02:17 PM
**Final training job marked as succeeded**: 4:22:25 PM
**Duration**: 20 minutes and 8 seconds

### After

Submitting 10 30-second training jobs:
**First run picked up by agent**: 3:38:18 PM
**Final training job marked as succeeded**: 3:40:05 PM
**Duration**: 1 minute and 47 seconds

Submitting 50 30-second training jobs:
**First run picked up by agent**: 4:24:52 PM
**Final training job marked as succeeded**: 4:27:11 PM
**Duration**: 2 minutes and 19 seconds

# Memory consumption
Memory profiling is started *after* the agent/worker is already running, so peak memory usage data doesn't reflect the entire memory usage of the process, and is intended to highlight allocations associated with Vertex job submission and monitoring.

## Worker

Submitting 50 concurrent jobs before adding Vertex client caching:
Peak memory usage: 39.5 MiB
Note that the width of a call stack represents its memory consumption relative to the width of the root. Here, the widest single call stack is the creation of many Vertex Job Service Clients, comprising ~16 MiB.
<img width="2528" alt="image" src="https://github.com/PrefectHQ/prefect/assets/146098880/198aec50-2742-47c4-9d54-f45ef755046a">

Submitting 50 concurrent jobs after adding Vertex client caching:
Peak memory usage: 8.4 MiB
Using a single cached Vertex client, comprising 1.3 MiB.
<img width="2528" alt="image" src="https://github.com/PrefectHQ/prefect/assets/146098880/7f7253a9-0604-42f1-b575-b384c34db98f">


## Agent
How memory profiling appears when attached to a running agent looks a bit different since imports are captured, but the Vertex client diff is about the same, going from ~16 MiB to 1.3 MiB.

Submitting 50 concurrent jobs before adding Vertex client caching:
Peak memory usage: 217.2 MiB
The Vertex client allocations are the smaller orange bar on the left.
![image](https://github.com/PrefectHQ/prefect/assets/146098880/2cf3377b-3e7c-4d58-8eb2-b1c9936aca2a)

Submitting 50 concurrent jobs after adding Vertex client caching:
Peak memory usage: 186.3 MiB
The Vertex client allocations are the smallest orange bar on the right.
<img width="2528" alt="image" src="https://github.com/PrefectHQ/prefect/assets/146098880/044e5eec-bfa3-437b-8279-8098cbc926ac">



### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
