### PR TITLE
Separate CI for the 2.x line

### DIFF
--- a/.github/workflows/api-compatibility-tests.yaml
+++ b/.github/workflows/api-compatibility-tests.yaml
@@ -10,7 +10,7 @@ on:
       - compat-tests
   push:
     branches:
-      - main
+      - 2.x
 
 # Limit concurrency by workflow/branch combination.
 #

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -15,7 +15,7 @@ on:
       - Dockerfile
   push:
     branches:
-      - main
+      - 2.x
 
 permissions:
   contents: read

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -3,7 +3,7 @@ name: Update Docs
 on:
   push:
     branches:
-      - main
+      - 2.x
     paths:
       - 'docs/**'
       - 'netlify.toml'
@@ -23,7 +23,7 @@ jobs:
         if [[ $GITHUB_EVENT_NAME == "release" ]]; then
           version="${{ github.event.release.tag_name }}"
         fi
-        
+
         curl -XPOST -H "Authorization: Bearer $REPO_ACCESS_TOKEN" \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,11 +3,11 @@ name: "CodeQL"
 on:
   push:
     branches:
-      - main
+      - 2.x
 
   pull_request:
     branches:
-      - main
+      - 2.x
     paths:
       - .github/workflows/codeql-analysis.yaml
       - "**/*.py"

--- a/.github/workflows/integration-pacakge-tests.yaml
+++ b/.github/workflows/integration-pacakge-tests.yaml
@@ -6,7 +6,7 @@ on:
       - "src/integrations/*/**"
   push:
     branches:
-      - main
+      - 2.x
     paths:
       - "src/integrations/*/**"
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -12,7 +12,7 @@ on:
       - Dockerfile
   push:
     branches:
-      - main
+      - 2.x
     paths:
       - .github/workflows/integration-tests.yaml
       - "**/*.py"

--- a/.github/workflows/prefect-client.yaml
+++ b/.github/workflows/prefect-client.yaml
@@ -3,7 +3,7 @@ name: Verify prefect-client build
 on:
   pull_request:
     branches:
-      - main
+      - 2.x
     paths:
       - src/prefect/**/*.py
       - requirements.txt
@@ -11,7 +11,7 @@ on:
       - setup.cfg
   push:
     branches:
-      - main
+      - 2.x
     paths:
       - src/prefect/**/*.py
       - requirements.txt
@@ -50,7 +50,7 @@ jobs:
         run: echo "TMPDIR=$(mktemp -d)" >> $GITHUB_ENV
 
       - name: Prepare files for prefect-client build (omit the local build)
-        run: sh client/build_client.sh   
+        run: sh client/build_client.sh
         env:
           TMPDIR: ${{ env.TMPDIR }}
 
@@ -68,7 +68,7 @@ jobs:
         env:
           PREFECT_API_KEY: ${{ secrets.PREFECT_CLIENT_SA_API_KEY }}
           PREFECT_API_URL: "https://api.prefect.cloud/api/accounts/9b649228-0419-40e1-9e0d-44954b5c0ab6/workspaces/96bd3cf8-85c9-4545-9713-b4e3c3e03466" # sandbox, prefect-client workspace
-      
+
       - name: Install prefect from source
         run: pip install .
 
@@ -81,7 +81,7 @@ jobs:
         env:
           PREFECT_API_KEY: ${{ secrets.PREFECT_CLIENT_SA_API_KEY }}
           PREFECT_API_URL: "https://api.prefect.cloud/api/accounts/9b649228-0419-40e1-9e0d-44954b5c0ab6/workspaces/96bd3cf8-85c9-4545-9713-b4e3c3e03466" # sandbox, prefect-client workspace
-      
+
       - name: Publish build artifacts
         if: ${{ inputs.upload-artifacts }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -18,7 +18,7 @@ on:
       - Dockerfile
   push:
     branches:
-      - main
+      - 2.x
     paths:
       - .github/workflows/python-tests.yaml
       - "src/prefect/**/*.py"

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -8,7 +8,7 @@ on:
       - .nvmrc
   push:
     branches:
-      - main
+      - 2.x
 
 permissions:
   contents: read

--- a/.github/workflows/validate_worker_metadata.yaml
+++ b/.github/workflows/validate_worker_metadata.yaml
@@ -2,7 +2,7 @@ name: Ensure JSON views are valid on PR
 on:
   pull_request:
     branches:
-      - main
+      - 2.x
     paths:
       - "src/prefect/server/api/collections_data/views/*.json"
 jobs:

--- a/.github/workflows/windows-pull-request.yaml
+++ b/.github/workflows/windows-pull-request.yaml
@@ -3,7 +3,7 @@ name: Windows tests (Pull Request)
 on:
   pull_request:
     branches:
-      - main
+      - 2.x
     types:
       - opened
       - reopened
@@ -37,7 +37,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12"         
+          - "3.12"
 
       fail-fast: true
 


### PR DESCRIPTION
This adjusts all of the CI/CD workflows to operate on the 2.x line (either for
pushes or for PRs).  This will allow us to evolve the 3.x CI but still test any
2.x backports against our traditional 2.x CI.
