### PR TITLE
Standardize work pool name as Process

### DIFF
--- a/docs/concepts/work-pools.md
+++ b/docs/concepts/work-pools.md
@@ -84,7 +84,7 @@ If you don't use the `--type` flag to specify an infrastructure type, you are pr
     | Infrastructure Type                  | Description                                                                                                                |
     | ------------------------------       | -------------------------------------------------------------------------------------------------------------------------- |
     | Prefect Agent                        | Execute flow runs on heterogeneous infrastructure using infrastructure blocks.                                              |
-    | Local Subprocess                     | Execute flow runs as subprocesses on a worker. Works well for local execution when first getting started.                    |
+    | Process                              | Execute flow runs as subprocesses on a worker. Works well for local execution when first getting started.                    |
     | AWS Elastic Container Service        | Execute flow runs within containers on AWS ECS. Works with EC2 and Fargate clusters. Requires an AWS account.               |
     | Azure Container Instances            | Execute flow runs within containers on Azure's Container Instances service. Requires an Azure account.                      |
     | Docker                               | Execute flow runs within Docker containers. Works well for managing flow execution environments via Docker images. Requires  access to a running Docker daemon.  |
@@ -103,7 +103,7 @@ If you don't use the `--type` flag to specify an infrastructure type, you are pr
     | Infrastructure Type           | Description              |
     | ----------------------------  | ------------------------ |
     | Prefect Agent                 | Execute flow runs on heterogeneous infrastructure using infrastructure blocks.                                                  |
-    | Local Subprocess              | Execute flow runs as subprocesses on a worker. Works well for local execution when first getting started.                       |
+    | Process                       | Execute flow runs as subprocesses on a worker. Works well for local execution when first getting started.                       |
     | AWS Elastic Container Service | Execute flow runs within containers on AWS ECS. Works with EC2 and Fargate clusters. Requires an AWS account.                  |
     | Azure Container Instances     | Execute flow runs within containers on Azure's Container Instances service. Requires an Azure account.                         |
     | Docker                        | Execute flow runs within Docker containers. Works well for managing flow execution environments via Docker images. Requires access to a running Docker daemon.    |
@@ -275,7 +275,7 @@ prefect work-pool get-default-base-job-template --type process
 ```
 </div>
 
-You can override each of these attributes on a per-deployment or per-flow run basis. When creating a deployment, you can specify these overrides in the `deployments.work_pool.job_variables` section of a `prefect.yaml` file or in the `job_variables` argument of a Python `flow.deploy` method. 
+You can override each of these attributes on a per-deployment or per-flow run basis. When creating a deployment, you can specify these overrides in the `deployments.work_pool.job_variables` section of a `prefect.yaml` file or in the `job_variables` argument of a Python `flow.deploy` method.
 
 For example, to turn off streaming output for a specific deployment, we could add the following to our `prefect.yaml`:
 

--- a/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
+++ b/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
@@ -64,7 +64,7 @@
         }
       },
       "description": "Execute flow runs as subprocesses on a worker. Works well for local execution when first getting started.",
-      "display_name": "Local Subprocess",
+      "display_name": "Process",
       "documentation_url": "https://docs.prefect.io/latest/api-ref/prefect/workers/process/",
       "install_command": "pip install prefect",
       "is_beta": false,

--- a/src/prefect/workers/process.py
+++ b/src/prefect/workers/process.py
@@ -13,6 +13,7 @@ to poll for flow runs.
 For more information about work pools and workers,
 checkout out the [Prefect docs](/concepts/work-pools/).
 """
+
 import asyncio
 import contextlib
 import os
@@ -142,7 +143,7 @@ class ProcessWorker(BaseWorker):
         "Execute flow runs as subprocesses on a worker. Works well for local execution"
         " when first getting started."
     )
-    _display_name = "Local Subprocess"
+    _display_name = "Process"
     _documentation_url = (
         "https://docs.prefect.io/latest/api-ref/prefect/workers/process/"
     )


### PR DESCRIPTION
Closes #10842

Updates docs and server instance UI to refer to Process work pool instead of subprocess. 

Most places it already was Process (e.g. CLI, type in UI, most docs).


### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [X] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
