### PR TITLE
Fix events setting name

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -154,7 +154,7 @@ jobs:
       - name: Start server@${{ matrix.prefect-version }}
         if: ${{ ! matrix.server-incompatible }}
         env:
-          PREFECT_EXPERIMENTAL_EVENTS: True
+          PREFECT_EXPERIMENTAL_ENABLE_EVENTS: True
           PREFECT_API_URL: http://127.0.0.1:4200/api
         run: >
           docker run
@@ -162,7 +162,7 @@ jobs:
           --detach
           --publish 4200:4200
           ${{ matrix.extra_docker_run_options }}
-          --env PREFECT_EXPERIMENTAL_EVENTS=True
+          --env PREFECT_EXPERIMENTAL_ENABLE_EVENTS=True
           --env PREFECT_LOGGING_SERVER_LEVEL=DEBUG
           prefecthq/prefect:${{ matrix.prefect-version }}-python3.10
           ${{ matrix.server_command || 'prefect server start --analytics-off' }} --host 0.0.0.0
@@ -176,7 +176,7 @@ jobs:
         if: ${{ ! matrix.server-incompatible }}
         env:
           PREFECT_API_URL: http://127.0.0.1:4200/api
-          PREFECT_EXPERIMENTAL_EVENTS: True
+          PREFECT_EXPERIMENTAL_ENABLE_EVENTS: True
         run: >
           TEST_SERVER_VERSION=${{ matrix.prefect-version }}
           TEST_CLIENT_VERSION=$(python -c 'import prefect; print(prefect.__version__)')
@@ -195,7 +195,7 @@ jobs:
       - name: Start server@dev
         env:
           PREFECT_API_URL: http://127.0.0.1:4200/api
-          PREFECT_EXPERIMENTAL_EVENTS: True
+          PREFECT_EXPERIMENTAL_ENABLE_EVENTS: True
           PREFECT_LOGGING_SERVER_LEVEL: DEBUG
         run: |
           # First, we must stop the server container if it exists
@@ -213,7 +213,7 @@ jobs:
           --env TEST_SERVER_VERSION=$(python -c 'import prefect; print(prefect.__version__)')
           --env TEST_CLIENT_VERSION=${{ matrix.client_version }}
           --env PREFECT_API_URL="http://127.0.0.1:4200/api"
-          --env PREFECT_EXPERIMENTAL_EVENTS=True
+          --env PREFECT_EXPERIMENTAL_ENABLE_EVENTS=True
           --volume $(pwd)/flows:/opt/prefect/integration/flows
           --volume $(pwd)/scripts:/opt/prefect/integration/scripts
           --network host

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -31,7 +31,7 @@ from prefect.client.schemas import sorting
 from prefect.events import filters
 from prefect.settings import (
     PREFECT_API_SERVICES_TRIGGERS_ENABLED,
-    PREFECT_EXPERIMENTAL_EVENTS,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
 )
 
 if HAS_PYDANTIC_V2:
@@ -175,7 +175,9 @@ class ServerType(AutoEnum):
         if self == ServerType.CLOUD:
             return True
 
