### PR TITLE
New engine: handle *args / **kwargs correctly

### DIFF
--- a/src/prefect/new_flow_engine.py
+++ b/src/prefect/new_flow_engine.py
@@ -294,7 +294,6 @@ async def run_flow(
     """
 
     engine = FlowRunEngine[P, R](flow, parameters, flow_run)
-    call_args, call_kwargs = parameters_to_args_kwargs(flow.fn, parameters or {})
 
     async with engine.start() as run:
         # This is a context manager that keeps track of the state of the flow run.
@@ -304,6 +303,9 @@ async def run_flow(
             async with run.enter_run_context():
                 try:
                     # This is where the flow is actually run.
+                    call_args, call_kwargs = parameters_to_args_kwargs(
+                        flow.fn, run.parameters or {}
+                    )
                     if flow.isasync:
                         result = cast(R, await flow.fn(*call_args, **call_kwargs))  # type: ignore
                     else:

--- a/src/prefect/new_flow_engine.py
+++ b/src/prefect/new_flow_engine.py
@@ -365,8 +365,8 @@ async def run_flow(
 
     engine = FlowRunEngine[P, R](flow, parameters, flow_run)
 
+    # This is a context manager that keeps track of the state of the flow run.
     async with engine.start() as run:
-        # This is a context manager that keeps track of the state of the flow run.
         await run.begin_run()
 
         while run.is_running():
@@ -376,7 +376,7 @@ async def run_flow(
                     call_args, call_kwargs = parameters_to_args_kwargs(
                         flow.fn, run.parameters or {}
                     )
-                    result = cast(R, await flow.fn(**(run.parameters or {})))  # type: ignore
+                    result = cast(R, await flow.fn(*call_args, **call_kwargs))  # type: ignore
                     # If the flow run is successful, finalize it.
                     await run.handle_success(result)
 
@@ -397,6 +397,7 @@ def run_flow_sync(
     return_type: Literal["state", "result"] = "result",
 ) -> Union[R, None]:
     engine = FlowRunEngine[P, R](flow, parameters, flow_run)
+
     # This is a context manager that keeps track of the state of the flow run.
     with engine.start_sync() as run:
         run_sync(run.begin_run())
@@ -405,7 +406,10 @@ def run_flow_sync(
             with run.enter_run_context_sync():
                 try:
                     # This is where the flow is actually run.
-                    result = cast(R, flow.fn(**(run.parameters or {})))  # type: ignore
+                    call_args, call_kwargs = parameters_to_args_kwargs(
+                        flow.fn, run.parameters or {}
+                    )
+                    result = cast(R, flow.fn(*call_args, **call_kwargs))  # type: ignore
                     # If the flow run is successful, finalize it.
                     run_sync(run.handle_success(result))
 

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -349,7 +349,6 @@ async def run_task(
     We will most likely want to use this logic as a wrapper and return a coroutine for type inference.
     """
     engine = TaskRunEngine[P, R](task=task, parameters=parameters, task_run=task_run)
-    call_args, call_kwargs = parameters_to_args_kwargs(task.fn, parameters or {})
 
     async with engine.start() as run:
         # This is a context manager that keeps track of the run of the task run.
@@ -360,6 +359,9 @@ async def run_task(
                 try:
                     # This is where the task is actually run.
                     async with timeout(run.task.timeout_seconds):
+                        call_args, call_kwargs = parameters_to_args_kwargs(
+                            task.fn, run.parameters or {}
+                        )
                         if task.isasync:
                             result = cast(R, await task.fn(*call_args, **call_kwargs))  # type: ignore
                         else:

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -408,8 +408,8 @@ async def run_task(
     """
     engine = TaskRunEngine[P, R](task=task, parameters=parameters, task_run=task_run)
 
+    # This is a context manager that keeps track of the run of the task run.
     async with engine.start() as run:
-        # This is a context manager that keeps track of the run of the task run.
         await run.begin_run()
 
         while run.is_running():
@@ -420,7 +420,7 @@ async def run_task(
                         call_args, call_kwargs = parameters_to_args_kwargs(
                             task.fn, run.parameters or {}
                         )
-                        result = cast(R, await task.fn(**(parameters or {})))  # type: ignore
+                        result = cast(R, await task.fn(*call_args, **call_kwargs))  # type: ignore
 
                     # If the task run is successful, finalize it.
                     await run.handle_success(result)
@@ -443,6 +443,7 @@ def run_task_sync(
     return_type: Literal["state", "result"] = "result",
 ) -> Union[R, State, None]:
     engine = TaskRunEngine[P, R](task=task, parameters=parameters, task_run=task_run)
+
     # This is a context manager that keeps track of the run of the task run.
     with engine.start_sync() as run:
         run_sync(run.begin_run())
@@ -452,7 +453,10 @@ def run_task_sync(
                 try:
                     # This is where the task is actually run.
                     with timeout_sync(run.task.timeout_seconds):
-                        result = cast(R, task.fn(**(parameters or {})))  # type: ignore
+                        call_args, call_kwargs = parameters_to_args_kwargs(
+                            task.fn, run.parameters or {}
+                        )
+                        result = cast(R, task.fn(*call_args, **call_kwargs))  # type: ignore
 
                     # If the task run is successful, finalize it.
                     run_sync(run.handle_success(result))

--- a/tests/test_new_flow_engine.py
+++ b/tests/test_new_flow_engine.py
@@ -52,7 +52,7 @@ class TestFlowRunEngine:
             engine.client
 
 
-class TestFlowRuns:
+class TestFlowRunsAsync:
     async def test_basic(self):
         @flow
         async def foo():
@@ -253,6 +253,32 @@ class TestFlowRunsSync:
         run = await prefect_client.read_flow_run(result)
 
         assert run.name == "name is blue"
+
+    def test_with_args(self):
+        @flow
+        def f(*args):
+            return args
+
+        args = (42, "nate")
+        result = f(*args)
+        assert result == args
+
+    def test_with_kwargs(self):
+        @flow
+        def f(**kwargs):
+            return kwargs
+
+        kwargs = dict(x=42, y="nate")
+        result = f(**kwargs)
+        assert result == kwargs
+
+    def test_with_args_kwargs(self):
+        @flow
+        def f(*args, x, **kwargs):
+            return args, x, kwargs
+
+        result = f(1, 2, x=5, y=6, z=7)
+        assert result == ((1, 2), 5, dict(y=6, z=7))
 
     async def test_get_run_logger(self, caplog):
         caplog.set_level(logging.CRITICAL)

--- a/tests/test_new_flow_engine.py
+++ b/tests/test_new_flow_engine.py
@@ -106,6 +106,32 @@ class TestFlowRuns:
 
         assert run.name == "name is blue"
 
+    async def test_with_args(self):
+        @flow
+        async def f(*args):
+            return args
+
+        args = (42, "nate")
+        result = await f(*args)
+        assert result == args
+
+    async def test_with_kwargs(self):
+        @flow
+        async def f(**kwargs):
+            return kwargs
+
+        kwargs = dict(x=42, y="nate")
+        result = await f(**kwargs)
+        assert result == kwargs
+
+    async def test_with_args_kwargs(self):
+        @flow
+        async def f(*args, x, **kwargs):
+            return args, x, kwargs
+
+        result = await f(1, 2, x=5, y=6, z=7)
+        assert result == ((1, 2), 5, dict(y=6, z=7))
+
     async def test_get_run_logger(self, caplog):
         caplog.set_level(logging.CRITICAL)
 

--- a/tests/test_new_task_engine.py
+++ b/tests/test_new_task_engine.py
@@ -78,6 +78,32 @@ class TestTaskRuns:
 
         assert result == (42, "nate")
 
+    async def test_with_args(self):
+        @task
+        async def f(*args):
+            return args
+
+        args = (42, "nate")
+        result = await f(*args)
+        assert result == args
+
+    async def test_with_kwargs(self):
+        @task
+        async def f(**kwargs):
+            return kwargs
+
+        kwargs = dict(x=42, y="nate")
+        result = await f(**kwargs)
+        assert result == kwargs
+
+    async def test_with_args_kwargs(self):
+        @task
+        async def f(*args, x, **kwargs):
+            return args, x, kwargs
+
+        result = await f(1, 2, x=5, y=6, z=7)
+        assert result == ((1, 2), 5, dict(y=6, z=7))
+
     async def test_task_run_name(self, prefect_client):
         @task(task_run_name="name is {x}")
         async def foo(x):

--- a/tests/test_new_task_engine.py
+++ b/tests/test_new_task_engine.py
@@ -60,7 +60,7 @@ class TestTaskRunEngine:
             engine.client
 
 
-class TestTaskRuns:
+class TestTaskRunsAsync:
     async def test_basic(self):
         @task
         async def foo():
@@ -274,6 +274,32 @@ class TestTaskRunsSync:
         parameters = get_call_parameters(bar.fn, (42,), dict(y="nate"))
         result = run_task_sync(bar, parameters=parameters)
         assert result == (42, "nate")
+
+    def test_with_args(self):
+        @task
+        def f(*args):
+            return args
+
+        args = (42, "nate")
+        result = f(*args)
+        assert result == args
+
+    def test_with_kwargs(self):
+        @task
+        def f(**kwargs):
+            return kwargs
+
+        kwargs = dict(x=42, y="nate")
+        result = f(**kwargs)
+        assert result == kwargs
+
+    def test_with_args_kwargs(self):
+        @task
+        def f(*args, x, **kwargs):
+            return args, x, kwargs
+
+        result = f(1, 2, x=5, y=6, z=7)
+        assert result == ((1, 2), 5, dict(y=6, z=7))
 
     async def test_task_run_name(self, prefect_client):
         @task(task_run_name="name is {x}")


### PR DESCRIPTION
The new engine currently doesn't handle args/kwargs because they are not "unwrapped" appropriately (they are passed to the underlying functions as literally `args=<args>` and `kwargs=<kwargs>`. This PR calls the appropriate utility to prepare them for the function call, and adds tests.

```python
from prefect import task

@task
def f(**kwargs):
	return kwargs

assert f(x=1, y=2) == {'x': 1, 'y': 2}
# on `main` this would error because the result is {'kwargs': {'x': 1, 'y': 2}} 
```