### PR TITLE
Chore/prune artifact UI entrypoints

### DIFF
--- a/ui/src/components/ContextSidebar.vue
+++ b/ui/src/components/ContextSidebar.vue
@@ -15,7 +15,6 @@
     <p-context-nav-item :title="localization.info.variables" :to="routes.variables()" />
     <p-context-nav-item title="Notifications" :to="routes.notifications()" />
     <p-context-nav-item title="Concurrency" :to="routes.concurrencyLimits()" />
-    <p-context-nav-item v-if="canSeeArtifacts" title="Artifacts" :to="routes.artifacts()" />
 
     <template #footer>
       <a href="https://www.prefect.io/cloud-vs-oss?utm_source=oss&utm_medium=oss&utm_campaign=oss&utm_term=none&utm_content=none" target="_blank">
@@ -42,7 +41,6 @@
 
   const can = useCan()
   const canSeeWorkPools = computed(() => can.access.work_pools && can.read.work_pool)
-  const canSeeArtifacts = computed(() => can.access.artifacts)
 </script>
 
 <style>

--- a/ui/src/pages/FlowRun.vue
+++ b/ui/src/pages/FlowRun.vue
@@ -19,10 +19,6 @@
         <FlowRunResults v-if="flowRun" :flow-run="flowRun" />
       </template>
 
-      <template #artifacts>
-        <FlowRunArtifacts v-if="flowRun" :flow-run="flowRun" />
-      </template>
-
       <template #task-runs>
         <FlowRunTaskRuns v-if="flowRun" :flow-run-id="flowRun.id" />
       </template>
@@ -49,7 +45,6 @@
 <script lang="ts" setup>
   import {
     PageHeadingFlowRun,
-    FlowRunArtifacts,
     FlowRunDetails,
     FlowRunLogs,
     FlowRunTaskRuns,
@@ -94,7 +89,6 @@
     { label: 'Task Runs', hidden: isPending.value },
     { label: 'Subflow Runs', hidden: isPending.value },
     { label: 'Results', hidden: isPending.value },
-    { label: 'Artifacts', hidden: isPending.value },
     { label: 'Details' },
     { label: 'Parameters' },
     { label: 'Job Variables', hidden: !can.access.flowRunInfraOverrides },


### PR DESCRIPTION
In an effort to reduce the top-level surface area of user entrypoints in the UI, this PR removes:
- the Artifacts nav item
- the Artifacts tab on the flow run page

The goal here is to reduce the # of forks at the highest level of the app. While artifacts can be created and exist outside the context of flows, they rarely are and so we want the UI to better reflect the relationship that artifacts do have - namely with flow runs and task runs. 

After these changes, artifacts are still available in the UI through the flow run graph on the flow run page. Their individual pages are also still available and exposed throughout the app but just not via top-level site navigations.