### PR TITLE
Log full output of databricks job

### DIFF
--- a/src/integrations/prefect-databricks/prefect_databricks/flows.py
+++ b/src/integrations/prefect-databricks/prefect_databricks/flows.py
@@ -4,7 +4,7 @@ Module containing flows for interacting with Databricks
 
 import asyncio
 from logging import Logger
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from prefect import flow, get_run_logger
 from prefect_databricks import DatabricksCredentials
@@ -65,8 +65,9 @@ async def jobs_runs_submit_and_wait_for_completion(
     timeout_seconds: Optional[int] = None,
     idempotency_token: Optional[str] = None,
     access_control_list: Optional[List[AccessControlRequest]] = None,
+    return_metadata: bool = False,
     **jobs_runs_submit_kwargs: Dict[str, Any],
-) -> Tuple[Dict, Any]:
+) -> Union[Dict, Tuple[Dict, Any]]:
     """
     Flow that triggers a job run and waits for the triggered run to complete.
 
@@ -178,12 +179,16 @@ async def jobs_runs_submit_and_wait_for_completion(
         max_wait_seconds: Maximum number of seconds to wait for the entire flow to complete.
         poll_frequency_seconds: Number of seconds to wait in between checks for
             run completion.
+        return_metadata: When True, method will return a tuple of notebook outputs as well as
+            job run metadata; by default though, the method only returns notebook output
         **jobs_runs_submit_kwargs: Additional keyword arguments to pass to `jobs_runs_submit`.
 
     Returns:
-        A tuple comprised of
-        * task_notebook_outputs: dictionary of task keys to its corresponding notebook output.
-        * jobs_runs_metadata: dictionary containing IDs of the jobs runs tasks.
+        Either a dict or a tuple (depends on `return_metadata`) comprised of
+        * task_notebook_outputs: dictionary of task keys to its corresponding notebook output;
+          this is the only object returned by default from this method
+        * jobs_runs_metadata: dictionary containing IDs of the jobs runs tasks; this is only
+          return if `return_metadata=True`.
 
     Examples:
         Submit jobs runs and wait.
@@ -292,7 +297,9 @@ async def jobs_runs_submit_and_wait_for_completion(
                 run_name,
                 multi_task_jobs_runs_id,
             )
-            return task_notebook_outputs, jobs_runs_metadata
+            if return_metadata:
+                return task_notebook_outputs, jobs_runs_metadata
+            return task_notebook_outputs
         else:
             raise DatabricksJobTerminated(
                 f"Databricks Jobs Runs Submit "

--- a/src/integrations/prefect-databricks/prefect_databricks/flows.py
+++ b/src/integrations/prefect-databricks/prefect_databricks/flows.py
@@ -4,7 +4,7 @@ Module containing flows for interacting with Databricks
 
 import asyncio
 from logging import Logger
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from prefect import flow, get_run_logger
 from prefect_databricks import DatabricksCredentials
@@ -66,7 +66,7 @@ async def jobs_runs_submit_and_wait_for_completion(
     idempotency_token: Optional[str] = None,
     access_control_list: Optional[List[AccessControlRequest]] = None,
     **jobs_runs_submit_kwargs: Dict[str, Any],
-) -> Dict:
+) -> Tuple[Dict, Any]:
     """
     Flow that triggers a job run and waits for the triggered run to complete.
 
