### PR TITLE
Creating a Prefect `model_dump_for_orm` extension

### DIFF
--- a/src/prefect/server/events/models/automations.py
+++ b/src/prefect/server/events/models/automations.py
@@ -160,7 +160,7 @@ async def update_automation(
     result = await session.execute(
         sa.update(db.Automation)
         .where(db.Automation.id == automation_id)
-        .values(**automation_update.model_dump(exclude_unset=True))
+        .values(**automation_update.model_dump_for_orm(exclude_unset=True))
     )
 
     if isinstance(automation_update, AutomationUpdate):

--- a/src/prefect/server/models/agents.py
+++ b/src/prefect/server/models/agents.py
@@ -117,7 +117,7 @@ async def update_agent(
         .where(db.Agent.id == agent_id)
         # exclude_unset=True allows us to only update values provided by
         # the user, ignoring any defaults on the model
-        .values(**agent.model_dump(exclude_unset=True))
+        .values(**agent.model_dump_for_orm(exclude_unset=True))
     )
     result = await session.execute(update_stmt)
     return result.rowcount > 0
@@ -157,7 +157,9 @@ async def record_agent_poll(
         )
         .on_conflict_do_update(
             index_elements=[db.Agent.id],
-            set_=agent_data.model_dump(include={"work_queue_id", "last_activity_time"}),
+            set_=agent_data.model_dump_for_orm(
+                include={"work_queue_id", "last_activity_time"}
+            ),
         )
     )
     await session.execute(insert_stmt)

