### PR TITLE
Implementing work pool status events

### DIFF
--- a/docs/concepts/automations.md
+++ b/docs/concepts/automations.md
@@ -516,7 +516,7 @@ Any type of trigger may be composed into higher-order composite triggers, includ
     {
       "type": "event",
       "posture": "Reactive",
-      "expect": ["prefect.work-pool.not-ready"],
+      "expect": ["prefect.work-pool.not_ready"],
       "match": {
         "prefect.resource.name": "kubernetes-workers",
       }

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     from prefect.deprecated.data_documents import DataDocument
     from prefect.results import BaseResult
 
+
 R = TypeVar("R")
 
 

--- a/src/prefect/server/api/workers.py
+++ b/src/prefect/server/api/workers.py
@@ -3,8 +3,9 @@ Routes for interacting with work queue objects.
 """
 
 from typing import TYPE_CHECKING, List, Optional
-from uuid import UUID
+from uuid import UUID, uuid4
 
+import pendulum
 import sqlalchemy as sa
 from prefect._vendor.fastapi import (
     BackgroundTasks,
@@ -26,6 +27,7 @@ from prefect.server.models.work_queues import (
     emit_work_queue_status_event,
     mark_work_queues_ready,
 )
+from prefect.server.models.workers import emit_work_pool_status_event
 from prefect.server.schemas.statuses import WorkQueueStatus
 from prefect.server.utilities.schemas import DateTimeTZ
 from prefect.server.utilities.server import PrefectRouter
@@ -155,7 +157,7 @@ class WorkerLookups:
 async def create_work_pool(
     work_pool: schemas.actions.WorkPoolCreate,
     db: PrefectDBInterface = Depends(provide_database_interface),
-) -> schemas.responses.WorkPoolResponse:
+) -> schemas.core.WorkPool:
     """
     Creates a new work pool. If a work pool with the same
     name already exists, an error will be raised.
@@ -178,7 +180,15 @@ async def create_work_pool(
             model = await models.workers.create_work_pool(
                 session=session, work_pool=work_pool
             )
-            return await schemas.responses.WorkPoolResponse.from_orm(model, session)
+
+            await emit_work_pool_status_event(
+                event_id=uuid4(),
+                occurred=pendulum.now("UTC"),
+                pre_update_work_pool=None,
+                work_pool=model,
+            )
+
+            return schemas.core.WorkPool.from_orm(model)
 
     except sa.exc.IntegrityError:
         raise HTTPException(
@@ -192,7 +202,7 @@ async def read_work_pool(
     work_pool_name: str = Path(..., description="The work pool name", alias="name"),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: PrefectDBInterface = Depends(provide_database_interface),
-) -> schemas.responses.WorkPoolResponse:
+) -> schemas.core.WorkPool:
     """
     Read a work pool by name
     """
@@ -204,7 +214,7 @@ async def read_work_pool(
         orm_work_pool = await models.workers.read_work_pool(
             session=session, work_pool_id=work_pool_id
         )
-        return await schemas.responses.WorkPoolResponse.from_orm(orm_work_pool, session)
+        return schemas.core.WorkPool.from_orm(orm_work_pool)
 
 
 @router.post("/filter")
@@ -214,7 +224,7 @@ async def read_work_pools(
     offset: int = Body(0, ge=0),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),
     db: PrefectDBInterface = Depends(provide_database_interface),
-) -> List[schemas.responses.WorkPoolResponse]:
+) -> List[schemas.core.WorkPool]:
     """
     Read multiple work pools
     """
@@ -225,10 +235,7 @@ async def read_work_pools(
             offset=offset,
             limit=limit,
         )
-        return [
-            await schemas.responses.WorkPoolResponse.from_orm(w, session)
-            for w in orm_work_pools
-        ]
+        return [schemas.core.WorkPool.from_orm(w) for w in orm_work_pools]
 
 
 @router.post("/count")
@@ -277,6 +284,7 @@ async def update_work_pool(
             session=session,
             work_pool_id=work_pool_id,
             work_pool=work_pool,
+            emit_status_change=emit_work_pool_status_event,
         )
 
 
@@ -562,16 +570,32 @@ async def worker_heartbeat(
     db: PrefectDBInterface = Depends(provide_database_interface),
 ):
     async with db.session_context(begin_transaction=True) as session:
-        work_pool_id = await worker_lookups._get_work_pool_id_from_name(
-            session=session, work_pool_name=work_pool_name
+        work_pool = await models.workers.read_work_pool_by_name(
+            session=session,
+            work_pool_name=work_pool_name,
         )
+        if not work_pool:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f'Work pool "{work_pool_name}" not found.',
+            )
 
         await models.workers.worker_heartbeat(
             session=session,
-            work_pool_id=work_pool_id,
+            work_pool_id=work_pool.id,
             worker_name=name,
             heartbeat_interval_seconds=heartbeat_interval_seconds,
         )
+
+        if work_pool.status == schemas.statuses.WorkPoolStatus.NOT_READY:
+            await models.workers.update_work_pool(
+                session=session,
+                work_pool_id=work_pool.id,
+                work_pool=schemas.internal.InternalWorkPoolUpdate(
+                    status=schemas.statuses.WorkPoolStatus.READY
+                ),
+                emit_status_change=emit_work_pool_status_event,
+            )
 
 
 @router.post("/{work_pool_name}/workers/filter")

--- a/src/prefect/server/database/migrations/versions/postgresql/2024_04_25_155240_8905262ec07f_worker_status_field.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2024_04_25_155240_8905262ec07f_worker_status_field.py
@@ -1,0 +1,44 @@
+"""Worker status field
+
+Revision ID: 8905262ec07f
+Revises: 7ae9e431e67a
+Create Date: 2024-04-25 15:52:40.235822
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from prefect.server.utilities.database import UUID, Timestamp
+
+# revision identifiers, used by Alembic.
+revision = "8905262ec07f"
+down_revision = "7ae9e431e67a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "work_pool",
+        sa.Column(
+            "last_transitioned_status_at", Timestamp(timezone=True), nullable=True
+        ),
+    )
+    op.add_column("work_pool", sa.Column("last_status_event_id", UUID(), nullable=True))
+
+    worker_status = postgresql.ENUM("ONLINE", "OFFLINE", name="worker_status")
+    worker_status.create(op.get_bind())
+
+    op.add_column(
+        "worker",
+        sa.Column("status", worker_status, server_default="OFFLINE", nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_column("worker", "status")
+
+    op.drop_column("work_pool", "last_transitioned_status_at")
+    op.drop_column("work_pool", "last_status_event_id")

--- a/src/prefect/server/database/migrations/versions/sqlite/2024_04_25_155120_a8e62d4c72cf_worker_status_field.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2024_04_25_155120_a8e62d4c72cf_worker_status_field.py
@@ -1,0 +1,47 @@
+"""Worker status field
+
+Revision ID: a8e62d4c72cf
+Revises: 75c8f17b8b51
+Create Date: 2024-04-25 15:51:20.234353
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from prefect.server.utilities.database import UUID, Timestamp
+
+# revision identifiers, used by Alembic.
+revision = "a8e62d4c72cf"
+down_revision = "75c8f17b8b51"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("work_pool", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "last_transitioned_status_at", Timestamp(timezone=True), nullable=True
+            ),
+        )
+        batch_op.add_column(sa.Column("last_status_event_id", UUID(), nullable=True))
+
+    with op.batch_alter_table("worker", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "status",
+                sa.Enum("ONLINE", "OFFLINE", name="worker_status"),
+                server_default="OFFLINE",
+                nullable=False,
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("worker", schema=None) as batch_op:
+        batch_op.drop_column("status")
+
+    with op.batch_alter_table("work_pool", schema=None) as batch_op:
+        batch_op.drop_column("last_transitioned_status_at")
+        batch_op.drop_column("last_status_event_id")

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -28,6 +28,7 @@ from prefect.server.events.schemas.automations import (
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.schemas.statuses import (
     DeploymentStatus,
+    WorkerStatus,
     WorkPoolStatus,
     WorkQueueStatus,
 )
@@ -1253,7 +1254,7 @@ class ORMWorkQueue:
         sa.Enum(WorkQueueStatus, name="work_queue_status"),
         nullable=False,
         default=WorkQueueStatus.NOT_READY,
-        server_default="NOT_READY",
+        server_default=WorkQueueStatus.NOT_READY.value,
     )
 
     @declared_attr
@@ -1297,8 +1298,10 @@ class ORMWorkPool:
         sa.Enum(WorkPoolStatus, name="work_pool_status"),
         nullable=False,
         default=WorkPoolStatus.NOT_READY,
-        server_default="NOT_READY",
+        server_default=WorkPoolStatus.NOT_READY.value,
     )
