### PR TITLE
Remove private run methods

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1232,51 +1232,6 @@ class Flow(Generic[P, R]):
             return_type=return_type,
         )
 
-    @overload
-    def _run(self: "Flow[P, NoReturn]", *args: P.args, **kwargs: P.kwargs) -> State[T]:
-        # `NoReturn` matches if a type can't be inferred for the function which stops a
-        # sync function from matching the `Coroutine` overload
-        ...
-
-    @overload
-    def _run(
-        self: "Flow[P, Coroutine[Any, Any, T]]", *args: P.args, **kwargs: P.kwargs
-    ) -> Awaitable[T]:
-        ...
-
-    @overload
-    def _run(self: "Flow[P, T]", *args: P.args, **kwargs: P.kwargs) -> State[T]:
-        ...
-
-    def _run(
-        self,
-        *args: "P.args",
-        wait_for: Optional[Iterable[PrefectFuture]] = None,
-        **kwargs: "P.kwargs",
-    ):
-        """
-        Run the flow and return its final state.
-
-        Examples:
-
-            Run a flow and get the returned result
-
-            >>> state = my_flow._run("marvin")
-            >>> state.result()
-           "goodbye marvin"
-        """
-        from prefect.engine import enter_flow_run_engine_from_flow_call
-
-        # Convert the call args/kwargs to a parameter dict
-        parameters = get_call_parameters(self.fn, args, kwargs)
-
-        return enter_flow_run_engine_from_flow_call(
-            self,
-            parameters,
-            wait_for=wait_for,
-            return_type="state",
-        )
-
     @sync_compatible
     async def visualize(self, *args, **kwargs):
         """

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -698,56 +698,6 @@ class Task(Generic[P, R]):
         )
 
     @overload
-    def _run(
-        self: "Task[P, NoReturn]",
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> PrefectFuture[None, Sync]:
-        # `NoReturn` matches if a type can't be inferred for the function which stops a
-        # sync function from matching the `Coroutine` overload
-        ...
-
-    @overload
-    def _run(
-        self: "Task[P, Coroutine[Any, Any, T]]",
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> Awaitable[State[T]]:
-        ...
-
-    @overload
-    def _run(
-        self: "Task[P, T]",
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> State[T]:
-        ...
-
-    def _run(
-        self,
-        *args: P.args,
-        wait_for: Optional[Iterable[PrefectFuture]] = None,
-        **kwargs: P.kwargs,
-    ) -> Union[State, Awaitable[State]]:
-        """
-        Run the task and return the final state.
-        """
-        from prefect.engine import enter_task_run_engine
-        from prefect.task_runners import SequentialTaskRunner
-
-        # Convert the call args/kwargs to a parameter dict
-        parameters = get_call_parameters(self.fn, args, kwargs)
-
-        return enter_task_run_engine(
-            self,
-            parameters=parameters,
-            wait_for=wait_for,
-            return_type="state",
-            task_runner=SequentialTaskRunner(),
-            mapped=False,
-        )
-
-    @overload
     def submit(
         self: "Task[P, NoReturn]",
         *args: P.args,

--- a/src/prefect/testing/standard_test_suites/task_runners.py
+++ b/src/prefect/testing/standard_test_suites/task_runners.py
@@ -106,7 +106,7 @@ class TaskRunnerStandardTestSuite(ABC):
 
             return a, b, c, d
 
-        state = test_flow._run()
+        state = test_flow(return_state=True)
 
         assert state.is_failed()
         a, b, c, d = state.result(raise_on_failure=False)
@@ -406,7 +406,7 @@ class TaskRunnerStandardTestSuite(ABC):
 
             return a, b, c
 
-        state = await test_flow._run()
+        state = await test_flow(return_state=True)
 
         assert state.is_failed()
         ax, bx, cx = await state.result(raise_on_failure=False)
@@ -440,7 +440,7 @@ class TaskRunnerStandardTestSuite(ABC):
 
             return a, b, c
 
-        state = test_flow._run()
+        state = test_flow(return_state=True)
 
         assert state.is_failed()
         ax, bx, cx = state.result(raise_on_failure=False)

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -30,9 +30,9 @@ async def test_task_state_change_happy_path(
 
     @flow
     def happy_path():
-        return happy_little_tree._run()
+        return happy_little_tree(return_state=True)
 
-    flow_state: State[State[str]] = happy_path._run()
+    flow_state: State[State[str]] = happy_path(return_state=True)
 
     task_state: State[str] = await flow_state.result()
     task_run_id = task_state.state_details.task_run_id
@@ -94,9 +94,9 @@ async def test_task_state_change_task_failure(
 
     @flow
     def happy_path():
-        return happy_little_tree._run()
+        return happy_little_tree(return_state=True)
 
-    flow_state = happy_path._run()
+    flow_state = happy_path(return_state=True)
 
     task_state = await flow_state.result(raise_on_failure=False)
     task_run_id = task_state.state_details.task_run_id

--- a/tests/events/client/test_events_related_from_context.py
+++ b/tests/events/client/test_events_related_from_context.py
@@ -126,7 +126,7 @@ async def test_can_exclude_by_resource_id(prefect_client):
 
         return await related_resources_from_run_context(exclude=exclude)
 
-    state = await test_flow._run()
+    state = await test_flow(return_state=True)
 
     flow_run = await prefect_client.read_flow_run(state.state_details.flow_run_id)
 
@@ -144,9 +144,9 @@ async def test_gets_related_from_task_run_context(prefect_client):
 
     @flow
     async def test_flow():
-        return await test_task._run()
+        return await test_task(return_state=True)
 
-    state = await test_flow._run()
+    state = await test_flow(return_state=True)
     task_state = await state.result()
 
     flow_run = await prefect_client.read_flow_run(state.state_details.flow_run_id)

--- a/tests/events/client/test_events_worker.py
+++ b/tests/events/client/test_events_worker.py
@@ -69,7 +69,7 @@ async def test_includes_related_resources_from_run_context(
             resource={"prefect.resource.id": "vogon.poem.oh-freddled-gruntbuggly"},
         )
 
-    state: State[None] = emitting_flow._run()
+    state: State[None] = emitting_flow(return_state=True)
 
     flow_run = await prefect_client.read_flow_run(state.state_details.flow_run_id)
     db_flow = await prefect_client.read_flow(flow_run.flow_id)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2544,7 +2544,7 @@ class TestTaskRunCrashes:
 
         @flow
         async def my_flow():
-            await my_task._run()
+            await my_task(return_state=True)
 
         # Note exception should not be re-raised
         state = await begin_flow_run(
@@ -2743,7 +2743,7 @@ class TestDynamicKeyHandling:
             subflow()
             my_task()
 
-        state = my_flow._run()
+        state = my_flow(return_state=True)
 
         task_runs = await prefect_client.read_task_runs()
         parent_task_runs = [

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -171,13 +171,13 @@ def test_raise_warning_futures_in_condition():
 
     match = "A 'PrefectFuture' from a task call was cast to a boolean"
     with pytest.warns(UserWarning, match=match):
-        if_flow._run()
+        if_flow(return_state=True)
 
     with pytest.warns(UserWarning, match=match):
-        elif_flow._run()
+        elif_flow(return_state=True)
 
     with assert_does_not_warn():
-        if_result_flow._run()
+        if_result_flow(return_state=True)
 
 
 async def test_resolve_futures_to_data_raises_exception_default(task_run):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -956,7 +956,7 @@ async def test_run_logger_in_flow(prefect_client):
     def test_flow():
         return get_run_logger()
 
-    state = test_flow._run()
+    state = test_flow(return_state=True)
     flow_run = await prefect_client.read_flow_run(state.state_details.flow_run_id)
     logger = await state.result()
     assert logger.name == "prefect.flow_runs"
@@ -972,7 +972,7 @@ async def test_run_logger_extra_data(prefect_client):
     def test_flow():
         return get_run_logger(foo="test", flow_name="bar")
 
-    state = test_flow._run()
+    state = test_flow(return_state=True)
     flow_run = await prefect_client.read_flow_run(state.state_details.flow_run_id)
     logger = await state.result()
     assert logger.name == "prefect.flow_runs"
@@ -991,9 +991,9 @@ async def test_run_logger_in_nested_flow(prefect_client):
 
     @flow
     def test_flow():
-        return child_flow._run()
+        return child_flow(return_state=True)
 
-    child_state = await test_flow._run().result()
+    child_state = await test_flow(return_state=True).result()
     flow_run = await prefect_client.read_flow_run(child_state.state_details.flow_run_id)
     logger = await child_state.result()
     assert logger.name == "prefect.flow_runs"
@@ -1011,9 +1011,9 @@ async def test_run_logger_in_task(prefect_client):
 
     @flow
     def test_flow():
-        return test_task._run()
+        return test_task(return_state=True)
 
-    flow_state = test_flow._run()
+    flow_state = test_flow(return_state=True)
     flow_run = await prefect_client.read_flow_run(flow_state.state_details.flow_run_id)
     task_state = await flow_state.result()
     task_run = await prefect_client.read_task_run(task_state.state_details.task_run_id)

--- a/tests/test_new_flow_engine.py
+++ b/tests/test_new_flow_engine.py
@@ -538,7 +538,7 @@ class TestFlowRetries:
             flow_run_count += 1
             return await child_flow()
 
-        state = await parent_flow._run()
+        state = await parent_flow(return_state=True)
         assert await state.result() == "hello"
         assert flow_run_count == 2
         assert child_run_count == 2, "Child flow should be reset and run again"
@@ -603,7 +603,7 @@ class TestFlowRetries:
             nonlocal flow_run_count
             flow_run_count += 1
 
-            state = child_flow._run()
+            state = child_flow(return_state=True)
 
             # It is important that the flow run fails after the child flow run is created
             if flow_run_count == 1:
@@ -611,7 +611,7 @@ class TestFlowRetries:
 
             return state
 
-        parent_state = parent_flow._run()
+        parent_state = parent_flow(return_state=True)
         child_state = await parent_state.result()
         assert await child_state.result() == "hello"
         assert flow_run_count == 2

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -325,7 +325,7 @@ class TestTaskCall:
             foo()
             return "bar"
 
-        state = bar._run()
+        state = bar(return_state=True)
         assert state.is_failed()
         with pytest.raises(ValueError, match="Test"):
             state.result()
@@ -390,7 +390,7 @@ class TestTaskRun:
 
         @flow
         def bar():
-            return foo._run(1)
+            return foo(1, return_state=True)
 
         task_state = bar()
         assert isinstance(task_state, State)
@@ -404,7 +404,7 @@ class TestTaskRun:
 
         @flow
         async def bar():
-            return await foo._run(1)
+            return await foo(1, return_state=True)
 
         task_state = await bar()
         assert isinstance(task_state, State)
@@ -418,7 +418,7 @@ class TestTaskRun:
 
         @flow
         async def bar():
-            return foo._run(1)
+            return foo(1, return_state=True)
 
         task_state = await bar()
         assert isinstance(task_state, State)
@@ -432,7 +432,7 @@ class TestTaskRun:
 
         @flow
         def bar():
-            return foo._run(1)
+            return foo(1, return_state=True)
 
         task_state = bar()
         assert isinstance(task_state, State)
@@ -446,7 +446,7 @@ class TestTaskRun:
 
         @flow
         def bar():
-            foo._run()
+            foo(return_state=True)
             return "bar"
 
         assert bar() == "bar"
@@ -730,7 +730,7 @@ class TestTaskStates:
 
         @flow(version="test")
         def foo():
-            return quote(bar._run())
+            return quote(bar(return_state=True))
 
         task_state = foo().unquote()
 
@@ -750,7 +750,7 @@ class TestTaskStates:
 
         @flow(version="test")
         def foo():
-            return quote(bar._run())
+            return quote(bar(return_state=True))
 
         task_state = foo().unquote()
 
@@ -783,7 +783,7 @@ class TestTaskVersion:
 
         @flow
         def test():
-            return my_task._run()
+            return my_task(return_state=True)
 
         task_state = test()
         task_run = await prefect_client.read_task_run(
@@ -1081,7 +1081,7 @@ class TestTaskCaching:
 
         @flow
         def bar():
-            return foo._run(1), foo._run(1)
+            return foo(1, return_state=True), foo(1, return_state=True)
 
         first_state, second_state = bar()
         assert first_state.name == "Completed"
@@ -1096,7 +1096,7 @@ class TestTaskCaching:
 
         @flow
         def bar():
-            return foo._run(1), foo._run(2)
+            return foo(1, return_state=True), foo(2, return_state=True)
 
         first_state, second_state = bar()
         assert first_state.name == "Completed"
@@ -1111,8 +1111,8 @@ class TestTaskCaching:
 
         @flow
         def bar():
-            foo._run(1)  # populate the cache
-            return [foo._run(i) for i in range(5)]
+            foo(1, return_state=True)  # populate the cache
+            return [foo(i, return_state=True) for i in range(5)]
 
         states = bar()
         assert all(state.name == "Cached" for state in states), states
@@ -1125,7 +1125,7 @@ class TestTaskCaching:
 
         @flow
         def bar(x):
-            return foo._run(x)
+            return foo(x, return_state=True)
 
         first_state = bar(1)
         second_state = bar(2)
@@ -1146,7 +1146,7 @@ class TestTaskCaching:
 
         @flow
         def bar():
-            return foo._run(1), foo._run(1)
+            return foo(1, return_state=True), foo(1, return_state=True)
 
         first_state, second_state = bar()
         assert first_state.name == "Completed"
@@ -1163,7 +1163,9 @@ class TestTaskCaching:
 
         @flow
         def bar():
-            return foo._run("something"), foo._run("different")
+            return foo("something", return_state=True), foo(
+                "different", return_state=True
+            )
 
         first_state, second_state = bar()
         assert first_state.name == "Completed"
@@ -1197,7 +1199,7 @@ class TestTaskCaching:
         def my_flow():
             future = foo.submit("something")
             # Mix run/submit to cover both cases
-            return bar._run(future), bar.submit(future).wait()
+            return bar(future, return_state=True), bar.submit(future).wait()
 
         first_state, second_state = my_flow()
         assert first_state.name == "Completed"
@@ -1218,9 +1220,9 @@ class TestTaskCaching:
         @flow
         def bar():
             return (
-                foo._run(1, 2, 3),
-                foo._run(1, b=2),
-                foo._run(c=3, a=1, b=2),
+                foo(1, 2, 3, return_state=True),
+                foo(1, b=2, return_state=True),
+                foo(c=3, a=1, b=2, return_state=True),
             )
 
         first_state, second_state, third_state = bar()
@@ -1244,7 +1246,7 @@ class TestTaskCaching:
 
         @flow
         def bar():
-            return foo._run(1), foo._run(2)
+            return foo(1, return_state=True), foo(2, return_state=True)
 
         first_state, second_state = bar()
         assert first_state.name == "Completed"
@@ -1262,7 +1264,7 @@ class TestTaskCaching:
 
         @flow
         def bar():
-            return foo._run(1), foo._run(2)
+            return foo(1, return_state=True), foo(2, return_state=True)
 
         first_state, second_state = bar()
         assert first_state.name == "Completed"
@@ -1337,7 +1339,11 @@ class TestCacheFunctionBuiltins:
 
         @flow
         def bar():
-            return foo._run(1), foo._run(2), foo._run(1)
+            return (
+                foo(1, return_state=True),
+                foo(2, return_state=True),
+                foo(1, return_state=True),
+            )
 
         first_state, second_state, third_state = bar()
         assert first_state.name == "Completed"
@@ -1356,7 +1362,7 @@ class TestCacheFunctionBuiltins:
 
         @flow
         def bar(x):
-            return foo._run(x)
+            return foo(x, return_state=True)
 
         first_state = bar(1)
         second_state = bar(2)
@@ -1391,7 +1397,11 @@ class TestCacheFunctionBuiltins:
 
         @flow
         def bar():
-            return foo._run(1), foo._run(2), foo._run(1)
+            return (
+                foo(1, return_state=True),
+                foo(2, return_state=True),
+                foo(1, return_state=True),
+            )
 
         first_state, second_state, third_state = bar()
         assert first_state.name == "Completed"
@@ -1417,9 +1427,9 @@ class TestCacheFunctionBuiltins:
         @flow
         def bar():
             return (
-                foo._run(TestClass(1)),
-                foo._run(TestClass(2)),
-                foo._run(TestClass(1)),
+                foo(TestClass(1), return_state=True),
+                foo(TestClass(2), return_state=True),
+                foo(TestClass(1), return_state=True),
             )
 
         first_state, second_state, third_state = bar()
@@ -1444,9 +1454,9 @@ class TestCacheFunctionBuiltins:
         @flow
         def bar():
             return (
-                foo._run(TestBlock(x=1, y=2, z=3)),
-                foo._run(TestBlock(x=4, y=2, z=3)),
-                foo._run(TestBlock(x=1, y=2, z=3)),
+                foo(TestBlock(x=1, y=2, z=3), return_state=True),
+                foo(TestBlock(x=4, y=2, z=3), return_state=True),
+                foo(TestBlock(x=1, y=2, z=3), return_state=True),
             )
 
         first_state, second_state, third_state = bar()
@@ -1475,13 +1485,13 @@ class TestCacheFunctionBuiltins:
 
         @flow
         def my_flow():
-            first = foo._run(1)
+            first = foo(1, return_state=True)
             foo.fn = foo_same_code
-            second = foo._run(1)
+            second = foo(1, return_state=True)
             foo.fn = foo_new_code
-            third = foo._run(1)
-            fourth = bar._run(1)
-            fifth = bar._run(1)
+            third = foo(1, return_state=True)
+            fourth = bar(1, return_state=True)
+            fifth = bar(1, return_state=True)
             return first, second, third, fourth, fifth
 
         (
@@ -1515,11 +1525,21 @@ class TestCacheFunctionBuiltins:
         @flow
         def bar():
             return (
-                foo._run(TestBlock(x=1, y=2, z="dog".encode("utf-8"))),  # same
-                foo._run(TestBlock(x=4, y=2, z="dog".encode("utf-8"))),  # different x
-                foo._run(TestBlock(x=1, y=2, z="dog".encode("utf-8"))),  # same
-                foo._run(TestBlock(x=1, y=2, z="dog".encode("latin-1"))),  # same
-                foo._run(TestBlock(x=1, y=2, z="cat".encode("utf-8"))),  # different z
+                foo(
+                    TestBlock(x=1, y=2, z="dog".encode("utf-8")), return_state=True
+                ),  # same
+                foo(
+                    TestBlock(x=4, y=2, z="dog".encode("utf-8")), return_state=True
+                ),  # different x
+                foo(
+                    TestBlock(x=1, y=2, z="dog".encode("utf-8")), return_state=True
+                ),  # same
+                foo(
+                    TestBlock(x=1, y=2, z="dog".encode("latin-1")), return_state=True
+                ),  # same
+                foo(
+                    TestBlock(x=1, y=2, z="cat".encode("utf-8")), return_state=True
+                ),  # different z
             )
 
         first_state, second_state, third_state, fourth_state, fifth_state = bar()
@@ -1538,20 +1558,20 @@ class TestCacheFunctionBuiltins:
 class TestTaskTimeouts:
     @fails_with_new_engine
     async def test_task_timeouts_actually_timeout(self, timeout_test_flow):
-        flow_state = timeout_test_flow._run()
+        flow_state = timeout_test_flow(return_state=True)
         timed_out, _, _ = await flow_state.result(raise_on_failure=False)
         assert timed_out.name == "TimedOut"
         assert timed_out.is_failed()
 
     @fails_with_new_engine
     async def test_task_timeouts_are_not_task_crashes(self, timeout_test_flow):
-        flow_state = timeout_test_flow._run()
+        flow_state = timeout_test_flow(return_state=True)
         timed_out, _, _ = await flow_state.result(raise_on_failure=False)
         assert timed_out.is_crashed() is False
 
     @fails_with_new_engine
     async def test_task_timeouts_do_not_crash_flow_runs(self, timeout_test_flow):
-        flow_state = timeout_test_flow._run()
+        flow_state = timeout_test_flow(return_state=True)
         timed_out, _, _ = await flow_state.result(raise_on_failure=False)
 
         assert timed_out.name == "TimedOut"
@@ -1571,7 +1591,7 @@ class TestTaskTimeouts:
             x = my_task.submit()
             return x
 
-        flow_state = my_flow._run()
+        flow_state = my_flow(return_state=True)
         assert flow_state.type == StateType.COMPLETED
 
         task_res = await flow_state.result()
@@ -1603,7 +1623,7 @@ class TestTaskRunTags:
         @flow
         def my_flow():
             with tags("a", "b"):
-                state = my_task._run()
+                state = my_task(return_state=True)
 
             return state
 
@@ -1641,7 +1661,7 @@ class TestTaskRunTags:
         @flow
         def my_flow():
             with tags("c", "d"):
-                state = my_task._run()
+                state = my_task(return_state=True)
 
             return state
 
@@ -1660,7 +1680,7 @@ class TestTaskRunTags:
         @flow
         def my_flow():
             with tags("c", "d"):
-                state = my_task._run()
+                state = my_task(return_state=True)
 
             return state
 
@@ -1682,7 +1702,7 @@ class TestTaskRunTags:
         def my_flow():
             with tags("a", "b"):
                 my_task()
-            state = my_task._run()
+            state = my_task(return_state=True)
 
             return state
 
@@ -1702,7 +1722,7 @@ class TestTaskRunTags:
         def my_flow():
             with tags("a", "b"):
                 with tags("c", "d"):
-                    state = my_task._run()
+                    state = my_task(return_state=True)
 
             return state
 
@@ -1732,8 +1752,8 @@ class TestTaskInputs:
 
         @flow
         def upstream_downstream_flow(result):
-            upstream_state = upstream._run(result)
-            downstream_state = downstream._run(upstream_state.result())
+            upstream_state = upstream(result, return_state=True)
+            downstream_state = downstream(upstream_state.result(), return_state=True)
             return upstream_state, downstream_state
 
         return upstream_downstream_flow
@@ -1748,7 +1768,7 @@ class TestTaskInputs:
         def test_flow():
             return foo.submit(1)
 
-        flow_state = test_flow._run()
+        flow_state = test_flow(return_state=True)
         x = await flow_state.result()
 
         task_run = await prefect_client.read_task_run(x.state_details.task_run_id)
@@ -1767,7 +1787,7 @@ class TestTaskInputs:
         def test_flow():
             return foo.submit(1)
 
-        flow_state = test_flow._run()
+        flow_state = test_flow(return_state=True)
         x = await flow_state.result()
 
         task_run = await prefect_client.read_task_run(x.state_details.task_run_id)
@@ -1790,10 +1810,10 @@ class TestTaskInputs:
         def test_flow():
             a = foo.submit(1)
             b = foo.submit(2)
-            c = bar._run(a, 1)
+            c = bar(a, 1, return_state=True)
             return a, b, c
 
-        flow_state = test_flow._run()
+        flow_state = test_flow(return_state=True)
         a, b, c = await flow_state.result()
 
         task_run = await prefect_client.read_task_run(c.state_details.task_run_id)
@@ -1819,10 +1839,10 @@ class TestTaskInputs:
         def test_flow():
             a = foo.submit(1)
             b = foo.submit(2)
-            c = bar._run(x=a, y=1)
+            c = bar(x=a, y=1, return_state=True)
             return a, b, c
 
-        flow_state = test_flow._run()
+        flow_state = test_flow(return_state=True)
         a, b, c = await flow_state.result()
 
         task_run = await prefect_client.read_task_run(c.state_details.task_run_id)
@@ -1848,10 +1868,10 @@ class TestTaskInputs:
         def test_flow():
             a = foo.submit(1)
             b = foo.submit(2)
-            c = bar._run(a, b)
+            c = bar(a, b, return_state=True)
             return a, b, c
 
-        flow_state = test_flow._run()
+        flow_state = test_flow(return_state=True)
         a, b, c = await flow_state.result()
 
         task_run = await prefect_client.read_task_run(c.state_details.task_run_id)
@@ -1876,10 +1896,10 @@ class TestTaskInputs:
         @flow
         def test_flow():
             a = foo.submit(1)
-            c = bar._run(a, a)
+            c = bar(a, a, return_state=True)
             return a, c
 
-        flow_state = test_flow._run()
+        flow_state = test_flow(return_state=True)
         a, c = await flow_state.result()
 
         task_run = await prefect_client.read_task_run(c.state_details.task_run_id)
@@ -1906,10 +1926,10 @@ class TestTaskInputs:
             a = foo.submit(1)
             b = foo.submit(2)
             c = foo.submit(3)
-            d = bar._run([a, a, b], {3: b, 4: {5: {c, 4}}})
+            d = bar([a, a, b], {3: b, 4: {5: {c, 4}}}, return_state=True)
             return a, b, c, d
 
-        flow_state = test_flow._run()
+        flow_state = test_flow(return_state=True)
 
         a, b, c, d = await flow_state.result()
 
@@ -1938,10 +1958,10 @@ class TestTaskInputs:
 
         @flow
         def parent():
-            child_state = child._run(1)
+            child_state = child(1, return_state=True)
             return child_state, foo.submit(child_state)
 
-        parent_state = parent._run()
+        parent_state = parent(return_state=True)
         child_state, task_state = await parent_state.result()
 
         task_run = await prefect_client.read_task_run(
@@ -1963,11 +1983,11 @@ class TestTaskInputs:
 
         @flow
         def test_flow():
-            my_name = name._run()
-            hi = say_hi._run(my_name.result())
+            my_name = name(return_state=True)
+            hi = say_hi(my_name.result(), return_state=True)
             return my_name, hi
 
-        flow_state = test_flow._run()
+        flow_state = test_flow(return_state=True)
         name_state, hi_state = await flow_state.result()
 
         task_run = await prefect_client.read_task_run(
@@ -1994,7 +2014,7 @@ class TestTaskInputs:
         def test_flow():
             upstream_future = upstream.submit(257)
             upstream_result = upstream_future.result()
-            downstream_state = downstream._run(upstream_result)
+            downstream_state = downstream(upstream_result, return_state=True)
             upstream_state = upstream_future.wait()
             return upstream_state, downstream_state
 
@@ -2022,9 +2042,9 @@ class TestTaskInputs:
 
         @flow
         def test_flow():
-            upstream_state = upstream._run(1)
+            upstream_state = upstream(1, return_state=True)
             upstream_result = upstream_state.result()
-            downstream_state = downstream._run(upstream_result)
+            downstream_state = downstream(upstream_result, return_state=True)
             return upstream_state, downstream_state
 
         upstream_state, downstream_state = test_flow()
@@ -2043,8 +2063,8 @@ class TestTaskInputs:
 
         @flow
         def test_flow():
-            upstream_state = upstream._run(1)
-            downstream_state = downstream._run(upstream_state)
+            upstream_state = upstream(1, return_state=True)
+            downstream_state = downstream(upstream_state, return_state=True)
             return upstream_state, downstream_state
 
         upstream_state, downstream_state = test_flow()
@@ -2090,7 +2110,7 @@ class TestTaskInputs:
     async def test_task_inputs_populated_with_collection_result_upstream(
         self, result, prefect_client, flow_with_upstream_downstream
     ):
-        flow_state = flow_with_upstream_downstream._run(result)
+        flow_state = flow_with_upstream_downstream(result, return_state=True)
         upstream_state, downstream_state = await flow_state.result()
 
         task_run = await prefect_client.read_task_run(
@@ -2105,7 +2125,7 @@ class TestTaskInputs:
     async def test_task_inputs_populated_with_basic_result_types_upstream(
         self, result, prefect_client, flow_with_upstream_downstream
     ):
-        flow_state = flow_with_upstream_downstream._run(result)
+        flow_state = flow_with_upstream_downstream(result, return_state=True)
         upstream_state, downstream_state = await flow_state.result()
 
         task_run = await prefect_client.read_task_run(
@@ -2119,7 +2139,7 @@ class TestTaskInputs:
     async def test_task_inputs_not_populated_with_singleton_results_upstream(
         self, result, prefect_client, flow_with_upstream_downstream
     ):
-        flow_state = flow_with_upstream_downstream._run(result)
+        flow_state = flow_with_upstream_downstream(result, return_state=True)
         _, downstream_state = await flow_state.result()
 
         task_run = await prefect_client.read_task_run(
@@ -2149,10 +2169,10 @@ class TestTaskInputs:
 
         @flow
         def unpacking_flow():
-            t1_state = task_1._run()
+            t1_state = task_1(return_state=True)
             t1_res_1, t1_res_2 = t1_state.result()
-            t2_state = task_2._run(t1_res_1)
-            t3_state = task_3._run(t1_res_2)
+            t2_state = task_2(t1_res_1, return_state=True)
+            t3_state = task_3(t1_res_2, return_state=True)
             return t1_state, t2_state, t3_state
 
         t1_state, t2_state, t3_state = unpacking_flow()
@@ -2194,10 +2214,10 @@ class TestTaskInputs:
 
         @flow
         def unpacking_flow():
-            t1_state = task_1._run()
+            t1_state = task_1(return_state=True)
             t1_res_1, t1_res_2 = t1_state.result()
-            t2_state = task_2._run(t1_res_1)
-            t3_state = task_3._run(t1_res_2)
+            t2_state = task_2(t1_res_1, return_state=True)
+            t3_state = task_3(t1_res_2, return_state=True)
             return t1_state, t2_state, t3_state
 
         t1_state, t2_state, t3_state = unpacking_flow()
@@ -2238,10 +2258,10 @@ class TestTaskInputs:
 
         @flow
         def unpacking_flow():
-            t1_state = task_1._run()
+            t1_state = task_1(return_state=True)
             t1_res_1, t1_res_2 = t1_state.result()
-            t2_state = task_2._run(t1_res_1)
-            t3_state = task_3._run(t1_res_2)
+            t2_state = task_2(t1_res_1, return_state=True)
+            t3_state = task_3(t1_res_2, return_state=True)
             return t1_state, t2_state, t3_state
 
         t1_state, t2_state, t3_state = unpacking_flow()
@@ -2277,10 +2297,10 @@ class TestSubflowWaitForTasks:
         @flow
         def test_flow():
             f = fails.submit()
-            b = bar._run(2, wait_for=[f])
+            b = bar(2, wait_for=[f], return_state=True)
             return b
 
-        flow_state = test_flow._run()
+        flow_state = test_flow(return_state=True)
         subflow_state = flow_state.result(raise_on_failure=False)
         assert subflow_state.is_pending()
         assert subflow_state.name == "NotReady"
@@ -2384,7 +2404,7 @@ class TestSubflowWaitForTasks:
             b = await setter_flow(e, wait_for=[f])
             return b
 
-        flow_state = await test_flow._run()
+        flow_state = await test_flow(return_state=True)
         assert flow_state.is_failed()
         assert "UnfinishedRun" in flow_state.message
 
@@ -2432,10 +2452,10 @@ class TestTaskWaitFor:
         @flow
         def test_flow():
             f = fails.submit()
-            b = bar._run(2, wait_for=[f])
+            b = bar(2, wait_for=[f], return_state=True)
             return b
 
-        flow_state = test_flow._run()
+        flow_state = test_flow(return_state=True)
         task_state = flow_state.result(raise_on_failure=False)
         assert task_state.is_pending()
         assert task_state.name == "NotReady"
@@ -2580,7 +2600,7 @@ class TestTaskRunLogs:
 
         @flow
         def my_flow():
-            return my_task._run()
+            return my_task(return_state=True)
 
         task_state = my_flow()
         flow_run_id = task_state.state_details.flow_run_id
@@ -2852,7 +2872,7 @@ class TestTaskMap:
 
         @flow
         def my_flow():
-            numbers_state = some_numbers._run()
+            numbers_state = some_numbers(return_state=True)
             return TestTaskMap.add_one.map(numbers_state)
 
         task_states = my_flow()
@@ -3097,7 +3117,7 @@ class TestTaskMap:
 
         @flow
         def my_flow():
-            numbers_state = child_flow._run()
+            numbers_state = child_flow(return_state=True)
             return TestTaskMap.add_one.map(numbers_state)
 
         task_states = my_flow()
@@ -3655,7 +3675,7 @@ class TestTaskHooksOnCompletion:
 
         @flow
         def my_flow():
-            return my_task._run()
+            return my_task(return_state=True)
 
         state = my_flow()
         assert state.type == StateType.COMPLETED
@@ -3704,7 +3724,7 @@ class TestTaskHooksOnCompletion:
 
         @flow
         def my_flow():
-            return my_task._run()
+            return my_task(return_state=True)
 
         state = my_flow()
         assert state.type == StateType.COMPLETED
@@ -3731,7 +3751,7 @@ class TestTaskHooksOnCompletion:
 
         @flow
         def my_flow():
-            return my_task._run()
+            return my_task(return_state=True)
 
         state = my_flow()
         assert state.type == StateType.COMPLETED
@@ -3913,7 +3933,7 @@ class TestTaskHooksOnFailure:
             future = my_task.submit()
             return future.wait()
 
-        state = my_flow._run()
+        state = my_flow(return_state=True)
         assert state.type == StateType.FAILED
         assert my_mock.call_args_list == [call("failed1")]
 


### PR DESCRIPTION
Removes all uses of the `._run` interface; this interface simply hard-coded `return_state=True`, which IMO does not justify having more interface surface area to maintain even if it is private.