### PR TITLE
Fix pydantic v1 prefect-databricks

### DIFF
--- a/src/integrations/prefect-databricks/prefect_databricks/rest.py
+++ b/src/integrations/prefect-databricks/prefect_databricks/rest.py
@@ -17,8 +17,12 @@ from prefect._internal.pydantic._compat import model_dump
 if HAS_PYDANTIC_V2:
     from pydantic import BaseModel as V2BaseModel
     from pydantic.v1 import BaseModel
+
+    MODELS = (BaseModel, V2BaseModel)
 else:
     from pydantic import BaseModel
+
+    MODELS = BaseModel
 
 from prefect import task
 
@@ -54,7 +58,7 @@ def serialize_model(obj: Any) -> Any:
     elif isinstance(obj, Dict):
         return {k: serialize_model(v) for k, v in obj.items()}
 
-    if isinstance(obj, (BaseModel, V2BaseModel)):
+    if isinstance(obj, MODELS):
         return model_dump(obj, mode="json")
     elif isinstance(obj, Enum):
         return obj.value


### PR DESCRIPTION
We're testing a codebase with both pydantic v1 & v2 and we found the v1 versions failing with:
```
NameError: name 'V2BaseModel' is not defined
```

We observed this happen sometime after [0.2.3](https://pypi.org/project/prefect-databricks/0.2.3/).

I'm not sure what your test suite looks like and/if you test with both versions of Pydantic - so it's not clear to me how to add another unit test for this.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
