### PR TITLE
Fix work pool base job template generation for `ECSTask` block

### DIFF
--- a/src/integrations/prefect-aws/prefect_aws/ecs.py
+++ b/src/integrations/prefect-aws/prefect_aws/ecs.py
@@ -774,7 +774,9 @@ class ECSTask(Infrastructure):
                 )
                 base_job_template["variables"]["properties"]["network_configuration"][
                     "default"
-                ] = minimal_network_config_with_patches["networkConfiguration"]
+                ] = minimal_network_config_with_patches["networkConfiguration"][
+                    "awsvpcConfiguration"
+                ]
             try:
                 base_job_template["job_configuration"][
                     "task_run_request"

--- a/src/integrations/prefect-aws/tests/test_ecs.py
+++ b/src/integrations/prefect-aws/tests/test_ecs.py
@@ -2144,12 +2144,11 @@ def base_job_template_with_defaults(default_base_job_template, aws_credentials):
     base_job_template_with_defaults["variables"]["properties"]["network_configuration"][
         "default"
     ] = {
-        "awsvpcConfiguration": {
-            "subnets": ["subnet-***"],
-            "assignPublicIp": "DISABLED",
-            "securityGroups": ["sg-***"],
-        }
+        "subnets": ["subnet-***"],
+        "assignPublicIp": "DISABLED",
+        "securityGroups": ["sg-***"],
     }
+    breakpoint()
     return base_job_template_with_defaults
 
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Fixes duplicate nesting of `awsvpcConfiguration` when using a base job template generated for from an `ECSTask` block.

Closes https://github.com/PrefectHQ/prefect/issues/13255

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
