### PR TITLE
Adding a retention policy for events

### DIFF
--- a/src/prefect/server/events/services/event_persister.py
+++ b/src/prefect/server/events/services/event_persister.py
@@ -8,6 +8,9 @@ from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import AsyncGenerator, List, Optional
 
+import pendulum
+import sqlalchemy as sa
+
 from prefect.logging import get_logger
 from prefect.server.database.dependencies import provide_database_interface
 from prefect.server.events.schemas.events import ReceivedEvent
@@ -16,6 +19,7 @@ from prefect.server.utilities.messaging import Message, MessageHandler, create_c
 from prefect.settings import (
     PREFECT_API_SERVICES_EVENT_PERSISTER_BATCH_SIZE,
     PREFECT_API_SERVICES_EVENT_PERSISTER_FLUSH_INTERVAL,
+    PREFECT_EVENTS_RETENTION_PERIOD,
 )
 
 logger = get_logger(__name__)
@@ -66,6 +70,7 @@ class EventPersister:
 async def create_handler(
     batch_size: int = 20,
     flush_every: timedelta = timedelta(seconds=5),
+    trim_every: timedelta = timedelta(minutes=15),
 ) -> AsyncGenerator[MessageHandler, None]:
     """
     Set up a message handler that will accumulate and send events to
@@ -84,17 +89,47 @@ async def create_handler(
         while queue.qsize() > 0:
             batch.append(await queue.get())
 
-        async with await db.session() as session:
-            await write_events(session=session, events=batch)
-            await session.commit()
+        try:
+            async with await db.session() as session:
+                await write_events(session=session, events=batch)
+                await session.commit()
+                logger.debug("Finished persisting events.")
+        except Exception:
+            logger.debug("Error flushing events, restoring to queue", exc_info=True)
+            for event in batch:
+                queue.put_nowait(event)
 
-        logger.debug("Finished persisting events.")
+    async def trim() -> None:
+        older_than = pendulum.now("UTC") - PREFECT_EVENTS_RETENTION_PERIOD.value()
+
+        logger.debug("Trimming events older than %s", older_than)
+
+        try:
+            async with await db.session() as session:
+                await session.execute(
+                    sa.delete(db.Event).where(db.Event.occurred < older_than)
+                )
+                await session.commit()
+            logger.debug("Finished trimming events.")
+        except Exception:
+            logger.exception("Error trimming events", exc_info=True)
 
     async def flush_periodically():
-        while True:
-            await asyncio.sleep(flush_every.total_seconds())
-            if queue.qsize():
-                await flush()
+        try:
+            while True:
+                await asyncio.sleep(flush_every.total_seconds())
+                if queue.qsize():
+                    await flush()
+        except asyncio.CancelledError:
+            return
+
+    async def trim_periodically():
+        try:
+            while True:
+                await asyncio.sleep(trim_every.total_seconds())
+                await trim()
+        except asyncio.CancelledError:
+            return
 
     async def message_handler(message: Message):
         if not message.data:
@@ -106,11 +141,13 @@ async def create_handler(
         if queue.qsize() >= batch_size:
             await flush()
 
-    periodic_task = asyncio.create_task(flush_periodically())
+    periodic_flush = asyncio.create_task(flush_periodically())
+    periodic_trim = asyncio.create_task(trim_periodically())
 
     try:
         yield message_handler
     finally:
-        periodic_task.cancel()
+        periodic_flush.cancel()
+        periodic_trim.cancel()
         if queue.qsize():
             await flush()

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1728,6 +1728,11 @@ PREFECT_API_SERVICES_EVENT_PERSISTER_FLUSH_INTERVAL = Setting(float, default=5, 
 The maximum number of seconds between flushes of the event persister.
 """
 
+PREFECT_EVENTS_RETENTION_PERIOD = Setting(timedelta, default=timedelta(days=7))
+"""
+The amount of time to retain events in the database.
+"""
+
 PREFECT_API_EVENTS_STREAM_OUT_ENABLED = Setting(bool, default=True)
 """
 Whether or not to allow streaming events out of via websockets.

--- a/tests/events/server/storage/test_event_persister.py
+++ b/tests/events/server/storage/test_event_persister.py
@@ -14,9 +14,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
+from prefect.server.events.filters import EventFilter
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.events.services import event_persister
+from prefect.server.events.storage.database import query_events, write_events
 from prefect.server.utilities.messaging import CapturedMessage, Message, MessageHandler
+from prefect.settings import PREFECT_EVENTS_RETENTION_PERIOD, temporary_settings
 
 if HAS_PYDANTIC_V2:
     from pydantic.v1 import ValidationError
@@ -306,3 +309,42 @@ async def test_flushes_messages_periodically(
         # no matter how many batches this ended up being distributed over due to the
         # periodic flushes, we should definitely have flushed all of the records by here
         assert (await get_event_count(session)) == 9
+
+
+async def test_trims_messages_periodically(
+    event: ReceivedEvent,
+    session: AsyncSession,
+):
+    await write_events(
+        session,
+        [
+            event.copy(
+                update={
+                    "id": uuid4(),
+                    "occurred": pendulum.now("UTC") - timedelta(days=i),
+                }
+            )
+            for i in range(10)
+        ],
+    )
+
+    five_days_ago = pendulum.now("UTC") - timedelta(days=5)
+
+    initial_events, total, _ = await query_events(session, filter=EventFilter())
+    assert total == 10
+    assert len(initial_events) == 10
+    assert any(event.occurred < five_days_ago for event in initial_events)
+    assert any(event.occurred >= five_days_ago for event in initial_events)
+
+    with temporary_settings({PREFECT_EVENTS_RETENTION_PERIOD: timedelta(days=5)}):
+        async with event_persister.create_handler(
+            flush_every=timedelta(seconds=0.001),
+            trim_every=timedelta(seconds=0.001),
+        ):
+            await asyncio.sleep(0.1)  # this is 100x the time necessary
+
+    remaining_events, total, _ = await query_events(session, filter=EventFilter())
+    assert total == 5
+    assert len(remaining_events) == 5
+
+    assert all(event.occurred >= five_days_ago for event in remaining_events)

--- a/tests/events/server/storage/test_event_persister.py
+++ b/tests/events/server/storage/test_event_persister.py
@@ -327,6 +327,7 @@ async def test_trims_messages_periodically(
             for i in range(10)
         ],
     )
+    await session.commit()
 
     five_days_ago = pendulum.now("UTC") - timedelta(days=5)
 


### PR DESCRIPTION
This setting, `PREFECT_EVENTS_RETENTION_PERIOD`, will be enforced periodically
by the event persister service as it is recording other events.  The setting
defaults to 7 days but can be set arbitrarily high.
