### PR TITLE
Remove `prefect-agent` as a possible work pool type

### DIFF
--- a/src/prefect/server/api/collections.py
+++ b/src/prefect/server/api/collections.py
@@ -54,8 +54,12 @@ async def get_collection_view(view: str):
             resp = await client.get(KNOWN_VIEWS[view])
             resp.raise_for_status()
 
-            GLOBAL_COLLECTIONS_VIEW_CACHE[view] = resp.json()
-            return resp.json()
+            data = resp.json()
+            if view == "aggregate-worker-metadata":
+                data["prefect"].pop("prefect-agent", None)
+
+            GLOBAL_COLLECTIONS_VIEW_CACHE[view] = data
+            return data
     except Exception:
         local_file = Path(__file__).parent / Path(f"collections_data/views/{view}.json")
         if await local_file.exists():

--- a/src/prefect/server/api/collections.py
+++ b/src/prefect/server/api/collections.py
@@ -56,7 +56,7 @@ async def get_collection_view(view: str):
 
             data = resp.json()
             if view == "aggregate-worker-metadata":
-                data["prefect"].pop("prefect-agent", None)
+                data.get("prefect", {}).pop("prefect-agent", None)
 
             GLOBAL_COLLECTIONS_VIEW_CACHE[view] = data
             return data