+    last_transitioned_status_at = sa.Column(Timestamp(), nullable=True)
+    last_status_event_id = sa.Column(UUID, nullable=True)
 
     @declared_attr
     def __table_args__(cls):
@@ -1327,6 +1330,13 @@ class ORMWorker:
         index=True,
     )
     heartbeat_interval_seconds = sa.Column(sa.Integer, nullable=True)
+
+    status = sa.Column(
+        sa.Enum(WorkerStatus, name="worker_status"),
+        nullable=False,
+        default=WorkerStatus.OFFLINE,
+        server_default=WorkerStatus.OFFLINE.value,
+    )
 
     @declared_attr
     def __table_args__(cls):

--- a/src/prefect/server/events/actions.py
+++ b/src/prefect/server/events/actions.py
@@ -70,7 +70,6 @@ from prefect.server.schemas.responses import (
     FlowRunResponse,
     OrchestrationResult,
     StateAcceptDetails,
-    WorkPoolResponse,
     WorkQueueWithStatus,
 )
 from prefect.server.schemas.states import Scheduled, State, StateType, Suspended
@@ -432,7 +431,7 @@ class JinjaTemplateAction(ExternalDataAction):
             ),
             "prefect.task-run": (TaskRun, [orchestration_client.read_task_run_raw]),
             "prefect.work-pool": (
-                WorkPoolResponse,
+                WorkPool,
                 [orchestration_client.read_work_pool_raw],
             ),
             "prefect.work-queue": (

--- a/src/prefect/server/models/events.py
+++ b/src/prefect/server/models/events.py
@@ -402,7 +402,9 @@ async def work_pool_status_event(
     return Event(
         id=event_id,
         occurred=occurred,
-        event=f"prefect.work-pool.{work_pool.status.in_kebab_case()}",
+        # TODO: this should be
+        # event=f"prefect.work-pool.{work_pool.status.in_kebab_case()}",
+        event=f"prefect.work-pool.{work_pool.status.value.lower()}",
         resource={
             "prefect.resource.id": f"prefect.work-pool.{work_pool.id}",
             "prefect.resource.name": work_pool.name,

--- a/src/prefect/server/models/events.py
+++ b/src/prefect/server/models/events.py
@@ -389,3 +389,47 @@ async def work_queue_status_event(
         related=related_work_pool_info,
         id=uuid4(),
     )
+
+
+async def work_pool_status_event(
+    event_id: UUID,
+    occurred: pendulum.DateTime,
+    pre_update_work_pool: Optional["ORMWorkPool"],
+    work_pool: "ORMWorkPool",
+):
+    assert work_pool.status
+
+    return Event(
+        id=event_id,
+        occurred=occurred,
+        event=f"prefect.work-pool.{work_pool.status.in_kebab_case()}",
+        resource={
+            "prefect.resource.id": f"prefect.work-pool.{work_pool.id}",
+            "prefect.resource.name": work_pool.name,
+            "prefect.work-pool.type": work_pool.type,
+        },
+        follows=_get_recent_preceding_work_pool_event_id(pre_update_work_pool),
+    )
+
+
+def _get_recent_preceding_work_pool_event_id(
+    work_pool: Optional["ORMWorkPool"],
+) -> Optional[UUID]:
+    """
+    Returns the preceding event ID if the work pool transitioned status
+    recently to help ensure correct event ordering.
+    """
+    if not work_pool:
+        return None
+
+    time_since_last_event = timedelta(hours=24)
+    if work_pool.last_transitioned_status_at:
+        time_since_last_event = (
+            pendulum.now("UTC") - work_pool.last_transitioned_status_at
+        )
+
+    return (
+        work_pool.last_status_event_id
+        if time_since_last_event < timedelta(minutes=10)
+        else None
+    )

--- a/src/prefect/server/schemas/__init__.py
+++ b/src/prefect/server/schemas/__init__.py
@@ -7,6 +7,7 @@ from . import (
     filters,
     responses,
     actions,
+    internal,
 )  # noqa
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "sorting",
     "states",
     "statuses",
+    "internal",
 ]

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -9,9 +9,7 @@ from uuid import UUID, uuid4
 
 import jsonschema
 
-from prefect._internal.compatibility.deprecated import DeprecatedInfraOverridesField
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
-from prefect.types import NonNegativeInteger, PositiveInteger
 
 if HAS_PYDANTIC_V2:
     from pydantic.v1 import Field, HttpUrl, root_validator, validator
@@ -19,6 +17,7 @@ else:
     from pydantic import Field, HttpUrl, root_validator, validator
 
 import prefect.server.schemas as schemas
+from prefect._internal.compatibility.deprecated import DeprecatedInfraOverridesField
 from prefect._internal.schemas.validators import (
     get_or_create_run_name,
     get_or_create_state_name,
@@ -40,6 +39,7 @@ from prefect.server.utilities.schemas import get_class_fields_only
 from prefect.server.utilities.schemas.bases import PrefectBaseModel
 from prefect.server.utilities.schemas.fields import DateTimeTZ
 from prefect.server.utilities.schemas.serializers import orjson_dumps_extra_compatible
+from prefect.types import NonNegativeInteger, PositiveInteger
 from prefect.utilities.collections import listrepr
 from prefect.utilities.names import generate_slug
 from prefect.utilities.templating import find_placeholders

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -1626,6 +1626,25 @@ class WorkerFilterWorkPoolId(PrefectFilterBaseModel):
         return filters
 
 
+class WorkerFilterStatus(PrefectFilterBaseModel):
+    """Filter by `Worker.status`."""
+
+    any_: Optional[List[schemas.statuses.WorkerStatus]] = Field(
+        default=None, description="A list of worker statuses to include"
+    )
+    not_any_: Optional[List[schemas.statuses.WorkerStatus]] = Field(
+        default=None, description="A list of worker statuses to exclude"
+    )
+
+    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+        filters = []
+        if self.any_ is not None:
+            filters.append(db.Worker.status.in_(self.any_))
+        if self.not_any_ is not None:
+            filters.append(db.Worker.status.notin_(self.not_any_))
+        return filters
+
+
 class WorkerFilterLastHeartbeatTime(PrefectFilterBaseModel):
     """Filter by `Worker.last_heartbeat_time`."""
 
@@ -1661,6 +1680,10 @@ class WorkerFilter(PrefectOperatorFilterBaseModel):
     last_heartbeat_time: Optional[WorkerFilterLastHeartbeatTime] = Field(
         default=None,
         description="Filter criteria for `Worker.last_heartbeat_time`",
+    )
+
+    status: Optional[WorkerFilterStatus] = Field(
+        default=None, description="Filter criteria for `Worker.status`"
     )
 
     def _get_filter_list(self, db: "PrefectDBInterface") -> List:

--- a/src/prefect/server/schemas/internal.py
+++ b/src/prefect/server/schemas/internal.py
@@ -1,0 +1,17 @@
+"""Schemas for _internal_ use within the Prefect server, but that would not be
+appropriate for use on the API itself."""
+
+from typing import Optional
+
+from prefect._internal.pydantic import HAS_PYDANTIC_V2
+
+if HAS_PYDANTIC_V2:
+    from pydantic.v1 import Field
+else:
+    from pydantic import Field
+
+from prefect.server.schemas import actions, statuses
+
+
+class InternalWorkPoolUpdate(actions.WorkPoolUpdate):
+    status: Optional[statuses.WorkPoolStatus] = Field(default=None)

--- a/src/prefect/server/schemas/responses.py
+++ b/src/prefect/server/schemas/responses.py
@@ -15,7 +15,6 @@ else:
 
 from typing_extensions import TYPE_CHECKING, Literal
 
-import prefect.server.models as models
 import prefect.server.schemas as schemas
 from prefect._internal.compatibility.deprecated import DeprecatedInfraOverridesField
 from prefect.server.schemas.core import (
@@ -476,36 +475,6 @@ class WorkQueueResponse(schemas.core.WorkQueue):
 
 class WorkQueueWithStatus(WorkQueueResponse, WorkQueueStatusDetail):
     """Combines a work queue and its status details into a single object"""
-
-
-class WorkPoolResponse(schemas.core.WorkPool):
-    status: Optional[schemas.statuses.WorkPoolStatus] = Field(
-        default=None, description="The current status of the work pool."
-    )
-
-    @classmethod
-    async def from_orm(cls, orm_work_pool, session):
-        work_pool = super().from_orm(orm_work_pool)
-        if work_pool.type == "prefect-agent":
-            work_pool.status = None
-        elif work_pool.is_paused:
-            work_pool.status = schemas.statuses.WorkPoolStatus.PAUSED
-        else:
-            read_workers = await models.workers.read_workers(
-                session=session,
-                work_pool_id=work_pool.id,
-            )
-            online_workers = [
-                worker
-                for worker in read_workers
-                if schemas.responses.WorkerResponse.from_orm(worker).status
-                == schemas.statuses.WorkerStatus.ONLINE
-            ]
-            if len(online_workers) > 0:
-                work_pool.status = schemas.statuses.WorkPoolStatus.READY
-            else:
-                work_pool.status = schemas.statuses.WorkPoolStatus.NOT_READY
-        return work_pool
 
 
 DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 30

--- a/src/prefect/server/services/foreman.py
+++ b/src/prefect/server/services/foreman.py
@@ -9,14 +9,19 @@ import pendulum
 import sqlalchemy as sa
 from typing_extensions import Self
 
+from prefect.server import models
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.models.deployments import mark_deployments_not_ready
 from prefect.server.models.work_queues import mark_work_queues_not_ready
-from prefect.server.schemas.statuses import DeploymentStatus
+from prefect.server.models.workers import emit_work_pool_status_event
+from prefect.server.schemas.internal import InternalWorkPoolUpdate
+from prefect.server.schemas.statuses import DeploymentStatus, WorkPoolStatus
 from prefect.server.services.loop_service import LoopService
 from prefect.settings import (
     PREFECT_API_SERVICES_FOREMAN_DEPLOYMENT_LAST_POLLED_TIMEOUT_SECONDS,
+    PREFECT_API_SERVICES_FOREMAN_FALLBACK_HEARTBEAT_INTERVAL_SECONDS,
+    PREFECT_API_SERVICES_FOREMAN_INACTIVITY_HEARTBEAT_MULTIPLE,
     PREFECT_API_SERVICES_FOREMAN_LOOP_SECONDS,
     PREFECT_API_SERVICES_FOREMAN_WORK_QUEUE_LAST_POLLED_TIMEOUT_SECONDS,
 )
@@ -32,6 +37,8 @@ class Foreman(LoopService):
     def __init__(
         self,
         loop_seconds: Optional[float] = None,
+        inactivity_heartbeat_multiple: Optional[int] = None,
+        fallback_heartbeat_interval_seconds: Optional[int] = None,
         deployment_last_polled_timeout_seconds: Optional[int] = None,
         work_queue_last_polled_timeout_seconds: Optional[int] = None,
         **kwargs,
@@ -40,6 +47,16 @@ class Foreman(LoopService):
             loop_seconds=loop_seconds
             or PREFECT_API_SERVICES_FOREMAN_LOOP_SECONDS.value(),
             **kwargs,
+        )
+        self._inactivity_heartbeat_multiple = (
+            PREFECT_API_SERVICES_FOREMAN_INACTIVITY_HEARTBEAT_MULTIPLE.value()
+            if inactivity_heartbeat_multiple is None
+            else inactivity_heartbeat_multiple
+        )
+        self._fallback_heartbeat_interval_seconds = (
+            PREFECT_API_SERVICES_FOREMAN_FALLBACK_HEARTBEAT_INTERVAL_SECONDS.value()
+            if fallback_heartbeat_interval_seconds is None
+            else fallback_heartbeat_interval_seconds
         )
         self._deployment_last_polled_timeout_seconds = (
             PREFECT_API_SERVICES_FOREMAN_DEPLOYMENT_LAST_POLLED_TIMEOUT_SECONDS.value()
@@ -61,8 +78,112 @@ class Foreman(LoopService):
         Mark deployments as not ready if they have a last_polled time that is
         older than the configured deployment last polled timeout.
         """
+        await self._mark_online_workers_without_a_recent_heartbeat_as_offline()
+        await self._mark_work_pools_as_not_ready()
         await self._mark_deployments_as_not_ready()
         await self._mark_work_queues_as_not_ready()
+
+    @db_injector
+    async def _mark_online_workers_without_a_recent_heartbeat_as_offline(
+        db: PrefectDBInterface,
+        self: Self,
+    ) -> None:
+        """
+        Updates the status of workers that have an old last heartbeat time
+        to OFFLINE.
+
+        An old heartbeat last heartbeat that is one more than
+        their heartbeat interval multiplied by the
+        INACTIVITY_HEARTBEAT_MULTIPLE seconds ago.
+
+        Args:
+            session (AsyncSession): The session to use for the database operation.
+        """
+        async with db.session_context(begin_transaction=True) as session:
+            if db.dialect.name == "postgresql":
+                worker_update_stmt = sa.text(
+                    """
+                    UPDATE worker
+                    SET status = 'OFFLINE'
+                    WHERE (
+                        last_heartbeat_time <
+                        CURRENT_TIMESTAMP - (
+                            interval '1 second' * :multiplier *
+                            COALESCE(heartbeat_interval_seconds, :default_interval)
+                        )
+                    )
+                    AND status = 'ONLINE';
+                    """
+                )
+            elif db.dialect.name == "sqlite":
+                worker_update_stmt = sa.text(
+                    """
+                    UPDATE worker
+                    SET status = 'OFFLINE'
+                    WHERE (
+                        julianday(last_heartbeat_time) <
+                        julianday('now') - ((
+                            :multiplier *
+                            COALESCE(heartbeat_interval_seconds, :default_interval)
+                        ) / 86400.0)
+                    )
+                    AND status = 'ONLINE';
+                    """
+                )
+            else:
+                raise NotImplementedError(
+                    f"No implementation for database dialect {db.dialect.name}"
+                )
+
+            result = await session.execute(
+                worker_update_stmt,
+                {
+                    "multiplier": self._inactivity_heartbeat_multiple,
+                    "default_interval": self._fallback_heartbeat_interval_seconds,
+                },
+            )
+
+        assert isinstance(result, sa.CursorResult)
+        if result.rowcount:
+            self.logger.info(f"Marked {result.rowcount} workers as offline.")
+
+    @db_injector
+    async def _mark_work_pools_as_not_ready(db: PrefectDBInterface, self: Self):
+        """
+        Marks a work pool as not ready.
+
+        Emits and event and updates any bookkeeping fields on the work pool.
+
+        Args:
+            work_pool (db.WorkPool): The work pool to mark as not ready.
+        """
+        async with db.session_context(begin_transaction=True) as session:
+            work_pools_select_stmt = (
+                sa.select(db.WorkPool)
+                .filter(db.WorkPool.status == "READY")
+                .outerjoin(
+                    db.Worker,
+                    sa.and_(
+                        db.Worker.work_pool_id == db.WorkPool.id,
+                        db.Worker.status == "ONLINE",
+                    ),
+                )
+                .group_by(db.WorkPool.id)
+                .having(sa.func.count(db.Worker.id) == 0)
+            )
+
+            result = await session.execute(work_pools_select_stmt)
+            work_pools = result.scalars().all()
+
+            for work_pool in work_pools:
+                await models.workers.update_work_pool(
+                    session=session,
+                    work_pool_id=work_pool.id,
+                    work_pool=InternalWorkPoolUpdate(status=WorkPoolStatus.NOT_READY),
+                    emit_status_change=emit_work_pool_status_event,
+                )
+
+                self.logger.info(f"Marked work pool {work_pool.id} as NOT_READY.")
 
     @db_injector
     async def _mark_deployments_as_not_ready(

--- a/src/prefect/server/services/foreman.py
+++ b/src/prefect/server/services/foreman.py
@@ -143,7 +143,6 @@ class Foreman(LoopService):
                 },
             )
 
-        assert isinstance(result, sa.CursorResult)
         if result.rowcount:
             self.logger.info(f"Marked {result.rowcount} workers as offline.")
 

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1221,6 +1221,16 @@ PREFECT_API_SERVICES_FOREMAN_LOOP_SECONDS = Setting(float, default=15)
 """The number of seconds to wait between each iteration of the Foreman loop which checks
 for offline workers and updates work pool status."""
 
+
+PREFECT_API_SERVICES_FOREMAN_INACTIVITY_HEARTBEAT_MULTIPLE = Setting(int, default=3)
+"The number of heartbeats that must be missed before a worker is marked as offline."
+
+PREFECT_API_SERVICES_FOREMAN_FALLBACK_HEARTBEAT_INTERVAL_SECONDS = Setting(
+    int, default=30
+)
+"""The number of seconds to use for online/offline evaluation if a worker's heartbeat
+interval is not set."""
+
 PREFECT_API_SERVICES_FOREMAN_DEPLOYMENT_LAST_POLLED_TIMEOUT_SECONDS = Setting(
     int, default=60
 )

--- a/tests/server/api/test_workers.py
+++ b/tests/server/api/test_workers.py
@@ -101,7 +101,7 @@ class TestCreateWorkPool:
         )
         assert model.name == "Pool 1"
 
-        assert_status_events("Pool 1", ["prefect.work-pool.not-ready"])
+        assert_status_events("Pool 1", ["prefect.work-pool.not_ready"])
 
     async def test_create_work_pool_with_options(self, client):
         response = await client.post(
@@ -326,7 +326,7 @@ class TestUpdateWorkPool:
         )
 
         assert_status_events(
-            work_pool.name, ["prefect.work-pool.paused", "prefect.work-pool.not-ready"]
+            work_pool.name, ["prefect.work-pool.paused", "prefect.work-pool.not_ready"]
         )
 
     async def test_unpause_work_pool_with_online_workers(self, client, work_pool):

--- a/tests/server/database/test_queries.py
+++ b/tests/server/database/test_queries.py
@@ -455,6 +455,7 @@ class TestGetRunsFromWorkQueueQuery:
             session=session,
             work_pool_id=work_pools["wp_a"].id,
             work_pool=schemas.actions.WorkPoolUpdate(is_paused=True),
+            emit_status_change=None,
         )
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
@@ -506,6 +507,7 @@ class TestGetRunsFromWorkQueueQuery:
             work_pool=schemas.actions.WorkPoolUpdate(
                 concurrency_limit=concurrency_limit
             ),
+            emit_status_change=None,
         )
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
@@ -532,6 +534,7 @@ class TestGetRunsFromWorkQueueQuery:
             work_pool=schemas.actions.WorkPoolUpdate(
                 concurrency_limit=concurrency_limit
             ),
+            emit_status_change=None,
         )
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
@@ -558,6 +561,7 @@ class TestGetRunsFromWorkQueueQuery:
             session=session,
             work_pool_id=work_pools["wp_a"].id,
             work_pool=schemas.actions.WorkPoolUpdate(is_paused=True),
+            emit_status_change=None,
         )
 
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(

--- a/tests/server/models/test_workers.py
+++ b/tests/server/models/test_workers.py
@@ -153,6 +153,7 @@ class TestUpdateWorkPool:
             work_pool=schemas.actions.WorkPoolUpdate(
                 is_paused=True, concurrency_limit=5
             ),
+            emit_status_change=None,
         )
 
         result = await models.workers.read_work_pool(
@@ -167,6 +168,7 @@ class TestUpdateWorkPool:
                 session=session,
                 work_pool_id=work_pool.id,
                 work_pool=schemas.actions.WorkPoolUpdate(concurrency_limit=-5),
+                emit_status_change=None,
             )
 
     async def test_update_work_pool_zero_concurrency(self, session, work_pool):
@@ -174,6 +176,7 @@ class TestUpdateWorkPool:
             session=session,
             work_pool_id=work_pool.id,
             work_pool=schemas.actions.WorkPoolUpdate(concurrency_limit=0),
+            emit_status_change=None,
         )
         result = await models.workers.read_work_pool(
             session=session, work_pool_id=work_pool.id

--- a/tests/server/services/test_foreman.py
+++ b/tests/server/services/test_foreman.py
@@ -279,7 +279,7 @@ class TestForeman:
         assert len(events) == 1
 
         event = events[0]
-        assert event.event == "prefect.work-pool.not-ready"
+        assert event.event == "prefect.work-pool.not_ready"
         assert event.resource.id == f"prefect.work-pool.{ready_work_pool.id}"
         assert event.resource.name == ready_work_pool.name
         assert event.resource["prefect.work-pool.type"] == "test"
@@ -470,11 +470,11 @@ class TestForeman:
         for event in events:
             print(event.id, event.follows, event.event, event.resource.id)
 
-        assert events[0].event == "prefect.work-pool.not-ready"
+        assert events[0].event == "prefect.work-pool.not_ready"
         assert events[0].follows is None
         assert events[1].event == "prefect.work-pool.ready"
         assert events[1].follows == events[0].id
-        assert events[2].event == "prefect.work-pool.not-ready"
+        assert events[2].event == "prefect.work-pool.not_ready"
         assert events[2].follows == events[1].id
 
     async def test_status_update_when_deployment_has_old_last_polled_time(

--- a/tests/server/services/test_foreman.py
+++ b/tests/server/services/test_foreman.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 from uuid import uuid4
 
 import pendulum
@@ -14,6 +14,10 @@ from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.events.clients import AssertingEventsClient
 from prefect.server.schemas.statuses import DeploymentStatus
 from prefect.server.services.foreman import Foreman
+from prefect.settings import (
+    PREFECT_API_SERVICES_FOREMAN_FALLBACK_HEARTBEAT_INTERVAL_SECONDS,
+    PREFECT_API_SERVICES_FOREMAN_INACTIVITY_HEARTBEAT_MULTIPLE,
+)
 
 if TYPE_CHECKING:
     from prefect.server.database.orm_models import (
@@ -29,6 +33,10 @@ def patch_events_client(monkeypatch: pytest.MonkeyPatch) -> None:
         "prefect.server.models.work_queues.PrefectServerEventsClient",
         AssertingEventsClient,
     )
+    monkeypatch.setattr(
+        "prefect.server.models.workers.PrefectServerEventsClient",
+        AssertingEventsClient,
+    )
 
 
 @pytest.fixture
@@ -40,6 +48,92 @@ async def ready_work_pool(session: AsyncSession):
     work_pool.status = schemas.statuses.WorkPoolStatus.READY
     await session.commit()
     return work_pool
+
+
+@pytest.fixture
+async def not_ready_work_pool(session: AsyncSession):
+    work_pool = await models.workers.create_work_pool(
+        session=session,
+        work_pool=schemas.actions.WorkPoolCreate(
+            name="ready-work-pool",
+            type="test",
+        ),
+    )
+    work_pool.status = schemas.statuses.WorkPoolStatus.NOT_READY
+    await session.commit()
+    return work_pool
+
+
+@pytest.fixture
+async def paused_work_pool(session: AsyncSession):
+    work_pool = await models.workers.create_work_pool(
+        session=session,
+        work_pool=schemas.actions.WorkPoolCreate(
+            name="ready-work-pool", type="test", is_paused=True
+        ),
+    )
+    await session.commit()
+    return work_pool
+
+
+@db_injector
+async def create_online_worker_with_old_heartbeat(
+    db: PrefectDBInterface,
+    session: AsyncSession,
+    work_pool: "ORMWorkPool",
+    heartbeat_interval_seconds: Optional[int] = 60,
+):
+    worker_name = "online-worker-with-old-heartbeat"
+    last_heartbeat_time = pendulum.now("UTC") - timedelta(
+        seconds=PREFECT_API_SERVICES_FOREMAN_INACTIVITY_HEARTBEAT_MULTIPLE.value()
+        * (
+            heartbeat_interval_seconds
+            or PREFECT_API_SERVICES_FOREMAN_FALLBACK_HEARTBEAT_INTERVAL_SECONDS.value()
+        )
+    )
+
+    values = dict(
+        work_pool_id=work_pool.id,
+        name=worker_name,
+        last_heartbeat_time=last_heartbeat_time,
+        status=schemas.statuses.WorkerStatus.ONLINE,
+    )
+
+    if heartbeat_interval_seconds:
+        values["heartbeat_interval_seconds"] = heartbeat_interval_seconds
+
+    insert_stmt = sa.insert(db.Worker).values(**values)
+
+    await session.execute(insert_stmt)
+
+    await session.commit()
+
+    workers = await models.workers.read_workers(
+        session=session, work_pool_id=work_pool.id
+    )
+
+    return next(worker for worker in workers if worker.name == worker_name)
+
+
+async def create_online_worker_with_new_heartbeat(
+    session: AsyncSession, work_pool: "ORMWorkPool"
+):
+    worker_name = "online-worker-with-new-heartbeat"
+    heartbeat_interval_seconds = 60
+    await models.workers.worker_heartbeat(
+        session=session,
+        work_pool_id=work_pool.id,
+        worker_name=worker_name,
+        heartbeat_interval_seconds=heartbeat_interval_seconds,
+    )
+
+    await session.commit()
+
+    workers = await models.workers.read_workers(
+        session=session, work_pool_id=work_pool.id
+    )
+
+    return next(worker for worker in workers if worker.name == worker_name)
 
 
 @db_injector
@@ -148,6 +242,241 @@ async def create_deployment_with_new_last_polled_time(
 
 
 class TestForeman:
+    async def test_status_update_when_worker_has_old_heartbeat(
+        self,
+        session: AsyncSession,
+        ready_work_pool,
+        client,
+    ):
+        """
+        Workers that haven't sent a heartbeat in greater than
+        INACTIVITY_HEARTBEAT_MULTIPLE * heartbeat_interval_seconds
+        seconds should have their status set to OFFLINE.
+
+        When the worker that is marked offline is the only worker
+        in a work pool, the work pool should be marked as NOT_READY.
+        """
+        await create_online_worker_with_old_heartbeat(session, ready_work_pool)
+        await session.commit()
+
+        await Foreman().run_once()
+
+        # Check worker is marked offline
+        workers_response = await client.post(
+            f"/work_pools/{ready_work_pool.name}/workers/filter"
+        )
+
+        assert len(workers_response.json()) == 1
+        assert workers_response.json()[0]["status"] == "OFFLINE"
+
+        # Check work pool is marked not_ready
+        work_pools_response = await client.get(f"/work_pools/{ready_work_pool.name}")
+
+        assert work_pools_response.json()["status"] == "NOT_READY"
+
+        assert AssertingEventsClient.last
+        events = [event for item in AssertingEventsClient.all for event in item.events]
+        assert len(events) == 1
+
+        event = events[0]
+        assert event.event == "prefect.work-pool.not-ready"
+        assert event.resource.id == f"prefect.work-pool.{ready_work_pool.id}"
+        assert event.resource.name == ready_work_pool.name
+        assert event.resource["prefect.work-pool.type"] == "test"
+
+    async def test_work_pool_status_update_with_multiple_workers(
+        self,
+        ready_work_pool,
+        session: AsyncSession,
+        client,
+    ):
+        """
+        When a work pool has multiple workers, and one of them has an old heartbeat,
+        the work pools should remain READY.
+        """
+        old_heartbeat_worker = await create_online_worker_with_old_heartbeat(
+            session, ready_work_pool
+        )
+        assert old_heartbeat_worker.status == schemas.statuses.WorkerStatus.ONLINE
+
+        new_heartbeat_worker = await create_online_worker_with_new_heartbeat(
+            session, ready_work_pool
+        )
+        assert new_heartbeat_worker.status == schemas.statuses.WorkerStatus.ONLINE
+
+        assert ready_work_pool.status == schemas.statuses.WorkPoolStatus.READY
+        await session.commit()
+
+        await Foreman().run_once()
+
+        # Check one worker is marked offline
+        workers_response = await client.post(
+            f"/work_pools/{ready_work_pool.name}/workers/filter"
+        )
+
+        assert len(workers_response.json()) == 2
+        old_heartbeat_worker = next(
+            worker
+            for worker in workers_response.json()
+            if worker["name"] == old_heartbeat_worker.name
+        )
+        new_heartbeat_worker = next(
+            worker
+            for worker in workers_response.json()
+            if worker["name"] == new_heartbeat_worker.name
+        )
+        assert new_heartbeat_worker["status"] == "ONLINE"
+        assert old_heartbeat_worker["status"] == "OFFLINE"
+
+        # Check work pool is marked ready
+        work_pools_response = await client.get(f"/work_pools/{ready_work_pool.name}")
+
+        assert work_pools_response.json()["status"] == "READY"
+
+    async def test_foreman_does_not_update_status_of_paused_work_pools(
+        self,
+        paused_work_pool,
+        client,
+    ):
+        """
+        Foreman should not update the status of PAUSED work pools. The work pool
+        will be given the correct status by the orchestrator when it is unpaused.
+        """
+        assert paused_work_pool.status == schemas.statuses.WorkPoolStatus.PAUSED
+
+        await Foreman().run_once()
+
+        # Check work pool is still marked paused
+        work_pool_response = await client.get(f"/work_pools/{paused_work_pool.name}")
+
+        assert work_pool_response.json()["status"] == "PAUSED"
+
+    async def test_foreman_does_not_update_not_ready_work_pools(
+        self,
+        db,
+        not_ready_work_pool,
+        session: AsyncSession,
+        client,
+    ):
+        """
+        A somewhat contrived test where a NOT_READY work pool has an online worker
+        with a recent heartbeat. The work pool should remain NOT_READY because it
+        is not Foreman's responsibility to mark work pools as READY.
+        """
+        # Purposely create a worker with a recent heartbeat without using the
+        # worker_heartbeat function to avoid the work pool being marked as READY
+        worker_name = "online-worker-with-old-heartbeat"
+        heartbeat_interval_seconds = 60
+        last_heartbeat_time = pendulum.now("UTC")
+
+        values = dict(
+            work_pool_id=not_ready_work_pool.id,
+            name=worker_name,
+            last_heartbeat_time=last_heartbeat_time,
+            heartbeat_interval_seconds=heartbeat_interval_seconds,
+            status=schemas.statuses.WorkerStatus.ONLINE,
+        )
+
+        insert_stmt = sa.insert(db.Worker).values(**values)
+
+        await session.execute(insert_stmt)
+
+        await session.commit()
+
+        work_pool_response = await client.get(f"/work_pools/{not_ready_work_pool.name}")
+
+        assert work_pool_response.json()["status"] == "NOT_READY"
+
+        await Foreman().run_once()
+
+        work_pool_response = await client.get(f"/work_pools/{not_ready_work_pool.name}")
+
+    async def test_foreman_can_mark_workers_without_heartbeat_interval_offline(
+        self,
+        not_ready_work_pool,
+        session: AsyncSession,
+        client,
+    ):
+        """
+        Workers that do not have a heartbeat interval should be marked offline
+        if they have not sent a heartbeat by using the fallback heartbeat interval.
+        """
+        await create_online_worker_with_old_heartbeat(
+            session=session,
+            work_pool=not_ready_work_pool,
+            heartbeat_interval_seconds=None,
+        )
+        await session.commit()
+
+        await Foreman().run_once()
+
+        # Check worker is marked offline
+        workers_response = await client.post(
+            f"/work_pools/{not_ready_work_pool.name}/workers/filter"
+        )
+
+        assert len(workers_response.json()) == 1
+        assert workers_response.json()[0]["status"] == "OFFLINE"
+
+    async def test_foreman_events_correctly_set_follows_on_events(
+        self,
+        session: AsyncSession,
+        ready_work_pool,
+        client,
+    ):
+        """
+        Events should be properly ordered via follows when work pool status
+        changes quickly in succession.
+        """
+        await create_online_worker_with_old_heartbeat(session, ready_work_pool)
+        await session.commit()
+
+        await Foreman().run_once()
+
+        # Check worker is marked offline
+        workers_response = await client.post(
+            f"/work_pools/{ready_work_pool.name}/workers/filter"
+        )
+
+        assert len(workers_response.json()) == 1
+        assert workers_response.json()[0]["status"] == "OFFLINE"
+
+        # Check work pool is marked not_ready
+        work_pools_response = await client.get(f"/work_pools/{ready_work_pool.name}")
+
+        assert work_pools_response.json()["status"] == "NOT_READY"
+
+        # Heartbeat a worker
+        await client.post(
+            f"/work_pools/{ready_work_pool.name}/workers/heartbeat",
+            json=dict(name="test-worker"),
+        )
+
+        # Check work pool is marked ready
+        work_pools_response = await client.get(f"/work_pools/{ready_work_pool.name}")
+
+        assert work_pools_response.json()["status"] == "READY"
+
+        await Foreman(inactivity_heartbeat_multiple=0).run_once()
+
+        # Check work pool is marked not_ready
+        work_pools_response = await client.get(f"/work_pools/{ready_work_pool.name}")
+
+        assert work_pools_response.json()["status"] == "NOT_READY"
+
+        events = [event for item in AssertingEventsClient.all for event in item.events]
+        assert len(events) == 3
+
+        for event in events:
+            print(event.id, event.follows, event.event, event.resource.id)
+
+        assert events[0].event == "prefect.work-pool.not-ready"
+        assert events[0].follows is None
+        assert events[1].event == "prefect.work-pool.ready"
+        assert events[1].follows == events[0].id
+        assert events[2].event == "prefect.work-pool.not-ready"
+        assert events[2].follows == events[1].id
+
     async def test_status_update_when_deployment_has_old_last_polled_time(
         self,
         session: AsyncSession,
@@ -156,6 +485,7 @@ class TestForeman:
         deployment = await create_deployment_with_old_last_polled_time(session=session)
         assert deployment
         assert deployment.status == "READY"
+        await session.commit()
 
         await Foreman().run_once()
 
@@ -206,9 +536,10 @@ class TestForeman:
         client: AsyncClient,
     ):
         deployment = await create_deployment_with_new_last_polled_time(session=session)
-
         assert deployment
         assert deployment.status == "READY"
+
+        await session.commit()
 
         await Foreman().run_once()
 
@@ -507,7 +838,12 @@ class TestForemanWorkQueueService:
 
         assert wq_response_1.json()["last_polled"] < wq_response_2.json()["last_polled"]
 
-        events = [event for item in AssertingEventsClient.all for event in item.events]
+        events = [
+            event
+            for item in AssertingEventsClient.all
+            for event in item.events
+            if event.event.startswith("prefect.work-queue.")
+        ]
 
         # Until work pool status events are emitted, we have 2 work queue status events
         assert len(events) == 2  # 2 work queue status events


### PR DESCRIPTION
This implements the work pool status events, using persisted information on
the work pool and workers to decide when to emit the events.

Inspecting the output from the `EventLogger` debugging service:

```
...start up a worker...

Event: f24dc1ee 2024-04-29T18:25:15.628018+00:00  ( -0.00) 
[prefect.work-pool.ready] prefect.work-pool.513c569d-0e93-4841-91d4-bc0d596e9163
Event: e5f4fa72 2024-04-29T18:25:15.700495+00:00  ( -0.00) 
[prefect.work-queue.ready] 
prefect.work-queue.64c0f2c6-bce3-41e4-a1cc-20a26a5bb581
Event: 14c047a8 2024-04-29T18:25:15.706885+00:00  ( -0.01) 
[prefect.deployment.ready] 
prefect.deployment.4f4e186c-b159-451c-9647-5fe638e434b5

...start up a second worker...

...kill first worker...

14:27:28.802 | INFO    | prefect.server.services.foreman - Marked 1 workers as offline.
Event: d1637be7 2024-04-29T18:27:43.801441+00:00  ( -0.01) 
[prefect.deployment.not-ready] 
prefect.deployment.4f4e186c-b159-451c-9647-5fe638e434b5
Event: ff8aa582 2024-04-29T18:27:43.845776+00:00  ( -0.00) 
[prefect.work-queue.not-ready] 
prefect.work-queue.64c0f2c6-bce3-41e4-a1cc-20a26a5bb581

...kill second worker...

14:28:13.799 | INFO    | prefect.server.services.foreman - Marked 1 workers as offline.
14:28:13.805 | INFO    | prefect.server.services.foreman - Marked work pool 513c569d-0e93-4841-91d4-bc0d596e9163 as NOT_READY.
Event: 6f262ae2 2024-04-29T18:28:13.803672+00:00  ( -0.00) 
[prefect.work-pool.not-ready] 
prefect.work-pool.513c569d-0e93-4841-91d4-bc0d596e9163
```