-        return PREFECT_EXPERIMENTAL_EVENTS and PREFECT_API_SERVICES_TRIGGERS_ENABLED
+        return (
+            PREFECT_EXPERIMENTAL_ENABLE_EVENTS and PREFECT_API_SERVICES_TRIGGERS_ENABLED
+        )
 
 
 def get_client(
@@ -3144,7 +3146,7 @@ class PrefectClient:
         response.raise_for_status()
 
     def _raise_for_unsupported_automations(self) -> NoReturn:
-        if not PREFECT_EXPERIMENTAL_EVENTS:
+        if not PREFECT_EXPERIMENTAL_ENABLE_EVENTS:
             raise RuntimeError(
                 "The current server and client configuration does not support "
                 "events.  Enable experimental events support with the "

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -3150,7 +3150,7 @@ class PrefectClient:
             raise RuntimeError(
                 "The current server and client configuration does not support "
                 "events.  Enable experimental events support with the "
-                "PREFECT_EXPERIMENTAL_EVENTS setting."
+                "PREFECT_EXPERIMENTAL_ENABLE_EVENTS setting."
             )
         else:
             raise RuntimeError(

--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -35,7 +35,7 @@ from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
-    PREFECT_EXPERIMENTAL_EVENTS,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
 )
 
 if TYPE_CHECKING:
@@ -54,7 +54,7 @@ def get_events_client(
             reconnection_attempts=reconnection_attempts,
             checkpoint_every=checkpoint_every,
         )
-    elif PREFECT_EXPERIMENTAL_EVENTS:
+    elif PREFECT_EXPERIMENTAL_ENABLE_EVENTS:
         if PREFECT_API_URL:
             return PrefectEventsClient(
                 reconnection_attempts=reconnection_attempts,
@@ -79,7 +79,7 @@ def get_events_subscriber(
         return PrefectCloudEventSubscriber(
             filter=filter, reconnection_attempts=reconnection_attempts
         )
-    elif PREFECT_EXPERIMENTAL_EVENTS:
+    elif PREFECT_EXPERIMENTAL_ENABLE_EVENTS:
         return PrefectEventSubscriber(
             filter=filter, reconnection_attempts=reconnection_attempts
         )
@@ -179,7 +179,7 @@ class PrefectEphemeralEventsClient(EventsClient):
     """A Prefect Events client that sends events to an ephemeral Prefect server"""
 
     def __init__(self):
-        if not PREFECT_EXPERIMENTAL_EVENTS:
+        if not PREFECT_EXPERIMENTAL_ENABLE_EVENTS:
             raise ValueError(
                 "PrefectEphemeralEventsClient can only be used when "
                 "PREFECT_EXPERIMENTAL_EVENTS is set to True"

--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -66,7 +66,7 @@ def get_events_client(
     raise RuntimeError(
         "The current server and client configuration does not support "
         "events.  Enable experimental events support with the "
-        "PREFECT_EXPERIMENTAL_EVENTS setting."
+        "PREFECT_EXPERIMENTAL_ENABLE_EVENTS setting."
     )
 
 
@@ -87,7 +87,7 @@ def get_events_subscriber(
     raise RuntimeError(
         "The current server and client configuration does not support "
         "events.  Enable experimental events support with the "
-        "PREFECT_EXPERIMENTAL_EVENTS setting."
+        "PREFECT_EXPERIMENTAL_ENABLE_EVENTS setting."
     )
 
 
@@ -182,7 +182,7 @@ class PrefectEphemeralEventsClient(EventsClient):
         if not PREFECT_EXPERIMENTAL_ENABLE_EVENTS:
             raise ValueError(
                 "PrefectEphemeralEventsClient can only be used when "
-                "PREFECT_EXPERIMENTAL_EVENTS is set to True"
+                "PREFECT_EXPERIMENTAL_ENABLE_EVENTS is set to True"
             )
         if PREFECT_API_KEY.value():
             raise ValueError(

--- a/src/prefect/events/worker.py
+++ b/src/prefect/events/worker.py
@@ -10,7 +10,7 @@ from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
-    PREFECT_EXPERIMENTAL_EVENTS,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
 )
 from prefect.utilities.context import temporary_context
 
@@ -42,11 +42,13 @@ def emit_events_to_cloud() -> bool:
 
 def should_emit_events_to_running_server() -> bool:
     api_url = PREFECT_API_URL.value()
-    return isinstance(api_url, str) and PREFECT_EXPERIMENTAL_EVENTS.value()
+    return isinstance(api_url, str) and PREFECT_EXPERIMENTAL_ENABLE_EVENTS.value()
 
 
 def should_emit_events_to_ephemeral_server() -> bool:
-    return PREFECT_API_KEY.value() is None and PREFECT_EXPERIMENTAL_EVENTS.value()
+    return (
+        PREFECT_API_KEY.value() is None and PREFECT_EXPERIMENTAL_ENABLE_EVENTS.value()
+    )
 
 
 class EventsWorker(QueueService[Event]):

--- a/src/prefect/server/api/automations.py
+++ b/src/prefect/server/api/automations.py
@@ -50,7 +50,7 @@ def automations_enabled() -> bool:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Automations are not enabled. Please enable the"
-            " PREFECT_EXPERIMENTAL_EVENTS and"
+            " PREFECT_EXPERIMENTAL_ENABLE_EVENTS and"
             " PREFECT_API_SERVICES_TRIGGERS_ENABLED settings.",
         )
 

--- a/src/prefect/server/api/automations.py
+++ b/src/prefect/server/api/automations.py
@@ -35,7 +35,7 @@ from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.utilities.server import PrefectRouter
 from prefect.settings import (
     PREFECT_API_SERVICES_TRIGGERS_ENABLED,
-    PREFECT_EXPERIMENTAL_EVENTS,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
 )
 from prefect.utilities.schema_tools.validation import (
     ValidationError as JSONSchemaValidationError,
@@ -43,7 +43,10 @@ from prefect.utilities.schema_tools.validation import (
 
 
 def automations_enabled() -> bool:
-    if not PREFECT_EXPERIMENTAL_EVENTS or not PREFECT_API_SERVICES_TRIGGERS_ENABLED:
+    if (
+        not PREFECT_EXPERIMENTAL_ENABLE_EVENTS
+        or not PREFECT_API_SERVICES_TRIGGERS_ENABLED
+    ):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Automations are not enabled. Please enable the"

--- a/src/prefect/server/api/events.py
+++ b/src/prefect/server/api/events.py
@@ -38,7 +38,7 @@ def events_enabled() -> bool:
     if not PREFECT_EXPERIMENTAL_ENABLE_EVENTS:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Events are not enabled. Please enable the PREFECT_EXPERIMENTAL_EVENTS setting.",
+            detail="Events are not enabled. Please enable the PREFECT_EXPERIMENTAL_ENABLE_EVENTS setting.",
         )
 
 

--- a/src/prefect/server/api/events.py
+++ b/src/prefect/server/api/events.py
@@ -29,13 +29,13 @@ from prefect.server.events.storage import (
 )
 from prefect.server.utilities import subscriptions
 from prefect.server.utilities.server import PrefectRouter
-from prefect.settings import PREFECT_EXPERIMENTAL_EVENTS
+from prefect.settings import PREFECT_EXPERIMENTAL_ENABLE_EVENTS
 
 logger = get_logger(__name__)
 
 
 def events_enabled() -> bool:
-    if not PREFECT_EXPERIMENTAL_EVENTS:
+    if not PREFECT_EXPERIMENTAL_ENABLE_EVENTS:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Events are not enabled. Please enable the PREFECT_EXPERIMENTAL_EVENTS setting.",

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -582,13 +582,13 @@ def create_app(
             service_instances.append(services.task_scheduling.TaskSchedulingTimeouts())
 
         if (
-            prefect.settings.PREFECT_EXPERIMENTAL_EVENTS.value()
+            prefect.settings.PREFECT_EXPERIMENTAL_ENABLE_EVENTS.value()
             and prefect.settings.PREFECT_API_SERVICES_EVENT_LOGGER_ENABLED.value()
         ):
             service_instances.append(EventLogger())
 
         if (
-            prefect.settings.PREFECT_EXPERIMENTAL_EVENTS.value()
+            prefect.settings.PREFECT_EXPERIMENTAL_ENABLE_EVENTS.value()
             and prefect.settings.PREFECT_API_SERVICES_TRIGGERS_ENABLED.value()
         ):
             service_instances.append(ReactiveTriggers())
@@ -596,13 +596,13 @@ def create_app(
             service_instances.append(Actions())
 
         if (
-            prefect.settings.PREFECT_EXPERIMENTAL_EVENTS
+            prefect.settings.PREFECT_EXPERIMENTAL_ENABLE_EVENTS
             and prefect.settings.PREFECT_API_SERVICES_EVENT_PERSISTER_ENABLED
         ):
             service_instances.append(EventPersister())
 
         if (
-            prefect.settings.PREFECT_EXPERIMENTAL_EVENTS
+            prefect.settings.PREFECT_EXPERIMENTAL_ENABLE_EVENTS
             and prefect.settings.PREFECT_API_EVENTS_STREAM_OUT_ENABLED
         ):
             service_instances.append(stream.Distributor())

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -25,7 +25,7 @@ from prefect.settings import (
     PREFECT_API_SERVICES_SCHEDULER_MAX_SCHEDULED_TIME,
     PREFECT_API_SERVICES_SCHEDULER_MIN_RUNS,
     PREFECT_API_SERVICES_SCHEDULER_MIN_SCHEDULED_TIME,
-    PREFECT_EXPERIMENTAL_EVENTS,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
 )
 
 if TYPE_CHECKING:
@@ -974,7 +974,7 @@ async def mark_deployments_ready(
         if not unready_deployments:
             return
 
-        if not PREFECT_EXPERIMENTAL_EVENTS:
+        if not PREFECT_EXPERIMENTAL_ENABLE_EVENTS:
             return
 
         async with PrefectServerEventsClient() as events:
@@ -1029,7 +1029,7 @@ async def mark_deployments_not_ready(
         if not ready_deployments:
             return
 
-        if not PREFECT_EXPERIMENTAL_EVENTS:
+        if not PREFECT_EXPERIMENTAL_ENABLE_EVENTS:
             return
 
         async with PrefectServerEventsClient() as events:

--- a/src/prefect/server/models/work_queues.py
+++ b/src/prefect/server/models/work_queues.py
@@ -22,7 +22,7 @@ from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect.server.events.clients import PrefectServerEventsClient
 from prefect.server.models.events import work_queue_status_event
 from prefect.server.schemas.statuses import WorkQueueStatus
-from prefect.settings import PREFECT_EXPERIMENTAL_EVENTS
+from prefect.settings import PREFECT_EXPERIMENTAL_ENABLE_EVENTS
 
 if HAS_PYDANTIC_V2:
     from pydantic.v1 import parse_obj_as
@@ -544,7 +544,7 @@ async def mark_work_queues_ready(
             ready_work_queue_ids=ready_work_queue_ids,
         )
 
-    if not PREFECT_EXPERIMENTAL_EVENTS:
+    if not PREFECT_EXPERIMENTAL_ENABLE_EVENTS:
         return
 
     # Emit events for any work queues that have transitioned to ready during this poll
@@ -587,7 +587,7 @@ async def mark_work_queues_not_ready(
             .values(status=WorkQueueStatus.NOT_READY)
         )
 
-    if not PREFECT_EXPERIMENTAL_EVENTS:
+    if not PREFECT_EXPERIMENTAL_ENABLE_EVENTS:
         return
 
     # Emit events for any work queues that have transitioned to ready during this poll

--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -34,8 +34,8 @@ from prefect.server.schemas import core, filters, states
 from prefect.server.schemas.states import StateType
 from prefect.server.task_queue import TaskQueue
 from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
     PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
-    PREFECT_EXPERIMENTAL_EVENTS,
     PREFECT_TASK_RUN_TAG_CONCURRENCY_SLOT_WAIT_SECONDS,
 )
 from prefect.utilities.math import clamped_poisson_interval
@@ -61,7 +61,11 @@ class CoreFlowPolicy(BaseOrchestrationPolicy):
             CopyScheduledTime,
             WaitForScheduledTime,
             RetryFailedFlows,
-        ] + ([InstrumentFlowRunStateTransitions] if PREFECT_EXPERIMENTAL_EVENTS else [])
+        ] + (
+            [InstrumentFlowRunStateTransitions]
+            if PREFECT_EXPERIMENTAL_ENABLE_EVENTS
+            else []
+        )
 
 
 class CoreTaskPolicy(BaseOrchestrationPolicy):
@@ -116,7 +120,7 @@ class MinimalFlowPolicy(BaseOrchestrationPolicy):
             ]
             + (
                 [InstrumentFlowRunStateTransitions]
-                if PREFECT_EXPERIMENTAL_EVENTS
+                if PREFECT_EXPERIMENTAL_ENABLE_EVENTS
                 else []
             )
         )
@@ -126,7 +130,11 @@ class MarkLateRunsPolicy(BaseOrchestrationPolicy):
     def priority():
         return [
             EnsureOnlyScheduledFlowsMarkedLate,
-        ] + ([InstrumentFlowRunStateTransitions] if PREFECT_EXPERIMENTAL_EVENTS else [])
+        ] + (
+            [InstrumentFlowRunStateTransitions]
+            if PREFECT_EXPERIMENTAL_ENABLE_EVENTS
+            else []
+        )
 
 
 class MinimalTaskPolicy(BaseOrchestrationPolicy):

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1459,7 +1459,7 @@ Whether or not to enable flow run input.
 
 # Prefect Events feature flags
 
-PREFECT_EXPERIMENTAL_EVENTS = Setting(bool, default=False)
+PREFECT_EXPERIMENTAL_ENABLE_EVENTS = Setting(bool, default=False)
 """
 Whether to enable Prefect's server-side event features. Note that Prefect Cloud clients
 will always emit events during flow and task runs regardless of this setting.

--- a/tests/cli/test_events.py
+++ b/tests/cli/test_events.py
@@ -5,7 +5,7 @@ from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
-    PREFECT_EXPERIMENTAL_EVENTS,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
     temporary_settings,
 )
 from prefect.testing.cli import invoke_and_assert
@@ -133,7 +133,7 @@ def oss_api_setup(events_api_url: str):
 def enable_oss_events():
     with temporary_settings(
         updates={
-            PREFECT_EXPERIMENTAL_EVENTS: True,
+            PREFECT_EXPERIMENTAL_ENABLE_EVENTS: True,
         }
     ):
         yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,8 +53,8 @@ from prefect.settings import (
     PREFECT_CLI_COLORS,
     PREFECT_CLI_WRAP_LINES,
     PREFECT_EXPERIMENTAL_ENABLE_ENHANCED_CANCELLATION,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
     PREFECT_EXPERIMENTAL_ENABLE_WORKERS,
-    PREFECT_EXPERIMENTAL_EVENTS,
     PREFECT_EXPERIMENTAL_WARN_ENHANCED_CANCELLATION,
     PREFECT_EXPERIMENTAL_WARN_WORKERS,
     PREFECT_HOME,
@@ -335,7 +335,7 @@ def pytest_sessionstart(session):
             PREFECT_UNIT_TEST_MODE: True,
             # Events: disable the event persister, which may lock the DB during
             # tests while writing events
-            PREFECT_EXPERIMENTAL_EVENTS: True,
+            PREFECT_EXPERIMENTAL_ENABLE_EVENTS: True,
             PREFECT_API_SERVICES_EVENT_PERSISTER_ENABLED: False,
         },
         source=__file__,
@@ -565,7 +565,7 @@ def disable_enhanced_cancellation():
 
 @pytest.fixture
 def events_disabled():
-    with temporary_settings({PREFECT_EXPERIMENTAL_EVENTS: False}):
+    with temporary_settings({PREFECT_EXPERIMENTAL_ENABLE_EVENTS: False}):
         yield
 
 

--- a/tests/events/client/test_automations_server_compatibility.py
+++ b/tests/events/client/test_automations_server_compatibility.py
@@ -45,7 +45,7 @@ from prefect.events.schemas.deployment_triggers import (
 )
 from prefect.settings import (
     PREFECT_API_SERVICES_TRIGGERS_ENABLED,
-    PREFECT_EXPERIMENTAL_EVENTS,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
     temporary_settings,
 )
 
@@ -131,7 +131,7 @@ EXAMPLE_TRIGGERS: List[TriggerTypes] = [
 def enable_events():
     with temporary_settings(
         {
-            PREFECT_EXPERIMENTAL_EVENTS: True,
+            PREFECT_EXPERIMENTAL_ENABLE_EVENTS: True,
             PREFECT_API_SERVICES_TRIGGERS_ENABLED: True,
         }
     ):

--- a/tests/events/client/test_events_client.py
+++ b/tests/events/client/test_events_client.py
@@ -15,7 +15,7 @@ from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
-    PREFECT_EXPERIMENTAL_EVENTS,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
     temporary_settings,
 )
 from prefect.testing.fixtures import Puppeteer, Recorder
@@ -28,7 +28,7 @@ def no_viable_settings(events_disabled):
             PREFECT_API_URL: "https://locally/api",
             PREFECT_API_KEY: None,
             PREFECT_CLOUD_API_URL: "https://cloudy/api",
-            PREFECT_EXPERIMENTAL_EVENTS: False,
+            PREFECT_EXPERIMENTAL_ENABLE_EVENTS: False,
         }
     ):
         yield
@@ -46,7 +46,7 @@ def ephemeral_settings():
             PREFECT_API_URL: None,
             PREFECT_API_KEY: None,
             PREFECT_CLOUD_API_URL: "https://cloudy/api",
-            PREFECT_EXPERIMENTAL_EVENTS: True,
+            PREFECT_EXPERIMENTAL_ENABLE_EVENTS: True,
         }
     ):
         yield
@@ -63,7 +63,7 @@ def server_settings():
             PREFECT_API_URL: "https://locally/api",
             PREFECT_API_KEY: None,
             PREFECT_CLOUD_API_URL: "https://cloudy/api",
-            PREFECT_EXPERIMENTAL_EVENTS: True,
+            PREFECT_EXPERIMENTAL_ENABLE_EVENTS: True,
         }
     ):
         yield
@@ -80,7 +80,7 @@ def cloud_settings():
             PREFECT_API_URL: "https://cloudy/api/accounts/1/workspaces/2",
             PREFECT_CLOUD_API_URL: "https://cloudy/api",
             PREFECT_API_KEY: "howdy-doody",
-            PREFECT_EXPERIMENTAL_EVENTS: False,
+            PREFECT_EXPERIMENTAL_ENABLE_EVENTS: False,
         }
     ):
         yield

--- a/tests/events/client/test_events_emit_event.py
+++ b/tests/events/client/test_events_emit_event.py
@@ -10,7 +10,7 @@ from prefect.events.worker import EventsWorker
 from prefect.server.utilities.schemas import DateTimeTZ
 from prefect.settings import (
     PREFECT_API_URL,
-    PREFECT_EXPERIMENTAL_EVENTS,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
     temporary_settings,
 )
 
@@ -118,7 +118,7 @@ def test_does_not_set_follows_not_tight_timing(
 
 
 def test_noop_with_null_events_client():
-    with temporary_settings(updates={PREFECT_EXPERIMENTAL_EVENTS: False}):
+    with temporary_settings(updates={PREFECT_EXPERIMENTAL_ENABLE_EVENTS: False}):
         worker = EventsWorker.instance()
         assert worker.client_type == NullEventsClient
 

--- a/tests/events/client/test_events_subscriber.py
+++ b/tests/events/client/test_events_subscriber.py
@@ -14,7 +14,7 @@ from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
-    PREFECT_EXPERIMENTAL_EVENTS,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
     temporary_settings,
 )
 from prefect.testing.fixtures import Puppeteer, Recorder
@@ -26,7 +26,7 @@ def no_viable_settings():
         {
             PREFECT_API_URL: "https://locally/api",
             PREFECT_CLOUD_API_URL: "https://cloudy/api",
-            PREFECT_EXPERIMENTAL_EVENTS: False,
+            PREFECT_EXPERIMENTAL_ENABLE_EVENTS: False,
         }
     ):
         yield
@@ -43,7 +43,7 @@ def server_settings():
         {
             PREFECT_API_URL: "https://locally/api",
             PREFECT_CLOUD_API_URL: "https://cloudy/api",
-            PREFECT_EXPERIMENTAL_EVENTS: True,
+            PREFECT_EXPERIMENTAL_ENABLE_EVENTS: True,
         }
     ):
         yield
@@ -60,7 +60,7 @@ def cloud_settings():
             PREFECT_API_URL: "https://cloudy/api/accounts/1/workspaces/2",
             PREFECT_CLOUD_API_URL: "https://cloudy/api",
             PREFECT_API_KEY: "howdy-doody",
-            PREFECT_EXPERIMENTAL_EVENTS: False,
+            PREFECT_EXPERIMENTAL_ENABLE_EVENTS: False,
         }
     ):
         yield

--- a/tests/events/client/test_events_worker.py
+++ b/tests/events/client/test_events_worker.py
@@ -14,7 +14,7 @@ from prefect.events.clients import (
 from prefect.events.worker import EventsWorker
 from prefect.settings import (
     PREFECT_API_URL,
-    PREFECT_EXPERIMENTAL_EVENTS,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
     temporary_settings,
 )
 
@@ -40,7 +40,7 @@ def test_worker_instance_null_client_events_disabled():
     with temporary_settings(
         updates={
             PREFECT_API_URL: None,
-            PREFECT_EXPERIMENTAL_EVENTS: False,
+            PREFECT_EXPERIMENTAL_ENABLE_EVENTS: False,
         }
     ):
         worker = EventsWorker.instance()

--- a/tests/events/server/actions/test_pausing_resuming_automation.py
+++ b/tests/events/server/actions/test_pausing_resuming_automation.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect.settings import (
     PREFECT_API_SERVICES_TRIGGERS_ENABLED,
-    PREFECT_EXPERIMENTAL_EVENTS,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
     temporary_settings,
 )
 
@@ -39,7 +39,10 @@ from prefect.server.events.schemas.events import RelatedResource
 @pytest.fixture
 def enable_automations():
     with temporary_settings(
-        {PREFECT_EXPERIMENTAL_EVENTS: True, PREFECT_API_SERVICES_TRIGGERS_ENABLED: True}
+        {
+            PREFECT_EXPERIMENTAL_ENABLE_EVENTS: True,
+            PREFECT_API_SERVICES_TRIGGERS_ENABLED: True,
+        }
     ):
         yield
 

--- a/tests/events/server/test_automations_api.py
+++ b/tests/events/server/test_automations_api.py
@@ -46,7 +46,7 @@ from prefect.server.events.schemas.automations import (
 from prefect.server.models import deployments
 from prefect.settings import (
     PREFECT_API_SERVICES_TRIGGERS_ENABLED,
-    PREFECT_EXPERIMENTAL_EVENTS,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
     temporary_settings,
 )
 
@@ -54,7 +54,10 @@ from prefect.settings import (
 @pytest.fixture(autouse=True)
 def enable_automations():
     with temporary_settings(
-        {PREFECT_EXPERIMENTAL_EVENTS: True, PREFECT_API_SERVICES_TRIGGERS_ENABLED: True}
+        {
+            PREFECT_EXPERIMENTAL_ENABLE_EVENTS: True,
+            PREFECT_API_SERVICES_TRIGGERS_ENABLED: True,
+        }
     ):
         yield
 
@@ -188,7 +191,7 @@ async def create_objects_for_automation(
     "settings",
     [
         {
-            PREFECT_EXPERIMENTAL_EVENTS: False,
+            PREFECT_EXPERIMENTAL_ENABLE_EVENTS: False,
         },
         {
             PREFECT_API_SERVICES_TRIGGERS_ENABLED: False,

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -30,7 +30,7 @@ from prefect.server.orchestration.rules import (
 )
 from prefect.server.schemas import states
 from prefect.server.schemas.core import ConcurrencyLimitV2
-from prefect.settings import PREFECT_EXPERIMENTAL_EVENTS, temporary_settings
+from prefect.settings import PREFECT_EXPERIMENTAL_ENABLE_EVENTS, temporary_settings
 from prefect.utilities.callables import parameter_schema
 from prefect.workers.process import ProcessWorker
 
@@ -403,7 +403,7 @@ async def task_run_states(session, task_run, task_run_state):
 
 @pytest.fixture
 async def storage_document_id(prefect_client, tmpdir):
-    with temporary_settings({PREFECT_EXPERIMENTAL_EVENTS: False}):
+    with temporary_settings({PREFECT_EXPERIMENTAL_ENABLE_EVENTS: False}):
         return await LocalFileSystem(basepath=str(tmpdir)).save(
             name=f"local-test-{uuid.uuid4()}", client=prefect_client
         )
@@ -411,7 +411,7 @@ async def storage_document_id(prefect_client, tmpdir):
 
 @pytest.fixture
 async def infrastructure_document_id(prefect_client):
-    with temporary_settings({PREFECT_EXPERIMENTAL_EVENTS: False}):
+    with temporary_settings({PREFECT_EXPERIMENTAL_ENABLE_EVENTS: False}):
         return await Process(env={"MY_TEST_VARIABLE": 1})._save(
             is_anonymous=True, client=prefect_client
         )
@@ -419,7 +419,7 @@ async def infrastructure_document_id(prefect_client):
 
 @pytest.fixture
 async def infrastructure_document_id_2(prefect_client):
-    with temporary_settings({PREFECT_EXPERIMENTAL_EVENTS: False}):
+    with temporary_settings({PREFECT_EXPERIMENTAL_ENABLE_EVENTS: False}):
         return await DockerContainer(env={"MY_TEST_VARIABLE": 1})._save(
             is_anonymous=True, client=prefect_client
         )

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -7,12 +7,12 @@ from prefect.automations import Automation
 from prefect.events.schemas.automations import EventTrigger, Posture
 from prefect.server.events import ResourceSpecification
 from prefect.server.events.actions import DoNothing
-from prefect.settings import PREFECT_EXPERIMENTAL_EVENTS, temporary_settings
+from prefect.settings import PREFECT_EXPERIMENTAL_ENABLE_EVENTS, temporary_settings
 
 
 @pytest.fixture(autouse=True)
 def enable_task_scheduling():
-    with temporary_settings({PREFECT_EXPERIMENTAL_EVENTS: True}):
+    with temporary_settings({PREFECT_EXPERIMENTAL_ENABLE_EVENTS: True}):
         yield
 
 

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -44,7 +44,7 @@ from prefect.settings import (
     PREFECT_API_URL,
     PREFECT_CLIENT_CSRF_SUPPORT_ENABLED,
     PREFECT_CLOUD_API_URL,
-    PREFECT_EXPERIMENTAL_EVENTS,
+    PREFECT_EXPERIMENTAL_ENABLE_EVENTS,
     temporary_settings,
 )
 from prefect.utilities.slugify import slugify
@@ -932,7 +932,7 @@ class TestDeploymentApply:
             updates={
                 PREFECT_API_URL: f"https://api.prefect.cloud/api/accounts/{uuid4()}/workspaces/{uuid4()}",
                 PREFECT_CLOUD_API_URL: "https://api.prefect.cloud/api/",
-                PREFECT_EXPERIMENTAL_EVENTS: False,
+                PREFECT_EXPERIMENTAL_ENABLE_EVENTS: False,
             }
         ):
             assert get_client().server_type.supports_automations()
@@ -984,7 +984,7 @@ class TestDeploymentApply:
             updates={
                 PREFECT_API_URL: "http://localhost:4242/api",
                 PREFECT_CLIENT_CSRF_SUPPORT_ENABLED: False,
-                PREFECT_EXPERIMENTAL_EVENTS: True,
+                PREFECT_EXPERIMENTAL_ENABLE_EVENTS: True,
             }
         ):
             assert get_client().server_type.supports_automations()


### PR DESCRIPTION
This PR renames the `PREFECT_EXPERIMENTAL_EVENTS` setting to `PREFECT_EXPERIMENTAL_ENABLE_EVENTS` so that it is more consistent with other settings and is compatible with other experimental helpers but more importantly so that _it is available for consumption via the UI through the `/ui-settings` route_. 