### PR TITLE
Allow client-provided ID when creating a task run

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2226,6 +2226,9 @@ class PrefectClient:
             state=state.to_state_create(),
             task_inputs=task_inputs or {},
         )
+        json = task_run_data.dict(json_compatible=True)
+        if json.get("id") is not None:
+            del json["id"]
 
         response = await self._client.post(
             "/task_runs/", json=task_run_data.dict(json_compatible=True)
@@ -3873,7 +3876,7 @@ class SyncPrefectClient:
         )
 
         json = task_run_data.dict(json_compatible=True)
-        if json.get("id") is None:
+        if json.get("id") is not None:
             del json["id"]
 
         response = self._client.post(

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2226,11 +2226,9 @@ class PrefectClient:
             state=state.to_state_create(),
             task_inputs=task_inputs or {},
         )
-        json = task_run_data.dict(json_compatible=True)
-        if json.get("id") is None:
-            json.pop("id", None)
+        content = task_run_data.json(exclude={"id"} if id is None else None)
 
-        response = await self._client.post("/task_runs/", json=json)
+        response = await self._client.post("/task_runs/", content=content)
         return TaskRun.parse_obj(response.json())
 
     async def read_task_run(self, task_run_id: UUID) -> TaskRun:
@@ -3873,11 +3871,9 @@ class SyncPrefectClient:
             task_inputs=task_inputs or {},
         )
 
-        json = task_run_data.dict(json_compatible=True)
-        if json.get("id") is None:
-            json.pop("id", None)
+        content = task_run_data.json(exclude={"id"} if id is None else None)
 
-        response = self._client.post("/task_runs/", json=json)
+        response = self._client.post("/task_runs/", content=content)
         return TaskRun.parse_obj(response.json())
 
     def read_task_run(self, task_run_id: UUID) -> TaskRun:

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2169,6 +2169,7 @@ class PrefectClient:
         task: "TaskObject[P, R]",
         flow_run_id: Optional[UUID],
         dynamic_key: str,
+        id: Optional[UUID] = None,
         name: Optional[str] = None,
         extra_tags: Optional[Iterable[str]] = None,
         state: Optional[prefect.states.State[R]] = None,
@@ -2192,6 +2193,8 @@ class PrefectClient:
             task: The Task to run
             flow_run_id: The flow run id with which to associate the task run
             dynamic_key: A key unique to this particular run of a Task within the flow
+            id: An optional ID for the task run. If not provided, one will be generated
+                server-side.
             name: An optional name for the task run
             extra_tags: an optional list of extra tags to apply to the task run in
                 addition to `task.tags`
