### PR TITLE
Pin the lower bounds of `pydantic` and `sqlalchemy` for 3.x line

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -94,7 +94,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev] 'pydantic>=2.4,<3'
+          uv pip install --upgrade --system -e .[dev]
 
       - name: Start database container
         if: ${{ startsWith(matrix.database, 'postgres') }}
@@ -128,6 +128,8 @@ jobs:
         # Do not run Kubernetes service tests, we do not have a cluster available
         # maxprocesses 6 is based on empirical testing; higher than 6 sees diminishing returns
       - name: Run tests
+        env:
+          PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS: "1"
         run: >
           pytest tests
           --numprocesses auto
@@ -144,356 +146,6 @@ jobs:
         id: create_failure_flag
         run: |
           sanitized_name="${{ matrix.python-version }}-${{ matrix.database }}"
-          sanitized_name="${sanitized_name//:/-}"
-          echo "Failure in $sanitized_name" > "${sanitized_name}-failure.txt"
-          echo "artifact_name=${sanitized_name}-failure" >> $GITHUB_OUTPUT
-
-      - name: Upload failure flag
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.create_failure_flag.outputs.artifact_name }}
-          path: "${{ steps.create_failure_flag.outputs.artifact_name }}.txt"
-
-      - name: Check database container
-        # Only applicable for Postgres, but we want this to run even when tests fail
-        if: always()
-        run: >
-          docker container inspect postgres
-          && docker container logs postgres
-          || echo "Ignoring bad exit code"
-
-  run-pydantic-v1-tests:
-    runs-on:
-      group: oss-larger-runners
-    name: pydantic v1, python:${{ matrix.python-version }}
-    strategy:
-      matrix:
-        database:
-          - "postgres:14"
-        python-version:
-          - "3.8"
-          - "3.12"
-
-      fail-fast: true
-
-    timeout-minutes: 45
-
-    steps:
-      - name: Display current test matrix
-        run: echo '${{ toJSON(matrix) }}'
-
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        id: setup_python
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: UV Cache
-        # Manually cache the uv cache directory
-        # until setup-python supports it:
-        # https://github.com/actions/setup-python/issues/822
-        uses: actions/cache@v4
-        id: cache-uv
-        with:
-          path: ~/.cache/uv
-          key: uvcache-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-client.txt', 'requirements.txt', 'requirements-dev.txt') }}
-
-      - name: Install packages
-        run: |
-          python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev] 'pydantic<2'
-
-      - name: Start database container
-        if: ${{ startsWith(matrix.database, 'postgres') }}
-        run: >
-          docker run
-          --name "postgres"
-          --detach
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-          --publish 5432:5432
-          --tmpfs /var/lib/postgresql/data
-          --env POSTGRES_USER="prefect"
-          --env POSTGRES_PASSWORD="prefect"
-          --env POSTGRES_DB="prefect"
-          --env LANG="C.UTF-8"
-          --env LANGUAGE="C.UTF-8"
-          --env LC_ALL="C.UTF-8"
-          --env LC_COLLATE="C.UTF-8"
-          --env LC_CTYPE="C.UTF-8"
-          ${{ matrix.database }}
-          -c max_connections=250
-
-          ./scripts/wait-for-healthy-container.sh postgres 30
-
-          echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
-
-        # Parallelize tests by scope to reduce expensive service fixture duplication
-        # Do not allow the test suite to build images, as we want the prebuilt images to be tested
-        # Do not run Kubernetes service tests, we do not have a cluster available
-        # maxprocesses 6 is based on empirical testing; higher than 6 sees diminishing returns
-      - name: Run tests
-        run: >
-          pytest tests
-          --numprocesses auto
-          --maxprocesses 6
-          --dist loadscope
-          --disable-docker-image-builds
-          --exclude-service kubernetes
-          --exclude-service docker
-          --durations 26
-          --no-cov
-
-      - name: Create and Upload failure flag
-        if: ${{ failure() }}
-        id: create_failure_flag
-        run: |
-          sanitized_name="pydantic-v1-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}"
-          sanitized_name="${sanitized_name//:/-}"
-          echo "Failure in $sanitized_name" > "${sanitized_name}-failure.txt"
-          echo "artifact_name=${sanitized_name}-failure" >> $GITHUB_OUTPUT
-
-      - name: Upload failure flag
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.create_failure_flag.outputs.artifact_name }}
-          path: "${{ steps.create_failure_flag.outputs.artifact_name }}.txt"
-
-      - name: Check database container
-        # Only applicable for Postgres, but we want this to run even when tests fail
-        if: always()
-        run: >
-          docker container inspect postgres
-          && docker container logs postgres
-          || echo "Ignoring bad exit code"
-
-  run-pydantic-v2-internals-tests:
-    runs-on:
-      group: oss-larger-runners
-    name: pydantic v2 internals, python:${{ matrix.python-version }}
-    strategy:
-      matrix:
-        database:
-          - "postgres:14"
-        python-version:
-          - "3.8"
-          - "3.12"
-
-      fail-fast: true
-
-    timeout-minutes: 45
-
-    steps:
-      - name: Display current test matrix
-        run: echo '${{ toJSON(matrix) }}'
-
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        id: setup_python
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: UV Cache
-        # Manually cache the uv cache directory
-        # until setup-python supports it:
-        # https://github.com/actions/setup-python/issues/822
-        uses: actions/cache@v4
-        id: cache-uv
-        with:
-          path: ~/.cache/uv
-          key: uvcache-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-client.txt', 'requirements.txt', 'requirements-dev.txt') }}
-
-      - name: Get image tag
-        id: get_image_tag
-        run: |
-          SHORT_SHA=$(git rev-parse --short=7 HEAD)
-          tmp="sha-$SHORT_SHA-python${{ matrix.python-version }}"
-          echo "image_tag=${tmp}" >> $GITHUB_OUTPUT
-
-      - name: Install packages
-        run: |
-          python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev] 'pydantic>=2.4,<3'
-
-      - name: Set PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS env var
-        run: echo "PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS=1" >> $GITHUB_ENV
-
-      - name: Start database container
-        if: ${{ startsWith(matrix.database, 'postgres') }}
-        run: >
-          docker run
-          --name "postgres"
-          --detach
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-          --publish 5432:5432
-          --tmpfs /var/lib/postgresql/data
-          --env POSTGRES_USER="prefect"
-          --env POSTGRES_PASSWORD="prefect"
-          --env POSTGRES_DB="prefect"
-          --env LANG="C.UTF-8"
-          --env LANGUAGE="C.UTF-8"
-          --env LC_ALL="C.UTF-8"
-          --env LC_COLLATE="C.UTF-8"
-          --env LC_CTYPE="C.UTF-8"
-          ${{ matrix.database }}
-          -c max_connections=250
-
-          ./scripts/wait-for-healthy-container.sh postgres 30
-
-          echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
-
-        # Parallelize tests by scope to reduce expensive service fixture duplication
-        # Do not allow the test suite to build images, as we want the prebuilt images to be tested
-        # Do not run Kubernetes service tests, we do not have a cluster available
-        # maxprocesses 6 is based on empirical testing; higher than 6 sees diminishing returns
-      - name: Run tests
-        run: >
-          pytest tests
-          --numprocesses auto
-          --maxprocesses 6
-          --dist loadscope
-          --disable-docker-image-builds
-          --exclude-service kubernetes
-          --exclude-service docker
-          --durations 26
-          --no-cov
-
-      - name: Create and Upload failure flag
-        if: ${{ failure() }}
-        id: create_failure_flag
-        run: |
-          sanitized_name="pydantic-v2-internals-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}"
-          sanitized_name="${sanitized_name//:/-}"
-          echo "Failure in $sanitized_name" > "${sanitized_name}-failure.txt"
-          echo "artifact_name=${sanitized_name}-failure" >> $GITHUB_OUTPUT
-
-      - name: Upload failure flag
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.create_failure_flag.outputs.artifact_name }}
-          path: "${{ steps.create_failure_flag.outputs.artifact_name }}.txt"
-
-      - name: Check database container
-        # Only applicable for Postgres, but we want this to run even when tests fail
-        if: always()
-        run: >
-          docker container inspect postgres
-          && docker container logs postgres
-          || echo "Ignoring bad exit code"
-
-  run-sqlalchemy-v1-tests:
-    runs-on:
-      group: oss-larger-runners
-    name: sqlalchemy v1, ${{ matrix.database }} python:${{ matrix.python-version }}
-    strategy:
-      matrix:
-        database:
-          - "postgres:14"
-          - "sqlite"
-        python-version:
-          - "3.8"
-          - "3.12"
-
-      fail-fast: true
-
-    timeout-minutes: 45
-
-    steps:
-      - name: Display current test matrix
-        run: echo '${{ toJSON(matrix) }}'
-
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        id: setup_python
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: UV Cache
-        # Manually cache the uv cache directory
-        # until setup-python supports it:
-        # https://github.com/actions/setup-python/issues/822
-        uses: actions/cache@v4
-        id: cache-uv
-        with:
-          path: ~/.cache/uv
-          key: uvcache-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-client.txt', 'requirements.txt', 'requirements-dev.txt') }}
-
-      - name: Install packages
-        run: |
-          python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev] 'sqlalchemy[asyncio]<2'
-
-      - name: Start database container
-        if: ${{ startsWith(matrix.database, 'postgres') }}
-        run: >
-          docker run
-          --name "postgres"
-          --detach
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-          --publish 5432:5432
-          --tmpfs /var/lib/postgresql/data
-          --env POSTGRES_USER="prefect"
-          --env POSTGRES_PASSWORD="prefect"
-          --env POSTGRES_DB="prefect"
-          --env LANG="C.UTF-8"
-          --env LANGUAGE="C.UTF-8"
-          --env LC_ALL="C.UTF-8"
-          --env LC_COLLATE="C.UTF-8"
-          --env LC_CTYPE="C.UTF-8"
-          ${{ matrix.database }}
-          -c max_connections=250
-
-          ./scripts/wait-for-healthy-container.sh postgres 30
-
-          echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
-
-        # Parallelize tests by scope to reduce expensive service fixture duplication
-        # Do not allow the test suite to build images, as we want the prebuilt images to be tested
-        # Do not run Kubernetes service tests, we do not have a cluster available
-        # maxprocesses 6 is based on empirical testing; higher than 6 sees diminishing returns
-      - name: Run tests
-        run: >
-          pytest tests
-          --numprocesses auto
-          --maxprocesses 6
-          --dist loadscope
-          --disable-docker-image-builds
-          --exclude-service kubernetes
-          --exclude-service docker
-          --durations 26
-          --no-cov
-
-      - name: Create and Upload failure flag
-        if: ${{ failure() }}
-        id: create_failure_flag
-        run: |
-          sanitized_name="sqlalchemy-v1-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.database }}-${{ matrix.pytest-options }}"
           sanitized_name="${sanitized_name//:/-}"
           echo "Failure in $sanitized_name" > "${sanitized_name}-failure.txt"
           echo "artifact_name=${sanitized_name}-failure" >> $GITHUB_OUTPUT
