### PR TITLE
Use Prefect-specific TestClient for sync calls

### DIFF
--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -26,6 +26,7 @@ import httpx
 from asgi_lifespan import LifespanManager
 from httpx import HTTPStatusError, Request, Response
 from prefect._vendor.starlette import status
+from prefect._vendor.starlette.testclient import TestClient
 from typing_extensions import Self
 
 import prefect
@@ -609,3 +610,30 @@ class PrefectHttpxSyncClient(httpx.Client):
 
         request.headers["Prefect-Csrf-Token"] = self.csrf_token
         request.headers["Prefect-Csrf-Client"] = str(self.csrf_client_id)
+
+
+class PrefectHttpxSyncEphemeralClient(TestClient, PrefectHttpxSyncClient):
+    """
+    This client is a synchronous httpx client that can be used to talk directly
+    to an ASGI app, such as an ephemeral Prefect API.
+
+    It is a subclass of both Starlette's `TestClient` and Prefect's
+    `PrefectHttpxSyncClient`, so it combines the synchronous testing
+    capabilities of `TestClient` with the Prefect-specific behaviors of
+    `PrefectHttpxSyncClient`.
+    """
+
+    def __init__(
+        self,
+        *args,
+        # override TestClient default
+        raise_server_exceptions=False,
+        **kwargs,
+    ):
+        super().__init__(
+            *args,
+            raise_server_exceptions=raise_server_exceptions,
+            **kwargs,
+        )
+
+    pass

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -21,7 +21,6 @@ import certifi
 import httpcore
 import httpx
 import pendulum
-from prefect._vendor.starlette.testclient import TestClient
 from typing_extensions import ParamSpec
 
 from prefect._internal.compatibility.deprecated import (
@@ -159,6 +158,7 @@ from prefect.client.base import (
     ASGIApp,
     PrefectHttpxAsyncClient,
     PrefectHttpxSyncClient,
+    PrefectHttpxSyncEphemeralClient,
     app_lifespan_context,
 )
 
@@ -3491,10 +3491,8 @@ class SyncPrefectClient:
         )
 
         if self.server_type == ServerType.EPHEMERAL:
-            self._client = TestClient(
-                api,
-                base_url="http://ephemeral-prefect/api",
-                raise_server_exceptions=False,
+            self._client = PrefectHttpxSyncEphemeralClient(
+                api, base_url="http://ephemeral-prefect/api"
             )
         else:
             self._client = PrefectHttpxSyncClient(


### PR DESCRIPTION
A nested task test has been causing intermittent failures e.g. https://github.com/PrefectHQ/prefect/actions/runs/8972915998/job/24641970356. The failures appear related to SQLite contention.

Prefect API clients retry on certain API errors, including SQLite database locked errors, that indicate transient issues. The sync engine currently uses a Starlette TestClient for synchronous access to the ephemeral API. However, that TestClient doesn't have any of Prefect's retry logic. This PR replaces the raw TestClient with one that inherits our retry behavior.