### PR TITLE
Allow case-insensitive state and state type handling when listing flow runs via CLI

### DIFF
--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -66,7 +66,7 @@ async def ls(
 
         flow_name: Name of the flow
 
-        limit: Maximum number of flow runs to list
+        limit: Maximum number of flow runs to list. Defaults to 15.
 
         state: Name of the flow run's state. Can be provided multiple times. Options are 'SCHEDULED', 'PENDING', 'RUNNING', 'COMPLETED', 'FAILED', 'CRASHED', 'CANCELLING', 'CANCELLED', 'PAUSED', 'SUSPENDED', 'AWAITINGRETRY', 'RETRYING', and 'LATE'.
 
@@ -78,9 +78,9 @@ async def ls(
 
     $ prefect flow-runs ls --state Running --state late
 
-    $ prefect flow-runs ls --state_type RUNNING
+    $ prefect flow-runs ls --state-type RUNNING
 
-    $ prefect flow-runs ls --state_type RUNNING --state_type FAILED
+    $ prefect flow-runs ls --state-type RUNNING --state-type FAILED
     """
 
     # Handling `state` and `state_type` argument validity in the function instead of by specifying

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -86,7 +86,6 @@ async def ls(
     state_filter = {}
     if state:
         upper_cased_states = [s.upper() for s in state]
-        # Upper case to check `StateName` enum membership
         if not all(s in StateName.__members__ for s in upper_cased_states):
             exit_with_error(
                 f"Invalid state name. Options are {', '.join([name.value for name in StateName])}."

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -63,19 +63,23 @@ async def ls(
     View recent flow runs or flow runs for specific flows.
 
     Arguments:
+
         flow_name: Name of the flow
+
         limit: Maximum number of flow runs to list
-        state: Name of the flow run's state. Can be provided multiple times. Options are
-            'SCHEDULED', 'PENDING', 'RUNNING', 'COMPLETED', 'FAILED', 'CRASHED', 'CANCELLING',
-            'CANCELLED', 'PAUSED', 'SUSPENDED', 'AWAITINGRETRY', 'RETRYING', and 'LATE'.
-        state_type: Type of the flow run's state. Can be provided multiple times. Options are
-            'SCHEDULED', 'PENDING', 'RUNNING', 'COMPLETED', 'FAILED', 'CRASHED', 'CANCELLING', 'CANCELLED',
-            'CRASHED', and 'PAUSED'.
+
+        state: Name of the flow run's state. Can be provided multiple times. Options are 'SCHEDULED', 'PENDING', 'RUNNING', 'COMPLETED', 'FAILED', 'CRASHED', 'CANCELLING', 'CANCELLED', 'PAUSED', 'SUSPENDED', 'AWAITINGRETRY', 'RETRYING', and 'LATE'.
+
+        state_type: Type of the flow run's state. Can be provided multiple times. Options are 'SCHEDULED', 'PENDING', 'RUNNING', 'COMPLETED', 'FAILED', 'CRASHED', 'CANCELLING', 'CANCELLED', 'CRASHED', and 'PAUSED'.
 
     Examples:
+
     $ prefect flow-runs ls --state Running
+
     $ prefect flow-runs ls --state Running --state late
+
     $ prefect flow-runs ls --state_type RUNNING
+
     $ prefect flow-runs ls --state_type RUNNING --state_type FAILED
     """
 
@@ -118,6 +122,9 @@ async def ls(
                 flow_filter=FlowFilter(id={"any_": [run.flow_id for run in flow_runs]})
             )
         }
+
+        if not flow_runs:
+            exit_with_success("No flow runs found.")
 
     table = Table(title="Flow Runs")
     table.add_column("ID", justify="right", style="cyan", no_wrap=True)

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -90,22 +90,6 @@ class StateType(AutoEnum):
     CANCELLING = AutoEnum.auto()
 
 
-class StateName(AutoEnum):
-    SCHEDULED = "Scheduled"
-    PENDING = "Pending"
-    RUNNING = "Running"
-    COMPLETED = "Completed"
-    FAILED = "Failed"
-    CANCELLED = "Cancelled"
-    CRASHED = "Crashed"
-    PAUSED = "Paused"
-    CANCELLING = "Cancelling"
-    SUSPENDED = "Suspended"
-    AWAITINGRETRY = "AwaitingRetry"
-    RETRYING = "Retrying"
-    LATE = "Late"
-
-
 class WorkPoolStatus(AutoEnum):
     """Enumeration of work pool statuses."""
 

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -90,19 +90,19 @@ class StateType(AutoEnum):
 
 
 class StateName(AutoEnum):
-    SCHEDULED = AutoEnum.auto()
-    PENDING = AutoEnum.auto()
-    RUNNING = AutoEnum.auto()
-    COMPLETED = AutoEnum.auto()
-    FAILED = AutoEnum.auto()
-    CANCELLED = AutoEnum.auto()
-    CRASHED = AutoEnum.auto()
-    PAUSED = AutoEnum.auto()
-    CANCELLING = AutoEnum.auto()
-    SUSPENDED = AutoEnum.auto()
-    AWAITINGRETRY = AutoEnum.auto()
-    RETRYING = AutoEnum.auto()
-    LATE = AutoEnum.auto()
+    SCHEDULED = "Scheduled"
+    PENDING = "Pending"
+    RUNNING = "Running"
+    COMPLETED = "Completed"
+    FAILED = "Failed"
+    CANCELLED = "Cancelled"
+    CRASHED = "Crashed"
+    PAUSED = "Paused"
+    CANCELLING = "Cancelling"
+    SUSPENDED = "Suspended"
+    AWAITINGRETRY = "AwaitingRetry"
+    RETRYING = "Retrying"
+    LATE = "Late"
 
 
 class WorkPoolStatus(AutoEnum):

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -89,6 +89,22 @@ class StateType(AutoEnum):
     CANCELLING = AutoEnum.auto()
 
 
+class StateName(AutoEnum):
+    SCHEDULED = AutoEnum.auto()
+    PENDING = AutoEnum.auto()
+    RUNNING = AutoEnum.auto()
+    COMPLETED = AutoEnum.auto()
+    FAILED = AutoEnum.auto()
+    CANCELLED = AutoEnum.auto()
+    CRASHED = AutoEnum.auto()
+    PAUSED = AutoEnum.auto()
+    CANCELLING = AutoEnum.auto()
+    SUSPENDED = AutoEnum.auto()
+    AWAITINGRETRY = AutoEnum.auto()
+    RETRYING = AutoEnum.auto()
+    LATE = AutoEnum.auto()
+
+
 class WorkPoolStatus(AutoEnum):
     """Enumeration of work pool statuses."""
 

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -194,31 +194,31 @@ def test_ls_state_type_filter_invalid_raises():
     )
 
 