@@ -621,7 +273,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev] 'pydantic>=2.4,<3'
+          uv pip install --upgrade --system -e .[dev]
 
       - name: Start database container
         run: >
@@ -650,6 +302,13 @@ jobs:
           echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
 
       - name: Run tests
+        env:
+          PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS: "1"
+          DD_CIVISIBILITY_AGENTLESS_ENABLED: true
+          DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VISIBILITY }}
+          DD_SITE: datadoghq.com
+          DD_ENV: ci
+          DD_SERVICE: prefect
         run: >
           pytest tests
           --numprocesses auto
@@ -661,12 +320,6 @@ jobs:
           --durations 26
           --cov
           --cov-config setup.cfg
-        env:
-          DD_CIVISIBILITY_AGENTLESS_ENABLED: true
-          DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VISIBILITY }}
-          DD_SITE: datadoghq.com
-          DD_ENV: ci
-          DD_SERVICE: prefect
 
   run-docker-tests:
     runs-on:
@@ -742,7 +395,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev] 'pydantic>=2.4,<3'
+          uv pip install --upgrade --system -e .[dev]
 
       - name: Start database container
         if: ${{ startsWith(matrix.database, 'postgres') }}
@@ -776,6 +429,8 @@ jobs:
         # Do not run Kubernetes service tests, we do not have a cluster available
         # maxprocesses 6 is based on empirical testing; higher than 6 sees diminishing returns
       - name: Run tests
+        env:
+          PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS: "1"
         run: >
           pytest tests
           --numprocesses auto

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -20,7 +20,7 @@ pathspec >= 0.8.0
 pendulum < 3.0; python_version < '3.12'
 pendulum >= 3.0.0, <4; python_version >= '3.12'
 # the version constraints for pydantic are merged with those from fastapi 0.103.2
-pydantic[email]>=1.10.0,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0
+pydantic >= 2.4, < 3.0.0
 pydantic_core >= 2.12.0, < 3.0.0
 python_dateutil >= 2.8.2, < 3.0.0
 python-slugify >= 5.0, < 9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ humanize >= 4.9.0
 kubernetes >= 24.2.0, < 30.0.0
 pytz >= 2021.1, < 2025
 readchar >= 4.0.0, < 5.0.0
-sqlalchemy[asyncio] >= 1.4.22, != 1.4.33, < 3.0.0
+sqlalchemy[asyncio] >= 2.0, < 3.0.0
 typer >= 0.12.0, != 0.12.2, < 0.13.0


### PR DESCRIPTION
This also removes the extra CI checks for the 1.x series of those two libraries,
as well as enabling our experimental pydantic flag for all unit tests.
