### PR TITLE
let typing be compatible with python 3.8

### DIFF
--- a/src/integrations/prefect-dask/prefect_dask/task_runners.py
+++ b/src/integrations/prefect-dask/prefect_dask/task_runners.py
@@ -73,7 +73,7 @@ Example:
 
 import inspect
 from contextlib import AsyncExitStack
-from typing import Awaitable, Callable, Dict, Optional, Union
+from typing import Callable, Dict, Optional, Union
 from uuid import UUID
 
 import distributed
@@ -82,7 +82,7 @@ from prefect.client.schemas.objects import State
 from prefect.context import FlowRunContext
 from prefect.futures import PrefectFuture
 from prefect.states import exception_to_crashed_state
-from prefect.task_runners import BaseTaskRunner, R, TaskConcurrencyType
+from prefect.task_runners import BaseTaskRunner, CallableGeneric, R, TaskConcurrencyType
 from prefect.utilities.collections import visit_collection
 from prefect.utilities.importtools import from_qualified_name, to_qualified_name
 
@@ -254,7 +254,7 @@ class DaskTaskRunner(BaseTaskRunner):
     async def submit(
         self,
         key: UUID,
-        call: Callable[..., Awaitable[State[R]]],
+        call: CallableGeneric[R],
     ) -> None:
         if not self._started:
             raise RuntimeError(

--- a/src/integrations/prefect-ray/prefect_ray/task_runners.py
+++ b/src/integrations/prefect-ray/prefect_ray/task_runners.py
@@ -72,7 +72,7 @@ Example:
 """
 
 from contextlib import AsyncExitStack
-from typing import Awaitable, Callable, Dict, Optional
+from typing import Dict, Optional
 from uuid import UUID
 
 import anyio
@@ -81,7 +81,7 @@ from ray.exceptions import RayTaskError
 
 from prefect.futures import PrefectFuture
 from prefect.states import State, exception_to_crashed_state
-from prefect.task_runners import BaseTaskRunner, R, TaskConcurrencyType
+from prefect.task_runners import BaseTaskRunner, CallableGeneric, R, TaskConcurrencyType
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.collections import visit_collection
 from prefect_ray.context import RemoteOptionsContext
@@ -153,7 +153,7 @@ class RayTaskRunner(BaseTaskRunner):
     async def submit(
         self,
         key: UUID,
-        call: Callable[..., Awaitable[State[R]]],
+        call: CallableGeneric[R],
     ) -> None:
         if not self._started:
             raise RuntimeError(

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -51,6 +51,7 @@ Example:
 
 For usage details, see the [Task Runners](/concepts/task-runners/) documentation.
 """
+
 import abc
 from contextlib import AsyncExitStack, asynccontextmanager
 from typing import (
@@ -60,6 +61,7 @@ from typing import (
     Awaitable,
     Callable,
     Dict,
+    Generic,
     Optional,
     Set,
     TypeVar,
@@ -80,6 +82,13 @@ if TYPE_CHECKING:
 
 T = TypeVar("T", bound="BaseTaskRunner")
 R = TypeVar("R")
+StateR = TypeVar("StateR", bound=State[R])
+
+
+class CallableGeneric(Generic[R]):
+    # create this class to be compatible with python 3.8
+    def __call__(self, *args, **kwargs) -> Awaitable[StateR]:
+        pass
 
 
 class TaskConcurrencyType(AutoEnum):


### PR DESCRIPTION
Hi, when I import `prefect_ray` with python 3.8, I met a typing error:
```python
→ python -c "import prefect_ray as pr; print(pr.__file__, pr.__version__)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".../.venv/lib/python3.8/site-packages/prefect_ray/__init__.py", line 6, in <module>
    from .task_runners import RayTaskRunner  # noqa
  File ".../.venv/lib/python3.8/site-packages/prefect_ray/task_runners.py", line 91, in <module>
    class RayTaskRunner(BaseTaskRunner):
  File ".../.venv/lib/python3.8/site-packages/prefect_ray/task_runners.py", line 157, in RayTaskRunner
    call: Callable[..., Awaitable[State[R]]],
TypeError: 'ModelMetaclass' object is not subscriptable
```

So I tried to give a fix about this issue. `prefect_dask` has the similar issue I think.
Not sure where to add a test for this.