### PR TITLE
Disable integration tests for main

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -27,6 +27,7 @@ on:
 jobs:
   compatibility-tests:
     name: "Check compatibility with Prefect ${{ matrix.prefect-version }}"
+    if: false # disable while we iterate on 3.0
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
We know these will break now that we're prepping a major version bump