### PR TITLE
Allow flow parameter schema generation when dependencies are missing

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -58,7 +58,7 @@ from prefect.deployments.base import (
 from prefect.deployments.steps.core import run_steps
 from prefect.events import DeploymentTriggerTypes, TriggerTypes
 from prefect.exceptions import ObjectNotFound, PrefectHTTPStatusError
-from prefect.flows import load_flow_name_from_entrypoint
+from prefect.flows import load_flow_argument_from_entrypoint
 from prefect.settings import (
     PREFECT_DEFAULT_WORK_POOL_NAME,
     PREFECT_UI_URL,
@@ -472,9 +472,9 @@ async def _run_single_deploy(
             )
         deploy_config["entrypoint"] = await prompt_entrypoint(app.console)
 
-    # entrypoint logic
-    if deploy_config.get("entrypoint"):
-        flow = load_flow_name_from_entrypoint(deploy_config["entrypoint"])
+    deploy_config["flow_name"] = load_flow_argument_from_entrypoint(
+        deploy_config["entrypoint"], arg="name"
+    )
 
     deployment_name = deploy_config.get("name")
     if not deployment_name:
@@ -664,8 +664,9 @@ async def _run_single_deploy(
         deploy_config["work_pool"]["job_variables"]["image"] = "{{ build-image.image }}"
 
     if not deploy_config.get("description"):
-        deploy_config["description"] = flow.description
-
+        deploy_config["description"] = load_flow_argument_from_entrypoint(
+            deploy_config["entrypoint"], arg="description"
+        )
     # save deploy_config before templating
     deploy_config_before_templating = deepcopy(deploy_config)
     ## apply templating from build and push steps to the final deployment spec

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1222,14 +1222,16 @@ class Flow(Generic[P, R]):
     @overload
     def __call__(
         self: "Flow[P, Coroutine[Any, Any, T]]", *args: P.args, **kwargs: P.kwargs
-    ) -> Awaitable[T]: ...
+    ) -> Awaitable[T]:
+        ...
 
     @overload
     def __call__(
         self: "Flow[P, T]",
         *args: P.args,
         **kwargs: P.kwargs,
-    ) -> T: ...
+    ) -> T:
+        ...
 
     @overload
     def __call__(
@@ -1237,7 +1239,8 @@ class Flow(Generic[P, R]):
         *args: P.args,
         return_state: Literal[True],
         **kwargs: P.kwargs,
-    ) -> State[T]: ...
+    ) -> State[T]:
+        ...
 
     def __call__(
         self,
@@ -1380,7 +1383,8 @@ class Flow(Generic[P, R]):
 
 
 @overload
-def flow(__fn: Callable[P, R]) -> Flow[P, R]: ...
+def flow(__fn: Callable[P, R]) -> Flow[P, R]:
+    ...
 
 
 @overload
@@ -1411,7 +1415,8 @@ def flow(
     ] = None,
     on_crashed: Optional[List[Callable[[FlowSchema, FlowRun, State], None]]] = None,
     on_running: Optional[List[Callable[[FlowSchema, FlowRun, State], None]]] = None,
-) -> Callable[[Callable[P, R]], Flow[P, R]]: ...
+) -> Callable[[Callable[P, R]], Flow[P, R]]:
+    ...
 
 
 def flow(

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1944,7 +1944,20 @@ async def load_flow_from_flow_run(
     return flow
 
 
-def load_flow_name_from_entrypoint(entrypoint: str):
+def load_flow_argument_from_entrypoint(entrypoint: str, arg: str = "name"):
+    """
+    Extract a flow argument from an entrypoint string.
+
+    Loads the source code of the entrypoint and extracts the flow argument from the
+    `flow` decorator.
+
+    Args:
+        entrypoint: a string in the format `<path_to_script>:<flow_func_name>` or a module path
+            to a flow function
+
+    Returns:
+        The flow argument value
+    """
     if ":" in entrypoint:
         # split by the last colon once to handle Windows paths with drive letters i.e C:\path\to\file.py:do_stuff
         path, func_name = entrypoint.rsplit(":", maxsplit=1)
@@ -1967,8 +1980,12 @@ def load_flow_name_from_entrypoint(entrypoint: str):
             and getattr(decorator.func, "id", "") == "flow"
         ):
             for keyword in decorator.keywords:
-                if keyword.arg == "name":
-                    return keyword.value.s  # Return the string value of the argument
-    return func_name.replace(
-        "_", "-"
-    )  # If no matching decorator or keyword argument is found
+                if keyword.arg == arg:
+                    return (
+                        keyword.value.value
+                    )  # Return the string value of the argument
+
+    if arg == "name":
+        return func_name.replace(
+            "_", "-"
+        )  # If no matching decorator or keyword argument is found

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1944,7 +1944,9 @@ async def load_flow_from_flow_run(
     return flow
 
 
-def load_flow_argument_from_entrypoint(entrypoint: str, arg: str = "name"):
+def load_flow_argument_from_entrypoint(
+    entrypoint: str, arg: str = "name"
+) -> Optional[str]:
     """
     Extract a flow argument from an entrypoint string.
 
@@ -1970,10 +1972,15 @@ def load_flow_argument_from_entrypoint(entrypoint: str, arg: str = "name"):
         source_code = Path(spec.origin).read_text()
     parsed_code = ast.parse(source_code)
     func_def = next(
-        node
-        for node in ast.walk(parsed_code)
-        if isinstance(node, ast.FunctionDef) and node.name == func_name
+        (
+            node
+            for node in ast.walk(parsed_code)
+            if isinstance(node, ast.FunctionDef) and node.name == func_name
+        ),
+        None,
     )
+    if not func_def:
+        raise ValueError(f"Could not find flow {func_name!r} in {path!r}")
     for decorator in func_def.decorator_list:
         if (
             isinstance(decorator, ast.Call)

--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -32,6 +32,7 @@ from prefect.exceptions import (
 from prefect.logging.loggers import disable_logger, get_logger
 from prefect.utilities.annotations import allow_failure, quote, unmapped
 from prefect.utilities.collections import isiterable
+from prefect.utilities.importtools import safe_load_namespace
 
 logger = get_logger(__name__)
 

--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -531,7 +531,7 @@ def generate_signature_from_source(
         if default is not None:
             try:
                 def_code = compile(ast.Expression(default), "<string>", "eval")
-                default = eval(def_code)
+                default = eval(def_code, namespace)
             except Exception as e:
                 logger.debug(
                     "Failed to evaluate default value for %s: %s", param.name, e
@@ -592,7 +592,7 @@ def get_docstring_from_source(source_code: str, func_name: str) -> Optional[str]
     if (
         func_def.body
         and isinstance(func_def.body[0], ast.Expr)
-        and isinstance(func_def.body[0].value, (ast.Str, ast.Constant))
+        and isinstance(func_def.body[0].value, ast.Constant)
     ):
-        return func_def.body[0].value.s
+        return func_def.body[0].value.value
     return None

--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -333,6 +333,22 @@ def parameter_schema(fn: Callable) -> ParameterSchema:
 
 
 def parameter_schema_from_entrypoint(entrypoint: str) -> ParameterSchema:
+    """
+    Generate a parameter schema from an entrypoint string.
+
+    Will load the source code of the function and extract the signature and docstring
+    to generate the schema.
+
+    Useful for generating a schema for a function when instantiating the function may
+    not be possible due to missing imports or other issues.
+
+    Args:
+        entrypoint: A string representing the entrypoint to a function. The string
+            should be in the format of `module.path.to.function:do_stuff`.
+
+    Returns:
+        ParameterSchema: The parameter schema for the function.
+    """
     if ":" in entrypoint:
         # split by the last colon once to handle Windows paths with drive letters i.e C:\path\to\file.py:do_stuff
         path, func_name = entrypoint.rsplit(":", maxsplit=1)
@@ -351,6 +367,20 @@ def parameter_schema_from_entrypoint(entrypoint: str) -> ParameterSchema:
 def generate_parameter_schema(
     signature: inspect.Signature, docstrings: Dict[str, str]
 ) -> ParameterSchema:
+    """
+    Generate a parameter schema from a function signature and docstrings.
+
+    To get a signature from a function, use `inspect.signature(fn)` or
+    `_generate_signature_from_source(source_code, func_name)`.
+
+    Args:
+        signature: The function signature.
+        docstrings: A dictionary mapping parameter names to docstrings.
+
+    Returns:
+        ParameterSchema: The parameter schema.
+    """
+
     model_fields = {}
     aliases = {}
 

--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -342,8 +342,8 @@ def parameter_schema_from_entrypoint(entrypoint: str) -> ParameterSchema:
         if not spec or not spec.origin:
             raise ValueError(f"Could not find module {path!r}")
         source_code = Path(spec.origin).read_text()
-    signature = generate_signature_from_source(source_code, func_name)
-    docstring = get_docstring_from_source(source_code, func_name)
+    signature = _generate_signature_from_source(source_code, func_name)
+    docstring = _get_docstring_from_source(source_code, func_name)
     return generate_parameter_schema(signature, parameter_docstrings(docstring))
 
 
@@ -397,79 +397,7 @@ def raise_for_reserved_arguments(fn: Callable, reserved_arguments: Iterable[str]
             )
 
 
-def expand_mapping_parameters(
-    func: Callable, parameters: Dict[str, Any]
-) -> List[Dict[str, Any]]:
-    """
-    Generates a list of call parameters to be used for individual calls in a mapping
-    operation.
-
-    Args:
-        func: The function to be called
-        parameters: A dictionary of parameters with iterables to be mapped over
-
-    Returns:
-        List: A list of dictionaries to be used as parameters for each
-            call in the mapping operation
-    """
-    # Ensure that any parameters in kwargs are expanded before this check
-    parameters = explode_variadic_parameter(func, parameters)
-
-    iterable_parameters = {}
-    static_parameters = {}
-    annotated_parameters = {}
-    for key, val in parameters.items():
-        if isinstance(val, (allow_failure, quote)):
-            # Unwrap annotated parameters to determine if they are iterable
-            annotated_parameters[key] = val
-            val = val.unwrap()
-
-        if isinstance(val, unmapped):
-            static_parameters[key] = val.value
-        elif isiterable(val):
-            iterable_parameters[key] = list(val)
-        else:
-            static_parameters[key] = val
-
-    if not len(iterable_parameters):
-        raise MappingMissingIterable(
-            "No iterable parameters were received. Parameters for map must "
-            f"include at least one iterable. Parameters: {parameters}"
-        )
-
-    iterable_parameter_lengths = {
-        key: len(val) for key, val in iterable_parameters.items()
-    }
-    lengths = set(iterable_parameter_lengths.values())
-    if len(lengths) > 1:
-        raise MappingLengthMismatch(
-            "Received iterable parameters with different lengths. Parameters for map"
-            f" must all be the same length. Got lengths: {iterable_parameter_lengths}"
-        )
-
-    map_length = list(lengths)[0]
-
-    call_parameters_list = []
-    for i in range(map_length):
-        call_parameters = {key: value[i] for key, value in iterable_parameters.items()}
-        call_parameters.update({key: value for key, value in static_parameters.items()})
-
-        # Add default values for parameters; these are skipped earlier since they should
-        # not be mapped over
-        for key, value in get_parameter_defaults(func).items():
-            call_parameters.setdefault(key, value)
-
-        # Re-apply annotations to each key again
-        for key, annotation in annotated_parameters.items():
-            call_parameters[key] = annotation.rewrap(call_parameters[key])
-
-        # Collapse any previously exploded kwargs
-        call_parameters_list.append(collapse_variadic_parameters(func, call_parameters))
-
-    return call_parameters_list
-
-
-def generate_signature_from_source(
+def _generate_signature_from_source(
     source_code: str, func_name: str
 ) -> inspect.Signature:
     """
@@ -565,7 +493,7 @@ def generate_signature_from_source(
     return inspect.Signature(parameters, return_annotation=return_annotation)
 
 
-def get_docstring_from_source(source_code: str, func_name: str) -> Optional[str]:
+def _get_docstring_from_source(source_code: str, func_name: str) -> Optional[str]:
     """
     Extract the docstring of a function from its source code.
 
@@ -596,3 +524,75 @@ def get_docstring_from_source(source_code: str, func_name: str) -> Optional[str]
     ):
         return func_def.body[0].value.value
     return None
+
+
+def expand_mapping_parameters(
+    func: Callable, parameters: Dict[str, Any]
+) -> List[Dict[str, Any]]:
+    """
+    Generates a list of call parameters to be used for individual calls in a mapping
+    operation.
+
+    Args:
+        func: The function to be called
+        parameters: A dictionary of parameters with iterables to be mapped over
+
+    Returns:
+        List: A list of dictionaries to be used as parameters for each
+            call in the mapping operation
+    """
+    # Ensure that any parameters in kwargs are expanded before this check
+    parameters = explode_variadic_parameter(func, parameters)
+
+    iterable_parameters = {}
+    static_parameters = {}
+    annotated_parameters = {}
+    for key, val in parameters.items():
+        if isinstance(val, (allow_failure, quote)):
+            # Unwrap annotated parameters to determine if they are iterable
+            annotated_parameters[key] = val
+            val = val.unwrap()
+
+        if isinstance(val, unmapped):
+            static_parameters[key] = val.value
+        elif isiterable(val):
+            iterable_parameters[key] = list(val)
+        else:
+            static_parameters[key] = val
+
+    if not len(iterable_parameters):
+        raise MappingMissingIterable(
+            "No iterable parameters were received. Parameters for map must "
+            f"include at least one iterable. Parameters: {parameters}"
+        )
+
+    iterable_parameter_lengths = {
+        key: len(val) for key, val in iterable_parameters.items()
+    }
+    lengths = set(iterable_parameter_lengths.values())
+    if len(lengths) > 1:
+        raise MappingLengthMismatch(
+            "Received iterable parameters with different lengths. Parameters for map"
+            f" must all be the same length. Got lengths: {iterable_parameter_lengths}"
+        )
+
+    map_length = list(lengths)[0]
+
+    call_parameters_list = []
+    for i in range(map_length):
+        call_parameters = {key: value[i] for key, value in iterable_parameters.items()}
+        call_parameters.update({key: value for key, value in static_parameters.items()})
+
+        # Add default values for parameters; these are skipped earlier since they should
+        # not be mapped over
+        for key, value in get_parameter_defaults(func).items():
+            call_parameters.setdefault(key, value)
+
+        # Re-apply annotations to each key again
+        for key, annotation in annotated_parameters.items():
+            call_parameters[key] = annotation.rewrap(call_parameters[key])
+
+        # Collapse any previously exploded kwargs
+        call_parameters_list.append(collapse_variadic_parameters(func, call_parameters))
+
+    return call_parameters_list

--- a/src/prefect/utilities/importtools.py
+++ b/src/prefect/utilities/importtools.py
@@ -363,6 +363,20 @@ class AliasedModuleLoader(Loader):
 
 
 def safe_load_namespace(source_code: str):
+    """
+    Safely load a namespace from source code.
+
+    This function will attempt to import all modules and classes defined in the source
+    code. If an import fails, the error is caught and the import is skipped. This function
+    will also attempt to compile and evaluate class and function definitions locally.
+
+    Args:
+        source_code: The source code to load
+
+    Returns:
+        The namespace loaded from the source code. Can be used when evaluating source
+        code.
+    """
     parsed_code = ast.parse(source_code)
 
     namespace = {}

--- a/src/prefect/utilities/importtools.py
+++ b/src/prefect/utilities/importtools.py
@@ -415,10 +415,14 @@ def safe_load_namespace(source_code: str):
 
     # Handle local class definitions
     for node in ast.walk(parsed_code):
-        if isinstance(node, ast.ClassDef):
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef)):
             try:
-                # Compile and evaluate each class and function definition locally
-                code = compile(ast.Module(body=[node]), filename="<ast>", mode="exec")
+                # Compile and execute each class and function definition locally
+                code = compile(
+                    ast.Module(body=[node], type_ignores=[]),
+                    filename="<ast>",
+                    mode="exec",
+                )
                 exec(code, namespace)
             except Exception as e:
                 logger.debug("Failed to compile class definition: %s", e)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -41,7 +41,12 @@ from prefect.exceptions import (
     ReservedArgumentError,
 )
 from prefect.filesystems import LocalFileSystem
-from prefect.flows import Flow, load_flow_from_entrypoint, load_flow_from_flow_run
+from prefect.flows import (
+    Flow,
+    load_flow_argument_from_entrypoint,
+    load_flow_from_entrypoint,
+    load_flow_from_flow_run,
+)
 from prefect.runtime import flow_run as flow_run_ctx
 from prefect.server.schemas.core import TaskRunResult
 from prefect.server.schemas.filters import FlowFilter, FlowRunFilter
@@ -4086,3 +4091,100 @@ class TestTransactions:
         main(return_state=True)
 
         assert data == {}
+
+
+class TestLoadFlowArgumentFromEntrypoint:
+    def test_load_flow_name_from_entrypoint(self, tmp_path: Path):
+        flow_source = dedent(
+            """
+                            
+        from prefect import flow
+                            
+        @flow(name="My custom name")
+        def flow_function(name: str) -> str:
+            return name
+        """
+        )
+
+        tmp_path.joinpath("flow.py").write_text(flow_source)
+
+        entrypoint = f"{tmp_path.joinpath('flow.py')}:flow_function"
+
+        result = load_flow_argument_from_entrypoint(entrypoint, "name")
+
+        assert result == "My custom name"
+
+    def test_load_flow_name_from_entrypoint_no_name(self, tmp_path: Path):
+        flow_source = dedent(
+            """
+                            
+        from prefect import flow
+                            
+        @flow
+        def flow_function(name: str) -> str:
+            return name
+        """
+        )
+
+        tmp_path.joinpath("flow.py").write_text(flow_source)
+
+        entrypoint = f"{tmp_path.joinpath('flow.py')}:flow_function"
+
+        result = load_flow_argument_from_entrypoint(entrypoint, "name")
+
+        assert result == "flow-function"
+
+    def test_load_flow_description_from_entrypoint(self, tmp_path: Path):
+        flow_source = dedent(
+            """
+                            
+        from prefect import flow
+                            
+        @flow(description="My custom description")
+        def flow_function(name: str) -> str:
+            return name
+        """
+        )
+
+        tmp_path.joinpath("flow.py").write_text(flow_source)
+
+        entrypoint = f"{tmp_path.joinpath('flow.py')}:flow_function"
+
+        result = load_flow_argument_from_entrypoint(entrypoint, "description")
+
+        assert result == "My custom description"
+
+    def test_load_flow_description_from_entrypoint_no_description(self, tmp_path: Path):
+        flow_source = dedent(
+            """
+                            
+        from prefect import flow
+                            
+        @flow
+        def flow_function(name: str) -> str:
+            return name
+        """
+        )
+
+        tmp_path.joinpath("flow.py").write_text(flow_source)
+
+        entrypoint = f"{tmp_path.joinpath('flow.py')}:flow_function"
+
+        result = load_flow_argument_from_entrypoint(entrypoint, "description")
+
+        assert result is None
+
+    def test_load_no_flow(self, tmp_path: Path):
+        flow_source = dedent(
+            """
+                            
+        from prefect import flow
+        """
+        )
+
+        tmp_path.joinpath("flow.py").write_text(flow_source)
+
+        entrypoint = f"{tmp_path.joinpath('flow.py')}:flow_function"
+
+        with pytest.raises(ValueError, match="Could not find flow"):
+            load_flow_argument_from_entrypoint(entrypoint, "name")

--- a/tests/utilities/test_callables.py
+++ b/tests/utilities/test_callables.py
@@ -1,5 +1,7 @@
 import datetime
 from enum import Enum
+from pathlib import Path
+from textwrap import dedent
 from typing import Any, Dict, List, Tuple, Union
 
 import pendulum
@@ -794,3 +796,754 @@ class TestCollapseVariadicParameter:
 
         with pytest.raises(ValueError):
             callables.collapse_variadic_parameters(foo, parameters)
+
+
+class TestEntrypointToSchema:
+    def test_function_not_found(self, tmp_path: Path):
+        source_code = dedent(
+            """
+        def f():
+            pass
+        """
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+
+        with pytest.raises(ValueError):
+            callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:g")
+
+    def test_simple_function_with_no_arguments(self, tmp_path: Path):
+        source_code = dedent(
+            """
+        def f():
+            pass
+        """
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+        assert schema.dict() == {
+            "properties": {},
+            "title": "Parameters",
+            "type": "object",
+        }
+
+    def test_function_with_pydantic_base_model_collisions(self, tmp_path: Path):
+        source_code = dedent(
+            """
+        def f(
+            json,
+            copy,
+            parse_obj,
+            parse_raw,
+            parse_file,
+            from_orm,
+            schema,
+            schema_json,
+            construct,
+            validate,
+            foo,
+        ):
+            pass
+        """
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+        assert schema.dict() == {
+            "title": "Parameters",
+            "type": "object",
+            "properties": {
+                "foo": {"title": "foo", "position": 10},
+                "json": {"title": "json", "position": 0},
+                "copy": {"title": "copy", "position": 1},
+                "parse_obj": {"title": "parse_obj", "position": 2},
+                "parse_raw": {"title": "parse_raw", "position": 3},
+                "parse_file": {"title": "parse_file", "position": 4},
+                "from_orm": {"title": "from_orm", "position": 5},
+                "schema": {"title": "schema", "position": 6},
+                "schema_json": {"title": "schema_json", "position": 7},
+                "construct": {"title": "construct", "position": 8},
+                "validate": {"title": "validate", "position": 9},
+            },
+            "required": [
+                "json",
+                "copy",
+                "parse_obj",
+                "parse_raw",
+                "parse_file",
+                "from_orm",
+                "schema",
+                "schema_json",
+                "construct",
+                "validate",
+                "foo",
+            ],
+        }
+
+    def test_function_with_one_required_argument(self, tmp_path: Path):
+        source_code = dedent(
+            """
+        def f(x):
+            pass
+        """
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+        assert schema.dict() == {
+            "title": "Parameters",
+            "type": "object",
+            "properties": {"x": {"title": "x", "position": 0}},
+            "required": ["x"],
+        }
+
+    def test_function_with_one_optional_argument(self, tmp_path: Path):
+        source_code = dedent(
+            """
+        def f(x=42):
+            pass
+        """
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+        assert schema.dict() == {
+            "title": "Parameters",
+            "type": "object",
+            "properties": {"x": {"title": "x", "default": 42, "position": 0}},
+        }
+
+    def test_function_with_one_optional_annotated_argument(self, tmp_path: Path):
+        source_code = dedent(
+            """
+        def f(x: int = 42):
+            pass
+        """
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+        assert schema.dict() == {
+            "title": "Parameters",
+            "type": "object",
+            "properties": {
+                "x": {"title": "x", "default": 42, "type": "integer", "position": 0}
+            },
+        }
+
+    def test_function_with_two_arguments(self, tmp_path: Path):
+        source_code = dedent(
+            """
+        def f(x: int, y: float = 5.0):
+            pass
+        """
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+        assert schema.dict() == {
+            "title": "Parameters",
+            "type": "object",
+            "properties": {
+                "x": {"title": "x", "type": "integer", "position": 0},
+                "y": {"title": "y", "default": 5.0, "type": "number", "position": 1},
+            },
+            "required": ["x"],
+        }
+
+    def test_function_with_datetime_arguments(self, tmp_path: Path):
+        source_code = dedent(
+            """
+        import pendulum
+        import datetime                 
+
+        def f(
+            x: datetime.datetime,
+            y: pendulum.DateTime = pendulum.datetime(2025, 1, 1),
+            z: datetime.timedelta = datetime.timedelta(seconds=5),
+        ):
+            pass
+        """
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+        if HAS_PYDANTIC_V2:
+            expected_schema = {
+                "title": "Parameters",
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "format": "date-time",
+                        "position": 0,
+                        "title": "x",
+                        "type": "string",
+                    },
+                    "y": {
+                        "default": "2025-01-01T00:00:00Z",
+                        "format": "date-time",
+                        "position": 1,
+                        "title": "y",
+                        "type": "string",
+                    },
+                    "z": {
+                        "default": "PT5S",
+                        "format": "duration",
+                        "position": 2,
+                        "title": "z",
+                        "type": "string",
+                    },
+                },
+                "required": ["x"],
+            }
+        else:
+            expected_schema = {
+                "title": "Parameters",
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "title": "x",
+                        "type": "string",
+                        "format": "date-time",
+                        "position": 0,
+                    },
+                    "y": {
+                        "title": "y",
+                        "default": "2025-01-01T00:00:00+00:00",
+                        "type": "string",
+                        "format": "date-time",
+                        "position": 1,
+                    },
+                    "z": {
+                        "title": "z",
+                        "default": 5.0,
+                        "type": "number",
+                        "format": "time-delta",
+                        "position": 2,
+                    },
+                },
+                "required": ["x"],
+            }
+        assert schema.dict() == expected_schema
+
+    def test_function_with_enum_argument(self, tmp_path: Path):
+        class Color(Enum):
+            RED = "RED"
+            GREEN = "GREEN"
+            BLUE = "BLUE"
+
+        source_code = dedent(
+            """
+        from enum import Enum
+
+        class Color(Enum):
+            RED = "RED"
+            GREEN = "GREEN"
+            BLUE = "BLUE"
+
+        def f(x: Color = Color.RED):
+            pass
+        """
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+
+        if HAS_PYDANTIC_V2:
+            expected_schema = {
+                "title": "Parameters",
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "allOf": [{"$ref": "#/definitions/Color"}],
+                        "default": "RED",
+                        "position": 0,
+                        "title": "x",
+                    }
+                },
+                "definitions": {
+                    "Color": {
+                        "enum": ["RED", "GREEN", "BLUE"],
+                        "title": "Color",
+                        "type": "string",
+                    }
+                },
+            }
+        else:
+            expected_schema = {
+                "title": "Parameters",
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "title": "x",
+                        "default": "RED",
+                        "allOf": [{"$ref": "#/definitions/Color"}],
+                        "position": 0,
+                    }
+                },
+                "definitions": {
+                    "Color": {
+                        "title": "Color",
+                        "description": "An enumeration.",
+                        "enum": [
+                            "RED",
+                            "GREEN",
+                            "BLUE",
+                        ],
+                    }
+                },
+            }
+
+        assert schema.dict() == expected_schema
+
+    def test_function_with_generic_arguments(self, tmp_path: Path):
+        source_code = dedent(
+            """
+        from typing import List, Dict, Any, Tuple, Union
+
+        def f(
+            a: List[str],
+            b: Dict[str, Any],
+            c: Any,
+            d: Tuple[int, float],
+            e: Union[str, bytes, int],
+        ):
+            pass
+        """
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+
+        if HAS_PYDANTIC_V2:
+            expected_schema = {
+                "title": "Parameters",
+                "type": "object",
+                "properties": {
+                    "a": {
+                        "items": {"type": "string"},
+                        "position": 0,
+                        "title": "a",
+                        "type": "array",
+                    },
+                    "b": {"position": 1, "title": "b", "type": "object"},
+                    "c": {"position": 2, "title": "c"},
+                    "d": {
+                        "maxItems": 2,
+                        "minItems": 2,
+                        "position": 3,
+                        "prefixItems": [{"type": "integer"}, {"type": "number"}],
+                        "title": "d",
+                        "type": "array",
+                    },
+                    "e": {
+                        "anyOf": [
+                            {"type": "string"},
+                            {"format": "binary", "type": "string"},
+                            {"type": "integer"},
+                        ],
+                        "position": 4,
+                        "title": "e",
+                    },
+                },
+                "required": ["a", "b", "c", "d", "e"],
+            }
+        else:
+            # pydantic 1.9.0 adds min and max item counts to the parameter schema
+            min_max_items = (
+                {
+                    "minItems": 2,
+                    "maxItems": 2,
+                }
+                if Version(pydantic.version.VERSION) >= Version("1.9.0")
+                else {}
+            )
+            expected_schema = {
+                "title": "Parameters",
+                "type": "object",
+                "properties": {
+                    "a": {
+                        "title": "a",
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "position": 0,
+                    },
+                    "b": {"title": "b", "type": "object", "position": 1},
+                    "c": {"title": "c", "position": 2},
+                    "d": {
+                        "title": "d",
+                        "type": "array",
+                        "items": [{"type": "integer"}, {"type": "number"}],
+                        **min_max_items,
+                        "position": 3,
+                    },
+                    "e": {
+                        "title": "e",
+                        "anyOf": [
+                            {"type": "string"},
+                            {"type": "string", "format": "binary"},
+                            {"type": "integer"},
+                        ],
+                        "position": 4,
+                    },
+                },
+                "required": ["a", "b", "c", "d", "e"],
+            }
+
+        assert schema.dict() == expected_schema
+
+    def test_function_with_user_defined_type(self, tmp_path: Path):
+        source_code = dedent(
+            """
+        class Foo:
+            y: int
+
+        def f(x: Foo):
+            pass
+        """
+        )
+
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+        assert schema.dict() == {
+            "title": "Parameters",
+            "type": "object",
+            "properties": {"x": {"title": "x", "position": 0}},
+            "required": ["x"],
+        }
+
+    def test_function_with_user_defined_pydantic_model(self, tmp_path: Path):
+        source_code = dedent(
+            """
+        import pydantic
+
+        class Foo(pydantic.BaseModel):
+            y: int
+            z: str
+
+        def f(x: Foo):
+            pass
+        """
+        )
+
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+        assert schema.dict() == {
+            "definitions": {
+                "Foo": {
+                    "properties": {
+                        "y": {"title": "Y", "type": "integer"},
+                        "z": {"title": "Z", "type": "string"},
+                    },
+                    "required": ["y", "z"],
+                    "title": "Foo",
+                    "type": "object",
+                }
+            },
+            "properties": {
+                "x": {
+                    "allOf": [{"$ref": "#/definitions/Foo"}],
+                    "title": "x",
+                    "position": 0,
+                }
+            },
+            "required": ["x"],
+            "title": "Parameters",
+            "type": "object",
+        }
+
+    def test_function_with_pydantic_model_default_across_v1_and_v2(
+        self, tmp_path: Path
+    ):
+        source_code = dedent(
+            """
+        import pydantic
+
+        class Foo(pydantic.BaseModel):
+            bar: str
+
+        def f(foo: Foo = Foo(bar="baz")):
+            pass
+        """
+        )
+
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+        assert schema.dict() == {
+            "title": "Parameters",
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "allOf": [{"$ref": "#/definitions/Foo"}],
+                    "default": {"bar": "baz"},
+                    "position": 0,
+                    "title": "foo",
+                }
+            },
+            "definitions": {
+                "Foo": {
+                    "properties": {"bar": {"title": "Bar", "type": "string"}},
+                    "required": ["bar"],
+                    "title": "Foo",
+                    "type": "object",
+                }
+            },
+        }
+
+    def test_function_with_complex_args_across_v1_and_v2(self, tmp_path: Path):
+        source_code = dedent(
+            """
+        import pydantic
+        import pendulum
+        import datetime
+        from enum import Enum
+        from typing import List
+
+        class Foo(pydantic.BaseModel):
+            bar: str
+
+        class Color(Enum):
+            RED = "RED"
+            GREEN = "GREEN"
+            BLUE = "BLUE"
+
+        def f(
+            a: int,
+            s: List[None],
+            m: Foo,
+            i: int = 0,
+            x: float = 1.0,
+            model: Foo = Foo(bar="bar"),
+            pdt: pendulum.DateTime = pendulum.datetime(2025, 1, 1),
+            pdate: pendulum.Date = pendulum.date(2025, 1, 1),
+            pduration: pendulum.Duration = pendulum.duration(seconds=5),
+            c: Color = Color.BLUE,
+        ):
+            pass
+        """
+        )
+
+        datetime_schema = {
+            "title": "pdt",
+            "default": "2025-01-01T00:00:00+00:00",
+            "position": 6,
+            "type": "string",
+            "format": "date-time",
+        }
+        duration_schema = {
+            "title": "pduration",
+            "default": 5.0,
+            "position": 8,
+            "type": "number",
+            "format": "time-delta",
+        }
+        enum_schema = {
+            "enum": ["RED", "GREEN", "BLUE"],
+            "title": "Color",
+            "type": "string",
+            "description": "An enumeration.",
+        }
+
+        if HAS_PYDANTIC_V2:
+            # these overrides represent changes in how pydantic generates schemas in v2
+            datetime_schema["default"] = "2025-01-01T00:00:00Z"
+            duration_schema["default"] = "PT5S"
+            duration_schema["type"] = "string"
+            duration_schema["format"] = "duration"
+            enum_schema.pop("description")
+        else:
+            enum_schema.pop("type")
+
+        schema = tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+
+        assert schema.dict() == {
+            "title": "Parameters",
+            "type": "object",
+            "properties": {
+                "a": {"position": 0, "title": "a", "type": "integer"},
+                "s": {
+                    "items": {"type": "null"},
+                    "position": 1,
+                    "title": "s",
+                    "type": "array",
+                },
+                "m": {
+                    "allOf": [{"$ref": "#/definitions/Foo"}],
+                    "position": 2,
+                    "title": "m",
+                },
+                "i": {"default": 0, "position": 3, "title": "i", "type": "integer"},
+                "x": {"default": 1.0, "position": 4, "title": "x", "type": "number"},
+                "model": {
+                    "allOf": [{"$ref": "#/definitions/Foo"}],
+                    "default": {"bar": "bar"},
+                    "position": 5,
+                    "title": "model",
+                },
+                "pdt": datetime_schema,
+                "pdate": {
+                    "title": "pdate",
+                    "default": "2025-01-01",
+                    "position": 7,
+                    "type": "string",
+                    "format": "date",
+                },
+                "pduration": duration_schema,
+                "c": {
+                    "title": "c",
+                    "default": "BLUE",
+                    "position": 9,
+                    "allOf": [{"$ref": "#/definitions/Color"}],
+                },
+            },
+            "required": ["a", "s", "m"],
+            "definitions": {
+                "Foo": {
+                    "properties": {"bar": {"title": "Bar", "type": "string"}},
+                    "required": ["bar"],
+                    "title": "Foo",
+                    "type": "object",
+                },
+                "Color": enum_schema,
+            },
+        }
+
+    def test_function_with_secretstr(self, tmp_path: Path):
+        source_code = dedent(
+            """
+        from pydantic import SecretStr
+
+        def f(x: SecretStr):
+            pass
+        """
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+        assert schema.dict() == {
+            "title": "Parameters",
+            "type": "object",
+            "properties": {
+                "x": {
+                    "title": "x",
+                    "position": 0,
+                    "format": "password",
+                    "type": "string",
+                    "writeOnly": True,
+                },
+            },
+            "required": ["x"],
+        }
+
+    def test_function_with_v1_secretstr_from_compat_module(self, tmp_path: Path):
+        source_code = dedent(
+            """
+        import pydantic.v1 as pydantic
+
+        def f(x: pydantic.SecretStr):
+            pass
+        """
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+        assert schema.dict() == {
+            "title": "Parameters",
+            "type": "object",
+            "properties": {
+                "x": {
+                    "title": "x",
+                    "position": 0,
+                    "format": "password",
+                    "type": "string",
+                    "writeOnly": True,
+                },
+            },
+            "required": ["x"],
+        }
+
+    def test_flow_with_args_docstring(self, tmp_path: Path):
+        source_code = dedent(
+            '''
+        def f(x):
+            """Function f.
+
+            Args:
+                x: required argument x
+            """
+        '''
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+        assert schema.dict() == {
+            "title": "Parameters",
+            "type": "object",
+            "properties": {
+                "x": {"title": "x", "description": "required argument x", "position": 0}
+            },
+            "required": ["x"],
+        }
+
+    def test_flow_without_args_docstring(self, tmp_path: Path):
+        source_code = dedent(
+            '''
+        def f(x):
+            """Function f."""
+        '''
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+        assert schema.dict() == {
+            "title": "Parameters",
+            "type": "object",
+            "properties": {"x": {"title": "x", "position": 0}},
+            "required": ["x"],
+        }
+
+    def test_flow_with_complex_args_docstring(self, tmp_path: Path):
+        source_code = dedent(
+            '''
+        def f(x, y):
+            """Function f.
+
+            Second line of docstring.
+
+            Args:
+                x: required argument x
+                y (str): required typed argument y
+                  with second line
+
+            Returns:
+                None: nothing
+            """
+        '''
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+        assert schema.dict() == {
+            "title": "Parameters",
+            "type": "object",
+            "properties": {
+                "x": {
+                    "title": "x",
+                    "description": "required argument x",
+                    "position": 0,
+                },
+                "y": {
+                    "title": "y",
+                    "description": "required typed argument y\nwith second line",
+                    "position": 1,
+                },
+            },
+            "required": ["x", "y"],
+        }
+
+    def test_does_not_raise_when_missing_dependencies(self, tmp_path: Path):
+        source_code = dedent(
+            """
+        import bipitty_boopity
+                             
+        def f(x):
+            pass
+        """
+        )
+        tmp_path.joinpath("test.py").write_text(source_code)
+        schema = callables.parameter_schema_from_entrypoint(f"{tmp_path}/test.py:f")
+
+        assert schema.dict() == {
+            "title": "Parameters",
+            "type": "object",
+            "properties": {"x": {"title": "x", "position": 0}},
+            "required": ["x"],
+        }

--- a/tests/utilities/test_importtools.py
+++ b/tests/utilities/test_importtools.py
@@ -273,8 +273,8 @@ def test_safe_load_namespace():
     assert "now" not in namespace
     # module-level classes should be present
     assert "MyModel" in namespace
-    # module-level functions should not be present
-    assert "my_fn" not in namespace
+    # module-level functions should be present
+    assert "my_fn" in namespace
 
     assert namespace["MyModel"].__name__ == "MyModel"
 

--- a/tests/utilities/test_importtools.py
+++ b/tests/utilities/test_importtools.py
@@ -2,6 +2,7 @@ import importlib.util
 import runpy
 import sys
 from pathlib import Path
+from textwrap import dedent
 from types import ModuleType
 from unittest.mock import MagicMock
 from uuid import uuid4
@@ -17,6 +18,7 @@ from prefect.utilities.importtools import (
     from_qualified_name,
     import_object,
     lazy_import,
+    safe_load_namespace,
     to_qualified_name,
 )
 
@@ -238,3 +240,79 @@ def test_import_object_from_module_with_relative_imports_expected_failures(
         # Python would raise the same error
         with pytest.raises((ValueError, ImportError)):
             runpy.run_module(import_path)
+
+
+def test_safe_load_namespace():
+    source_code = dedent(
+        """
+        import math
+        from datetime import datetime
+        from pydantic import BaseModel
+                         
+        class MyModel(BaseModel):
+            x: int
+                         
+        def my_fn():
+            return 42
+
+        x = 10
+        y = math.sqrt(x)
+        now = datetime.now()
+    """
+    )
+
+    namespace = safe_load_namespace(source_code)
+
+    # module-level imports should be present
+    assert "math" in namespace
+    assert "datetime" in namespace
+    assert "BaseModel" in namespace
+    # module-level variables should not be present
+    assert "x" not in namespace
+    assert "y" not in namespace
+    assert "now" not in namespace
+    # module-level classes should be present
+    assert "MyModel" in namespace
+    # module-level functions should not be present
+    assert "my_fn" not in namespace
+
+    assert namespace["MyModel"].__name__ == "MyModel"
+
+
+def test_safe_load_namespace_ignores_import_errors():
+    source_code = dedent(
+        """
+        import flibbidy
+                         
+        from pydantic import BaseModel
+                         
+        class MyModel(BaseModel):
+            x: int
+    """
+    )
+
+    # should not raise an ImportError
+    namespace = safe_load_namespace(source_code)
+
+    assert "flibbidy" not in namespace
+    # other imports and classes should be present
+    assert "BaseModel" in namespace
+    assert "MyModel" in namespace
+    assert namespace["MyModel"].__name__ == "MyModel"
+
+
+def test_safe_load_namespace_ignore_class_declaration_errors():
+    source_code = dedent(
+        """
+        from fake_pandas import DataFrame
+                         
+        class CoolDataFrame(DataFrame):
+            pass
+    """
+    )
+
+    # should not raise any errors
+    namespace = safe_load_namespace(source_code)
+
+    assert "DataFrame" not in namespace
+    assert "CoolDataFrame" not in namespace


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
This PR adds a new method of generating a parameter schema for a function so users and use `prefect deploy` when not all dependencies are available on the current machine.

Our current method of generating a parameter schema requires us to load the flow function itself and get the signature using the built-in `inspect` module. This causes issues when not all dependencies are present because loading the flow causes the entire module the flow is located in to be run and can result in Python raising an `ImportError`.

This PR updates this approach to allow a parameter schema given an entrypoint that points to a function with the new `parameter_schema_from_entrypoint` function. This new function will generate a `inspect.Signature` object and docstring dictionary from the source code directly and use it with the existing machinery for generating a parameter schema.

Under the hood, the new functionality will load the source code at the provided entrypoint and parse it using the `ast` module. A new utility called `safe_load_namespace` will load each module-scoped import one by one and create a namespace dictionary for downstream use. Custom class definitions will also be included in the namespace. Any import errors will be caught and logged, but will not stop execution. The created namespace is used as context when walking the AST for the given function so that custom typing can be correctly resolved. In the case that typing cannot be resolved, the generated `Signature` will use no annotation to prevent interrupting execution. This can result in overly broad typing if the annotations rely on external types that aren't installed at deployment time.

The diff is big, but it's mostly tests.

Closes #9512

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Given code stored at `flow.py`:
```
from prefect import flow
from pandas import DataFrame
from pydantic import BaseModel

class MyModel(BaseModel):
    x: int

@flow
def my_flow(input: MyModel) -> pandas.DataFrame:
    # creates the dataframe in a clever way
```

The following call will generate the expected parameter schema with or without `panadas` installed:

```
parameter_schema_from_entrypoint("flow.py:my_flow")
```

The dictionary format looks like this:
```
{
    "title": "Parameters",
    "type": "object",
    "properties": {
        "input": {
            "allOf": [{"$ref": "#/definitions/MyModel"}],
            "position": 0,
            "title": "input",
        }
    },
    "required": ["input"],
    "definitions": {
        "MyModel": {
            "properties": {"x": {"title": "X", "type": "integer"}},
            "required": ["x"],
            "title": "MyModel",
            "type": "object",
        }
    },
}
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
