### PR TITLE
Add 2.19 to compatibility tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -53,6 +53,7 @@ jobs:
           - "2.16"
           - "2.17"
           - "2.18"
+          - "2.19"
 
           # We can include the following to always test against the last release
           # but the value is not particularly clear and we can just append the


### PR DESCRIPTION
Ensure we test the latest release of `2.19.0` as well as prior versions.