### PR TITLE
Lazily instantiate `asyncio.Event` in `EventPersister` for context safety

### DIFF
--- a/src/prefect/server/events/services/event_persister.py
+++ b/src/prefect/server/events/services/event_persister.py
@@ -31,7 +31,19 @@ class EventPersister:
     name: str = "EventLogger"
 
     consumer_task: Optional[asyncio.Task] = None
-    started_event: Optional[asyncio.Event] = asyncio.Event()
+
+    def __init__(self):
+        self._started_event: Optional[asyncio.Event] = None
+
+    @property
+    def started_event(self) -> asyncio.Event:
+        if self._started_event is None:
+            self._started_event = asyncio.Event()
+        return self._started_event
+
+    @started_event.setter
+    def started_event(self, value: asyncio.Event) -> None:
+        self._started_event = value
 
     async def start(self):
         assert self.consumer_task is None, "Event persister already started"


### PR DESCRIPTION
Previously, the `asyncio.Event` was being initialized directly within the class constructor, which was leading to issues in tests, such as 
```bash
RuntimeError("There is no current event loop in thread \'AnyIO worker thread\'.")
```
where event loop wasn't available. 

This PR removes direct instantiation of `asyncio.Event` from the class constructor, and adds a property method `started_event` that initializes the `asyncio.Event` upon first access. It adds a setter method for `started_event` to allow controlled modification in the tests

This hopefully also reduces overhead during class instantiation, only creating the event when needed instead of upon import. This will hopefully prevent runtime errors when this module is imported as part of future tests as well.
<details>
<pre>
        assert flow_run.state
>       assert flow_run.state.is_completed()
E       assert False
E        +  where False = <bound method State.is_completed of Failed(message='Flow could not be retrieved from deployment. ScriptError: Script a...ception: RuntimeError("There is no current event loop in thread \'AnyIO worker thread\'.")', type=FAILED, result=None)>()
E        +    where <bound method State.is_completed of Failed(message='Flow could not be retrieved from deployment. ScriptError: Script a...ception: RuntimeError("There is no current event loop in thread \'AnyIO worker thread\'.")', type=FAILED, result=None)> = Failed(message='Flow could not be retrieved from deployment. ScriptError: Script at \'tests/runner/test_runner.py\' en...xception: RuntimeError("There is no current event loop in thread \'AnyIO worker thread\'.")', type=FAILED, result=None).is_completed
E        +      where Failed(message='Flow could not be retrieved from deployment. ScriptError: Script at \'tests/runner/test_runner.py\' en...xception: RuntimeError("There is no current event loop in thread \'AnyIO worker thread\'.")', type=FAILED, result=None) = FlowRun(id=UUID('aa089f31-b0a9-4c92-9bdd-c860a0c68865'), name='hasty-stallion', flow_id=UUID('79fdf158-a670-4bf3-945d-...yIO worker thread\'.")', type=FAILED, result=None), job_variables={}, state_type=StateType.FAILED, state_name='Failed').state

