### PR TITLE
Removes an unused/deprecated parameter from CodeQL checks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -73,7 +73,6 @@ jobs:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql-config.yml
           queries: security-extended
-          setup-python-dependencies: false
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
This has been putting a little annotation icon on all our CI checks with the
message:

```
The setup-python-dependencies input is deprecated and no longer has any effect.
We recommend removing any references from your workflows.
See https://github.blog/changelog/2024-01-23-codeql-2-16-python-dependency-installation-disabled-new-queries-and-bug-fixes/
for more information.
```

![image](https://github.com/PrefectHQ/prefect/assets/8194/7cd8aeab-a0f7-4ba8-8c25-61b88217077a)
