### PR TITLE
enable cli autocompletion

### DIFF
--- a/src/prefect/cli/root.py
+++ b/src/prefect/cli/root.py
@@ -22,7 +22,7 @@ from prefect.settings import (
     PREFECT_TEST_MODE,
 )
 
-app = PrefectTyper(add_completion=False, no_args_is_help=True)
+app = PrefectTyper(add_completion=True, no_args_is_help=True)
 
 
 def version_callback(value: bool):


### PR DESCRIPTION
not sure why we had this turned off

when on, allows
```console
» prefect --install-completion
```

which gives

<img width="852" alt="image" src="https://github.com/PrefectHQ/prefect/assets/31014960/378cb72f-ea6f-4b3b-beb3-51349e69c2b7">
