### PR TITLE
[prefect-docker] add cached docker build and push steps

### DIFF
--- a/src/integrations/prefect-docker/prefect_docker/deployments/steps.py
+++ b/src/integrations/prefect-docker/prefect_docker/deployments/steps.py
@@ -364,7 +364,33 @@ def cached_build_docker_image(
     additional_tags: Optional[List[str]] = None,
     **build_kwargs,
 ) -> BuildDockerImageResult:
-    """Cached version of `prefect_docker.deployments.steps.build_docker_image`."""
+    """Cached version of `prefect_docker.deployments.steps.build_docker_image`.
+
+    Args:
+        image_name: The name of the Docker image to build, including the registry and
+            repository.
+        dockerfile: The path to the Dockerfile used to build the image. If "auto" is
+            passed, a temporary Dockerfile will be created to build the image.
+        tag: The tag to apply to the built image.
+        additional_tags: Additional tags on the image, in addition to `tag`, to apply to the built image.
+        **build_kwargs: Additional keyword arguments to pass to Docker when building
+            the image. Available options can be found in the [`docker-py`](https://docker-py.readthedocs.io/en/stable/images.html#docker.models.images.ImageCollection.build)
+            documentation.
+
+    Returns:
+        A dictionary containing the image name and tag of the built image.
+
+    Example:
+        Build a Docker image that is cached if the same image is built again in the same `prefect deploy` run:
+        ```yaml
+        build:
+            - prefect_docker.deployments.steps.cached_build_docker_image:
+                id: build-image
+                requires: prefect-docker
+                image_name: repo-name/image-name
+                tag: dev
+        ```
+    """
     return build_docker_image(
         image_name=image_name,
         dockerfile=dockerfile,
@@ -382,7 +408,33 @@ def cached_push_docker_image(
     additional_tags: Optional[List[str]] = None,
     **push_kwargs,
 ) -> PushDockerImageResult:
-    """Cached version of `prefect_docker.deployments.steps.push_docker_image`."""
+    """Cached version of `prefect_docker.deployments.steps.push_docker_image`.
+
+    Args:
+        image_name: The name of the Docker image to push, including the registry and
+            repository.
+        tag: The tag of the Docker image to push.
+        credentials: A dictionary containing the username, password, and URL for the
+            registry to push the image to.
+        additional_tags: Additional tags on the image, in addition to `tag`, to apply to the built image.
+        **push_kwargs: Additional keyword arguments to pass to Docker when pushing
+            the image. Available options can be found in the [`docker-py`](https://docker-py.readthedocs.io/en/stable/images.html#docker.models.images.ImageCollection.push)
+            documentation.
+
+    Returns:
+        A dictionary containing the image name and tag of the pushed image.
+
+    Example:
+        Push a Docker image that is cached if the same image is pushed again in the same `prefect deploy` run:
+        ```yaml
+        push:
+            - prefect_docker.deployments.steps.cached_push_docker_image:
+                requires: prefect-docker
+                image_name: repo-name/image-name
+                tag: dev
+                credentials: "{{ prefect.blocks.docker-registry-credentials.dev-registry }}"
+        ```
+    """
     return push_docker_image(
         image_name=image_name,
         tag=tag,

--- a/src/integrations/prefect-docker/prefect_docker/deployments/steps.py
+++ b/src/integrations/prefect-docker/prefect_docker/deployments/steps.py
@@ -36,7 +36,6 @@ import pendulum
 from docker.models.images import Image
 from typing_extensions import TypedDict
 
-from prefect.logging.loggers import get_logger
 from prefect.utilities.dockerutils import (
     IMAGE_LABELS,
     BuildError,
@@ -44,8 +43,6 @@ from prefect.utilities.dockerutils import (
     get_prefect_image_name,
 )
 from prefect.utilities.slugify import slugify
-
-logger = get_logger("prefect_docker.deployments.steps")
 
 
 class BuildDockerImageResult(TypedDict):


### PR DESCRIPTION
this will cache the results of the existing build and push steps in memory so that if the same build or push is requested during a `build` step more than once, it will no-op and the result will be fetched from the cache

this is an alternative way to address https://github.com/PrefectHQ/prefect/issues/9921

i could see the argument that we should simply add caching to the existing step, but it felt like I needed a layer to handle the `list` / `dict` (non-hashable) inputs and avoid any potential weirdness associated with changing the canonical step

### usage
```yaml
build:
    - prefect_docker.deployments.steps.cached_build_docker_image:
        id: build-image
        requires: prefect-docker
        image_name: repo-name/image-name
        tag: dev

push:
    - prefect_docker.deployments.steps.cached_push_docker_image:
        requires: prefect-docker
        image_name: repo-name/image-name
        tag: dev
        credentials: "{{ prefect.blocks.docker-registry-credentials.dev-registry }}"
```