--- a/src/prefect/server/models/artifacts.py
+++ b/src/prefect/server/models/artifacts.py
@@ -20,7 +20,7 @@ async def _insert_into_artifact_collection(
     """
     Inserts a new artifact into the artifact_collection table or updates it.
     """
-    insert_values = artifact.model_dump(
+    insert_values = artifact.model_dump_for_orm(
         exclude_unset=True, exclude={"id", "updated", "created"}
     )
     upsert_new_latest_id = (
@@ -81,7 +81,7 @@ async def _insert_into_artifact(
     insert_stmt = db.insert(db.Artifact).values(
         created=now,
         updated=now,
-        **artifact.model_dump(exclude={"created", "updated"}),
+        **artifact.model_dump_for_orm(exclude={"created", "updated"}),
     )
     await session.execute(insert_stmt)
 
@@ -431,7 +431,7 @@ async def update_artifact(
     Returns:
         bool: True if the update was successful, False otherwise
     """
-    update_artifact_data = artifact.model_dump(exclude_unset=True)
+    update_artifact_data = artifact.model_dump_for_orm(exclude_unset=True)
 
     update_artifact_stmt = (
         sa.update(db.Artifact)
@@ -441,7 +441,7 @@ async def update_artifact(
 
     await session.execute(update_artifact_stmt)
 
-    update_artifact_collection_data = artifact.model_dump(exclude_unset=True)
+    update_artifact_collection_data = artifact.model_dump_for_orm(exclude_unset=True)
     update_artifact_collection_stmt = (
         sa.update(db.ArtifactCollection)
         .where(db.ArtifactCollection.latest_id == artifact_id)

--- a/src/prefect/server/models/block_documents.py
+++ b/src/prefect/server/models/block_documents.py
@@ -480,7 +480,7 @@ async def update_block_document(
     if not current_block_document:
         return False
 
-    update_values = block_document.model_dump(
+    update_values = block_document.model_dump_for_orm(
         exclude_unset=merge_existing_data,
         exclude={"merge_existing_data"},
     )
@@ -628,7 +628,7 @@ async def create_block_document_reference(
     db: PrefectDBInterface,
 ):
     insert_stmt = db.insert(db.BlockDocumentReference).values(
-        **block_document_reference.model_dump(
+        **block_document_reference.model_dump_for_orm(
             exclude_unset=True, exclude={"created", "updated"}
         )
     )

--- a/src/prefect/server/models/block_schemas.py
+++ b/src/prefect/server/models/block_schemas.py
@@ -45,7 +45,7 @@ async def create_block_schema(
     """
     from prefect.blocks.core import Block, _get_non_block_reference_definitions
 
-    insert_values = block_schema.model_dump(
+    insert_values = block_schema.model_dump_for_orm(
         exclude_unset=False,
         exclude={"block_type", "id", "created", "updated"},
     )
@@ -800,7 +800,7 @@ async def create_block_schema_reference(
         return existing_reference
 
     insert_stmt = db.insert(db.BlockSchemaReference).values(
-        **block_schema_reference.model_dump(
+        **block_schema_reference.model_dump_for_orm(
             exclude_unset=True, exclude={"created", "updated"}
         )
     )

--- a/src/prefect/server/models/block_schemas.py
+++ b/src/prefect/server/models/block_schemas.py
@@ -5,11 +5,12 @@ Intended for internal use by the Prefect REST API.
 
 import json
 from copy import copy
-from typing import Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server import schemas
 from prefect.server.database.dependencies import inject_db
@@ -17,6 +18,12 @@ from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.models.block_types import read_block_type_by_slug
 from prefect.server.schemas.actions import BlockSchemaCreate
 from prefect.server.schemas.core import BlockSchema, BlockSchemaReference, BlockType
+from prefect.settings import PREFECT_TEST_MODE
+
+if TYPE_CHECKING:
+    from prefect.client.schemas.actions import (
+        BlockSchemaCreate as ClientBlockSchemaCreate,
+    )
 
 
 class MissingBlockTypeException(Exception):
@@ -25,8 +32,8 @@ class MissingBlockTypeException(Exception):
 
 @inject_db
 async def create_block_schema(
-    session: sa.orm.Session,
-    block_schema: schemas.actions.BlockSchemaCreate,
+    session: AsyncSession,
+    block_schema: Union[schemas.actions.BlockSchemaCreate, "ClientBlockSchemaCreate"],
     db: PrefectDBInterface,
     override: bool = False,
     definitions: Optional[Dict] = None,
@@ -44,6 +51,19 @@ async def create_block_schema(
         block_schema: an ORM block schema model
     """
     from prefect.blocks.core import Block, _get_non_block_reference_definitions
+
+    # We take a shortcut in many unit tests to pass client models directly to
+    # this function.  We will support this (only in unit tests) by converting them
+    # to the appropriate server model.
+    if not isinstance(block_schema, schemas.actions.BlockSchemaCreate):
+        if not PREFECT_TEST_MODE.value():
+            raise ValueError("block_schema must be a server model")
+        block_schema = schemas.actions.BlockSchemaCreate.model_validate(
+            block_schema.model_dump(
+                mode="json",
+                exclude={"id", "created", "updated", "checksum", "block_type"},
+            )
+        )
 
     insert_values = block_schema.model_dump_for_orm(
         exclude_unset=False,
@@ -131,7 +151,7 @@ async def create_block_schema(
 
 
 async def _register_nested_block_schemas(
-    session: sa.orm.Session,
+    session: AsyncSession,
     parent_block_schema_id: UUID,
     block_schema_references: Dict[str, Union[Dict[str, str], List[Dict[str, str]]]],
     base_fields: Dict,
@@ -256,7 +276,7 @@ def _get_fields_for_child_schema(
 
 @inject_db
 async def delete_block_schema(
-    session: sa.orm.Session, block_schema_id: UUID, db: PrefectDBInterface
+    session: AsyncSession, block_schema_id: UUID, db: PrefectDBInterface
 ) -> bool:
     """
     Delete a block schema by id.
@@ -277,7 +297,7 @@ async def delete_block_schema(
 
 @inject_db
 async def read_block_schema(
-    session: sa.orm.Session,
+    session: AsyncSession,
     block_schema_id: UUID,
     db: PrefectDBInterface,
 ):
@@ -557,7 +577,7 @@ def _construct_block_schema_fields_with_block_references(
 
 @inject_db
 async def read_block_schemas(
-    session: sa.orm.Session,
+    session: AsyncSession,
     db: PrefectDBInterface,
     block_schema_filter: Optional[schemas.filters.BlockSchemaFilter] = None,
     limit: Optional[int] = None,
@@ -670,7 +690,7 @@ async def read_block_schemas(
 
 @inject_db
 async def read_block_schema_by_checksum(
-    session: sa.orm.Session,
+    session: AsyncSession,
     checksum: str,
     db: PrefectDBInterface,
     version: Optional[str] = None,
@@ -751,7 +771,7 @@ async def read_block_schema_by_checksum(
 
 @inject_db
 async def read_available_block_capabilities(
-    session: sa.orm.Session, db: PrefectDBInterface
+    session: AsyncSession, db: PrefectDBInterface
 ) -> List[str]:
     """
     Retrieves a list of all available block capabilities.
@@ -773,7 +793,7 @@ async def read_available_block_capabilities(
 
 @inject_db
 async def create_block_schema_reference(
-    session: sa.orm.Session,
+    session: AsyncSession,
     block_schema_reference: schemas.core.BlockSchemaReference,
     db: PrefectDBInterface,
 ):

--- a/src/prefect/server/models/block_types.py
+++ b/src/prefect/server/models/block_types.py
@@ -34,7 +34,7 @@ async def create_block_type(
     Returns:
         block_type: an ORM block type model
     """
-    insert_values = block_type.model_dump(
+    insert_values = block_type.model_dump_for_orm(
         exclude_unset=False, exclude={"created", "updated", "id"}
     )
     if insert_values.get("description") is not None:
@@ -167,7 +167,7 @@ async def update_block_type(
     update_statement = (
         sa.update(db.BlockType)
         .where(db.BlockType.id == block_type_id)
-        .values(**block_type.model_dump(exclude_unset=True, exclude={"id"}))
+        .values(**block_type.model_dump_for_orm(exclude_unset=True, exclude={"id"}))
     )
     result = await session.execute(update_statement)
     return result.rowcount > 0

--- a/src/prefect/server/models/concurrency_limits.py
+++ b/src/prefect/server/models/concurrency_limits.py
@@ -20,7 +20,7 @@ async def create_concurrency_limit(
     concurrency_limit: schemas.core.ConcurrencyLimit,
     db: PrefectDBInterface,
 ):
-    insert_values = concurrency_limit.model_dump(exclude_unset=False)
+    insert_values = concurrency_limit.model_dump_for_orm(exclude_unset=False)
     insert_values.pop("created")
     insert_values.pop("updated")
     concurrency_tag = insert_values["tag"]
@@ -35,7 +35,9 @@ async def create_concurrency_limit(
         .values(**insert_values)
         .on_conflict_do_update(
             index_elements=db.concurrency_limit_unique_upsert_columns,
-            set_=concurrency_limit.model_dump(include={"concurrency_limit", "updated"}),
+            set_=concurrency_limit.model_dump_for_orm(
+                include={"concurrency_limit", "updated"}
+            ),
         )
     )
 

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -83,7 +83,9 @@ async def create_deployment(
     deployment.updated = pendulum.now("UTC")
 
     schedules = deployment.schedules
-    insert_values = deployment.model_dump(exclude_unset=True, exclude={"schedules"})
+    insert_values = deployment.model_dump_for_orm(
+        exclude_unset=True, exclude={"schedules"}
+    )
 
     # The job_variables field in client and server schemas is named
     # infra_overrides in the database.
@@ -91,7 +93,7 @@ async def create_deployment(
     if job_variables:
         insert_values["infra_overrides"] = job_variables
 
-    conflict_update_fields = deployment.model_dump(
+    conflict_update_fields = deployment.model_dump_for_orm(
         exclude_unset=True,
         exclude={"id", "created", "created_by", "schedules", "job_variables"},
     )
@@ -186,7 +188,7 @@ async def update_deployment(
 
     # exclude_unset=True allows us to only update values provided by
     # the user, ignoring any defaults on the model
-    update_data = deployment.model_dump(
+    update_data = deployment.model_dump_for_orm(
         exclude_unset=True,
         exclude={"work_pool_name"},
     )

--- a/src/prefect/server/models/flow_run_notification_policies.py
+++ b/src/prefect/server/models/flow_run_notification_policies.py
@@ -127,7 +127,7 @@ async def update_flow_run_notification_policy(
     """
     # exclude_unset=True allows us to only update values provided by
     # the user, ignoring any defaults on the model
-    update_data = flow_run_notification_policy.model_dump(exclude_unset=True)
+    update_data = flow_run_notification_policy.model_dump_for_orm(exclude_unset=True)
 
     update_stmt = (
         sa.update(db.FlowRunNotificationPolicy)

--- a/src/prefect/server/models/flow_runs.py
+++ b/src/prefect/server/models/flow_runs.py
@@ -59,7 +59,7 @@ async def create_flow_run(
     now = pendulum.now("UTC")
 
     flow_run_dict = dict(
-        **flow_run.model_dump(
+        **flow_run.model_dump_for_orm(
             exclude={
                 "created",
                 "state",
@@ -142,7 +142,7 @@ async def update_flow_run(
         .where(db.FlowRun.id == flow_run_id)
         # exclude_unset=True allows us to only update values provided by
         # the user, ignoring any defaults on the model
-        .values(**flow_run.model_dump(exclude_unset=True))
+        .values(**flow_run.model_dump_for_orm(exclude_unset=True))
     )
     result = await session.execute(update_stmt)
     return result.rowcount > 0

--- a/src/prefect/server/models/flows.py
+++ b/src/prefect/server/models/flows.py
@@ -41,7 +41,7 @@ async def create_flow(
 
     insert_stmt = (
         db.insert(db.Flow)
-        .values(**flow.model_dump(exclude_unset=True))
+        .values(**flow.model_dump_for_orm(exclude_unset=True))
         .on_conflict_do_nothing(
             index_elements=db.flow_unique_upsert_columns,
         )
@@ -84,7 +84,7 @@ async def update_flow(
         .where(db.Flow.id == flow_id)
         # exclude_unset=True allows us to only update values provided by
         # the user, ignoring any defaults on the model
-        .values(**flow.model_dump(exclude_unset=True))
+        .values(**flow.model_dump_for_orm(exclude_unset=True))
     )
     result = await session.execute(update_stmt)
     return result.rowcount > 0

--- a/src/prefect/server/models/saved_searches.py
+++ b/src/prefect/server/models/saved_searches.py
@@ -35,10 +35,10 @@ async def create_saved_search(
 
     insert_stmt = (
         db.insert(db.SavedSearch)
-        .values(**saved_search.model_dump(exclude_unset=True))
+        .values(**saved_search.model_dump_for_orm(exclude_unset=True))
         .on_conflict_do_update(
             index_elements=db.saved_search_unique_upsert_columns,
-            set_=saved_search.model_dump(include={"filters"}),
+            set_=saved_search.model_dump_for_orm(include={"filters"}),
         )
     )
 

--- a/src/prefect/server/models/task_runs.py
+++ b/src/prefect/server/models/task_runs.py
@@ -60,7 +60,9 @@ async def create_task_run(
             db.insert(db.TaskRun)
             .values(
                 created=now,
-                **task_run.model_dump(exclude={"state", "created"}, exclude_unset=True),
+                **task_run.model_dump_for_orm(
+                    exclude={"state", "created"}, exclude_unset=True
+                ),
             )
             .on_conflict_do_nothing(
                 index_elements=db.task_run_unique_upsert_columns,
@@ -103,7 +105,9 @@ async def create_task_run(
         if model is None:
             model = db.TaskRun(
                 created=now,
-                **task_run.model_dump(exclude={"state", "created"}, exclude_unset=True),
+                **task_run.model_dump_for_orm(
+                    exclude={"state", "created"}, exclude_unset=True
+                ),
                 state=None,
             )
             session.add(model)
@@ -143,7 +147,7 @@ async def update_task_run(
         .where(db.TaskRun.id == task_run_id)
         # exclude_unset=True allows us to only update values provided by
         # the user, ignoring any defaults on the model
-        .values(**task_run.model_dump(exclude_unset=True))
+        .values(**task_run.model_dump_for_orm(exclude_unset=True))
     )
     result = await session.execute(update_stmt)
     return result.rowcount > 0

--- a/src/prefect/server/models/variables.py
+++ b/src/prefect/server/models/variables.py
@@ -126,7 +126,7 @@ async def update_variable(
     query = (
         sa.update(db.Variable)
         .where(db.Variable.id == variable_id)
-        .values(**variable.model_dump(exclude_unset=True))
+        .values(**variable.model_dump_for_orm(exclude_unset=True))
     )
 
     result = await session.execute(query)
@@ -146,7 +146,7 @@ async def update_variable_by_name(
     query = (
         sa.update(db.Variable)
         .where(db.Variable.name == name)
-        .values(**variable.model_dump(exclude_unset=True))
+        .values(**variable.model_dump_for_orm(exclude_unset=True))
     )
 
     result = await session.execute(query)

--- a/src/prefect/server/models/work_queues.py
+++ b/src/prefect/server/models/work_queues.py
@@ -231,7 +231,7 @@ async def update_work_queue(
     """
     # exclude_unset=True allows us to only update values provided by
     # the user, ignoring any defaults on the model
-    update_data = work_queue.model_dump(exclude_unset=True)
+    update_data = work_queue.model_dump_for_orm(exclude_unset=True)
 
     if "is_paused" in update_data:
         wq = await read_work_queue(session=session, work_queue_id=work_queue_id)

--- a/src/prefect/server/models/workers.py
+++ b/src/prefect/server/models/workers.py
@@ -210,7 +210,7 @@ async def update_work_pool(
     """
     # exclude_unset=True allows us to only update values provided by
     # the user, ignoring any defaults on the model
-    update_data = work_pool.model_dump(exclude_unset=True)
+    update_data = work_pool.model_dump_for_orm(exclude_unset=True)
 
     current_work_pool = await read_work_pool(session=session, work_pool_id=work_pool_id)
     if not current_work_pool:
@@ -584,7 +584,7 @@ async def update_work_queue(
     """
     from prefect.server.models.work_queues import is_last_polled_recent
 
-    update_values = work_queue.model_dump(exclude_unset=True)
+    update_values = work_queue.model_dump_for_orm(exclude_unset=True)
 
     if "is_paused" in update_values:
         if (wq := await session.get(db.WorkQueue, work_queue_id)) is None:

--- a/src/prefect/server/orchestration/rules.py
+++ b/src/prefect/server/orchestration/rules.py
@@ -269,7 +269,7 @@ class FlowOrchestrationContext(OrchestrationContext):
                 else None
             )
         else:
-            state_payload = self.proposed_state.model_dump()
+            state_payload = self.proposed_state.model_dump_for_orm()
             state_data = state_payload.pop("data", None)
 
             if state_data is not None and not (
@@ -423,7 +423,7 @@ class TaskOrchestrationContext(OrchestrationContext):
                 else None
             )
         else:
-            state_payload = self.proposed_state.model_dump()
+            state_payload = self.proposed_state.model_dump_for_orm()
             state_data = state_payload.pop("data", None)
 
             if state_data is not None and not (

--- a/tests/server/api/test_task_run_subscriptions.py
+++ b/tests/server/api/test_task_run_subscriptions.py
@@ -13,6 +13,7 @@ from starlette.testclient import TestClient, WebSocketTestSession
 from prefect.client.schemas import TaskRun
 from prefect.server import models
 from prefect.server.api import task_runs
+from prefect.server.schemas.core import TaskRun as ServerTaskRun
 from prefect.settings import (
     PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
     temporary_settings,
@@ -253,11 +254,11 @@ async def preexisting_runs(
     stored_runA = TaskRun.from_orm(
         await models.task_runs.create_task_run(
             session,
-            TaskRun(
+            ServerTaskRun(
                 flow_run_id=None,
                 task_key="mytasks.taskA",
                 dynamic_key="mytasks.taskA-1",
-                state=Scheduled(),
+                state=Scheduled().model_dump(exclude={"created", "updated"}),
             ),
         )
     )
@@ -265,11 +266,11 @@ async def preexisting_runs(
     stored_runB = TaskRun.from_orm(
         await models.task_runs.create_task_run(
             session,
-            TaskRun(
+            ServerTaskRun(
                 flow_run_id=None,
                 task_key="mytasks.taskA",
                 dynamic_key="mytasks.taskA-2",
-                state=Scheduled(),
+                state=Scheduled().model_dump(exclude={"created", "updated"}),
             ),
         )
     )


### PR DESCRIPTION
This replaces our previous uses of `.dict(shallow=True)`, where we want to
preserve nested `BaseModel` instances in fields.  Our ORM layer is able to
understand Pydantic columns, so we generally want to always work in terms of
base models with it.  Pydantic v1's `.dict` and v2's `.model_dump` both dump
recursively through the whole object graph, so we had previously introduced
an extension `shallow=True`.

We now know how fragile it can get if we're adding new `kwargs` to well-known
Pydantic methods, so our new approach is to add special-purpose methods for
Prefect-specific behavior.



```
class Engine(BaseModel):
    cylinders: int
    volume: float

class Car(BaseModel):
    model: str
    make: str
    year: int
    engine: Engine
```

`.model_dump(mode="python")`
```python
{
  "model": "Liberty",
  "make": "Jeep",
  "year": 2012,
  "engine": {
    "cylinders": 6,
    "volume": 400.0
  }
}
```

`.model_dump_for_orm()`
```python
{
  "model": "Liberty",
  "make": "Jeep",
  "year": 2012,
  "engine": Engine(cylinders=6, volume=400.0)
}
```