### PR TITLE
rm `not HAS_PYDANTIC_v2` branch of conditional imports from top level modules

### DIFF
--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -31,13 +31,7 @@ from typing import (
 
 import anyio.abc
 import pendulum
-
-from prefect._internal.pydantic import HAS_PYDANTIC_V2
-
-if HAS_PYDANTIC_V2:
-    from pydantic.v1 import BaseModel, Field, PrivateAttr
-else:
-    from pydantic import BaseModel, Field, PrivateAttr
+from pydantic.v1 import BaseModel, Field, PrivateAttr
 
 import prefect.logging
 import prefect.logging.configuration

--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -9,15 +9,9 @@ from typing import Any, Dict, Optional, Tuple, Union
 
 import anyio
 import fsspec
+from pydantic.v1 import Field, SecretStr, validator
 
 from prefect._internal.compatibility.deprecated import deprecated_class
-from prefect._internal.pydantic import HAS_PYDANTIC_V2
-
-if HAS_PYDANTIC_V2:
-    from pydantic.v1 import Field, SecretStr, validator
-else:
-    from pydantic import Field, SecretStr, validator
-
 from prefect._internal.schemas.validators import (
     stringify_path,
     validate_basepath,

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -34,33 +34,17 @@ from typing import (
 )
 from uuid import UUID
 
+import pydantic.v1 as pydantic
+from prefect._vendor.fastapi.encoders import jsonable_encoder
+from pydantic import ValidationError as V2ValidationError
+from pydantic.v1 import BaseModel as V1BaseModel
+from pydantic.v1.decorator import ValidatedFunction as V1ValidatedFunction
 from rich.console import Console
 from typing_extensions import Literal, ParamSpec, Self
 
-from prefect._internal.pydantic import HAS_PYDANTIC_V2
-
-if HAS_PYDANTIC_V2:
-    import pydantic.v1 as pydantic
-    from pydantic import ValidationError as V2ValidationError
-    from pydantic.v1 import BaseModel as V1BaseModel
-    from pydantic.v1.decorator import ValidatedFunction as V1ValidatedFunction
-
-    from ._internal.pydantic.v2_schema import is_v2_type
-    from ._internal.pydantic.v2_validated_func import V2ValidatedFunction
-    from ._internal.pydantic.v2_validated_func import (
-        V2ValidatedFunction as ValidatedFunction,
-    )
-
-else:
-    import pydantic
-    from pydantic.decorator import ValidatedFunction
-
-    V2ValidationError = None
-
-from prefect._vendor.fastapi.encoders import jsonable_encoder
-
 from prefect._internal.compatibility.deprecated import deprecated_parameter
 from prefect._internal.concurrency.api import create_call, from_async
+from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect._internal.schemas.validators import raise_on_name_with_banned_characters
 from prefect.client.orchestration import get_client
 from prefect.client.schemas.objects import Flow as FlowSchema
@@ -115,6 +99,12 @@ from prefect.utilities.visualization import (
     get_task_viz_tracker,
     track_viz_task,
     visualize_task_dependencies,
+)
+
+from ._internal.pydantic.v2_schema import is_v2_type
+from ._internal.pydantic.v2_validated_func import V2ValidatedFunction
+from ._internal.pydantic.v2_validated_func import (
+    V2ValidatedFunction as ValidatedFunction,
 )
 
 T = TypeVar("T")  # Generic type var for capturing the inner return type of async funcs

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -16,10 +16,10 @@ from typing import (
 )
 from uuid import UUID
 
+import pydantic.v1 as pydantic
 from typing_extensions import ParamSpec, Self
 
 import prefect
-from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect.blocks.core import Block
 from prefect.client.utilities import inject_client
 from prefect.exceptions import MissingResult
@@ -40,13 +40,6 @@ from prefect.settings import (
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.pydantic import get_dispatch_key, lookup_type, register_base_type
-
-if HAS_PYDANTIC_V2:
-    import pydantic.v1 as pydantic
-
-else:
-    import pydantic
-
 
 if TYPE_CHECKING:
     from prefect import Flow, Task

--- a/src/prefect/serializers.py
+++ b/src/prefect/serializers.py
@@ -15,6 +15,14 @@ import abc
 import base64
 from typing import Any, Dict, Generic, Optional, Type, TypeVar
 
+from pydantic.v1 import (
+    BaseModel,
+    Field,
+    ValidationError,
+    parse_obj_as,
+    root_validator,
+    validator,
+)
 from typing_extensions import Literal, Self
 
 from prefect._internal.schemas.validators import (
@@ -25,29 +33,9 @@ from prefect._internal.schemas.validators import (
     validate_picklelib,
     validate_picklelib_version,
 )
-from prefect.pydantic import HAS_PYDANTIC_V2
 from prefect.utilities.dispatch import get_dispatch_key, lookup_type, register_base_type
 from prefect.utilities.importtools import from_qualified_name, to_qualified_name
 from prefect.utilities.pydantic import custom_pydantic_encoder
-
-if HAS_PYDANTIC_V2:
-    from pydantic.v1 import (
-        BaseModel,
-        Field,
-        ValidationError,
-        parse_obj_as,
-        root_validator,
-        validator,
-    )
-else:
-    from pydantic import (
-        BaseModel,
-        Field,
-        ValidationError,
-        parse_obj_as,
-        root_validator,
-        validator,
-    )
 
 D = TypeVar("D")
 

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -66,35 +66,19 @@ from typing import (
 from urllib.parse import urlparse
 
 import toml
-
-from prefect._internal.pydantic import HAS_PYDANTIC_V2
-from prefect._internal.schemas.validators import validate_settings
-
-if HAS_PYDANTIC_V2:
-    from pydantic.v1 import (
-        BaseModel,
-        BaseSettings,
-        Field,
-        create_model,
-        fields,
-        root_validator,
-        validator,
-    )
-else:
-    from pydantic import (
-        BaseModel,
-        BaseSettings,
-        Field,
-        create_model,
-        fields,
-        root_validator,
-        validator,
-    )
-
+from pydantic.v1 import (
+    BaseModel,
+    BaseSettings,
+    Field,
+    create_model,
+    fields,
+    root_validator,
+    validator,
+)
 from typing_extensions import Literal
 
 from prefect._internal.compatibility.deprecated import generate_deprecation_message
-from prefect._internal.pydantic import HAS_PYDANTIC_V2
+from prefect._internal.schemas.validators import validate_settings
 from prefect.exceptions import MissingProfileError
 from prefect.utilities.names import OBFUSCATED_PREFIX, obfuscate
 from prefect.utilities.pydantic import add_cloudpickle_reduction


### PR DESCRIPTION
starts the process of replacing the pydantic conditional imports with just imports from the v1 backport of v2 since we will always have pydantic 2 on main