tests/runner/test_runner.py:1958: AssertionError
---------------------------------------------------------------------------------------------------------------------------- Captured stdout setup ----------------------------------------------------------------------------------------------------------------------------
Generating test database connection URL from 'sqlite+aiosqlite:////var/folders/w4/979gp2bx3td2207pd3fd_vsm0000gn/T/tmpgefa9sjj/prefect.db'
---------------------------------------------------------------------------------------------------------------------------- Captured stderr setup ----------------------------------------------------------------------------------------------------------------------------
22:06:17.382 | DEBUG   | prefect.profiles - Using profile 'default'
22:06:18.219 | INFO    | prefect.server - Distributor service scheduled to start in-app
22:06:18.220 | INFO    | prefect.server - Distributor service stopped!
22:06:18.367 | DEBUG   | prefect.client - Connecting to API at http://localhost:50669/api/
----------------------------------------------------------------------------------------------------------------------------- Captured log setup ------------------------------------------------------------------------------------------------------------------------------
DEBUG    prefect.client:orchestration.py:3251 Connecting to API at http://localhost:50669/api/
---------------------------------------------------------------------------------------------------------------------------- Captured stderr call -----------------------------------------------------------------------------------------------------------------------------
22:06:18.374 | DEBUG   | MainThread   | prefect._internal.concurrency - <function Flow.to_deployment at 0x109a85430> --> return coroutine for user await
22:06:18.375 | DEBUG   | MainThread   | prefect._internal.concurrency - <function Runner.add_deployment at 0x109a9bee0> --> return coroutine for user await
22:06:18.376 | DEBUG   | MainThread   | prefect._internal.concurrency - <function RunnerDeployment.apply at 0x1099c0af0> --> return coroutine for user await
22:06:18.380 | DEBUG   | prefect.client - Connecting to API at http://localhost:50669/api/
22:06:18.450 | DEBUG   | MainThread   | prefect._internal.concurrency - <function Runner.start at 0x109a9e310> --> return coroutine for user await
22:06:18.450 | DEBUG   | prefect.runner - Starting runner...
22:06:18.456 | DEBUG   | prefect.client - Connecting to API at http://localhost:50669/api/
22:06:18.456 | DEBUG   | prefect.utilities.services.critical_service_loop - Starting run of '_get_and_submit_flow_runs'
22:06:18.457 | DEBUG   | prefect.runner - Querying for flow runs scheduled before 2024-05-17T03:06:28.456976+00:00
22:06:18.457 | DEBUG   | prefect.utilities.services.critical_service_loop - Starting run of '_check_for_cancelled_flow_runs'
22:06:18.457 | DEBUG   | prefect.runner - Checking for cancelled flow runs...
22:06:18.480 | DEBUG   | prefect.runner - Discovered 0 scheduled_flow_runs
22:06:18.567 | DEBUG   | prefect.runner - Stopping runner...
22:06:18.568 | INFO    | prefect.runner - Pausing all deployments...
22:06:18.569 | DEBUG   | prefect.runner - Pausing deployment '99242818-8538-434f-8c32-ce6fb6edece1'
22:06:18.605 | INFO    | prefect.runner - All deployments have been paused!
22:06:18.999 | INFO    | prefect.server.api.validation - Cannot validate job variables for deployment 99242818-8538-434f-8c32-ce6fb6edece1 because it does not have a work pool
22:06:19.054 | DEBUG   | MainThread   | prefect._internal.concurrency - <function Runner.start at 0x109a9e310> --> return coroutine for user await
22:06:19.054 | DEBUG   | prefect.runner - Starting runner...
22:06:19.060 | DEBUG   | prefect.client - Connecting to API at http://localhost:50669/api/
22:06:19.061 | DEBUG   | prefect.utilities.services.critical_service_loop - Starting run of '_get_and_submit_flow_runs'
22:06:19.061 | DEBUG   | prefect.runner - Querying for flow runs scheduled before 2024-05-17T03:06:29.061733+00:00
22:06:19.062 | DEBUG   | prefect.utilities.services.critical_service_loop - Starting run of '_check_for_cancelled_flow_runs'
22:06:19.062 | DEBUG   | prefect.runner - Checking for cancelled flow runs...
22:06:19.086 | DEBUG   | prefect.runner - Discovered 1 scheduled_flow_runs
22:06:19.086 | DEBUG   | prefect.runner - Limit slot acquired for flow run 'aa089f31-b0a9-4c92-9bdd-c860a0c68865'
22:06:19.086 | INFO    | prefect.flow_runs.runner - Runner 'runner-bc706fac-3ea3-426b-83d6-8314dc2558c4' submitting flow run 'aa089f31-b0a9-4c92-9bdd-c860a0c68865'
22:06:19.094 | DEBUG   | prefect.runner - Stopping runner...
22:06:19.095 | INFO    | prefect.runner - Pausing all deployments...
22:06:19.095 | DEBUG   | prefect.runner - Pausing deployment '99242818-8538-434f-8c32-ce6fb6edece1'
22:06:19.105 | INFO    | prefect.flow_runs.runner - Opening process...
22:06:19.115 | INFO    | prefect.runner - All deployments have been paused!
22:06:19.117 | INFO    | prefect.flow_runs.runner - Completed submission of flow run 'aa089f31-b0a9-4c92-9bdd-c860a0c68865'
22:06:19.723 | DEBUG   | prefect.profiles - Using profile 'default'
/Users/bean/.pyenv/versions/3.9.13/lib/python3.9/runpy.py:127: RuntimeWarning: 'prefect.engine' found in sys.modules after import of package 'prefect', but prior to execution of 'prefect.engine'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
22:06:19.738 | DEBUG   | MainThread   | prefect._internal.concurrency - Waiter <SyncWaiter call=retrieve_flow_then_begin_flow_run(UUID('aa089f31-b0a9-4c92-9bdd-c860a0c68865'), user_thread=<_MainThread(MainThread, started 868959712...), owner='MainThread'> watching for callbacks
22:06:19.738 | DEBUG   | GlobalEventLoopThread | prefect._internal.concurrency - Running call retrieve_flow_then_begin_flow_run(UUID('aa089f31-b0a9-4c92-9bdd-c860a0c68865'), user_thread=<_MainThread(MainThread, started 868959712...) in thread 'GlobalEventLoopThread'
22:06:19.738 | DEBUG   | GlobalEventLoopThread | prefect._internal.concurrency - <WatcherThreadCancelScope, name='retrieve_flow_then_begin_flow_run' RUNNING, runtime=0.00> entered
22:06:19.738 | DEBUG   | GlobalEventLoopThread | prefect._internal.concurrency - <WatcherThreadCancelScope, name='retrieve_flow_then_begin_flow_run' COMPLETED, runtime=0.00> exited
22:06:19.738 | DEBUG   | GlobalEventLoopThread | prefect._internal.concurrency - Scheduling coroutine for call retrieve_flow_then_begin_flow_run(<dropped>) in running loop <_UnixSelectorEventLoop running=True closed=False debug=False>
22:06:19.738 | DEBUG   | GlobalEventLoopThread | prefect._internal.concurrency - <AsyncCancelScope, name='retrieve_flow_then_begin_flow_run' RUNNING, runtime=0.00> entered
22:06:19.747 | DEBUG   | prefect.client - Connecting to API at http://localhost:50669/api/
22:06:19.764 | INFO    | Flow run 'hasty-stallion' - Downloading flow code from storage at '.'
22:06:19.764 | DEBUG   | GlobalEventLoopThread | prefect._internal.concurrency - <function LocalFileSystem.get_directory at 0x104815d30> --> return coroutine for internal await
22:06:19.764 | DEBUG   | Flow run 'hasty-stallion' - Importing flow code from 'tests/runner/test_runner.py:dummy_flow_1'
22:06:20.380 | ERROR   | Flow run 'hasty-stallion' - Flow could not be retrieved from deployment.
Traceback (most recent call last):
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "tests/runner/test_runner.py", line 46, in <module>
    from prefect.testing.utilities import AsyncMock
  File "/Users/bean/code-oss/prefect/src/prefect/testing/utilities.py", line 21, in <module>
    from prefect.server.database.dependencies import temporary_database_interface
  File "/Users/bean/code-oss/prefect/src/prefect/server/__init__.py", line 1, in <module>
    from . import models, orchestration, schemas, services
  File "/Users/bean/code-oss/prefect/src/prefect/server/services/__init__.py", line 8, in <module>
    import prefect.server.services.task_scheduling
  File "/Users/bean/code-oss/prefect/src/prefect/server/services/task_scheduling.py", line 12, in <module>
    from prefect.server.api.task_runs import TaskQueue
  File "/Users/bean/code-oss/prefect/src/prefect/server/api/__init__.py", line 33, in <module>
    from . import server  # Server relies on all of the above routes
  File "/Users/bean/code-oss/prefect/src/prefect/server/api/server.py", line 40, in <module>
    from prefect.server.events.services.event_persister import EventPersister
  File "/Users/bean/code-oss/prefect/src/prefect/server/events/services/event_persister.py", line 28, in <module>
    class EventPersister:
  File "/Users/bean/code-oss/prefect/src/prefect/server/events/services/event_persister.py", line 34, in EventPersister
    started_event: Optional[asyncio.Event] = asyncio.Event()
  File "/Users/bean/.pyenv/versions/3.9.13/lib/python3.9/asyncio/locks.py", line 177, in __init__
    self._loop = events.get_event_loop()
  File "/Users/bean/.pyenv/versions/3.9.13/lib/python3.9/asyncio/events.py", line 642, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
RuntimeError: There is no current event loop in thread 'AnyIO worker thread'.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/bean/code-oss/prefect/src/prefect/engine.py", line 421, in retrieve_flow_then_begin_flow_run
    else await load_flow_from_flow_run(flow_run, client=client)
  File "/Users/bean/code-oss/prefect/src/prefect/client/utilities.py", line 100, in with_injected_client
    return await fn(*args, **kwargs)
  File "/Users/bean/code-oss/prefect/src/prefect/flows.py", line 1894, in load_flow_from_flow_run
    flow = await run_sync_in_worker_thread(load_flow_from_entrypoint, str(import_path))
  File "/Users/bean/code-oss/prefect/src/prefect/utilities/asyncutils.py", line 136, in run_sync_in_worker_thread
    return await anyio.to_thread.run_sync(
  File "/Users/bean/code-oss/prefect/venv3913/lib/python3.9/site-packages/anyio/to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "/Users/bean/code-oss/prefect/venv3913/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
  File "/Users/bean/code-oss/prefect/venv3913/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 807, in run
    result = context.run(func, *args)
  File "/Users/bean/code-oss/prefect/src/prefect/flows.py", line 1688, in load_flow_from_entrypoint
    flow = import_object(entrypoint)
  File "/Users/bean/code-oss/prefect/src/prefect/utilities/importtools.py", line 201, in import_object
    module = load_script_as_module(script_path)
  File "/Users/bean/code-oss/prefect/src/prefect/utilities/importtools.py", line 164, in load_script_as_module
    raise ScriptError(user_exc=exc, path=path) from exc
prefect.exceptions.ScriptError: Script at 'tests/runner/test_runner.py' encountered an exception: RuntimeError("There is no current event loop in thread 'AnyIO worker thread'.")
22:06:20.404 | DEBUG   | GlobalEventLoopThread | prefect._internal.concurrency - <AsyncCancelScope, name='retrieve_flow_then_begin_flow_run' COMPLETED, runtime=0.67> exited
22:06:20.405 | DEBUG   | GlobalEventLoopThread | prefect._internal.concurrency - Finished async call retrieve_flow_then_begin_flow_run(<dropped>)
22:06:20.648 | INFO    | prefect.flow_runs.runner - Process for flow run 'hasty-stallion' exited cleanly.
22:06:20.648 | DEBUG   | prefect.runner - Limit slot released for flow run 'aa089f31-b0a9-4c92-9bdd-c860a0c68865'
------------------------------------------------------------------------------------------------------------------------------ Captured log call ------------------------------------------------------------------------------------------------------------------------------
DEBUG    prefect.client:orchestration.py:3251 Connecting to API at http://localhost:50669/api/
DEBUG    prefect.runner:runner.py:1157 Starting runner...
DEBUG    prefect.client:orchestration.py:3251 Connecting to API at http://localhost:50669/api/
DEBUG    prefect.utilities.services.critical_service_loop:services.py:59 Starting run of '_get_and_submit_flow_runs'
DEBUG    prefect.runner:runner.py:830 Querying for flow runs scheduled before 2024-05-17T03:06:28.456976+00:00
DEBUG    prefect.utilities.services.critical_service_loop:services.py:59 Starting run of '_check_for_cancelled_flow_runs'
DEBUG    prefect.runner:runner.py:737 Checking for cancelled flow runs...
DEBUG    prefect.runner:runner.py:840 Discovered 0 scheduled_flow_runs
DEBUG    prefect.runner:runner.py:1167 Stopping runner...
INFO     prefect.runner:runner.py:696 Pausing all deployments...
DEBUG    prefect.runner:runner.py:698 Pausing deployment '99242818-8538-434f-8c32-ce6fb6edece1'
INFO     prefect.runner:runner.py:700 All deployments have been paused!
DEBUG    prefect.runner:runner.py:1157 Starting runner...
DEBUG    prefect.client:orchestration.py:3251 Connecting to API at http://localhost:50669/api/
DEBUG    prefect.utilities.services.critical_service_loop:services.py:59 Starting run of '_get_and_submit_flow_runs'
DEBUG    prefect.runner:runner.py:830 Querying for flow runs scheduled before 2024-05-17T03:06:29.061733+00:00
DEBUG    prefect.utilities.services.critical_service_loop:services.py:59 Starting run of '_check_for_cancelled_flow_runs'
DEBUG    prefect.runner:runner.py:737 Checking for cancelled flow runs...
DEBUG    prefect.runner:runner.py:840 Discovered 1 scheduled_flow_runs
DEBUG    prefect.runner:runner.py:862 Limit slot acquired for flow run 'aa089f31-b0a9-4c92-9bdd-c860a0c68865'
INFO     prefect.flow_runs.runner:runner.py:909 Runner 'runner-bc706fac-3ea3-426b-83d6-8314dc2558c4' submitting flow run 'aa089f31-b0a9-4c92-9bdd-c860a0c68865'
DEBUG    prefect.runner:runner.py:1167 Stopping runner...
INFO     prefect.runner:runner.py:696 Pausing all deployments...
DEBUG    prefect.runner:runner.py:698 Pausing deployment '99242818-8538-434f-8c32-ce6fb6edece1'
INFO     prefect.flow_runs.runner:runner.py:549 Opening process...
INFO     prefect.runner:runner.py:700 All deployments have been paused!
INFO     prefect.flow_runs.runner:runner.py:954 Completed submission of flow run 'aa089f31-b0a9-4c92-9bdd-c860a0c68865'
INFO     prefect.flow_runs.runner:runner.py:633 Process for flow run 'hasty-stallion' exited cleanly.
DEBUG    prefect.runner:runner.py:890 Limit slot released for flow run 'aa089f31-b0a9-4c92-9bdd-c860a0c68865'
=========================================================================================================================== short test summary info ===========================================================================================================================
FAILED tests/runner/test_runner.py::TestRunner::test_runner_executes_flow_runs - assert False
</pre>
</details>