### PR TITLE
Migrating all uses of the banned characters validation to a self-validator

### DIFF
--- a/src/prefect/_internal/schemas/validators.py
+++ b/src/prefect/_internal/schemas/validators.py
@@ -24,7 +24,7 @@ import yaml
 from prefect._internal.pydantic import HAS_PYDANTIC_V2
 from prefect._internal.pydantic._flags import USE_PYDANTIC_V2
 from prefect._internal.schemas.fields import DateTimeTZ
-from prefect.exceptions import InvalidNameError, InvalidRepositoryURLError
+from prefect.exceptions import InvalidRepositoryURLError
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.dockerutils import get_prefect_image_name
 from prefect.utilities.filesystem import relative_path_to_current_platform
@@ -32,7 +32,6 @@ from prefect.utilities.importtools import from_qualified_name
 from prefect.utilities.names import generate_slug
 from prefect.utilities.pydantic import JsonPatch
 
-BANNED_CHARACTERS = ["/", "%", "&", ">", "<"]
 LOWERCASE_LETTERS_NUMBERS_AND_DASHES_ONLY_REGEX = "^[a-z0-9-]*$"
 LOWERCASE_LETTERS_NUMBERS_AND_UNDERSCORES_REGEX = "^[a-z0-9_]*$"
 
@@ -47,20 +46,6 @@ if TYPE_CHECKING:
             pass
         if not USE_PYDANTIC_V2:
             from pydantic.v1.fields import ModelField
