### PR TITLE
Fix database migrations to run normal-style

### DIFF
--- a/src/prefect/server/database/migrations/env.py
+++ b/src/prefect/server/database/migrations/env.py
@@ -1,6 +1,7 @@
 # Originally generated from `alembic init`
 # https://alembic.sqlalchemy.org/en/latest/tutorial.html#creating-an-environment
 
+import asyncio
 import contextlib
 
 import sqlalchemy
@@ -10,7 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from prefect.server.database.configurations import SQLITE_BEGIN_MODE
 from prefect.server.database.dependencies import provide_database_interface
 from prefect.server.utilities.database import get_dialect
-from prefect.utilities.asyncutils import sync_compatible
 
 db_interface = provide_database_interface()
 config = context.config
@@ -157,7 +157,6 @@ def disable_sqlite_foreign_keys(context):
         context.execute("BEGIN IMMEDIATE")
 
 
-@sync_compatible
 async def apply_migrations() -> None:
     """
     Apply migrations to the database.
@@ -172,4 +171,4 @@ async def apply_migrations() -> None:
 if context.is_offline_mode():
     dry_run_migrations()
 else:
-    apply_migrations()
+    asyncio.run(apply_migrations())

--- a/src/prefect/server/database/migrations/env.py
+++ b/src/prefect/server/database/migrations/env.py
@@ -1,7 +1,6 @@
 # Originally generated from `alembic init`
 # https://alembic.sqlalchemy.org/en/latest/tutorial.html#creating-an-environment
 
-import asyncio
 import contextlib
 
 import sqlalchemy
@@ -11,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from prefect.server.database.configurations import SQLITE_BEGIN_MODE
 from prefect.server.database.dependencies import provide_database_interface
 from prefect.server.utilities.database import get_dialect
+from prefect.utilities.asyncutils import run_sync
 
 db_interface = provide_database_interface()
 config = context.config
@@ -171,4 +171,4 @@ async def apply_migrations() -> None:
 if context.is_offline_mode():
     dry_run_migrations()
 else:
-    asyncio.run(apply_migrations())
+    run_sync(apply_migrations())

--- a/src/prefect/server/database/migrations/env.py
+++ b/src/prefect/server/database/migrations/env.py
@@ -1,6 +1,7 @@
 # Originally generated from `alembic init`
 # https://alembic.sqlalchemy.org/en/latest/tutorial.html#creating-an-environment
 
+import asyncio
 import contextlib
 
 import sqlalchemy
@@ -171,4 +172,8 @@ async def apply_migrations() -> None:
 if context.is_offline_mode():
     dry_run_migrations()
 else:
-    run_sync(apply_migrations())
+    try:
+        loop = asyncio.get_running_loop()
+        loop.run_until_complete(apply_migrations())
+    except RuntimeError:
+        run_sync(apply_migrations())


### PR DESCRIPTION
We run these migration functions as a part of our test suite, and therefore we should not rely on _any_ customized execution utilities such as `sync_compatible`. This creates incredibly hard to debug failure modes in our tests.