### PR TITLE
Fixes `fails_with_new_engine` to fail tests when they pass unexpectedly

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -54,17 +54,37 @@ def fails_with_new_engine(func):
     @wraps(func)
     def sync_wrapper(*args, **kwargs):
         if PREFECT_EXPERIMENTAL_ENABLE_NEW_ENGINE:
-            return pytest.xfail("This test fails with the new engine")(func)(
-                *args, **kwargs
-            )
+            try:
+                func(*args, **kwargs)
+                pytest.fail(
+                    "Test passed unexpectedly with the new engine", pytrace=False
+                )
+            except (
+                Exception,
+                anyio._backends._asyncio.ExceptionGroup,
+                pytest.fail.Exception,
+            ):
+                pytest.xfail(
+                    "This test fails with the new engine",
+                )
         return func(*args, **kwargs)
 
     @wraps(func)
     async def async_wrapper(*args, **kwargs):
         if PREFECT_EXPERIMENTAL_ENABLE_NEW_ENGINE:
-            return await pytest.xfail("This test fails with the new engine")(func)(
-                *args, **kwargs
-            )
+            try:
+                await func(*args, **kwargs)
+                pytest.fail(
+                    "Test passed unexpectedly with the new engine", pytrace=False
+                )
+            except (
+                Exception,
+                anyio._backends._asyncio.ExceptionGroup,
+                pytest.fail.Exception,
+            ):
+                pytest.xfail(
+                    "This test fails with the new engine",
+                )
         return await func(*args, **kwargs)
 
     if asyncio.iscoroutinefunction(func):
@@ -993,7 +1013,6 @@ class TestTaskRetries:
             "Completed",
         ]
 
-    @fails_with_new_engine
     async def test_task_retries_receive_latest_task_run_in_context(self):
         contexts: List[TaskRunContext] = []
 
@@ -1259,7 +1278,6 @@ class TestTaskCaching:
         assert second_state.name == "Completed"
         assert second_state.result() != first_state.result()
 
-    @fails_with_new_engine
     def test_cache_hits_wo_refresh_cache(self):
         @task(cache_key_fn=lambda *_: "cache hit", refresh_cache=False)
         def foo(x):
@@ -1274,7 +1292,6 @@ class TestTaskCaching:
         assert second_state.name == "Cached"
         assert second_state.result() == first_state.result()
 
-    @fails_with_new_engine
     def test_tasks_refresh_cache_setting(self):
         @task(cache_key_fn=lambda *_: "cache hit")
         def foo(x):
@@ -2023,7 +2040,6 @@ class TestTaskInputs:
             x=[TaskRunResult(id=upstream_state.state_details.task_run_id)],
         )
 
-    @fails_with_new_engine
     async def test_task_inputs_populated_with_state_upstream_wrapped_with_allow_failure(
         self, prefect_client
     ):
@@ -2231,7 +2247,6 @@ class TestTaskInputs:
 
 
 class TestSubflowWaitForTasks:
-    @fails_with_new_engine
     def test_downstream_does_not_run_if_upstream_fails(self):
         @task
         def fails():
@@ -2252,7 +2267,6 @@ class TestSubflowWaitForTasks:
         assert subflow_state.is_pending()
         assert subflow_state.name == "NotReady"
 
-    @fails_with_new_engine
     def test_downstream_runs_if_upstream_succeeds(self):
         @flow
         def foo(x):
@@ -2524,7 +2538,6 @@ class TestTaskRunLogs:
         assert "NameError" in error_log
         assert "x + y" in error_log
 
-    @fails_with_new_engine
     async def test_opt_out_logs_are_not_sent_to_api(self, prefect_client):
         @task
         def my_task():
@@ -2726,7 +2739,6 @@ class TestTaskWithOptions:
         assert task_with_options.retries == 0
         assert task_with_options.retry_delay_seconds == 0
 
-    @fails_with_new_engine
     def test_with_options_refresh_cache(self):
         @task(cache_key_fn=lambda *_: "cache hit")
         def foo(x):
@@ -3371,7 +3383,6 @@ class TestTaskConstructorValidation:
                 raise RuntimeError("try again!")
 
 
-@fails_with_new_engine
 async def test_task_run_name_is_set(prefect_client):
     @task(task_run_name="fixed-name")
     def my_task(name):
@@ -3389,7 +3400,6 @@ async def test_task_run_name_is_set(prefect_client):
     assert task_run.name == "fixed-name"
 
 
-@fails_with_new_engine
 async def test_task_run_name_is_set_with_kwargs_including_defaults(prefect_client):
     @task(task_run_name="{name}-wuz-{where}")
     def my_task(name, where="here"):
@@ -3407,7 +3417,6 @@ async def test_task_run_name_is_set_with_kwargs_including_defaults(prefect_clien
     assert task_run.name == "chris-wuz-here"
 
 
-@fails_with_new_engine
 async def test_task_run_name_is_set_with_function(prefect_client):
     def generate_task_run_name():
         return "is-this-a-bird"
@@ -3480,7 +3489,6 @@ async def test_task_run_name_is_set_with_function_not_returning_string(prefect_c
         my_flow("anon")
 
 
-@fails_with_new_engine
 async def test_sets_run_name_once():
     generate_task_run_name = MagicMock(return_value="some-string")
     mocked_task_method = MagicMock(side_effect=RuntimeError("Oh-no!, anyway"))
@@ -3500,7 +3508,6 @@ async def test_sets_run_name_once():
     assert generate_task_run_name.call_count == 1
 
 
-@fails_with_new_engine
 async def test_sets_run_name_once_per_call():
     generate_task_run_name = MagicMock(return_value="some-string")
     mocked_task_method = MagicMock()
@@ -3935,7 +3942,6 @@ class TestTaskHooksOnFailure:
 
 
 class TestNestedTasks:
-    @fails_with_new_engine
     def test_nested_task(self):
         @task
         def inner_task():
@@ -4217,7 +4223,6 @@ class TestNestedTasks:
         assert await inner_state1.result() == 4
         assert await inner_state2.result() == 4
 
-    @fails_with_new_engine
     def test_nested_task_with_retries(self):
         count = 0
 
@@ -4240,7 +4245,6 @@ class TestNestedTasks:
         assert result == "Failed"
         assert count == 2
 
-    @fails_with_new_engine
     def test_nested_task_with_retries_on_inner_and_outer_task(self):
         count = 0
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Updates `fails_with_new_engine` to fail when decorated tests pass unexpectedly. Also, removes decorators from tests that now pass with changes in https://github.com/PrefectHQ/prefect/pull/12889.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