@@ -2208,6 +2211,7 @@ class PrefectClient:
             state = prefect.states.Pending()
 
         task_run_data = TaskRunCreate(
+            id=id,
             name=name,
             flow_run_id=flow_run_id,
             task_key=task.task_key,
@@ -3810,6 +3814,7 @@ class SyncPrefectClient:
         task: "TaskObject[P, R]",
         flow_run_id: Optional[UUID],
         dynamic_key: str,
+        id: Optional[UUID] = None,
         name: Optional[str] = None,
         extra_tags: Optional[Iterable[str]] = None,
         state: Optional[prefect.states.State[R]] = None,
@@ -3833,6 +3838,8 @@ class SyncPrefectClient:
             task: The Task to run
             flow_run_id: The flow run id with which to associate the task run
             dynamic_key: A key unique to this particular run of a Task within the flow
+            id: An optional ID for the task run. If not provided, one will be generated
+                server-side.
             name: An optional name for the task run
             extra_tags: an optional list of extra tags to apply to the task run in
                 addition to `task.tags`
@@ -3849,6 +3856,7 @@ class SyncPrefectClient:
             state = prefect.states.Pending()
 
         task_run_data = TaskRunCreate(
+            id=id,
             name=name,
             flow_run_id=flow_run_id,
             task_key=task.task_key,

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2227,8 +2227,8 @@ class PrefectClient:
             task_inputs=task_inputs or {},
         )
         json = task_run_data.dict(json_compatible=True)
-        if json.get("id") is not None:
-            del json["id"]
+        if json.get("id") is None:
+            json.pop("id", None)
 
         response = await self._client.post(
             "/task_runs/", json=task_run_data.dict(json_compatible=True)
@@ -3876,8 +3876,8 @@ class SyncPrefectClient:
         )
 
         json = task_run_data.dict(json_compatible=True)
-        if json.get("id") is not None:
-            del json["id"]
+        if json.get("id") is None:
+            json.pop("id", None)
 
         response = self._client.post(
             "/task_runs/", json=task_run_data.dict(json_compatible=True)

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2211,7 +2211,6 @@ class PrefectClient:
             state = prefect.states.Pending()
 
         task_run_data = TaskRunCreate(
-            id=id,
             name=name,
             flow_run_id=flow_run_id,
             task_key=task.task_key,
@@ -2226,6 +2225,8 @@ class PrefectClient:
             state=state.to_state_create(),
             task_inputs=task_inputs or {},
         )
+        if id is not None:
+            task_run_data.id = id
 
         response = await self._client.post(
             "/task_runs/", json=task_run_data.dict(json_compatible=True)
@@ -3856,7 +3857,6 @@ class SyncPrefectClient:
             state = prefect.states.Pending()
 
         task_run_data = TaskRunCreate(
-            id=id,
             name=name,
             flow_run_id=flow_run_id,
             task_key=task.task_key,
@@ -3871,6 +3871,8 @@ class SyncPrefectClient:
             state=state.to_state_create(),
             task_inputs=task_inputs or {},
         )
+        if id is not None:
+            task_run_data.id = id
 
         response = self._client.post(
             "/task_runs/", json=task_run_data.dict(json_compatible=True)

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2211,6 +2211,7 @@ class PrefectClient:
             state = prefect.states.Pending()
 
         task_run_data = TaskRunCreate(
+            id=id,
             name=name,
             flow_run_id=flow_run_id,
             task_key=task.task_key,
@@ -2225,8 +2226,6 @@ class PrefectClient:
             state=state.to_state_create(),
             task_inputs=task_inputs or {},
         )
-        if id is not None:
-            task_run_data.id = id
 
         response = await self._client.post(
             "/task_runs/", json=task_run_data.dict(json_compatible=True)
@@ -3857,6 +3856,7 @@ class SyncPrefectClient:
             state = prefect.states.Pending()
 
         task_run_data = TaskRunCreate(
+            id=id,
             name=name,
             flow_run_id=flow_run_id,
             task_key=task.task_key,
@@ -3871,8 +3871,10 @@ class SyncPrefectClient:
             state=state.to_state_create(),
             task_inputs=task_inputs or {},
         )
-        if id is not None:
-            task_run_data.id = id
+
+        json = task_run_data.dict(json_compatible=True)
+        if json.get("id") is None:
+            del json["id"]
 
         response = self._client.post(
             "/task_runs/", json=task_run_data.dict(json_compatible=True)

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2230,9 +2230,7 @@ class PrefectClient:
         if json.get("id") is None:
             json.pop("id", None)
 
-        response = await self._client.post(
-            "/task_runs/", json=task_run_data.dict(json_compatible=True)
-        )
+        response = await self._client.post("/task_runs/", json=json)
         return TaskRun.parse_obj(response.json())
 
     async def read_task_run(self, task_run_id: UUID) -> TaskRun:
@@ -3879,9 +3877,7 @@ class SyncPrefectClient:
         if json.get("id") is None:
             json.pop("id", None)
 
-        response = self._client.post(
-            "/task_runs/", json=task_run_data.dict(json_compatible=True)
-        )
+        response = self._client.post("/task_runs/", json=json)
         return TaskRun.parse_obj(response.json())
 
     def read_task_run(self, task_run_id: UUID) -> TaskRun:

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -302,6 +302,7 @@ class FlowRunUpdate(ActionBaseModel):
 class TaskRunCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a task run"""
 
+    id: Optional[UUID] = Field(None, description="The ID to assign to the task run")
     # TaskRunCreate states must be provided as StateCreate objects
     state: Optional[StateCreate] = Field(
         default=None, description="The state of the task run to create"

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -17,6 +17,7 @@ from typing import (
     Union,
     cast,
 )
+from uuid import UUID
 
 import pendulum
 from typing_extensions import ParamSpec
@@ -275,7 +276,9 @@ class TaskRunEngine(Generic[P, R]):
                 self.logger = current_logger
 
     @contextmanager
-    def start(self) -> Generator["TaskRunEngine", Any, Any]:
+    def start(
+        self, task_run_id: Optional[UUID] = None
+    ) -> Generator["TaskRunEngine", Any, Any]:
         """
         Enters a client context and creates a task run if needed.
         """
@@ -286,6 +289,7 @@ class TaskRunEngine(Generic[P, R]):
                 if not self.task_run:
                     self.task_run = run_sync(
                         self.task.create_run(
+                            id=task_run_id,
                             client=client,
                             parameters=self.parameters,
                             flow_run_context=FlowRunContext.get(),
@@ -324,15 +328,20 @@ class TaskRunEngine(Generic[P, R]):
 
 def run_task_sync(
     task: Task[P, R],
+    task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[Dict[str, Any]] = None,
     wait_for: Optional[Iterable[PrefectFuture[A, Async]]] = None,
     return_type: Literal["state", "result"] = "result",
 ) -> Union[R, State, None]:
-    engine = TaskRunEngine[P, R](task=task, parameters=parameters, task_run=task_run)
+    engine = TaskRunEngine[P, R](
+        task=task,
+        parameters=parameters,
+        task_run=task_run,
+    )
 
     # This is a context manager that keeps track of the run of the task run.
-    with engine.start() as run:
+    with engine.start(task_run_id=task_run_id) as run:
         run.begin_run()
 
         while run.is_running():
@@ -362,6 +371,7 @@ def run_task_sync(
 
 async def run_task_async(
     task: Task[P, Coroutine[Any, Any, R]],
+    task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[Dict[str, Any]] = None,
     wait_for: Optional[Iterable[PrefectFuture[A, Async]]] = None,
@@ -375,7 +385,7 @@ async def run_task_async(
     engine = TaskRunEngine[P, R](task=task, parameters=parameters, task_run=task_run)
 
     # This is a context manager that keeps track of the run of the task run.
-    with engine.start() as run:
+    with engine.start(task_run_id=task_run_id) as run:
         run.begin_run()
 
         while run.is_running():
@@ -405,6 +415,7 @@ async def run_task_async(
 
 def run_task(
     task: Task[P, R],
+    task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[Dict[str, Any]] = None,
     wait_for: Optional[Iterable[PrefectFuture[A, Async]]] = None,
@@ -412,6 +423,7 @@ def run_task(
 ) -> Union[R, State, None]:
     kwargs = dict(
         task=task,
+        task_run_id=task_run_id,
         task_run=task_run,
         parameters=parameters,
         wait_for=wait_for,

--- a/src/prefect/server/api/task_runs.py
+++ b/src/prefect/server/api/task_runs.py
@@ -57,7 +57,10 @@ async def create_task_run(
     If no state is provided, the task run will be created in a PENDING state.
     """
     # hydrate the input model into a full task run / state model
-    task_run = schemas.core.TaskRun(**task_run.dict())
+    task_run_dict = task_run.dict()
+    if not task_run_dict.get("id"):
+        task_run_dict.pop("id", None)
+    task_run = schemas.core.TaskRun(**task_run_dict)
 
     if not task_run.state:
         task_run.state = schemas.states.Pending()

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -421,6 +421,10 @@ class StateCreate(ActionBaseModel):
 class TaskRunCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a task run"""
 
+    id: Optional[UUID] = Field(
+        default=None,
+        description="The ID to assign to the task run. If not provided, a random UUID will be generated.",
+    )
     # TaskRunCreate states must be provided as StateCreate objects
     state: Optional[StateCreate] = Field(
         default=None, description="The state of the task run to create"

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -27,7 +27,7 @@ from typing import (
     cast,
     overload,
 )
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from typing_extensions import Literal, ParamSpec
 
@@ -518,8 +518,9 @@ class Task(Generic[P, R]):
 
     async def create_run(
         self,
-        client: Optional[Union[PrefectClient, SyncPrefectClient]],
-        parameters: Dict[str, Any] = None,
+        client: Union[PrefectClient, SyncPrefectClient],
+        id: Optional[UUID] = None,
+        parameters: Optional[Dict[str, Any]] = None,
         flow_run_context: Optional[FlowRunContext] = None,
         parent_task_run_context: Optional[TaskRunContext] = None,
         wait_for: Optional[Iterable[PrefectFuture]] = None,
@@ -591,6 +592,7 @@ class Task(Generic[P, R]):
                 else None
             ),
             dynamic_key=str(dynamic_key),
+            id=id,
             state=Pending(),
             task_inputs=task_inputs,
             extra_tags=TagsContext.get().current_tags,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
When working on the new task run engine, we identified an opportunity to remove our API as a bottleneck when submitting tasks to remote infrastructure, allowing the client to generate a UUID and provide that as the ID when creating a task run. Using a client-generated ID will enable us to submit to the task execution layer before creating a task run on the server while also allowing future enhancements where the client can track dependencies between runs.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
