### PR TITLE
Add new sync compat setting

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1614,6 +1614,11 @@ PREFECT_EXPERIMENTAL_ENABLE_NEW_ENGINE = Setting(bool, default=False)
 Whether or not to enable experimental new engine.
 """
 
+PREFECT_EXPERIMENTAL_DISABLE_SYNC_COMPAT = Setting(bool, default=False)
+"""
+Whether or not to disable the sync_compatible decorator utility.
+"""
+
 
 # Defaults -----------------------------------------------------------------------------
 

--- a/src/prefect/utilities/asyncutils.py
+++ b/src/prefect/utilities/asyncutils.py
@@ -266,6 +266,10 @@ def sync_compatible(async_fn: T) -> T:
         from prefect._internal.concurrency.calls import get_current_call, logger
         from prefect._internal.concurrency.event_loop import get_running_loop
         from prefect._internal.concurrency.threads import get_global_loop
+        from prefect.settings import PREFECT_EXPERIMENTAL_DISABLE_SYNC_COMPAT
+
+        if PREFECT_EXPERIMENTAL_DISABLE_SYNC_COMPAT:
+            return async_fn(*args, **kwargs)
 
         global_thread_portal = get_global_loop()
         current_thread = threading.current_thread()

--- a/tests/utilities/test_asyncutils.py
+++ b/tests/utilities/test_asyncutils.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import threading
 import time
 import uuid
@@ -10,6 +11,10 @@ import anyio
 import pytest
 
 from prefect.context import ContextModel
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_DISABLE_SYNC_COMPAT,
+    temporary_settings,
+)
 from prefect.utilities.asyncutils import (
     GatherIncomplete,
     LazySemaphore,
@@ -277,6 +282,12 @@ def test_sync_compatible_call_from_sync(fn):
 @pytest.mark.parametrize("fn", SYNC_COMPAT_TEST_CASES)
 async def test_sync_compatible_call_from_async(fn):
     assert await fn(1, y=2) == 6
+
+
+@pytest.mark.parametrize("fn", SYNC_COMPAT_TEST_CASES)
+def test_sync_compatible_is_disabled_by_flag(fn):
+    with temporary_settings({PREFECT_EXPERIMENTAL_DISABLE_SYNC_COMPAT: True}):
+        assert inspect.isawaitable(fn(1, y=2))
 
 
 async def test_sync_compatible_call_from_sync_in_async_thread():


### PR DESCRIPTION
This PR adds a new experimental setting that, when set, _disables_ the `sync_compatible` interface. As we continue to build out the new engine we are confronting various issues with sync/async interfaces and this allows us to test.  The ultimate goal will be to remove this utility entirely, but this setting will help us do that safely.