-
-
-def raise_on_name_with_banned_characters(name: str) -> str:
-    """
-    Raise an InvalidNameError if the given name contains any invalid
-    characters.
-    """
-    if name is not None:
-        if any(c in name for c in BANNED_CHARACTERS):
-            raise InvalidNameError(
-                f"Name {name!r} contains an invalid character. "
-                f"Must not contain any of: {BANNED_CHARACTERS}."
-            )
-    return name
 
 
 def raise_on_name_alphanumeric_dashes_only(

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -13,7 +13,6 @@ from prefect._internal.schemas.serializers import orjson_dumps_extra_compatible
 from prefect._internal.schemas.validators import (
     raise_on_name_alphanumeric_dashes_only,
     raise_on_name_alphanumeric_underscores_only,
-    raise_on_name_with_banned_characters,
     remove_old_deployment_fields,
     return_none_schedule,
     validate_message_template_variables,
@@ -23,7 +22,13 @@ from prefect._internal.schemas.validators import (
 from prefect.client.schemas.objects import StateDetails, StateType
 from prefect.client.schemas.schedules import SCHEDULE_TYPES
 from prefect.settings import PREFECT_DEPLOYMENT_SCHEDULE_MAX_SCHEDULED_RUNS
-from prefect.types import NonNegativeFloat, NonNegativeInteger, PositiveInteger
+from prefect.types import (
+    Name,
+    NonEmptyishName,
+    NonNegativeFloat,
+    NonNegativeInteger,
+    PositiveInteger,
+)
 from prefect.utilities.collections import listrepr
 from prefect.utilities.pydantic import get_class_fields_only
 
@@ -548,7 +553,7 @@ class LogCreate(ActionBaseModel):
 class WorkPoolCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a work pool."""
 
-    name: str = Field(
+    name: NonEmptyishName = Field(
         description="The name of the work pool.",
     )
     description: Optional[str] = Field(None)
@@ -740,7 +745,7 @@ class VariableUpdate(ActionBaseModel):
 class GlobalConcurrencyLimitCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a global concurrency limit."""
 
-    name: str = Field(description="The name of the global concurrency limit.")
+    name: Name = Field(description="The name of the global concurrency limit.")
     limit: NonNegativeInteger = Field(
         description=(
             "The maximum number of slots that can be occupied on this concurrency"
@@ -763,20 +768,12 @@ class GlobalConcurrencyLimitCreate(ActionBaseModel):
         ),
     )
 
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
-
 
 class GlobalConcurrencyLimitUpdate(ActionBaseModel):
     """Data used by the Prefect REST API to update a global concurrency limit."""
 
-    name: Optional[str] = Field(None)
+    name: Optional[Name] = Field(None)
     limit: Optional[NonNegativeInteger] = Field(None)
     active: Optional[NonNegativeInteger] = Field(None)
     active_slots: Optional[NonNegativeInteger] = Field(None)
     slot_decay_per_second: Optional[NonNegativeFloat] = Field(None)
-
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -27,7 +27,6 @@ from prefect._internal.schemas.validators import (
     get_or_create_state_name,
     list_length_50_or_less,
     raise_on_name_alphanumeric_dashes_only,
-    raise_on_name_with_banned_characters,
     set_run_policy_deprecated_fields,
     validate_default_queue_id_not_none,
     validate_max_metadata_length,
@@ -38,7 +37,7 @@ from prefect._internal.schemas.validators import (
 )
 from prefect.client.schemas.schedules import SCHEDULE_TYPES
 from prefect.settings import PREFECT_CLOUD_API_URL, PREFECT_CLOUD_UI_URL
-from prefect.types import NonNegativeInteger, PositiveInteger
+from prefect.types import Name, NonNegativeInteger, PositiveInteger
 from prefect.utilities.collections import AutoEnum, listrepr
 from prefect.utilities.names import generate_slug
 
@@ -800,7 +799,7 @@ class Workspace(PrefectBaseModel):
 class BlockType(ObjectBaseModel):
     """An ORM representation of a block type"""
 
-    name: str = Field(default=..., description="A block type's name")
+    name: Name = Field(default=..., description="A block type's name")
     slug: str = Field(default=..., description="A block type's slug")
     logo_url: Optional[HttpUrl] = Field(
         default=None, description="Web URL for the block type's logo"
@@ -819,10 +818,6 @@ class BlockType(ObjectBaseModel):
     is_protected: bool = Field(
         default=False, description="Protected block types cannot be modified via API."
     )
-
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
 
 
 class BlockSchema(ObjectBaseModel):
@@ -849,7 +844,7 @@ class BlockSchema(ObjectBaseModel):
 class BlockDocument(ObjectBaseModel):
     """An ORM representation of a block document."""
 
-    name: Optional[str] = Field(
+    name: Optional[Name] = Field(
         default=None,
         description=(
             "The block document's name. Not required for anonymous block documents."
@@ -878,12 +873,6 @@ class BlockDocument(ObjectBaseModel):
         ),
     )
 
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        # the BlockDocumentCreate subclass allows name=None
-        # and will inherit this validator
-        return raise_on_name_with_banned_characters(v)
-
     @root_validator
     def validate_name_is_present_if_not_anonymous(cls, values):
         return validate_name_present_on_nonanonymous_blocks(values)
@@ -892,7 +881,7 @@ class BlockDocument(ObjectBaseModel):
 class Flow(ObjectBaseModel):
     """An ORM representation of flow data."""
 
-    name: str = Field(
+    name: Name = Field(
         default=..., description="The name of the flow", examples=["my-flow"]
     )
     tags: List[str] = Field(
@@ -900,10 +889,6 @@ class Flow(ObjectBaseModel):
         description="A list of flow tags",
         examples=[["tag-1", "tag-2"]],
     )
-
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
 
 
 class MinimalDeploymentSchedule(PrefectBaseModel):
@@ -951,7 +936,7 @@ class DeploymentSchedule(ObjectBaseModel):
 class Deployment(DeprecatedInfraOverridesField, ObjectBaseModel):
     """An ORM representation of deployment data."""
 
-    name: str = Field(default=..., description="The name of the deployment.")
+    name: Name = Field(default=..., description="The name of the deployment.")
     version: Optional[str] = Field(
         default=None, description="An optional version for the deployment."
     )
@@ -1052,10 +1037,6 @@ class Deployment(DeprecatedInfraOverridesField, ObjectBaseModel):
             "Whether or not the deployment should enforce the parameter schema."
         ),
     )
-
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
 
 
 class ConcurrencyLimit(ObjectBaseModel):
@@ -1200,7 +1181,7 @@ class QueueFilter(PrefectBaseModel):
 class WorkQueue(ObjectBaseModel):
     """An ORM representation of a work queue"""
 
-    name: str = Field(default=..., description="The name of the work queue.")
+    name: Name = Field(default=..., description="The name of the work queue.")
     description: Optional[str] = Field(
         default="", description="An optional description for the work queue."
     )
@@ -1232,10 +1213,6 @@ class WorkQueue(ObjectBaseModel):
     status: Optional[WorkQueueStatus] = Field(
         default=None, description="The queue status."
     )
-
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
 
 
 class WorkQueueHealthPolicy(PrefectBaseModel):
@@ -1356,7 +1333,7 @@ class Agent(ObjectBaseModel):
 class WorkPool(ObjectBaseModel):
     """An ORM representation of a work pool"""
 
-    name: str = Field(
+    name: Name = Field(
         description="The name of the work pool.",
     )
     description: Optional[str] = Field(
@@ -1390,10 +1367,6 @@ class WorkPool(ObjectBaseModel):
     @property
     def is_managed_pool(self) -> bool:
         return self.type.endswith(":managed")
-
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
 
     @validator("default_queue_id", always=True)
     def helpful_error_for_missing_default_queue_id(cls, v):

--- a/src/prefect/server/api/workers.py
+++ b/src/prefect/server/api/workers.py
@@ -163,13 +163,6 @@ async def create_work_pool(
     Creates a new work pool. If a work pool with the same
     name already exists, an error will be raised.
     """
-
-    if not work_pool.name.lower().strip("' \""):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Work pool name cannot be empty.",
-        )
-
     if work_pool.name.lower().startswith("prefect"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -16,7 +16,6 @@ from prefect._internal.schemas.validators import (
     get_or_create_state_name,
     raise_on_name_alphanumeric_dashes_only,
     raise_on_name_alphanumeric_underscores_only,
-    raise_on_name_with_banned_characters,
     remove_old_deployment_fields,
     set_default_scheduled_time,
     set_deployment_schedules,
@@ -34,7 +33,13 @@ from prefect.server.utilities.schemas.bases import PrefectBaseModel
 from prefect.server.utilities.schemas.fields import DateTimeTZ
 from prefect.server.utilities.schemas.serializers import orjson_dumps_extra_compatible
 from prefect.settings import PREFECT_DEPLOYMENT_SCHEDULE_MAX_SCHEDULED_RUNS
-from prefect.types import NonNegativeFloat, NonNegativeInteger, PositiveInteger
+from prefect.types import (
+    Name,
+    NonEmptyishName,
+    NonNegativeFloat,
+    NonNegativeInteger,
+    PositiveInteger,
+)
 from prefect.utilities.collections import listrepr
 from prefect.utilities.names import generate_slug
 from prefect.utilities.templating import find_placeholders
@@ -86,7 +91,7 @@ class ActionBaseModel(PrefectBaseModel):
 class FlowCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a flow."""
 
-    name: str = Field(
+    name: Name = Field(
         default=..., description="The name of the flow", examples=["my-flow"]
     )
     tags: List[str] = Field(
@@ -94,10 +99,6 @@ class FlowCreate(ActionBaseModel):
         description="A list of flow tags",
         examples=[["tag-1", "tag-2"]],
     )
-
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
 
 
 class FlowUpdate(ActionBaseModel):
@@ -108,10 +109,6 @@ class FlowUpdate(ActionBaseModel):
         description="A list of flow tags",
         examples=[["tag-1", "tag-2"]],
     )
-
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
 
 
 class DeploymentScheduleCreate(ActionBaseModel):
@@ -629,7 +626,7 @@ class ConcurrencyLimitV2Create(ActionBaseModel):
     active: bool = Field(
         default=True, description="Whether the concurrency limit is active."
     )
-    name: str = Field(default=..., description="The name of the concurrency limit.")
+    name: Name = Field(default=..., description="The name of the concurrency limit.")
     limit: NonNegativeInteger = Field(default=..., description="The concurrency limit.")
     active_slots: NonNegativeInteger = Field(
         default=0, description="The number of active slots."
@@ -642,30 +639,22 @@ class ConcurrencyLimitV2Create(ActionBaseModel):
         description="The decay rate for active slots when used as a rate limit.",
     )
 
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
-
 
 class ConcurrencyLimitV2Update(ActionBaseModel):
     """Data used by the Prefect REST API to update a v2 concurrency limit."""
 
     active: Optional[bool] = Field(None)
-    name: Optional[str] = Field(None)
+    name: Optional[Name] = Field(None)
     limit: Optional[NonNegativeInteger] = Field(None)
     active_slots: Optional[NonNegativeInteger] = Field(None)
     denied_slots: Optional[NonNegativeInteger] = Field(None)
     slot_decay_per_second: Optional[NonNegativeFloat] = Field(None)
 
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
-
 
 class BlockTypeCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a block type."""
 
-    name: str = Field(default=..., description="A block type's name")
+    name: Name = Field(default=..., description="A block type's name")
     slug: str = Field(default=..., description="A block type's slug")
     logo_url: Optional[HttpUrl] = Field(
         default=None, description="Web URL for the block type's logo"
@@ -685,10 +674,6 @@ class BlockTypeCreate(ActionBaseModel):
     # validators
     _validate_slug_format = validator("slug", allow_reuse=True)(
         validate_block_type_slug
-    )
-
-    _validate_name_characters = validator("name", check_fields=False)(
-        raise_on_name_with_banned_characters
     )
 
 
@@ -834,7 +819,7 @@ def validate_base_job_template(v):
 class WorkPoolCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a work pool."""
 
-    name: str = Field(..., description="The name of the work pool.")
+    name: NonEmptyishName = Field(..., description="The name of the work pool.")
     description: Optional[str] = Field(None, description="The work pool description.")
     type: str = Field(description="The work pool type.", default="prefect-agent")
     base_job_template: Dict[str, Any] = Field(
@@ -852,10 +837,6 @@ class WorkPoolCreate(ActionBaseModel):
         validate_base_job_template
     )
 
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
-
 
 class WorkPoolUpdate(ActionBaseModel):
     """Data used by the Prefect REST API to update a work pool."""
@@ -869,15 +850,11 @@ class WorkPoolUpdate(ActionBaseModel):
         validate_base_job_template
     )
 
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
-
 
 class WorkQueueCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a work queue."""
 
-    name: str = Field(default=..., description="The name of the work queue.")
+    name: Name = Field(default=..., description="The name of the work queue.")
     description: Optional[str] = Field(
         default="", description="An optional description for the work queue."
     )
@@ -901,10 +878,6 @@ class WorkQueueCreate(ActionBaseModel):
         description="DEPRECATED: Filter criteria for the work queue.",
         deprecated=True,
     )
-
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
 
 
 class WorkQueueUpdate(ActionBaseModel):

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -16,7 +16,6 @@ from prefect._internal.schemas.validators import (
     get_or_create_run_name,
     list_length_50_or_less,
     raise_on_name_alphanumeric_dashes_only,
-    raise_on_name_with_banned_characters,
     set_run_policy_deprecated_fields,
     validate_cache_key_length,
     validate_default_queue_id_not_none,
@@ -35,7 +34,7 @@ from prefect.server.utilities.schemas.bases import (
 )
 from prefect.server.utilities.schemas.fields import DateTimeTZ
 from prefect.settings import PREFECT_DEPLOYMENT_SCHEDULE_MAX_SCHEDULED_RUNS
-from prefect.types import NonNegativeInteger, PositiveInteger
+from prefect.types import Name, NameOrEmpty, NonNegativeInteger, PositiveInteger
 from prefect.utilities.collections import dict_to_flatdict, flatdict_to_dict, listrepr
 from prefect.utilities.names import generate_slug, obfuscate, obfuscate_string
 
@@ -65,7 +64,7 @@ MAX_VARIABLE_VALUE_LENGTH = 5000
 class Flow(ORMBaseModel):
     """An ORM representation of flow data."""
 
-    name: str = Field(
+    name: Name = Field(
         default=..., description="The name of the flow", examples=["my-flow"]
     )
     tags: List[str] = Field(
@@ -73,10 +72,6 @@ class Flow(ORMBaseModel):
         description="A list of flow tags",
         examples=[["tag-1", "tag-2"]],
     )
-
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
 
 
 class FlowRunPolicy(PrefectBaseModel):
@@ -518,7 +513,7 @@ class DeploymentSchedule(ORMBaseModel):
 class Deployment(DeprecatedInfraOverridesField, ORMBaseModel):
     """An ORM representation of deployment data."""
 
-    name: str = Field(default=..., description="The name of the deployment.")
+    name: NameOrEmpty = Field(default=..., description="The name of the deployment.")
     version: Optional[str] = Field(
         default=None, description="An optional version for the deployment."
     )
@@ -623,10 +618,6 @@ class Deployment(DeprecatedInfraOverridesField, ORMBaseModel):
     class Config:
         allow_population_by_field_name = True
 
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
-
 
 class ConcurrencyLimit(ORMBaseModel):
     """An ORM representation of a concurrency limit."""
@@ -647,7 +638,7 @@ class ConcurrencyLimitV2(ORMBaseModel):
     active: bool = Field(
         default=True, description="Whether the concurrency limit is active."
     )
-    name: str = Field(default=..., description="The name of the concurrency limit.")
+    name: Name = Field(default=..., description="The name of the concurrency limit.")
     limit: int = Field(default=..., description="The concurrency limit.")
     active_slots: int = Field(default=0, description="The number of active slots.")
     denied_slots: int = Field(default=0, description="The number of denied slots.")
@@ -659,15 +650,11 @@ class ConcurrencyLimitV2(ORMBaseModel):
         default=2.0, description="The average amount of time a slot is occupied."
     )
 
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
-
 
 class BlockType(ORMBaseModel):
     """An ORM representation of a block type"""
 
-    name: str = Field(default=..., description="A block type's name")
+    name: Name = Field(default=..., description="A block type's name")
     slug: str = Field(default=..., description="A block type's slug")
     logo_url: Optional[HttpUrl] = Field(
         default=None, description="Web URL for the block type's logo"
@@ -686,10 +673,6 @@ class BlockType(ORMBaseModel):
     is_protected: bool = Field(
         default=False, description="Protected block types cannot be modified via API."
     )
-
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
 
 
 class BlockSchema(ORMBaseModel):
@@ -736,7 +719,7 @@ class BlockSchemaReference(ORMBaseModel):
 class BlockDocument(ORMBaseModel):
     """An ORM representation of a block document."""
 
-    name: Optional[str] = Field(
+    name: Optional[Name] = Field(
         default=None,
         description=(
             "The block document's name. Not required for anonymous block documents."
@@ -766,12 +749,6 @@ class BlockDocument(ORMBaseModel):
             " Prefect automatically)"
         ),
     )
-
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        # the BlockDocumentCreate subclass allows name=None
-        # and will inherit this validator
-        return raise_on_name_with_banned_characters(v)
 
     @root_validator
     def validate_name_is_present_if_not_anonymous(cls, values):
@@ -914,7 +891,7 @@ class QueueFilter(PrefectBaseModel):
 class WorkQueue(ORMBaseModel):
     """An ORM representation of a work queue"""
 
-    name: str = Field(default=..., description="The name of the work queue.")
+    name: Name = Field(default=..., description="The name of the work queue.")
     description: Optional[str] = Field(
         default="", description="An optional description for the work queue."
     )
@@ -942,10 +919,6 @@ class WorkQueue(ORMBaseModel):
     last_polled: Optional[DateTimeTZ] = Field(
         default=None, description="The last time an agent polled this queue for work."
     )
-
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
 
 
 class WorkQueueHealthPolicy(PrefectBaseModel):
@@ -1066,7 +1039,7 @@ class Agent(ORMBaseModel):
 class WorkPool(ORMBaseModel):
     """An ORM representation of a work pool"""
 
-    name: str = Field(
+    name: Name = Field(
         description="The name of the work pool.",
     )
     description: Optional[str] = Field(
@@ -1092,10 +1065,6 @@ class WorkPool(ORMBaseModel):
     default_queue_id: UUID = Field(
         None, description="The id of the pool's default queue."
     )
-
-    @validator("name", check_fields=False)
-    def validate_name_characters(cls, v):
-        return raise_on_name_with_banned_characters(v)
 
     @validator("default_queue_id", always=True)
     def helpful_error_for_missing_default_queue_id(cls, v):

--- a/src/prefect/types/__init__.py
+++ b/src/prefect/types/__init__.py
@@ -103,10 +103,62 @@ class PositiveDuration(timedelta):
         return SchemaValidator(schema=cls.schema).validate_python(v)
 
 
+BANNED_CHARACTERS = ["/", "%", "&", ">", "<"]
+WITHOUT_BANNED_CHARACTERS = r"^[^" + "".join(BANNED_CHARACTERS) + "]+$"
+
+
+class Name(str):
+    """A string that does not include characters that are problematic for URLs, file
+    paths, or other escaping contexts"""
+
+    schema: ClassVar = core_schema.str_schema(pattern=WITHOUT_BANNED_CHARACTERS)
+
+    @classmethod
+    def __get_validators__(cls) -> Generator[Callable[..., Any], None, None]:
+        yield cls.validate
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: Callable[..., Any]
+    ) -> CoreSchema:
+        return cls.schema
+
+    @classmethod
+    def validate(cls, v: Any) -> Self:
+        if isinstance(v, str) and v:
+            if not v.strip("' \""):
+                raise ValueError("name cannot be an empty string")
+        return SchemaValidator(schema=cls.schema).validate_python(v)
+
+
+class NonEmptyishName(Name):
+    """A Name that also doesn't include trailing whitespace or embedded quoted empty
+    strings"""
+
+    @classmethod
+    def validate(cls, v: Any) -> Self:
+        if isinstance(v, str) and v:
+            if not v.strip("' \""):
+                raise ValueError("name cannot be an empty string")
+        return super().validate(v)
+
+
+WITHOUT_BANNED_CHARACTERS_EMPTY_OK = r"^[^" + "".join(BANNED_CHARACTERS) + "]*$"
+
+
+class NameOrEmpty(Name):
+    """A Name that may also be an empty string"""
+
+    schema: ClassVar = core_schema.str_schema(
+        pattern=WITHOUT_BANNED_CHARACTERS_EMPTY_OK
+    )
+
+
 __all__ = [
     "NonNegativeInteger",
     "PositiveInteger",
     "NonNegativeFloat",
     "NonNegativeDuration",
     "PositiveDuration",
+    "Name",
 ]

--- a/tests/server/api/test_work_queues.py
+++ b/tests/server/api/test_work_queues.py
@@ -164,7 +164,7 @@ class TestCreateWorkQueue:
     async def test_create_work_queue_with_invalid_characters_fails(self, client, name):
         response = await client.post("/work_queues/", json=dict(name=name))
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-        assert b"contains an invalid character" in response.content
+        assert b"String should match pattern" in response.content
 
     async def test_create_work_queue_initially_is_not_ready(self, client):
         response = await client.post("/work_queues/", json=dict(name=str(uuid.uuid4())))

--- a/tests/server/api/test_workers.py
+++ b/tests/server/api/test_workers.py
@@ -147,16 +147,16 @@ class TestCreateWorkPool:
         )
         assert response.status_code == status.HTTP_409_CONFLICT
 
-    @pytest.mark.parametrize("name", ["hi/there", "hi%there"])
+    @pytest.mark.parametrize("name", ["", "hi/there", "hi%there"])
     async def test_create_work_pool_with_invalid_name(self, client, name):
         response = await client.post("/work_pools/", json=dict(name=name))
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
-    @pytest.mark.parametrize("name", ["", "''", " ", "' ' "])
-    async def test_create_work_pool_with_empty_name(self, client, name):
+    @pytest.mark.parametrize("name", ["''", " ", "' ' "])
+    async def test_create_work_pool_with_emptyish_name(self, client, name):
         response = await client.post("/work_pools/", json=dict(name=name))
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "name cannot be empty" in response.json()["detail"]
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert "name cannot be an empty string" in response.content.decode()
 
     @pytest.mark.parametrize("type", ["PROCESS", "K8S", "AGENT"])
     async def test_create_typed_work_pool(self, session, client, type):

--- a/tests/server/models/test_concurrency_limits_v2.py
+++ b/tests/server/models/test_concurrency_limits_v2.py
@@ -101,7 +101,7 @@ async def test_create_concurrency_limit(session: AsyncSession):
 async def test_create_concurrency_limit_with_invalid_name_raises(session: AsyncSession):
     with pytest.raises(
         pydantic.error_wrappers.ValidationError,
-        match="contains an invalid character",
+        match="String should match pattern",
     ):
         await create_concurrency_limit(
             session=session,
@@ -286,7 +286,7 @@ async def test_update_concurrency_limit_with_invalid_name_raises(
 ):
     with pytest.raises(
         pydantic.error_wrappers.ValidationError,
-        match="contains an invalid character",
+        match="String should match pattern",
     ):
         await update_concurrency_limit(
             session=session,

--- a/tests/server/models/test_workers.py
+++ b/tests/server/models/test_workers.py
@@ -48,7 +48,9 @@ class TestCreateWorkPool:
 
     @pytest.mark.parametrize("name", ["hi/there", "hi%there"])
     async def test_create_invalid_name(self, session, name):
-        with pytest.raises(pydantic.ValidationError, match="(invalid character)"):
+        with pytest.raises(
+            pydantic.ValidationError, match="String should match pattern"
+        ):
             schemas.core.WorkPool(name=name)
 
     @pytest.mark.parametrize("type", ["PROCESS", "K8S", "AGENT"])
@@ -306,7 +308,9 @@ class TestCreateWorkQueue:
 
     @pytest.mark.parametrize("name", ["hi/there", "hi%there"])
     async def test_create_invalid_name(self, session, work_pool, name):
-        with pytest.raises(pydantic.ValidationError, match="(invalid character)"):
+        with pytest.raises(
+            pydantic.ValidationError, match="String should match pattern"
+        ):
             schemas.actions.WorkQueueCreate(name=name)
 
 

--- a/tests/server/schemas/test_core.py
+++ b/tests/server/schemas/test_core.py
@@ -48,15 +48,15 @@ async def test_valid_names(name):
     ],
 )
 async def test_invalid_names(name):
-    with pytest.raises(pydantic.ValidationError, match="contains an invalid character"):
+    with pytest.raises(pydantic.ValidationError, match="String should match pattern"):
         assert schemas.core.Flow(name=name)
-    with pytest.raises(pydantic.ValidationError, match="contains an invalid character"):
+    with pytest.raises(pydantic.ValidationError, match="String should match pattern"):
         assert schemas.core.Deployment(
             name=name,
             flow_id=uuid4(),
             manifest_path="file.json",
         )
-    with pytest.raises(pydantic.ValidationError, match="contains an invalid character"):
+    with pytest.raises(pydantic.ValidationError, match="String should match pattern"):
         assert schemas.core.BlockDocument(
             name=name, block_schema_id=uuid4(), block_type_id=uuid4()
         )


### PR DESCRIPTION
There were a few sub-flavors of this, but I was most surprised that we allow
for `Deployments` to have empty string names.  I'll track that separate issue.
My aim here was for no behavioral changes except for the new normalized
validation message from Pydantic (and the 422s instead of 400s).
