### PR TITLE
prefect-dbt - 2.x Cause unsuccessful dbt tasks to fail 

### DIFF
--- a/src/integrations/prefect-dbt/tests/cli/test_commands.py
+++ b/src/integrations/prefect-dbt/tests/cli/test_commands.py
@@ -506,7 +506,10 @@ def test_run_dbt_model_creates_unsuccessful_artifact(
             create_summary_artifact=True,
         )
 
-    test_flow()
+    with pytest.raises(
+        Exception, match="dbt task result unsuccessful with exception: None"
+    ):
+        test_flow()
     assert (a := Artifact.get(key="foo"))
     assert a.type == "markdown"
     assert a.data.startswith("# dbt run Task Summary")


### PR DESCRIPTION
Currently in prefect-dbt 0.4.3, unsuccessful dbt core runs will cause the Prefect task to fail. This changes the new, programmatically-invoked dbt tasks to match that behavior. Compares with #13405 

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
