### PR TITLE
Fix jinja template in automations doc.

### DIFF
--- a/docs/concepts/automations.md
+++ b/docs/concepts/automations.md
@@ -844,7 +844,7 @@ Resource:
 Related Resources:
 {% for related in event.related %}
     Role: {{ related.role }}
-    {% for label, value in event.resource %}
+    {% for label, value in related %}
     {{ label }}: {{ value }}
     {% endfor %}
 {% endfor %}


### PR DESCRIPTION
When using the example in the doc for an email notification automation:

| **Before** | **After** |
| ---- | ---- |
| <img width="816" alt="image" src="https://github.com/PrefectHQ/prefect/assets/22418768/460dfd5c-780f-4e5e-9b58-319ee6fedba6"> | <img width="811" alt="image" src="https://github.com/PrefectHQ/prefect/assets/22418768/0d7d483a-80b2-47fd-801f-ae6f1458a75e"> |

Notice that before, the related resources being rendered are actually all just the top-level resource. 