### PR TITLE
[New Engine] Add new `ThreadPoolTaskRunner` and new `PrefectFuture` implementation

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2221,8 +2221,14 @@ class PrefectClient:
         Returns:
             a Task Run model representation of the task run
         """
-        response = await self._client.get(f"/task_runs/{task_run_id}")
-        return TaskRun.parse_obj(response.json())
+        try:
+            response = await self._client.get(f"/task_runs/{task_run_id}")
+            return TaskRun.parse_obj(response.json())
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == status.HTTP_404_NOT_FOUND:
+                raise prefect.exceptions.ObjectNotFound(http_exc=e) from e
+            else:
+                raise
 
     async def read_task_runs(
         self,
@@ -3793,8 +3799,14 @@ class SyncPrefectClient:
         Returns:
             a Task Run model representation of the task run
         """
-        response = self._client.get(f"/task_runs/{task_run_id}")
-        return TaskRun.parse_obj(response.json())
+        try:
+            response = self._client.get(f"/task_runs/{task_run_id}")
+            return TaskRun.parse_obj(response.json())
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == status.HTTP_404_NOT_FOUND:
+                raise prefect.exceptions.ObjectNotFound(http_exc=e) from e
+            else:
+                raise
 
     def read_task_runs(
         self,

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -42,6 +42,7 @@ from prefect.client.schemas import FlowRun, TaskRun
 from prefect.events.worker import EventsWorker
 from prefect.exceptions import MissingContextError
 from prefect.futures import PrefectFuture
+from prefect.new_task_runners import TaskRunner
 from prefect.results import ResultFactory
 from prefect.settings import PREFECT_HOME, Profile, Settings
 from prefect.states import State
@@ -230,7 +231,7 @@ class EngineContext(RunContext):
     flow: Optional["Flow"] = None
     flow_run: Optional[FlowRun] = None
     autonomous_task_run: Optional[TaskRun] = None
-    task_runner: BaseTaskRunner
+    task_runner: Union[BaseTaskRunner, TaskRunner]
     log_prints: bool = False
     parameters: Optional[Dict[str, Any]] = None
 

--- a/src/prefect/new_flow_engine.py
+++ b/src/prefect/new_flow_engine.py
@@ -273,6 +273,8 @@ class FlowRunEngine(Generic[P, R]):
             task_group = anyio._backends._asyncio.TaskGroup()
 
         with ExitStack() as stack:
+            # TODO: Explore closing task runner before completing the flow to
+            # wait for futures to complete
             task_runner = stack.enter_context(self.flow.task_runner.duplicate())
             stack.enter_context(
                 FlowRunContext(

--- a/src/prefect/new_flow_engine.py
+++ b/src/prefect/new_flow_engine.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 import os
 import time
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
 from typing import (
     Any,
@@ -32,8 +32,8 @@ from prefect.client.schemas.sorting import FlowRunSort
 from prefect.context import FlowRunContext
 from prefect.exceptions import Abort, Pause
 from prefect.flows import Flow, load_flow_from_entrypoint, load_flow_from_flow_run
-from prefect.futures import PrefectFuture, resolve_futures_to_states
 from prefect.logging.loggers import flow_run_logger, get_logger
+from prefect.new_futures import PrefectFuture, resolve_futures_to_states
 from prefect.results import ResultFactory
 from prefect.states import (
     Pending,
@@ -43,7 +43,7 @@ from prefect.states import (
     exception_to_failed_state,
     return_value_to_state,
 )
-from prefect.utilities.asyncutils import A, Async, run_sync
+from prefect.utilities.asyncutils import run_sync
 from prefect.utilities.callables import parameters_to_args_kwargs
 from prefect.utilities.engine import (
     _resolve_custom_flow_run_name,
@@ -71,7 +71,7 @@ def load_flow_and_flow_run(flow_run_id: UUID) -> Tuple[FlowRun, Flow]:
 
 @dataclass
 class FlowRunEngine(Generic[P, R]):
-    flow: Optional[Union[Flow[P, R], Flow[P, Coroutine[Any, Any, R]]]] = None
+    flow: Union[Flow[P, R], Flow[P, Coroutine[Any, Any, R]]]
     parameters: Optional[Dict[str, Any]] = None
     flow_run: Optional[FlowRun] = None
     flow_run_id: Optional[UUID] = None
@@ -133,7 +133,7 @@ class FlowRunEngine(Generic[P, R]):
             raise ValueError("Result factory is not set")
         terminal_state = run_sync(
             return_value_to_state(
-                run_sync(resolve_futures_to_states(result)),
+                resolve_futures_to_states(result),
                 result_factory=result_factory,
             )
         )
@@ -272,16 +272,20 @@ class FlowRunEngine(Generic[P, R]):
         except AsyncLibraryNotFoundError:
             task_group = anyio._backends._asyncio.TaskGroup()
 
-        with FlowRunContext(
-            flow=self.flow,
-            log_prints=self.flow.log_prints or False,
-            flow_run=self.flow_run,
-            parameters=self.parameters,
-            client=client,
-            background_tasks=task_group,
-            result_factory=run_sync(ResultFactory.from_flow(self.flow)),
-            task_runner=self.flow.task_runner.duplicate(),
-        ):
+        with ExitStack() as stack:
+            task_runner = stack.enter_context(self.flow.task_runner.duplicate())
+            stack.enter_context(
+                FlowRunContext(
+                    flow=self.flow,
+                    log_prints=self.flow.log_prints or False,
+                    flow_run=self.flow_run,
+                    parameters=self.parameters,
+                    client=client,
+                    background_tasks=task_group,
+                    result_factory=run_sync(ResultFactory.from_flow(self.flow)),
+                    task_runner=task_runner,
+                )
+            )
             # set the logger to the flow run logger
             current_logger = self.logger
             try:
@@ -356,11 +360,11 @@ class FlowRunEngine(Generic[P, R]):
 
 
 async def run_flow_async(
-    flow: Optional[Flow[P, Coroutine[Any, Any, R]]] = None,
+    flow: Flow[P, Coroutine[Any, Any, R]],
     flow_run: Optional[FlowRun] = None,
     flow_run_id: Optional[UUID] = None,
     parameters: Optional[Dict[str, Any]] = None,
-    wait_for: Optional[Iterable[PrefectFuture[A, Async]]] = None,
+    wait_for: Optional[Iterable[PrefectFuture]] = None,
     return_type: Literal["state", "result"] = "result",
 ) -> Union[R, None]:
     """
@@ -399,7 +403,7 @@ def run_flow_sync(
     flow: Flow[P, R],
     flow_run: Optional[FlowRun] = None,
     parameters: Optional[Dict[str, Any]] = None,
-    wait_for: Optional[Iterable[PrefectFuture[A, Async]]] = None,
+    wait_for: Optional[Iterable[PrefectFuture]] = None,
     return_type: Literal["state", "result"] = "result",
 ) -> Union[R, State, None]:
     engine = FlowRunEngine[P, R](flow, parameters, flow_run)
@@ -432,7 +436,7 @@ def run_flow(
     flow: Flow[P, R],
     flow_run: Optional[FlowRun] = None,
     parameters: Optional[Dict[str, Any]] = None,
-    wait_for: Optional[Iterable[PrefectFuture[A, Async]]] = None,
+    wait_for: Optional[Iterable[PrefectFuture]] = None,
     return_type: Literal["state", "result"] = "result",
 ) -> Union[R, State, None]:
     kwargs = dict(

--- a/src/prefect/new_futures.py
+++ b/src/prefect/new_futures.py
@@ -1,0 +1,138 @@
+import abc
+import inspect
+import uuid
+from concurrent.futures import Future
+from functools import partial
+from typing import Any, Generic, Optional, Set, Union, cast
+
+from typing_extensions import TypeVar
+
+from prefect.client.orchestration import get_client
+from prefect.client.schemas.objects import TaskRun
+from prefect.exceptions import ObjectNotFound
+from prefect.states import Pending, State
+from prefect.utilities.annotations import quote
+from prefect.utilities.asyncutils import run_sync
+from prefect.utilities.collections import StopVisiting, visit_collection
+
+R = TypeVar("R")
+
+
+class PrefectFuture(abc.ABC, Generic[R]):
+    def __init__(self, task_run_id: uuid.UUID, wrapped_future: Future):
+        self._task_run_id = task_run_id
+        self._wrapped_future = wrapped_future
+        self._final_state = None
+
+    @property
+    def task_run_id(self) -> uuid.UUID:
+        return self._task_run_id
+
+    @property
+    def wrapped_future(self) -> Future:
+        return self._wrapped_future
+
+    @property
+    def state(self) -> State[R]:
+        if self._final_state:
+            return self._final_state
+        client = get_client(sync_client=True)
+        try:
+            task_run = cast(TaskRun, client.read_task_run(task_run_id=self.task_run_id))
+        except ObjectNotFound:
+            # We'll be optimistic and assume this task will eventually start
+            # TODO: Consider using task run events to wait for the task to start
+            return Pending()
+        return cast(State[R], task_run.state or Pending())
+
+    @abc.abstractmethod
+    def wait(self, timeout: Optional[float] = None) -> None:
+        ...
+
+    @abc.abstractmethod
+    def result(
+        self, raise_on_failure: bool = True, timeout: Optional[float] = None
+    ) -> Any:
+        ...
+
+
+class PrefectConcurrentFuture(PrefectFuture):
+    def wait(self, timeout: Optional[float] = None) -> None:
+        result = self._wrapped_future.result(timeout=timeout)
+        if isinstance(result, State):
+            self._final_state = result
+
+    def result(
+        self, raise_on_failure: bool = True, timeout: Optional[float] = None
+    ) -> Any:
+        if not self._final_state:
+            future_result = self._wrapped_future.result(timeout=timeout)
+            if isinstance(future_result, State):
+                self._final_state = future_result
+            else:
+                return future_result
+
+        _result = self._final_state.result(
+            raise_on_failure=raise_on_failure, fetch=True
+        )
+        # state.result is a `sync_compatible` function that may or may not return an awaitable
+        # depending on whether the parent frame is sync or not
+        if inspect.isawaitable(_result):
+            _result = run_sync(_result)
+        return _result
+
+
+def _collect_futures(futures, expr, context):
+    # Expressions inside quotes should not be traversed
+    if isinstance(context.get("annotation"), quote):
+        raise StopVisiting()
+
+    if isinstance(expr, PrefectFuture):
+        futures.add(expr)
+
+    return expr
+
+
+def resolve_futures_to_states(
+    expr: Union[PrefectFuture[R], Any],
+) -> Union[State[R], Any]:
+    """
+    Given a Python built-in collection, recursively find `PrefectFutures` and build a
+    new collection with the same structure with futures resolved to their final states.
+    Resolving futures to their final states may wait for execution to complete.
+
+    Unsupported object types will be returned without modification.
+    """
+    futures: Set[PrefectFuture] = set()
+
+    visit_collection(
+        expr,
+        visit_fn=partial(_collect_futures, futures),
+        return_data=False,
+        context={},
+    )
+
+    # Get final states for each future
+    states = []
+    for future in futures:
+        future.wait()
+        states.append(future.state)
+
+    states_by_future = dict(zip(futures, states))
+
+    def replace_futures_with_states(expr, context):
+        # Expressions inside quotes should not be modified
+        if isinstance(context.get("annotation"), quote):
+            raise StopVisiting()
+
+        if isinstance(expr, PrefectFuture):
+            return states_by_future[expr]
+        else:
+            return expr
+
+    return visit_collection(
+        expr,
+        visit_fn=replace_futures_with_states,
+        return_data=True,
+        context={},
+    )

--- a/src/prefect/new_futures.py
+++ b/src/prefect/new_futures.py
@@ -51,7 +51,9 @@ class PrefectFuture(abc.ABC, Generic[R]):
 
     @abc.abstractmethod
     def result(
-        self, raise_on_failure: bool = True, timeout: Optional[float] = None
+        self,
+        timeout: Optional[float] = None,
+        raise_on_failure: bool = True,
     ) -> Any:
         ...
 
@@ -66,7 +68,9 @@ class PrefectConcurrentFuture(PrefectFuture):
             self._final_state = result
 
     def result(
-        self, raise_on_failure: bool = True, timeout: Optional[float] = None
+        self,
+        timeout: Optional[float] = None,
+        raise_on_failure: bool = True,
     ) -> Any:
         if not self._final_state:
             future_result = self._wrapped_future.result(timeout=timeout)

--- a/src/prefect/new_futures.py
+++ b/src/prefect/new_futures.py
@@ -58,7 +58,10 @@ class PrefectFuture(abc.ABC, Generic[R]):
 
 class PrefectConcurrentFuture(PrefectFuture):
     def wait(self, timeout: Optional[float] = None) -> None:
-        result = self._wrapped_future.result(timeout=timeout)
+        try:
+            result = self._wrapped_future.result(timeout=timeout)
+        except TimeoutError:
+            return
         if isinstance(result, State):
             self._final_state = result
 

--- a/src/prefect/new_futures.py
+++ b/src/prefect/new_futures.py
@@ -1,6 +1,7 @@
 import abc
 import inspect
 import uuid
+from concurrent.futures import TimeoutError
 from functools import partial
 from typing import Any, Generic, Optional, Set, Union, cast
 

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -29,6 +29,7 @@ from prefect.client.schemas.objects import State
 from prefect.context import FlowRunContext, TaskRunContext
 from prefect.exceptions import Abort, Pause, PrefectException, UpstreamTaskError
 from prefect.logging.loggers import get_logger, task_run_logger
+from prefect.new_futures import PrefectFuture, resolve_futures_to_states
 from prefect.results import ResultFactory
 from prefect.settings import PREFECT_TASKS_REFRESH_CACHE
 from prefect.states import (

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -139,7 +139,9 @@ class TaskRunEngine(Generic[P, R]):
 
                 def _hook_fn():
                     with hook_context():
-                        hook(task, task_run, state)
+                        result = hook(task, task_run, state)
+                        if inspect.isawaitable(result):
+                            run_sync(result)
 
             yield _hook_fn
 

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -47,7 +47,7 @@ from prefect.utilities.collections import visit_collection
 from prefect.utilities.engine import (
     _get_hook_name,
     propose_state_sync,
-    resolve_input,
+    resolve_to_final_result,
 )
 from prefect.utilities.math import clamped_poisson_interval
 from prefect.utilities.timeout import timeout, timeout_async
@@ -189,7 +189,7 @@ class TaskRunEngine(Generic[P, R]):
             try:
                 resolved_parameters[parameter] = visit_collection(
                     value,
-                    visit_fn=resolve_input,
+                    visit_fn=resolve_to_final_result,
                     return_data=True,
                     max_depth=-1,
                     remove_annotations=True,
@@ -212,7 +212,7 @@ class TaskRunEngine(Generic[P, R]):
 
         visit_collection(
             self.wait_for,
-            visit_fn=resolve_input,
+            visit_fn=resolve_to_final_result,
             return_data=False,
             max_depth=-1,
             remove_annotations=True,

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -28,7 +28,6 @@ from prefect.client.schemas import TaskRun
 from prefect.client.schemas.objects import State
 from prefect.context import FlowRunContext, TaskRunContext
 from prefect.exceptions import Abort, Pause, PrefectException, UpstreamTaskError
-from prefect.futures import PrefectFuture, resolve_futures_to_states
 from prefect.logging.loggers import get_logger, task_run_logger
 from prefect.results import ResultFactory
 from prefect.settings import PREFECT_TASKS_REFRESH_CACHE

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -222,17 +222,20 @@ class TaskRunEngine(Generic[P, R]):
             self._resolve_parameters()
             self._wait_for_dependencies()
         except UpstreamTaskError as upstream_exc:
-            new_state = Pending(
-                name="NotReady",
-                message=str(upstream_exc),
+            state = self.set_state(
+                Pending(
+                    name="NotReady",
+                    message=str(upstream_exc),
+                ),
                 # if orchestrating a run already in a pending state, force orchestration to
                 # update the state name
                 force=self.state.is_pending(),
             )
+            return
         else:
             state_details = self._compute_state_details()
             new_state = Running(state_details=state_details)
-        state = self.set_state(new_state)
+            state = self.set_state(new_state)
 
         BACKOFF_MAX = 10
         backoff_count = 0

--- a/src/prefect/new_task_runners.py
+++ b/src/prefect/new_task_runners.py
@@ -111,6 +111,8 @@ class ThreadPoolTaskRunner(TaskRunner):
         context = copy_context()
 
         if task.isasync:
+            # TODO: Explore possibly using a long-lived thread with an event loop
+            # for better performance
             future = self._executor.submit(
                 context.run,
                 asyncio.run,

--- a/src/prefect/new_task_runners.py
+++ b/src/prefect/new_task_runners.py
@@ -3,14 +3,12 @@ import asyncio
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from contextvars import copy_context
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional
 
 from typing_extensions import ParamSpec, Self, TypeVar
 
-from prefect.client.schemas.objects import TaskRunInput, TaskRunResult
 from prefect.logging.loggers import get_logger
 from prefect.new_futures import PrefectConcurrentFuture, PrefectFuture
-from prefect.utilities.collections import visit_collection
 
 if TYPE_CHECKING:
     from prefect.tasks import Task
@@ -112,20 +110,3 @@ class ThreadPoolTaskRunner(TaskRunner):
             self._executor.shutdown()
             self._executor = None
         super().__exit__(exc_type, exc_value, traceback)
-
-
-def _collect_task_run_inputs(expr: Any, max_depth: int = -1) -> Set[TaskRunInput]:
-    dependencies = set()
-
-    def add_futures_to_dependencies(obj):
-        if isinstance(obj, PrefectFuture):
-            dependencies.add(TaskRunResult(id=obj.task_run_id))
-
-    visit_collection(
-        expr,
-        visit_fn=add_futures_to_dependencies,
-        return_data=False,
-        max_depth=max_depth,
-    )
-
-    return dependencies

--- a/src/prefect/new_task_runners.py
+++ b/src/prefect/new_task_runners.py
@@ -1,0 +1,131 @@
+import abc
+import asyncio
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Set
+
+from typing_extensions import ParamSpec, Self, TypeVar
+
+from prefect.client.schemas.objects import TaskRunInput, TaskRunResult
+from prefect.logging.loggers import get_logger
+from prefect.new_futures import PrefectConcurrentFuture, PrefectFuture
+from prefect.utilities.collections import visit_collection
+
+if TYPE_CHECKING:
+    from prefect.tasks import Task
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+class TaskRunner(abc.ABC):
+    def __init__(self):
+        self.logger = get_logger(f"task_runner.{self.name}")
+        self._started = False
+
+    @property
+    def name(self):
+        return type(self).__name__.lower().replace("taskrunner", "")
+
+    @abc.abstractmethod
+    def duplicate(self) -> Self:
+        ...
+
+    @abc.abstractmethod
+    def submit(
+        self,
+        task: "Task",
+        parameters: Dict[str, Any],
+        wait_for: Iterable[PrefectFuture],
+    ) -> PrefectFuture:
+        ...
+
+    def __enter__(self):
+        if self._started:
+            raise RuntimeError("This task runner is already started")
+
+        self.logger.debug("Starting task runner")
+        self._started = True
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.logger.debug("Stopping task runner")
+        self._started = False
+
+
+class ThreadPoolTaskRunner(TaskRunner):
+    def __init__(self):
+        super().__init__()
+        self._executor: Optional[ThreadPoolExecutor] = None
+
+    def duplicate(self) -> "ThreadPoolTaskRunner":
+        return type(self)()
+
+    def submit(
+        self,
+        task: "Task",
+        parameters: Dict[str, Any],
+        wait_for: Optional[Iterable[PrefectFuture]] = None,
+    ) -> PrefectConcurrentFuture:
+        if not self._started or self._executor is None:
+            raise RuntimeError("Task runner is not started")
+        from prefect.new_task_engine import run_task_async, run_task_sync
+
+        task_run_id = uuid.uuid4()
+        context = copy_context()
+
+        if task.isasync:
+            future = self._executor.submit(
+                context.run,
+                asyncio.run,
+                run_task_async(
+                    task=task,
+                    task_run_id=task_run_id,
+                    parameters=parameters,
+                    wait_for=wait_for,
+                    return_type="state",
+                ),
+            )
+        else:
+            future = self._executor.submit(
+                context.run,
+                run_task_sync,
+                task=task,
+                task_run_id=task_run_id,
+                parameters=parameters,
+                wait_for=wait_for,
+                return_type="state",
+            )
+        prefect_future = PrefectConcurrentFuture(
+            task_run_id=task_run_id, wrapped_future=future
+        )
+        return prefect_future
+
+    def __enter__(self):
+        super().__enter__()
+        self._executor = ThreadPoolExecutor()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._executor is not None:
+            self._executor.shutdown()
+            self._executor = None
+        super().__exit__(exc_type, exc_value, traceback)
+
+
+def _collect_task_run_inputs(expr: Any, max_depth: int = -1) -> Set[TaskRunInput]:
+    dependencies = set()
+
+    def add_futures_to_dependencies(obj):
+        if isinstance(obj, PrefectFuture):
+            dependencies.add(TaskRunResult(id=obj.task_run_id))
+
+    visit_collection(
+        expr,
+        visit_fn=add_futures_to_dependencies,
+        return_data=False,
+        max_depth=max_depth,
+    )
+
+    return dependencies

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -43,7 +43,6 @@ def get_state_result(
     ):
         # Fetch defaults to `True` for sync users or async users who have opted in
         fetch = True
-
     if not fetch:
         if fetch is None and in_async_main_thread():
             warnings.warn(

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -529,7 +529,7 @@ class Task(Generic[P, R]):
         from prefect.utilities.engine import (
             _dynamic_key_for_task_run,
             _resolve_custom_task_run_name,
-            collect_task_run_inputs,
+            collect_task_run_inputs_sync,
         )
 
         if flow_run_context is None:
@@ -551,7 +551,7 @@ class Task(Generic[P, R]):
 
         # collect task inputs
         task_inputs = {
-            k: await collect_task_run_inputs(v) for k, v in parameters.items()
+            k: collect_task_run_inputs_sync(v) for k, v in parameters.items()
         }
 
         # check if this task has a parent task run based on running in another
@@ -576,7 +576,7 @@ class Task(Generic[P, R]):
                 ]
 
         if wait_for:
-            task_inputs["wait_for"] = await collect_task_run_inputs(wait_for)
+            task_inputs["wait_for"] = collect_task_run_inputs_sync(wait_for)
 
         # Join extra task inputs
         for k, extras in (extra_task_inputs or {}).items():

--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -220,7 +220,7 @@ class StopVisiting(BaseException):
 
 def visit_collection(
     expr,
-    visit_fn: Callable[[Any, Optional[dict]], Any],
+    visit_fn: Union[Callable[[Any, dict], Any], Callable[[Any], Any]],
     return_data: bool = False,
     max_depth: int = -1,
     context: Optional[dict] = None,

--- a/src/prefect/utilities/collections.py
+++ b/src/prefect/utilities/collections.py
@@ -220,7 +220,7 @@ class StopVisiting(BaseException):
 
 def visit_collection(
     expr,
-    visit_fn: Callable[[Any], Any],
+    visit_fn: Callable[[Any, Optional[dict]], Any],
     return_data: bool = False,
     max_depth: int = -1,
     context: Optional[dict] = None,
@@ -247,8 +247,10 @@ def visit_collection(
 
     Args:
         expr (Any): a Python object or expression
-        visit_fn (Callable[[Any], Awaitable[Any]]): an async function that
-            will be applied to every non-collection element of expr.
+        visit_fn (Callable[[Any, Optional[dict]], Awaitable[Any]]): a function that
+            will be applied to every non-collection element of expr. The function can
+            accept one or two arguments. If two arguments are accepted, the second
+            argument will be the context dictionary.
         return_data (bool): if `True`, a copy of `expr` containing data modified
             by `visit_fn` will be returned. This is slower than `return_data=False`
             (the default).

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -48,6 +48,7 @@ from prefect.logging.loggers import (
     get_logger,
     task_run_logger,
 )
+from prefect.new_futures import PrefectFuture as NewPrefectFuture
 from prefect.results import BaseResult
 from prefect.settings import (
     PREFECT_LOGGING_LOG_PRINTS,
@@ -117,6 +118,49 @@ async def collect_task_run_inputs(expr: Any, max_depth: int = -1) -> Set[TaskRun
     await asyncio.gather(*[future._wait_for_submission() for future in futures])
     for future in futures:
         inputs.add(TaskRunResult(id=future.task_run.id))
+
+    return inputs
+
+
+def collect_task_run_inputs_sync(expr: Any, max_depth: int = -1) -> Set[TaskRunInput]:
+    """
+    This function recurses through an expression to generate a set of any discernible
+    task run inputs it finds in the data structure. It produces a set of all inputs
+    found.
+
+    Examples:
+        >>> task_inputs = {
+        >>>    k: collect_task_run_inputs(v) for k, v in parameters.items()
+        >>> }
+    """
+    # TODO: This function needs to be updated to detect parameters and constants
+
+    inputs = set()
+    futures: Set[NewPrefectFuture] = set()
+
+    def add_futures_and_states_to_inputs(obj):
+        if isinstance(obj, NewPrefectFuture):
+            futures.add(obj)
+        elif is_state(obj):
+            if obj.state_details.task_run_id:
+                inputs.add(TaskRunResult(id=obj.state_details.task_run_id))
+        # Expressions inside quotes should not be traversed
+        elif isinstance(obj, quote):
+            raise StopVisiting
+        else:
+            state = get_state_for_result(obj)
+            if state and state.state_details.task_run_id:
+                inputs.add(TaskRunResult(id=state.state_details.task_run_id))
+
+    visit_collection(
+        expr,
+        visit_fn=add_futures_and_states_to_inputs,
+        return_data=False,
+        max_depth=max_depth,
+    )
+
+    for future in futures:
+        inputs.add(TaskRunResult(id=future.task_run_id))
 
     return inputs
 
@@ -737,3 +781,41 @@ def emit_task_run_state_change_event(
         },
         follows=follows,
     )
+
+
+def resolve_input(expr, context):
+    state = None
+
+    # Expressions inside quotes should not be modified
+    if isinstance(context.get("annotation"), quote):
+        raise StopVisiting()
+
+    if isinstance(expr, NewPrefectFuture):
+        expr.wait()
+        state = expr.state
+    elif is_state(expr):
+        state = expr
+    else:
+        return expr
+
+    assert state
+
+    # Do not allow uncompleted upstreams except failures when `allow_failure` has
+    # been used
+    if not state.is_completed() and not (
+        # TODO: Note that the contextual annotation here is only at the current level
+        #       if `allow_failure` is used then another annotation is used, this will
+        #       incorrectly evaluate to false — to resolve this, we must track all
+        #       annotations wrapping the current expression but this is not yet
+        #       implemented.
+        isinstance(context.get("annotation"), allow_failure) and state.is_failed()
+    ):
+        raise UpstreamTaskError(
+            f"Upstream task run '{state.state_details.task_run_id}' did not reach a"
+            " 'COMPLETED' state."
+        )
+
+    _result = state.result(raise_on_failure=False, fetch=True)
+    if inspect.isawaitable(_result):
+        _result = run_sync(_result)
+    return _result

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -783,7 +783,11 @@ def emit_task_run_state_change_event(
     )
 
 
-def resolve_input(expr, context):
+def resolve_to_final_result(expr, context):
+    """
+    Resolve any `PrefectFuture`, or `State` types nested in parameters into
+    data. Designed to be use with `visit_collection`.
+    """
     state = None
 
     # Expressions inside quotes should not be modified

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -1137,7 +1137,7 @@ async def test_delete_task_run(prefect_client):
     )
 
     await prefect_client.delete_task_run(task_run.id)
-    with pytest.raises(prefect.exceptions.PrefectHTTPStatusError, match="Not Found"):
+    with pytest.raises(prefect.exceptions.ObjectNotFound):
         await prefect_client.read_task_run(task_run.id)
 
 

--- a/tests/test_new_flow_engine.py
+++ b/tests/test_new_flow_engine.py
@@ -54,7 +54,9 @@ class TestFlowRunEngine:
         assert engine.parameters == {}
 
     async def test_empty_init(self):
-        with pytest.raises(ValueError, match="must be provided"):
+        with pytest.raises(
+            TypeError, match="missing 1 required positional argument: 'flow'"
+        ):
             FlowRunEngine()
 
     async def test_client_attr_raises_informative_error(self):

--- a/tests/test_new_futures.py
+++ b/tests/test_new_futures.py
@@ -1,0 +1,131 @@
+import uuid
+from collections import OrderedDict
+from concurrent.futures import Future
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import pytest
+
+from prefect.new_futures import (
+    PrefectConcurrentFuture,
+    PrefectFuture,
+    resolve_futures_to_states,
+)
+from prefect.states import Completed, Failed
+
+
+class MockFuture(PrefectFuture):
+    def __init__(self, data: Any = 42):
+        super().__init__(uuid.uuid4(), Future())
+        self._final_state = Completed(data=data)
+
+    def wait(self, timeout: Optional[float] = None) -> None:
+        pass
+
+    def result(
+        self,
+        timeout: Optional[float] = None,
+        raise_on_failure: bool = True,
+    ) -> Any:
+        return self._final_state.result()
+
+
+class TestPrefectConcurrentFuture:
+    def test_wait_with_timeout(self):
+        wrapped_future = Future()
+        future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
+        future.wait(timeout=0.01)  # should not raise a TimeoutError
+
+        assert (
+            future.state.is_pending()
+        )  # should return a Pending state when task run is not found
+
+    def test_wait_without_timeout(self):
+        wrapped_future = Future()
+        future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
+        wrapped_future.set_result(Completed())
+        future.wait(timeout=0)
+
+        assert future.state.is_completed()
+
+    def test_result_with_final_state(self):
+        final_state = Completed(data=42)
+        wrapped_future = Future()
+        future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
+        wrapped_future.set_result(final_state)
+        result = future.result()
+
+        assert result == 42
+
+    def test_result_without_final_state(self):
+        wrapped_future = Future()
+        future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
+        wrapped_future.set_result(42)
+        result = future.result()
+
+        assert result == 42
+
+    def test_result_with_final_state_and_raise_on_failure(self):
+        final_state = Failed(data=ValueError("oops"))
+        wrapped_future = Future()
+        future = PrefectConcurrentFuture(uuid.uuid4(), wrapped_future)
+        wrapped_future.set_result(final_state)
+
+        with pytest.raises(ValueError, match="oops"):
+            future.result(raise_on_failure=True)
+
+
+class TestResolveFuturesToStates:
+    async def test_resolve_futures_transforms_future(self):
+        future = future = MockFuture()
+        assert resolve_futures_to_states(future).is_completed()
+
+    def test_resolve_futures_to_states_with_no_futures(self):
+        expr = [1, 2, 3]
+        result = resolve_futures_to_states(expr)
+        assert result == [1, 2, 3]
+
+    @pytest.mark.parametrize("_type", [list, tuple, set])
+    def test_resolve_futures_transforms_future_in_listlike_type(self, _type):
+        future = MockFuture(data="foo")
+        result = resolve_futures_to_states(_type(["a", future, "b"]))
+        assert result == _type(["a", future.state, "b"])
+
+    @pytest.mark.parametrize("_type", [dict, OrderedDict])
+    def test_resolve_futures_transforms_future_in_dictlike_type(self, _type):
+        key_future = MockFuture(data="foo")
+        value_future = MockFuture(data="bar")
+        result = resolve_futures_to_states(
+            _type([("a", 1), (key_future, value_future), ("b", 2)])
+        )
+        assert result == _type(
+            [("a", 1), (key_future.state, value_future.state), ("b", 2)]
+        )
+
+    def test_resolve_futures_transforms_future_in_dataclass(self):
+        @dataclass
+        class Foo:
+            a: int
+            foo: str
+            b: int = 2
+
+        future = MockFuture(data="bar")
+        assert resolve_futures_to_states(Foo(a=1, foo=future)) == Foo(
+            a=1, foo=future.state, b=2
+        )
+
+    def test_resolves_futures_in_nested_collections(self):
+        @dataclass
+        class Foo:
+            foo: str
+            nested_list: list
+            nested_dict: dict
+
+        future = MockFuture(data="bar")
+        assert resolve_futures_to_states(
+            Foo(foo=future, nested_list=[[future]], nested_dict={"key": [future]})
+        ) == Foo(
+            foo=future.state,
+            nested_list=[[future.state]],
+            nested_dict={"key": [future.state]},
+        )

--- a/tests/test_new_task_runners.py
+++ b/tests/test_new_task_runners.py
@@ -1,0 +1,107 @@
+import uuid
+from concurrent.futures import Future
+from typing import Any, Optional
+from uuid import UUID
+
+import pytest
+
+from prefect.context import TagsContext, tags
+from prefect.new_futures import PrefectFuture
+from prefect.new_task_runners import ThreadPoolTaskRunner
+from prefect.states import Completed, Running
+from prefect.tasks import task
+
+
+@task
+def my_test_task(param1, param2):
+    return param1, param2
+
+
+@task
+async def my_test_async_task(param1, param2):
+    return param1, param2
+
+
+@task
+def context_matters():
+    return TagsContext.get().current_tags
+
+
+@task
+async def context_matters_async():
+    return TagsContext.get().current_tags
+
+
+class MockFuture(PrefectFuture):
+    def __init__(self, data: Any = 42):
+        super().__init__(uuid.uuid4(), Future())
+        self._data = data
+        self._state = Running()
+
+    def wait(self, timeout: Optional[float] = None) -> None:
+        self._state = Completed(data=self._data)
+
+    def result(
+        self,
+        timeout: Optional[float] = None,
+        raise_on_failure: bool = True,
+    ) -> Any:
+        self.wait()
+        return self._state.result()
+
+    @property
+    def state(self) -> Any:
+        return self._state
+
+
+class TestThreadPoolTaskRunner:
+    def test_duplicate(self):
+        runner = ThreadPoolTaskRunner()
+        duplicate_runner = runner.duplicate()
+        assert isinstance(duplicate_runner, ThreadPoolTaskRunner)
+        assert duplicate_runner is not runner
+
+    def test_runner_must_be_started(self):
+        runner = ThreadPoolTaskRunner()
+        with pytest.raises(RuntimeError, match="Task runner is not started"):
+            runner.submit(my_test_task, {})
+
+    def test_submit_sync_task(self):
+        with ThreadPoolTaskRunner() as runner:
+            parameters = {"param1": 1, "param2": 2}
+            future = runner.submit(my_test_task, parameters)
+            assert isinstance(future, PrefectFuture)
+            assert isinstance(future.task_run_id, UUID)
+            assert isinstance(future.wrapped_future, Future)
+
+            assert future.result() == (1, 2)
+
+    def test_submit_async_task(self):
+        with ThreadPoolTaskRunner() as runner:
+            parameters = {"param1": 1, "param2": 2}
+            future = runner.submit(my_test_async_task, parameters)
+            assert isinstance(future, PrefectFuture)
+            assert isinstance(future.task_run_id, UUID)
+            assert isinstance(future.wrapped_future, Future)
+
+            assert future.result() == (1, 2)
+
+    def test_submit_sync_task_receives_context(self):
+        with tags("tag1", "tag2"):
+            with ThreadPoolTaskRunner() as runner:
+                future = runner.submit(context_matters, {})
+                assert isinstance(future, PrefectFuture)
+                assert isinstance(future.task_run_id, UUID)
+                assert isinstance(future.wrapped_future, Future)
+
+                assert future.result() == {"tag1", "tag2"}
+
+    def test_submit_async_task_receives_context(self):
+        with tags("tag1", "tag2"):
+            with ThreadPoolTaskRunner() as runner:
+                future = runner.submit(context_matters_async, {})
+                assert isinstance(future, PrefectFuture)
+                assert isinstance(future.task_run_id, UUID)
+                assert isinstance(future.wrapped_future, Future)
+
+                assert future.result() == {"tag1", "tag2"}


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
This PR creates a new interface for task runners and prefect futures to work with the new engine. The new `ThreadPoolTaskRunner` is intended to replace the existing `ConcurrentTaskRunner`. The new `PrefectFuture` implementation is meant to serve as a wrapper for specific future implementations. More implementations will be added when we update the Dask and Ray task runners.

This PR turns on the logic to run the existing task tests through the new engine to ensure compatibility and expose differences. 

Two main differences are:
1. `.submit` on a task is always a sync call
2. `.result` and `.wait` on a `PrefectFuture` are always sync calls

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Example of a flow submitting tasks to a `ThreadPoolTaskRunner` (should look familiar)

```python
from time import sleep

from prefect import flow, task


@task
def task_the_first():
    sleep(10)
    return "hello"


@task
def task_the_second(thing_to_say):
    print(f"Upstream told me to say {thing_to_say}")


@task
def task_the_third():
    print("I'm the third task")


@flow
def my_flow():
    future1 = task_the_first.submit()
    future2 = task_the_second.submit(future1)
    task_the_third(wait_for=[future2])


if __name__ == "__main__":
    my_flow()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
