### PR TITLE
Revert console setup changes to fix interactivity

### DIFF
--- a/src/prefect/cli/_types.py
+++ b/src/prefect/cli/_types.py
@@ -168,3 +168,12 @@ class PrefectTyper(typer.Typer):
             return original_command
 
         return wrapper
+
+    def setup_console(self, soft_wrap: bool, prompt: bool):
+        self.console = Console(
+            highlight=False,
+            color_system="auto" if PREFECT_CLI_COLORS else None,
+            theme=Theme({"prompt.choices": "bold blue"}),
+            soft_wrap=not soft_wrap,
+            force_interactive=prompt,
+        )

--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -7,9 +7,7 @@ import platform
 import sys
 
 import pendulum
-import rich.console
 import typer
-from rich.theme import Theme
 
 import prefect
 import prefect.context
@@ -20,7 +18,6 @@ from prefect.client.constants import SERVER_API_VERSION
 from prefect.client.orchestration import ServerType
 from prefect.logging.configuration import setup_logging
 from prefect.settings import (
-    PREFECT_CLI_COLORS,
     PREFECT_CLI_WRAP_LINES,
     PREFECT_TEST_MODE,
 )
@@ -77,14 +74,7 @@ def main(
             exit(1)
 
     # Configure the output console after loading the profile
-    app.console = rich.console.Console(
-        highlight=False,
-        color_system="auto" if PREFECT_CLI_COLORS else None,
-        theme=Theme({"prompt.choices": "bold blue"}),
-        # `soft_wrap` disables wrapping when `True`
-        soft_wrap=not PREFECT_CLI_WRAP_LINES.value(),
-        force_interactive=prompt,
-    )
+    app.setup_console(soft_wrap=PREFECT_CLI_WRAP_LINES.value(), prompt=prompt)
 
     if not PREFECT_TEST_MODE:
         # When testing, this entrypoint can be called multiple times per process which

--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -7,7 +7,9 @@ import platform
 import sys
 
 import pendulum
+import rich.console
 import typer
+from rich.theme import Theme
 
 import prefect
 import prefect.context
@@ -18,6 +20,7 @@ from prefect.client.constants import SERVER_API_VERSION
 from prefect.client.orchestration import ServerType
 from prefect.logging.configuration import setup_logging
 from prefect.settings import (
+    PREFECT_CLI_COLORS,
     PREFECT_CLI_WRAP_LINES,
     PREFECT_TEST_MODE,
 )
@@ -74,9 +77,14 @@ def main(
             exit(1)
 
     # Configure the output console after loading the profile
-
-    app.console.is_interactive = prompt
-    app.console.soft_wrap = not PREFECT_CLI_WRAP_LINES.value()
+    app.console = rich.console.Console(
+        highlight=False,
+        color_system="auto" if PREFECT_CLI_COLORS else None,
+        theme=Theme({"prompt.choices": "bold blue"}),
+        # `soft_wrap` disables wrapping when `True`
+        soft_wrap=not PREFECT_CLI_WRAP_LINES.value(),
+        force_interactive=prompt,
+    )
 
     if not PREFECT_TEST_MODE:
         # When testing, this entrypoint can be called multiple times per process which


### PR DESCRIPTION
fixes bad interactive CLI detection that seems to have been introduced by https://github.com/PrefectHQ/prefect/pull/12800

leading to the following behavior (currently on `main`)
```python
» prefect cloud login
When not using an interactive terminal, you must supply a `--key` and `--workspace`.
```

even though
```python
In [1]: from rich.console import Console

In [2]: Console().is_interactive
Out[2]: True
```

which is the only thing that should matter with `PREFECT_CLI_PROMPT` unset