-# @pytest.mark.parametrize(
-#     "state_name",
-#     [
-#         "Late",
-#         "LATE",
-#         "late",
-#     ],
-# )
-# def test_ls_state_name_filter(
-#     scheduled_flow_run,
-#     completed_flow_run,
-#     running_flow_run,
-#     late_flow_run,
-#     state_name,
-# ):
-#     result = invoke_and_assert(
-#         command=["flow-run", "ls", "--state", state_name],
-#         expected_code=0,
-#     )
+@pytest.mark.parametrize(
+    "state_name",
+    [
+        "Late",
+        "LATE",
+        "late",
+    ],
+)
+def test_ls_state_name_filter(
+    scheduled_flow_run,
+    completed_flow_run,
+    running_flow_run,
+    late_flow_run,
+    state_name,
+):
+    result = invoke_and_assert(
+        command=["flow-run", "ls", "--state", state_name],
+        expected_code=0,
+    )
 
-#     assert_flow_runs_in_result(
-#         result,
-#         expected=[late_flow_run],
-#         unexpected=[running_flow_run, scheduled_flow_run, completed_flow_run],
-#     )
+    assert_flow_runs_in_result(
+        result,
+        expected=[late_flow_run],
+        unexpected=[running_flow_run, scheduled_flow_run, completed_flow_run],
+    )
 
 
 def test_ls_state_name_filter_invalid_raises():

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -131,104 +131,104 @@ def test_ls_no_args(
     )
 
 