--- a/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
+++ b/src/prefect/server/api/collections_data/views/aggregate-worker-metadata.json
@@ -1,14 +1,5 @@
 {
   "prefect": {
-    "prefect-agent": {
-      "type": "prefect-agent",
-      "documentation_url": "https://docs.prefect.io/latest/concepts/work-pools/#agent-overview",
-      "display_name": "Prefect Agent",
-      "logo_url": "https://cdn.sanity.io/images/3ugk85nk/production/c771bb53894c877e169c8db158c5598558b8f175-24x24.svg",
-      "install_command": "pip install prefect",
-      "default_base_job_configuration": {},
-      "description": "Execute flow runs on heterogeneous infrastructure using infrastructure blocks."
-    },
     "process": {
       "default_base_job_configuration": {
         "job_configuration": {

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -57,7 +57,7 @@ class TestCreate:
         pool_name = "my-pool"
         res = await run_sync_in_worker_thread(
             invoke_and_assert,
-            f"work-pool create {pool_name} -t prefect-agent",
+            f"work-pool create {pool_name} -t process",
         )
         assert res.exit_code == 0
         assert f"Created work pool {pool_name!r}" in res.output
@@ -114,7 +114,7 @@ class TestCreate:
     ):
         await run_sync_in_worker_thread(
             invoke_and_assert,
-            "work-pool create '' -t prefect-agent",
+            "work-pool create '' -t process",
             expected_code=1,
             expected_output_contains=["name cannot be empty"],
         )
@@ -126,13 +126,13 @@ class TestCreate:
         pool_name = "my-pool"
         await run_sync_in_worker_thread(
             invoke_and_assert,
-            f"work-pool create {pool_name} -t prefect-agent",
+            f"work-pool create {pool_name} -t process",
             expected_code=0,
             expected_output_contains=[f"Created work pool {pool_name!r}"],
         )
         await run_sync_in_worker_thread(
             invoke_and_assert,
-            f"work-pool create {pool_name} -t prefect-agent",
+            f"work-pool create {pool_name} -t process",
             expected_code=1,
             expected_output_contains=[
                 f"Work pool named {pool_name!r} already exists. Please try creating"
@@ -145,7 +145,7 @@ class TestCreate:
         pool_name = "my-pool"
         res = await run_sync_in_worker_thread(
             invoke_and_assert,
-            f"work-pool create {pool_name} -t prefect-agent",
+            f"work-pool create {pool_name} -t process",
         )
         assert res.exit_code == 0
         client_res = await prefect_client.read_work_pool(pool_name)
@@ -156,7 +156,7 @@ class TestCreate:
         pool_name = "my-pool"
         res = await run_sync_in_worker_thread(
             invoke_and_assert,
-            f"work-pool create {pool_name} -t prefect-agent",
+            f"work-pool create {pool_name} -t process",
         )
         assert res.exit_code == 0
         client_res = await prefect_client.read_work_pool(pool_name)
@@ -167,7 +167,7 @@ class TestCreate:
         pool_name = "my-pool"
         res = await run_sync_in_worker_thread(
             invoke_and_assert,
-            f"work-pool create {pool_name} --paused -t prefect-agent",
+            f"work-pool create {pool_name} --paused -t process",
         )
         assert res.exit_code == 0
         client_res = await prefect_client.read_work_pool(pool_name)
@@ -239,7 +239,7 @@ class TestCreate:
         )
         client_res = await prefect_client.read_work_pool(work_pool_name)
         assert client_res.name == work_pool_name
-        assert client_res.type == "prefect-agent"
+        assert client_res.type == "fake"
         assert isinstance(client_res, WorkPool)
 
     @pytest.mark.usefixtures("interactive_console", "mock_collection_registry")
@@ -254,7 +254,7 @@ class TestCreate:
         )
         client_res = await prefect_client.read_work_pool(work_pool_name)
         assert client_res.name == work_pool_name
-        assert client_res.type == "fake"
+        assert client_res.type == "cloud-run:push"
         assert isinstance(client_res, WorkPool)
 
     @pytest.mark.usefixtures("mock_collection_registry")

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -57,13 +57,13 @@ class TestCreate:
         pool_name = "my-pool"
         res = await run_sync_in_worker_thread(
             invoke_and_assert,
-            f"work-pool create {pool_name} -t process",
+            f"work-pool create {pool_name} -t fake",
         )
         assert res.exit_code == 0
         assert f"Created work pool {pool_name!r}" in res.output
         client_res = await prefect_client.read_work_pool(pool_name)
         assert client_res.name == pool_name
-        assert client_res.base_job_template == {}
+        assert client_res.base_job_template == FAKE_DEFAULT_BASE_JOB_TEMPLATE
         assert isinstance(client_res, WorkPool)
 
     @pytest.mark.usefixtures("mock_collection_registry")
@@ -145,11 +145,11 @@ class TestCreate:
         pool_name = "my-pool"
         res = await run_sync_in_worker_thread(
             invoke_and_assert,
-            f"work-pool create {pool_name} -t process",
+            f"work-pool create {pool_name} -t fake",
         )
         assert res.exit_code == 0
         client_res = await prefect_client.read_work_pool(pool_name)
-        assert client_res.base_job_template == dict()
+        assert client_res.base_job_template == FAKE_DEFAULT_BASE_JOB_TEMPLATE
 
     @pytest.mark.usefixtures("mock_collection_registry")
     async def test_default_paused(self, prefect_client):

--- a/tests/fixtures/collections_registry.py
+++ b/tests/fixtures/collections_registry.py
@@ -393,14 +393,6 @@ def mock_collection_registry(
     k8s_default_base_job_template,
 ):
     mock_body = {
-        "prefect": {
-            "prefect-agent": {
-                "type": "prefect-agent",
-                "default_base_job_configuration": {},
-                "display_name": "Prefect Agent",
-                "description": "A Prefect Agent pool.",
-            }
-        },
         "prefect-fake": {
             "fake": {
                 "type": "fake",

--- a/tests/workers/test_utilities.py
+++ b/tests/workers/test_utilities.py
@@ -50,7 +50,6 @@ class TestGetAvailableWorkPoolTypes:
             "fake",
             "faker",
             "kubernetes",
-            "prefect-agent",
             "process",
         ]
 
@@ -74,7 +73,6 @@ class TestGetAvailableWorkPoolTypes:
             "docker",
             "ecs",
             "kubernetes",
-            "prefect-agent",
             "process",
             "vertex-ai",
         }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Removes `prefect-agent` as a selectable work pool type. `PrefectAgent` has been removed for the 3.0 release, so this is no longer needed. The collection registry will still contain data for the `prefect-agent` work pool type until `PrefectAgent` is removed from the 2.x line.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
