### PR TITLE
prefect-dbt - Cause unsuccessful dbt tasks to fail

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py
@@ -12,6 +12,7 @@ from pydantic import VERSION as PYDANTIC_VERSION
 
 from prefect import get_run_logger, task
 from prefect.artifacts import create_markdown_artifact
+from prefect.states import Failed
 from prefect.utilities.filesystem import relative_path_to_current_platform
 
 if PYDANTIC_VERSION.startswith("2."):
@@ -174,7 +175,7 @@ async def trigger_dbt_cli_command(
     result: dbtRunnerResult = dbt_runner_client.invoke(cli_args)
 
     if result.exception is not None:
-        logger.error(f"dbt build task failed with exception: {result.exception}")
+        logger.error(f"dbt task failed with exception: {result.exception}")
         raise result.exception
 
     # Creating the dbt Summary Markdown if enabled
@@ -198,6 +199,10 @@ async def trigger_dbt_cli_command(
                      return any RunExecutionResults. \
                      See https://docs.getdbt.com/reference/programmatic-invocations \
                      for more details on dbtRunnerResult."
+        )
+    if isinstance(result.result, RunExecutionResult) and not result.success:
+        return Failed(
+            message=f"dbt task result success: {result.success} with exception: {result.exception}"
         )
     return result
 

--- a/src/integrations/prefect-dbt/tests/cli/test_commands.py
+++ b/src/integrations/prefect-dbt/tests/cli/test_commands.py
@@ -506,7 +506,10 @@ def test_run_dbt_model_creates_unsuccessful_artifact(
             create_summary_artifact=True,
         )
 
-    test_flow()
+    with pytest.raises(
+        Exception, match="dbt task result success: False with exception: None"
+    ):
+        test_flow()
     assert (a := Artifact.get(key="foo"))
     assert a.type == "markdown"
     assert a.data.startswith("# dbt run Task Summary")


### PR DESCRIPTION
Currently in `prefect-dbt` 0.4.3, unsuccessful dbt core runs will cause the Prefect task to fail.  This changes the new, programmatically-invoked dbt tasks to match that behavior.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