@@ -181,7 +181,9 @@ async def jobs_runs_submit_and_wait_for_completion(
         **jobs_runs_submit_kwargs: Additional keyword arguments to pass to `jobs_runs_submit`.
 
     Returns:
-        A dictionary of task keys to its corresponding notebook output.
+        A tuple comprised of
+        * task_notebook_outputs: dictionary of task keys to its corresponding notebook output.
+        * jobs_runs_metadata: dictionary containing IDs of the jobs runs tasks.
 
     Examples:
         Submit jobs runs and wait.
@@ -290,7 +292,7 @@ async def jobs_runs_submit_and_wait_for_completion(
                 run_name,
                 multi_task_jobs_runs_id,
             )
-            return task_notebook_outputs
+            return task_notebook_outputs, jobs_runs_metadata
         else:
             raise DatabricksJobTerminated(
                 f"Databricks Jobs Runs Submit "

--- a/src/integrations/prefect-databricks/prefect_databricks/flows.py
+++ b/src/integrations/prefect-databricks/prefect_databricks/flows.py
@@ -21,6 +21,9 @@ from prefect_databricks.models.jobs import (
     RunSubmitTaskSettings,
 )
 
+JobMetadata = Dict[str, Any]
+NotebookOutput = Dict[str, Any]
+
 
 class DatabricksJobTerminated(Exception):
     """Raised when Databricks jobs runs submit terminates"""
@@ -67,7 +70,7 @@ async def jobs_runs_submit_and_wait_for_completion(
     access_control_list: Optional[List[AccessControlRequest]] = None,
     return_metadata: bool = False,
     **jobs_runs_submit_kwargs: Dict[str, Any],
-) -> Union[Dict, Tuple[Dict, Any]]:
+) -> Union[NotebookOutput, Tuple[NotebookOutput, JobMetadata]]:
     """
     Flow that triggers a job run and waits for the triggered run to complete.
 
@@ -179,7 +182,7 @@ async def jobs_runs_submit_and_wait_for_completion(
         max_wait_seconds: Maximum number of seconds to wait for the entire flow to complete.
         poll_frequency_seconds: Number of seconds to wait in between checks for
             run completion.
-        return_metadata: When True, method will return a tuple of notebook outputs as well as
+        return_metadata: When True, method will return a tuple of notebook output as well as
             job run metadata; by default though, the method only returns notebook output
         **jobs_runs_submit_kwargs: Additional keyword arguments to pass to `jobs_runs_submit`.
 
@@ -188,7 +191,7 @@ async def jobs_runs_submit_and_wait_for_completion(
         * task_notebook_outputs: dictionary of task keys to its corresponding notebook output;
           this is the only object returned by default from this method
         * jobs_runs_metadata: dictionary containing IDs of the jobs runs tasks; this is only
-          return if `return_metadata=True`.
+          returned if `return_metadata=True`.
 
     Examples:
         Submit jobs runs and wait.

--- a/src/integrations/prefect-databricks/tests/test_flows.py
+++ b/src/integrations/prefect-databricks/tests/test_flows.py
@@ -132,6 +132,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         result, jobs_runs_metadata = await jobs_runs_submit_and_wait_for_completion(
             databricks_credentials=databricks_credentials,
             run_name="prefect-job",
+            return_metadata=True,
             tasks=[
                 {
                     "notebook_task": {
@@ -159,7 +160,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
             headers={"Authorization": "Bearer testing_token"},
         ).mock(return_value=Response(200, json={"metadata": {"cell": "output"}}))
 
-        result, jobs_runs_metadata = await jobs_runs_submit_and_wait_for_completion(
+        result = await jobs_runs_submit_and_wait_for_completion(
             databricks_credentials=databricks_credentials,
             run_name="prefect-job",
             tasks=[
@@ -176,25 +177,6 @@ class TestJobsRunsSubmitAndWaitForCompletion:
             poll_frequency_seconds=1,
         )
         assert result == {"prefect-task": {}}
-        assert jobs_runs_metadata == {
-            "run_id": 36108,
-            "state": {
-                "life_cycle_state": "TERMINATED",
-                "state_message": "",
-                "result_state": "SUCCESS",
-            },
-            "tasks": [
-                {
-                    "run_id": 36260,
-                    "task_key": "prefect-task",
-                    "state": {
-                        "life_cycle_state": "TERMINATED",
-                        "result_state": "",
-                        "state_message": "SUCCESS",
-                    },
-                }
-            ],
-        }
 
     @pytest.mark.respx(assert_all_called=True)
     @pytest.mark.parametrize("result_state", ["FAILED", "TIMEDOUT", "CANCELED"])
@@ -378,7 +360,7 @@ class TestJobsRunsSubmitAndWaitForCompletion:
             headers={"Authorization": "Bearer testing_token"},
         ).mock(return_value=Response(200, json={"notebook_output": {"cell": "output"}}))
 
-        result, jobs_runs_metadata = await jobs_runs_submit_and_wait_for_completion(
+        result = await jobs_runs_submit_and_wait_for_completion(
             databricks_credentials=databricks_credentials,
             tasks=[
                 {


### PR DESCRIPTION
When a databricks notebook is submitted for execution, it kicks off a cascade of subflows; when this notebook fails, it's difficult to get at the logs and to find the URL of the notebook execution that was created without having to click through all those subflows. This updates the return of `jobs_runs_submit_and_wait_for_completion` with the full metadata output of the job so that it can bubble up to the parent flow that kicks off this works - this means, for example, the notebook URL can be logged at the very top.

### Example
```python
from prefect import flow, get_logger
from prefect_databricks import jobs_runs_submit_and_wait_for_completion

@flow
def my_flow():

    logger = get_logger()
    notebook_output, jobs_meta = jobs_runs_submit_and_wait_for_completion(...)

    logger.info(jobs_meta.get("run_page_url")
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [x] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
