### PR TITLE
use v1 validation error

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
@@ -299,7 +299,7 @@ class CloudRunWorkerJobV2Configuration(BaseJobConfiguration):
 
 class CloudRunWorkerV2Variables(BaseVariables):
     """
-    Default variables for the Cloud Run worker V2.
+    Default variables for the v2 Cloud Run worker.
 
     The schema for this class is used to populate the `variables` section of the
     default base job template.

--- a/src/integrations/prefect-gcp/tests/test_cloud_run_worker.py
+++ b/src/integrations/prefect-gcp/tests/test_cloud_run_worker.py
@@ -11,7 +11,6 @@ else:
 
 import pytest
 from googleapiclient.errors import HttpError
-from jsonschema.exceptions import ValidationError
 from prefect_gcp.credentials import GcpCredentials
 from prefect_gcp.utilities import slugify_name
 from prefect_gcp.workers.cloud_run import (
@@ -23,6 +22,9 @@ from prefect_gcp.workers.cloud_run import (
 from prefect.client.schemas import FlowRun
 from prefect.exceptions import InfrastructureNotFound
 from prefect.server.schemas.actions import DeploymentCreate
+from prefect.utilities.schema_tools.validation import (
+    ValidationError as PrefectValidationError,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -313,12 +315,12 @@ class TestCloudRunWorkerValidConfiguration:
             flow_id=uuid.uuid4(),
             infra_overrides={"region": "test-region1", "cpu": cpu},
         )
-        with pytest.raises(ValidationError) as excinfo:
+        with pytest.raises(PrefectValidationError) as exc:
             deployment.check_valid_configuration(
                 CloudRunWorker.get_default_base_job_template()
             )
 
-        assert excinfo.value.message == f"'{cpu}' does not match '^(\\\\d*000)m$'"
+        assert f"'{cpu}' does not match '^(\\\\d*000)m$'" in str(exc.value)
 
     @pytest.mark.parametrize("cpu", ["1000m", "2000m", "3000m"])
     def test_valid_cpu_string(self, cpu):
@@ -338,14 +340,11 @@ class TestCloudRunWorkerValidConfiguration:
             flow_id=uuid.uuid4(),
             infra_overrides={"region": "test-region1", "memory": memory},
         )
-        with pytest.raises(ValidationError) as excinfo:
+        with pytest.raises(PrefectValidationError) as exc:
             deployment.check_valid_configuration(
                 CloudRunWorker.get_default_base_job_template()
             )
-        assert (
-            excinfo.value.message
-            == f"'{memory}' does not match '^\\\\d+(?:G|Gi|M|Mi)$'"
-        )
+        assert f"'{memory}' does not match '^\\\\d+(?:G|Gi|M|Mi)$'" in str(exc.value)
 
     @pytest.mark.parametrize("memory", ["512G", "512Gi", "512M", "512Mi"])
     def test_valid_memory_string(self, memory):

--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -8,7 +8,7 @@ from types import ModuleType, TracebackType
 from typing import Callable, Dict, Iterable, List, Optional, Type
 
 from httpx._exceptions import HTTPStatusError
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 from rich.traceback import Traceback
 from typing_extensions import Self
 


### PR DESCRIPTION
forgot to use v1 import in https://github.com/PrefectHQ/prefect/pull/13330

and fixes https://github.com/PrefectHQ/prefect/issues/13333, which was actually unrelated - although we did have a expected error mismatch where we are raising our own internal `ValidationError` from `schema_tools` but were expecting the one from `jsonschema` in the tests