-def test_ls_flow_name_filter(
-    scheduled_flow_run,
-    completed_flow_run,
-    running_flow_run,
-    late_flow_run,
-):
-    result = invoke_and_assert(
-        command=["flow-run", "ls", "--flow-name", "goodbye"],
-        expected_code=0,
-    )
+# def test_ls_flow_name_filter(
+#     scheduled_flow_run,
+#     completed_flow_run,
+#     running_flow_run,
+#     late_flow_run,
+# ):
+#     result = invoke_and_assert(
+#         command=["flow-run", "ls", "--flow-name", "goodbye"],
+#         expected_code=0,
+#     )
 
-    assert_flow_runs_in_result(
-        result,
-        expected=[running_flow_run, late_flow_run],
-        unexpected=[scheduled_flow_run, completed_flow_run],
-    )
-
-
-@pytest.mark.parametrize(
-    "state_type_1, state_type_2",
-    [
-        ("completed", "running"),
-        ("COMPLETED", "RUNNING"),
-        ("Completed", "Running"),
-    ],
-)
-def test_ls_state_type_filter(
-    scheduled_flow_run,
-    completed_flow_run,
-    running_flow_run,
-    late_flow_run,
-    state_type_1,
-    state_type_2,
-):
-    result = invoke_and_assert(
-        command=[
-            "flow-run",
-            "ls",
-            "--state-type",
-            state_type_1,
-            "--state-type",
-            state_type_2,
-        ],
-        expected_code=0,
-    )
-
-    assert_flow_runs_in_result(
-        result,
-        expected=[running_flow_run, completed_flow_run],
-        unexpected=[scheduled_flow_run, late_flow_run],
-    )
+#     assert_flow_runs_in_result(
+#         result,
+#         expected=[running_flow_run, late_flow_run],
+#         unexpected=[scheduled_flow_run, completed_flow_run],
+#     )
 
 
-def test_ls_state_type_filter_invalid_raises():
-    invoke_and_assert(
-        command=["flow-run", "ls", "--state-type", "invalid"],
-        expected_code=1,
-        expected_output_contains=(
-            "Invalid state type. Options are SCHEDULED, PENDING, RUNNING, COMPLETED, FAILED, CANCELLED, CRASHED, PAUSED, CANCELLING."
-        ),
-    )
+# @pytest.mark.parametrize(
+#     "state_type_1, state_type_2",
+#     [
+#         ("completed", "running"),
+#         ("COMPLETED", "RUNNING"),
+#         ("Completed", "Running"),
+#     ],
+# )
+# def test_ls_state_type_filter(
+#     scheduled_flow_run,
+#     completed_flow_run,
+#     running_flow_run,
+#     late_flow_run,
+#     state_type_1,
+#     state_type_2,
+# ):
+#     result = invoke_and_assert(
+#         command=[
+#             "flow-run",
+#             "ls",
+#             "--state-type",
+#             state_type_1,
+#             "--state-type",
+#             state_type_2,
+#         ],
+#         expected_code=0,
+#     )
+
+#     assert_flow_runs_in_result(
+#         result,
+#         expected=[running_flow_run, completed_flow_run],
+#         unexpected=[scheduled_flow_run, late_flow_run],
+#     )
 
 
-@pytest.mark.parametrize(
-    "state_name",
-    [
-        "Late",
-        "LATE",
-        "late",
-    ],
-)
-def test_ls_state_name_filter(
-    scheduled_flow_run,
-    completed_flow_run,
-    running_flow_run,
-    late_flow_run,
-    state_name,
-):
-    result = invoke_and_assert(
-        command=["flow-run", "ls", "--state", state_name],
-        expected_code=0,
-    )
-
-    assert_flow_runs_in_result(
-        result,
-        expected=[late_flow_run],
-        unexpected=[running_flow_run, scheduled_flow_run, completed_flow_run],
-    )
+# def test_ls_state_type_filter_invalid_raises():
+#     invoke_and_assert(
+#         command=["flow-run", "ls", "--state-type", "invalid"],
+#         expected_code=1,
+#         expected_output_contains=(
+#             "Invalid state type. Options are SCHEDULED, PENDING, RUNNING, COMPLETED, FAILED, CANCELLED, CRASHED, PAUSED, CANCELLING."
+#         ),
+#     )
 
 
-def test_ls_state_name_filter_invalid_raises():
-    invoke_and_assert(
-        command=["flow-run", "ls", "--state", "invalid"],
-        expected_code=1,
-        expected_output_contains=(
-            "Invalid state name. Options are Scheduled, Pending, Running, Completed, Failed, Cancelled, Crashed, Paused, Cancelling, Suspended, AwaitingRetry, Retrying, Late."
-        ),
-    )
+# @pytest.mark.parametrize(
+#     "state_name",
+#     [
+#         "Late",
+#         "LATE",
+#         "late",
+#     ],
+# )
+# def test_ls_state_name_filter(
+#     scheduled_flow_run,
+#     completed_flow_run,
+#     running_flow_run,
+#     late_flow_run,
+#     state_name,
+# ):
+#     result = invoke_and_assert(
+#         command=["flow-run", "ls", "--state", state_name],
+#         expected_code=0,
+#     )
+
+#     assert_flow_runs_in_result(
+#         result,
+#         expected=[late_flow_run],
+#         unexpected=[running_flow_run, scheduled_flow_run, completed_flow_run],
+#     )
+
+
+# def test_ls_state_name_filter_invalid_raises():
+#     invoke_and_assert(
+#         command=["flow-run", "ls", "--state", "invalid"],
+#         expected_code=1,
+#         expected_output_contains=(
+#             "Invalid state name. Options are Scheduled, Pending, Running, Completed, Failed, Cancelled, Crashed, Paused, Cancelling, Suspended, AwaitingRetry, Retrying, Late."
+#         ),
+#     )
 
 
 def test_ls_limit(

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -149,39 +149,39 @@ def test_ls_flow_name_filter(
     )
 
 
-# @pytest.mark.parametrize(
-#     "state_type_1, state_type_2",
-#     [
-#         ("completed", "running"),
-#         ("COMPLETED", "RUNNING"),
-#         ("Completed", "Running"),
-#     ],
-# )
-# def test_ls_state_type_filter(
-#     scheduled_flow_run,
-#     completed_flow_run,
-#     running_flow_run,
-#     late_flow_run,
-#     state_type_1,
-#     state_type_2,
-# ):
-#     result = invoke_and_assert(
-#         command=[
-#             "flow-run",
-#             "ls",
-#             "--state-type",
-#             state_type_1,
-#             "--state-type",
-#             state_type_2,
-#         ],
-#         expected_code=0,
-#     )
+@pytest.mark.parametrize(
+    "state_type_1, state_type_2",
+    [
+        ("completed", "running"),
+        ("COMPLETED", "RUNNING"),
+        ("Completed", "Running"),
+    ],
+)
+def test_ls_state_type_filter(
+    scheduled_flow_run,
+    completed_flow_run,
+    running_flow_run,
+    late_flow_run,
+    state_type_1,
+    state_type_2,
+):
+    result = invoke_and_assert(
+        command=[
+            "flow-run",
+            "ls",
+            "--state-type",
+            state_type_1,
+            "--state-type",
+            state_type_2,
+        ],
+        expected_code=0,
+    )
 
-#     assert_flow_runs_in_result(
-#         result,
-#         expected=[running_flow_run, completed_flow_run],
-#         unexpected=[scheduled_flow_run, late_flow_run],
-#     )
+    assert_flow_runs_in_result(
+        result,
+        expected=[running_flow_run, completed_flow_run],
+        unexpected=[scheduled_flow_run, late_flow_run],
+    )
 
 
 def test_ls_state_type_filter_invalid_raises():

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -149,20 +149,30 @@ def test_ls_flow_name_filter(
     )
 
 
+@pytest.mark.parametrize(
+    "state_type_1, state_type_2",
+    [
+        ("completed", "running"),
+        ("COMPLETED", "RUNNING"),
+        ("Completed", "Running"),
+    ],
+)
 def test_ls_state_type_filter(
     scheduled_flow_run,
     completed_flow_run,
     running_flow_run,
     late_flow_run,
+    state_type_1,
+    state_type_2,
 ):
     result = invoke_and_assert(
         command=[
             "flow-run",
             "ls",
             "--state-type",
-            "COMPLETED",
+            state_type_1,
             "--state-type",
-            "RUNNING",
+            state_type_2,
         ],
         expected_code=0,
     )
@@ -174,14 +184,33 @@ def test_ls_state_type_filter(
     )
 
 
+def test_ls_state_type_filter_invalid_raises():
+    invoke_and_assert(
+        command=["flow-run", "ls", "--state-type", "invalid"],
+        expected_code=1,
+        expected_output_contains=(
+            "Invalid state type. Options are SCHEDULED, PENDING, RUNNING, COMPLETED, FAILED, CANCELLED, CRASHED, PAUSED, CANCELLING."
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "state_name",
+    [
+        "Late",
+        "LATE",
+        "late",
+    ],
+)
 def test_ls_state_name_filter(
     scheduled_flow_run,
     completed_flow_run,
     running_flow_run,
     late_flow_run,
+    state_name,
 ):
     result = invoke_and_assert(
-        command=["flow-run", "ls", "--state", "Late"],
+        command=["flow-run", "ls", "--state", state_name],
         expected_code=0,
     )
 
@@ -189,6 +218,16 @@ def test_ls_state_name_filter(
         result,
         expected=[late_flow_run],
         unexpected=[running_flow_run, scheduled_flow_run, completed_flow_run],
+    )
+
+
+def test_ls_state_name_filter_invalid_raises():
+    invoke_and_assert(
+        command=["flow-run", "ls", "--state", "invalid"],
+        expected_code=1,
+        expected_output_contains=(
+            "Invalid state name. Options are Scheduled, Pending, Running, Completed, Failed, Cancelled, Crashed, Paused, Cancelling, Suspended, AwaitingRetry, Retrying, Late."
+        ),
     )
 
 

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -221,13 +221,16 @@ def test_ls_state_name_filter(
     )
 
 
-def test_ls_state_name_filter_invalid_raises():
+def test_ls_state_name_filter_unofficial_state_warns(caplog):
     invoke_and_assert(
-        command=["flow-run", "ls", "--state", "invalid"],
-        expected_code=1,
-        expected_output_contains=(
-            "Invalid state name. Options are Scheduled, Pending, Running, Completed, Failed, Cancelled, Crashed, Paused, Cancelling, Suspended, AwaitingRetry, Retrying, Late."
-        ),
+        command=["flow-run", "ls", "--state", "MyCustomState"],
+        expected_code=0,
+        expected_output_contains=("No flow runs found.",),
+    )
+
+    assert (
+        "State name 'MyCustomState' is not one of the official Prefect state names"
+        in caplog.text
     )
 
 

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -131,22 +131,22 @@ def test_ls_no_args(
     )
 
 
-# def test_ls_flow_name_filter(
-#     scheduled_flow_run,
-#     completed_flow_run,
-#     running_flow_run,
-#     late_flow_run,
-# ):
-#     result = invoke_and_assert(
-#         command=["flow-run", "ls", "--flow-name", "goodbye"],
-#         expected_code=0,
-#     )
+def test_ls_flow_name_filter(
+    scheduled_flow_run,
+    completed_flow_run,
+    running_flow_run,
+    late_flow_run,
+):
+    result = invoke_and_assert(
+        command=["flow-run", "ls", "--flow-name", "goodbye"],
+        expected_code=0,
+    )
 
-#     assert_flow_runs_in_result(
-#         result,
-#         expected=[running_flow_run, late_flow_run],
-#         unexpected=[scheduled_flow_run, completed_flow_run],
-#     )
+    assert_flow_runs_in_result(
+        result,
+        expected=[running_flow_run, late_flow_run],
+        unexpected=[scheduled_flow_run, completed_flow_run],
+    )
 
 
 # @pytest.mark.parametrize(
@@ -184,14 +184,14 @@ def test_ls_no_args(
 #     )
 
 
-# def test_ls_state_type_filter_invalid_raises():
-#     invoke_and_assert(
-#         command=["flow-run", "ls", "--state-type", "invalid"],
-#         expected_code=1,
-#         expected_output_contains=(
-#             "Invalid state type. Options are SCHEDULED, PENDING, RUNNING, COMPLETED, FAILED, CANCELLED, CRASHED, PAUSED, CANCELLING."
-#         ),
-#     )
+def test_ls_state_type_filter_invalid_raises():
+    invoke_and_assert(
+        command=["flow-run", "ls", "--state-type", "invalid"],
+        expected_code=1,
+        expected_output_contains=(
+            "Invalid state type. Options are SCHEDULED, PENDING, RUNNING, COMPLETED, FAILED, CANCELLED, CRASHED, PAUSED, CANCELLING."
+        ),
+    )
 
 
 # @pytest.mark.parametrize(
@@ -221,14 +221,14 @@ def test_ls_no_args(
 #     )
 
 
-# def test_ls_state_name_filter_invalid_raises():
-#     invoke_and_assert(
-#         command=["flow-run", "ls", "--state", "invalid"],
-#         expected_code=1,
-#         expected_output_contains=(
-#             "Invalid state name. Options are Scheduled, Pending, Running, Completed, Failed, Cancelled, Crashed, Paused, Cancelling, Suspended, AwaitingRetry, Retrying, Late."
-#         ),
-#     )
+def test_ls_state_name_filter_invalid_raises():
+    invoke_and_assert(
+        command=["flow-run", "ls", "--state", "invalid"],
+        expected_code=1,
+        expected_output_contains=(
+            "Invalid state name. Options are Scheduled, Pending, Running, Completed, Failed, Cancelled, Crashed, Paused, Cancelling, Suspended, AwaitingRetry, Retrying, Late."
+        ),
+    )
 
 
 def test_ls_limit(


### PR DESCRIPTION
### Examples
#### Improving `--help` display for `prefect flow-runs ls`
```bash
❯ prefect flow-runs ls --help
                                                                                                                                                                                                              
 Usage: prefect flow-runs ls [OPTIONS]                                                                                                                                                                        
                                                                                                                                                                                                              
 View recent flow runs or flow runs for specific flows.                                                                                                                                                       
 Arguments:                                                                                                                                                                                                   
 flow_name: Name of the flow                                                                                                                                                                                  
 limit: Maximum number of flow runs to list                                                                                                                                                                   
 state: Name of the flow run's state. Can be provided multiple times. Options are 'SCHEDULED', 'PENDING', 'RUNNING', 'COMPLETED', 'FAILED', 'CRASHED', 'CANCELLING', 'CANCELLED', 'PAUSED', 'SUSPENDED',      
 'AWAITINGRETRY', 'RETRYING', and 'LATE'.                                                                                                                                                                     
 state_type: Type of the flow run's state. Can be provided multiple times. Options are 'SCHEDULED', 'PENDING', 'RUNNING', 'COMPLETED', 'FAILED', 'CRASHED', 'CANCELLING', 'CANCELLED', 'CRASHED', and         
 'PAUSED'.                                                                                                                                                                                                    
 Examples:                                                                                                                                                                                                    
 $ prefect flow-runs ls --state Running                                                                                                                                                                       
 $ prefect flow-runs ls --state Running --state late                                                                                                                                                          
 $ prefect flow-runs ls --state_type RUNNING                                                                                                                                                                  
 $ prefect flow-runs ls --state_type RUNNING --state_type FAILED                                                                                                                                              
                                                                                                                                                                                                              
╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --flow-name         TEXT     Name of the flow [default: None]                                                                                                                                              │
│ --limit             INTEGER  Maximum number of flow runs to list [default: 15]                                                                                                                             │
│ --state             TEXT     Name of the flow run's state [default: None]                                                                                                                                  │
│ --state-type        TEXT     Type of the flow run's state [default: None]                                                                                                                                  │
│ --help                       Show this message and exit.                                                                                                                                                   │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
---------------------
### `--state` option
#### Specifies helpful error when state name invalid
```bash
❯ prefect flow-runs ls --state nonexistent
Invalid state name. Options are Scheduled, Pending, Running, Completed, Failed, Cancelled, Crashed, Paused, Cancelling, Suspended, AwaitingRetry, Retrying, Late.
```
#### Allows for case-insensitive state name arg
```bash
❯ prefect flow-runs ls --state completed
                                                     Flow Runs                                                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
┃                                   ID ┃ Flow                  ┃ Name                  ┃ State     ┃ When         ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
│ c6c22580-9aa1-4459-ba99-df3375dc6d6f │ towering-infernflow   │ defiant-caracal       │ COMPLETED │ 1 week ago   │
│ 70f78024-f342-45bd-922d-afc81faae96b │ Second important name │ real-shark            │ COMPLETED │ 1 week ago   │
│ e34d5419-b9da-4681-8fdc-97fcf756bfef │ child_flow-0          │ practical-weasel      │ COMPLETED │ 3 months ago │
└──────────────────────────────────────┴───────────────────────┴───────────────────────┴───────────┴──────────────┘
```
#### `AwaitingRetry` is a subtype of the `Scheduled` state
```bash
❯ prefect flow-runs ls --state awaitingretry
                                          Flow Runs                                          
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
┃                                   ID ┃ Flow    ┃ Name          ┃ State     ┃ When         ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
│ d68e9192-3ce5-49b3-9f38-af27b2011c1f │ my-flow │ beige-gorilla │ SCHEDULED │ 7 months ago │
└──────────────────────────────────────┴─────────┴───────────────┴───────────┴──────────────┘
```

#### `Late` is a subtype of the `Scheduled` state
```bash
❯ prefect flow-runs ls --state late
                                                    Flow Runs                                                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
┃                                   ID ┃ Flow                  ┃ Name               ┃ State     ┃ When           ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━┩
│ cf7f0253-52c8-406b-9603-e460e4a42771 │ Second important name │ piquant-ocelot     │ SCHEDULED │ 30 minutes ago │
│ 185f67c4-986a-4228-a838-5d8b1d639119 │ Second important name │ conscious-elephant │ SCHEDULED │ 1 hour ago     │
│ 1f0f97fe-60be-46b8-8324-d4830932f7d0 │ Second important name │ cherubic-porcupine │ SCHEDULED │ 2 hours ago    │
│ 2fa8dc6a-43c0-4b29-b8d8-a454dc5911bb │ Second important name │ groovy-skua        │ SCHEDULED │ 3 hours ago    │
│ 531d1036-9f31-44d8-87e7-89bfa86302a3 │ Second important name │ ambitious-koala    │ SCHEDULED │ 14 hours ago   │
└──────────────────────────────────────┴───────────────────────┴────────────────────┴───────────┴────────────────┘
```
#### Previously, we would show an empty table. I'm indifferent to whether we display this instead but it feels more explicit.
```bash
❯ prefect flow-runs ls --state suspended
No flow runs found.
```
-----------------------
### `--state-type` option
#### Specifies helpful error when state type invalid
```bash
❯ prefect flow-runs ls --state-type nonexistent
Invalid state type. Options are SCHEDULED, PENDING, RUNNING, COMPLETED, FAILED, CANCELLED, CRASHED, PAUSED, CANCELLING.
```
#### Allows for case-insensitive state type arg
```bash
❯ prefect flow-runs ls --state-type completed
                                                     Flow Runs                                                     
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
┃                                   ID ┃ Flow                  ┃ Name                  ┃ State     ┃ When         ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
│ c6c22580-9aa1-4459-ba99-df3375dc6d6f │ towering-infernflow   │ defiant-caracal       │ COMPLETED │ 1 week ago   │
│ 70f78024-f342-45bd-922d-afc81faae96b │ Second important name │ real-shark            │ COMPLETED │ 1 week ago   │
│ e34d5419-b9da-4681-8fdc-97fcf756bfef │ child_flow-0          │ practical-weasel      │ COMPLETED │ 3 months ago │
└──────────────────────────────────────┴───────────────────────┴───────────────────────┴───────────┴──────────────┘
```
#### Previously, we would show an empty table. I'm indifferent to whether we display this instead but it feels more explicit.
```bash
❯ prefect flow-runs ls --state-type paused
No flow runs found.
```