### PR TITLE
Add columns to ORM `DeploymentSchedule` and add migrations

### DIFF
--- a/src/prefect/server/database/migrations/versions/postgresql/2024_05_01_105401_b23c83a12cb4_add_catchup_fields_to_deploymentschedule.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2024_05_01_105401_b23c83a12cb4_add_catchup_fields_to_deploymentschedule.py
@@ -1,0 +1,35 @@
+"""add catchup fields to DeploymentSchedule
+
+Revision ID: b23c83a12cb4
+Revises: 8905262ec07f
+Create Date: 2024-05-01 10:54:01.271642
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b23c83a12cb4"
+down_revision = "8905262ec07f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "deployment_schedule", sa.Column("max_active_runs", sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        "deployment_schedule",
+        sa.Column("max_scheduled_runs", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "deployment_schedule", sa.Column("catchup", sa.Boolean(), nullable=False)
+    )
+
+
+def downgrade():
+    op.drop_column("deployment_schedule", "catchup")
+    op.drop_column("deployment_schedule", "max_scheduled_runs")
+    op.drop_column("deployment_schedule", "max_active_runs")

--- a/src/prefect/server/database/migrations/versions/sqlite/2024_05_01_103824_20fbd53b3cef_add_catchup_fields_to_deploymentschedule.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2024_05_01_103824_20fbd53b3cef_add_catchup_fields_to_deploymentschedule.py
@@ -1,0 +1,32 @@
+"""add catchup fields to DeploymentSchedule
+
+Revision ID: 20fbd53b3cef
+Revises: a8e62d4c72cf
+Create Date: 2024-05-01 10:38:24.336255
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20fbd53b3cef"
+down_revision = "a8e62d4c72cf"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("deployment_schedule", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("max_active_runs", sa.Integer(), nullable=True))
+        batch_op.add_column(
+            sa.Column("max_scheduled_runs", sa.Integer(), nullable=True)
+        )
+        batch_op.add_column(sa.Column("catchup", sa.Boolean(), nullable=False))
+
+
+def downgrade():
+    with op.batch_alter_table("deployment_schedule", schema=None) as batch_op:
+        batch_op.drop_column("catchup")
+        batch_op.drop_column("max_scheduled_runs")
+        batch_op.drop_column("max_active_runs")

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -864,6 +864,9 @@ class ORMDeploymentSchedule:
 
     schedule = sa.Column(Pydantic(schemas.schedules.SCHEDULE_TYPES), nullable=False)
     active = sa.Column(sa.Boolean, nullable=False, default=True)
+    max_active_runs = sa.Column(sa.Integer, nullable=True)
+    max_scheduled_runs = sa.Column(sa.Integer, nullable=True)
+    catchup = sa.Column(sa.Boolean, nullable=False, default=False)
 
 
 @declarative_mixin


### PR DESCRIPTION
adds columns to the `ORMDeploymentSchedule`
```python
    max_active_runs = sa.Column(sa.Integer, nullable=True)
    max_scheduled_runs = sa.Column(sa.Integer, nullable=True)
    catchup = sa.Column(sa.Boolean, nullable=False, default=False)
```

and adds the corresponding migrations