### PR TITLE
Fixing stray files from the test suite, with a utility to notify us about them

### DIFF
--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -5021,6 +5021,11 @@ class TestDeployWithoutEntrypoint:
 
 
 class TestCheckForMatchingDeployment:
+    @pytest.fixture(autouse=True)
+    def in_temporary_directory(self, tmp_path: Path):
+        with tmpchdir(tmp_path):
+            yield
+
     async def test_matching_deployment_in_prefect_file_returns_true(self):
         deployment = {
             "name": "existing_deployment",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -594,3 +594,22 @@ def reset_sys_modules():
             del sys.modules[module]
 
     importlib.invalidate_caches()
+
+
+@pytest.fixture(autouse=True, scope="module")
+def leaves_no_extraneous_files():
+    """This fixture will fail a test if it seems to have left new files or directories
+    in the root of the local working tree.  For performance, it only checks for changes
+    at the test module level, but that should generally be enough to narrow down what
+    is happening.  If you're having trouble isolating the problematic test, you can
+    switch it to scope="function" temporarily.  It may also help to run the test suite
+    with one process (-n0) so that unrelated tests won't fail."""
+    before = set(Path(".").iterdir())
+    yield
+    after = set(Path(".").iterdir())
+    new_files = after - before
+    if new_files:
+        raise AssertionError(
+            "One of the tests in this module left new files in the "
+            f"working directory: {new_files}"
+        )

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -16,6 +16,7 @@ from prefect.deployments.steps import run_step
 from prefect.deployments.steps.core import StepExecutionError, run_steps
 from prefect.deployments.steps.utility import run_shell_script
 from prefect.testing.utilities import AsyncMock, MagicMock
+from prefect.utilities.filesystem import tmpchdir
 
 
 @pytest.fixture
@@ -712,7 +713,7 @@ class TestPipInstallRequirements:
         )
 
     async def test_pip_install_reqs_with_directory_step_output_succeeds(
-        self, monkeypatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ):
         open_process_mock = MagicMock(return_value=MockProcess(0))
         monkeypatch.setattr(
@@ -753,7 +754,8 @@ class TestPipInstallRequirements:
 
         open_process_mock.run.return_value = MagicMock(**step_outputs)
 
-        output = await run_steps(steps)
+        with tmpchdir(tmp_path):
+            output = await run_steps(steps)
 
         assert output == step_outputs
 

--- a/tests/results/test_flow_results.py
+++ b/tests/results/test_flow_results.py
@@ -1,5 +1,6 @@
 import base64
 import pickle
+from pathlib import Path
 
 import pytest
 
@@ -453,13 +454,13 @@ def test_flow_server_state_schema_result_is_respected(persist_result, return_sta
             assert state.result(raise_on_failure=False) == return_state.data
 
 
-async def test_root_flow_default_remote_storage():
+async def test_root_flow_default_remote_storage(tmp_path: Path):
     @flow
     async def foo():
         result_fac = get_run_context().result_factory
         return result_fac.storage_block
 
-    block = LocalFileSystem()
+    block = LocalFileSystem(basepath=tmp_path)
     await block.save("my-result-storage")
 
     with temporary_settings(

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -45,6 +45,7 @@ from prefect.settings import (
 )
 from prefect.testing.utilities import AsyncMock
 from prefect.utilities.dockerutils import parse_image_tag
+from prefect.utilities.filesystem import tmpchdir
 
 
 @flow(version="test")
@@ -140,9 +141,11 @@ def temp_storage() -> Generator[MockStorage, Any, None]:
     with tempfile.TemporaryDirectory() as temp_dir:
         yield MockStorage(base_path=Path(temp_dir))
 
-    flows_path = Path.cwd() / "flows.py"
-    if flows_path.exists():
-        os.unlink(Path.cwd() / "flows.py")
+
+@pytest.fixture
+def in_temporary_runner_directory(tmp_path: Path):
+    with tmpchdir(tmp_path):
+        yield
 
 
 class TestInit:
@@ -403,6 +406,7 @@ class TestRunner:
         self,
         prefect_client: PrefectClient,
         caplog: pytest.LogCaptureFixture,
+        in_temporary_runner_directory: None,
         temp_storage: MockStorage,
     ):
         runner = Runner(query_seconds=2)
@@ -475,6 +479,7 @@ class TestRunner:
         self,
         prefect_client: PrefectClient,
         caplog: pytest.LogCaptureFixture,
+        in_temporary_runner_directory: None,
         temp_storage: MockStorage,
     ):
         runner = Runner()

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -338,7 +338,9 @@ class TestFlowWithOptions:
         assert flow_with_options.on_cancellation == [cancellation_hook]
         assert flow_with_options.on_crashed == [crash_hook]
 
-    def test_with_options_uses_existing_settings_when_no_override(self):
+    def test_with_options_uses_existing_settings_when_no_override(self, tmp_path: Path):
+        storage = LocalFileSystem(basepath=tmp_path)
+
         @flow(
             name="Initial flow",
             description="Flow before with options",
@@ -349,7 +351,7 @@ class TestFlowWithOptions:
             retry_delay_seconds=20,
             persist_result=False,
             result_serializer="json",
-            result_storage=LocalFileSystem(),
+            result_storage=storage,
             cache_result_in_memory=False,
             log_prints=False,
         )
@@ -368,7 +370,7 @@ class TestFlowWithOptions:
         assert flow_with_options.retry_delay_seconds == 20
         assert flow_with_options.persist_result is False
         assert flow_with_options.result_serializer == "json"
-        assert flow_with_options.result_storage == LocalFileSystem()
+        assert flow_with_options.result_storage == storage
         assert flow_with_options.cache_result_in_memory is False
         assert flow_with_options.log_prints is False
 
@@ -407,11 +409,11 @@ class TestFlowWithOptions:
         flow_with_options = initial_flow.with_options()
         assert flow_with_options.flow_run_name is generate_flow_run_name
 
-    def test_with_options_can_unset_result_options_with_none(self):
+    def test_with_options_can_unset_result_options_with_none(self, tmp_path: Path):
         @flow(
             persist_result=True,
             result_serializer="json",
-            result_storage=LocalFileSystem(),
+            result_storage=LocalFileSystem(basepath=tmp_path),
         )
         def initial_flow():
             pass

--- a/tests/test_new_task_engine.py
+++ b/tests/test_new_task_engine.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import time
+from pathlib import Path
 from typing import List
 from unittest.mock import MagicMock
 from uuid import UUID
@@ -345,7 +346,7 @@ class TestTaskRunsAsync:
 
         assert await api_state.result() == str(run_id)
 
-    async def test_task_runs_respect_cache_key(self):
+    async def test_task_runs_respect_cache_key(self, tmp_path: Path):
         @task(cache_key_fn=lambda *args, **kwargs: "key")
         async def first():
             return 42
@@ -354,7 +355,7 @@ class TestTaskRunsAsync:
         async def second():
             return 500
 
-        fs = LocalFileSystem(base_url="/tmp/prefect")
+        fs = LocalFileSystem(basepath=tmp_path)
 
         one = await run_task_async(first.with_options(result_storage=fs))
         two = await run_task_async(second.with_options(result_storage=fs))
@@ -543,7 +544,7 @@ class TestTaskRunsSync:
 
         assert await api_state.result() == str(run_id)
 
-    async def test_task_runs_respect_cache_key(self):
+    async def test_task_runs_respect_cache_key(self, tmp_path: Path):
         @task(cache_key_fn=lambda *args, **kwargs: "key")
         def first():
             return 42
@@ -552,7 +553,7 @@ class TestTaskRunsSync:
         def second():
             return 500
 
-        fs = LocalFileSystem(base_url="/tmp/prefect")
+        fs = LocalFileSystem(basepath=tmp_path)
 
         one = run_task_sync(first.with_options(result_storage=fs))
         two = run_task_sync(second.with_options(result_storage=fs))


### PR DESCRIPTION
We've had trouble in the past with tests inadvertently writing files to the
current working directory instead of isolated to a temporary directory.  It's
far too easy to introduce these, and they can be frustrating to track down.

This adds a module-level autouse fixture to alert us when a test suite had
dropped new files in the working tree.

Counterpart of #13380
