### PR TITLE
Replace `declarative_mixin` with `DeclarativeBase` for all models

### DIFF
--- a/src/prefect/server/api/ui/task_runs.py
+++ b/src/prefect/server/api/ui/task_runs.py
@@ -194,7 +194,6 @@ async def read_task_run_counts_by_state(
     async with db.session_context(begin_transaction=False) as session:
         return await models.task_runs.count_task_runs_by_state(
             session=session,
-            db=db,
             flow_filter=flows,
             flow_run_filter=flow_runs,
             task_run_filter=task_runs,

--- a/src/prefect/server/database/interface.py
+++ b/src/prefect/server/database/interface.py
@@ -4,9 +4,9 @@ from contextlib import asynccontextmanager
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+from prefect.server.database import orm_models
 from prefect.server.database.alembic_commands import alembic_downgrade, alembic_upgrade
 from prefect.server.database.configurations import BaseDatabaseConfiguration
-from prefect.server.database.orm_models import BaseORMConfiguration
 from prefect.server.database.query_components import BaseQueryComponents
 from prefect.server.utilities.database import get_dialect
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
@@ -45,7 +45,7 @@ class PrefectDBInterface(metaclass=DBSingleton):
         self,
         database_config: BaseDatabaseConfiguration,
         query_components: BaseQueryComponents,
-        orm: BaseORMConfiguration,
+        orm: orm_models.BaseORMConfiguration,
     ):
         self.database_config = database_config
         self.queries = query_components
@@ -127,187 +127,187 @@ class PrefectDBInterface(metaclass=DBSingleton):
     @property
     def Base(self):
         """Base class for orm models"""
-        return self.orm.Base
+        return orm_models.Base
 
     @property
     def Flow(self):
         """A flow orm model"""
-        return self.orm.Flow
+        return orm_models.Flow
 
     @property
     def FlowRun(self):
         """A flow run orm model"""
-        return self.orm.FlowRun
+        return orm_models.FlowRun
 
     @property
     def FlowRunState(self):
         """A flow run state orm model"""
-        return self.orm.FlowRunState
+        return orm_models.FlowRunState
 
     @property
     def TaskRun(self):
         """A task run orm model"""
-        return self.orm.TaskRun
+        return orm_models.TaskRun
 
     @property
     def TaskRunState(self):
         """A task run state orm model"""
-        return self.orm.TaskRunState
+        return orm_models.TaskRunState
 
     @property
     def Artifact(self):
         """An artifact orm model"""
-        return self.orm.Artifact
+        return orm_models.Artifact
 
     @property
     def ArtifactCollection(self):
         """An artifact collection orm model"""
-        return self.orm.ArtifactCollection
+        return orm_models.ArtifactCollection
 
     @property
     def TaskRunStateCache(self):
         """A task run state cache orm model"""
-        return self.orm.TaskRunStateCache
+        return orm_models.TaskRunStateCache
 
     @property
     def Deployment(self):
         """A deployment orm model"""
-        return self.orm.Deployment
+        return orm_models.Deployment
 
     @property
     def DeploymentSchedule(self):
         """A deployment schedule orm model"""
-        return self.orm.DeploymentSchedule
+        return orm_models.DeploymentSchedule
 
     @property
     def SavedSearch(self):
         """A saved search orm model"""
-        return self.orm.SavedSearch
+        return orm_models.SavedSearch
 
     @property
     def WorkPool(self):
         """A work pool orm model"""
-        return self.orm.WorkPool
+        return orm_models.WorkPool
 
     @property
     def Worker(self):
         """A worker process orm model"""
-        return self.orm.Worker
+        return orm_models.Worker
 
     @property
     def Log(self):
         """A log orm model"""
-        return self.orm.Log
+        return orm_models.Log
 
     @property
     def ConcurrencyLimit(self):
         """A concurrency model"""
-        return self.orm.ConcurrencyLimit
+        return orm_models.ConcurrencyLimit
 
     @property
     def ConcurrencyLimitV2(self):
         """A v2 concurrency model"""
-        return self.orm.ConcurrencyLimitV2
+        return orm_models.ConcurrencyLimitV2
 
     @property
     def CsrfToken(self):
         """A csrf token model"""
-        return self.orm.CsrfToken
+        return orm_models.CsrfToken
 
     @property
     def WorkQueue(self):
         """A work queue model"""
-        return self.orm.WorkQueue
+        return orm_models.WorkQueue
 
     @property
     def Agent(self):
         """An agent model"""
-        return self.orm.Agent
+        return orm_models.Agent
 
     @property
     def BlockType(self):
         """A block type model"""
-        return self.orm.BlockType
+        return orm_models.BlockType
 
     @property
     def BlockSchema(self):
         """A block schema model"""
-        return self.orm.BlockSchema
+        return orm_models.BlockSchema
 
     @property
     def BlockSchemaReference(self):
         """A block schema reference model"""
-        return self.orm.BlockSchemaReference
+        return orm_models.BlockSchemaReference
 
     @property
     def BlockDocument(self):
         """A block document model"""
-        return self.orm.BlockDocument
+        return orm_models.BlockDocument
 
     @property
     def BlockDocumentReference(self):
         """A block document reference model"""
-        return self.orm.BlockDocumentReference
+        return orm_models.BlockDocumentReference
 
     @property
     def FlowRunNotificationPolicy(self):
         """A flow run notification policy model"""
-        return self.orm.FlowRunNotificationPolicy
+        return orm_models.FlowRunNotificationPolicy
 
     @property
     def FlowRunNotificationQueue(self):
         """A flow run notification queue model"""
-        return self.orm.FlowRunNotificationQueue
+        return orm_models.FlowRunNotificationQueue
 
     @property
     def Configuration(self):
         """An configuration model"""
-        return self.orm.Configuration
+        return orm_models.Configuration
 
     @property
     def Variable(self):
         """A variable model"""
-        return self.orm.Variable
+        return orm_models.Variable
 
     @property
     def FlowRunInput(self):
         """A flow run input model"""
-        return self.orm.FlowRunInput
+        return orm_models.FlowRunInput
 
     @property
     def Automation(self):
         """An automation model"""
-        return self.orm.Automation
+        return orm_models.Automation
 
     @property
     def AutomationBucket(self):
         """An automation bucket model"""
-        return self.orm.AutomationBucket
+        return orm_models.AutomationBucket
 
     @property
     def AutomationRelatedResource(self):
         """An automation related resource model"""
-        return self.orm.AutomationRelatedResource
+        return orm_models.AutomationRelatedResource
 
     @property
     def CompositeTriggerChildFiring(self):
         """A model capturing a composite trigger's child firing"""
-        return self.orm.CompositeTriggerChildFiring
+        return orm_models.CompositeTriggerChildFiring
 
     @property
     def AutomationEventFollower(self):
         """A model capturing one event following another event"""
-        return self.orm.AutomationEventFollower
+        return orm_models.AutomationEventFollower
 
     @property
     def Event(self):
         """An event model"""
-        return self.orm.Event
+        return orm_models.Event
 
     @property
     def EventResource(self):
         """An event resource model"""
-        return self.orm.EventResource
+        return orm_models.EventResource
 
     @property
     def deployment_unique_upsert_columns(self):
@@ -380,8 +380,8 @@ class PrefectDBInterface(metaclass=DBSingleton):
         """Given a list of flow run ids and associated states, set the state_id
         to the appropriate state for all flow runs"""
         return self.queries.set_state_id_on_inserted_flow_runs_statement(
-            self.FlowRun,
-            self.FlowRunState,
+            orm_models.FlowRun,
+            orm_models.FlowRunState,
             inserted_flow_run_ids,
             insert_flow_run_states,
         )
@@ -403,14 +403,12 @@ class PrefectDBInterface(metaclass=DBSingleton):
         self, session: sa.orm.Session, limit: int
     ):
         return await self.queries.get_flow_run_notifications_from_queue(
-            session=session, db=self, limit=limit
+            session=session, limit=limit
         )
 
     async def read_configuration_value(self, session: sa.orm.Session, key: str):
         """Read a configuration value"""
-        return await self.queries.read_configuration_value(
-            db=self, session=session, key=key
-        )
+        return await self.queries.read_configuration_value(session=session, key=key)
 
     def clear_configuration_value_cache_for_key(self, key: str):
         """Removes a configuration key from the cache."""

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -9,9 +9,9 @@ import sqlalchemy as sa
 from sqlalchemy import FetchedValue
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import (
-    as_declarative,
-    declarative_mixin,
+    DeclarativeBase,
     declared_attr,
+    registry,
     synonym,
 )
 from sqlalchemy.sql.expression import ColumnElement
@@ -47,11 +47,41 @@ from prefect.server.utilities.encryption import decrypt_fernet, encrypt_fernet
 from prefect.utilities.names import generate_slug
 
 
-class ORMBase:
+class Base(DeclarativeBase):
     """
     Base SQLAlchemy model that automatically infers the table name
     and provides ID, created, and updated columns
     """
+
+    registry = registry(
+        metadata=sa.schema.MetaData(
+            # define naming conventions for our Base class to use
+            # sqlalchemy will use the following templated strings
+            # to generate the names of indices, constraints, and keys
+            #
+            # we offset the table name with two underscores (__) to
+            # help differentiate, for example, between "flow_run.state_type"
+            # and "flow_run_state.type".
+            #
+            # more information on this templating and available
+            # customization can be found here
+            # https://docs.sqlalchemy.org/en/14/core/metadata.html#sqlalchemy.schema.MetaData
+            #
+            # this also allows us to avoid having to specify names explicitly
+            # when using sa.ForeignKey.use_alter = True
+            # https://docs.sqlalchemy.org/en/14/core/constraints.html
+            naming_convention={
+                "ix": "ix_%(table_name)s__%(column_0_N_name)s",
+                "uq": "uq_%(table_name)s__%(column_0_N_name)s",
+                "ck": "ck_%(table_name)s__%(constraint_name)s",
+                "fk": "fk_%(table_name)s__%(column_0_N_name)s__%(referred_table_name)s",
+                "pk": "pk_%(table_name)s",
+            }
+        ),
+        type_annotation_map={
+            uuid.UUID: UUID,
+        },
+    )
 
     # required in order to access columns with server defaults
     # or SQL expression defaults, subsequent to a flush, without
@@ -103,37 +133,27 @@ class ORMBase:
     )
 
 
-@declarative_mixin
-class ORMFlow:
+class Flow(Base):
     """SQLAlchemy mixin of a flow."""
 
     name = sa.Column(sa.String, nullable=False)
     tags = sa.Column(JSON, server_default="[]", default=list, nullable=False)
 
-    @declared_attr
-    def flow_runs(cls):
-        return sa.orm.relationship("FlowRun", back_populates="flow", lazy="raise")
+    flow_runs = sa.orm.relationship("FlowRun", back_populates="flow", lazy="raise")
+    deployments = sa.orm.relationship("Deployment", back_populates="flow", lazy="raise")
 
-    @declared_attr
-    def deployments(cls):
-        return sa.orm.relationship("Deployment", back_populates="flow", lazy="raise")
-
-    @declared_attr
-    def __table_args__(cls):
-        return (sa.UniqueConstraint("name"), sa.Index("ix_flow__created", "created"))
+    __table_args__ = (
+        sa.UniqueConstraint("name"),
+        sa.Index("ix_flow__created", "created"),
+    )
 
 
-@declarative_mixin
-class ORMFlowRunState:
+class FlowRunState(Base):
     """SQLAlchemy mixin of a flow run state."""
 
-    # this column isn't explicitly indexed because it is included in
-    # the unique compound index on (flow_run_id, timestamp)
-    @declared_attr
-    def flow_run_id(cls):
-        return sa.Column(
-            UUID(), sa.ForeignKey("flow_run.id", ondelete="cascade"), nullable=False
-        )
+    flow_run_id = sa.Column(
+        UUID(), sa.ForeignKey("flow_run.id", ondelete="cascade"), nullable=False
+    )
 
     type = sa.Column(
         sa.Enum(schemas.states.StateType, name="state_type"), nullable=False, index=True
@@ -154,26 +174,22 @@ class ORMFlowRunState:
     )
     _data = sa.Column(sa.JSON, nullable=True, name="data")
 
-    @declared_attr
-    def result_artifact_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey(
-                "artifact.id",
-                ondelete="SET NULL",
-                use_alter=True,
-            ),
-            index=True,
-        )
+    result_artifact_id = sa.Column(
+        UUID(),
+        sa.ForeignKey(
+            "artifact.id",
+            ondelete="SET NULL",
+            use_alter=True,
+        ),
+        index=True,
+    )
 
-    @declared_attr
-    def _result_artifact(cls):
-        return sa.orm.relationship(
-            "Artifact",
-            lazy="selectin",
-            foreign_keys=[cls.result_artifact_id],
-            primaryjoin="Artifact.id==%s.result_artifact_id" % cls.__name__,
-        )
+    _result_artifact = sa.orm.relationship(
+        "Artifact",
+        lazy="selectin",
+        foreign_keys=[result_artifact_id],
+        primaryjoin="Artifact.id==FlowRunState.result_artifact_id",
+    )
 
     @hybrid_property
     def data(self):
@@ -185,40 +201,33 @@ class ORMFlowRunState:
             return None
         return self._result_artifact.data
 
-    @declared_attr
-    def flow_run(cls):
-        return sa.orm.relationship(
-            "FlowRun",
-            lazy="raise",
-            foreign_keys=[cls.flow_run_id],
-        )
+    flow_run = sa.orm.relationship(
+        "FlowRun",
+        lazy="raise",
+        foreign_keys=[flow_run_id],
+    )
 
     def as_state(self) -> schemas.states.State:
         return schemas.states.State.from_orm(self)
 
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index(
-                "uq_flow_run_state__flow_run_id_timestamp_desc",
-                "flow_run_id",
-                sa.desc("timestamp"),
-                unique=True,
-            ),
-        )
+    __table_args__ = (
+        sa.Index(
+            "uq_flow_run_state__flow_run_id_timestamp_desc",
+            "flow_run_id",
+            sa.desc("timestamp"),
+            unique=True,
+        ),
+    )
 
 
-@declarative_mixin
-class ORMTaskRunState:
+class TaskRunState(Base):
     """SQLAlchemy model of a task run state."""
 
     # this column isn't explicitly indexed because it is included in
     # the unique compound index on (task_run_id, timestamp)
-    @declared_attr
-    def task_run_id(cls):
-        return sa.Column(
-            UUID(), sa.ForeignKey("task_run.id", ondelete="cascade"), nullable=False
-        )
+    task_run_id = sa.Column(
+        UUID(), sa.ForeignKey("task_run.id", ondelete="cascade"), nullable=False
+    )
 
     type = sa.Column(
         sa.Enum(schemas.states.StateType, name="state_type"), nullable=False, index=True
@@ -239,26 +248,22 @@ class ORMTaskRunState:
     )
     _data = sa.Column(sa.JSON, nullable=True, name="data")
 
-    @declared_attr
-    def result_artifact_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey(
-                "artifact.id",
-                ondelete="SET NULL",
-                use_alter=True,
-            ),
-            index=True,
-        )
+    result_artifact_id = sa.Column(
+        UUID(),
+        sa.ForeignKey(
+            "artifact.id",
+            ondelete="SET NULL",
+            use_alter=True,
+        ),
+        index=True,
+    )
 
-    @declared_attr
-    def _result_artifact(cls):
-        return sa.orm.relationship(
-            "Artifact",
-            lazy="selectin",
-            foreign_keys=[cls.result_artifact_id],
-            primaryjoin="Artifact.id==%s.result_artifact_id" % cls.__name__,
-        )
+    _result_artifact = sa.orm.relationship(
+        "Artifact",
+        lazy="selectin",
+        foreign_keys=[result_artifact_id],
+        primaryjoin="Artifact.id==TaskRunState.result_artifact_id",
+    )
 
     @hybrid_property
     def data(self):
@@ -270,31 +275,26 @@ class ORMTaskRunState:
             return None
         return self._result_artifact.data
 
-    @declared_attr
-    def task_run(cls):
-        return sa.orm.relationship(
-            "TaskRun",
-            lazy="raise",
-            foreign_keys=[cls.task_run_id],
-        )
+    task_run = sa.orm.relationship(
+        "TaskRun",
+        lazy="raise",
+        foreign_keys=[task_run_id],
+    )
 
     def as_state(self) -> schemas.states.State:
         return schemas.states.State.from_orm(self)
 
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index(
-                "uq_task_run_state__task_run_id_timestamp_desc",
-                "task_run_id",
-                sa.desc("timestamp"),
-                unique=True,
-            ),
-        )
+    __table_args__ = (
+        sa.Index(
+            "uq_task_run_state__task_run_id_timestamp_desc",
+            "task_run_id",
+            sa.desc("timestamp"),
+            unique=True,
+        ),
+    )
 
 
-@declarative_mixin
-class ORMArtifact:
+class Artifact(Base):
     """
     SQLAlchemy model of artifacts.
     """
@@ -305,21 +305,17 @@ class ORMArtifact:
         index=True,
     )
 
-    @declared_attr
-    def task_run_id(cls):
-        return sa.Column(
-            UUID(),
-            nullable=True,
-            index=True,
-        )
+    task_run_id = sa.Column(
+        UUID(),
+        nullable=True,
+        index=True,
+    )
 
-    @declared_attr
-    def flow_run_id(cls):
-        return sa.Column(
-            UUID(),
-            nullable=True,
-            index=True,
-        )
+    flow_run_id = sa.Column(
+        UUID(),
+        nullable=True,
+        index=True,
+    )
 
     type = sa.Column(sa.String)
     data = sa.Column(sa.JSON, nullable=True)
@@ -328,17 +324,15 @@ class ORMArtifact:
     # Suffixed with underscore as attribute name 'metadata' is reserved for the MetaData instance when using a declarative base class.
     metadata_ = sa.Column(sa.JSON, nullable=True)
 
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index(
-                "ix_artifact__key",
-                "key",
-            ),
-        )
+    __table_args__ = (
+        sa.Index(
+            "ix_artifact__key",
+            "key",
+        ),
+    )
 
 
-class ORMArtifactCollection:
+class ArtifactCollection(Base):
     key = sa.Column(
         sa.String,
         nullable=False,
@@ -361,19 +355,17 @@ class ORMArtifactCollection:
     description = sa.Column(sa.String, nullable=True)
     metadata_ = sa.Column(sa.JSON, nullable=True)
 
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.UniqueConstraint("key"),
-            sa.Index(
-                "ix_artifact_collection__key_latest_id",
-                "key",
-                "latest_id",
-            ),
-        )
+    __table_args__ = (
+        sa.UniqueConstraint("key"),
+        sa.Index(
+            "ix_artifact_collection__key_latest_id",
+            "key",
+            "latest_id",
+        ),
+    )
 
 
-class ORMTaskRunStateCache:
+class TaskRunStateCache(Base):
     """
     SQLAlchemy model of a task run state cache.
     """
@@ -385,22 +377,21 @@ class ORMTaskRunStateCache:
     )
     task_run_state_id = sa.Column(UUID(), nullable=False)
 
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index(
-                "ix_task_run_state_cache__cache_key_created_desc",
-                "cache_key",
-                sa.desc("created"),
-            ),
-        )
+    __table_args__ = (
+        sa.Index(
+            "ix_task_run_state_cache__cache_key_created_desc",
+            "cache_key",
+            sa.desc("created"),
+        ),
+    )
 
 
-@declarative_mixin
-class ORMRun:
+class Run(Base):
     """
     Common columns and logic for FlowRun and TaskRun models
     """
+
+    __abstract__ = True
 
     name = sa.Column(
         sa.String,
@@ -492,18 +483,15 @@ class ORMRun:
         )
 
 
-@declarative_mixin
-class ORMFlowRun(ORMRun):
+class FlowRun(Run):
     """SQLAlchemy model of a flow run."""
 
-    @declared_attr
-    def flow_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey("flow.id", ondelete="cascade"),
-            nullable=False,
-            index=True,
-        )
+    flow_id = sa.Column(
+        UUID(),
+        sa.ForeignKey("flow.id", ondelete="cascade"),
+        nullable=False,
+        index=True,
+    )
 
     deployment_id = sa.Column(UUID(), nullable=True)
     work_queue_name = sa.Column(sa.String, index=True)
@@ -529,64 +517,54 @@ class ORMFlowRun(ORMRun):
     infrastructure_pid = sa.Column(sa.String)
     job_variables = sa.Column(JSON, server_default="{}", default=dict, nullable=True)
 
-    @declared_attr
-    def infrastructure_document_id(cls):
-        return sa.Column(
-            UUID,
-            sa.ForeignKey("block_document.id", ondelete="CASCADE"),
-            nullable=True,
-            index=True,
-        )
+    infrastructure_document_id = sa.Column(
+        UUID,
+        sa.ForeignKey("block_document.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
 
-    @declared_attr
-    def parent_task_run_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey(
-                "task_run.id",
-                ondelete="SET NULL",
-                use_alter=True,
-            ),
-            index=True,
-        )
+    parent_task_run_id = sa.Column(
+        UUID(),
+        sa.ForeignKey(
+            "task_run.id",
+            ondelete="SET NULL",
+            use_alter=True,
+        ),
+        index=True,
+    )
 
     auto_scheduled = sa.Column(
         sa.Boolean, server_default="0", default=False, nullable=False
     )
 
     # TODO remove this foreign key for significant delete performance gains
-    @declared_attr
-    def state_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey(
-                "flow_run_state.id",
-                ondelete="SET NULL",
-                use_alter=True,
-            ),
-            index=True,
-        )
+    state_id = sa.Column(
+        UUID(),
+        sa.ForeignKey(
+            "flow_run_state.id",
+            ondelete="SET NULL",
+            use_alter=True,
+        ),
+        index=True,
+    )
 
-    @declared_attr
-    def work_queue_id(cls):
-        return sa.Column(
-            UUID,
-            sa.ForeignKey("work_queue.id", ondelete="SET NULL"),
-            nullable=True,
-            index=True,
-        )
+    work_queue_id = sa.Column(
+        UUID,
+        sa.ForeignKey("work_queue.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
 
     # -------------------------- relationships
 
     # current states are eagerly loaded unless otherwise specified
-    @declared_attr
-    def _state(cls):
-        return sa.orm.relationship(
-            "FlowRunState",
-            lazy="selectin",
-            foreign_keys=[cls.state_id],
-            primaryjoin="FlowRunState.id==%s.state_id" % cls.__name__,
-        )
+    _state = sa.orm.relationship(
+        "FlowRunState",
+        lazy="selectin",
+        foreign_keys=[state_id],
+        primaryjoin="FlowRunState.id==FlowRun.state_id",
+    )
 
     @hybrid_property
     def state(self):
@@ -614,97 +592,84 @@ class ORMFlowRun(ORMRun):
             state.flow_run_id = self.id
         self._state = state
 
-    @declared_attr
-    def flow(cls):
-        return sa.orm.relationship("Flow", back_populates="flow_runs", lazy="raise")
+    flow = sa.orm.relationship("Flow", back_populates="flow_runs", lazy="raise")
 
-    @declared_attr
-    def task_runs(cls):
-        return sa.orm.relationship(
-            "TaskRun",
-            back_populates="flow_run",
-            lazy="raise",
-            # foreign_keys=lambda: [cls.flow_run_id],
-            primaryjoin="TaskRun.flow_run_id==%s.id" % cls.__name__,
-        )
+    task_runs = sa.orm.relationship(
+        "TaskRun",
+        back_populates="flow_run",
+        lazy="raise",
+        # foreign_keys=lambda: [flow_run_id],
+        primaryjoin="TaskRun.flow_run_id==FlowRun.id",
+    )
 
-    @declared_attr
-    def parent_task_run(cls):
-        return sa.orm.relationship(
-            "TaskRun",
-            back_populates="subflow_run",
-            lazy="raise",
-            foreign_keys=lambda: [cls.parent_task_run_id],
-        )
+    parent_task_run = sa.orm.relationship(
+        "TaskRun",
+        back_populates="subflow_run",
+        lazy="raise",
+        foreign_keys=[parent_task_run_id],
+    )
 
-    @declared_attr
-    def work_queue(cls):
-        return sa.orm.relationship(
-            "WorkQueue",
-            lazy="selectin",
-            foreign_keys=[cls.work_queue_id],
-        )
+    work_queue = sa.orm.relationship(
+        "WorkQueue",
+        lazy="selectin",
+        foreign_keys=[work_queue_id],
+    )
 
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index(
-                "uq_flow_run__flow_id_idempotency_key",
-                "flow_id",
-                "idempotency_key",
-                unique=True,
-            ),
-            sa.Index(
-                "ix_flow_run__coalesce_start_time_expected_start_time_desc",
-                sa.desc(coalesce("start_time", "expected_start_time")),
-            ),
-            sa.Index(
-                "ix_flow_run__coalesce_start_time_expected_start_time_asc",
-                sa.asc(coalesce("start_time", "expected_start_time")),
-            ),
-            sa.Index(
-                "ix_flow_run__expected_start_time_desc",
-                sa.desc("expected_start_time"),
-            ),
-            sa.Index(
-                "ix_flow_run__next_scheduled_start_time_asc",
-                sa.asc("next_scheduled_start_time"),
-            ),
-            sa.Index(
-                "ix_flow_run__end_time_desc",
-                sa.desc("end_time"),
-            ),
-            sa.Index(
-                "ix_flow_run__start_time",
-                "start_time",
-            ),
-            sa.Index(
-                "ix_flow_run__state_type",
-                "state_type",
-            ),
-            sa.Index(
-                "ix_flow_run__state_name",
-                "state_name",
-            ),
-            sa.Index(
-                "ix_flow_run__state_timestamp",
-                "state_timestamp",
-            ),
-        )
+    __table_args__ = (
+        sa.Index(
+            "uq_flow_run__flow_id_idempotency_key",
+            "flow_id",
+            "idempotency_key",
+            unique=True,
+        ),
+        sa.Index(
+            "ix_flow_run__coalesce_start_time_expected_start_time_desc",
+            sa.desc(coalesce("start_time", "expected_start_time")),
+        ),
+        sa.Index(
+            "ix_flow_run__coalesce_start_time_expected_start_time_asc",
+            sa.asc(coalesce("start_time", "expected_start_time")),
+        ),
+        sa.Index(
+            "ix_flow_run__expected_start_time_desc",
+            sa.desc("expected_start_time"),
+        ),
+        sa.Index(
+            "ix_flow_run__next_scheduled_start_time_asc",
+            sa.asc("next_scheduled_start_time"),
+        ),
+        sa.Index(
+            "ix_flow_run__end_time_desc",
+            sa.desc("end_time"),
+        ),
+        sa.Index(
+            "ix_flow_run__start_time",
+            "start_time",
+        ),
+        sa.Index(
+            "ix_flow_run__state_type",
+            "state_type",
+        ),
+        sa.Index(
+            "ix_flow_run__state_name",
+            "state_name",
+        ),
+        sa.Index(
+            "ix_flow_run__state_timestamp",
+            "state_timestamp",
+        ),
+    )
 
 
-@declarative_mixin
-class ORMTaskRun(ORMRun):
+class TaskRun(Run):
     """SQLAlchemy model of a task run."""
 
-    @declared_attr
-    def flow_run_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey("flow_run.id", ondelete="cascade"),
-            nullable=True,
-            index=True,
-        )
+    flow_run_id = sa.Column(
+        UUID(),
+        sa.ForeignKey("flow_run.id", ondelete="cascade"),
+        nullable=True,
+        index=True,
+    )
 
     task_key = sa.Column(sa.String, nullable=False)
     dynamic_key = sa.Column(sa.String, nullable=False)
@@ -740,29 +705,25 @@ class ORMTaskRun(ORMRun):
     tags = sa.Column(JSON, server_default="[]", default=list, nullable=False)
 
     # TODO remove this foreign key for significant delete performance gains
-    @declared_attr
-    def state_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey(
-                "task_run_state.id",
-                ondelete="SET NULL",
-                use_alter=True,
-            ),
-            index=True,
-        )
+    state_id = sa.Column(
+        UUID(),
+        sa.ForeignKey(
+            "task_run_state.id",
+            ondelete="SET NULL",
+            use_alter=True,
+        ),
+        index=True,
+    )
 
     # -------------------------- relationships
 
     # current states are eagerly loaded unless otherwise specified
-    @declared_attr
-    def _state(cls):
-        return sa.orm.relationship(
-            "TaskRunState",
-            lazy="selectin",
-            foreign_keys=[cls.state_id],
-            primaryjoin="TaskRunState.id==%s.state_id" % cls.__name__,
-        )
+    _state = sa.orm.relationship(
+        "TaskRunState",
+        lazy="selectin",
+        foreign_keys=[state_id],
+        primaryjoin="TaskRunState.id==TaskRun.state_id",
+    )
 
     @hybrid_property
     def state(self):
@@ -790,77 +751,68 @@ class ORMTaskRun(ORMRun):
             state.task_run_id = self.id
         self._state = state
 
-    @declared_attr
-    def flow_run(cls):
-        return sa.orm.relationship(
-            "FlowRun",
-            back_populates="task_runs",
-            lazy="raise",
-            foreign_keys=[cls.flow_run_id],
-        )
+    flow_run = sa.orm.relationship(
+        "FlowRun",
+        back_populates="task_runs",
+        lazy="raise",
+        foreign_keys=[flow_run_id],
+    )
 
-    @declared_attr
-    def subflow_run(cls):
-        return sa.orm.relationship(
-            "FlowRun",
-            back_populates="parent_task_run",
-            lazy="raise",
-            # foreign_keys=["FlowRun.parent_task_run_id"],
-            primaryjoin="FlowRun.parent_task_run_id==%s.id" % cls.__name__,
-            uselist=False,
-        )
+    subflow_run = sa.orm.relationship(
+        "FlowRun",
+        back_populates="parent_task_run",
+        lazy="raise",
+        # foreign_keys=["FlowRun.parent_task_run_id"],
+        primaryjoin="FlowRun.parent_task_run_id==TaskRun.id",
+        uselist=False,
+    )
 
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index(
-                "uq_task_run__flow_run_id_task_key_dynamic_key",
-                "flow_run_id",
-                "task_key",
-                "dynamic_key",
-                unique=True,
-            ),
-            sa.Index(
-                "ix_task_run__expected_start_time_desc",
-                sa.desc("expected_start_time"),
-            ),
-            sa.Index(
-                "ix_task_run__next_scheduled_start_time_asc",
-                sa.asc("next_scheduled_start_time"),
-            ),
-            sa.Index(
-                "ix_task_run__end_time_desc",
-                sa.desc("end_time"),
-            ),
-            sa.Index(
-                "ix_task_run__start_time",
-                "start_time",
-            ),
-            sa.Index(
-                "ix_task_run__state_type",
-                "state_type",
-            ),
-            sa.Index(
-                "ix_task_run__state_name",
-                "state_name",
-            ),
-            sa.Index(
-                "ix_task_run__state_timestamp",
-                "state_timestamp",
-            ),
-        )
+    __table_args__ = (
+        sa.Index(
+            "uq_task_run__flow_run_id_task_key_dynamic_key",
+            "flow_run_id",
+            "task_key",
+            "dynamic_key",
+            unique=True,
+        ),
+        sa.Index(
+            "ix_task_run__expected_start_time_desc",
+            sa.desc("expected_start_time"),
+        ),
+        sa.Index(
+            "ix_task_run__next_scheduled_start_time_asc",
+            sa.asc("next_scheduled_start_time"),
+        ),
+        sa.Index(
+            "ix_task_run__end_time_desc",
+            sa.desc("end_time"),
+        ),
+        sa.Index(
+            "ix_task_run__start_time",
+            "start_time",
+        ),
+        sa.Index(
+            "ix_task_run__state_type",
+            "state_type",
+        ),
+        sa.Index(
+            "ix_task_run__state_name",
+            "state_name",
+        ),
+        sa.Index(
+            "ix_task_run__state_timestamp",
+            "state_timestamp",
+        ),
+    )
 
 
-@declarative_mixin
-class ORMDeploymentSchedule:
-    @declared_attr
-    def deployment_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey("deployment.id", ondelete="CASCADE"),
-            nullable=False,
-            index=True,
-        )
+class DeploymentSchedule(Base):
+    deployment_id = sa.Column(
+        UUID(),
+        sa.ForeignKey("deployment.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
 
     schedule = sa.Column(Pydantic(schemas.schedules.SCHEDULE_TYPES), nullable=False)
     active = sa.Column(sa.Boolean, nullable=False, default=True)
@@ -869,8 +821,7 @@ class ORMDeploymentSchedule:
     catchup = sa.Column(sa.Boolean, nullable=False, default=False)
 
 
-@declarative_mixin
-class ORMDeployment:
+class Deployment(Base):
     """SQLAlchemy model of a deployment."""
 
     name = sa.Column(sa.String, nullable=False)
@@ -894,23 +845,19 @@ class ORMDeployment:
     def job_variables(self):
         return synonym("infra_overrides")
 
-    @declared_attr
-    def flow_id(cls):
-        return sa.Column(
-            UUID,
-            sa.ForeignKey("flow.id", ondelete="CASCADE"),
-            nullable=False,
-            index=True,
-        )
+    flow_id = sa.Column(
+        UUID,
+        sa.ForeignKey("flow.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
 
-    @declared_attr
-    def work_queue_id(cls):
-        return sa.Column(
-            UUID,
-            sa.ForeignKey("work_queue.id", ondelete="SET NULL"),
-            nullable=True,
-            index=True,
-        )
+    work_queue_id = sa.Column(
+        UUID,
+        sa.ForeignKey("work_queue.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
 
     schedule = sa.Column(Pydantic(schemas.schedules.SCHEDULE_TYPES))
     is_schedule_active = sa.Column(
@@ -920,13 +867,11 @@ class ORMDeployment:
         sa.Boolean, nullable=False, server_default="0", default=False, index=True
     )
 
-    @declared_attr
-    def schedules(cls):
-        return sa.orm.relationship(
-            "DeploymentSchedule",
-            lazy="selectin",
-            order_by=sa.desc(sa.text("updated")),
-        )
+    schedules = sa.orm.relationship(
+        "DeploymentSchedule",
+        lazy="selectin",
+        order_by=sa.desc(sa.text("updated")),
+    )
 
     tags = sa.Column(JSON, server_default="[]", default=list, nullable=False)
     parameters = sa.Column(JSON, server_default="{}", default=dict, nullable=False)
@@ -948,52 +893,41 @@ class ORMDeployment:
         nullable=True,
     )
 
-    @declared_attr
-    def infrastructure_document_id(cls):
-        return sa.Column(
-            UUID,
-            sa.ForeignKey("block_document.id", ondelete="CASCADE"),
-            nullable=True,
-            index=False,
-        )
+    infrastructure_document_id = sa.Column(
+        UUID,
+        sa.ForeignKey("block_document.id", ondelete="CASCADE"),
+        nullable=True,
+        index=False,
+    )
 
-    @declared_attr
-    def storage_document_id(cls):
-        return sa.Column(
-            UUID,
-            sa.ForeignKey("block_document.id", ondelete="CASCADE"),
-            nullable=True,
-            index=False,
-        )
+    storage_document_id = sa.Column(
+        UUID,
+        sa.ForeignKey("block_document.id", ondelete="CASCADE"),
+        nullable=True,
+        index=False,
+    )
 
-    @declared_attr
-    def flow(cls):
-        return sa.orm.relationship("Flow", back_populates="deployments", lazy="raise")
+    flow = sa.orm.relationship("Flow", back_populates="deployments", lazy="raise")
 
-    @declared_attr
-    def work_queue(cls):
-        return sa.orm.relationship(
-            "WorkQueue", lazy="selectin", foreign_keys=[cls.work_queue_id]
-        )
+    work_queue = sa.orm.relationship(
+        "WorkQueue", lazy="selectin", foreign_keys=[work_queue_id]
+    )
 
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index(
-                "uq_deployment__flow_id_name",
-                "flow_id",
-                "name",
-                unique=True,
-            ),
-            sa.Index(
-                "ix_deployment__created",
-                "created",
-            ),
-        )
+    __table_args__ = (
+        sa.Index(
+            "uq_deployment__flow_id_name",
+            "flow_id",
+            "name",
+            unique=True,
+        ),
+        sa.Index(
+            "ix_deployment__created",
+            "created",
+        ),
+    )
 
 
-@declarative_mixin
-class ORMLog:
+class Log(Base):
     """
     SQLAlchemy model of a logging statement.
     """
@@ -1007,30 +941,24 @@ class ORMLog:
     # The client-side timestamp of this logged statement.
     timestamp = sa.Column(Timestamp(), nullable=False, index=True)
 
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index(
-                "ix_log__flow_run_id_timestamp",
-                "flow_run_id",
-                "timestamp",
-            ),
-        )
+    __table_args__ = (
+        sa.Index(
+            "ix_log__flow_run_id_timestamp",
+            "flow_run_id",
+            "timestamp",
+        ),
+    )
 
 
-@declarative_mixin
-class ORMConcurrencyLimit:
+class ConcurrencyLimit(Base):
     tag = sa.Column(sa.String, nullable=False)
     concurrency_limit = sa.Column(sa.Integer, nullable=False)
     active_slots = sa.Column(JSON, server_default="[]", default=list, nullable=False)
 
-    @declared_attr
-    def __table_args__(cls):
-        return (sa.Index("uq_concurrency_limit__tag", "tag", unique=True),)
+    __table_args__ = (sa.Index("uq_concurrency_limit__tag", "tag", unique=True),)
 
 
-@declarative_mixin
-class ORMConcurrencyLimitV2:
+class ConcurrencyLimitV2(Base):
     active = sa.Column(sa.Boolean, nullable=False, default=True)
     name = sa.Column(sa.String, nullable=False)
     limit = sa.Column(sa.Integer, nullable=False)
@@ -1043,8 +971,7 @@ class ORMConcurrencyLimitV2:
     __table_args__ = (sa.UniqueConstraint("name"),)
 
 
-@declarative_mixin
-class ORMBlockType:
+class BlockType(Base):
     name = sa.Column(sa.String, nullable=False)
     slug = sa.Column(sa.String, nullable=False)
     logo_url = sa.Column(sa.String, nullable=True)
@@ -1055,19 +982,16 @@ class ORMBlockType:
         sa.Boolean, nullable=False, server_default="0", default=False
     )
 
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index(
-                "uq_block_type__slug",
-                "slug",
-                unique=True,
-            ),
-        )
+    __table_args__ = (
+        sa.Index(
+            "uq_block_type__slug",
+            "slug",
+            unique=True,
+        ),
+    )
 
 
-@declarative_mixin
-class ORMBlockSchema:
+class BlockSchema(Base):
     checksum = sa.Column(sa.String, nullable=False)
     fields = sa.Column(JSON, server_default="{}", default=dict, nullable=False)
     capabilities = sa.Column(JSON, server_default="[]", default=list, nullable=False)
@@ -1077,95 +1001,73 @@ class ORMBlockSchema:
         nullable=False,
     )
 
-    @declared_attr
-    def block_type_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey("block_type.id", ondelete="cascade"),
-            nullable=False,
-            index=True,
-        )
+    block_type_id = sa.Column(
+        UUID(),
+        sa.ForeignKey("block_type.id", ondelete="cascade"),
+        nullable=False,
+        index=True,
+    )
 
-    @declared_attr
-    def block_type(cls):
-        return sa.orm.relationship("BlockType", lazy="selectin")
+    block_type = sa.orm.relationship("BlockType", lazy="selectin")
 
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index(
-                "uq_block_schema__checksum_version",
-                "checksum",
-                "version",
-                unique=True,
-            ),
-            sa.Index("ix_block_schema__created", "created"),
-        )
+    __table_args__ = (
+        sa.Index(
+            "uq_block_schema__checksum_version",
+            "checksum",
+            "version",
+            unique=True,
+        ),
+        sa.Index("ix_block_schema__created", "created"),
+    )
 
 
-@declarative_mixin
-class ORMBlockSchemaReference:
+class BlockSchemaReference(Base):
     name = sa.Column(sa.String, nullable=False)
 
-    @declared_attr
-    def parent_block_schema_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey("block_schema.id", ondelete="cascade"),
-            nullable=False,
-        )
+    parent_block_schema_id = sa.Column(
+        UUID(),
+        sa.ForeignKey("block_schema.id", ondelete="cascade"),
+        nullable=False,
+    )
 
-    @declared_attr
-    def reference_block_schema_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey("block_schema.id", ondelete="cascade"),
-            nullable=False,
-        )
+    reference_block_schema_id = sa.Column(
+        UUID(),
+        sa.ForeignKey("block_schema.id", ondelete="cascade"),
+        nullable=False,
+    )
 
 
-@declarative_mixin
-class ORMBlockDocument:
+class BlockDocument(Base):
     name = sa.Column(sa.String, nullable=False, index=True)
     data = sa.Column(JSON, server_default="{}", default=dict, nullable=False)
     is_anonymous = sa.Column(sa.Boolean, server_default="0", index=True, nullable=False)
 
     block_type_name = sa.Column(sa.String, nullable=True)
 
-    @declared_attr
-    def block_type_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey("block_type.id", ondelete="cascade"),
-            nullable=False,
-        )
+    block_type_id = sa.Column(
+        UUID(),
+        sa.ForeignKey("block_type.id", ondelete="cascade"),
+        nullable=False,
+    )
 
-    @declared_attr
-    def block_type(cls):
-        return sa.orm.relationship("BlockType", lazy="selectin")
+    block_type = sa.orm.relationship("BlockType", lazy="selectin")
 
-    @declared_attr
-    def block_schema_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey("block_schema.id", ondelete="cascade"),
-            nullable=False,
-        )
+    block_schema_id = sa.Column(
+        UUID(),
+        sa.ForeignKey("block_schema.id", ondelete="cascade"),
+        nullable=False,
+    )
 
-    @declared_attr
-    def block_schema(cls):
-        return sa.orm.relationship("BlockSchema", lazy="selectin")
+    block_schema = sa.orm.relationship("BlockSchema", lazy="selectin")
 
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index(
-                "uq_block__type_id_name",
-                "block_type_id",
-                "name",
-                unique=True,
-            ),
-        )
+    __table_args__ = (
+        sa.Index(
+            "uq_block__type_id_name",
+            "block_type_id",
+            "name",
+            unique=True,
+        ),
+    )
 
     async def encrypt_data(self, session, data):
         """
@@ -1184,39 +1086,30 @@ class ORMBlockDocument:
         return await decrypt_fernet(session, self.data)
 
 
-@declarative_mixin
-class ORMBlockDocumentReference:
+class BlockDocumentReference(Base):
     name = sa.Column(sa.String, nullable=False)
 
-    @declared_attr
-    def parent_block_document_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey("block_document.id", ondelete="cascade"),
-            nullable=False,
-        )
+    parent_block_document_id = sa.Column(
+        UUID(),
+        sa.ForeignKey("block_document.id", ondelete="cascade"),
+        nullable=False,
+    )
 
-    @declared_attr
-    def reference_block_document_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey("block_document.id", ondelete="cascade"),
-            nullable=False,
-        )
+    reference_block_document_id = sa.Column(
+        UUID(),
+        sa.ForeignKey("block_document.id", ondelete="cascade"),
+        nullable=False,
+    )
 
 
-@declarative_mixin
-class ORMConfiguration:
+class Configuration(Base):
     key = sa.Column(sa.String, nullable=False, index=True)
     value = sa.Column(JSON, nullable=False)
 
-    @declared_attr
-    def __table_args__(cls):
-        return (sa.UniqueConstraint("key"),)
+    __table_args__ = (sa.UniqueConstraint("key"),)
 
 
-@declarative_mixin
-class ORMSavedSearch:
+class SavedSearch(Base):
     """SQLAlchemy model of a saved search."""
 
     name = sa.Column(sa.String, nullable=False)
@@ -1227,13 +1120,10 @@ class ORMSavedSearch:
         nullable=False,
     )
 
-    @declared_attr
-    def __table_args__(cls):
-        return (sa.UniqueConstraint("name"),)
+    __table_args__ = (sa.UniqueConstraint("name"),)
 
 
-@declarative_mixin
-class ORMWorkQueue:
+class WorkQueue(Base):
     """SQLAlchemy model of a work queue"""
 
     name = sa.Column(sa.String, nullable=False)
@@ -1260,30 +1150,23 @@ class ORMWorkQueue:
         server_default=WorkQueueStatus.NOT_READY.value,
     )
 
-    @declared_attr
-    def __table_args__(cls):
-        return (sa.UniqueConstraint("work_pool_id", "name"),)
+    __table_args__ = (sa.UniqueConstraint("work_pool_id", "name"),)
 
-    @declared_attr
-    def work_pool_id(cls):
-        return sa.Column(
-            UUID,
-            sa.ForeignKey("work_pool.id", ondelete="cascade"),
-            nullable=False,
-            index=True,
-        )
+    work_pool_id = sa.Column(
+        UUID,
+        sa.ForeignKey("work_pool.id", ondelete="cascade"),
+        nullable=False,
+        index=True,
+    )
 
-    @declared_attr
-    def work_pool(cls):
-        return sa.orm.relationship(
-            "WorkPool",
-            lazy="selectin",
-            foreign_keys=[cls.work_pool_id],
-        )
+    work_pool = sa.orm.relationship(
+        "WorkPool",
+        lazy="selectin",
+        foreign_keys=[work_pool_id],
+    )
 
 
-@declarative_mixin
-class ORMWorkPool:
+class WorkPool(Base):
     """SQLAlchemy model of an worker"""
 
     name = sa.Column(sa.String, nullable=False)
@@ -1306,13 +1189,10 @@ class ORMWorkPool:
     last_transitioned_status_at = sa.Column(Timestamp(), nullable=True)
     last_status_event_id = sa.Column(UUID, nullable=True)
 
-    @declared_attr
-    def __table_args__(cls):
-        return (sa.UniqueConstraint("name"),)
+    __table_args__ = (sa.UniqueConstraint("name"),)
 
 
-@declarative_mixin
-class ORMWorker:
+class Worker(Base):
     """SQLAlchemy model of an worker"""
 
     @declared_attr
@@ -1341,25 +1221,20 @@ class ORMWorker:
         server_default=WorkerStatus.OFFLINE.value,
     )
 
-    @declared_attr
-    def __table_args__(cls):
-        return (sa.UniqueConstraint("work_pool_id", "name"),)
+    __table_args__ = (sa.UniqueConstraint("work_pool_id", "name"),)
 
 
-@declarative_mixin
-class ORMAgent:
+class Agent(Base):
     """SQLAlchemy model of an agent"""
 
     name = sa.Column(sa.String, nullable=False)
 
-    @declared_attr
-    def work_queue_id(cls):
-        return sa.Column(
-            UUID,
-            sa.ForeignKey("work_queue.id"),
-            nullable=False,
-            index=True,
-        )
+    work_queue_id = sa.Column(
+        UUID,
+        sa.ForeignKey("work_queue.id"),
+        nullable=False,
+        index=True,
+    )
 
     last_activity_time = sa.Column(
         Timestamp(),
@@ -1368,37 +1243,29 @@ class ORMAgent:
         default=lambda: pendulum.now("UTC"),
     )
 
-    @declared_attr
-    def __table_args__(cls):
-        return (sa.UniqueConstraint("name"),)
+    __table_args__ = (sa.UniqueConstraint("name"),)
 
 
-@declarative_mixin
-class ORMFlowRunNotificationPolicy:
+class FlowRunNotificationPolicy(Base):
     is_active = sa.Column(sa.Boolean, server_default="1", default=True, nullable=False)
     state_names = sa.Column(JSON, server_default="[]", default=[], nullable=False)
     tags = sa.Column(JSON, server_default="[]", default=[], nullable=False)
     message_template = sa.Column(sa.String, nullable=True)
 
-    @declared_attr
-    def block_document_id(cls):
-        return sa.Column(
-            UUID(),
-            sa.ForeignKey("block_document.id", ondelete="cascade"),
-            nullable=False,
-        )
+    block_document_id = sa.Column(
+        UUID(),
+        sa.ForeignKey("block_document.id", ondelete="cascade"),
+        nullable=False,
+    )
 
-    @declared_attr
-    def block_document(cls):
-        return sa.orm.relationship(
-            "BlockDocument",
-            lazy="selectin",
-            foreign_keys=[cls.block_document_id],
-        )
+    block_document = sa.orm.relationship(
+        "BlockDocument",
+        lazy="selectin",
+        foreign_keys=[block_document_id],
+    )
 
 
-@declarative_mixin
-class ORMFlowRunNotificationQueue:
+class FlowRunNotificationQueue(Base):
     # these are both foreign keys but there is no need to enforce that constraint
     # as this is just a queue for service workers; if the keys don't match at the
     # time work is pulled, the work can be discarded
@@ -1406,8 +1273,7 @@ class ORMFlowRunNotificationQueue:
     flow_run_state_id = sa.Column(UUID, nullable=False)
 
 
-@declarative_mixin
-class ORMVariable:
+class Variable(Base):
     name = sa.Column(sa.String, nullable=False)
     value = sa.Column(sa.String, nullable=False)
     tags = sa.Column(JSON, server_default="[]", default=list, nullable=False)
@@ -1415,13 +1281,10 @@ class ORMVariable:
     __table_args__ = (sa.UniqueConstraint("name"),)
 
 
-@declarative_mixin
-class ORMFlowRunInput:
-    @declared_attr
-    def flow_run_id(cls):
-        return sa.Column(
-            UUID(), sa.ForeignKey("flow_run.id", ondelete="cascade"), nullable=False
-        )
+class FlowRunInput(Base):
+    flow_run_id = sa.Column(
+        UUID(), sa.ForeignKey("flow_run.id", ondelete="cascade"), nullable=False
+    )
 
     key = sa.Column(sa.String, nullable=False)
     value = sa.Column(sa.Text(), nullable=False)
@@ -1430,15 +1293,13 @@ class ORMFlowRunInput:
     __table_args__ = (sa.UniqueConstraint("flow_run_id", "key"),)
 
 
-@declarative_mixin
-class ORMCsrfToken:
+class CsrfToken(Base):
     token = sa.Column(sa.String, nullable=False)
     client = sa.Column(sa.String, nullable=False, unique=True)
     expiration = sa.Column(Timestamp(), nullable=False)
 
 
-@declarative_mixin
-class ORMAutomation:
+class Automation(Base):
     name = sa.Column(sa.String, nullable=False)
     description = sa.Column(sa.String, nullable=False, default="")
 
@@ -1454,11 +1315,9 @@ class ORMAutomation:
         Pydantic(List[ActionTypes]), server_default="[]", default=list, nullable=False
     )
 
-    @declared_attr
-    def related_resources(cls):
-        return sa.orm.relationship(
-            "AutomationRelatedResource", back_populates="automation", lazy="raise"
-        )
+    related_resources = sa.orm.relationship(
+        "AutomationRelatedResource", back_populates="automation", lazy="raise"
+    )
 
     @classmethod
     def sort_expression(cls, value: AutomationSort) -> ColumnElement:
@@ -1472,30 +1331,25 @@ class ORMAutomation:
         return sort_mapping[value]
 
 
-@declarative_mixin
-class ORMAutomationBucket:
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index(
-                "uq_automation_bucket__automation_id__trigger_id__bucketing_key",
-                "automation_id",
-                "trigger_id",
-                "bucketing_key",
-                unique=True,
-            ),
-            sa.Index(
-                "ix_automation_bucket__automation_id__end",
-                "automation_id",
-                "end",
-            ),
-        )
+class AutomationBucket(Base):
+    __table_args__ = (
+        sa.Index(
+            "uq_automation_bucket__automation_id__trigger_id__bucketing_key",
+            "automation_id",
+            "trigger_id",
+            "bucketing_key",
+            unique=True,
+        ),
+        sa.Index(
+            "ix_automation_bucket__automation_id__end",
+            "automation_id",
+            "end",
+        ),
+    )
 
-    @declared_attr
-    def automation_id(cls):
-        return sa.Column(
-            UUID(), sa.ForeignKey("automation.id", ondelete="CASCADE"), nullable=False
-        )
+    automation_id = sa.Column(
+        UUID(), sa.ForeignKey("automation.id", ondelete="CASCADE"), nullable=False
+    )
 
     trigger_id = sa.Column(UUID, nullable=False)
 
@@ -1513,56 +1367,44 @@ class ORMAutomationBucket:
     triggered_at = sa.Column(Timestamp(), nullable=True)
 
 
-@declarative_mixin
-class ORMAutomationRelatedResource:
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index(
-                "uq_automation_related_resource__automation_id__resource_id",
-                "automation_id",
-                "resource_id",
-                unique=True,
-            ),
-        )
+class AutomationRelatedResource(Base):
+    __table_args__ = (
+        sa.Index(
+            "uq_automation_related_resource__automation_id__resource_id",
+            "automation_id",
+            "resource_id",
+            unique=True,
+        ),
+    )
 
-    @declared_attr
-    def automation_id(cls):
-        return sa.Column(
-            UUID(), sa.ForeignKey("automation.id", ondelete="CASCADE"), nullable=False
-        )
+    automation_id = sa.Column(
+        UUID(), sa.ForeignKey("automation.id", ondelete="CASCADE"), nullable=False
+    )
 
     resource_id = sa.Column(sa.String, index=True)
     automation_owned_by_resource = sa.Column(
         sa.Boolean, nullable=False, default=False, server_default="0"
     )
 
-    @declared_attr
-    def automation(cls):
-        return sa.orm.relationship(
-            "Automation", back_populates="related_resources", lazy="raise"
-        )
+    automation = sa.orm.relationship(
+        "Automation", back_populates="related_resources", lazy="raise"
+    )
 
 
-@declarative_mixin
-class ORMCompositeTriggerChildFiring:
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index(
-                "uq_composite_trigger_child_firing__a_id__pt_id__ct__id",
-                "automation_id",
-                "parent_trigger_id",
-                "child_trigger_id",
-                unique=True,
-            ),
-        )
+class CompositeTriggerChildFiring(Base):
+    __table_args__ = (
+        sa.Index(
+            "uq_composite_trigger_child_firing__a_id__pt_id__ct__id",
+            "automation_id",
+            "parent_trigger_id",
+            "child_trigger_id",
+            unique=True,
+        ),
+    )
 
-    @declared_attr
-    def automation_id(cls):
-        return sa.Column(
-            UUID(), sa.ForeignKey("automation.id", ondelete="CASCADE"), nullable=False
-        )
+    automation_id = sa.Column(
+        UUID(), sa.ForeignKey("automation.id", ondelete="CASCADE"), nullable=False
+    )
 
     parent_trigger_id = sa.Column(UUID(), nullable=False)
 
@@ -1572,38 +1414,32 @@ class ORMCompositeTriggerChildFiring:
     child_firing = sa.Column(Pydantic(Firing), nullable=False)
 
 
-@declarative_mixin
-class ORMAutomationEventFollower:
+class AutomationEventFollower(Base):
     leader_event_id = sa.Column(UUID(), nullable=False, index=True)
     follower_event_id = sa.Column(UUID(), nullable=False, unique=True)
     received = sa.Column(Timestamp(), nullable=False, index=True)
     follower = sa.Column(Pydantic(ReceivedEvent), nullable=False)
 
 
-@declarative_mixin
-class ORMEvent:
+class Event(Base):
     @declared_attr
     def __tablename__(cls):
         return "events"
 
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index("ix_events__related_resource_ids", "related_resource_ids"),
-            sa.Index("ix_events__occurred", "occurred"),
-            sa.Index("ix_events__event__id", "event", "id"),
-            sa.Index(
-                "ix_events__event_resource_id_occurred",
-                "event",
-                "resource_id",
-                "occurred",
-            ),
-            sa.Index("ix_events__occurred_id", "occurred", "id"),
-            sa.Index("ix_events__event_occurred_id", "event", "occurred", "id"),
-            sa.Index(
-                "ix_events__event_related_occurred", "event", "related", "occurred"
-            ),
-        )
+    __table_args__ = (
+        sa.Index("ix_events__related_resource_ids", "related_resource_ids"),
+        sa.Index("ix_events__occurred", "occurred"),
+        sa.Index("ix_events__event__id", "event", "id"),
+        sa.Index(
+            "ix_events__event_resource_id_occurred",
+            "event",
+            "resource_id",
+            "occurred",
+        ),
+        sa.Index("ix_events__occurred_id", "occurred", "id"),
+        sa.Index("ix_events__event_occurred_id", "event", "occurred", "id"),
+        sa.Index("ix_events__event_related_occurred", "event", "related", "occurred"),
+    )
 
     occurred = sa.Column(Timestamp(), nullable=False)
     event = sa.Column(sa.Text(), nullable=False)
@@ -1619,21 +1455,18 @@ class ORMEvent:
     follows = sa.Column(UUID(), nullable=True)
 
 
-@declarative_mixin
-class ORMEventResource:
+class EventResource(Base):
     @declared_attr
     def __tablename__(cls):
         return "event_resources"
 
-    @declared_attr
-    def __table_args__(cls):
-        return (
-            sa.Index(
-                "ix_event_resources__resource_id__occurred",
-                "resource_id",
-                "occurred",
-            ),
-        )
+    __table_args__ = (
+        sa.Index(
+            "ix_event_resources__resource_id__occurred",
+            "resource_id",
+            "occurred",
+        ),
+    )
 
     occurred = sa.Column("occurred", Timestamp(), nullable=False)
     resource_id = sa.Column("resource_id", sa.Text(), nullable=False)
@@ -1642,349 +1475,61 @@ class ORMEventResource:
     event_id = sa.Column("event_id", UUID(), nullable=False)
 
 
+# These are temporary until we've migrated all the references to the new,
+# non-ORM names
+
+ORMFlow = Flow
+ORMFlowRunState = FlowRunState
+ORMTaskRunState = TaskRunState
+ORMArtifact = Artifact
+ORMArtifactCollection = ArtifactCollection
+ORMTaskRunStateCache = TaskRunStateCache
+ORMRun = Run
+ORMFlowRun = FlowRun
+ORMTaskRun = TaskRun
+ORMDeploymentSchedule = DeploymentSchedule
+ORMDeployment = Deployment
+ORMLog = Log
+ORMConcurrencyLimit = ConcurrencyLimit
+ORMConcurrencyLimitV2 = ConcurrencyLimitV2
+ORMBlockType = BlockType
+ORMBlockSchema = BlockSchema
+ORMBlockSchemaReference = BlockSchemaReference
+ORMBlockDocument = BlockDocument
+ORMBlockDocumentReference = BlockDocumentReference
+ORMConfiguration = Configuration
+ORMSavedSearch = SavedSearch
+ORMWorkQueue = WorkQueue
+ORMWorkPool = WorkPool
+ORMWorker = Worker
+ORMAgent = Agent
+ORMFlowRunNotificationPolicy = FlowRunNotificationPolicy
+ORMFlowRunNotificationQueue = FlowRunNotificationQueue
+ORMVariable = Variable
+ORMFlowRunInput = FlowRunInput
+ORMCsrfToken = CsrfToken
+ORMAutomation = Automation
+ORMAutomationBucket = AutomationBucket
+ORMAutomationRelatedResource = AutomationRelatedResource
+ORMCompositeTriggerChildFiring = CompositeTriggerChildFiring
+ORMAutomationEventFollower = AutomationEventFollower
+ORMEvent = Event
+ORMEventResource = EventResource
+
+
 class BaseORMConfiguration(ABC):
     """
     Abstract base class used to inject database-specific ORM configuration into Prefect.
 
     Modifications to core Prefect REST API data structures can have unintended consequences.
     Use with caution.
-
-    Args:
-        base_metadata: sqlalchemy.schema.Metadata used to create the Base orm class
-        base_model_mixins: a list of mixins to add to the Base orm model
-        flow_mixin: flow orm mixin, combined with Base orm class
-        flow_run_mixin: flow run orm mixin, combined with Base orm class
-        flow_run_state_mixin: flow run state mixin, combined with Base orm class
-        task_run_mixin: task run mixin, combined with Base orm class
-        task_run_state_mixin: task run state, combined with Base orm class
-        task_run_state_cache_mixin: task run state cache orm mixin, combined with Base orm class
-        deployment_mixin: deployment orm mixin, combined with Base orm class
-        saved_search_mixin: saved search orm mixin, combined with Base orm class
-        log_mixin: log orm mixin, combined with Base orm class
-        work_pool_mixin: work pool orm mixin, combined with Base orm class
-        worker_mixin: worker orm mixin, combined with Base orm class
-        concurrency_limit_mixin: concurrency limit orm mixin, combined with Base orm class
-        block_type_mixin: block_type orm mixin, combined with Base orm class
-        block_schema_mixin: block_schema orm mixin, combined with Base orm class
-        block_schema_reference_mixin: block_schema_reference orm mixin, combined with Base orm class
-        block_document_mixin: block_document orm mixin, combined with Base orm class
-        block_document_reference_mixin: block_document_reference orm mixin, combined with Base orm class
-        configuration_mixin: configuration orm mixin, combined with Base orm class
-
     """
-
-    def __init__(
-        self,
-        base_metadata: sa.schema.MetaData = None,
-        base_model_mixins: List = None,
-        flow_mixin=ORMFlow,
-        flow_run_mixin=ORMFlowRun,
-        flow_run_state_mixin=ORMFlowRunState,
-        task_run_mixin=ORMTaskRun,
-        task_run_state_mixin=ORMTaskRunState,
-        artifact_mixin=ORMArtifact,
-        artifact_collection_mixin=ORMArtifactCollection,
-        task_run_state_cache_mixin=ORMTaskRunStateCache,
-        deployment_mixin=ORMDeployment,
-        deployment_schedule_mixin=ORMDeploymentSchedule,
-        saved_search_mixin=ORMSavedSearch,
-        log_mixin=ORMLog,
-        concurrency_limit_mixin=ORMConcurrencyLimit,
-        concurrency_limit_v2_mixin=ORMConcurrencyLimitV2,
-        work_pool_mixin=ORMWorkPool,
-        worker_mixin=ORMWorker,
-        block_type_mixin=ORMBlockType,
-        block_schema_mixin=ORMBlockSchema,
-        block_schema_reference_mixin=ORMBlockSchemaReference,
-        block_document_mixin=ORMBlockDocument,
-        block_document_reference_mixin=ORMBlockDocumentReference,
-        work_queue_mixin=ORMWorkQueue,
-        agent_mixin=ORMAgent,
-        configuration_mixin=ORMConfiguration,
-        variable_mixin=ORMVariable,
-        csrf_token_mixin=ORMCsrfToken,
-        flow_run_input_mixin=ORMFlowRunInput,
-        automation_mixin=ORMAutomation,
-        automation_bucket_mixin=ORMAutomationBucket,
-        automation_related_resource_mixin=ORMAutomationRelatedResource,
-        composite_trigger_child_firing_mixin=ORMCompositeTriggerChildFiring,
-        event_follower_mixin=ORMAutomationEventFollower,
-        event_mixin=ORMEvent,
-        event_resource_mixin=ORMEventResource,
-    ):
-        self.base_metadata = base_metadata or sa.schema.MetaData(
-            # define naming conventions for our Base class to use
-            # sqlalchemy will use the following templated strings
-            # to generate the names of indices, constraints, and keys
-            #
-            # we offset the table name with two underscores (__) to
-            # help differentiate, for example, between "flow_run.state_type"
-            # and "flow_run_state.type".
-            #
-            # more information on this templating and available
-            # customization can be found here
-            # https://docs.sqlalchemy.org/en/14/core/metadata.html#sqlalchemy.schema.MetaData
-            #
-            # this also allows us to avoid having to specify names explicitly
-            # when using sa.ForeignKey.use_alter = True
-            # https://docs.sqlalchemy.org/en/14/core/constraints.html
-            naming_convention={
-                "ix": "ix_%(table_name)s__%(column_0_N_name)s",
-                "uq": "uq_%(table_name)s__%(column_0_N_name)s",
-                "ck": "ck_%(table_name)s__%(constraint_name)s",
-                "fk": "fk_%(table_name)s__%(column_0_N_name)s__%(referred_table_name)s",
-                "pk": "pk_%(table_name)s",
-            }
-        )
-        self.base_model_mixins = base_model_mixins or []
-
-        self._create_base_model()
-        self._create_orm_models(
-            flow_mixin=flow_mixin,
-            flow_run_mixin=flow_run_mixin,
-            flow_run_state_mixin=flow_run_state_mixin,
-            task_run_mixin=task_run_mixin,
-            task_run_state_mixin=task_run_state_mixin,
-            artifact_mixin=artifact_mixin,
-            artifact_collection_mixin=artifact_collection_mixin,
-            task_run_state_cache_mixin=task_run_state_cache_mixin,
-            deployment_mixin=deployment_mixin,
-            deployment_schedule_mixin=deployment_schedule_mixin,
-            saved_search_mixin=saved_search_mixin,
-            log_mixin=log_mixin,
-            concurrency_limit_mixin=concurrency_limit_mixin,
-            concurrency_limit_v2_mixin=concurrency_limit_v2_mixin,
-            work_pool_mixin=work_pool_mixin,
-            worker_mixin=worker_mixin,
-            work_queue_mixin=work_queue_mixin,
-            agent_mixin=agent_mixin,
-            block_type_mixin=block_type_mixin,
-            block_schema_mixin=block_schema_mixin,
-            block_schema_reference_mixin=block_schema_reference_mixin,
-            block_document_mixin=block_document_mixin,
-            block_document_reference_mixin=block_document_reference_mixin,
-            configuration_mixin=configuration_mixin,
-            variable_mixin=variable_mixin,
-            flow_run_input_mixin=flow_run_input_mixin,
-            csrf_token_mixin=csrf_token_mixin,
-            automation_mixin=automation_mixin,
-            automation_bucket_mixin=automation_bucket_mixin,
-            automation_related_resource_mixin=automation_related_resource_mixin,
-            composite_trigger_child_firing_mixin=composite_trigger_child_firing_mixin,
-            event_follower_mixin=event_follower_mixin,
-            event_mixin=event_mixin,
-            event_resource_mixin=event_resource_mixin,
-        )
 
     def _unique_key(self) -> Tuple[Hashable, ...]:
         """
         Returns a key used to determine whether to instantiate a new DB interface.
         """
-        return (self.__class__, self.base_metadata, tuple(self.base_model_mixins))
-
-    def _create_base_model(self):
-        """
-        Defines the base ORM model and binds it to `self`. The base model will be
-        extended by mixins specified in the database configuration. This method only
-        runs on instantiation.
-        """
-
-        @as_declarative(metadata=self.base_metadata)
-        class Base(*self.base_model_mixins, ORMBase):
-            pass
-
-        self.Base = Base
-
-    def _create_orm_models(
-        self,
-        flow_mixin=ORMFlow,
-        flow_run_mixin=ORMFlowRun,
-        flow_run_state_mixin=ORMFlowRunState,
-        task_run_mixin=ORMTaskRun,
-        task_run_state_mixin=ORMTaskRunState,
-        artifact_mixin=ORMArtifact,
-        artifact_collection_mixin=ORMArtifactCollection,
-        task_run_state_cache_mixin=ORMTaskRunStateCache,
-        deployment_mixin=ORMDeployment,
-        deployment_schedule_mixin=ORMDeploymentSchedule,
-        saved_search_mixin=ORMSavedSearch,
-        log_mixin=ORMLog,
-        concurrency_limit_mixin=ORMConcurrencyLimit,
-        concurrency_limit_v2_mixin=ORMConcurrencyLimitV2,
-        work_pool_mixin=ORMWorkPool,
-        worker_mixin=ORMWorker,
-        block_type_mixin=ORMBlockType,
-        block_schema_mixin=ORMBlockSchema,
-        block_schema_reference_mixin=ORMBlockSchemaReference,
-        block_document_mixin=ORMBlockDocument,
-        block_document_reference_mixin=ORMBlockDocumentReference,
-        flow_run_notification_policy_mixin=ORMFlowRunNotificationPolicy,
-        flow_run_notification_queue_mixin=ORMFlowRunNotificationQueue,
-        work_queue_mixin=ORMWorkQueue,
-        agent_mixin=ORMAgent,
-        configuration_mixin=ORMConfiguration,
-        variable_mixin=ORMVariable,
-        csrf_token_mixin=ORMCsrfToken,
-        flow_run_input_mixin=ORMFlowRunInput,
-        automation_mixin=ORMAutomation,
-        automation_bucket_mixin=ORMAutomationBucket,
-        automation_related_resource_mixin=ORMAutomationRelatedResource,
-        composite_trigger_child_firing_mixin=ORMCompositeTriggerChildFiring,
-        event_follower_mixin=ORMAutomationEventFollower,
-        event_mixin=ORMEvent,
-        event_resource_mixin=ORMEventResource,
-    ):
-        """
-        Defines the ORM models used in Prefect REST API and binds them to the `self`. This method
-        only runs on instantiation.
-        """
-
-        class Flow(flow_mixin, self.Base):
-            pass
-
-        class FlowRunState(flow_run_state_mixin, self.Base):
-            pass
-
-        class TaskRunState(task_run_state_mixin, self.Base):
-            pass
-
-        class Artifact(artifact_mixin, self.Base):
-            pass
-
-        class ArtifactCollection(artifact_collection_mixin, self.Base):
-            pass
-
-        class TaskRunStateCache(task_run_state_cache_mixin, self.Base):
-            pass
-
-        class FlowRun(flow_run_mixin, self.Base):
-            pass
-
-        class TaskRun(task_run_mixin, self.Base):
-            pass
-
-        class Deployment(deployment_mixin, self.Base):
-            pass
-
-        class DeploymentSchedule(deployment_schedule_mixin, self.Base):
-            pass
-
-        class SavedSearch(saved_search_mixin, self.Base):
-            pass
-
-        class Log(log_mixin, self.Base):
-            pass
-
-        class ConcurrencyLimit(concurrency_limit_mixin, self.Base):
-            pass
-
-        class ConcurrencyLimitV2(concurrency_limit_v2_mixin, self.Base):
-            pass
-
-        class WorkPool(work_pool_mixin, self.Base):
-            pass
-
-        class Worker(worker_mixin, self.Base):
-            pass
-
-        class WorkQueue(work_queue_mixin, self.Base):
-            pass
-
-        class Agent(agent_mixin, self.Base):
-            pass
-
-        class BlockType(block_type_mixin, self.Base):
-            pass
-
-        class BlockSchema(block_schema_mixin, self.Base):
-            pass
-
-        class BlockSchemaReference(block_schema_reference_mixin, self.Base):
-            pass
-
-        class BlockDocument(block_document_mixin, self.Base):
-            pass
-
-        class BlockDocumentReference(block_document_reference_mixin, self.Base):
-            pass
-
-        class CsrfToken(csrf_token_mixin, self.Base):
-            pass
-
-        class FlowRunNotificationPolicy(flow_run_notification_policy_mixin, self.Base):
-            pass
-
-        class FlowRunNotificationQueue(flow_run_notification_queue_mixin, self.Base):
-            pass
-
-        class Configuration(configuration_mixin, self.Base):
-            pass
-
-        class Variable(variable_mixin, self.Base):
-            pass
-
-        class FlowRunInput(flow_run_input_mixin, self.Base):
-            pass
-
-        class Automation(automation_mixin, self.Base):
-            pass
-
-        class AutomationBucket(automation_bucket_mixin, self.Base):
-            pass
-
-        class AutomationRelatedResource(automation_related_resource_mixin, self.Base):
-            pass
-
-        class CompositeTriggerChildFiring(
-            composite_trigger_child_firing_mixin, self.Base
-        ):
-            pass
-
-        class AutomationEventFollower(event_follower_mixin, self.Base):
-            pass
-
-        class Event(event_mixin, self.Base):
-            pass
-
-        class EventResource(event_resource_mixin, self.Base):
-            pass
-
-        self.Flow = Flow
-        self.FlowRunState = FlowRunState
-        self.TaskRunState = TaskRunState
-        self.Artifact = Artifact
-        self.ArtifactCollection = ArtifactCollection
-        self.TaskRunStateCache = TaskRunStateCache
-        self.FlowRun = FlowRun
-        self.TaskRun = TaskRun
-        self.Deployment = Deployment
-        self.DeploymentSchedule = DeploymentSchedule
-        self.SavedSearch = SavedSearch
-        self.Log = Log
-        self.ConcurrencyLimit = ConcurrencyLimit
-        self.ConcurrencyLimitV2 = ConcurrencyLimitV2
-        self.WorkPool = WorkPool
-        self.Worker = Worker
-        self.WorkQueue = WorkQueue
-        self.Agent = Agent
-        self.BlockType = BlockType
-        self.BlockSchema = BlockSchema
-        self.BlockSchemaReference = BlockSchemaReference
-        self.BlockDocument = BlockDocument
-        self.BlockDocumentReference = BlockDocumentReference
-        self.FlowRunNotificationPolicy = FlowRunNotificationPolicy
-        self.FlowRunNotificationQueue = FlowRunNotificationQueue
-        self.Configuration = Configuration
-        self.Variable = Variable
-        self.FlowRunInput = FlowRunInput
-        self.CsrfToken = CsrfToken
-        self.Automation = Automation
-        self.AutomationBucket = AutomationBucket
-        self.AutomationRelatedResource = AutomationRelatedResource
-        self.CompositeTriggerChildFiring = CompositeTriggerChildFiring
-        self.AutomationEventFollower = AutomationEventFollower
-        self.Event = Event
-        self.EventResource = EventResource
+        return (self.__class__, Base.metadata)
 
     @property
     @abstractmethod
@@ -1995,56 +1540,56 @@ class BaseORMConfiguration(ABC):
     @property
     def deployment_unique_upsert_columns(self):
         """Unique columns for upserting a Deployment"""
-        return [self.Deployment.flow_id, self.Deployment.name]
+        return [Deployment.flow_id, Deployment.name]
 
     @property
     def concurrency_limit_unique_upsert_columns(self):
         """Unique columns for upserting a ConcurrencyLimit"""
-        return [self.ConcurrencyLimit.tag]
+        return [ConcurrencyLimit.tag]
 
     @property
     def flow_run_unique_upsert_columns(self):
         """Unique columns for upserting a FlowRun"""
-        return [self.FlowRun.flow_id, self.FlowRun.idempotency_key]
+        return [FlowRun.flow_id, FlowRun.idempotency_key]
 
     @property
     def block_type_unique_upsert_columns(self):
         """Unique columns for upserting a BlockType"""
-        return [self.BlockType.slug]
+        return [BlockType.slug]
 
     @property
     def artifact_collection_unique_upsert_columns(self):
         """Unique columns for upserting an ArtifactCollection"""
-        return [self.ArtifactCollection.key]
+        return [ArtifactCollection.key]
 
     @property
     def block_schema_unique_upsert_columns(self):
         """Unique columns for upserting a BlockSchema"""
-        return [self.BlockSchema.checksum, self.BlockSchema.version]
+        return [BlockSchema.checksum, BlockSchema.version]
 
     @property
     def flow_unique_upsert_columns(self):
         """Unique columns for upserting a Flow"""
-        return [self.Flow.name]
+        return [Flow.name]
 
     @property
     def saved_search_unique_upsert_columns(self):
         """Unique columns for upserting a SavedSearch"""
-        return [self.SavedSearch.name]
+        return [SavedSearch.name]
 
     @property
     def task_run_unique_upsert_columns(self):
         """Unique columns for upserting a TaskRun"""
         return [
-            self.TaskRun.flow_run_id,
-            self.TaskRun.task_key,
-            self.TaskRun.dynamic_key,
+            TaskRun.flow_run_id,
+            TaskRun.task_key,
+            TaskRun.dynamic_key,
         ]
 
     @property
     def block_document_unique_upsert_columns(self):
         """Unique columns for upserting a BlockDocument"""
-        return [self.BlockDocument.block_type_id, self.BlockDocument.name]
+        return [BlockDocument.block_type_id, BlockDocument.name]
 
 
 class AsyncPostgresORMConfiguration(BaseORMConfiguration):

--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -24,6 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect._internal.compatibility.experimental import experiment_enabled
 from prefect.server import models, schemas
+from prefect.server.database import orm_models
 from prefect.server.exceptions import FlowRunGraphTooLarge, ObjectNotFoundError
 from prefect.server.schemas.graph import Edge, Graph, GraphArtifact, GraphState, Node
 from prefect.server.utilities.database import UUID as UUIDTypeDecorator
@@ -110,7 +111,7 @@ class BaseQueryComponents(ABC):
 
     @abstractmethod
     async def get_flow_run_notifications_from_queue(
-        self, session: AsyncSession, db: "PrefectDBInterface", limit: int
+        self, session: AsyncSession, limit: int
     ):
         """Database-specific implementation of reading notifications from the queue and deleting them"""
 
@@ -122,34 +123,34 @@ class BaseQueryComponents(ABC):
     ):
         """Database-specific implementation of queueing notifications for a flow run"""
         # insert a <policy, state> pair into the notification queue
-        stmt = db.insert(db.FlowRunNotificationQueue).from_select(
+        stmt = db.insert(orm_models.FlowRunNotificationQueue).from_select(
             [
-                db.FlowRunNotificationQueue.flow_run_notification_policy_id,
-                db.FlowRunNotificationQueue.flow_run_state_id,
+                orm_models.FlowRunNotificationQueue.flow_run_notification_policy_id,
+                orm_models.FlowRunNotificationQueue.flow_run_state_id,
             ],
             # ... by selecting from any notification policy that matches the criteria
             sa.select(
-                db.FlowRunNotificationPolicy.id,
+                orm_models.FlowRunNotificationPolicy.id,
                 sa.cast(sa.literal(str(flow_run.state_id)), UUIDTypeDecorator),
             )
-            .select_from(db.FlowRunNotificationPolicy)
+            .select_from(orm_models.FlowRunNotificationPolicy)
             .where(
                 sa.and_(
                     # the policy is active
-                    db.FlowRunNotificationPolicy.is_active.is_(True),
+                    orm_models.FlowRunNotificationPolicy.is_active.is_(True),
                     # the policy state names aren't set or match the current state name
                     sa.or_(
-                        db.FlowRunNotificationPolicy.state_names == [],
+                        orm_models.FlowRunNotificationPolicy.state_names == [],
                         json_has_any_key(
-                            db.FlowRunNotificationPolicy.state_names,
+                            orm_models.FlowRunNotificationPolicy.state_names,
                             [flow_run.state_name],
                         ),
                     ),
                     # the policy tags aren't set, or the tags match the flow run tags
                     sa.or_(
-                        db.FlowRunNotificationPolicy.tags == [],
+                        orm_models.FlowRunNotificationPolicy.tags == [],
                         json_has_any_key(
-                            db.FlowRunNotificationPolicy.tags, flow_run.tags
+                            orm_models.FlowRunNotificationPolicy.tags, flow_run.tags
                         ),
                     ),
                 )
@@ -162,7 +163,6 @@ class BaseQueryComponents(ABC):
 
     def get_scheduled_flow_runs_from_work_queues(
         self,
-        db: "PrefectDBInterface",
         limit_per_queue: Optional[int] = None,
         work_queue_ids: Optional[List[UUID]] = None,
         scheduled_before: Optional[datetime.datetime] = None,
@@ -170,7 +170,7 @@ class BaseQueryComponents(ABC):
         """
         Returns all scheduled runs in work queues, subject to provided parameters.
 
-        This query returns a `(db.FlowRun, db.WorkQueue.id)` pair; calling
+        This query returns a `(orm_models.FlowRun, orm_models.WorkQueue.id)` pair; calling
         `result.all()` will return both; calling `result.scalars().unique().all()`
         will return only the flow run because it grabs the first result.
         """
@@ -179,29 +179,34 @@ class BaseQueryComponents(ABC):
         # slots as their limit less the number of running flows
         concurrency_queues = (
             sa.select(
-                db.WorkQueue.id,
+                orm_models.WorkQueue.id,
                 self.greatest(
-                    0, db.WorkQueue.concurrency_limit - sa.func.count(db.FlowRun.id)
+                    0,
+                    orm_models.WorkQueue.concurrency_limit
+                    - sa.func.count(orm_models.FlowRun.id),
                 ).label("available_slots"),
             )
-            .select_from(db.WorkQueue)
+            .select_from(orm_models.WorkQueue)
             .join(
-                db.FlowRun,
+                orm_models.FlowRun,
                 sa.and_(
-                    self._flow_run_work_queue_join_clause(db.FlowRun, db.WorkQueue),
-                    db.FlowRun.state_type.in_(["RUNNING", "PENDING", "CANCELLING"]),
+                    self._flow_run_work_queue_join_clause(
+                        orm_models.FlowRun, orm_models.WorkQueue
+                    ),
+                    orm_models.FlowRun.state_type.in_(
+                        ["RUNNING", "PENDING", "CANCELLING"]
+                    ),
                 ),
                 isouter=True,
             )
-            .where(db.WorkQueue.concurrency_limit.is_not(None))
-            .group_by(db.WorkQueue.id)
+            .where(orm_models.WorkQueue.concurrency_limit.is_not(None))
+            .group_by(orm_models.WorkQueue.id)
             .cte("concurrency_queues")
         )
 
         # use the available slots information to generate a join
         # for all scheduled runs
         scheduled_flow_runs, join_criteria = self._get_scheduled_flow_runs_join(
-            db=db,
             work_queue_query=concurrency_queues,
             limit_per_queue=limit_per_queue,
             scheduled_before=scheduled_before,
@@ -213,19 +218,19 @@ class BaseQueryComponents(ABC):
         query = (
             # return a flow run and work queue id
             sa.select(
-                sa.orm.aliased(db.FlowRun, scheduled_flow_runs),
-                db.WorkQueue.id.label("wq_id"),
+                sa.orm.aliased(orm_models.FlowRun, scheduled_flow_runs),
+                orm_models.WorkQueue.id.label("wq_id"),
             )
-            .select_from(db.WorkQueue)
+            .select_from(orm_models.WorkQueue)
             .join(
                 concurrency_queues,
-                db.WorkQueue.id == concurrency_queues.c.id,
+                orm_models.WorkQueue.id == concurrency_queues.c.id,
                 isouter=True,
             )
             .join(scheduled_flow_runs, join_criteria)
             .where(
-                db.WorkQueue.is_paused.is_(False),
-                db.WorkQueue.id.in_(work_queue_ids) if work_queue_ids else True,
+                orm_models.WorkQueue.is_paused.is_(False),
+                orm_models.WorkQueue.id.in_(work_queue_ids) if work_queue_ids else True,
             )
             .order_by(
                 scheduled_flow_runs.c.next_scheduled_start_time,
@@ -237,7 +242,6 @@ class BaseQueryComponents(ABC):
 
     def _get_scheduled_flow_runs_join(
         self,
-        db: "PrefectDBInterface",
         work_queue_query,
         limit_per_queue: Optional[int],
         scheduled_before: Optional[datetime.datetime],
@@ -247,7 +251,7 @@ class BaseQueryComponents(ABC):
 
         # precompute for readability
         scheduled_before_clause = (
-            db.FlowRun.next_scheduled_start_time <= scheduled_before
+            orm_models.FlowRun.next_scheduled_start_time <= scheduled_before
             if scheduled_before is not None
             else True
         )
@@ -255,15 +259,17 @@ class BaseQueryComponents(ABC):
         # get scheduled flow runs with lateral join where the limit is the
         # available slots per queue
         scheduled_flow_runs = (
-            sa.select(db.FlowRun)
+            sa.select(orm_models.FlowRun)
             .where(
-                self._flow_run_work_queue_join_clause(db.FlowRun, db.WorkQueue),
-                db.FlowRun.state_type == "SCHEDULED",
+                self._flow_run_work_queue_join_clause(
+                    orm_models.FlowRun, orm_models.WorkQueue
+                ),
+                orm_models.FlowRun.state_type == "SCHEDULED",
                 scheduled_before_clause,
             )
             .with_for_update(skip_locked=True)
             # priority given to runs with earlier next_scheduled_start_time
-            .order_by(db.FlowRun.next_scheduled_start_time)
+            .order_by(orm_models.FlowRun.next_scheduled_start_time)
             # if null, no limit will be applied
             .limit(sa.func.least(limit_per_queue, work_queue_query.c.available_slots))
             .lateral("scheduled_flow_runs")
@@ -296,7 +302,6 @@ class BaseQueryComponents(ABC):
     async def get_scheduled_flow_runs_from_work_pool(
         self,
         session,
-        db: "PrefectDBInterface",
         limit: Optional[int] = None,
         worker_limit: Optional[int] = None,
         queue_limit: Optional[int] = None,
@@ -367,11 +372,11 @@ class BaseQueryComponents(ABC):
             sa.select(
                 sa.column("run_work_pool_id"),
                 sa.column("run_work_queue_id"),
-                db.FlowRun,
+                orm_models.FlowRun,
             )
             .from_statement(query)
             # indicate that the state relationship isn't being loaded
-            .options(sa.orm.noload(db.FlowRun.state))
+            .options(sa.orm.noload(orm_models.FlowRun.state))
         )
 
         result = await session.execute(orm_query)
@@ -388,7 +393,6 @@ class BaseQueryComponents(ABC):
     async def read_block_documents(
         self,
         session: sa.orm.Session,
-        db: "PrefectDBInterface",
         block_document_filter: Optional[schemas.filters.BlockDocumentFilter] = None,
         block_type_filter: Optional[schemas.filters.BlockTypeFilter] = None,
         block_schema_filter: Optional[schemas.filters.BlockSchemaFilter] = None,
@@ -405,23 +409,23 @@ class BaseQueryComponents(ABC):
         # --- Query for Parent Block Documents
         # begin by building a query for only those block documents that are selected
         # by the provided filters
-        filtered_block_documents_query = sa.select(db.BlockDocument.id).where(
-            block_document_filter.as_sql_filter(db)
+        filtered_block_documents_query = sa.select(orm_models.BlockDocument.id).where(
+            block_document_filter.as_sql_filter()
         )
 
         if block_type_filter is not None:
-            block_type_exists_clause = sa.select(db.BlockType).where(
-                db.BlockType.id == db.BlockDocument.block_type_id,
-                block_type_filter.as_sql_filter(db),
+            block_type_exists_clause = sa.select(orm_models.BlockType).where(
+                orm_models.BlockType.id == orm_models.BlockDocument.block_type_id,
+                block_type_filter.as_sql_filter(),
             )
             filtered_block_documents_query = filtered_block_documents_query.where(
                 block_type_exists_clause.exists()
             )
 
         if block_schema_filter is not None:
-            block_schema_exists_clause = sa.select(db.BlockSchema).where(
-                db.BlockSchema.id == db.BlockDocument.block_schema_id,
-                block_schema_filter.as_sql_filter(db),
+            block_schema_exists_clause = sa.select(orm_models.BlockSchema).where(
+                orm_models.BlockSchema.id == orm_models.BlockDocument.block_schema_id,
+                block_schema_filter.as_sql_filter(),
             )
             filtered_block_documents_query = filtered_block_documents_query.where(
                 block_schema_exists_clause.exists()
@@ -443,17 +447,19 @@ class BaseQueryComponents(ABC):
         # next build a recursive query for (potentially nested) block documents
         # that reference the filtered block documents
         block_document_references_query = (
-            sa.select(db.BlockDocumentReference)
+            sa.select(orm_models.BlockDocumentReference)
             .filter(
-                db.BlockDocumentReference.parent_block_document_id.in_(
+                orm_models.BlockDocumentReference.parent_block_document_id.in_(
                     sa.select(filtered_block_documents_query.c.id)
                 )
             )
             .cte("block_document_references", recursive=True)
         )
-        block_document_references_join = sa.select(db.BlockDocumentReference).join(
+        block_document_references_join = sa.select(
+            orm_models.BlockDocumentReference
+        ).join(
             block_document_references_query,
-            db.BlockDocumentReference.parent_block_document_id
+            orm_models.BlockDocumentReference.parent_block_document_id
             == block_document_references_query.c.reference_block_document_id,
         )
         recursive_block_document_references_cte = (
@@ -467,25 +473,27 @@ class BaseQueryComponents(ABC):
         all_block_documents_query = sa.union_all(
             # first select the parent block
             sa.select(
-                db.BlockDocument,
+                orm_models.BlockDocument,
                 sa.null().label("reference_name"),
                 sa.null().label("reference_parent_block_document_id"),
             )
-            .select_from(db.BlockDocument)
+            .select_from(orm_models.BlockDocument)
             .where(
-                db.BlockDocument.id.in_(sa.select(filtered_block_documents_query.c.id))
+                orm_models.BlockDocument.id.in_(
+                    sa.select(filtered_block_documents_query.c.id)
+                )
             ),
             #
             # then select any referenced blocks
             sa.select(
-                db.BlockDocument,
+                orm_models.BlockDocument,
                 recursive_block_document_references_cte.c.name,
                 recursive_block_document_references_cte.c.parent_block_document_id,
             )
-            .select_from(db.BlockDocument)
+            .select_from(orm_models.BlockDocument)
             .join(
                 recursive_block_document_references_cte,
-                db.BlockDocument.id
+                orm_models.BlockDocument.id
                 == recursive_block_document_references_cte.c.reference_block_document_id,
             ),
         ).cte("all_block_documents_query")
@@ -494,7 +502,7 @@ class BaseQueryComponents(ABC):
         # and also be sorted
         return (
             sa.select(
-                sa.orm.aliased(db.BlockDocument, all_block_documents_query),
+                sa.orm.aliased(orm_models.BlockDocument, all_block_documents_query),
                 all_block_documents_query.c.reference_name,
                 all_block_documents_query.c.reference_parent_block_document_id,
             )
@@ -503,7 +511,7 @@ class BaseQueryComponents(ABC):
         )
 
     async def read_configuration_value(
-        self, db: "PrefectDBInterface", session: sa.orm.Session, key: str
+        self, session: sa.orm.Session, key: str
     ) -> Optional[Dict]:
         """
         Read a configuration value by key.
@@ -517,7 +525,9 @@ class BaseQueryComponents(ABC):
         try:
             return self.CONFIGURATION_CACHE[key]
         except KeyError:
-            query = sa.select(db.Configuration).where(db.Configuration.key == key)
+            query = sa.select(orm_models.Configuration).where(
+                orm_models.Configuration.key == key
+            )
             result = await session.execute(query)
             configuration = result.scalar()
             if configuration is not None:
@@ -532,7 +542,6 @@ class BaseQueryComponents(ABC):
     @abstractmethod
     async def flow_run_graph_v2(
         self,
-        db: "PrefectDBInterface",
         session: AsyncSession,
         flow_run_id: UUID,
         since: datetime.datetime,
@@ -544,7 +553,6 @@ class BaseQueryComponents(ABC):
 
     async def _get_flow_run_graph_artifacts(
         self,
-        db: "PrefectDBInterface",
         session: AsyncSession,
         flow_run_id: UUID,
         max_artifacts: int,
@@ -559,19 +567,20 @@ class BaseQueryComponents(ABC):
 
         query = (
             sa.select(
-                db.Artifact, db.ArtifactCollection.id.label("latest_in_collection_id")
+                orm_models.Artifact,
+                orm_models.ArtifactCollection.id.label("latest_in_collection_id"),
             )
             .where(
-                db.Artifact.flow_run_id == flow_run_id,
-                db.Artifact.type != "result",
+                orm_models.Artifact.flow_run_id == flow_run_id,
+                orm_models.Artifact.type != "result",
             )
             .join(
-                db.ArtifactCollection,
-                (db.ArtifactCollection.key == db.Artifact.key)
-                & (db.ArtifactCollection.latest_id == db.Artifact.id),
+                orm_models.ArtifactCollection,
+                (orm_models.ArtifactCollection.key == orm_models.Artifact.key)
+                & (orm_models.ArtifactCollection.latest_id == orm_models.Artifact.id),
                 isouter=True,
             )
-            .order_by(db.Artifact.created.asc())
+            .order_by(orm_models.Artifact.created.asc())
             .limit(max_artifacts)
         )
 
@@ -692,7 +701,7 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
         return stmt
 
     async def get_flow_run_notifications_from_queue(
-        self, session: AsyncSession, db: "PrefectDBInterface", limit: int
+        self, session: AsyncSession, limit: int
     ) -> List:
         # including this as a subquery in the where clause of the
         # `queued_notifications` statement below, leads to errors where the limit
@@ -700,22 +709,24 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
         # prevents this. see link for more details:
         # https://www.postgresql.org/message-id/16497.1553640836%40sss.pgh.pa.us
         queued_notifications_ids = (
-            sa.select(db.FlowRunNotificationQueue.id)
-            .select_from(db.FlowRunNotificationQueue)
-            .order_by(db.FlowRunNotificationQueue.updated)
+            sa.select(orm_models.FlowRunNotificationQueue.id)
+            .select_from(orm_models.FlowRunNotificationQueue)
+            .order_by(orm_models.FlowRunNotificationQueue.updated)
             .limit(limit)
             .with_for_update(skip_locked=True)
         ).cte("queued_notifications_ids")
 
         queued_notifications = (
-            sa.delete(db.FlowRunNotificationQueue)
+            sa.delete(orm_models.FlowRunNotificationQueue)
             .returning(
-                db.FlowRunNotificationQueue.id,
-                db.FlowRunNotificationQueue.flow_run_notification_policy_id,
-                db.FlowRunNotificationQueue.flow_run_state_id,
+                orm_models.FlowRunNotificationQueue.id,
+                orm_models.FlowRunNotificationQueue.flow_run_notification_policy_id,
+                orm_models.FlowRunNotificationQueue.flow_run_state_id,
             )
             .where(
-                db.FlowRunNotificationQueue.id.in_(sa.select(queued_notifications_ids))
+                orm_models.FlowRunNotificationQueue.id.in_(
+                    sa.select(queued_notifications_ids)
+                )
             )
             .cte("queued_notifications")
         )
@@ -723,40 +734,40 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
         notification_details_stmt = (
             sa.select(
                 queued_notifications.c.id.label("queue_id"),
-                db.FlowRunNotificationPolicy.id.label(
+                orm_models.FlowRunNotificationPolicy.id.label(
                     "flow_run_notification_policy_id"
                 ),
-                db.FlowRunNotificationPolicy.message_template.label(
+                orm_models.FlowRunNotificationPolicy.message_template.label(
                     "flow_run_notification_policy_message_template"
                 ),
-                db.FlowRunNotificationPolicy.block_document_id,
-                db.Flow.id.label("flow_id"),
-                db.Flow.name.label("flow_name"),
-                db.FlowRun.id.label("flow_run_id"),
-                db.FlowRun.name.label("flow_run_name"),
-                db.FlowRun.parameters.label("flow_run_parameters"),
-                db.FlowRunState.type.label("flow_run_state_type"),
-                db.FlowRunState.name.label("flow_run_state_name"),
-                db.FlowRunState.timestamp.label("flow_run_state_timestamp"),
-                db.FlowRunState.message.label("flow_run_state_message"),
+                orm_models.FlowRunNotificationPolicy.block_document_id,
+                orm_models.Flow.id.label("flow_id"),
+                orm_models.Flow.name.label("flow_name"),
+                orm_models.FlowRun.id.label("flow_run_id"),
+                orm_models.FlowRun.name.label("flow_run_name"),
+                orm_models.FlowRun.parameters.label("flow_run_parameters"),
+                orm_models.FlowRunState.type.label("flow_run_state_type"),
+                orm_models.FlowRunState.name.label("flow_run_state_name"),
+                orm_models.FlowRunState.timestamp.label("flow_run_state_timestamp"),
+                orm_models.FlowRunState.message.label("flow_run_state_message"),
             )
             .select_from(queued_notifications)
             .join(
-                db.FlowRunNotificationPolicy,
+                orm_models.FlowRunNotificationPolicy,
                 queued_notifications.c.flow_run_notification_policy_id
-                == db.FlowRunNotificationPolicy.id,
+                == orm_models.FlowRunNotificationPolicy.id,
             )
             .join(
-                db.FlowRunState,
-                queued_notifications.c.flow_run_state_id == db.FlowRunState.id,
+                orm_models.FlowRunState,
+                queued_notifications.c.flow_run_state_id == orm_models.FlowRunState.id,
             )
             .join(
-                db.FlowRun,
-                db.FlowRunState.flow_run_id == db.FlowRun.id,
+                orm_models.FlowRun,
+                orm_models.FlowRunState.flow_run_id == orm_models.FlowRun.id,
             )
             .join(
-                db.Flow,
-                db.FlowRun.flow_id == db.Flow.id,
+                orm_models.Flow,
+                orm_models.FlowRun.flow_id == orm_models.Flow.id,
             )
         )
 
@@ -772,7 +783,6 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
 
     async def flow_run_graph_v2(
         self,
-        db: "PrefectDBInterface",
         session: AsyncSession,
         flow_run_id: UUID,
         since: datetime.datetime,
@@ -783,10 +793,13 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
         graph (version 2)."""
         result = await session.execute(
             sa.select(
-                sa.func.coalesce(db.FlowRun.start_time, db.FlowRun.expected_start_time),
-                db.FlowRun.end_time,
+                sa.func.coalesce(
+                    orm_models.FlowRun.start_time,
+                    orm_models.FlowRun.expected_start_time,
+                ),
+                orm_models.FlowRun.end_time,
             ).where(
-                db.FlowRun.id == flow_run_id,
+                orm_models.FlowRun.id == flow_run_id,
             )
         )
         try:
@@ -898,7 +911,7 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
         results = await session.execute(query)
 
         graph_artifacts = await self._get_flow_run_graph_artifacts(
-            db, session, flow_run_id, max_artifacts
+            session, flow_run_id, max_artifacts
         )
         graph_states = await self._get_flow_run_graph_states(session, flow_run_id)
 
@@ -1049,7 +1062,7 @@ class AioSqliteQueryComponents(BaseQueryComponents):
         return stmt
 
     async def get_flow_run_notifications_from_queue(
-        self, session: AsyncSession, db: "PrefectDBInterface", limit: int
+        self, session: AsyncSession, limit: int
     ) -> List:
         """
         Sqlalchemy has no support for DELETE RETURNING in sqlite (as of May 2022)
@@ -1060,43 +1073,44 @@ class AioSqliteQueryComponents(BaseQueryComponents):
 
         notification_details_stmt = (
             sa.select(
-                db.FlowRunNotificationQueue.id.label("queue_id"),
-                db.FlowRunNotificationPolicy.id.label(
+                orm_models.FlowRunNotificationQueue.id.label("queue_id"),
+                orm_models.FlowRunNotificationPolicy.id.label(
                     "flow_run_notification_policy_id"
                 ),
-                db.FlowRunNotificationPolicy.message_template.label(
+                orm_models.FlowRunNotificationPolicy.message_template.label(
                     "flow_run_notification_policy_message_template"
                 ),
-                db.FlowRunNotificationPolicy.block_document_id,
-                db.Flow.id.label("flow_id"),
-                db.Flow.name.label("flow_name"),
-                db.FlowRun.id.label("flow_run_id"),
-                db.FlowRun.name.label("flow_run_name"),
-                db.FlowRun.parameters.label("flow_run_parameters"),
-                db.FlowRunState.type.label("flow_run_state_type"),
-                db.FlowRunState.name.label("flow_run_state_name"),
-                db.FlowRunState.timestamp.label("flow_run_state_timestamp"),
-                db.FlowRunState.message.label("flow_run_state_message"),
+                orm_models.FlowRunNotificationPolicy.block_document_id,
+                orm_models.Flow.id.label("flow_id"),
+                orm_models.Flow.name.label("flow_name"),
+                orm_models.FlowRun.id.label("flow_run_id"),
+                orm_models.FlowRun.name.label("flow_run_name"),
+                orm_models.FlowRun.parameters.label("flow_run_parameters"),
+                orm_models.FlowRunState.type.label("flow_run_state_type"),
+                orm_models.FlowRunState.name.label("flow_run_state_name"),
+                orm_models.FlowRunState.timestamp.label("flow_run_state_timestamp"),
+                orm_models.FlowRunState.message.label("flow_run_state_message"),
             )
-            .select_from(db.FlowRunNotificationQueue)
+            .select_from(orm_models.FlowRunNotificationQueue)
             .join(
-                db.FlowRunNotificationPolicy,
-                db.FlowRunNotificationQueue.flow_run_notification_policy_id
-                == db.FlowRunNotificationPolicy.id,
-            )
-            .join(
-                db.FlowRunState,
-                db.FlowRunNotificationQueue.flow_run_state_id == db.FlowRunState.id,
+                orm_models.FlowRunNotificationPolicy,
+                orm_models.FlowRunNotificationQueue.flow_run_notification_policy_id
+                == orm_models.FlowRunNotificationPolicy.id,
             )
             .join(
-                db.FlowRun,
-                db.FlowRunState.flow_run_id == db.FlowRun.id,
+                orm_models.FlowRunState,
+                orm_models.FlowRunNotificationQueue.flow_run_state_id
+                == orm_models.FlowRunState.id,
             )
             .join(
-                db.Flow,
-                db.FlowRun.flow_id == db.Flow.id,
+                orm_models.FlowRun,
+                orm_models.FlowRunState.flow_run_id == orm_models.FlowRun.id,
             )
-            .order_by(db.FlowRunNotificationQueue.updated)
+            .join(
+                orm_models.Flow,
+                orm_models.FlowRun.flow_id == orm_models.Flow.id,
+            )
+            .order_by(orm_models.FlowRunNotificationQueue.updated)
             .limit(limit)
         )
 
@@ -1105,9 +1119,11 @@ class AioSqliteQueryComponents(BaseQueryComponents):
 
         # delete the notifications
         delete_stmt = (
-            sa.delete(db.FlowRunNotificationQueue)
+            sa.delete(orm_models.FlowRunNotificationQueue)
             .where(
-                db.FlowRunNotificationQueue.id.in_([n.queue_id for n in notifications])
+                orm_models.FlowRunNotificationQueue.id.in_(
+                    [n.queue_id for n in notifications]
+                )
             )
             .execution_options(synchronize_session="fetch")
         )
@@ -1132,14 +1148,13 @@ class AioSqliteQueryComponents(BaseQueryComponents):
 
     def _get_scheduled_flow_runs_join(
         self,
-        db: "PrefectDBInterface",
         work_queue_query,
         limit_per_queue: Optional[int],
         scheduled_before: Optional[datetime.datetime],
     ):
         # precompute for readability
         scheduled_before_clause = (
-            db.FlowRun.next_scheduled_start_time <= scheduled_before
+            orm_models.FlowRun.next_scheduled_start_time <= scheduled_before
             if scheduled_before is not None
             else True
         )
@@ -1150,15 +1165,15 @@ class AioSqliteQueryComponents(BaseQueryComponents):
                 (
                     sa.func.row_number()
                     .over(
-                        partition_by=[db.FlowRun.work_queue_name],
-                        order_by=db.FlowRun.next_scheduled_start_time,
+                        partition_by=[orm_models.FlowRun.work_queue_name],
+                        order_by=orm_models.FlowRun.next_scheduled_start_time,
                     )
                     .label("rank")
                 ),
-                db.FlowRun,
+                orm_models.FlowRun,
             )
             .where(
-                db.FlowRun.state_type == "SCHEDULED",
+                orm_models.FlowRun.state_type == "SCHEDULED",
                 scheduled_before_clause,
             )
             .subquery("scheduled_flow_runs")
@@ -1171,7 +1186,9 @@ class AioSqliteQueryComponents(BaseQueryComponents):
         # in the join, only keep flow runs whose rank is less than or equal to the
         # available slots for each queue
         join_criteria = sa.and_(
-            self._flow_run_work_queue_join_clause(scheduled_flow_runs.c, db.WorkQueue),
+            self._flow_run_work_queue_join_clause(
+                scheduled_flow_runs.c, orm_models.WorkQueue
+            ),
             scheduled_flow_runs.c.rank
             <= sa.func.min(
                 sa.func.coalesce(work_queue_query.c.available_slots, limit), limit
@@ -1192,7 +1209,6 @@ class AioSqliteQueryComponents(BaseQueryComponents):
 
     async def flow_run_graph_v2(
         self,
-        db: "PrefectDBInterface",
         session: AsyncSession,
         flow_run_id: UUID,
         since: datetime.datetime,
@@ -1203,10 +1219,13 @@ class AioSqliteQueryComponents(BaseQueryComponents):
         graph (version 2)."""
         result = await session.execute(
             sa.select(
-                sa.func.coalesce(db.FlowRun.start_time, db.FlowRun.expected_start_time),
-                db.FlowRun.end_time,
+                sa.func.coalesce(
+                    orm_models.FlowRun.start_time,
+                    orm_models.FlowRun.expected_start_time,
+                ),
+                orm_models.FlowRun.end_time,
             ).where(
-                db.FlowRun.id == flow_run_id,
+                orm_models.FlowRun.id == flow_run_id,
             )
         )
         try:
@@ -1331,7 +1350,7 @@ class AioSqliteQueryComponents(BaseQueryComponents):
         results = await session.execute(query)
 
         graph_artifacts = await self._get_flow_run_graph_artifacts(
-            db, session, flow_run_id, max_artifacts
+            session, flow_run_id, max_artifacts
         )
         graph_states = await self._get_flow_run_graph_states(session, flow_run_id)
 

--- a/src/prefect/server/events/counting.py
+++ b/src/prefect/server/events/counting.py
@@ -203,7 +203,7 @@ class Countable(AutoEnum):
                 sa.func.min(db.Event.occurred).label("oldest"),
                 sa.func.count().label("count"),
             )
-            .where(sa.and_(*filter.build_where_clauses(db)))
+            .where(sa.and_(*filter.build_where_clauses()))
             .group_by("value", "label")
         )
 

--- a/src/prefect/server/events/filters.py
+++ b/src/prefect/server/events/filters.py
@@ -10,7 +10,7 @@ from sqlalchemy.sql import Select
 
 from prefect._internal.schemas.bases import PrefectBaseModel
 from prefect._internal.schemas.fields import DateTimeTZ
-from prefect.server.database.interface import PrefectDBInterface
+from prefect.server.database import orm_models
 from prefect.server.schemas.filters import (
     PrefectFilterBaseModel,
     PrefectOperatorFilterBaseModel,
@@ -32,10 +32,10 @@ class AutomationFilterCreated(PrefectFilterBaseModel):
         description="Only include automations created before this datetime",
     )
 
-    def _get_filter_list(self, db: PrefectDBInterface) -> list:
+    def _get_filter_list(self) -> list:
         filters = []
         if self.before_ is not None:
-            filters.append(db.Automation.created <= self.before_)
+            filters.append(orm_models.Automation.created <= self.before_)
         return filters
 
 
@@ -47,10 +47,10 @@ class AutomationFilterName(PrefectFilterBaseModel):
         description="Only include automations with names that match any of these strings",
     )
 
-    def _get_filter_list(self, db: PrefectDBInterface) -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Automation.name.in_(self.any_))
+            filters.append(orm_models.Automation.name.in_(self.any_))
         return filters
 
 
@@ -62,7 +62,7 @@ class AutomationFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `Automation.created`"
     )
 
-    def _get_filter_list(self, db: PrefectDBInterface) -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.name is not None:
@@ -100,13 +100,11 @@ class EventDataFilter(PrefectBaseModel, extra="forbid"):
         """Would the given filter exclude this event?"""
         return not self.includes(event)
 
-    def build_where_clauses(
-        self, db: PrefectDBInterface
-    ) -> Sequence["ColumnExpressionArgument[bool]"]:
+    def build_where_clauses(self) -> Sequence["ColumnExpressionArgument[bool]"]:
         """Convert the criteria to a WHERE clause."""
         clauses: List["ColumnExpressionArgument[bool]"] = []
         for filter in self.get_filters():
-            clauses.extend(filter.build_where_clauses(db))
+            clauses.extend(filter.build_where_clauses())
         return clauses
 
 
@@ -126,13 +124,11 @@ class EventOccurredFilter(EventDataFilter):
     def includes(self, event: Event) -> bool:
         return self.since <= event.occurred <= self.until
 
-    def build_where_clauses(
-        self, db: PrefectDBInterface
-    ) -> Sequence["ColumnExpressionArgument[bool]"]:
+    def build_where_clauses(self) -> Sequence["ColumnExpressionArgument[bool]"]:
         filters: List["ColumnExpressionArgument[bool]"] = []
 
-        filters.append(db.Event.occurred >= self.since)
-        filters.append(db.Event.occurred <= self.until)
+        filters.append(orm_models.Event.occurred >= self.since)
+        filters.append(orm_models.Event.occurred <= self.until)
 
         return filters
 
@@ -171,31 +167,34 @@ class EventNameFilter(EventDataFilter):
 
         return True
 
-    def build_where_clauses(
-        self, db: PrefectDBInterface
-    ) -> Sequence["ColumnExpressionArgument[bool]"]:
+    def build_where_clauses(self) -> Sequence["ColumnExpressionArgument[bool]"]:
         filters: List["ColumnExpressionArgument[bool]"] = []
 
         if self.prefix:
             filters.append(
-                sa.or_(*[db.Event.event.startswith(prefix) for prefix in self.prefix])
+                sa.or_(
+                    *[
+                        orm_models.Event.event.startswith(prefix)
+                        for prefix in self.prefix
+                    ]
+                )
             )
 
         if self.exclude_prefix:
             filters.append(
                 sa.and_(
                     *[
-                        sa.not_(db.Event.event.startswith(prefix))
+                        sa.not_(orm_models.Event.event.startswith(prefix))
                         for prefix in self.exclude_prefix
                     ]
                 )
             )
 
         if self.name:
-            filters.append(db.Event.event.in_(self.name))
+            filters.append(orm_models.Event.event.in_(self.name))
 
         if self.exclude_name:
-            filters.append(db.Event.event.not_in(self.exclude_name))
+            filters.append(orm_models.Event.event.not_in(self.exclude_name))
 
         return filters
 
@@ -260,22 +259,20 @@ class EventResourceFilter(EventDataFilter):
 
         return True
 
-    def build_where_clauses(
-        self, db: PrefectDBInterface
-    ) -> Sequence["ColumnExpressionArgument[bool]"]:
+    def build_where_clauses(self) -> Sequence["ColumnExpressionArgument[bool]"]:
         filters: List["ColumnExpressionArgument[bool]"] = []
 
         # If we're doing an exact or prefix search on resource_id, this is efficient
         # enough to do on the events table without going to the event_resources table
 
         if self.id:
-            filters.append(db.Event.resource_id.in_(self.id))
+            filters.append(orm_models.Event.resource_id.in_(self.id))
 
         if self.id_prefix:
             filters.append(
                 sa.or_(
                     *[
-                        db.Event.resource_id.startswith(prefix)
+                        orm_models.Event.resource_id.startswith(prefix)
                         for prefix in self.id_prefix
                     ]
                 )
@@ -286,14 +283,14 @@ class EventResourceFilter(EventDataFilter):
 
             # We are explicitly searching for the primary resource here so the
             # resource_role must be ''
-            label_filters = [db.EventResource.resource_role == ""]
+            label_filters = [orm_models.EventResource.resource_role == ""]
 
             # On the event_resources table, resource_id is unpacked
             # into a column, so we should search for it there
             if resource_ids := labels.pop("prefect.resource.id", None):
                 label_ops = LabelOperations(resource_ids)
 
-                resource_id_column = db.EventResource.resource_id
+                resource_id_column = orm_models.EventResource.resource_id
 
                 if values := label_ops.positive.simple:
                     label_filters.append(resource_id_column.in_(values))
@@ -308,7 +305,9 @@ class EventResourceFilter(EventDataFilter):
                 for _, (label, values) in enumerate(labels.items()):
                     label_ops = LabelOperations(values)
 
-                    label_column = json_extract(db.EventResource.resource, label)
+                    label_column = json_extract(
+                        orm_models.EventResource.resource, label
+                    )
 
                     # With negative labels, the resource _must_ have the label
                     if label_ops.negative.simple or label_ops.negative.prefixes:
@@ -325,8 +324,8 @@ class EventResourceFilter(EventDataFilter):
 
             assert self._top_level_filter
             filters.append(
-                db.Event.id.in_(
-                    self._top_level_filter._scoped_event_resources(db).where(
+                orm_models.Event.id.in_(
+                    self._top_level_filter._scoped_event_resources().where(
                         *label_filters
                     )
                 )
@@ -352,24 +351,22 @@ class EventRelatedFilter(EventDataFilter):
         None, description="Only include events for related resources with these labels"
     )
 
-    def build_where_clauses(
-        self, db: PrefectDBInterface
-    ) -> Sequence["ColumnExpressionArgument[bool]"]:
+    def build_where_clauses(self) -> Sequence["ColumnExpressionArgument[bool]"]:
         filters: List["ColumnExpressionArgument[bool]"] = []
 
         if self.id:
-            filters.append(db.EventResource.resource_id.in_(self.id))
+            filters.append(orm_models.EventResource.resource_id.in_(self.id))
 
         if self.role:
-            filters.append(db.EventResource.resource_role.in_(self.role))
+            filters.append(orm_models.EventResource.resource_role.in_(self.role))
 
         if self.resources_in_roles:
             filters.append(
                 sa.or_(
                     *[
                         sa.and_(
-                            db.EventResource.resource_id == resource_id,
-                            db.EventResource.resource_role == role,
+                            orm_models.EventResource.resource_id == resource_id,
+                            orm_models.EventResource.resource_role == role,
                         )
                         for resource_id, role in self.resources_in_roles
                     ]
@@ -385,7 +382,7 @@ class EventRelatedFilter(EventDataFilter):
             if resource_ids := labels.pop("prefect.resource.id", None):
                 label_ops = LabelOperations(resource_ids)
 
-                resource_id_column = db.EventResource.resource_id
+                resource_id_column = orm_models.EventResource.resource_id
 
                 if values := label_ops.positive.simple:
                     label_filters.append(resource_id_column.in_(values))
@@ -397,13 +394,15 @@ class EventRelatedFilter(EventDataFilter):
                     label_filters.append(sa.not_(resource_id_column.startswith(prefix)))
 
             if roles := labels.pop("prefect.resource.role", None):
-                label_filters.append(db.EventResource.resource_role.in_(roles))
+                label_filters.append(orm_models.EventResource.resource_role.in_(roles))
 
             if labels:
                 for _, (label, values) in enumerate(labels.items()):
                     label_ops = LabelOperations(values)
 
-                    label_column = json_extract(db.EventResource.resource, label)
+                    label_column = json_extract(
+                        orm_models.EventResource.resource, label
+                    )
 
                     if label_ops.negative.simple or label_ops.negative.prefixes:
                         label_filters.append(label_column.is_not(None))
@@ -425,12 +424,12 @@ class EventRelatedFilter(EventDataFilter):
             # also filter out primary resources (those with an empty role) for any of
             # these queries
             if not self.role:
-                filters.append(db.EventResource.resource_role != "")
+                filters.append(orm_models.EventResource.resource_role != "")
 
             assert self._top_level_filter
             filters = [
-                db.Event.id.in_(
-                    self._top_level_filter._scoped_event_resources(db).where(*filters)
+                orm_models.Event.id.in_(
+                    self._top_level_filter._scoped_event_resources().where(*filters)
                 )
             ]
 
@@ -472,19 +471,17 @@ class EventAnyResourceFilter(EventDataFilter):
 
         return True
 
-    def build_where_clauses(
-        self, db: PrefectDBInterface
-    ) -> Sequence["ColumnExpressionArgument[bool]"]:
+    def build_where_clauses(self) -> Sequence["ColumnExpressionArgument[bool]"]:
         filters: List["ColumnExpressionArgument[bool]"] = []
 
         if self.id:
-            filters.append(db.EventResource.resource_id.in_(self.id))
+            filters.append(orm_models.EventResource.resource_id.in_(self.id))
 
         if self.id_prefix:
             filters.append(
                 sa.or_(
                     *[
-                        db.EventResource.resource_id.startswith(prefix)
+                        orm_models.EventResource.resource_id.startswith(prefix)
                         for prefix in self.id_prefix
                     ]
                 )
@@ -499,7 +496,7 @@ class EventAnyResourceFilter(EventDataFilter):
             if resource_ids := labels.pop("prefect.resource.id", None):
                 label_ops = LabelOperations(resource_ids)
 
-                resource_id_column = db.EventResource.resource_id
+                resource_id_column = orm_models.EventResource.resource_id
 
                 if values := label_ops.positive.simple:
                     label_filters.append(resource_id_column.in_(values))
@@ -511,13 +508,15 @@ class EventAnyResourceFilter(EventDataFilter):
                     label_filters.append(sa.not_(resource_id_column.startswith(prefix)))
 
             if roles := labels.pop("prefect.resource.role", None):
-                label_filters.append(db.EventResource.resource_role.in_(roles))
+                label_filters.append(orm_models.EventResource.resource_role.in_(roles))
 
             if labels:
                 for _, (label, values) in enumerate(labels.items()):
                     label_ops = LabelOperations(values)
 
-                    label_column = json_extract(db.EventResource.resource, label)
+                    label_column = json_extract(
+                        orm_models.EventResource.resource, label
+                    )
 
                     if label_ops.negative.simple or label_ops.negative.prefixes:
                         label_filters.append(label_column.is_not(None))
@@ -536,8 +535,8 @@ class EventAnyResourceFilter(EventDataFilter):
         if filters:
             assert self._top_level_filter
             filters = [
-                db.Event.id.in_(
-                    self._top_level_filter._scoped_event_resources(db).where(*filters)
+                orm_models.Event.id.in_(
+                    self._top_level_filter._scoped_event_resources().where(*filters)
                 )
             ]
 
@@ -556,13 +555,11 @@ class EventIDFilter(EventDataFilter):
 
         return True
 
-    def build_where_clauses(
-        self, db: PrefectDBInterface
-    ) -> Sequence["ColumnExpressionArgument[bool]"]:
+    def build_where_clauses(self) -> Sequence["ColumnExpressionArgument[bool]"]:
         filters: List["ColumnExpressionArgument[bool]"] = []
 
         if self.id:
-            filters.append(db.Event.id.in_(self.id))
+            filters.append(orm_models.Event.id.in_(self.id))
 
         return filters
 
@@ -600,17 +597,15 @@ class EventFilter(EventDataFilter):
         description="The order to return filtered events",
     )
 
-    def build_where_clauses(
-        self, db: PrefectDBInterface
-    ) -> Sequence["ColumnExpressionArgument[bool]"]:
+    def build_where_clauses(self) -> Sequence["ColumnExpressionArgument[bool]"]:
         self._top_level_filter = self
-        return super().build_where_clauses(db)
+        return super().build_where_clauses()
 
-    def _scoped_event_resources(self, db: PrefectDBInterface) -> Select:
+    def _scoped_event_resources(self) -> Select:
         """Returns an event_resources query that is scoped to this filter's scope by occurred."""
-        query = sa.select(db.EventResource.event_id).where(
-            db.EventResource.occurred >= self.occurred.since,
-            db.EventResource.occurred <= self.occurred.until,
+        query = sa.select(orm_models.EventResource.event_id).where(
+            orm_models.EventResource.occurred >= self.occurred.since,
+            orm_models.EventResource.occurred <= self.occurred.until,
         )
         return query
 

--- a/src/prefect/server/events/filters.py
+++ b/src/prefect/server/events/filters.py
@@ -66,9 +66,9 @@ class AutomationFilter(PrefectOperatorFilterBaseModel):
         filters = []
 
         if self.name is not None:
-            filters.append(self.name.as_sql_filter(db))
+            filters.append(self.name.as_sql_filter())
         if self.created is not None:
-            filters.append(self.created.as_sql_filter(db))
+            filters.append(self.created.as_sql_filter())
 
         return filters
 

--- a/src/prefect/server/events/models/automations.py
+++ b/src/prefect/server/events/models/automations.py
@@ -42,7 +42,7 @@ async def read_automations_for_workspace(
     query = query.order_by(db.Automation.sort_expression(sort))
 
     if automation_filter:
-        query = query.where(automation_filter.as_sql_filter(db))
+        query = query.where(automation_filter.as_sql_filter())
     if limit is not None:
         query = query.limit(limit)
     if offset is not None:
@@ -325,7 +325,7 @@ async def read_automations_related_to_resource(
         )
 
     if automation_filter:
-        query = query.where(automation_filter.as_sql_filter(db))
+        query = query.where(automation_filter.as_sql_filter())
 
     result = await session.execute(query)
     return [Automation.from_orm(a) for a in result.scalars().all()]

--- a/src/prefect/server/events/storage/database.py
+++ b/src/prefect/server/events/storage/database.py
@@ -114,7 +114,7 @@ async def raw_count_events(
         ).select_from(db.Event)
 
     select_events_query_result = await session.execute(
-        select_events_query.where(sa.and_(*events_filter.build_where_clauses(db)))
+        select_events_query.where(sa.and_(*events_filter.build_where_clauses()))
     )
     return select_events_query_result.scalar() or 0
 
@@ -155,7 +155,7 @@ async def read_events(
             sa.select(db.Event, window_function)
             .where(
                 sa.and_(
-                    *events_filter.build_where_clauses(db)
+                    *events_filter.build_where_clauses()
                 )  # Ensure the same filters are applied here
             )
             .subquery()
@@ -173,7 +173,7 @@ async def read_events(
     else:
         # If no distinct fields are provided, create a query for all events
         select_events_query = sa.select(db.Event).where(
-            sa.and_(*events_filter.build_where_clauses(db))
+            sa.and_(*events_filter.build_where_clauses())
         )
         # Order by the occurred timestamp
         select_events_query = select_events_query.order_by(order(db.Event.occurred))

--- a/src/prefect/server/models/artifacts.py
+++ b/src/prefect/server/models/artifacts.py
@@ -4,17 +4,18 @@ import pendulum
 import sqlalchemy as sa
 from sqlalchemy import select
 
-from prefect.server.database.dependencies import inject_db
+from prefect.server.database import orm_models
+from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.schemas import actions, filters, sorting
 from prefect.server.schemas.core import Artifact
 
 
-@inject_db
+@db_injector
 async def _insert_into_artifact_collection(
+    db: PrefectDBInterface,
     session: sa.orm.Session,
     artifact: Artifact,
-    db: PrefectDBInterface,
     now: pendulum.DateTime = None,
 ):
     """
@@ -24,7 +25,7 @@ async def _insert_into_artifact_collection(
         shallow=True, exclude_unset=True, exclude={"id", "updated", "created"}
     )
     upsert_new_latest_id = (
-        db.insert(db.ArtifactCollection)
+        db.insert(orm_models.ArtifactCollection)
         .values(latest_id=artifact.id, updated=now, created=now, **insert_values)
         .on_conflict_do_update(
             index_elements=db.artifact_collection_unique_upsert_columns,
@@ -39,10 +40,10 @@ async def _insert_into_artifact_collection(
     await session.execute(upsert_new_latest_id)
 
     query = (
-        sa.select(db.ArtifactCollection)
+        sa.select(orm_models.ArtifactCollection)
         .where(
             sa.and_(
-                db.ArtifactCollection.key == artifact.key,
+                orm_models.ArtifactCollection.key == artifact.key,
             )
         )
         .execution_options(populate_existing=True)
@@ -67,18 +68,18 @@ async def _insert_into_artifact_collection(
     return model
 
 
-@inject_db
+@db_injector
 async def _insert_into_artifact(
+    db: PrefectDBInterface,
     session: sa.orm.Session,
     artifact: Artifact,
-    db: PrefectDBInterface,
     now: pendulum.DateTime = None,
 ) -> Artifact:
     """
     Inserts a new artifact into the artifact table.
     """
     artifact_id = artifact.id
-    insert_stmt = db.insert(db.Artifact).values(
+    insert_stmt = db.insert(orm_models.Artifact).values(
         created=now,
         updated=now,
         **artifact.dict(exclude={"created", "updated"}, shallow=True),
@@ -86,8 +87,8 @@ async def _insert_into_artifact(
     await session.execute(insert_stmt)
 
     query = (
-        sa.select(db.Artifact)
-        .where(db.Artifact.id == artifact_id)
+        sa.select(orm_models.Artifact)
+        .where(orm_models.Artifact.id == artifact_id)
         .limit(1)
         .execution_options(populate_existing=True)
     )
@@ -98,33 +99,28 @@ async def _insert_into_artifact(
     return model
 
 
-@inject_db
 async def create_artifact(
     session: sa.orm.Session,
     artifact: Artifact,
-    db: PrefectDBInterface,
 ):
     now = pendulum.now("UTC")
 
     if artifact.key is not None:
         await _insert_into_artifact_collection(
-            session=session, now=now, db=db, artifact=artifact
+            session=session, now=now, artifact=artifact
         )
 
     result = await _insert_into_artifact(
         session=session,
         now=now,
-        db=db,
         artifact=artifact,
     )
 
     return result
 
 
-@inject_db
 async def read_latest_artifact(
     session: sa.orm.Session,
-    db: PrefectDBInterface,
     key: str,
 ):
     """
@@ -135,33 +131,29 @@ async def read_latest_artifact(
     Returns:
         Artifact: The latest artifact
     """
-    latest_artifact_query = sa.select(db.ArtifactCollection).where(
-        db.ArtifactCollection.key == key
+    latest_artifact_query = sa.select(orm_models.ArtifactCollection).where(
+        orm_models.ArtifactCollection.key == key
     )
     result = await session.execute(latest_artifact_query)
     return result.scalar()
 
 
-@inject_db
 async def read_artifact(
     session: sa.orm.Session,
     artifact_id: UUID,
-    db: PrefectDBInterface,
 ):
     """
     Reads an artifact by id.
     """
 
-    query = sa.select(db.Artifact).where(db.Artifact.id == artifact_id)
+    query = sa.select(orm_models.Artifact).where(orm_models.Artifact.id == artifact_id)
 
     result = await session.execute(query)
     return result.scalar()
 
 
-@inject_db
 async def _apply_artifact_filters(
     query,
-    db: PrefectDBInterface,
     flow_run_filter: filters.FlowRunFilter = None,
     task_run_filter: filters.TaskRunFilter = None,
     artifact_filter: filters.ArtifactFilter = None,
@@ -170,44 +162,42 @@ async def _apply_artifact_filters(
 ):
     """Applies filters to an artifact query as a combination of EXISTS subqueries."""
     if artifact_filter:
-        query = query.where(artifact_filter.as_sql_filter(db))
+        query = query.where(artifact_filter.as_sql_filter())
 
     if flow_filter or flow_run_filter or deployment_filter:
-        exists_clause = select(db.FlowRun).where(
-            db.Artifact.flow_run_id == db.FlowRun.id
+        exists_clause = select(orm_models.FlowRun).where(
+            orm_models.Artifact.flow_run_id == orm_models.FlowRun.id
         )
         if flow_run_filter:
-            exists_clause = exists_clause.where(flow_run_filter.as_sql_filter(db))
+            exists_clause = exists_clause.where(flow_run_filter.as_sql_filter())
 
         if flow_filter:
             exists_clause = exists_clause.join(
-                db.Flow,
-                db.Flow.id == db.FlowRun.flow_id,
-            ).where(flow_filter.as_sql_filter(db))
+                orm_models.Flow,
+                orm_models.Flow.id == orm_models.FlowRun.flow_id,
+            ).where(flow_filter.as_sql_filter())
 
         if deployment_filter:
             exists_clause = exists_clause.join(
-                db.Deployment,
-                db.Deployment.id == db.FlowRun.deployment_id,
-            ).where(deployment_filter.as_sql_filter(db))
+                orm_models.Deployment,
+                orm_models.Deployment.id == orm_models.FlowRun.deployment_id,
+            ).where(deployment_filter.as_sql_filter())
 
         query = query.where(exists_clause.exists())
 
     if task_run_filter:
-        exists_clause = select(db.TaskRun).where(
-            db.Artifact.task_run_id == db.TaskRun.id
+        exists_clause = select(orm_models.TaskRun).where(
+            orm_models.Artifact.task_run_id == orm_models.TaskRun.id
         )
-        exists_clause = exists_clause.where(task_run_filter.as_sql_filter(db))
+        exists_clause = exists_clause.where(task_run_filter.as_sql_filter())
 
         query = query.where(exists_clause.exists())
 
     return query
 
 
-@inject_db
 async def _apply_artifact_collection_filters(
     query,
-    db: PrefectDBInterface,
     flow_run_filter: filters.FlowRunFilter = None,
     task_run_filter: filters.TaskRunFilter = None,
     artifact_filter: filters.ArtifactCollectionFilter = None,
@@ -216,44 +206,42 @@ async def _apply_artifact_collection_filters(
 ):
     """Applies filters to an artifact collection query as a combination of EXISTS subqueries."""
     if artifact_filter:
-        query = query.where(artifact_filter.as_sql_filter(db))
+        query = query.where(artifact_filter.as_sql_filter())
 
     if flow_filter or flow_run_filter or deployment_filter:
-        exists_clause = select(db.FlowRun).where(
-            db.ArtifactCollection.flow_run_id == db.FlowRun.id
+        exists_clause = select(orm_models.FlowRun).where(
+            orm_models.ArtifactCollection.flow_run_id == orm_models.FlowRun.id
         )
         if flow_run_filter:
-            exists_clause = exists_clause.where(flow_run_filter.as_sql_filter(db))
+            exists_clause = exists_clause.where(flow_run_filter.as_sql_filter())
 
         if flow_filter:
             exists_clause = exists_clause.join(
-                db.Flow,
-                db.Flow.id == db.FlowRun.flow_id,
-            ).where(flow_filter.as_sql_filter(db))
+                orm_models.Flow,
+                orm_models.Flow.id == orm_models.FlowRun.flow_id,
+            ).where(flow_filter.as_sql_filter())
 
         if deployment_filter:
             exists_clause = exists_clause.join(
-                db.Deployment,
-                db.Deployment.id == db.FlowRun.deployment_id,
-            ).where(deployment_filter.as_sql_filter(db))
+                orm_models.Deployment,
+                orm_models.Deployment.id == orm_models.FlowRun.deployment_id,
+            ).where(deployment_filter.as_sql_filter())
 
         query = query.where(exists_clause.exists())
 
     if task_run_filter:
-        exists_clause = select(db.TaskRun).where(
-            db.ArtifactCollection.task_run_id == db.TaskRun.id
+        exists_clause = select(orm_models.TaskRun).where(
+            orm_models.ArtifactCollection.task_run_id == orm_models.TaskRun.id
         )
-        exists_clause = exists_clause.where(task_run_filter.as_sql_filter(db))
+        exists_clause = exists_clause.where(task_run_filter.as_sql_filter())
 
         query = query.where(exists_clause.exists())
 
     return query
 
 
-@inject_db
 async def read_artifacts(
     session: sa.orm.Session,
-    db: PrefectDBInterface,
     offset: int = None,
     limit: int = None,
     artifact_filter: filters.ArtifactFilter = None,
@@ -277,11 +265,10 @@ async def read_artifacts(
         flow_filter: Only select artifacts whose flow runs belong to flows matching this filter
         work_pool_filter: Only select artifacts whose flow runs belong to work pools matching this filter
     """
-    query = sa.select(db.Artifact).order_by(sort.as_sql_sort(db))
+    query = sa.select(orm_models.Artifact).order_by(sort.as_sql_sort())
 
     query = await _apply_artifact_filters(
         query,
-        db=db,
         artifact_filter=artifact_filter,
         flow_run_filter=flow_run_filter,
         task_run_filter=task_run_filter,
@@ -298,10 +285,8 @@ async def read_artifacts(
     return result.scalars().unique().all()
 
 
-@inject_db
 async def read_latest_artifacts(
     session: sa.orm.Session,
-    db: PrefectDBInterface,
     offset: int = None,
     limit: int = None,
     artifact_filter: filters.ArtifactCollectionFilter = None,
@@ -325,10 +310,9 @@ async def read_latest_artifacts(
         flow_filter: Only select artifacts whose flow runs belong to flows matching this filter
         work_pool_filter: Only select artifacts whose flow runs belong to work pools matching this filter
     """
-    query = sa.select(db.ArtifactCollection).order_by(sort.as_sql_sort(db))
+    query = sa.select(orm_models.ArtifactCollection).order_by(sort.as_sql_sort())
     query = await _apply_artifact_collection_filters(
         query,
-        db=db,
         artifact_filter=artifact_filter,
         flow_run_filter=flow_run_filter,
         task_run_filter=task_run_filter,
@@ -345,10 +329,8 @@ async def read_latest_artifacts(
     return result.scalars().unique().all()
 
 
-@inject_db
 async def count_artifacts(
     session: sa.orm.Session,
-    db: PrefectDBInterface,
     artifact_filter: filters.ArtifactFilter = None,
     flow_run_filter: filters.FlowRunFilter = None,
     task_run_filter: filters.TaskRunFilter = None,
@@ -363,11 +345,10 @@ async def count_artifacts(
         flow_run_filter: Only select artifacts whose flow runs matching this filter
         task_run_filter: Only select artifacts whose task runs matching this filter
     """
-    query = sa.select(sa.func.count(db.Artifact.id))
+    query = sa.select(sa.func.count(orm_models.Artifact.id))
 
     query = await _apply_artifact_filters(
         query,
-        db=db,
         artifact_filter=artifact_filter,
         flow_run_filter=flow_run_filter,
         task_run_filter=task_run_filter,
@@ -379,10 +360,8 @@ async def count_artifacts(
     return result.scalar_one()
 
 
-@inject_db
 async def count_latest_artifacts(
     session: sa.orm.Session,
-    db: PrefectDBInterface,
     artifact_filter: filters.ArtifactCollectionFilter = None,
     flow_run_filter: filters.FlowRunFilter = None,
     task_run_filter: filters.TaskRunFilter = None,
@@ -397,11 +376,10 @@ async def count_latest_artifacts(
         flow_run_filter: Only select artifacts whose flow runs matching this filter
         task_run_filter: Only select artifacts whose task runs matching this filter
     """
-    query = sa.select(sa.func.count(db.ArtifactCollection.id))
+    query = sa.select(sa.func.count(orm_models.ArtifactCollection.id))
 
     query = await _apply_artifact_collection_filters(
         query,
-        db=db,
         artifact_filter=artifact_filter,
         flow_run_filter=flow_run_filter,
         task_run_filter=task_run_filter,
@@ -413,12 +391,10 @@ async def count_latest_artifacts(
     return result.scalar_one()
 
 
-@inject_db
 async def update_artifact(
     session: sa.orm.Session,
     artifact_id: UUID,
     artifact: actions.ArtifactUpdate,
-    db: PrefectDBInterface,
 ) -> bool:
     """
     Updates an artifact by id.
@@ -434,8 +410,8 @@ async def update_artifact(
     update_artifact_data = artifact.dict(shallow=True, exclude_unset=True)
 
     update_artifact_stmt = (
-        sa.update(db.Artifact)
-        .where(db.Artifact.id == artifact_id)
+        sa.update(orm_models.Artifact)
+        .where(orm_models.Artifact.id == artifact_id)
         .values(**update_artifact_data)
     )
 
@@ -443,8 +419,8 @@ async def update_artifact(
 
     update_artifact_collection_data = artifact.dict(shallow=True, exclude_unset=True)
     update_artifact_collection_stmt = (
-        sa.update(db.ArtifactCollection)
-        .where(db.ArtifactCollection.latest_id == artifact_id)
+        sa.update(orm_models.ArtifactCollection)
+        .where(orm_models.ArtifactCollection.latest_id == artifact_id)
         .values(**update_artifact_collection_data)
     )
     result = await session.execute(update_artifact_collection_stmt)
@@ -452,11 +428,9 @@ async def update_artifact(
     return result.rowcount > 0
 
 
-@inject_db
 async def delete_artifact(
     session: sa.orm.Session,
     artifact_id: UUID,
-    db: PrefectDBInterface,
 ) -> bool:
     """
     Deletes an artifact by id.
@@ -485,33 +459,33 @@ async def delete_artifact(
     Returns:
         bool: True if the delete was successful, False otherwise
     """
-    artifact = await session.get(db.Artifact, artifact_id)
+    artifact = await session.get(orm_models.Artifact, artifact_id)
     if artifact is None:
         return False
 
     is_latest_version = (
         await session.execute(
-            sa.select(db.ArtifactCollection)
-            .where(db.ArtifactCollection.key == artifact.key)
-            .where(db.ArtifactCollection.latest_id == artifact_id)
+            sa.select(orm_models.ArtifactCollection)
+            .where(orm_models.ArtifactCollection.key == artifact.key)
+            .where(orm_models.ArtifactCollection.latest_id == artifact_id)
         )
     ).scalar_one_or_none() is not None
 
     if is_latest_version:
         next_latest_version = (
             await session.execute(
-                sa.select(db.Artifact)
-                .where(db.Artifact.key == artifact.key)
-                .where(db.Artifact.id != artifact_id)
-                .order_by(db.Artifact.created.desc())
+                sa.select(orm_models.Artifact)
+                .where(orm_models.Artifact.key == artifact.key)
+                .where(orm_models.Artifact.id != artifact_id)
+                .order_by(orm_models.Artifact.created.desc())
                 .limit(1)
             )
         ).scalar_one_or_none()
 
         if next_latest_version is not None:
             set_next_latest_version = (
-                sa.update(db.ArtifactCollection)
-                .where(db.ArtifactCollection.key == artifact.key)
+                sa.update(orm_models.ArtifactCollection)
+                .where(orm_models.ArtifactCollection.key == artifact.key)
                 .values(
                     latest_id=next_latest_version.id,
                     data=next_latest_version.data,
@@ -528,12 +502,14 @@ async def delete_artifact(
 
         else:
             await session.execute(
-                sa.delete(db.ArtifactCollection)
-                .where(db.ArtifactCollection.key == artifact.key)
-                .where(db.ArtifactCollection.latest_id == artifact_id)
+                sa.delete(orm_models.ArtifactCollection)
+                .where(orm_models.ArtifactCollection.key == artifact.key)
+                .where(orm_models.ArtifactCollection.latest_id == artifact_id)
             )
 
-    delete_stmt = sa.delete(db.Artifact).where(db.Artifact.id == artifact_id)
+    delete_stmt = sa.delete(orm_models.Artifact).where(
+        orm_models.Artifact.id == artifact_id
+    )
 
     result = await session.execute(delete_stmt)
     return result.rowcount > 0

--- a/src/prefect/server/models/block_documents.py
+++ b/src/prefect/server/models/block_documents.py
@@ -4,7 +4,7 @@ Intended for internal use by the Prefect REST API.
 """
 
 from copy import copy
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 from uuid import UUID, uuid4
 
 import sqlalchemy as sa
@@ -12,7 +12,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import prefect.server.models as models
 from prefect.server import schemas
-from prefect.server.database.dependencies import inject_db
+from prefect.server.database import orm_models
+from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.schemas.actions import BlockDocumentReferenceCreate
 from prefect.server.schemas.core import BlockDocument, BlockDocumentReference
@@ -22,15 +23,10 @@ from prefect.server.utilities.names import obfuscate_string
 from prefect.utilities.collections import dict_to_flatdict, flatdict_to_dict
 from prefect.utilities.names import obfuscate
 
-if TYPE_CHECKING:
-    from prefect.server.database.orm_models import ORMBlockDocument
 
-
-@inject_db
 async def create_block_document(
     session: AsyncSession,
     block_document: schemas.actions.BlockDocumentCreate,
-    db: PrefectDBInterface,
 ):
     # lookup block type name and copy to the block document table
     block_type = await models.block_types.read_block_type(
@@ -43,7 +39,7 @@ async def create_block_document(
     else:
         name = block_document.name
 
-    orm_block = db.BlockDocument(
+    orm_block = orm_models.BlockDocument(
         name=name,
         block_schema_id=block_document.block_schema_id,
         block_type_id=block_document.block_type_id,
@@ -82,14 +78,13 @@ async def create_block_document(
     )
 
 
-@inject_db
 async def block_document_with_unique_values_exists(
-    session: AsyncSession, block_type_id: UUID, name: str, db: PrefectDBInterface
+    session: AsyncSession, block_type_id: UUID, name: str
 ) -> bool:
     result = await session.execute(
-        sa.select(sa.exists(db.BlockDocument)).where(
-            db.BlockDocument.block_type_id == block_type_id,
-            db.BlockDocument.name == name,
+        sa.select(sa.exists(orm_models.BlockDocument)).where(
+            orm_models.BlockDocument.block_type_id == block_type_id,
+            orm_models.BlockDocument.name == name,
         )
     )
     return bool(result.scalar_one_or_none())
@@ -131,16 +126,13 @@ def _separate_block_references_from_data(
     return block_document_data_without_refs, block_document_references
 
 
-@inject_db
 async def read_block_document_by_id(
     session: AsyncSession,
     block_document_id: UUID,
-    db: PrefectDBInterface,
     include_secrets: bool = False,
 ):
     block_documents = await read_block_documents(
         session=session,
-        db=db,
         block_document_filter=schemas.filters.BlockDocumentFilter(
             id=dict(any_=[block_document_id]),
             # don't apply any anonymous filtering
@@ -155,7 +147,7 @@ async def read_block_document_by_id(
 async def _construct_full_block_document(
     session: AsyncSession,
     block_documents_with_references: List[
-        Tuple["ORMBlockDocument", Optional[str], Optional[UUID]]
+        Tuple[orm_models.ORMBlockDocument, Optional[str], Optional[UUID]]
     ],
     parent_block_document: Optional[BlockDocument] = None,
     include_secrets: bool = False,
@@ -234,12 +226,10 @@ async def _find_parent_block_document(
     )
 
 
-@inject_db
 async def read_block_document_by_name(
     session: AsyncSession,
     name: str,
     block_type_slug: str,
-    db: PrefectDBInterface,
     include_secrets: bool = False,
 ):
     """
@@ -247,7 +237,6 @@ async def read_block_document_by_name(
     """
     block_documents = await read_block_documents(
         session=session,
-        db=db,
         block_document_filter=schemas.filters.BlockDocumentFilter(
             name=dict(any_=[name]),
             # don't apply any anonymous filtering
@@ -262,10 +251,8 @@ async def read_block_document_by_name(
     return block_documents[0] if block_documents else None
 
 
-@inject_db
 def _apply_block_document_filters(
     query,
-    db: PrefectDBInterface,
     block_document_filter: Optional[schemas.filters.BlockDocumentFilter] = None,
     block_schema_filter: Optional[schemas.filters.BlockSchemaFilter] = None,
     block_type_filter: Optional[schemas.filters.BlockTypeFilter] = None,
@@ -277,29 +264,27 @@ def _apply_block_document_filters(
         )
 
     # --- Build an initial query that filters for the requested block documents
-    query = query.where(block_document_filter.as_sql_filter(db=db))
+    query = query.where(block_document_filter.as_sql_filter())
 
     if block_type_filter is not None:
-        block_type_exists_clause = sa.select(db.BlockType).where(
-            db.BlockType.id == db.BlockDocument.block_type_id,
-            block_type_filter.as_sql_filter(db=db),
+        block_type_exists_clause = sa.select(orm_models.BlockType).where(
+            orm_models.BlockType.id == orm_models.BlockDocument.block_type_id,
+            block_type_filter.as_sql_filter(),
         )
         query = query.where(block_type_exists_clause.exists())
 
     if block_schema_filter is not None:
-        block_schema_exists_clause = sa.select(db.BlockSchema).where(
-            db.BlockSchema.id == db.BlockDocument.block_schema_id,
-            block_schema_filter.as_sql_filter(db=db),
+        block_schema_exists_clause = sa.select(orm_models.BlockSchema).where(
+            orm_models.BlockSchema.id == orm_models.BlockDocument.block_schema_id,
+            block_schema_filter.as_sql_filter(),
         )
         query = query.where(block_schema_exists_clause.exists())
 
     return query
 
 
-@inject_db
 async def read_block_documents(
     session: AsyncSession,
-    db: PrefectDBInterface,
     block_document_filter: Optional[schemas.filters.BlockDocumentFilter] = None,
     block_type_filter: Optional[schemas.filters.BlockTypeFilter] = None,
     block_schema_filter: Optional[schemas.filters.BlockSchemaFilter] = None,
@@ -314,16 +299,15 @@ async def read_block_documents(
     Read block documents with an optional limit and offset
     """
     # --- Build an initial query that filters for the requested block documents
-    filtered_block_documents_query = sa.select(db.BlockDocument.id)
+    filtered_block_documents_query = sa.select(orm_models.BlockDocument.id)
     filtered_block_documents_query = _apply_block_document_filters(
         query=filtered_block_documents_query,
-        db=db,
         block_document_filter=block_document_filter,
         block_type_filter=block_type_filter,
         block_schema_filter=block_schema_filter,
     )
     filtered_block_documents_query = filtered_block_documents_query.order_by(
-        sort.as_sql_sort(db)
+        sort.as_sql_sort()
     )
 
     if offset is not None:
@@ -354,14 +338,15 @@ async def read_block_documents(
     # recursive part of query
     referenced_documents = (
         sa.select(
-            db.BlockDocumentReference.reference_block_document_id,
-            db.BlockDocumentReference.name,
-            db.BlockDocumentReference.parent_block_document_id,
+            orm_models.BlockDocumentReference.reference_block_document_id,
+            orm_models.BlockDocumentReference.name,
+            orm_models.BlockDocumentReference.parent_block_document_id,
         )
         .select_from(parent_documents)
         .join(
-            db.BlockDocumentReference,
-            db.BlockDocumentReference.parent_block_document_id == parent_documents.c.id,
+            orm_models.BlockDocumentReference,
+            orm_models.BlockDocumentReference.parent_block_document_id
+            == parent_documents.c.id,
         )
     )
     # union the recursive CTE
@@ -372,13 +357,16 @@ async def read_block_documents(
     # and order by name
     final_query = (
         sa.select(
-            db.BlockDocument,
+            orm_models.BlockDocument,
             all_block_documents_query.c.reference_name,
             all_block_documents_query.c.reference_parent_block_document_id,
         )
         .select_from(all_block_documents_query)
-        .join(db.BlockDocument, db.BlockDocument.id == all_block_documents_query.c.id)
-        .order_by(sort.as_sql_sort(db))
+        .join(
+            orm_models.BlockDocument,
+            orm_models.BlockDocument.id == all_block_documents_query.c.id,
+        )
+        .order_by(sort.as_sql_sort())
     )
 
     result = await session.execute(
@@ -433,10 +421,8 @@ async def read_block_documents(
     return fully_constructed_block_documents
 
 
-@inject_db
 async def count_block_documents(
     session: AsyncSession,
-    db: PrefectDBInterface,
     block_document_filter: Optional[schemas.filters.BlockDocumentFilter] = None,
     block_type_filter: Optional[schemas.filters.BlockTypeFilter] = None,
     block_schema_filter: Optional[schemas.filters.BlockSchemaFilter] = None,
@@ -444,7 +430,7 @@ async def count_block_documents(
     """
     Count block documents that match the filters.
     """
-    query = sa.select(sa.func.count()).select_from(db.BlockDocument)
+    query = sa.select(sa.func.count()).select_from(orm_models.BlockDocument)
 
     query = _apply_block_document_filters(
         query=query,
@@ -457,26 +443,26 @@ async def count_block_documents(
     return result.scalar()  # type: ignore
 
 
-@inject_db
 async def delete_block_document(
     session: AsyncSession,
     block_document_id: UUID,
-    db: PrefectDBInterface,
 ) -> bool:
-    query = sa.delete(db.BlockDocument).where(db.BlockDocument.id == block_document_id)
+    query = sa.delete(orm_models.BlockDocument).where(
+        orm_models.BlockDocument.id == block_document_id
+    )
     result = await session.execute(query)
     return result.rowcount > 0
 
 
-@inject_db
 async def update_block_document(
     session: AsyncSession,
     block_document_id: UUID,
     block_document: schemas.actions.BlockDocumentUpdate,
-    db: PrefectDBInterface,
 ) -> bool:
     merge_existing_data = block_document.merge_existing_data
-    current_block_document = await session.get(db.BlockDocument, block_document_id)
+    current_block_document = await session.get(
+        orm_models.BlockDocument, block_document_id
+    )
     if not current_block_document:
         return False
 
@@ -528,7 +514,7 @@ async def update_block_document(
         current_block_document_references = (
             (
                 await session.execute(
-                    sa.select(db.BlockDocumentReference).filter_by(
+                    sa.select(orm_models.BlockDocumentReference).filter_by(
                         parent_block_document_id=block_document_id
                     )
                 )
@@ -557,7 +543,7 @@ async def update_block_document(
             and proposed_block_schema_id != current_block_document.block_schema_id
         ):
             proposed_block_schema = await session.get(
-                db.BlockSchema, proposed_block_schema_id
+                orm_models.BlockSchema, proposed_block_schema_id
             )
 
             # make sure the proposed schema is of the same block type as the current document
@@ -570,8 +556,8 @@ async def update_block_document(
                     " type."
                 )
             await session.execute(
-                sa.update(db.BlockDocument)
-                .where(db.BlockDocument.id == block_document_id)
+                sa.update(orm_models.BlockDocument)
+                .where(orm_models.BlockDocument.id == block_document_id)
                 .values(block_schema_id=proposed_block_schema_id)
             )
 
@@ -622,13 +608,13 @@ def _find_block_document_reference(
     )
 
 
-@inject_db
+@db_injector
 async def create_block_document_reference(
+    db: PrefectDBInterface,
     session: AsyncSession,
     block_document_reference: schemas.actions.BlockDocumentReferenceCreate,
-    db: PrefectDBInterface,
 ):
-    insert_stmt = db.insert(db.BlockDocumentReference).values(
+    insert_stmt = db.insert(orm_models.BlockDocumentReference).values(
         **block_document_reference.dict(
             shallow=True, exclude_unset=True, exclude={"created", "updated"}
         )
@@ -636,22 +622,20 @@ async def create_block_document_reference(
     await session.execute(insert_stmt)
 
     result = await session.execute(
-        sa.select(db.BlockDocumentReference).where(
-            db.BlockDocumentReference.id == block_document_reference.id
+        sa.select(orm_models.BlockDocumentReference).where(
+            orm_models.BlockDocumentReference.id == block_document_reference.id
         )
     )
 
     return result.scalar()
 
 
-@inject_db
 async def delete_block_document_reference(
     session: AsyncSession,
     block_document_reference_id: UUID,
-    db: PrefectDBInterface,
 ):
-    query = sa.delete(db.BlockDocumentReference).where(
-        db.BlockDocumentReference.id == block_document_reference_id
+    query = sa.delete(orm_models.BlockDocumentReference).where(
+        orm_models.BlockDocumentReference.id == block_document_reference_id
     )
     result = await session.execute(query)
     return result.rowcount > 0

--- a/src/prefect/server/models/block_schemas.py
+++ b/src/prefect/server/models/block_schemas.py
@@ -12,7 +12,8 @@ import sqlalchemy as sa
 from sqlalchemy import delete, select
 
 from prefect.server import schemas
-from prefect.server.database.dependencies import inject_db
+from prefect.server.database import orm_models
+from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.models.block_types import read_block_type_by_slug
 from prefect.server.schemas.actions import BlockSchemaCreate
@@ -23,11 +24,11 @@ class MissingBlockTypeException(Exception):
     """Raised when the block type corresponding to a block schema cannot be found"""
 
 
-@inject_db
+@db_injector
 async def create_block_schema(
+    db: PrefectDBInterface,
     session: sa.orm.Session,
     block_schema: schemas.actions.BlockSchemaCreate,
-    db: PrefectDBInterface,
     override: bool = False,
     definitions: Optional[Dict] = None,
 ):
@@ -91,7 +92,7 @@ async def create_block_schema(
         "block_schema_references", {}
     )
 
-    insert_stmt = db.insert(db.BlockSchema).values(**insert_values)
+    insert_stmt = db.insert(orm_models.BlockSchema).values(**insert_values)
     if override:
         insert_stmt = insert_stmt.on_conflict_do_update(
             index_elements=db.block_schema_unique_upsert_columns,
@@ -100,17 +101,17 @@ async def create_block_schema(
     await session.execute(insert_stmt)
 
     query = (
-        sa.select(db.BlockSchema)
+        sa.select(orm_models.BlockSchema)
         .where(
-            db.BlockSchema.checksum == insert_values["checksum"],
+            orm_models.BlockSchema.checksum == insert_values["checksum"],
         )
-        .order_by(db.BlockSchema.created.desc())
+        .order_by(orm_models.BlockSchema.created.desc())
         .limit(1)
         .execution_options(populate_existing=True)
     )
 
     if block_schema.version is not None:
-        query = query.where(db.BlockSchema.version == block_schema.version)
+        query = query.where(orm_models.BlockSchema.version == block_schema.version)
 
     result = await session.execute(query)
     created_block_schema = copy(result.scalar())
@@ -255,10 +256,7 @@ def _get_fields_for_child_schema(
     return sub_block_schema_fields
 
 
-@inject_db
-async def delete_block_schema(
-    session: sa.orm.Session, block_schema_id: UUID, db: PrefectDBInterface
-) -> bool:
+async def delete_block_schema(session: sa.orm.Session, block_schema_id: UUID) -> bool:
     """
     Delete a block schema by id.
 
@@ -271,16 +269,16 @@ async def delete_block_schema(
     """
 
     result = await session.execute(
-        delete(db.BlockSchema).where(db.BlockSchema.id == block_schema_id)
+        delete(orm_models.BlockSchema).where(
+            orm_models.BlockSchema.id == block_schema_id
+        )
     )
     return result.rowcount > 0
 
 
-@inject_db
 async def read_block_schema(
     session: sa.orm.Session,
     block_schema_id: UUID,
-    db: PrefectDBInterface,
 ):
     """
     Reads a block schema by id. Will reconstruct the block schema's fields attribute
@@ -291,24 +289,24 @@ async def read_block_schema(
         block_schema_id: a block_schema id
 
     Returns:
-        db.Blockschema: the block_schema
+        orm_models..BlockSchema: the block_schema
     """
 
     # Construction of a recursive query which returns the specified block schema
     # along with and nested block schemas coupled with the ID of their parent schema
     # the key that they reside under.
     block_schema_references_query = (
-        sa.select(db.BlockSchemaReference)
-        .select_from(db.BlockSchemaReference)
+        sa.select(orm_models.BlockSchemaReference)
+        .select_from(orm_models.BlockSchemaReference)
         .filter_by(parent_block_schema_id=block_schema_id)
         .cte("block_schema_references", recursive=True)
     )
     block_schema_references_join = (
-        sa.select(db.BlockSchemaReference)
-        .select_from(db.BlockSchemaReference)
+        sa.select(orm_models.BlockSchemaReference)
+        .select_from(orm_models.BlockSchemaReference)
         .join(
             block_schema_references_query,
-            db.BlockSchemaReference.parent_block_schema_id
+            orm_models.BlockSchemaReference.parent_block_schema_id
             == block_schema_references_query.c.reference_block_schema_id,
         )
     )
@@ -317,20 +315,20 @@ async def read_block_schema(
     )
     nested_block_schemas_query = (
         sa.select(
-            db.BlockSchema,
+            orm_models.BlockSchema,
             recursive_block_schema_references_cte.c.name,
             recursive_block_schema_references_cte.c.parent_block_schema_id,
         )
-        .select_from(db.BlockSchema)
+        .select_from(orm_models.BlockSchema)
         .join(
             recursive_block_schema_references_cte,
-            db.BlockSchema.id
+            orm_models.BlockSchema.id
             == recursive_block_schema_references_cte.c.reference_block_schema_id,
             isouter=True,
         )
         .filter(
             sa.or_(
-                db.BlockSchema.id == block_schema_id,
+                orm_models.BlockSchema.id == block_schema_id,
                 recursive_block_schema_references_cte.c.parent_block_schema_id.is_not(
                     None
                 ),
@@ -556,10 +554,8 @@ def _construct_block_schema_fields_with_block_references(
     return block_schema_fields_copy
 
 
-@inject_db
 async def read_block_schemas(
     session: sa.orm.Session,
-    db: PrefectDBInterface,
     block_schema_filter: Optional[schemas.filters.BlockSchemaFilter] = None,
     limit: Optional[int] = None,
     offset: Optional[int] = None,
@@ -574,17 +570,17 @@ async def read_block_schemas(
         offset (int): query offset
 
     Returns:
-        List[db.BlockSchema]: the block_schemas
+        List[orm_models.BlockSchema]: the block_schemas
     """
     # schemas are ordered by `created DESC` to get the most recently created
     # ones first (and to facilitate getting the newest one with `limit=1`).
-    filtered_block_schemas_query = select(db.BlockSchema.id).order_by(
-        db.BlockSchema.created.desc()
+    filtered_block_schemas_query = select(orm_models.BlockSchema.id).order_by(
+        orm_models.BlockSchema.created.desc()
     )
 
     if block_schema_filter:
         filtered_block_schemas_query = filtered_block_schemas_query.where(
-            block_schema_filter.as_sql_filter(db)
+            block_schema_filter.as_sql_filter()
         )
 
     if offset is not None:
@@ -597,21 +593,21 @@ async def read_block_schemas(
     )
 
     block_schema_references_query = (
-        sa.select(db.BlockSchemaReference)
-        .select_from(db.BlockSchemaReference)
+        sa.select(orm_models.BlockSchemaReference)
+        .select_from(orm_models.BlockSchemaReference)
         .filter(
-            db.BlockSchemaReference.parent_block_schema_id.in_(
+            orm_models.BlockSchemaReference.parent_block_schema_id.in_(
                 filtered_block_schemas_query
             )
         )
         .cte("block_schema_references", recursive=True)
     )
     block_schema_references_join = (
-        sa.select(db.BlockSchemaReference)
-        .select_from(db.BlockSchemaReference)
+        sa.select(orm_models.BlockSchemaReference)
+        .select_from(orm_models.BlockSchemaReference)
         .join(
             block_schema_references_query,
-            db.BlockSchemaReference.parent_block_schema_id
+            orm_models.BlockSchemaReference.parent_block_schema_id
             == block_schema_references_query.c.reference_block_schema_id,
         )
     )
@@ -621,24 +617,24 @@ async def read_block_schemas(
 
     nested_block_schemas_query = (
         sa.select(
-            db.BlockSchema,
+            orm_models.BlockSchema,
             recursive_block_schema_references_cte.c.name,
             recursive_block_schema_references_cte.c.parent_block_schema_id,
         )
-        .select_from(db.BlockSchema)
+        .select_from(orm_models.BlockSchema)
         # in order to reconstruct nested block schemas efficiently, we need to visit them
         # in the order they were created (so that we guarantee that nested/referenced schemas)
         # have already been seen. Therefore this second query sorts by created ASC
-        .order_by(db.BlockSchema.created.asc())
+        .order_by(orm_models.BlockSchema.created.asc())
         .join(
             recursive_block_schema_references_cte,
-            db.BlockSchema.id
+            orm_models.BlockSchema.id
             == recursive_block_schema_references_cte.c.reference_block_schema_id,
             isouter=True,
         )
         .filter(
             sa.or_(
-                db.BlockSchema.id.in_(filtered_block_schemas_query),
+                orm_models.BlockSchema.id.in_(filtered_block_schemas_query),
                 recursive_block_schema_references_cte.c.parent_block_schema_id.is_not(
                     None
                 ),
@@ -669,11 +665,9 @@ async def read_block_schemas(
     return list(reversed(fully_constructed_block_schemas))
 
 
-@inject_db
 async def read_block_schema_by_checksum(
     session: sa.orm.Session,
     checksum: str,
-    db: PrefectDBInterface,
     version: Optional[str] = None,
 ) -> Optional[BlockSchema]:
     """
@@ -686,7 +680,7 @@ async def read_block_schema_by_checksum(
         version: A block_schema version
 
     Returns:
-        db.BlockSchema: the block_schema
+        orm_models.BlockSchema: the block_schema
     """
     # Construction of a recursive query which returns the specified block schema
     # along with and nested block schemas coupled with the ID of their parent schema
@@ -695,9 +689,9 @@ async def read_block_schema_by_checksum(
     # The same checksum with different versions can occur in the DB. Return only the
     # most recently created one.
     root_block_schema_query = (
-        sa.select(db.BlockSchema)
+        sa.select(orm_models.BlockSchema)
         .filter_by(checksum=checksum)
-        .order_by(db.BlockSchema.created.desc())
+        .order_by(orm_models.BlockSchema.created.desc())
         .limit(1)
     )
 
@@ -707,17 +701,17 @@ async def read_block_schema_by_checksum(
     root_block_schema_cte = root_block_schema_query.cte("root_block_schema")
 
     block_schema_references_query = (
-        sa.select(db.BlockSchemaReference)
-        .select_from(db.BlockSchemaReference)
+        sa.select(orm_models.BlockSchemaReference)
+        .select_from(orm_models.BlockSchemaReference)
         .filter_by(parent_block_schema_id=root_block_schema_cte.c.id)
         .cte("block_schema_references", recursive=True)
     )
     block_schema_references_join = (
-        sa.select(db.BlockSchemaReference)
-        .select_from(db.BlockSchemaReference)
+        sa.select(orm_models.BlockSchemaReference)
+        .select_from(orm_models.BlockSchemaReference)
         .join(
             block_schema_references_query,
-            db.BlockSchemaReference.parent_block_schema_id
+            orm_models.BlockSchemaReference.parent_block_schema_id
             == block_schema_references_query.c.reference_block_schema_id,
         )
     )
@@ -726,20 +720,20 @@ async def read_block_schema_by_checksum(
     )
     nested_block_schemas_query = (
         sa.select(
-            db.BlockSchema,
+            orm_models.BlockSchema,
             recursive_block_schema_references_cte.c.name,
             recursive_block_schema_references_cte.c.parent_block_schema_id,
         )
-        .select_from(db.BlockSchema)
+        .select_from(orm_models.BlockSchema)
         .join(
             recursive_block_schema_references_cte,
-            db.BlockSchema.id
+            orm_models.BlockSchema.id
             == recursive_block_schema_references_cte.c.reference_block_schema_id,
             isouter=True,
         )
         .filter(
             sa.or_(
-                db.BlockSchema.id == root_block_schema_cte.c.id,
+                orm_models.BlockSchema.id == root_block_schema_cte.c.id,
                 recursive_block_schema_references_cte.c.parent_block_schema_id.is_not(
                     None
                 ),
@@ -750,9 +744,10 @@ async def read_block_schema_by_checksum(
     return _construct_full_block_schema(result.all())
 
 
-@inject_db
+@db_injector
 async def read_available_block_capabilities(
-    session: sa.orm.Session, db: PrefectDBInterface
+    db: PrefectDBInterface,
+    session: sa.orm.Session,
 ) -> List[str]:
     """
     Retrieves a list of all available block capabilities.
@@ -764,7 +759,7 @@ async def read_available_block_capabilities(
         List[str]: List of all available block capabilities.
     """
     query = sa.select(
-        db.json_arr_agg(db.cast_to_json(db.BlockSchema.capabilities.distinct()))
+        db.json_arr_agg(db.cast_to_json(orm_models.BlockSchema.capabilities.distinct()))
     )
     capability_combinations = (await session.execute(query)).scalars().first() or list()
     if db.uses_json_strings and isinstance(capability_combinations, str):
@@ -772,11 +767,11 @@ async def read_available_block_capabilities(
     return list({c for capabilities in capability_combinations for c in capabilities})
 
 
-@inject_db
+@db_injector
 async def create_block_schema_reference(
+    db: PrefectDBInterface,
     session: sa.orm.Session,
     block_schema_reference: schemas.core.BlockSchemaReference,
-    db: PrefectDBInterface,
 ):
     """
     Retrieves a list of all available block capabilities.
@@ -786,13 +781,13 @@ async def create_block_schema_reference(
         block_schema_reference: A block schema reference object.
 
     Returns:
-        db.BlockSchemaReference: The created BlockSchemaReference
+        orm_models.BlockSchemaReference: The created BlockSchemaReference
     """
-    query_stmt = sa.select(db.BlockSchemaReference).where(
-        db.BlockSchemaReference.name == block_schema_reference.name,
-        db.BlockSchemaReference.parent_block_schema_id
+    query_stmt = sa.select(orm_models.BlockSchemaReference).where(
+        orm_models.BlockSchemaReference.name == block_schema_reference.name,
+        orm_models.BlockSchemaReference.parent_block_schema_id
         == block_schema_reference.parent_block_schema_id,
-        db.BlockSchemaReference.reference_block_schema_id
+        orm_models.BlockSchemaReference.reference_block_schema_id
         == block_schema_reference.reference_block_schema_id,
     )
 
@@ -800,7 +795,7 @@ async def create_block_schema_reference(
     if existing_reference:
         return existing_reference
 
-    insert_stmt = db.insert(db.BlockSchemaReference).values(
+    insert_stmt = db.insert(orm_models.BlockSchemaReference).values(
         **block_schema_reference.dict(
             shallow=True, exclude_unset=True, exclude={"created", "updated"}
         )
@@ -808,8 +803,8 @@ async def create_block_schema_reference(
     await session.execute(insert_stmt)
 
     result = await session.execute(
-        sa.select(db.BlockSchemaReference).where(
-            db.BlockSchemaReference.id == block_schema_reference.id
+        sa.select(orm_models.BlockSchemaReference).where(
+            orm_models.BlockSchemaReference.id == block_schema_reference.id
         )
     )
     return result.scalar()

--- a/src/prefect/server/models/block_types.py
+++ b/src/prefect/server/models/block_types.py
@@ -4,26 +4,24 @@ Intended for internal use by the Prefect REST API.
 """
 
 import html
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 from uuid import UUID
 
 import sqlalchemy as sa
 
 from prefect.server import schemas
-from prefect.server.database.dependencies import inject_db
+from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
-
-if TYPE_CHECKING:
-    from prefect.server.database.orm_models import ORMBlockType
+from prefect.server.database.orm_models import BlockSchema, BlockType
 
 
-@inject_db
+@db_injector
 async def create_block_type(
+    db: PrefectDBInterface,
     session: sa.orm.Session,
     block_type: schemas.core.BlockType,
-    db: PrefectDBInterface,
     override: bool = False,
-) -> "ORMBlockType":
+) -> "BlockType":
     """
     Create a new block type.
 
@@ -45,7 +43,7 @@ async def create_block_type(
         insert_values["code_example"] = html.escape(
             insert_values["code_example"], quote=False
         )
-    insert_stmt = db.insert(db.BlockType).values(**insert_values)
+    insert_stmt = db.insert(BlockType).values(**insert_values)
     if override:
         insert_stmt = insert_stmt.on_conflict_do_update(
             index_elements=db.block_type_unique_upsert_columns,
@@ -54,10 +52,10 @@ async def create_block_type(
     await session.execute(insert_stmt)
 
     query = (
-        sa.select(db.BlockType)
+        sa.select(BlockType)
         .where(
             sa.and_(
-                db.BlockType.name == insert_values["name"],
+                BlockType.name == insert_values["name"],
             )
         )
         .execution_options(populate_existing=True)
@@ -67,11 +65,9 @@ async def create_block_type(
     return result.scalar()
 
 
-@inject_db
 async def read_block_type(
     session: sa.orm.Session,
     block_type_id: UUID,
-    db: PrefectDBInterface,
 ):
     """
     Reads a block type by id.
@@ -81,15 +77,12 @@ async def read_block_type(
         block_type_id: a block_type id
 
     Returns:
-        db.BlockType: an ORM block type model
+        BlockType: an ORM block type model
     """
-    return await session.get(db.BlockType, block_type_id)
+    return await session.get(BlockType, block_type_id)
 
 
-@inject_db
-async def read_block_type_by_slug(
-    session: sa.orm.Session, block_type_slug: str, db: PrefectDBInterface
-):
+async def read_block_type_by_slug(session: sa.orm.Session, block_type_slug: str):
     """
     Reads a block type by slug.
 
@@ -98,19 +91,17 @@ async def read_block_type_by_slug(
         block_type_slug: a block type slug
 
     Returns:
-        db.BlockType: an ORM block type model
+        BlockType: an ORM block type model
 
     """
     result = await session.execute(
-        sa.select(db.BlockType).where(db.BlockType.slug == block_type_slug)
+        sa.select(BlockType).where(BlockType.slug == block_type_slug)
     )
     return result.scalar()
 
 
-@inject_db
 async def read_block_types(
     session: sa.orm.Session,
-    db: PrefectDBInterface,
     block_type_filter: Optional[schemas.filters.BlockTypeFilter] = None,
     block_schema_filter: Optional[schemas.filters.BlockSchemaFilter] = None,
     limit: Optional[int] = None,
@@ -122,17 +113,17 @@ async def read_block_types(
     Args:
 
     Returns:
-        List[db.BlockType]: List of
+        List[BlockType]: List of
     """
-    query = sa.select(db.BlockType).order_by(db.BlockType.name)
+    query = sa.select(BlockType).order_by(BlockType.name)
 
     if block_type_filter is not None:
-        query = query.where(block_type_filter.as_sql_filter(db))
+        query = query.where(block_type_filter.as_sql_filter())
 
     if block_schema_filter is not None:
-        exists_clause = sa.select(db.BlockSchema).where(
-            db.BlockSchema.block_type_id == db.BlockType.id,
-            block_schema_filter.as_sql_filter(db),
+        exists_clause = sa.select(BlockSchema).where(
+            BlockSchema.block_type_id == BlockType.id,
+            block_schema_filter.as_sql_filter(),
         )
         query = query.where(exists_clause.exists())
 
@@ -146,12 +137,10 @@ async def read_block_types(
     return result.scalars().unique().all()
 
 
-@inject_db
 async def update_block_type(
     session: sa.orm.Session,
     block_type_id: str,
     block_type: schemas.actions.BlockTypeUpdate,
-    db: PrefectDBInterface,
 ) -> bool:
     """
     Update a block type by id.
@@ -165,18 +154,15 @@ async def update_block_type(
         bool: True if the block type was updated
     """
     update_statement = (
-        sa.update(db.BlockType)
-        .where(db.BlockType.id == block_type_id)
+        sa.update(BlockType)
+        .where(BlockType.id == block_type_id)
         .values(**block_type.dict(shallow=True, exclude_unset=True, exclude={"id"}))
     )
     result = await session.execute(update_statement)
     return result.rowcount > 0
 
 
-@inject_db
-async def delete_block_type(
-    session: sa.orm.Session, block_type_id: str, db: PrefectDBInterface
-):
+async def delete_block_type(session: sa.orm.Session, block_type_id: str):
     """
     Delete a block type by id.
 
@@ -189,6 +175,6 @@ async def delete_block_type(
     """
 
     result = await session.execute(
-        sa.delete(db.BlockType).where(db.BlockType.id == block_type_id)
+        sa.delete(BlockType).where(BlockType.id == block_type_id)
     )
     return result.rowcount > 0

--- a/src/prefect/server/models/concurrency_limits.py
+++ b/src/prefect/server/models/concurrency_limits.py
@@ -10,15 +10,16 @@ import pendulum
 import sqlalchemy as sa
 
 import prefect.server.schemas as schemas
-from prefect.server.database.dependencies import inject_db
+from prefect.server.database import orm_models
+from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 
 
-@inject_db
+@db_injector
 async def create_concurrency_limit(
+    db: PrefectDBInterface,
     session: sa.orm.Session,
     concurrency_limit: schemas.core.ConcurrencyLimit,
-    db: PrefectDBInterface,
 ):
     insert_values = concurrency_limit.dict(shallow=True, exclude_unset=False)
     insert_values.pop("created")
@@ -31,7 +32,7 @@ async def create_concurrency_limit(
     concurrency_limit.updated = pendulum.now("UTC")
 
     insert_stmt = (
-        db.insert(db.ConcurrencyLimit)
+        db.insert(orm_models.ConcurrencyLimit)
         .values(**insert_values)
         .on_conflict_do_update(
             index_elements=db.concurrency_limit_unique_upsert_columns,
@@ -44,8 +45,8 @@ async def create_concurrency_limit(
     await session.execute(insert_stmt)
 
     query = (
-        sa.select(db.ConcurrencyLimit)
-        .where(db.ConcurrencyLimit.tag == concurrency_tag)
+        sa.select(orm_models.ConcurrencyLimit)
+        .where(orm_models.ConcurrencyLimit.tag == concurrency_tag)
         .execution_options(populate_existing=True)
     )
 
@@ -53,53 +54,51 @@ async def create_concurrency_limit(
     return result.scalar()
 
 
-@inject_db
 async def read_concurrency_limit(
     session: sa.orm.Session,
     concurrency_limit_id: UUID,
-    db: PrefectDBInterface,
 ):
     """
     Reads a concurrency limit by id. If used for orchestration, simultaneous read race
     conditions might allow the concurrency limit to be temporarily exceeded.
     """
 
-    query = sa.select(db.ConcurrencyLimit).where(
-        db.ConcurrencyLimit.id == concurrency_limit_id
+    query = sa.select(orm_models.ConcurrencyLimit).where(
+        orm_models.ConcurrencyLimit.id == concurrency_limit_id
     )
 
     result = await session.execute(query)
     return result.scalar()
 
 
-@inject_db
 async def read_concurrency_limit_by_tag(
     session: sa.orm.Session,
     tag: str,
-    db: PrefectDBInterface,
 ):
     """
     Reads a concurrency limit by tag. If used for orchestration, simultaneous read race
     conditions might allow the concurrency limit to be temporarily exceeded.
     """
 
-    query = sa.select(db.ConcurrencyLimit).where(db.ConcurrencyLimit.tag == tag)
+    query = sa.select(orm_models.ConcurrencyLimit).where(
+        orm_models.ConcurrencyLimit.tag == tag
+    )
 
     result = await session.execute(query)
     return result.scalar()
 
 
-@inject_db
 async def reset_concurrency_limit_by_tag(
     session: sa.orm.Session,
     tag: str,
-    db: PrefectDBInterface,
     slot_override: Optional[List[UUID]] = None,
 ):
     """
     Resets a concurrency limit by tag.
     """
-    query = sa.select(db.ConcurrencyLimit).where(db.ConcurrencyLimit.tag == tag)
+    query = sa.select(orm_models.ConcurrencyLimit).where(
+        orm_models.ConcurrencyLimit.tag == tag
+    )
     result = await session.execute(query)
     concurrency_limit = result.scalar()
     if concurrency_limit:
@@ -110,11 +109,9 @@ async def reset_concurrency_limit_by_tag(
     return concurrency_limit
 
 
-@inject_db
 async def filter_concurrency_limits_for_orchestration(
     session: sa.orm.Session,
     tags: List[str],
-    db: PrefectDBInterface,
 ):
     """
     Filters concurrency limits by tag. This will apply a "select for update" lock on
@@ -123,45 +120,41 @@ async def filter_concurrency_limits_for_orchestration(
     """
 
     query = (
-        sa.select(db.ConcurrencyLimit)
-        .filter(db.ConcurrencyLimit.tag.in_(tags))
-        .order_by(db.ConcurrencyLimit.tag)
+        sa.select(orm_models.ConcurrencyLimit)
+        .filter(orm_models.ConcurrencyLimit.tag.in_(tags))
+        .order_by(orm_models.ConcurrencyLimit.tag)
         .with_for_update()
     )
     result = await session.execute(query)
     return result.scalars().all()
 
 
-@inject_db
 async def delete_concurrency_limit(
     session: sa.orm.Session,
     concurrency_limit_id: UUID,
-    db: PrefectDBInterface,
 ) -> bool:
-    query = sa.delete(db.ConcurrencyLimit).where(
-        db.ConcurrencyLimit.id == concurrency_limit_id
+    query = sa.delete(orm_models.ConcurrencyLimit).where(
+        orm_models.ConcurrencyLimit.id == concurrency_limit_id
     )
 
     result = await session.execute(query)
     return result.rowcount > 0
 
 
-@inject_db
 async def delete_concurrency_limit_by_tag(
     session: sa.orm.Session,
     tag: str,
-    db: PrefectDBInterface,
 ) -> bool:
-    query = sa.delete(db.ConcurrencyLimit).where(db.ConcurrencyLimit.tag == tag)
+    query = sa.delete(orm_models.ConcurrencyLimit).where(
+        orm_models.ConcurrencyLimit.tag == tag
+    )
 
     result = await session.execute(query)
     return result.rowcount > 0
 
 
-@inject_db
 async def read_concurrency_limits(
     session: sa.orm.Session,
-    db: PrefectDBInterface,
     limit: Optional[int] = None,
     offset: Optional[int] = None,
 ):
@@ -175,10 +168,12 @@ async def read_concurrency_limits(
         limit: Query limit
 
     Returns:
-        List[db.ConcurrencyLimit]: concurrency limits
+        List[orm_models.ConcurrencyLimit]: concurrency limits
     """
 
-    query = sa.select(db.ConcurrencyLimit).order_by(db.ConcurrencyLimit.tag)
+    query = sa.select(orm_models.ConcurrencyLimit).order_by(
+        orm_models.ConcurrencyLimit.tag
+    )
 
     if offset is not None:
         query = query.offset(offset)

--- a/src/prefect/server/models/configuration.py
+++ b/src/prefect/server/models/configuration.py
@@ -3,18 +3,21 @@ from typing import Optional
 import sqlalchemy as sa
 
 from prefect.server import schemas
-from prefect.server.database.dependencies import inject_db
+from prefect.server.database import orm_models
+from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 
 
-@inject_db
+@db_injector
 async def write_configuration(
+    db: PrefectDBInterface,
     session: sa.orm.Session,
     configuration: schemas.core.Configuration,
-    db: PrefectDBInterface,
 ):
     # first see if the key already exists
-    query = sa.select(db.Configuration).where(db.Configuration.key == configuration.key)
+    query = sa.select(orm_models.Configuration).where(
+        orm_models.Configuration.key == configuration.key
+    )
     result = await session.execute(query)  # type: ignore
     existing_configuration = result.scalar()
     # if it exists, update its value
@@ -22,7 +25,7 @@ async def write_configuration(
         existing_configuration.value = configuration.value
     # else create a new ORM object
     else:
-        existing_configuration = db.Configuration(
+        existing_configuration = orm_models.Configuration(
             key=configuration.key, value=configuration.value
         )
     session.add(existing_configuration)
@@ -34,11 +37,11 @@ async def write_configuration(
     return existing_configuration
 
 
-@inject_db
+@db_injector
 async def read_configuration(
+    db: PrefectDBInterface,
     session: sa.orm.Session,
     key: str,
-    db: PrefectDBInterface,
 ) -> Optional[schemas.core.Configuration]:
     value = await db.read_configuration_value(session=session, key=key)
     return (

--- a/src/prefect/server/models/csrf_token.py
+++ b/src/prefect/server/models/csrf_token.py
@@ -6,6 +6,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect import settings
+from prefect.server.database import orm_models
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.schemas import core
@@ -35,14 +36,14 @@ async def create_or_update_csrf_token(
     token = secrets.token_hex(32)
 
     await session.execute(
-        db.insert(db.CsrfToken)
+        db.insert(orm_models.CsrfToken)
         .values(
             client=client,
             token=token,
             expiration=expiration,
         )
         .on_conflict_do_update(
-            index_elements=[db.CsrfToken.client],
+            index_elements=[orm_models.CsrfToken.client],
             set_={"token": token, "expiration": expiration},
         ),
     )
@@ -51,9 +52,7 @@ async def create_or_update_csrf_token(
     return await read_token_for_client(session=session, client=client)
 
 
-@db_injector
 async def read_token_for_client(
-    db: PrefectDBInterface,
     session: AsyncSession,
     client: str,
 ) -> Optional[core.CsrfToken]:
@@ -69,10 +68,10 @@ async def read_token_for_client(
     """
     token = (
         await session.execute(
-            sa.select(db.CsrfToken).where(
+            sa.select(orm_models.CsrfToken).where(
                 sa.and_(
-                    db.CsrfToken.expiration > datetime.now(timezone.utc),
-                    db.CsrfToken.client == client,
+                    orm_models.CsrfToken.expiration > datetime.now(timezone.utc),
+                    orm_models.CsrfToken.client == client,
                 )
             )
         )
@@ -84,8 +83,7 @@ async def read_token_for_client(
     return core.CsrfToken.from_orm(token)
 
 
-@db_injector
-async def delete_expired_tokens(db: PrefectDBInterface, session: AsyncSession) -> int:
+async def delete_expired_tokens(session: AsyncSession) -> int:
     """Delete expired CSRF tokens.
 
     Args:
@@ -96,8 +94,8 @@ async def delete_expired_tokens(db: PrefectDBInterface, session: AsyncSession) -
     """
 
     result = await session.execute(
-        sa.delete(db.CsrfToken).where(
-            db.CsrfToken.expiration < datetime.now(timezone.utc)
+        sa.delete(orm_models.CsrfToken).where(
+            orm_models.CsrfToken.expiration < datetime.now(timezone.utc)
         )
     )
     return result.rowcount

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -4,7 +4,7 @@ Intended for internal use by the Prefect REST API.
 """
 
 import datetime
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Sequence
+from typing import Dict, Iterable, List, Optional, Sequence
 from uuid import UUID, uuid4
 
 import pendulum
@@ -13,6 +13,7 @@ from sqlalchemy import delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server import models, schemas
+from prefect.server.database import orm_models
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.events.clients import PrefectServerEventsClient
@@ -27,13 +28,8 @@ from prefect.settings import (
     PREFECT_API_SERVICES_SCHEDULER_MIN_SCHEDULED_TIME,
 )
 
-if TYPE_CHECKING:
-    from prefect.server.database.orm_models import ORMDeployment
 
-
-@db_injector
 async def _delete_scheduled_runs(
-    db: PrefectDBInterface,
     session: AsyncSession,
     deployment_id: UUID,
     auto_scheduled_only: bool = False,
@@ -47,14 +43,14 @@ async def _delete_scheduled_runs(
         deployment_id: the deployment for which we should delete runs.
         auto_scheduled_only: if True, only delete auto scheduled runs. Defaults to `False`.
     """
-    delete_query = sa.delete(db.FlowRun).where(
-        db.FlowRun.deployment_id == deployment_id,
-        db.FlowRun.state_type == schemas.states.StateType.SCHEDULED.value,
+    delete_query = sa.delete(orm_models.FlowRun).where(
+        orm_models.FlowRun.deployment_id == deployment_id,
+        orm_models.FlowRun.state_type == schemas.states.StateType.SCHEDULED.value,
     )
 
     if auto_scheduled_only:
         delete_query = delete_query.where(
-            db.FlowRun.auto_scheduled.is_(True),
+            orm_models.FlowRun.auto_scheduled.is_(True),
         )
 
     await session.execute(delete_query)
@@ -65,7 +61,7 @@ async def create_deployment(
     db: PrefectDBInterface,
     session: AsyncSession,
     deployment: schemas.core.Deployment,
-) -> Optional["ORMDeployment"]:
+) -> Optional[orm_models.Deployment]:
     """Upserts a deployment.
 
     Args:
@@ -73,7 +69,7 @@ async def create_deployment(
         deployment: a deployment model
 
     Returns:
-        db.Deployment: the newly-created or updated deployment
+        orm_models.Deployment: the newly-created or updated deployment
 
     """
 
@@ -102,7 +98,7 @@ async def create_deployment(
         conflict_update_fields["infra_overrides"] = job_variables
 
     insert_stmt = (
-        db.insert(db.Deployment)
+        db.insert(orm_models.Deployment)
         .values(**insert_values)
         .on_conflict_do_update(
             index_elements=db.deployment_unique_upsert_columns,
@@ -114,10 +110,10 @@ async def create_deployment(
 
     # Get the id of the deployment we just created or updated
     result = await session.execute(
-        sa.select(db.Deployment.id).where(
+        sa.select(orm_models.Deployment.id).where(
             sa.and_(
-                db.Deployment.flow_id == deployment.flow_id,
-                db.Deployment.name == deployment.name,
+                orm_models.Deployment.flow_id == deployment.flow_id,
+                orm_models.Deployment.name == deployment.name,
             )
         )
     )
@@ -151,11 +147,11 @@ async def create_deployment(
         )
 
     query = (
-        sa.select(db.Deployment)
+        sa.select(orm_models.Deployment)
         .where(
             sa.and_(
-                db.Deployment.flow_id == deployment.flow_id,
-                db.Deployment.name == deployment.name,
+                orm_models.Deployment.flow_id == deployment.flow_id,
+                orm_models.Deployment.name == deployment.name,
             )
         )
         .execution_options(populate_existing=True)
@@ -164,9 +160,7 @@ async def create_deployment(
     return result.scalar()
 
 
-@db_injector
 async def update_deployment(
-    db: PrefectDBInterface,
     session: AsyncSession,
     deployment_id: UUID,
     deployment: schemas.actions.DeploymentUpdate,
@@ -235,8 +229,8 @@ async def update_deployment(
         update_data["paused"] = not update_data["is_schedule_active"]
 
     update_stmt = (
-        sa.update(db.Deployment)
-        .where(db.Deployment.id == deployment_id)
+        sa.update(orm_models.Deployment)
+        .where(orm_models.Deployment.id == deployment_id)
         .values(**update_data)
     )
     result = await session.execute(update_stmt)
@@ -267,10 +261,9 @@ async def update_deployment(
     return result.rowcount > 0
 
 
-@db_injector
 async def read_deployment(
-    db: PrefectDBInterface, session: AsyncSession, deployment_id: UUID
-) -> Optional["ORMDeployment"]:
+    session: AsyncSession, deployment_id: UUID
+) -> Optional[orm_models.Deployment]:
     """Reads a deployment by id.
 
     Args:
@@ -278,16 +271,15 @@ async def read_deployment(
         deployment_id: a deployment id
 
     Returns:
-        db.Deployment: the deployment
+        orm_models.Deployment: the deployment
     """
 
-    return await session.get(db.Deployment, deployment_id)
+    return await session.get(orm_models.Deployment, deployment_id)
 
 
-@db_injector
 async def read_deployment_by_name(
-    db: PrefectDBInterface, session: AsyncSession, name: str, flow_name: str
-) -> Optional["ORMDeployment"]:
+    session: AsyncSession, name: str, flow_name: str
+) -> Optional[orm_models.Deployment]:
     """Reads a deployment by name.
 
     Args:
@@ -296,16 +288,16 @@ async def read_deployment_by_name(
         flow_name: the name of the flow the deployment belongs to
 
     Returns:
-        db.Deployment: the deployment
+        orm_models.Deployment: the deployment
     """
 
     result = await session.execute(
-        select(db.Deployment)
-        .join(db.Flow, db.Deployment.flow_id == db.Flow.id)
+        select(orm_models.Deployment)
+        .join(orm_models.Flow, orm_models.Deployment.flow_id == orm_models.Flow.id)
         .where(
             sa.and_(
-                db.Flow.name == flow_name,
-                db.Deployment.name == name,
+                orm_models.Flow.name == flow_name,
+                orm_models.Deployment.name == name,
             )
         )
         .limit(1)
@@ -313,9 +305,7 @@ async def read_deployment_by_name(
     return result.scalar()
 
 
-@db_injector
 async def _apply_deployment_filters(
-    db: PrefectDBInterface,
     query,
     flow_filter: schemas.filters.FlowFilter = None,
     flow_run_filter: schemas.filters.FlowRunFilter = None,
@@ -329,52 +319,51 @@ async def _apply_deployment_filters(
     """
 
     if deployment_filter:
-        query = query.where(deployment_filter.as_sql_filter(db))
+        query = query.where(deployment_filter.as_sql_filter())
 
     if flow_filter:
-        exists_clause = select(db.Deployment.id).where(
-            db.Deployment.flow_id == db.Flow.id,
-            flow_filter.as_sql_filter(db),
+        exists_clause = select(orm_models.Deployment.id).where(
+            orm_models.Deployment.flow_id == orm_models.Flow.id,
+            flow_filter.as_sql_filter(),
         )
 
         query = query.where(exists_clause.exists())
 
     if flow_run_filter or task_run_filter:
-        exists_clause = select(db.FlowRun).where(
-            db.Deployment.id == db.FlowRun.deployment_id
+        exists_clause = select(orm_models.FlowRun).where(
+            orm_models.Deployment.id == orm_models.FlowRun.deployment_id
         )
 
         if flow_run_filter:
-            exists_clause = exists_clause.where(flow_run_filter.as_sql_filter(db))
+            exists_clause = exists_clause.where(flow_run_filter.as_sql_filter())
         if task_run_filter:
             exists_clause = exists_clause.join(
-                db.TaskRun,
-                db.TaskRun.flow_run_id == db.FlowRun.id,
-            ).where(task_run_filter.as_sql_filter(db))
+                orm_models.TaskRun,
+                orm_models.TaskRun.flow_run_id == orm_models.FlowRun.id,
+            ).where(task_run_filter.as_sql_filter())
 
         query = query.where(exists_clause.exists())
 
     if work_pool_filter or work_queue_filter:
-        exists_clause = select(db.WorkQueue).where(
-            db.Deployment.work_queue_id == db.WorkQueue.id
+        exists_clause = select(orm_models.WorkQueue).where(
+            orm_models.Deployment.work_queue_id == orm_models.WorkQueue.id
         )
 
         if work_queue_filter:
-            exists_clause = exists_clause.where(work_queue_filter.as_sql_filter(db))
+            exists_clause = exists_clause.where(work_queue_filter.as_sql_filter())
 
         if work_pool_filter:
             exists_clause = exists_clause.join(
-                db.WorkPool, db.WorkPool.id == db.WorkQueue.work_pool_id
-            ).where(work_pool_filter.as_sql_filter(db))
+                orm_models.WorkPool,
+                orm_models.WorkPool.id == orm_models.WorkQueue.work_pool_id,
+            ).where(work_pool_filter.as_sql_filter())
 
         query = query.where(exists_clause.exists())
 
     return query
 
 
-@db_injector
 async def read_deployments(
-    db: PrefectDBInterface,
     session: AsyncSession,
     offset: int = None,
     limit: int = None,
@@ -385,7 +374,7 @@ async def read_deployments(
     work_pool_filter: schemas.filters.WorkPoolFilter = None,
     work_queue_filter: schemas.filters.WorkQueueFilter = None,
     sort: schemas.sorting.DeploymentSort = schemas.sorting.DeploymentSort.NAME_ASC,
-) -> Sequence["ORMDeployment"]:
+) -> Sequence[orm_models.Deployment]:
     """
     Read deployments.
 
@@ -402,10 +391,10 @@ async def read_deployments(
         sort: the sort criteria for selected deployments. Defaults to `name` ASC.
 
     Returns:
-        List[db.Deployment]: deployments
+        List[orm_models.Deployment]: deployments
     """
 
-    query = select(db.Deployment).order_by(sort.as_sql_sort(db=db))
+    query = select(orm_models.Deployment).order_by(sort.as_sql_sort())
 
     query = await _apply_deployment_filters(
         query=query,
@@ -426,9 +415,7 @@ async def read_deployments(
     return result.scalars().unique().all()
 
 
-@db_injector
 async def count_deployments(
-    db: PrefectDBInterface,
     session: AsyncSession,
     flow_filter: schemas.filters.FlowFilter = None,
     flow_run_filter: schemas.filters.FlowRunFilter = None,
@@ -453,7 +440,7 @@ async def count_deployments(
         int: the number of deployments matching filters
     """
 
-    query = select(sa.func.count(sa.text("*"))).select_from(db.Deployment)
+    query = select(sa.func.count(sa.text("*"))).select_from(orm_models.Deployment)
 
     query = await _apply_deployment_filters(
         query=query,
@@ -469,10 +456,7 @@ async def count_deployments(
     return result.scalar()
 
 
-@db_injector
-async def delete_deployment(
-    db: PrefectDBInterface, session: AsyncSession, deployment_id: UUID
-) -> bool:
+async def delete_deployment(session: AsyncSession, deployment_id: UUID) -> bool:
     """
     Delete a deployment by id.
 
@@ -490,7 +474,7 @@ async def delete_deployment(
     )
 
     result = await session.execute(
-        delete(db.Deployment).where(db.Deployment.id == deployment_id)
+        delete(orm_models.Deployment).where(orm_models.Deployment.id == deployment_id)
     )
     return result.rowcount > 0
 
@@ -559,9 +543,7 @@ async def schedule_runs(
     return await _insert_scheduled_flow_runs(session=session, runs=runs)
 
 
-@db_injector
 async def _generate_scheduled_flow_runs(
-    db: PrefectDBInterface,
     session: AsyncSession,
     deployment_id: UUID,
     start_time: datetime.datetime,
@@ -604,7 +586,7 @@ async def _generate_scheduled_flow_runs(
     """
     runs = []
 
-    deployment = await session.get(db.Deployment, deployment_id)
+    deployment = await session.get(orm_models.Deployment, deployment_id)
 
     if not deployment:
         return []
@@ -686,7 +668,7 @@ async def _insert_scheduled_flow_runs(
     # this syntax (insert statement, values to insert) is most efficient
     # because it uses a single bind parameter
     await session.execute(
-        db.insert(db.FlowRun).on_conflict_do_nothing(
+        db.insert(orm_models.FlowRun).on_conflict_do_nothing(
             index_elements=db.flow_run_unique_upsert_columns
         ),
         runs,
@@ -695,15 +677,15 @@ async def _insert_scheduled_flow_runs(
     # query for the rows that were newly inserted (by checking for any flow runs with
     # no corresponding flow run states)
     inserted_rows = (
-        sa.select(db.FlowRun.id)
+        sa.select(orm_models.FlowRun.id)
         .join(
-            db.FlowRunState,
-            db.FlowRun.id == db.FlowRunState.flow_run_id,
+            orm_models.FlowRunState,
+            orm_models.FlowRun.id == orm_models.FlowRunState.flow_run_id,
             isouter=True,
         )
         .where(
-            db.FlowRun.id.in_([r["id"] for r in runs]),
-            db.FlowRunState.id.is_(None),
+            orm_models.FlowRun.id.in_([r["id"] for r in runs]),
+            orm_models.FlowRunState.id.is_(None),
         )
     )
     inserted_flow_run_ids = (await session.execute(inserted_rows)).scalars().all()
@@ -718,7 +700,7 @@ async def _insert_scheduled_flow_runs(
         # this syntax (insert statement, values to insert) is most efficient
         # because it uses a single bind parameter
         await session.execute(
-            db.FlowRunState.__table__.insert(), insert_flow_run_states
+            orm_models.FlowRunState.__table__.insert(), insert_flow_run_states
         )
 
         # set the `state_id` on the newly inserted runs
@@ -732,9 +714,8 @@ async def _insert_scheduled_flow_runs(
     return inserted_flow_run_ids
 
 
-@db_injector
 async def check_work_queues_for_deployment(
-    db: PrefectDBInterface, session: AsyncSession, deployment_id: UUID
+    session: AsyncSession, deployment_id: UUID
 ) -> List[schemas.core.WorkQueue]:
     """
     Get work queues that can pick up the specified deployment.
@@ -756,31 +737,31 @@ async def check_work_queues_for_deployment(
     contains B".
 
     Returns:
-        List[db.WorkQueue]: WorkQueues
+        List[orm_models.WorkQueue]: WorkQueues
     """
-    deployment = await session.get(db.Deployment, deployment_id)
+    deployment = await session.get(orm_models.Deployment, deployment_id)
     if not deployment:
         raise ObjectNotFoundError(f"Deployment with id {deployment_id} not found")
 
     query = (
-        select(db.WorkQueue)
+        select(orm_models.WorkQueue)
         # work queue tags are a subset of deployment tags
         .filter(
             or_(
-                json_contains(deployment.tags, db.WorkQueue.filter["tags"]),
-                json_contains([], db.WorkQueue.filter["tags"]),
-                json_contains(None, db.WorkQueue.filter["tags"]),
+                json_contains(deployment.tags, orm_models.WorkQueue.filter["tags"]),
+                json_contains([], orm_models.WorkQueue.filter["tags"]),
+                json_contains(None, orm_models.WorkQueue.filter["tags"]),
             )
         )
         # deployment_ids is null or contains the deployment's ID
         .filter(
             or_(
                 json_contains(
-                    db.WorkQueue.filter["deployment_ids"],
+                    orm_models.WorkQueue.filter["deployment_ids"],
                     str(deployment.id),
                 ),
-                json_contains(None, db.WorkQueue.filter["deployment_ids"]),
-                json_contains([], db.WorkQueue.filter["deployment_ids"]),
+                json_contains(None, orm_models.WorkQueue.filter["deployment_ids"]),
+                json_contains([], orm_models.WorkQueue.filter["deployment_ids"]),
             )
         )
     )
@@ -789,9 +770,7 @@ async def check_work_queues_for_deployment(
     return result.scalars().unique().all()
 
 
-@db_injector
 async def create_deployment_schedules(
-    db: PrefectDBInterface,
     session: AsyncSession,
     deployment_id: UUID,
     schedules: List[schemas.actions.DeploymentScheduleCreate],
@@ -812,7 +791,8 @@ async def create_deployment_schedules(
         schedules_with_deployment_id.append(data)
 
     models = [
-        db.DeploymentSchedule(**schedule) for schedule in schedules_with_deployment_id
+        orm_models.DeploymentSchedule(**schedule)
+        for schedule in schedules_with_deployment_id
     ]
     session.add_all(models)
     await session.flush()
@@ -820,9 +800,7 @@ async def create_deployment_schedules(
     return [schemas.core.DeploymentSchedule.from_orm(m) for m in models]
 
 
-@db_injector
 async def read_deployment_schedules(
-    db: PrefectDBInterface,
     session: AsyncSession,
     deployment_id: UUID,
     deployment_schedule_filter: Optional[
@@ -841,22 +819,20 @@ async def read_deployment_schedules(
     """
 
     query = (
-        sa.select(db.DeploymentSchedule)
-        .where(db.DeploymentSchedule.deployment_id == deployment_id)
-        .order_by(db.DeploymentSchedule.updated.desc())
+        sa.select(orm_models.DeploymentSchedule)
+        .where(orm_models.DeploymentSchedule.deployment_id == deployment_id)
+        .order_by(orm_models.DeploymentSchedule.updated.desc())
     )
 
     if deployment_schedule_filter:
-        query = query.where(deployment_schedule_filter.as_sql_filter(db))
+        query = query.where(deployment_schedule_filter.as_sql_filter())
 
     result = await session.execute(query)
 
     return [schemas.core.DeploymentSchedule.from_orm(s) for s in result.scalars().all()]
 
 
-@db_injector
 async def update_deployment_schedule(
-    db: PrefectDBInterface,
     session: AsyncSession,
     deployment_id: UUID,
     deployment_schedule_id: UUID,
@@ -872,11 +848,11 @@ async def update_deployment_schedule(
     """
 
     result = await session.execute(
-        sa.update(db.DeploymentSchedule)
+        sa.update(orm_models.DeploymentSchedule)
         .where(
             sa.and_(
-                db.DeploymentSchedule.id == deployment_schedule_id,
-                db.DeploymentSchedule.deployment_id == deployment_id,
+                orm_models.DeploymentSchedule.id == deployment_schedule_id,
+                orm_models.DeploymentSchedule.deployment_id == deployment_id,
             )
         )
         .values(**schedule.dict(exclude_none=True))
@@ -885,9 +861,8 @@ async def update_deployment_schedule(
     return result.rowcount > 0
 
 
-@db_injector
 async def delete_schedules_for_deployment(
-    db: PrefectDBInterface, session: AsyncSession, deployment_id: UUID
+    session: AsyncSession, deployment_id: UUID
 ) -> bool:
     """
     Deletes a deployment schedule.
@@ -898,17 +873,15 @@ async def delete_schedules_for_deployment(
     """
 
     result = await session.execute(
-        sa.delete(db.DeploymentSchedule).where(
-            db.DeploymentSchedule.deployment_id == deployment_id
+        sa.delete(orm_models.DeploymentSchedule).where(
+            orm_models.DeploymentSchedule.deployment_id == deployment_id
         )
     )
 
     return result.rowcount > 0
 
 
-@db_injector
 async def delete_deployment_schedule(
-    db: PrefectDBInterface,
     session: AsyncSession,
     deployment_id: UUID,
     deployment_schedule_id: UUID,
@@ -922,10 +895,10 @@ async def delete_deployment_schedule(
     """
 
     result = await session.execute(
-        sa.delete(db.DeploymentSchedule).where(
+        sa.delete(orm_models.DeploymentSchedule).where(
             sa.and_(
-                db.DeploymentSchedule.id == deployment_schedule_id,
-                db.DeploymentSchedule.deployment_id == deployment_id,
+                orm_models.DeploymentSchedule.id == deployment_schedule_id,
+                orm_models.DeploymentSchedule.deployment_id == deployment_id,
             )
         )
     )
@@ -949,12 +922,12 @@ async def mark_deployments_ready(
         begin_transaction=True, with_for_update=True
     ) as session:
         result = await session.execute(
-            select(db.Deployment.id).where(
+            select(orm_models.Deployment.id).where(
                 sa.or_(
-                    db.Deployment.id.in_(deployment_ids),
-                    db.Deployment.work_queue_id.in_(work_queue_ids),
+                    orm_models.Deployment.id.in_(deployment_ids),
+                    orm_models.Deployment.work_queue_id.in_(work_queue_ids),
                 ),
-                db.Deployment.status == DeploymentStatus.NOT_READY,
+                orm_models.Deployment.status == DeploymentStatus.NOT_READY,
             )
         )
         unready_deployments = list(result.scalars().unique().all())
@@ -962,11 +935,11 @@ async def mark_deployments_ready(
         last_polled = pendulum.now("UTC")
 
         await session.execute(
-            sa.update(db.Deployment)
+            sa.update(orm_models.Deployment)
             .where(
                 sa.or_(
-                    db.Deployment.id.in_(deployment_ids),
-                    db.Deployment.work_queue_id.in_(work_queue_ids),
+                    orm_models.Deployment.id.in_(deployment_ids),
+                    orm_models.Deployment.work_queue_id.in_(work_queue_ids),
                 )
             )
             .values(status=DeploymentStatus.READY, last_polled=last_polled)
@@ -1003,22 +976,22 @@ async def mark_deployments_not_ready(
         begin_transaction=True, with_for_update=True
     ) as session:
         result = await session.execute(
-            select(db.Deployment.id).where(
+            select(orm_models.Deployment.id).where(
                 sa.or_(
-                    db.Deployment.id.in_(deployment_ids),
-                    db.Deployment.work_queue_id.in_(work_queue_ids),
+                    orm_models.Deployment.id.in_(deployment_ids),
+                    orm_models.Deployment.work_queue_id.in_(work_queue_ids),
                 ),
-                db.Deployment.status == DeploymentStatus.READY,
+                orm_models.Deployment.status == DeploymentStatus.READY,
             )
         )
         ready_deployments = list(result.scalars().unique().all())
 
         await session.execute(
-            sa.update(db.Deployment)
+            sa.update(orm_models.Deployment)
             .where(
                 sa.or_(
-                    db.Deployment.id.in_(deployment_ids),
-                    db.Deployment.work_queue_id.in_(work_queue_ids),
+                    orm_models.Deployment.id.in_(deployment_ids),
+                    orm_models.Deployment.work_queue_id.in_(work_queue_ids),
                 )
             )
             .values(status=DeploymentStatus.NOT_READY)

--- a/src/prefect/server/models/flow_run_notification_policies.py
+++ b/src/prefect/server/models/flow_run_notification_policies.py
@@ -96,7 +96,7 @@ async def read_flow_run_notification_policies(
     )
 
     if flow_run_notification_policy_filter:
-        query = query.where(flow_run_notification_policy_filter.as_sql_filter(db))
+        query = query.where(flow_run_notification_policy_filter.as_sql_filter())
 
     if offset is not None:
         query = query.offset(offset)

--- a/src/prefect/server/models/flow_runs.py
+++ b/src/prefect/server/models/flow_runs.py
@@ -6,7 +6,7 @@ Intended for internal use by the Prefect REST API.
 import contextlib
 import datetime
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 from uuid import UUID
 
 import pendulum
@@ -17,6 +17,7 @@ from sqlalchemy.orm import load_only, selectinload
 
 import prefect.server.models as models
 import prefect.server.schemas as schemas
+from prefect.server.database import orm_models
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.exceptions import ObjectNotFoundError
@@ -34,9 +35,6 @@ from prefect.settings import (
     PREFECT_API_MAX_FLOW_RUN_GRAPH_NODES,
 )
 
-if TYPE_CHECKING:
-    from prefect.server.database.orm_models import ORMFlowRun
-
 
 @db_injector
 async def create_flow_run(
@@ -44,7 +42,7 @@ async def create_flow_run(
     session: AsyncSession,
     flow_run: schemas.core.FlowRun,
     orchestration_parameters: Optional[dict] = None,
-) -> "ORMFlowRun":
+) -> orm_models.FlowRun:
     """Creates a new flow run.
 
     If the provided flow run has a state attached, it will also be created.
@@ -54,7 +52,7 @@ async def create_flow_run(
         flow_run: a flow run model
 
     Returns:
-        db.FlowRun: the newly-created flow run
+        orm_models.FlowRun: the newly-created flow run
     """
     now = pendulum.now("UTC")
 
@@ -74,14 +72,14 @@ async def create_flow_run(
 
     # if no idempotency key was provided, create the run directly
     if not flow_run.idempotency_key:
-        model = db.FlowRun(**flow_run_dict)
+        model = orm_models.FlowRun(**flow_run_dict)
         session.add(model)
         await session.flush()
 
     # otherwise let the database take care of enforcing idempotency
     else:
         insert_stmt = (
-            db.insert(db.FlowRun)
+            db.insert(orm_models.FlowRun)
             .values(**flow_run_dict)
             .on_conflict_do_nothing(
                 index_elements=db.flow_run_unique_upsert_columns,
@@ -91,17 +89,19 @@ async def create_flow_run(
 
         # read the run to see if idempotency was applied or not
         query = (
-            sa.select(db.FlowRun)
+            sa.select(orm_models.FlowRun)
             .where(
                 sa.and_(
-                    db.FlowRun.flow_id == flow_run.flow_id,
-                    db.FlowRun.idempotency_key == flow_run.idempotency_key,
+                    orm_models.FlowRun.flow_id == flow_run.flow_id,
+                    orm_models.FlowRun.idempotency_key == flow_run.idempotency_key,
                 )
             )
             .limit(1)
             .execution_options(populate_existing=True)
             .options(
-                selectinload(db.FlowRun.work_queue).selectinload(db.WorkQueue.work_pool)
+                selectinload(orm_models.FlowRun.work_queue).selectinload(
+                    orm_models.WorkQueue.work_pool
+                )
             )
         )
         result = await session.execute(query)
@@ -120,9 +120,7 @@ async def create_flow_run(
     return model
 
 
-@db_injector
 async def update_flow_run(
-    db: PrefectDBInterface,
     session: AsyncSession,
     flow_run_id: UUID,
     flow_run: schemas.actions.FlowRunUpdate,
@@ -139,8 +137,8 @@ async def update_flow_run(
         bool: whether or not matching rows were found to update
     """
     update_stmt = (
-        sa.update(db.FlowRun)
-        .where(db.FlowRun.id == flow_run_id)
+        sa.update(orm_models.FlowRun)
+        .where(orm_models.FlowRun.id == flow_run_id)
         # exclude_unset=True allows us to only update values provided by
         # the user, ignoring any defaults on the model
         .values(**flow_run.dict(shallow=True, exclude_unset=True))
@@ -149,13 +147,11 @@ async def update_flow_run(
     return result.rowcount > 0
 
 
-@db_injector
 async def read_flow_run(
-    db: PrefectDBInterface,
     session: AsyncSession,
     flow_run_id: UUID,
     for_update: bool = False,
-) -> Optional["ORMFlowRun"]:
+) -> Optional[orm_models.FlowRun]:
     """
     Reads a flow run by id.
 
@@ -164,13 +160,15 @@ async def read_flow_run(
         flow_run_id: a flow run id
 
     Returns:
-        db.FlowRun: the flow run
+        orm_models.FlowRun: the flow run
     """
     select = (
-        sa.select(db.FlowRun)
-        .where(db.FlowRun.id == flow_run_id)
+        sa.select(orm_models.FlowRun)
+        .where(orm_models.FlowRun.id == flow_run_id)
         .options(
-            selectinload(db.FlowRun.work_queue).selectinload(db.WorkQueue.work_pool)
+            selectinload(orm_models.FlowRun.work_queue).selectinload(
+                orm_models.WorkQueue.work_pool
+            )
         )
     )
 
@@ -181,9 +179,7 @@ async def read_flow_run(
     return result.scalar()
 
 
-@db_injector
 async def _apply_flow_run_filters(
-    db: PrefectDBInterface,
     query,
     flow_filter: schemas.filters.FlowFilter = None,
     flow_run_filter: schemas.filters.FlowRunFilter = None,
@@ -197,51 +193,51 @@ async def _apply_flow_run_filters(
     """
 
     if flow_run_filter:
-        query = query.where(flow_run_filter.as_sql_filter(db))
+        query = query.where(flow_run_filter.as_sql_filter())
 
     if deployment_filter:
-        exists_clause = select(db.Deployment).where(
-            db.Deployment.id == db.FlowRun.deployment_id,
-            deployment_filter.as_sql_filter(db),
+        exists_clause = select(orm_models.Deployment).where(
+            orm_models.Deployment.id == orm_models.FlowRun.deployment_id,
+            deployment_filter.as_sql_filter(),
         )
         query = query.where(exists_clause.exists())
 
     if work_pool_filter:
-        exists_clause = select(db.WorkPool).where(
-            db.WorkQueue.id == db.FlowRun.work_queue_id,
-            db.WorkPool.id == db.WorkQueue.work_pool_id,
-            work_pool_filter.as_sql_filter(db),
+        exists_clause = select(orm_models.WorkPool).where(
+            orm_models.WorkQueue.id == orm_models.FlowRun.work_queue_id,
+            orm_models.WorkPool.id == orm_models.WorkQueue.work_pool_id,
+            work_pool_filter.as_sql_filter(),
         )
 
         query = query.where(exists_clause.exists())
 
     if work_queue_filter:
-        exists_clause = select(db.WorkQueue).where(
-            db.WorkQueue.id == db.FlowRun.work_queue_id,
-            work_queue_filter.as_sql_filter(db),
+        exists_clause = select(orm_models.WorkQueue).where(
+            orm_models.WorkQueue.id == orm_models.FlowRun.work_queue_id,
+            work_queue_filter.as_sql_filter(),
         )
         query = query.where(exists_clause.exists())
 
     if flow_filter or task_run_filter:
         if flow_filter:
-            exists_clause = select(db.Flow).where(
-                db.Flow.id == db.FlowRun.flow_id,
-                flow_filter.as_sql_filter(db),
+            exists_clause = select(orm_models.Flow).where(
+                orm_models.Flow.id == orm_models.FlowRun.flow_id,
+                flow_filter.as_sql_filter(),
             )
 
         if task_run_filter:
             if not flow_filter:
-                exists_clause = select(db.TaskRun).where(
-                    db.TaskRun.flow_run_id == db.FlowRun.id
+                exists_clause = select(orm_models.TaskRun).where(
+                    orm_models.TaskRun.flow_run_id == orm_models.FlowRun.id
                 )
             else:
                 exists_clause = exists_clause.join(
-                    db.TaskRun,
-                    db.TaskRun.flow_run_id == db.FlowRun.id,
+                    orm_models.TaskRun,
+                    orm_models.TaskRun.flow_run_id == orm_models.FlowRun.id,
                 )
             exists_clause = exists_clause.where(
-                db.FlowRun.id == db.TaskRun.flow_run_id,
-                task_run_filter.as_sql_filter(db),
+                orm_models.FlowRun.id == orm_models.TaskRun.flow_run_id,
+                task_run_filter.as_sql_filter(),
             )
 
         query = query.where(exists_clause.exists())
@@ -249,9 +245,7 @@ async def _apply_flow_run_filters(
     return query
 
 
-@db_injector
 async def read_flow_runs(
-    db: PrefectDBInterface,
     session: AsyncSession,
     columns: List = None,
     flow_filter: schemas.filters.FlowFilter = None,
@@ -263,7 +257,7 @@ async def read_flow_runs(
     offset: int = None,
     limit: int = None,
     sort: schemas.sorting.FlowRunSort = schemas.sorting.FlowRunSort.ID_DESC,
-) -> Sequence["ORMFlowRun"]:
+) -> Sequence[orm_models.FlowRun]:
     """
     Read flow runs.
 
@@ -279,13 +273,15 @@ async def read_flow_runs(
         sort: Query sort
 
     Returns:
-        List[db.FlowRun]: flow runs
+        List[orm_models.FlowRun]: flow runs
     """
     query = (
-        select(db.FlowRun)
-        .order_by(sort.as_sql_sort(db))
+        select(orm_models.FlowRun)
+        .order_by(sort.as_sql_sort())
         .options(
-            selectinload(db.FlowRun.work_queue).selectinload(db.WorkQueue.work_pool)
+            selectinload(orm_models.FlowRun.work_queue).selectinload(
+                orm_models.WorkQueue.work_pool
+            )
         )
     )
 
@@ -372,9 +368,7 @@ async def read_task_run_dependencies(
     return dependency_graph
 
 
-@db_injector
 async def count_flow_runs(
-    db: PrefectDBInterface,
     session: AsyncSession,
     flow_filter: schemas.filters.FlowFilter = None,
     flow_run_filter: schemas.filters.FlowRunFilter = None,
@@ -397,7 +391,7 @@ async def count_flow_runs(
         int: count of flow runs
     """
 
-    query = select(sa.func.count(sa.text("*"))).select_from(db.FlowRun)
+    query = select(sa.func.count(sa.text("*"))).select_from(orm_models.FlowRun)
 
     query = await _apply_flow_run_filters(
         query,
@@ -413,10 +407,7 @@ async def count_flow_runs(
     return result.scalar()
 
 
-@db_injector
-async def delete_flow_run(
-    db: PrefectDBInterface, session: AsyncSession, flow_run_id: UUID
-) -> bool:
+async def delete_flow_run(session: AsyncSession, flow_run_id: UUID) -> bool:
     """
     Delete a flow run by flow_run_id.
 
@@ -429,7 +420,7 @@ async def delete_flow_run(
     """
 
     result = await session.execute(
-        delete(db.FlowRun).where(db.FlowRun.id == flow_run_id)
+        delete(orm_models.FlowRun).where(orm_models.FlowRun.id == flow_run_id)
     )
     return result.rowcount > 0
 

--- a/src/prefect/server/models/flow_runs.py
+++ b/src/prefect/server/models/flow_runs.py
@@ -529,7 +529,6 @@ async def read_flow_run_graph(
     """Given a flow run, return the graph of it's task and subflow runs. If a `since`
     datetime is provided, only return items that may have changed since that time."""
     return await db.queries.flow_run_graph_v2(
-        db=db,
         session=session,
         flow_run_id=flow_run_id,
         since=since,

--- a/src/prefect/server/models/logs.py
+++ b/src/prefect/server/models/logs.py
@@ -68,10 +68,10 @@ async def read_logs(
     Returns:
         List[db.Log]: the matching logs
     """
-    query = select(db.Log).order_by(sort.as_sql_sort(db)).offset(offset).limit(limit)
+    query = select(db.Log).order_by(sort.as_sql_sort()).offset(offset).limit(limit)
 
     if log_filter:
-        query = query.where(log_filter.as_sql_filter(db))
+        query = query.where(log_filter.as_sql_filter())
 
     result = await session.execute(query)
     return result.scalars().unique().all()

--- a/src/prefect/server/models/task_runs.py
+++ b/src/prefect/server/models/task_runs.py
@@ -15,7 +15,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import prefect.server.models as models
 import prefect.server.schemas as schemas
 from prefect.logging import get_logger
-from prefect.server.database.dependencies import inject_db
+from prefect.server.database import orm_models
+from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.orchestration.core_policy import (
@@ -30,11 +31,11 @@ from prefect.server.schemas.responses import OrchestrationResult
 logger = get_logger("server")
 
 
-@inject_db
+@db_injector
 async def create_task_run(
+    db: PrefectDBInterface,
     session: sa.orm.Session,
     task_run: schemas.core.TaskRun,
-    db: PrefectDBInterface,
     orchestration_parameters: Optional[Dict[str, Any]] = None,
 ):
     """
@@ -49,7 +50,7 @@ async def create_task_run(
         task_run: a task run model
 
     Returns:
-        db.TaskRun: the newly-created or existing task run
+        orm_models.TaskRun: the newly-created or existing task run
     """
 
     now = pendulum.now("UTC")
@@ -57,7 +58,7 @@ async def create_task_run(
     # if a dynamic key exists, we need to guard against conflicts
     if task_run.flow_run_id:
         insert_stmt = (
-            db.insert(db.TaskRun)
+            db.insert(orm_models.TaskRun)
             .values(
                 created=now,
                 **task_run.dict(
@@ -71,12 +72,12 @@ async def create_task_run(
         await session.execute(insert_stmt)
 
         query = (
-            sa.select(db.TaskRun)
+            sa.select(orm_models.TaskRun)
             .where(
                 sa.and_(
-                    db.TaskRun.flow_run_id == task_run.flow_run_id,
-                    db.TaskRun.task_key == task_run.task_key,
-                    db.TaskRun.dynamic_key == task_run.dynamic_key,
+                    orm_models.TaskRun.flow_run_id == task_run.flow_run_id,
+                    orm_models.TaskRun.task_key == task_run.task_key,
+                    orm_models.TaskRun.dynamic_key == task_run.dynamic_key,
                 )
             )
             .limit(1)
@@ -87,12 +88,12 @@ async def create_task_run(
     else:
         # Upsert on (task_key, dynamic_key) application logic.
         query = (
-            sa.select(db.TaskRun)
+            sa.select(orm_models.TaskRun)
             .where(
                 sa.and_(
-                    db.TaskRun.flow_run_id.is_(None),
-                    db.TaskRun.task_key == task_run.task_key,
-                    db.TaskRun.dynamic_key == task_run.dynamic_key,
+                    orm_models.TaskRun.flow_run_id.is_(None),
+                    orm_models.TaskRun.task_key == task_run.task_key,
+                    orm_models.TaskRun.dynamic_key == task_run.dynamic_key,
                 )
             )
             .limit(1)
@@ -103,7 +104,7 @@ async def create_task_run(
         model = result.scalar()
 
         if model is None:
-            model = db.TaskRun(
+            model = orm_models.TaskRun(
                 created=now,
                 **task_run.dict(
                     shallow=True, exclude={"state", "created"}, exclude_unset=True
@@ -124,12 +125,10 @@ async def create_task_run(
     return model
 
 
-@inject_db
 async def update_task_run(
     session: AsyncSession,
     task_run_id: UUID,
     task_run: schemas.actions.TaskRunUpdate,
-    db: PrefectDBInterface,
 ) -> bool:
     """
     Updates a task run.
@@ -143,8 +142,8 @@ async def update_task_run(
         bool: whether or not matching rows were found to update
     """
     update_stmt = (
-        sa.update(db.TaskRun)
-        .where(db.TaskRun.id == task_run_id)
+        sa.update(orm_models.TaskRun)
+        .where(orm_models.TaskRun.id == task_run_id)
         # exclude_unset=True allows us to only update values provided by
         # the user, ignoring any defaults on the model
         .values(**task_run.dict(shallow=True, exclude_unset=True))
@@ -153,10 +152,7 @@ async def update_task_run(
     return result.rowcount > 0
 
 
-@inject_db
-async def read_task_run(
-    session: sa.orm.Session, task_run_id: UUID, db: PrefectDBInterface
-):
+async def read_task_run(session: sa.orm.Session, task_run_id: UUID):
     """
     Read a task run by id.
 
@@ -165,17 +161,15 @@ async def read_task_run(
         task_run_id: the task run id
 
     Returns:
-        db.TaskRun: the task run
+        orm_models.TaskRun: the task run
     """
 
-    model = await session.get(db.TaskRun, task_run_id)
+    model = await session.get(orm_models.TaskRun, task_run_id)
     return model
 
 
-@inject_db
 async def _apply_task_run_filters(
     query,
-    db: PrefectDBInterface,
     flow_filter: schemas.filters.FlowFilter = None,
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
@@ -188,7 +182,7 @@ async def _apply_task_run_filters(
     """
 
     if task_run_filter:
-        query = query.where(task_run_filter.as_sql_filter(db))
+        query = query.where(task_run_filter.as_sql_filter())
 
     # Return a simplified query in the case that the request is ONLY asking to filter on flow_run_id (and task_run_filter)
     # In this case there's no need to generate the complex EXISTS subqueries; the generated query here is much more efficient
@@ -199,7 +193,7 @@ async def _apply_task_run_filters(
             [flow_filter, deployment_filter, work_pool_filter, work_queue_filter]
         )
     ):
-        query = query.where(db.TaskRun.flow_run_id.in_(flow_run_filter.id.any_))
+        query = query.where(orm_models.TaskRun.flow_run_id.in_(flow_run_filter.id.any_))
 
         return query
 
@@ -210,47 +204,45 @@ async def _apply_task_run_filters(
         or work_pool_filter
         or work_queue_filter
     ):
-        exists_clause = select(db.FlowRun).where(
-            db.FlowRun.id == db.TaskRun.flow_run_id
+        exists_clause = select(orm_models.FlowRun).where(
+            orm_models.FlowRun.id == orm_models.TaskRun.flow_run_id
         )
 
         if flow_run_filter:
-            exists_clause = exists_clause.where(flow_run_filter.as_sql_filter(db))
+            exists_clause = exists_clause.where(flow_run_filter.as_sql_filter())
 
         if flow_filter:
             exists_clause = exists_clause.join(
-                db.Flow,
-                db.Flow.id == db.FlowRun.flow_id,
-            ).where(flow_filter.as_sql_filter(db))
+                orm_models.Flow,
+                orm_models.Flow.id == orm_models.FlowRun.flow_id,
+            ).where(flow_filter.as_sql_filter())
 
         if deployment_filter:
             exists_clause = exists_clause.join(
-                db.Deployment,
-                db.Deployment.id == db.FlowRun.deployment_id,
-            ).where(deployment_filter.as_sql_filter(db))
+                orm_models.Deployment,
+                orm_models.Deployment.id == orm_models.FlowRun.deployment_id,
+            ).where(deployment_filter.as_sql_filter())
 
         if work_queue_filter:
             exists_clause = exists_clause.join(
-                db.WorkQueue,
-                db.WorkQueue.id == db.FlowRun.work_queue_id,
-            ).where(work_queue_filter.as_sql_filter(db))
+                orm_models.WorkQueue,
+                orm_models.WorkQueue.id == orm_models.FlowRun.work_queue_id,
+            ).where(work_queue_filter.as_sql_filter())
 
         if work_pool_filter:
             exists_clause = exists_clause.join(
-                db.WorkPool,
-                db.WorkPool.id == db.WorkQueue.work_pool_id,
-                db.WorkQueue.id == db.FlowRun.work_queue_id,
-            ).where(work_pool_filter.as_sql_filter(db))
+                orm_models.WorkPool,
+                orm_models.WorkPool.id == orm_models.WorkQueue.work_pool_id,
+                orm_models.WorkQueue.id == orm_models.FlowRun.work_queue_id,
+            ).where(work_pool_filter.as_sql_filter())
 
         query = query.where(exists_clause.exists())
 
     return query
 
 
-@inject_db
 async def read_task_runs(
     session: sa.orm.Session,
-    db: PrefectDBInterface,
     flow_filter: schemas.filters.FlowFilter = None,
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
@@ -273,10 +265,10 @@ async def read_task_runs(
         sort: Query sort
 
     Returns:
-        List[db.TaskRun]: the task runs
+        List[orm_models.TaskRun]: the task runs
     """
 
-    query = select(db.TaskRun).order_by(sort.as_sql_sort(db))
+    query = select(orm_models.TaskRun).order_by(sort.as_sql_sort())
 
     query = await _apply_task_run_filters(
         query,
@@ -284,7 +276,6 @@ async def read_task_runs(
         flow_run_filter=flow_run_filter,
         task_run_filter=task_run_filter,
         deployment_filter=deployment_filter,
-        db=db,
     )
 
     if offset is not None:
@@ -298,10 +289,8 @@ async def read_task_runs(
     return result.scalars().unique().all()
 
 
-@inject_db
 async def count_task_runs(
     session: sa.orm.Session,
-    db: PrefectDBInterface,
     flow_filter: schemas.filters.FlowFilter = None,
     flow_run_filter: schemas.filters.FlowRunFilter = None,
     task_run_filter: schemas.filters.TaskRunFilter = None,
@@ -320,7 +309,7 @@ async def count_task_runs(
         int: count of task runs
     """
 
-    query = select(sa.func.count(sa.text("*"))).select_from(db.TaskRun)
+    query = select(sa.func.count(sa.text("*"))).select_from(orm_models.TaskRun)
 
     query = await _apply_task_run_filters(
         query,
@@ -328,7 +317,6 @@ async def count_task_runs(
         flow_run_filter=flow_run_filter,
         task_run_filter=task_run_filter,
         deployment_filter=deployment_filter,
-        db=db,
     )
 
     result = await session.execute(query)
@@ -337,7 +325,6 @@ async def count_task_runs(
 
 async def count_task_runs_by_state(
     session: AsyncSession,
-    db: PrefectDBInterface,
     flow_filter: Optional[schemas.filters.FlowFilter] = None,
     flow_run_filter: Optional[schemas.filters.FlowRunFilter] = None,
     task_run_filter: Optional[schemas.filters.TaskRunFilter] = None,
@@ -358,11 +345,11 @@ async def count_task_runs_by_state(
 
     base_query = (
         select(
-            db.TaskRun.state_type,
+            orm_models.TaskRun.state_type,
             sa.func.count(sa.text("*")).label("count"),
         )
-        .select_from(db.TaskRun)
-        .group_by(db.TaskRun.state_type)
+        .select_from(orm_models.TaskRun)
+        .group_by(orm_models.TaskRun.state_type)
     )
 
     query = await _apply_task_run_filters(
@@ -383,10 +370,7 @@ async def count_task_runs_by_state(
     return counts
 
 
-@inject_db
-async def delete_task_run(
-    session: sa.orm.Session, task_run_id: UUID, db: PrefectDBInterface
-) -> bool:
+async def delete_task_run(session: sa.orm.Session, task_run_id: UUID) -> bool:
     """
     Delete a task run by id.
 
@@ -399,7 +383,7 @@ async def delete_task_run(
     """
 
     result = await session.execute(
-        delete(db.TaskRun).where(db.TaskRun.id == task_run_id)
+        delete(orm_models.TaskRun).where(orm_models.TaskRun.id == task_run_id)
     )
     return result.rowcount > 0
 

--- a/src/prefect/server/models/variables.py
+++ b/src/prefect/server/models/variables.py
@@ -80,10 +80,10 @@ async def read_variables(
     """
     Read variables, applying filers.
     """
-    query = sa.select(db.Variable).order_by(sort.as_sql_sort(db))
+    query = sa.select(db.Variable).order_by(sort.as_sql_sort())
 
     if variable_filter:
-        query = query.where(variable_filter.as_sql_filter(db))
+        query = query.where(variable_filter.as_sql_filter())
 
     if offset is not None:
         query = query.offset(offset)
@@ -107,7 +107,7 @@ async def count_variables(
     query = sa.select(sa.func.count()).select_from(db.Variable)
 
     if variable_filter:
-        query = query.where(variable_filter.as_sql_filter(db))
+        query = query.where(variable_filter.as_sql_filter())
 
     result = await session.execute(query)
     return result.scalar()

--- a/src/prefect/server/models/work_queues.py
+++ b/src/prefect/server/models/work_queues.py
@@ -5,7 +5,6 @@ Intended for internal use by the Prefect REST API.
 
 import datetime
 from typing import (
-    TYPE_CHECKING,
     Awaitable,
     Callable,
     Iterable,
@@ -23,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import prefect.server.models as models
 import prefect.server.schemas as schemas
+from prefect.server.database import orm_models
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.events.clients import PrefectServerEventsClient
@@ -35,18 +35,13 @@ from prefect.server.models.workers import (
 from prefect.server.schemas.states import StateType
 from prefect.server.schemas.statuses import WorkQueueStatus
 
-if TYPE_CHECKING:
-    from prefect.server.database.orm_models import ORMFlowRun, ORMWorkQueue
-
 WORK_QUEUE_LAST_POLLED_TIMEOUT = datetime.timedelta(seconds=60)
 
 
-@db_injector
 async def create_work_queue(
-    db: PrefectDBInterface,
     session: AsyncSession,
     work_queue: schemas.core.WorkQueue,
-) -> "ORMWorkQueue":
+) -> orm_models.WorkQueue:
     """
     Inserts a WorkQueue.
 
@@ -57,7 +52,7 @@ async def create_work_queue(
         work_queue (schemas.core.WorkQueue): a WorkQueue model
 
     Returns:
-        db.WorkQueue: the newly-created or updated WorkQueue
+        orm_models.WorkQueue: the newly-created or updated WorkQueue
 
     """
     data = work_queue.dict()
@@ -89,8 +84,8 @@ async def create_work_queue(
     # This will make the new queue the lowest priority
     if data["priority"] is None:
         # Set the priority to be the first priority value that isn't already taken
-        priorities_query = sa.select(db.WorkQueue.priority).where(
-            db.WorkQueue.work_pool_id == data["work_pool_id"]
+        priorities_query = sa.select(orm_models.WorkQueue.priority).where(
+            orm_models.WorkQueue.work_pool_id == data["work_pool_id"]
         )
         priorities = (await session.execute(priorities_query)).scalars().all()
 
@@ -109,7 +104,7 @@ async def create_work_queue(
 
         data["priority"] = priority
 
-    model = db.WorkQueue(**data)
+    model = orm_models.WorkQueue(**data)
 
     session.add(model)
     await session.flush()
@@ -125,10 +120,9 @@ async def create_work_queue(
     return model
 
 
-@db_injector
 async def read_work_queue(
-    db: PrefectDBInterface, session: AsyncSession, work_queue_id: UUID
-) -> Optional["ORMWorkQueue"]:
+    session: AsyncSession, work_queue_id: UUID
+) -> Optional[orm_models.WorkQueue]:
     """
     Reads a WorkQueue by id.
 
@@ -137,16 +131,15 @@ async def read_work_queue(
         work_queue_id (str): a WorkQueue id
 
     Returns:
-        db.WorkQueue: the WorkQueue
+        orm_models.WorkQueue: the WorkQueue
     """
 
-    return await session.get(db.WorkQueue, work_queue_id)
+    return await session.get(orm_models.WorkQueue, work_queue_id)
 
 
-@db_injector
 async def read_work_queue_by_name(
-    db: PrefectDBInterface, session: AsyncSession, name: str
-) -> Optional["ORMWorkQueue"]:
+    session: AsyncSession, name: str
+) -> Optional[orm_models.WorkQueue]:
     """
     Reads a WorkQueue by id.
 
@@ -155,30 +148,28 @@ async def read_work_queue_by_name(
         work_queue_id (str): a WorkQueue id
 
     Returns:
-        db.WorkQueue: the WorkQueue
+        orm_models.WorkQueue: the WorkQueue
     """
     default_work_pool = await models.workers.read_work_pool_by_name(
         session=session, work_pool_name=DEFAULT_AGENT_WORK_POOL_NAME
     )
     # Logic to make sure this functionality doesn't break during migration
     if default_work_pool is not None:
-        query = select(db.WorkQueue).filter_by(
+        query = select(orm_models.WorkQueue).filter_by(
             name=name, work_pool_id=default_work_pool.id
         )
     else:
-        query = select(db.WorkQueue).filter_by(name=name)
+        query = select(orm_models.WorkQueue).filter_by(name=name)
     result = await session.execute(query)
     return result.scalar()
 
 
-@db_injector
 async def read_work_queues(
-    db: PrefectDBInterface,
     session: AsyncSession,
     offset: int = None,
     limit: int = None,
     work_queue_filter: schemas.filters.WorkQueueFilter = None,
-) -> Sequence["ORMWorkQueue"]:
+) -> Sequence[orm_models.WorkQueue]:
     """
     Read WorkQueues.
 
@@ -188,17 +179,17 @@ async def read_work_queues(
         limit: Query limit
         work_queue_filter: only select work queues matching these filters
     Returns:
-        Sequence[db.WorkQueue]: WorkQueues
+        Sequence[orm_models.WorkQueue]: WorkQueues
     """
 
-    query = select(db.WorkQueue).order_by(db.WorkQueue.name)
+    query = select(orm_models.WorkQueue).order_by(orm_models.WorkQueue.name)
 
     if offset is not None:
         query = query.offset(offset)
     if limit is not None:
         query = query.limit(limit)
     if work_queue_filter:
-        query = query.where(work_queue_filter.as_sql_filter(db))
+        query = query.where(work_queue_filter.as_sql_filter())
 
     result = await session.execute(query)
     return result.scalars().unique().all()
@@ -210,13 +201,13 @@ def is_last_polled_recent(last_polled):
     return (pendulum.now("UTC") - last_polled) <= WORK_QUEUE_LAST_POLLED_TIMEOUT
 
 
-@db_injector
 async def update_work_queue(
-    db: PrefectDBInterface,
     session: AsyncSession,
     work_queue_id: UUID,
     work_queue: schemas.actions.WorkQueueUpdate,
-    emit_status_change: Optional[Callable[["ORMWorkQueue"], Awaitable[None]]] = None,
+    emit_status_change: Optional[
+        Callable[[orm_models.WorkQueue], Awaitable[None]]
+    ] = None,
 ) -> bool:
     """
     Update a WorkQueue by id.
@@ -263,8 +254,8 @@ async def update_work_queue(
                 update_data["status"] = schemas.statuses.WorkQueueStatus.READY
 
     update_stmt = (
-        sa.update(db.WorkQueue)
-        .where(db.WorkQueue.id == work_queue_id)
+        sa.update(orm_models.WorkQueue)
+        .where(orm_models.WorkQueue.id == work_queue_id)
         .values(**update_data)
     )
     result = await session.execute(update_stmt)
@@ -278,10 +269,7 @@ async def update_work_queue(
     return updated
 
 
-@db_injector
-async def delete_work_queue(
-    db: PrefectDBInterface, session: AsyncSession, work_queue_id: UUID
-) -> bool:
+async def delete_work_queue(session: AsyncSession, work_queue_id: UUID) -> bool:
     """
     Delete a WorkQueue by id.
 
@@ -293,7 +281,7 @@ async def delete_work_queue(
         bool: whether or not the WorkQueue was deleted
     """
     result = await session.execute(
-        delete(db.WorkQueue).where(db.WorkQueue.id == work_queue_id)
+        delete(orm_models.WorkQueue).where(orm_models.WorkQueue.id == work_queue_id)
     )
 
     return result.rowcount > 0
@@ -306,7 +294,7 @@ async def get_runs_in_work_queue(
     work_queue_id: UUID,
     limit: int = None,
     scheduled_before: datetime.datetime = None,
-) -> Tuple["ORMWorkQueue", Sequence["ORMFlowRun"]]:
+) -> Tuple[orm_models.WorkQueue, Sequence[orm_models.FlowRun]]:
     """
     Get runs from a work queue.
 
@@ -325,7 +313,6 @@ async def get_runs_in_work_queue(
 
     if work_queue.filter is None:
         query = db.queries.get_scheduled_flow_runs_from_work_queues(
-            db=db,
             limit_per_queue=limit,
             work_queue_ids=[work_queue_id],
             scheduled_before=scheduled_before,
@@ -349,7 +336,7 @@ async def _legacy_get_runs_in_work_queue(
     work_queue_id: UUID,
     scheduled_before: datetime.datetime = None,
     limit: int = None,
-) -> Sequence["ORMFlowRun"]:
+) -> Sequence[orm_models.FlowRun]:
     """
     DEPRECATED method for getting runs from a tag-based work queue
 
@@ -497,9 +484,7 @@ async def read_work_queue_status(
     )
 
 
-@db_injector
 async def record_work_queue_polls(
-    db: PrefectDBInterface,
     session: AsyncSession,
     polled_work_queue_ids: Sequence[UUID],
     ready_work_queue_ids: Sequence[UUID],
@@ -510,15 +495,15 @@ async def record_work_queue_polls(
 
     if polled_work_queue_ids:
         await session.execute(
-            sa.update(db.WorkQueue)
-            .where(db.WorkQueue.id.in_(polled_work_queue_ids))
+            sa.update(orm_models.WorkQueue)
+            .where(orm_models.WorkQueue.id.in_(polled_work_queue_ids))
             .values(last_polled=polled)
         )
 
     if ready_work_queue_ids:
         await session.execute(
-            sa.update(db.WorkQueue)
-            .where(db.WorkQueue.id.in_(ready_work_queue_ids))
+            sa.update(orm_models.WorkQueue)
+            .where(orm_models.WorkQueue.id.in_(ready_work_queue_ids))
             .values(last_polled=polled, status=WorkQueueStatus.READY)
         )
 
@@ -544,7 +529,9 @@ async def mark_work_queues_ready(
 
     async with db.session_context(begin_transaction=True) as session:
         newly_ready_work_queues = await session.execute(
-            sa.select(db.WorkQueue).where(db.WorkQueue.id.in_(ready_work_queue_ids))
+            sa.select(orm_models.WorkQueue).where(
+                orm_models.WorkQueue.id.in_(ready_work_queue_ids)
+            )
         )
 
         events = [
@@ -571,8 +558,8 @@ async def mark_work_queues_not_ready(
 
     async with db.session_context(begin_transaction=True) as session:
         await session.execute(
-            sa.update(db.WorkQueue)
-            .where(db.WorkQueue.id.in_(work_queue_ids))
+            sa.update(orm_models.WorkQueue)
+            .where(orm_models.WorkQueue.id.in_(work_queue_ids))
             .values(status=WorkQueueStatus.NOT_READY)
         )
 
@@ -582,7 +569,9 @@ async def mark_work_queues_not_ready(
 
     async with db.session_context(begin_transaction=True) as session:
         newly_unready_work_queues = await session.execute(
-            sa.select(db.WorkQueue).where(db.WorkQueue.id.in_(work_queue_ids))
+            sa.select(orm_models.WorkQueue).where(
+                orm_models.WorkQueue.id.in_(work_queue_ids)
+            )
         )
 
         events = [
@@ -602,7 +591,7 @@ async def mark_work_queues_not_ready(
 @db_injector
 async def emit_work_queue_status_event(
     db: PrefectDBInterface,
-    work_queue: "ORMWorkQueue",
+    work_queue: orm_models.WorkQueue,
 ):
     async with db.session_context() as session:
         event = await work_queue_status_event(

--- a/src/prefect/server/models/workers.py
+++ b/src/prefect/server/models/workers.py
@@ -127,7 +127,6 @@ async def read_work_pool_by_name(
 
 
 async def read_work_pools(
-    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_filter: Optional[schemas.filters.WorkPoolFilter] = None,
     offset: Optional[int] = None,

--- a/src/prefect/server/models/workers.py
+++ b/src/prefect/server/models/workers.py
@@ -5,7 +5,6 @@ Intended for internal use by the Prefect REST API.
 
 import datetime
 from typing import (
-    TYPE_CHECKING,
     Awaitable,
     Callable,
     Dict,
@@ -21,15 +20,13 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import prefect.server.schemas as schemas
+from prefect.server.database import orm_models
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.events.clients import PrefectServerEventsClient
 from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.models.events import work_pool_status_event
 from prefect.server.schemas.statuses import WorkQueueStatus
-
-if TYPE_CHECKING:
-    from prefect.server.database.orm_models import ORMWorker, ORMWorkPool, ORMWorkQueue
 
 DEFAULT_AGENT_WORK_POOL_NAME = "default-agent-pool"
 
@@ -42,12 +39,10 @@ DEFAULT_AGENT_WORK_POOL_NAME = "default-agent-pool"
 # -----------------------------------------------------
 
 
-@db_injector
 async def create_work_pool(
-    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool: schemas.core.WorkPool,
-) -> "ORMWorkPool":
+) -> orm_models.WorkPool:
     """
     Creates a work pool.
 
@@ -58,11 +53,11 @@ async def create_work_pool(
         work_pool (schemas.core.WorkPool): a WorkPool model
 
     Returns:
-        db.WorkPool: the newly-created WorkPool
+        orm_models.WorkPool: the newly-created WorkPool
 
     """
 
-    pool = db.WorkPool(**work_pool.dict())
+    pool = orm_models.WorkPool(**work_pool.dict())
 
     if pool.type != "prefect-agent":
         if pool.is_paused:
@@ -87,10 +82,9 @@ async def create_work_pool(
     return pool
 
 
-@db_injector
 async def read_work_pool(
-    db: PrefectDBInterface, session: AsyncSession, work_pool_id: UUID
-) -> Optional["ORMWorkPool"]:
+    session: AsyncSession, work_pool_id: UUID
+) -> Optional[orm_models.WorkPool]:
     """
     Reads a WorkPool by id.
 
@@ -99,17 +93,20 @@ async def read_work_pool(
         work_pool_id (UUID): a WorkPool id
 
     Returns:
-        db.WorkPool: the WorkPool
+        orm_models.WorkPool: the WorkPool
     """
-    query = sa.select(db.WorkPool).where(db.WorkPool.id == work_pool_id).limit(1)
+    query = (
+        sa.select(orm_models.WorkPool)
+        .where(orm_models.WorkPool.id == work_pool_id)
+        .limit(1)
+    )
     result = await session.execute(query)
     return result.scalar()
 
 
-@db_injector
 async def read_work_pool_by_name(
-    db: PrefectDBInterface, session: AsyncSession, work_pool_name: str
-) -> Optional["ORMWorkPool"]:
+    session: AsyncSession, work_pool_name: str
+) -> Optional[orm_models.WorkPool]:
     """
     Reads a WorkPool by name.
 
@@ -118,21 +115,24 @@ async def read_work_pool_by_name(
         work_pool_name (str): a WorkPool name
 
     Returns:
-        db.WorkPool: the WorkPool
+        orm_models.WorkPool: the WorkPool
     """
-    query = sa.select(db.WorkPool).where(db.WorkPool.name == work_pool_name).limit(1)
+    query = (
+        sa.select(orm_models.WorkPool)
+        .where(orm_models.WorkPool.name == work_pool_name)
+        .limit(1)
+    )
     result = await session.execute(query)
     return result.scalar()
 
 
-@db_injector
 async def read_work_pools(
     db: PrefectDBInterface,
     session: AsyncSession,
-    work_pool_filter: schemas.filters.WorkPoolFilter = None,
-    offset: int = None,
-    limit: int = None,
-) -> Sequence["ORMWorkPool"]:
+    work_pool_filter: Optional[schemas.filters.WorkPoolFilter] = None,
+    offset: Optional[int] = None,
+    limit: Optional[int] = None,
+) -> Sequence[orm_models.WorkPool]:
     """
     Read worker configs.
 
@@ -141,13 +141,13 @@ async def read_work_pools(
         offset: Query offset
         limit: Query limit
     Returns:
-        List[db.WorkPool]: worker configs
+        List[orm_models.WorkPool]: worker configs
     """
 
-    query = select(db.WorkPool).order_by(db.WorkPool.name)
+    query = select(orm_models.WorkPool).order_by(orm_models.WorkPool.name)
 
     if work_pool_filter is not None:
-        query = query.where(work_pool_filter.as_sql_filter(db))
+        query = query.where(work_pool_filter.as_sql_filter())
     if offset is not None:
         query = query.offset(offset)
     if limit is not None:
@@ -157,11 +157,9 @@ async def read_work_pools(
     return result.scalars().unique().all()
 
 
-@db_injector
 async def count_work_pools(
-    db: PrefectDBInterface,
     session: AsyncSession,
-    work_pool_filter: schemas.filters.WorkPoolFilter = None,
+    work_pool_filter: Optional[schemas.filters.WorkPoolFilter] = None,
 ) -> int:
     """
     Read worker configs.
@@ -173,24 +171,22 @@ async def count_work_pools(
         int: the count of work pools matching the criteria
     """
 
-    query = select(sa.func.count()).select_from(db.WorkPool)
+    query = select(sa.func.count()).select_from(orm_models.WorkPool)
 
     if work_pool_filter is not None:
-        query = query.where(work_pool_filter.as_sql_filter(db))
+        query = query.where(work_pool_filter.as_sql_filter())
 
     result = await session.execute(query)
     return result.scalar()
 
 
-@db_injector
 async def update_work_pool(
-    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_id: UUID,
     work_pool: schemas.actions.WorkPoolUpdate,
     emit_status_change: Optional[
         Callable[
-            [UUID, pendulum.DateTime, "ORMWorkPool", "ORMWorkPool"],
+            [UUID, pendulum.DateTime, orm_models.WorkPool, orm_models.WorkPool],
             Awaitable[None],
         ]
     ],
@@ -246,8 +242,8 @@ async def update_work_pool(
         update_data["last_transitioned_status_at"] = pendulum.now("UTC")
 
     update_stmt = (
-        sa.update(db.WorkPool)
-        .where(db.WorkPool.id == work_pool_id)
+        sa.update(orm_models.WorkPool)
+        .where(orm_models.WorkPool.id == work_pool_id)
         .values(**update_data)
     )
     result = await session.execute(update_stmt)
@@ -270,10 +266,7 @@ async def update_work_pool(
     return updated
 
 
-@db_injector
-async def delete_work_pool(
-    db: PrefectDBInterface, session: AsyncSession, work_pool_id: UUID
-) -> bool:
+async def delete_work_pool(session: AsyncSession, work_pool_id: UUID) -> bool:
     """
     Delete a WorkPool by id.
 
@@ -286,7 +279,7 @@ async def delete_work_pool(
     """
 
     result = await session.execute(
-        delete(db.WorkPool).where(db.WorkPool.id == work_pool_id)
+        delete(orm_models.WorkPool).where(orm_models.WorkPool.id == work_pool_id)
     )
     return result.rowcount > 0
 
@@ -325,7 +318,6 @@ async def get_scheduled_flow_runs(
 
     return await db.queries.get_scheduled_flow_runs_from_work_pool(
         session=session,
-        db=db,
         work_pool_ids=work_pool_ids,
         work_queue_ids=work_queue_ids,
         scheduled_before=scheduled_before,
@@ -344,13 +336,11 @@ async def get_scheduled_flow_runs(
 # -----------------------------------------------------
 
 
-@db_injector
 async def create_work_queue(
-    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_id: UUID,
     work_queue: schemas.actions.WorkQueueCreate,
-) -> "ORMWorkQueue":
+) -> orm_models.WorkQueue:
     """
     Creates a work pool queue.
 
@@ -360,14 +350,14 @@ async def create_work_queue(
         work_queue (schemas.actions.WorkQueueCreate): a WorkQueue action model
 
     Returns:
-        db.WorkQueue: the newly-created WorkQueue
+        orm_models.WorkQueue: the newly-created WorkQueue
 
     """
     data = work_queue.dict(exclude={"work_pool_id"})
     if work_queue.priority is None:
         # Set the priority to be the first priority value that isn't already taken
-        priorities_query = sa.select(db.WorkQueue.priority).where(
-            db.WorkQueue.work_pool_id == work_pool_id
+        priorities_query = sa.select(orm_models.WorkQueue.priority).where(
+            orm_models.WorkQueue.work_pool_id == work_pool_id
         )
         priorities = (await session.execute(priorities_query)).scalars().all()
 
@@ -386,7 +376,7 @@ async def create_work_queue(
 
         data["priority"] = priority
 
-    model = db.WorkQueue(**data, work_pool_id=work_pool_id)
+    model = orm_models.WorkQueue(**data, work_pool_id=work_pool_id)
 
     session.add(model)
     await session.flush()
@@ -401,9 +391,7 @@ async def create_work_queue(
     return model
 
 
-@db_injector
 async def bulk_update_work_queue_priorities(
-    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_id: UUID,
     new_priorities: Dict[UUID, int],
@@ -413,7 +401,7 @@ async def bulk_update_work_queue_priorities(
     pool.
 
     It loads all queues fully into memory, sorts them, and flushes the update to
-    the db. The algorithm ensures that priorities are unique integers > 0, and
+    the orm_models. The algorithm ensures that priorities are unique integers > 0, and
     makes the minimum number of changes required to satisfy the provided
     `new_priorities`. For example, if no queues currently have the provided
     `new_priorities`, then they are assigned without affecting other queues. If
@@ -431,9 +419,9 @@ async def bulk_update_work_queue_priorities(
 
     # get all the work queues, sorted by priority
     work_queues_query = (
-        sa.select(db.WorkQueue)
-        .where(db.WorkQueue.work_pool_id == work_pool_id)
-        .order_by(db.WorkQueue.priority.asc())
+        sa.select(orm_models.WorkQueue)
+        .where(orm_models.WorkQueue.work_pool_id == work_pool_id)
+        .order_by(orm_models.WorkQueue.priority.asc())
     )
     result = await session.execute(work_queues_query)
     all_work_queues = result.scalars().all()
@@ -467,15 +455,13 @@ async def bulk_update_work_queue_priorities(
     await session.flush()
 
 
-@db_injector
 async def read_work_queues(
-    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_id: UUID,
     work_queue_filter: Optional[schemas.filters.WorkQueueFilter] = None,
     offset: Optional[int] = None,
     limit: Optional[int] = None,
-) -> Sequence["ORMWorkQueue"]:
+) -> Sequence[orm_models.WorkQueue]:
     """
     Read all work pool queues for a work pool. Results are ordered by ascending priority.
 
@@ -488,17 +474,17 @@ async def read_work_queues(
 
 
     Returns:
-        List[db.WorkQueue]: the WorkQueues
+        List[orm_models.WorkQueue]: the WorkQueues
 
     """
     query = (
-        sa.select(db.WorkQueue)
-        .where(db.WorkQueue.work_pool_id == work_pool_id)
-        .order_by(db.WorkQueue.priority.asc())
+        sa.select(orm_models.WorkQueue)
+        .where(orm_models.WorkQueue.work_pool_id == work_pool_id)
+        .order_by(orm_models.WorkQueue.priority.asc())
     )
 
     if work_queue_filter is not None:
-        query = query.where(work_queue_filter.as_sql_filter(db))
+        query = query.where(work_queue_filter.as_sql_filter())
     if offset is not None:
         query = query.offset(offset)
     if limit is not None:
@@ -508,12 +494,10 @@ async def read_work_queues(
     return result.scalars().unique().all()
 
 
-@db_injector
 async def read_work_queue(
-    db: PrefectDBInterface,
     session: AsyncSession,
     work_queue_id: UUID,
-) -> Optional["ORMWorkQueue"]:
+) -> Optional[orm_models.WorkQueue]:
     """
     Read a specific work pool queue.
 
@@ -522,19 +506,17 @@ async def read_work_queue(
         work_queue_id (UUID): a work pool queue id
 
     Returns:
-        db.WorkQueue: the WorkQueue
+        orm_models.WorkQueue: the WorkQueue
 
     """
-    return await session.get(db.WorkQueue, work_queue_id)
+    return await session.get(orm_models.WorkQueue, work_queue_id)
 
 
-@db_injector
 async def read_work_queue_by_name(
-    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_name: str,
     work_queue_name: str,
-) -> Optional["ORMWorkQueue"]:
+) -> Optional[orm_models.WorkQueue]:
     """
     Reads a WorkQueue by name.
 
@@ -544,14 +526,17 @@ async def read_work_queue_by_name(
         work_queue_name (str): a WorkQueue name
 
     Returns:
-        db.WorkQueue: the WorkQueue
+        orm_models.WorkQueue: the WorkQueue
     """
     query = (
-        sa.select(db.WorkQueue)
-        .join(db.WorkPool, db.WorkPool.id == db.WorkQueue.work_pool_id)
+        sa.select(orm_models.WorkQueue)
+        .join(
+            orm_models.WorkPool,
+            orm_models.WorkPool.id == orm_models.WorkQueue.work_pool_id,
+        )
         .where(
-            db.WorkPool.name == work_pool_name,
-            db.WorkQueue.name == work_queue_name,
+            orm_models.WorkPool.name == work_pool_name,
+            orm_models.WorkQueue.name == work_queue_name,
         )
         .limit(1)
     )
@@ -559,13 +544,13 @@ async def read_work_queue_by_name(
     return result.scalar()
 
 
-@db_injector
 async def update_work_queue(
-    db: PrefectDBInterface,
     session: AsyncSession,
     work_queue_id: UUID,
     work_queue: schemas.actions.WorkQueueUpdate,
-    emit_status_change: Optional[Callable[["ORMWorkQueue"], Awaitable[None]]] = None,
+    emit_status_change: Optional[
+        Callable[[orm_models.WorkQueue], Awaitable[None]]
+    ] = None,
     default_status: WorkQueueStatus = WorkQueueStatus.NOT_READY,
 ) -> bool:
     """
@@ -587,7 +572,7 @@ async def update_work_queue(
     update_values = work_queue.dict(shallow=True, exclude_unset=True)
 
     if "is_paused" in update_values:
-        if (wq := await session.get(db.WorkQueue, work_queue_id)) is None:
+        if (wq := await session.get(orm_models.WorkQueue, work_queue_id)) is None:
             return False
 
         # Only update the status to paused if it's not already paused. This ensures a work queue that is already
@@ -615,8 +600,8 @@ async def update_work_queue(
                 update_values["status"] = schemas.statuses.WorkQueueStatus.READY
 
     update_stmt = (
-        sa.update(db.WorkQueue)
-        .where(db.WorkQueue.id == work_queue_id)
+        sa.update(orm_models.WorkQueue)
+        .where(orm_models.WorkQueue.id == work_queue_id)
         .values(update_values)
     )
     result = await session.execute(update_stmt)
@@ -625,7 +610,7 @@ async def update_work_queue(
 
     if updated:
         if "priority" in update_values or "status" in update_values:
-            updated_work_queue = await session.get(db.WorkQueue, work_queue_id)
+            updated_work_queue = await session.get(orm_models.WorkQueue, work_queue_id)
 
             if "priority" in update_values:
                 await bulk_update_work_queue_priorities(
@@ -640,9 +625,7 @@ async def update_work_queue(
     return updated
 
 
-@db_injector
 async def delete_work_queue(
-    db: PrefectDBInterface,
     session: AsyncSession,
     work_queue_id: UUID,
 ) -> bool:
@@ -657,7 +640,7 @@ async def delete_work_queue(
         bool: whether or not the WorkQueue was deleted
 
     """
-    work_queue = await session.get(db.WorkQueue, work_queue_id)
+    work_queue = await session.get(orm_models.WorkQueue, work_queue_id)
     if work_queue is None:
         return False
 
@@ -688,24 +671,22 @@ async def delete_work_queue(
 # -----------------------------------------------------
 
 
-@db_injector
 async def read_workers(
-    db: PrefectDBInterface,
     session: AsyncSession,
     work_pool_id: UUID,
     worker_filter: schemas.filters.WorkerFilter = None,
     limit: int = None,
     offset: int = None,
-) -> Sequence["ORMWorker"]:
+) -> Sequence[orm_models.Worker]:
     query = (
-        sa.select(db.Worker)
-        .where(db.Worker.work_pool_id == work_pool_id)
-        .order_by(db.Worker.last_heartbeat_time.desc())
+        sa.select(orm_models.Worker)
+        .where(orm_models.Worker.work_pool_id == work_pool_id)
+        .order_by(orm_models.Worker.last_heartbeat_time.desc())
         .limit(limit)
     )
 
     if worker_filter:
-        query = query.where(worker_filter.as_sql_filter(db))
+        query = query.where(worker_filter.as_sql_filter())
 
     if limit is not None:
         query = query.limit(limit)
@@ -752,12 +733,12 @@ async def worker_heartbeat(
         update_values["heartbeat_interval_seconds"] = heartbeat_interval_seconds
 
     insert_stmt = (
-        db.insert(db.Worker)
+        db.insert(orm_models.Worker)
         .values(**base_values, **update_values)
         .on_conflict_do_update(
             index_elements=[
-                db.Worker.work_pool_id,
-                db.Worker.name,
+                orm_models.Worker.work_pool_id,
+                orm_models.Worker.name,
             ],
             set_=update_values,
         )
@@ -787,8 +768,9 @@ async def delete_worker(
 
     """
     result = await session.execute(
-        delete(db.Worker).where(
-            db.Worker.work_pool_id == work_pool_id, db.Worker.name == worker_name
+        delete(orm_models.Worker).where(
+            orm_models.Worker.work_pool_id == work_pool_id,
+            orm_models.Worker.name == worker_name,
         )
     )
 
@@ -798,8 +780,8 @@ async def delete_worker(
 async def emit_work_pool_status_event(
     event_id: UUID,
     occurred: pendulum.DateTime,
-    pre_update_work_pool: Optional["ORMWorkPool"],
-    work_pool: "ORMWorkPool",
+    pre_update_work_pool: Optional[orm_models.WorkPool],
+    work_pool: orm_models.WorkPool,
 ):
     if not work_pool.status:
         return

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from pydantic.v1 import Field
 
 import prefect.server.schemas as schemas
+from prefect.server.database import orm_models
 from prefect.server.utilities.schemas.bases import PrefectBaseModel
 from prefect.server.utilities.schemas.fields import DateTimeTZ
 from prefect.utilities.collections import AutoEnum
@@ -17,8 +18,6 @@ from prefect.utilities.importtools import lazy_import
 
 if TYPE_CHECKING:
     from sqlalchemy.sql.elements import BooleanClauseList
-
-    from prefect.server.database.interface import PrefectDBInterface
 
 sa = lazy_import("sqlalchemy")
 
@@ -40,14 +39,14 @@ class PrefectFilterBaseModel(PrefectBaseModel):
     class Config:
         extra = "forbid"
 
-    def as_sql_filter(self, db: "PrefectDBInterface") -> "BooleanClauseList":
+    def as_sql_filter(self) -> "BooleanClauseList":
         """Generate SQL filter from provided filter parameters. If no filters parameters are available, return a TRUE filter."""
-        filters = self._get_filter_list(db)
+        filters = self._get_filter_list()
         if not filters:
             return True
         return sa.and_(*filters)
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         """Return a list of boolean filter statements based on filter parameters"""
         raise NotImplementedError("_get_filter_list must be implemented")
 
@@ -60,8 +59,8 @@ class PrefectOperatorFilterBaseModel(PrefectFilterBaseModel):
         description="Operator for combining filter criteria. Defaults to 'and_'.",
     )
 
-    def as_sql_filter(self, db: "PrefectDBInterface") -> "BooleanClauseList":
-        filters = self._get_filter_list(db)
+    def as_sql_filter(self) -> "BooleanClauseList":
+        filters = self._get_filter_list()
         if not filters:
             return True
         return sa.and_(*filters) if self.operator == Operator.and_ else sa.or_(*filters)
@@ -74,10 +73,10 @@ class FlowFilterId(PrefectFilterBaseModel):
         default=None, description="A list of flow ids to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Flow.id.in_(self.any_))
+            filters.append(orm_models.Flow.id.in_(self.any_))
         return filters
 
 
@@ -89,21 +88,21 @@ class FlowFilterDeployment(PrefectOperatorFilterBaseModel):
         description="If true, only include flows without deployments",
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.is_null_ is not None:
             deployments_subquery = (
-                sa.select(db.Deployment.flow_id).distinct().subquery()
+                sa.select(orm_models.Deployment.flow_id).distinct().subquery()
             )
 
             if self.is_null_:
                 filters.append(
-                    db.Flow.id.not_in(sa.select(deployments_subquery.c.flow_id))
+                    orm_models.Flow.id.not_in(sa.select(deployments_subquery.c.flow_id))
                 )
             else:
                 filters.append(
-                    db.Flow.id.in_(sa.select(deployments_subquery.c.flow_id))
+                    orm_models.Flow.id.in_(sa.select(deployments_subquery.c.flow_id))
                 )
 
         return filters
@@ -128,12 +127,12 @@ class FlowFilterName(PrefectFilterBaseModel):
         examples=["marvin"],
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Flow.name.in_(self.any_))
+            filters.append(orm_models.Flow.name.in_(self.any_))
         if self.like_ is not None:
-            filters.append(db.Flow.name.ilike(f"%{self.like_}%"))
+            filters.append(orm_models.Flow.name.ilike(f"%{self.like_}%"))
         return filters
 
 
@@ -152,14 +151,18 @@ class FlowFilterTags(PrefectOperatorFilterBaseModel):
         default=None, description="If true, only include flows without tags"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         from prefect.server.utilities.database import json_has_all_keys
 
         filters = []
         if self.all_ is not None:
-            filters.append(json_has_all_keys(db.Flow.tags, self.all_))
+            filters.append(json_has_all_keys(orm_models.Flow.tags, self.all_))
         if self.is_null_ is not None:
-            filters.append(db.Flow.tags == [] if self.is_null_ else db.Flow.tags != [])
+            filters.append(
+                orm_models.Flow.tags == []
+                if self.is_null_
+                else orm_models.Flow.tags != []
+            )
         return filters
 
 
@@ -179,17 +182,17 @@ class FlowFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `Flow.tags`"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.id is not None:
-            filters.append(self.id.as_sql_filter(db))
+            filters.append(self.id.as_sql_filter())
         if self.deployment is not None:
-            filters.append(self.deployment.as_sql_filter(db))
+            filters.append(self.deployment.as_sql_filter())
         if self.name is not None:
-            filters.append(self.name.as_sql_filter(db))
+            filters.append(self.name.as_sql_filter())
         if self.tags is not None:
-            filters.append(self.tags.as_sql_filter(db))
+            filters.append(self.tags.as_sql_filter())
 
         return filters
 
@@ -204,12 +207,12 @@ class FlowRunFilterId(PrefectFilterBaseModel):
         default=None, description="A list of flow run ids to exclude"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.FlowRun.id.in_(self.any_))
+            filters.append(orm_models.FlowRun.id.in_(self.any_))
         if self.not_any_ is not None:
-            filters.append(db.FlowRun.id.not_in(self.not_any_))
+            filters.append(orm_models.FlowRun.id.not_in(self.not_any_))
         return filters
 
 
@@ -232,12 +235,12 @@ class FlowRunFilterName(PrefectFilterBaseModel):
         examples=["marvin"],
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.FlowRun.name.in_(self.any_))
+            filters.append(orm_models.FlowRun.name.in_(self.any_))
         if self.like_ is not None:
-            filters.append(db.FlowRun.name.ilike(f"%{self.like_}%"))
+            filters.append(orm_models.FlowRun.name.ilike(f"%{self.like_}%"))
         return filters
 
 
@@ -256,15 +259,17 @@ class FlowRunFilterTags(PrefectOperatorFilterBaseModel):
         default=None, description="If true, only include flow runs without tags"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         from prefect.server.utilities.database import json_has_all_keys
 
         filters = []
         if self.all_ is not None:
-            filters.append(json_has_all_keys(db.FlowRun.tags, self.all_))
+            filters.append(json_has_all_keys(orm_models.FlowRun.tags, self.all_))
         if self.is_null_ is not None:
             filters.append(
-                db.FlowRun.tags == [] if self.is_null_ else db.FlowRun.tags != []
+                orm_models.FlowRun.tags == []
+                if self.is_null_
+                else orm_models.FlowRun.tags != []
             )
         return filters
 
@@ -280,15 +285,15 @@ class FlowRunFilterDeploymentId(PrefectOperatorFilterBaseModel):
         description="If true, only include flow runs without deployment ids",
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.FlowRun.deployment_id.in_(self.any_))
+            filters.append(orm_models.FlowRun.deployment_id.in_(self.any_))
         if self.is_null_ is not None:
             filters.append(
-                db.FlowRun.deployment_id.is_(None)
+                orm_models.FlowRun.deployment_id.is_(None)
                 if self.is_null_
-                else db.FlowRun.deployment_id.is_not(None)
+                else orm_models.FlowRun.deployment_id.is_not(None)
             )
         return filters
 
@@ -306,15 +311,15 @@ class FlowRunFilterWorkQueueName(PrefectOperatorFilterBaseModel):
         description="If true, only include flow runs without work queue names",
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.FlowRun.work_queue_name.in_(self.any_))
+            filters.append(orm_models.FlowRun.work_queue_name.in_(self.any_))
         if self.is_null_ is not None:
             filters.append(
-                db.FlowRun.work_queue_name.is_(None)
+                orm_models.FlowRun.work_queue_name.is_(None)
                 if self.is_null_
-                else db.FlowRun.work_queue_name.is_not(None)
+                else orm_models.FlowRun.work_queue_name.is_not(None)
             )
         return filters
 
@@ -326,10 +331,10 @@ class FlowRunFilterStateType(PrefectFilterBaseModel):
         default=None, description="A list of flow run state types to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.FlowRun.state_type.in_(self.any_))
+            filters.append(orm_models.FlowRun.state_type.in_(self.any_))
         return filters
 
 
@@ -340,10 +345,10 @@ class FlowRunFilterStateName(PrefectFilterBaseModel):
         default=None, description="A list of flow run state names to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.FlowRun.state_name.in_(self.any_))
+            filters.append(orm_models.FlowRun.state_name.in_(self.any_))
         return filters
 
 
@@ -357,12 +362,12 @@ class FlowRunFilterState(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `FlowRun.state_name`"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.type is not None:
-            filters.extend(self.type._get_filter_list(db))
+            filters.extend(self.type._get_filter_list())
         if self.name is not None:
-            filters.extend(self.name._get_filter_list(db))
+            filters.extend(self.name._get_filter_list())
         return filters
 
 
@@ -373,10 +378,10 @@ class FlowRunFilterFlowVersion(PrefectFilterBaseModel):
         default=None, description="A list of flow run flow_versions to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.FlowRun.flow_version.in_(self.any_))
+            filters.append(orm_models.FlowRun.flow_version.in_(self.any_))
         return filters
 
 
@@ -395,17 +400,17 @@ class FlowRunFilterStartTime(PrefectFilterBaseModel):
         default=None, description="If true, only return flow runs without a start time"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.before_ is not None:
-            filters.append(db.FlowRun.start_time <= self.before_)
+            filters.append(orm_models.FlowRun.start_time <= self.before_)
         if self.after_ is not None:
-            filters.append(db.FlowRun.start_time >= self.after_)
+            filters.append(orm_models.FlowRun.start_time >= self.after_)
         if self.is_null_ is not None:
             filters.append(
-                db.FlowRun.start_time.is_(None)
+                orm_models.FlowRun.start_time.is_(None)
                 if self.is_null_
-                else db.FlowRun.start_time.is_not(None)
+                else orm_models.FlowRun.start_time.is_not(None)
             )
         return filters
 
@@ -422,12 +427,12 @@ class FlowRunFilterExpectedStartTime(PrefectFilterBaseModel):
         description="Only include flow runs scheduled to start at or after this time",
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.before_ is not None:
-            filters.append(db.FlowRun.expected_start_time <= self.before_)
+            filters.append(orm_models.FlowRun.expected_start_time <= self.before_)
         if self.after_ is not None:
-            filters.append(db.FlowRun.expected_start_time >= self.after_)
+            filters.append(orm_models.FlowRun.expected_start_time >= self.after_)
         return filters
 
 
@@ -449,12 +454,12 @@ class FlowRunFilterNextScheduledStartTime(PrefectFilterBaseModel):
         ),
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.before_ is not None:
-            filters.append(db.FlowRun.next_scheduled_start_time <= self.before_)
+            filters.append(orm_models.FlowRun.next_scheduled_start_time <= self.before_)
         if self.after_ is not None:
-            filters.append(db.FlowRun.next_scheduled_start_time >= self.after_)
+            filters.append(orm_models.FlowRun.next_scheduled_start_time >= self.after_)
         return filters
 
 
@@ -465,19 +470,20 @@ class FlowRunFilterParentFlowRunId(PrefectOperatorFilterBaseModel):
         default=None, description="A list of parent flow run ids to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
             filters.append(
-                db.FlowRun.id.in_(
-                    sa.select(db.FlowRun.id)
+                orm_models.FlowRun.id.in_(
+                    sa.select(orm_models.FlowRun.id)
                     .join(
-                        db.TaskRun,
+                        orm_models.TaskRun,
                         sa.and_(
-                            db.TaskRun.id == db.FlowRun.parent_task_run_id,
+                            orm_models.TaskRun.id
+                            == orm_models.FlowRun.parent_task_run_id,
                         ),
                     )
-                    .where(db.TaskRun.flow_run_id.in_(self.any_))
+                    .where(orm_models.TaskRun.flow_run_id.in_(self.any_))
                 )
             )
         return filters
@@ -494,15 +500,15 @@ class FlowRunFilterParentTaskRunId(PrefectOperatorFilterBaseModel):
         description="If true, only include flow runs without parent_task_run_id",
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.FlowRun.parent_task_run_id.in_(self.any_))
+            filters.append(orm_models.FlowRun.parent_task_run_id.in_(self.any_))
         if self.is_null_ is not None:
             filters.append(
-                db.FlowRun.parent_task_run_id.is_(None)
+                orm_models.FlowRun.parent_task_run_id.is_(None)
                 if self.is_null_
-                else db.FlowRun.parent_task_run_id.is_not(None)
+                else orm_models.FlowRun.parent_task_run_id.is_not(None)
             )
         return filters
 
@@ -517,12 +523,12 @@ class FlowRunFilterIdempotencyKey(PrefectFilterBaseModel):
         default=None, description="A list of flow run idempotency keys to exclude"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.FlowRun.idempotency_key.in_(self.any_))
+            filters.append(orm_models.FlowRun.idempotency_key.in_(self.any_))
         if self.not_any_ is not None:
-            filters.append(db.FlowRun.idempotency_key.not_in(self.not_any_))
+            filters.append(orm_models.FlowRun.idempotency_key.not_in(self.not_any_))
         return filters
 
 
@@ -588,35 +594,35 @@ class FlowRunFilter(PrefectOperatorFilterBaseModel):
             and self.idempotency_key is None
         )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.id is not None:
-            filters.append(self.id.as_sql_filter(db))
+            filters.append(self.id.as_sql_filter())
         if self.name is not None:
-            filters.append(self.name.as_sql_filter(db))
+            filters.append(self.name.as_sql_filter())
         if self.tags is not None:
-            filters.append(self.tags.as_sql_filter(db))
+            filters.append(self.tags.as_sql_filter())
         if self.deployment_id is not None:
-            filters.append(self.deployment_id.as_sql_filter(db))
+            filters.append(self.deployment_id.as_sql_filter())
         if self.work_queue_name is not None:
-            filters.append(self.work_queue_name.as_sql_filter(db))
+            filters.append(self.work_queue_name.as_sql_filter())
         if self.flow_version is not None:
-            filters.append(self.flow_version.as_sql_filter(db))
+            filters.append(self.flow_version.as_sql_filter())
         if self.state is not None:
-            filters.append(self.state.as_sql_filter(db))
+            filters.append(self.state.as_sql_filter())
         if self.start_time is not None:
-            filters.append(self.start_time.as_sql_filter(db))
+            filters.append(self.start_time.as_sql_filter())
         if self.expected_start_time is not None:
-            filters.append(self.expected_start_time.as_sql_filter(db))
+            filters.append(self.expected_start_time.as_sql_filter())
         if self.next_scheduled_start_time is not None:
-            filters.append(self.next_scheduled_start_time.as_sql_filter(db))
+            filters.append(self.next_scheduled_start_time.as_sql_filter())
         if self.parent_flow_run_id is not None:
-            filters.append(self.parent_flow_run_id.as_sql_filter(db))
+            filters.append(self.parent_flow_run_id.as_sql_filter())
         if self.parent_task_run_id is not None:
-            filters.append(self.parent_task_run_id.as_sql_filter(db))
+            filters.append(self.parent_task_run_id.as_sql_filter())
         if self.idempotency_key is not None:
-            filters.append(self.idempotency_key.as_sql_filter(db))
+            filters.append(self.idempotency_key.as_sql_filter())
 
         return filters
 
@@ -632,13 +638,13 @@ class TaskRunFilterFlowRunId(PrefectOperatorFilterBaseModel):
         default=False, description="Filter for task runs with None as their flow run id"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.is_null_ is True:
-            filters.append(db.TaskRun.flow_run_id.is_(None))
+            filters.append(orm_models.TaskRun.flow_run_id.is_(None))
         else:
             if self.any_ is not None:
-                filters.append(db.TaskRun.flow_run_id.in_(self.any_))
+                filters.append(orm_models.TaskRun.flow_run_id.in_(self.any_))
         return filters
 
 
@@ -649,10 +655,10 @@ class TaskRunFilterId(PrefectFilterBaseModel):
         default=None, description="A list of task run ids to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.TaskRun.id.in_(self.any_))
+            filters.append(orm_models.TaskRun.id.in_(self.any_))
         return filters
 
 
@@ -675,12 +681,12 @@ class TaskRunFilterName(PrefectFilterBaseModel):
         examples=["marvin"],
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.TaskRun.name.in_(self.any_))
+            filters.append(orm_models.TaskRun.name.in_(self.any_))
         if self.like_ is not None:
-            filters.append(db.TaskRun.name.ilike(f"%{self.like_}%"))
+            filters.append(orm_models.TaskRun.name.ilike(f"%{self.like_}%"))
         return filters
 
 
@@ -699,15 +705,17 @@ class TaskRunFilterTags(PrefectOperatorFilterBaseModel):
         default=None, description="If true, only include task runs without tags"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         from prefect.server.utilities.database import json_has_all_keys
 
         filters = []
         if self.all_ is not None:
-            filters.append(json_has_all_keys(db.TaskRun.tags, self.all_))
+            filters.append(json_has_all_keys(orm_models.TaskRun.tags, self.all_))
         if self.is_null_ is not None:
             filters.append(
-                db.TaskRun.tags == [] if self.is_null_ else db.TaskRun.tags != []
+                orm_models.TaskRun.tags == []
+                if self.is_null_
+                else orm_models.TaskRun.tags != []
             )
         return filters
 
@@ -719,10 +727,10 @@ class TaskRunFilterStateType(PrefectFilterBaseModel):
         default=None, description="A list of task run state types to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.TaskRun.state_type.in_(self.any_))
+            filters.append(orm_models.TaskRun.state_type.in_(self.any_))
         return filters
 
 
@@ -733,10 +741,10 @@ class TaskRunFilterStateName(PrefectFilterBaseModel):
         default=None, description="A list of task run state names to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.TaskRun.state_name.in_(self.any_))
+            filters.append(orm_models.TaskRun.state_name.in_(self.any_))
         return filters
 
 
@@ -746,12 +754,12 @@ class TaskRunFilterState(PrefectOperatorFilterBaseModel):
     type: Optional[TaskRunFilterStateType]
     name: Optional[TaskRunFilterStateName]
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.type is not None:
-            filters.extend(self.type._get_filter_list(db))
+            filters.extend(self.type._get_filter_list())
         if self.name is not None:
-            filters.extend(self.name._get_filter_list(db))
+            filters.extend(self.name._get_filter_list())
         return filters
 
 
@@ -766,12 +774,12 @@ class TaskRunFilterSubFlowRuns(PrefectFilterBaseModel):
         ),
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.exists_ is True:
-            filters.append(db.TaskRun.subflow_run.has())
+            filters.append(orm_models.TaskRun.subflow_run.has())
         elif self.exists_ is False:
-            filters.append(sa.not_(db.TaskRun.subflow_run.has()))
+            filters.append(sa.not_(orm_models.TaskRun.subflow_run.has()))
         return filters
 
 
@@ -790,17 +798,17 @@ class TaskRunFilterStartTime(PrefectFilterBaseModel):
         default=None, description="If true, only return task runs without a start time"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.before_ is not None:
-            filters.append(db.TaskRun.start_time <= self.before_)
+            filters.append(orm_models.TaskRun.start_time <= self.before_)
         if self.after_ is not None:
-            filters.append(db.TaskRun.start_time >= self.after_)
+            filters.append(orm_models.TaskRun.start_time >= self.after_)
         if self.is_null_ is not None:
             filters.append(
-                db.TaskRun.start_time.is_(None)
+                orm_models.TaskRun.start_time.is_(None)
                 if self.is_null_
-                else db.TaskRun.start_time.is_not(None)
+                else orm_models.TaskRun.start_time.is_not(None)
             )
         return filters
 
@@ -830,23 +838,23 @@ class TaskRunFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `TaskRun.flow_run_id`"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.id is not None:
-            filters.append(self.id.as_sql_filter(db))
+            filters.append(self.id.as_sql_filter())
         if self.name is not None:
-            filters.append(self.name.as_sql_filter(db))
+            filters.append(self.name.as_sql_filter())
         if self.tags is not None:
-            filters.append(self.tags.as_sql_filter(db))
+            filters.append(self.tags.as_sql_filter())
         if self.state is not None:
-            filters.append(self.state.as_sql_filter(db))
+            filters.append(self.state.as_sql_filter())
         if self.start_time is not None:
-            filters.append(self.start_time.as_sql_filter(db))
+            filters.append(self.start_time.as_sql_filter())
         if self.subflow_runs is not None:
-            filters.append(self.subflow_runs.as_sql_filter(db))
+            filters.append(self.subflow_runs.as_sql_filter())
         if self.flow_run_id is not None:
-            filters.append(self.flow_run_id.as_sql_filter(db))
+            filters.append(self.flow_run_id.as_sql_filter())
 
         return filters
 
@@ -858,10 +866,10 @@ class DeploymentFilterId(PrefectFilterBaseModel):
         default=None, description="A list of deployment ids to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Deployment.id.in_(self.any_))
+            filters.append(orm_models.Deployment.id.in_(self.any_))
         return filters
 
 
@@ -884,12 +892,12 @@ class DeploymentFilterName(PrefectFilterBaseModel):
         examples=["marvin"],
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Deployment.name.in_(self.any_))
+            filters.append(orm_models.Deployment.name.in_(self.any_))
         if self.like_ is not None:
-            filters.append(db.Deployment.name.ilike(f"%{self.like_}%"))
+            filters.append(orm_models.Deployment.name.ilike(f"%{self.like_}%"))
         return filters
 
 
@@ -901,10 +909,10 @@ class DeploymentFilterPaused(PrefectFilterBaseModel):
         description="Only returns where deployment is/is not paused",
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.eq_ is not None:
-            filters.append(db.Deployment.paused.is_(self.eq_))
+            filters.append(orm_models.Deployment.paused.is_(self.eq_))
         return filters
 
 
@@ -917,10 +925,10 @@ class DeploymentFilterWorkQueueName(PrefectFilterBaseModel):
         examples=[["work_queue_1", "work_queue_2"]],
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Deployment.work_queue_name.in_(self.any_))
+            filters.append(orm_models.Deployment.work_queue_name.in_(self.any_))
         return filters
 
 
@@ -933,10 +941,10 @@ class DeploymentFilterIsScheduleActive(PrefectFilterBaseModel):
         description="Only returns where deployment schedule is/is not active",
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.eq_ is not None:
-            filters.append(db.Deployment.paused.is_not(self.eq_))
+            filters.append(orm_models.Deployment.paused.is_not(self.eq_))
         return filters
 
 
@@ -955,15 +963,17 @@ class DeploymentFilterTags(PrefectOperatorFilterBaseModel):
         default=None, description="If true, only include deployments without tags"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         from prefect.server.utilities.database import json_has_all_keys
 
         filters = []
         if self.all_ is not None:
-            filters.append(json_has_all_keys(db.Deployment.tags, self.all_))
+            filters.append(json_has_all_keys(orm_models.Deployment.tags, self.all_))
         if self.is_null_ is not None:
             filters.append(
-                db.Deployment.tags == [] if self.is_null_ else db.Deployment.tags != []
+                orm_models.Deployment.tags == []
+                if self.is_null_
+                else orm_models.Deployment.tags != []
             )
         return filters
 
@@ -990,21 +1000,21 @@ class DeploymentFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `Deployment.work_queue_name`"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.id is not None:
-            filters.append(self.id.as_sql_filter(db))
+            filters.append(self.id.as_sql_filter())
         if self.name is not None:
-            filters.append(self.name.as_sql_filter(db))
+            filters.append(self.name.as_sql_filter())
         if self.paused is not None:
-            filters.append(self.paused.as_sql_filter(db))
+            filters.append(self.paused.as_sql_filter())
         if self.is_schedule_active is not None:
-            filters.append(self.is_schedule_active.as_sql_filter(db))
+            filters.append(self.is_schedule_active.as_sql_filter())
         if self.tags is not None:
-            filters.append(self.tags.as_sql_filter(db))
+            filters.append(self.tags.as_sql_filter())
         if self.work_queue_name is not None:
-            filters.append(self.work_queue_name.as_sql_filter(db))
+            filters.append(self.work_queue_name.as_sql_filter())
 
         return filters
 
@@ -1017,10 +1027,10 @@ class DeploymentScheduleFilterActive(PrefectFilterBaseModel):
         description="Only returns where deployment schedule is/is not active",
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.eq_ is not None:
-            filters.append(db.DeploymentSchedule.active.is_(self.eq_))
+            filters.append(orm_models.DeploymentSchedule.active.is_(self.eq_))
         return filters
 
 
@@ -1031,11 +1041,11 @@ class DeploymentScheduleFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `DeploymentSchedule.active`"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.active is not None:
-            filters.append(self.active.as_sql_filter(db))
+            filters.append(self.active.as_sql_filter())
 
         return filters
 
@@ -1049,10 +1059,10 @@ class LogFilterName(PrefectFilterBaseModel):
         examples=[["prefect.logger.flow_runs", "prefect.logger.task_runs"]],
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Log.name.in_(self.any_))
+            filters.append(orm_models.Log.name.in_(self.any_))
         return filters
 
 
@@ -1071,12 +1081,12 @@ class LogFilterLevel(PrefectFilterBaseModel):
         examples=[50],
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.ge_ is not None:
-            filters.append(db.Log.level >= self.ge_)
+            filters.append(orm_models.Log.level >= self.ge_)
         if self.le_ is not None:
-            filters.append(db.Log.level <= self.le_)
+            filters.append(orm_models.Log.level <= self.le_)
         return filters
 
 
@@ -1092,12 +1102,12 @@ class LogFilterTimestamp(PrefectFilterBaseModel):
         description="Only include logs with a timestamp at or after this time",
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.before_ is not None:
-            filters.append(db.Log.timestamp <= self.before_)
+            filters.append(orm_models.Log.timestamp <= self.before_)
         if self.after_ is not None:
-            filters.append(db.Log.timestamp >= self.after_)
+            filters.append(orm_models.Log.timestamp >= self.after_)
         return filters
 
 
@@ -1108,10 +1118,10 @@ class LogFilterFlowRunId(PrefectFilterBaseModel):
         default=None, description="A list of flow run IDs to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Log.flow_run_id.in_(self.any_))
+            filters.append(orm_models.Log.flow_run_id.in_(self.any_))
         return filters
 
 
@@ -1122,10 +1132,10 @@ class LogFilterTaskRunId(PrefectFilterBaseModel):
         default=None, description="A list of task run IDs to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Log.task_run_id.in_(self.any_))
+            filters.append(orm_models.Log.task_run_id.in_(self.any_))
         return filters
 
 
@@ -1145,17 +1155,17 @@ class LogFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `Log.task_run_id`"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.level is not None:
-            filters.append(self.level.as_sql_filter(db))
+            filters.append(self.level.as_sql_filter())
         if self.timestamp is not None:
-            filters.append(self.timestamp.as_sql_filter(db))
+            filters.append(self.timestamp.as_sql_filter())
         if self.flow_run_id is not None:
-            filters.append(self.flow_run_id.as_sql_filter(db))
+            filters.append(self.flow_run_id.as_sql_filter())
         if self.task_run_id is not None:
-            filters.append(self.task_run_id.as_sql_filter(db))
+            filters.append(self.task_run_id.as_sql_filter())
 
         return filters
 
@@ -1191,10 +1201,10 @@ class BlockTypeFilterName(PrefectFilterBaseModel):
         examples=["marvin"],
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.like_ is not None:
-            filters.append(db.BlockType.name.ilike(f"%{self.like_}%"))
+            filters.append(orm_models.BlockType.name.ilike(f"%{self.like_}%"))
         return filters
 
 
@@ -1205,10 +1215,10 @@ class BlockTypeFilterSlug(PrefectFilterBaseModel):
         default=None, description="A list of slugs to match"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.BlockType.slug.in_(self.any_))
+            filters.append(orm_models.BlockType.slug.in_(self.any_))
 
         return filters
 
@@ -1224,13 +1234,13 @@ class BlockTypeFilter(PrefectFilterBaseModel):
         default=None, description="Filter criteria for `BlockType.slug`"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.name is not None:
-            filters.append(self.name.as_sql_filter(db))
+            filters.append(self.name.as_sql_filter())
         if self.slug is not None:
-            filters.append(self.slug.as_sql_filter(db))
+            filters.append(self.slug.as_sql_filter())
 
         return filters
 
@@ -1242,10 +1252,10 @@ class BlockSchemaFilterBlockTypeId(PrefectFilterBaseModel):
         default=None, description="A list of block type ids to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.BlockSchema.block_type_id.in_(self.any_))
+            filters.append(orm_models.BlockSchema.block_type_id.in_(self.any_))
         return filters
 
 
@@ -1256,10 +1266,10 @@ class BlockSchemaFilterId(PrefectFilterBaseModel):
         default=None, description="A list of IDs to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.BlockSchema.id.in_(self.any_))
+            filters.append(orm_models.BlockSchema.id.in_(self.any_))
         return filters
 
 
@@ -1275,12 +1285,14 @@ class BlockSchemaFilterCapabilities(PrefectFilterBaseModel):
         ),
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         from prefect.server.utilities.database import json_has_all_keys
 
         filters = []
         if self.all_ is not None:
-            filters.append(json_has_all_keys(db.BlockSchema.capabilities, self.all_))
+            filters.append(
+                json_has_all_keys(orm_models.BlockSchema.capabilities, self.all_)
+            )
         return filters
 
 
@@ -1293,12 +1305,12 @@ class BlockSchemaFilterVersion(PrefectFilterBaseModel):
         description="A list of block schema versions.",
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         pass
 
         filters = []
         if self.any_ is not None:
-            filters.append(db.BlockSchema.version.in_(self.any_))
+            filters.append(orm_models.BlockSchema.version.in_(self.any_))
         return filters
 
 
@@ -1318,17 +1330,17 @@ class BlockSchemaFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `BlockSchema.version`"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.block_type_id is not None:
-            filters.append(self.block_type_id.as_sql_filter(db))
+            filters.append(self.block_type_id.as_sql_filter())
         if self.block_capabilities is not None:
-            filters.append(self.block_capabilities.as_sql_filter(db))
+            filters.append(self.block_capabilities.as_sql_filter())
         if self.id is not None:
-            filters.append(self.id.as_sql_filter(db))
+            filters.append(self.id.as_sql_filter())
         if self.version is not None:
-            filters.append(self.version.as_sql_filter(db))
+            filters.append(self.version.as_sql_filter())
 
         return filters
 
@@ -1343,10 +1355,10 @@ class BlockDocumentFilterIsAnonymous(PrefectFilterBaseModel):
         ),
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.eq_ is not None:
-            filters.append(db.BlockDocument.is_anonymous.is_(self.eq_))
+            filters.append(orm_models.BlockDocument.is_anonymous.is_(self.eq_))
         return filters
 
 
@@ -1357,10 +1369,10 @@ class BlockDocumentFilterBlockTypeId(PrefectFilterBaseModel):
         default=None, description="A list of block type ids to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.BlockDocument.block_type_id.in_(self.any_))
+            filters.append(orm_models.BlockDocument.block_type_id.in_(self.any_))
         return filters
 
 
@@ -1371,10 +1383,10 @@ class BlockDocumentFilterId(PrefectFilterBaseModel):
         default=None, description="A list of block ids to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.BlockDocument.id.in_(self.any_))
+            filters.append(orm_models.BlockDocument.id.in_(self.any_))
         return filters
 
 
@@ -1393,12 +1405,12 @@ class BlockDocumentFilterName(PrefectFilterBaseModel):
         examples=["my-block%"],
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.BlockDocument.name.in_(self.any_))
+            filters.append(orm_models.BlockDocument.name.in_(self.any_))
         if self.like_ is not None:
-            filters.append(db.BlockDocument.name.ilike(f"%{self.like_}%"))
+            filters.append(orm_models.BlockDocument.name.ilike(f"%{self.like_}%"))
         return filters
 
 
@@ -1423,16 +1435,16 @@ class BlockDocumentFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `BlockDocument.name`"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.id is not None:
-            filters.append(self.id.as_sql_filter(db))
+            filters.append(self.id.as_sql_filter())
         if self.is_anonymous is not None:
-            filters.append(self.is_anonymous.as_sql_filter(db))
+            filters.append(self.is_anonymous.as_sql_filter())
         if self.block_type_id is not None:
-            filters.append(self.block_type_id.as_sql_filter(db))
+            filters.append(self.block_type_id.as_sql_filter())
         if self.name is not None:
-            filters.append(self.name.as_sql_filter(db))
+            filters.append(self.name.as_sql_filter())
         return filters
 
 
@@ -1446,10 +1458,10 @@ class FlowRunNotificationPolicyFilterIsActive(PrefectFilterBaseModel):
         ),
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.eq_ is not None:
-            filters.append(db.FlowRunNotificationPolicy.is_active.is_(self.eq_))
+            filters.append(orm_models.FlowRunNotificationPolicy.is_active.is_(self.eq_))
         return filters
 
 
@@ -1461,10 +1473,10 @@ class FlowRunNotificationPolicyFilter(PrefectFilterBaseModel):
         description="Filter criteria for `FlowRunNotificationPolicy.is_active`. ",
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.is_active is not None:
-            filters.append(self.is_active.as_sql_filter(db))
+            filters.append(self.is_active.as_sql_filter())
 
         return filters
 
@@ -1477,10 +1489,10 @@ class WorkQueueFilterId(PrefectFilterBaseModel):
         description="A list of work queue ids to include",
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.WorkQueue.id.in_(self.any_))
+            filters.append(orm_models.WorkQueue.id.in_(self.any_))
         return filters
 
 
@@ -1503,14 +1515,17 @@ class WorkQueueFilterName(PrefectFilterBaseModel):
         examples=[["marvin", "Marvin-robot"]],
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.WorkQueue.name.in_(self.any_))
+            filters.append(orm_models.WorkQueue.name.in_(self.any_))
         if self.startswith_ is not None:
             filters.append(
                 sa.or_(
-                    *[db.WorkQueue.name.ilike(f"{item}%") for item in self.startswith_]
+                    *[
+                        orm_models.WorkQueue.name.ilike(f"{item}%")
+                        for item in self.startswith_
+                    ]
                 )
             )
         return filters
@@ -1528,13 +1543,13 @@ class WorkQueueFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `WorkQueue.name`"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.id is not None:
-            filters.append(self.id.as_sql_filter(db))
+            filters.append(self.id.as_sql_filter())
         if self.name is not None:
-            filters.append(self.name.as_sql_filter(db))
+            filters.append(self.name.as_sql_filter())
 
         return filters
 
@@ -1546,10 +1561,10 @@ class WorkPoolFilterId(PrefectFilterBaseModel):
         default=None, description="A list of work pool ids to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.WorkPool.id.in_(self.any_))
+            filters.append(orm_models.WorkPool.id.in_(self.any_))
         return filters
 
 
@@ -1560,10 +1575,10 @@ class WorkPoolFilterName(PrefectFilterBaseModel):
         default=None, description="A list of work pool names to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.WorkPool.name.in_(self.any_))
+            filters.append(orm_models.WorkPool.name.in_(self.any_))
         return filters
 
 
@@ -1574,10 +1589,10 @@ class WorkPoolFilterType(PrefectFilterBaseModel):
         default=None, description="A list of work pool types to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.WorkPool.type.in_(self.any_))
+            filters.append(orm_models.WorkPool.type.in_(self.any_))
         return filters
 
 
@@ -1594,15 +1609,15 @@ class WorkPoolFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `WorkPool.type`"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.id is not None:
-            filters.append(self.id.as_sql_filter(db))
+            filters.append(self.id.as_sql_filter())
         if self.name is not None:
-            filters.append(self.name.as_sql_filter(db))
+            filters.append(self.name.as_sql_filter())
         if self.type is not None:
-            filters.append(self.type.as_sql_filter(db))
+            filters.append(self.type.as_sql_filter())
 
         return filters
 
@@ -1614,10 +1629,10 @@ class WorkerFilterWorkPoolId(PrefectFilterBaseModel):
         default=None, description="A list of work pool ids to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Worker.worker_config_id.in_(self.any_))
+            filters.append(orm_models.Worker.worker_config_id.in_(self.any_))
         return filters
 
 
@@ -1631,12 +1646,12 @@ class WorkerFilterStatus(PrefectFilterBaseModel):
         default=None, description="A list of worker statuses to exclude"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Worker.status.in_(self.any_))
+            filters.append(orm_models.Worker.status.in_(self.any_))
         if self.not_any_ is not None:
-            filters.append(db.Worker.status.notin_(self.not_any_))
+            filters.append(orm_models.Worker.status.notin_(self.not_any_))
         return filters
 
 
@@ -1656,12 +1671,12 @@ class WorkerFilterLastHeartbeatTime(PrefectFilterBaseModel):
         ),
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.before_ is not None:
-            filters.append(db.Worker.last_heartbeat_time <= self.before_)
+            filters.append(orm_models.Worker.last_heartbeat_time <= self.before_)
         if self.after_ is not None:
-            filters.append(db.Worker.last_heartbeat_time >= self.after_)
+            filters.append(orm_models.Worker.last_heartbeat_time >= self.after_)
         return filters
 
 
@@ -1681,11 +1696,11 @@ class WorkerFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `Worker.status`"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.last_heartbeat_time is not None:
-            filters.append(self.last_heartbeat_time.as_sql_filter(db))
+            filters.append(self.last_heartbeat_time.as_sql_filter())
 
         return filters
 
@@ -1697,10 +1712,10 @@ class ArtifactFilterId(PrefectFilterBaseModel):
         default=None, description="A list of artifact ids to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Artifact.id.in_(self.any_))
+            filters.append(orm_models.Artifact.id.in_(self.any_))
         return filters
 
 
@@ -1728,17 +1743,17 @@ class ArtifactFilterKey(PrefectFilterBaseModel):
         ),
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Artifact.key.in_(self.any_))
+            filters.append(orm_models.Artifact.key.in_(self.any_))
         if self.like_ is not None:
-            filters.append(db.Artifact.key.ilike(f"%{self.like_}%"))
+            filters.append(orm_models.Artifact.key.ilike(f"%{self.like_}%"))
         if self.exists_ is not None:
             filters.append(
-                db.Artifact.key.isnot(None)
+                orm_models.Artifact.key.isnot(None)
                 if self.exists_
-                else db.Artifact.key.is_(None)
+                else orm_models.Artifact.key.is_(None)
             )
         return filters
 
@@ -1750,10 +1765,10 @@ class ArtifactFilterFlowRunId(PrefectFilterBaseModel):
         default=None, description="A list of flow run IDs to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Artifact.flow_run_id.in_(self.any_))
+            filters.append(orm_models.Artifact.flow_run_id.in_(self.any_))
         return filters
 
 
@@ -1764,10 +1779,10 @@ class ArtifactFilterTaskRunId(PrefectFilterBaseModel):
         default=None, description="A list of task run IDs to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Artifact.task_run_id.in_(self.any_))
+            filters.append(orm_models.Artifact.task_run_id.in_(self.any_))
         return filters
 
 
@@ -1781,12 +1796,12 @@ class ArtifactFilterType(PrefectFilterBaseModel):
         default=None, description="A list of artifact types to exclude"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Artifact.type.in_(self.any_))
+            filters.append(orm_models.Artifact.type.in_(self.any_))
         if self.not_any_ is not None:
-            filters.append(db.Artifact.type.notin_(self.not_any_))
+            filters.append(orm_models.Artifact.type.notin_(self.not_any_))
         return filters
 
 
@@ -1809,19 +1824,19 @@ class ArtifactFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `Artifact.type`"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.id is not None:
-            filters.append(self.id.as_sql_filter(db))
+            filters.append(self.id.as_sql_filter())
         if self.key is not None:
-            filters.append(self.key.as_sql_filter(db))
+            filters.append(self.key.as_sql_filter())
         if self.flow_run_id is not None:
-            filters.append(self.flow_run_id.as_sql_filter(db))
+            filters.append(self.flow_run_id.as_sql_filter())
         if self.task_run_id is not None:
-            filters.append(self.task_run_id.as_sql_filter(db))
+            filters.append(self.task_run_id.as_sql_filter())
         if self.type is not None:
-            filters.append(self.type.as_sql_filter(db))
+            filters.append(self.type.as_sql_filter())
 
         return filters
 
@@ -1833,10 +1848,10 @@ class ArtifactCollectionFilterLatestId(PrefectFilterBaseModel):
         default=None, description="A list of artifact ids to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.ArtifactCollection.latest_id.in_(self.any_))
+            filters.append(orm_models.ArtifactCollection.latest_id.in_(self.any_))
         return filters
 
 
@@ -1865,17 +1880,17 @@ class ArtifactCollectionFilterKey(PrefectFilterBaseModel):
         ),
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.ArtifactCollection.key.in_(self.any_))
+            filters.append(orm_models.ArtifactCollection.key.in_(self.any_))
         if self.like_ is not None:
-            filters.append(db.ArtifactCollection.key.ilike(f"%{self.like_}%"))
+            filters.append(orm_models.ArtifactCollection.key.ilike(f"%{self.like_}%"))
         if self.exists_ is not None:
             filters.append(
-                db.ArtifactCollection.key.isnot(None)
+                orm_models.ArtifactCollection.key.isnot(None)
                 if self.exists_
-                else db.ArtifactCollection.key.is_(None)
+                else orm_models.ArtifactCollection.key.is_(None)
             )
         return filters
 
@@ -1887,10 +1902,10 @@ class ArtifactCollectionFilterFlowRunId(PrefectFilterBaseModel):
         default=None, description="A list of flow run IDs to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.ArtifactCollection.flow_run_id.in_(self.any_))
+            filters.append(orm_models.ArtifactCollection.flow_run_id.in_(self.any_))
         return filters
 
 
@@ -1901,10 +1916,10 @@ class ArtifactCollectionFilterTaskRunId(PrefectFilterBaseModel):
         default=None, description="A list of task run IDs to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.ArtifactCollection.task_run_id.in_(self.any_))
+            filters.append(orm_models.ArtifactCollection.task_run_id.in_(self.any_))
         return filters
 
 
@@ -1918,12 +1933,12 @@ class ArtifactCollectionFilterType(PrefectFilterBaseModel):
         default=None, description="A list of artifact types to exclude"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.ArtifactCollection.type.in_(self.any_))
+            filters.append(orm_models.ArtifactCollection.type.in_(self.any_))
         if self.not_any_ is not None:
-            filters.append(db.ArtifactCollection.type.notin_(self.not_any_))
+            filters.append(orm_models.ArtifactCollection.type.notin_(self.not_any_))
         return filters
 
 
@@ -1946,19 +1961,19 @@ class ArtifactCollectionFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `Artifact.type`"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.latest_id is not None:
-            filters.append(self.latest_id.as_sql_filter(db))
+            filters.append(self.latest_id.as_sql_filter())
         if self.key is not None:
-            filters.append(self.key.as_sql_filter(db))
+            filters.append(self.key.as_sql_filter())
         if self.flow_run_id is not None:
-            filters.append(self.flow_run_id.as_sql_filter(db))
+            filters.append(self.flow_run_id.as_sql_filter())
         if self.task_run_id is not None:
-            filters.append(self.task_run_id.as_sql_filter(db))
+            filters.append(self.task_run_id.as_sql_filter())
         if self.type is not None:
-            filters.append(self.type.as_sql_filter(db))
+            filters.append(self.type.as_sql_filter())
 
         return filters
 
@@ -1970,10 +1985,10 @@ class VariableFilterId(PrefectFilterBaseModel):
         default=None, description="A list of variable ids to include"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Variable.id.in_(self.any_))
+            filters.append(orm_models.Variable.id.in_(self.any_))
         return filters
 
 
@@ -1992,12 +2007,12 @@ class VariableFilterName(PrefectFilterBaseModel):
         examples=["my_variable_%"],
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Variable.name.in_(self.any_))
+            filters.append(orm_models.Variable.name.in_(self.any_))
         if self.like_ is not None:
-            filters.append(db.Variable.name.ilike(f"%{self.like_}%"))
+            filters.append(orm_models.Variable.name.ilike(f"%{self.like_}%"))
         return filters
 
 
@@ -2016,12 +2031,12 @@ class VariableFilterValue(PrefectFilterBaseModel):
         examples=["my-value-%"],
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
-            filters.append(db.Variable.value.in_(self.any_))
+            filters.append(orm_models.Variable.value.in_(self.any_))
         if self.like_ is not None:
-            filters.append(db.Variable.value.ilike(f"%{self.like_}%"))
+            filters.append(orm_models.Variable.value.ilike(f"%{self.like_}%"))
         return filters
 
 
@@ -2040,15 +2055,17 @@ class VariableFilterTags(PrefectOperatorFilterBaseModel):
         default=None, description="If true, only include Variables without tags"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         from prefect.server.utilities.database import json_has_all_keys
 
         filters = []
         if self.all_ is not None:
-            filters.append(json_has_all_keys(db.Variable.tags, self.all_))
+            filters.append(json_has_all_keys(orm_models.Variable.tags, self.all_))
         if self.is_null_ is not None:
             filters.append(
-                db.Variable.tags == [] if self.is_null_ else db.Variable.tags != []
+                orm_models.Variable.tags == []
+                if self.is_null_
+                else orm_models.Variable.tags != []
             )
         return filters
 
@@ -2069,15 +2086,15 @@ class VariableFilter(PrefectOperatorFilterBaseModel):
         default=None, description="Filter criteria for `Variable.tags`"
     )
 
-    def _get_filter_list(self, db: "PrefectDBInterface") -> List:
+    def _get_filter_list(self) -> List:
         filters = []
 
         if self.id is not None:
-            filters.append(self.id.as_sql_filter(db))
+            filters.append(self.id.as_sql_filter())
         if self.name is not None:
-            filters.append(self.name.as_sql_filter(db))
+            filters.append(self.name.as_sql_filter())
         if self.value is not None:
-            filters.append(self.value.as_sql_filter(db))
+            filters.append(self.value.as_sql_filter())
         if self.tags is not None:
-            filters.append(self.tags.as_sql_filter(db))
+            filters.append(self.tags.as_sql_filter())
         return filters

--- a/src/prefect/server/schemas/sorting.py
+++ b/src/prefect/server/schemas/sorting.py
@@ -6,12 +6,11 @@ from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 
+from prefect.server.database import orm_models
 from prefect.utilities.collections import AutoEnum
 
 if TYPE_CHECKING:
     from sqlalchemy.sql.expression import ColumnElement
-
-    from prefect.server.database.interface import PrefectDBInterface
 
 # TODO: Consider moving the `as_sql_sort` functions out of here since they are a
 #       database model level function and do not properly separate concerns when
@@ -31,24 +30,24 @@ class FlowRunSort(AutoEnum):
     NEXT_SCHEDULED_START_TIME_ASC = AutoEnum.auto()
     END_TIME_DESC = AutoEnum.auto()
 
-    def as_sql_sort(self, db: "PrefectDBInterface") -> "ColumnElement":
+    def as_sql_sort(self) -> "ColumnElement":
         from sqlalchemy.sql.functions import coalesce
 
         """Return an expression used to sort flow runs"""
         sort_mapping = {
-            "ID_DESC": db.FlowRun.id.desc(),
+            "ID_DESC": orm_models.FlowRun.id.desc(),
             "START_TIME_ASC": coalesce(
-                db.FlowRun.start_time, db.FlowRun.expected_start_time
+                orm_models.FlowRun.start_time, orm_models.FlowRun.expected_start_time
             ).asc(),
             "START_TIME_DESC": coalesce(
-                db.FlowRun.start_time, db.FlowRun.expected_start_time
+                orm_models.FlowRun.start_time, orm_models.FlowRun.expected_start_time
             ).desc(),
-            "EXPECTED_START_TIME_ASC": db.FlowRun.expected_start_time.asc(),
-            "EXPECTED_START_TIME_DESC": db.FlowRun.expected_start_time.desc(),
-            "NAME_ASC": db.FlowRun.name.asc(),
-            "NAME_DESC": db.FlowRun.name.desc(),
-            "NEXT_SCHEDULED_START_TIME_ASC": db.FlowRun.next_scheduled_start_time.asc(),
-            "END_TIME_DESC": db.FlowRun.end_time.desc(),
+            "EXPECTED_START_TIME_ASC": orm_models.FlowRun.expected_start_time.asc(),
+            "EXPECTED_START_TIME_DESC": orm_models.FlowRun.expected_start_time.desc(),
+            "NAME_ASC": orm_models.FlowRun.name.asc(),
+            "NAME_DESC": orm_models.FlowRun.name.desc(),
+            "NEXT_SCHEDULED_START_TIME_ASC": orm_models.FlowRun.next_scheduled_start_time.asc(),
+            "END_TIME_DESC": orm_models.FlowRun.end_time.desc(),
         }
         return sort_mapping[self.value]
 
@@ -64,16 +63,16 @@ class TaskRunSort(AutoEnum):
     NEXT_SCHEDULED_START_TIME_ASC = AutoEnum.auto()
     END_TIME_DESC = AutoEnum.auto()
 
-    def as_sql_sort(self, db: "PrefectDBInterface") -> "ColumnElement":
+    def as_sql_sort(self) -> "ColumnElement":
         """Return an expression used to sort task runs"""
         sort_mapping = {
-            "ID_DESC": db.TaskRun.id.desc(),
-            "EXPECTED_START_TIME_ASC": db.TaskRun.expected_start_time.asc(),
-            "EXPECTED_START_TIME_DESC": db.TaskRun.expected_start_time.desc(),
-            "NAME_ASC": db.TaskRun.name.asc(),
-            "NAME_DESC": db.TaskRun.name.desc(),
-            "NEXT_SCHEDULED_START_TIME_ASC": db.TaskRun.next_scheduled_start_time.asc(),
-            "END_TIME_DESC": db.TaskRun.end_time.desc(),
+            "ID_DESC": orm_models.TaskRun.id.desc(),
+            "EXPECTED_START_TIME_ASC": orm_models.TaskRun.expected_start_time.asc(),
+            "EXPECTED_START_TIME_DESC": orm_models.TaskRun.expected_start_time.desc(),
+            "NAME_ASC": orm_models.TaskRun.name.asc(),
+            "NAME_DESC": orm_models.TaskRun.name.desc(),
+            "NEXT_SCHEDULED_START_TIME_ASC": orm_models.TaskRun.next_scheduled_start_time.asc(),
+            "END_TIME_DESC": orm_models.TaskRun.end_time.desc(),
         }
         return sort_mapping[self.value]
 
@@ -84,11 +83,11 @@ class LogSort(AutoEnum):
     TIMESTAMP_ASC = AutoEnum.auto()
     TIMESTAMP_DESC = AutoEnum.auto()
 
-    def as_sql_sort(self, db: "PrefectDBInterface") -> "ColumnElement":
+    def as_sql_sort(self) -> "ColumnElement":
         """Return an expression used to sort task runs"""
         sort_mapping = {
-            "TIMESTAMP_ASC": db.Log.timestamp.asc(),
-            "TIMESTAMP_DESC": db.Log.timestamp.desc(),
+            "TIMESTAMP_ASC": orm_models.Log.timestamp.asc(),
+            "TIMESTAMP_DESC": orm_models.Log.timestamp.desc(),
         }
         return sort_mapping[self.value]
 
@@ -101,13 +100,13 @@ class FlowSort(AutoEnum):
     NAME_ASC = AutoEnum.auto()
     NAME_DESC = AutoEnum.auto()
 
-    def as_sql_sort(self, db: "PrefectDBInterface") -> "ColumnElement":
+    def as_sql_sort(self) -> "ColumnElement":
         """Return an expression used to sort flows"""
         sort_mapping = {
-            "CREATED_DESC": db.Flow.created.desc(),
-            "UPDATED_DESC": db.Flow.updated.desc(),
-            "NAME_ASC": db.Flow.name.asc(),
-            "NAME_DESC": db.Flow.name.desc(),
+            "CREATED_DESC": orm_models.Flow.created.desc(),
+            "UPDATED_DESC": orm_models.Flow.updated.desc(),
+            "NAME_ASC": orm_models.Flow.name.asc(),
+            "NAME_DESC": orm_models.Flow.name.desc(),
         }
         return sort_mapping[self.value]
 
@@ -120,13 +119,13 @@ class DeploymentSort(AutoEnum):
     NAME_ASC = AutoEnum.auto()
     NAME_DESC = AutoEnum.auto()
 
-    def as_sql_sort(self, db: "PrefectDBInterface") -> "ColumnElement":
+    def as_sql_sort(self) -> "ColumnElement":
         """Return an expression used to sort deployments"""
         sort_mapping = {
-            "CREATED_DESC": db.Deployment.created.desc(),
-            "UPDATED_DESC": db.Deployment.updated.desc(),
-            "NAME_ASC": db.Deployment.name.asc(),
-            "NAME_DESC": db.Deployment.name.desc(),
+            "CREATED_DESC": orm_models.Deployment.created.desc(),
+            "UPDATED_DESC": orm_models.Deployment.updated.desc(),
+            "NAME_ASC": orm_models.Deployment.name.asc(),
+            "NAME_DESC": orm_models.Deployment.name.desc(),
         }
         return sort_mapping[self.value]
 
@@ -140,14 +139,14 @@ class ArtifactSort(AutoEnum):
     KEY_DESC = AutoEnum.auto()
     KEY_ASC = AutoEnum.auto()
 
-    def as_sql_sort(self, db: "PrefectDBInterface") -> "ColumnElement":
+    def as_sql_sort(self) -> "ColumnElement":
         """Return an expression used to sort artifacts"""
         sort_mapping = {
-            "CREATED_DESC": db.Artifact.created.desc(),
-            "UPDATED_DESC": db.Artifact.updated.desc(),
-            "ID_DESC": db.Artifact.id.desc(),
-            "KEY_DESC": db.Artifact.key.desc(),
-            "KEY_ASC": db.Artifact.key.asc(),
+            "CREATED_DESC": orm_models.Artifact.created.desc(),
+            "UPDATED_DESC": orm_models.Artifact.updated.desc(),
+            "ID_DESC": orm_models.Artifact.id.desc(),
+            "KEY_DESC": orm_models.Artifact.key.desc(),
+            "KEY_ASC": orm_models.Artifact.key.asc(),
         }
         return sort_mapping[self.value]
 
@@ -161,14 +160,14 @@ class ArtifactCollectionSort(AutoEnum):
     KEY_DESC = AutoEnum.auto()
     KEY_ASC = AutoEnum.auto()
 
-    def as_sql_sort(self, db: "PrefectDBInterface") -> "ColumnElement":
+    def as_sql_sort(self) -> "ColumnElement":
         """Return an expression used to sort artifact collections"""
         sort_mapping = {
-            "CREATED_DESC": db.ArtifactCollection.created.desc(),
-            "UPDATED_DESC": db.ArtifactCollection.updated.desc(),
-            "ID_DESC": db.ArtifactCollection.id.desc(),
-            "KEY_DESC": db.ArtifactCollection.key.desc(),
-            "KEY_ASC": db.ArtifactCollection.key.asc(),
+            "CREATED_DESC": orm_models.ArtifactCollection.created.desc(),
+            "UPDATED_DESC": orm_models.ArtifactCollection.updated.desc(),
+            "ID_DESC": orm_models.ArtifactCollection.id.desc(),
+            "KEY_DESC": orm_models.ArtifactCollection.key.desc(),
+            "KEY_ASC": orm_models.ArtifactCollection.key.asc(),
         }
         return sort_mapping[self.value]
 
@@ -181,13 +180,13 @@ class VariableSort(AutoEnum):
     NAME_DESC = "NAME_DESC"
     NAME_ASC = "NAME_ASC"
 
-    def as_sql_sort(self, db: "PrefectDBInterface") -> "ColumnElement":
+    def as_sql_sort(self) -> "ColumnElement":
         """Return an expression used to sort variables"""
         sort_mapping = {
-            "CREATED_DESC": db.Variable.created.desc(),
-            "UPDATED_DESC": db.Variable.updated.desc(),
-            "NAME_DESC": db.Variable.name.desc(),
-            "NAME_ASC": db.Variable.name.asc(),
+            "CREATED_DESC": orm_models.Variable.created.desc(),
+            "UPDATED_DESC": orm_models.Variable.updated.desc(),
+            "NAME_DESC": orm_models.Variable.name.desc(),
+            "NAME_ASC": orm_models.Variable.name.asc(),
         }
         return sort_mapping[self.value]
 
@@ -199,11 +198,11 @@ class BlockDocumentSort(AutoEnum):
     NAME_ASC = "NAME_ASC"
     BLOCK_TYPE_AND_NAME_ASC = "BLOCK_TYPE_AND_NAME_ASC"
 
-    def as_sql_sort(self, db: "PrefectDBInterface") -> "ColumnElement":
+    def as_sql_sort(self) -> "ColumnElement":
         """Return an expression used to sort block documents"""
         sort_mapping = {
-            "NAME_DESC": db.BlockDocument.name.desc(),
-            "NAME_ASC": db.BlockDocument.name.asc(),
+            "NAME_DESC": orm_models.BlockDocument.name.desc(),
+            "NAME_ASC": orm_models.BlockDocument.name.asc(),
             "BLOCK_TYPE_AND_NAME_ASC": sa.text("block_type_name asc, name asc"),
         }
         return sort_mapping[self.value]

--- a/src/prefect/server/services/cancellation_cleanup.py
+++ b/src/prefect/server/services/cancellation_cleanup.py
@@ -10,6 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.sql.expression import or_
 
 import prefect.server.models as models
+from prefect.server.database import orm_models
 from prefect.server.database.dependencies import inject_db
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.schemas import filters, states
@@ -52,11 +53,12 @@ class CancellationCleanup(LoopService):
     async def clean_up_cancelled_flow_run_task_runs(self, db):
         while True:
             cancelled_flow_query = (
-                sa.select(db.FlowRun)
+                sa.select(orm_models.FlowRun)
                 .where(
-                    db.FlowRun.state_type == states.StateType.CANCELLED,
-                    db.FlowRun.end_time.is_not(None),
-                    db.FlowRun.end_time >= (pendulum.now("UTC").subtract(days=1)),
+                    orm_models.FlowRun.state_type == states.StateType.CANCELLED,
+                    orm_models.FlowRun.end_time.is_not(None),
+                    orm_models.FlowRun.end_time
+                    >= (pendulum.now("UTC").subtract(days=1)),
                 )
                 .limit(self.batch_size)
             )
@@ -76,19 +78,19 @@ class CancellationCleanup(LoopService):
         high_water_mark = UUID(int=0)
         while True:
             subflow_query = (
-                sa.select(db.FlowRun)
+                sa.select(orm_models.FlowRun)
                 .where(
                     or_(
-                        db.FlowRun.state_type == states.StateType.PENDING,
-                        db.FlowRun.state_type == states.StateType.SCHEDULED,
-                        db.FlowRun.state_type == states.StateType.RUNNING,
-                        db.FlowRun.state_type == states.StateType.PAUSED,
-                        db.FlowRun.state_type == states.StateType.CANCELLING,
-                        db.FlowRun.id > high_water_mark,
+                        orm_models.FlowRun.state_type == states.StateType.PENDING,
+                        orm_models.FlowRun.state_type == states.StateType.SCHEDULED,
+                        orm_models.FlowRun.state_type == states.StateType.RUNNING,
+                        orm_models.FlowRun.state_type == states.StateType.PAUSED,
+                        orm_models.FlowRun.state_type == states.StateType.CANCELLING,
+                        orm_models.FlowRun.id > high_water_mark,
                     ),
-                    db.FlowRun.parent_task_run_id.is_not(None),
+                    orm_models.FlowRun.parent_task_run_id.is_not(None),
                 )
-                .order_by(db.FlowRun.id)
+                .order_by(orm_models.FlowRun.id)
                 .limit(self.batch_size)
             )
 
@@ -105,7 +107,7 @@ class CancellationCleanup(LoopService):
                 break
 
     async def _cancel_child_runs(
-        self, db: PrefectDBInterface, flow_run: PrefectDBInterface.FlowRun
+        self, db: PrefectDBInterface, flow_run: orm_models.FlowRun
     ) -> None:
         async with db.session_context() as session:
             child_task_runs = await models.task_runs.read_task_runs(
@@ -129,7 +131,7 @@ class CancellationCleanup(LoopService):
                 )
 
     async def _cancel_subflow(
-        self, db: PrefectDBInterface, flow_run: PrefectDBInterface.FlowRun
+        self, db: PrefectDBInterface, flow_run: orm_models.FlowRun
     ) -> None:
         if not flow_run.parent_task_run_id:
             return False

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from prefect.blocks.notifications import NotificationBlock
 from prefect.filesystems import LocalFileSystem
 from prefect.server import models, schemas
+from prefect.server.database import orm_models
 from prefect.server.database.configurations import ENGINES, TRACKER
 from prefect.server.database.dependencies import (
     PrefectDBInterface,
@@ -128,10 +129,10 @@ async def clear_db(db, request):
         for attempt in range(max_retries):
             try:
                 async with db.session_context(begin_transaction=True) as session:
-                    await session.execute(db.Agent.__table__.delete())
-                    await session.execute(db.WorkPool.__table__.delete())
+                    await session.execute(orm_models.Agent.__table__.delete())
+                    await session.execute(orm_models.WorkPool.__table__.delete())
 
-                    for table in reversed(db.Base.metadata.sorted_tables):
+                    for table in reversed(orm_models.Base.metadata.sorted_tables):
                         await session.execute(table.delete())
                     break
             except InterfaceError:

--- a/tests/server/database/test_dependencies.py
+++ b/tests/server/database/test_dependencies.py
@@ -121,7 +121,7 @@ async def test_injecting_really_dumb_query_components():
             pass
 
         def get_scheduled_flow_runs_from_work_queues(
-            self, db, limit_per_queue, work_queue_ids, scheduled_before
+            self, limit_per_queue, work_queue_ids, scheduled_before
         ):
             ...
 
@@ -130,7 +130,6 @@ async def test_injecting_really_dumb_query_components():
 
         async def flow_run_graph_v2(
             self,
-            db: PrefectDBInterface,
             session: AsyncSession,
             flow_run_id: UUID,
             since: datetime,

--- a/tests/server/database/test_queries.py
+++ b/tests/server/database/test_queries.py
@@ -359,9 +359,7 @@ class TestGetRunsFromWorkQueueQuery:
     async def test_get_all_runs(
         self, session, db: PrefectDBInterface, work_pools, work_queues
     ):
-        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
-            session=session, db=db
-        )
+        runs = await db.queries.get_scheduled_flow_runs_from_work_pool(session=session)
         assert len(runs) == 45
 
         # runs should be sorted
@@ -372,10 +370,10 @@ class TestGetRunsFromWorkQueueQuery:
         self, session, db: PrefectDBInterface, work_pools, work_queues, limit
     ):
         all_runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
-            session=session, db=db
+            session=session
         )
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
-            session=session, db=db, limit=min(limit, 45)
+            session=session, limit=min(limit, 45)
         )
         assert len(runs) == min(limit, 45)
 
@@ -388,7 +386,7 @@ class TestGetRunsFromWorkQueueQuery:
         self, session, db: PrefectDBInterface, work_pools, work_queues
     ):
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
-            session=session, db=db, work_pool_ids=[work_pools["wp_a"].id]
+            session=session, work_pool_ids=[work_pools["wp_a"].id]
         )
         assert len(runs) == 15
 
@@ -397,7 +395,6 @@ class TestGetRunsFromWorkQueueQuery:
     ):
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
-            db=db,
             work_pool_ids=[
                 work_pools["wp_a"].id,
                 work_pools["wp_b"].id,
@@ -411,7 +408,6 @@ class TestGetRunsFromWorkQueueQuery:
     ):
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
-            db=db,
             work_queue_ids=[work_queues["wq_aa"].id],
         )
         assert len(runs) == 5
@@ -422,7 +418,6 @@ class TestGetRunsFromWorkQueueQuery:
     ):
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
-            db=db,
             work_pool_ids=[
                 work_pools["wp_a"].id,
                 work_pools["wp_b"].id,
@@ -443,7 +438,6 @@ class TestGetRunsFromWorkQueueQuery:
         )
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
-            db=db,
             work_queue_ids=[work_queues["wq_aa"].id],
         )
         assert len(runs) == 0
@@ -459,7 +453,6 @@ class TestGetRunsFromWorkQueueQuery:
         )
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
-            db=db,
             work_queue_ids=[work_queues["wq_aa"].id],
         )
         assert len(runs) == 0
@@ -484,7 +477,6 @@ class TestGetRunsFromWorkQueueQuery:
         await session.commit()
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
-            db=db,
             work_queue_ids=[work_queues["wq_aa"].id],
         )
         assert len(runs) == expected
@@ -511,7 +503,6 @@ class TestGetRunsFromWorkQueueQuery:
         )
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
-            db=db,
             work_queue_ids=[work_queues["wq_aa"].id],
         )
         assert len(runs) == expected
@@ -538,7 +529,6 @@ class TestGetRunsFromWorkQueueQuery:
         )
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
-            db=db,
             work_pool_ids=[work_pools["wp_a"].id],
         )
         assert len(runs) == expected
@@ -548,7 +538,7 @@ class TestGetRunsFromWorkQueueQuery:
         self, session, db: PrefectDBInterface, work_pools, work_queues, limit
     ):
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
-            session=session, db=db, worker_limit=limit
+            session=session, worker_limit=limit
         )
         assert len(runs) == min(15, limit) * 3
         for wc in work_pools.values():
@@ -565,7 +555,7 @@ class TestGetRunsFromWorkQueueQuery:
         )
 
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
-            session=session, db=db, worker_limit=7
+            session=session, worker_limit=7
         )
 
         assert len(runs) == 14
@@ -578,7 +568,7 @@ class TestGetRunsFromWorkQueueQuery:
         self, session, db: PrefectDBInterface, work_pools, work_queues, limit
     ):
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
-            session=session, db=db, queue_limit=limit
+            session=session, queue_limit=limit
         )
         assert len(runs) == min(5, limit) * 9
         for wq in work_queues.values():
@@ -593,7 +583,7 @@ class TestGetRunsFromWorkQueueQuery:
             work_queue=schemas.actions.WorkQueueUpdate(is_paused=True),
         )
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
-            session=session, db=db, queue_limit=3
+            session=session, queue_limit=3
         )
         assert len(runs) == 24
         assert sum(1 for r in runs if r.work_queue_id == work_queues["wq_aa"].id) == 0
@@ -616,7 +606,6 @@ class TestGetRunsFromWorkQueueQuery:
 
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
-            db=db,
             work_pool_ids=[work_pools["wp_a"].id],
             respect_queue_priorities=respect_priorities,
         )
@@ -641,7 +630,6 @@ class TestGetRunsFromWorkQueueQuery:
 
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
-            db=db,
             work_pool_ids=[work_pools["wp_a"].id],
             respect_queue_priorities=True,
         )
@@ -672,7 +660,6 @@ class TestGetRunsFromWorkQueueQuery:
 
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
-            db=db,
             work_pool_ids=[work_pools["wp_a"].id, work_pools["wp_b"].id],
             respect_queue_priorities=True,
         )
@@ -743,7 +730,6 @@ class TestGetRunsFromWorkQueueQuery:
     ):
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
-            db=db,
             scheduled_before=pendulum.now("UTC").add(hours=hours),
         )
         assert len(runs) == expected
@@ -756,7 +742,6 @@ class TestGetRunsFromWorkQueueQuery:
     ):
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
-            db=db,
             scheduled_after=pendulum.now("UTC").add(hours=hours),
         )
         assert len(runs) == expected
@@ -764,7 +749,6 @@ class TestGetRunsFromWorkQueueQuery:
     async def test_scheduled_before_and_after(self, session, db: PrefectDBInterface):
         runs = await db.queries.get_scheduled_flow_runs_from_work_pool(
             session=session,
-            db=db,
             # criteria should match no runs
             scheduled_before=pendulum.now("UTC").subtract(hours=1),
             scheduled_after=pendulum.now("UTC").add(hours=1),

--- a/tests/server/models/test_block_documents.py
+++ b/tests/server/models/test_block_documents.py
@@ -15,6 +15,7 @@ else:
 from prefect.blocks.core import Block
 from prefect.blocks.fields import SecretDict
 from prefect.server import models, schemas
+from prefect.server.database import orm_models
 from prefect.server.schemas.actions import BlockDocumentCreate
 from prefect.utilities.names import obfuscate, obfuscate_string
 
@@ -229,7 +230,7 @@ class TestCreateBlockDocument:
         )
 
         before_count = await session.execute(
-            sa.select(sa.func.count()).select_from(db.BlockDocument)
+            sa.select(sa.func.count()).select_from(orm_models.BlockDocument)
         )
         await models.block_documents.create_block_document(
             session=session, block_document=block_document
@@ -243,7 +244,7 @@ class TestCreateBlockDocument:
         await session.rollback()
 
         after_count = await session.execute(
-            sa.select(sa.func.count()).select_from(db.BlockDocument)
+            sa.select(sa.func.count()).select_from(orm_models.BlockDocument)
         )
 
         # only one block created

--- a/tests/server/models/test_block_schemas.py
+++ b/tests/server/models/test_block_schemas.py
@@ -13,6 +13,7 @@ else:
 
 from prefect.blocks.core import Block
 from prefect.server import models, schemas
+from prefect.server.database import orm_models
 from prefect.server.models.block_schemas import read_block_schema_by_checksum
 from prefect.server.schemas.filters import BlockSchemaFilter
 from prefect.utilities.collections import AutoEnum
@@ -495,7 +496,9 @@ class TestReadBlockSchemas:
         )
         before_read = (
             await session.execute(
-                sa.select(db.BlockSchema).where(db.BlockSchema.id == block_schema.id)
+                sa.select(orm_models.BlockSchema).where(
+                    orm_models.BlockSchema.id == block_schema.id
+                )
             )
         ).scalar()
         assert before_read.fields.get("block_schema_references") is None
@@ -505,7 +508,9 @@ class TestReadBlockSchemas:
         await session.commit()
         after_read = (
             await session.execute(
-                sa.select(db.BlockSchema).where(db.BlockSchema.id == block_schema.id)
+                sa.select(orm_models.BlockSchema).where(
+                    orm_models.BlockSchema.id == block_schema.id
+                )
             )
         ).scalar()
         assert after_read.fields.get("block_schema_references") is None

--- a/tests/server/schemas/test_filters.py
+++ b/tests/server/schemas/test_filters.py
@@ -21,40 +21,40 @@ async def test_filters_without_params_do_not_error():
 class TestLogFilters:
     def test_applies_level_le_filter(self, db):
         log_filter = LogFilter(level={"le_": 10})
-        sql_filter = log_filter.as_sql_filter(db)
+        sql_filter = log_filter.as_sql_filter()
         assert sql_filter.compare(sa.and_(db.Log.level <= 10))
 
     def test_applies_level_ge_filter(self, db):
         log_filter = LogFilter(level={"ge_": 10})
-        sql_filter = log_filter.as_sql_filter(db)
+        sql_filter = log_filter.as_sql_filter()
         assert sql_filter.compare(sa.and_(db.Log.level >= 10))
 
     def test_applies_timestamp_filter_before(self, db):
         log_filter = LogFilter(timestamp={"before_": NOW})
-        sql_filter = log_filter.as_sql_filter(db)
+        sql_filter = log_filter.as_sql_filter()
         assert sql_filter.compare(sa.and_(db.Log.timestamp <= NOW))
 
     def test_applies_timestamp_filter_after(self, db):
         log_filter = LogFilter(timestamp={"after_": NOW})
-        sql_filter = log_filter.as_sql_filter(db)
+        sql_filter = log_filter.as_sql_filter()
         assert sql_filter.compare(sa.and_(db.Log.timestamp >= NOW))
 
     def test_applies_flow_run_id_filter(self, db):
         flow_run_id = uuid4()
         log_filter = LogFilter(flow_run_id={"any_": [flow_run_id]})
-        sql_filter = log_filter.as_sql_filter(db)
+        sql_filter = log_filter.as_sql_filter()
         assert sql_filter.compare(sa.and_(db.Log.flow_run_id.in_([flow_run_id])))
 
     def test_applies_task_run_id_filter(self, db):
         task_run_id = uuid4()
         log_filter = LogFilter(task_run_id={"any_": [task_run_id]})
-        sql_filter = log_filter.as_sql_filter(db)
+        sql_filter = log_filter.as_sql_filter()
         assert sql_filter.compare(sa.and_(db.Log.task_run_id.in_([task_run_id])))
 
     def test_applies_multiple_conditions(self, db):
         task_run_id = uuid4()
         log_filter = LogFilter(task_run_id={"any_": [task_run_id]}, level={"ge_": 20})
-        sql_filter = log_filter.as_sql_filter(db)
+        sql_filter = log_filter.as_sql_filter()
         assert sql_filter.compare(
             sa.and_(db.Log.task_run_id.in_([task_run_id]), db.Log.level >= 20)
         )

--- a/tests/server/schemas/test_filters.py
+++ b/tests/server/schemas/test_filters.py
@@ -3,19 +3,9 @@ from uuid import uuid4
 import pendulum
 import sqlalchemy as sa
 
-from prefect.server import schemas
 from prefect.server.schemas.filters import LogFilter
 
 NOW = pendulum.now("UTC")
-
-
-async def test_filters_without_params_do_not_error():
-    class MyFilter(schemas.filters.PrefectFilterBaseModel):
-        def _get_filter_list(self, db):
-            return []
-
-    # should not error
-    MyFilter().as_sql_filter(None)
 
 
 class TestLogFilters:


### PR DESCRIPTION
This is the first in what is likely to be a long series of PRs that remove the models from the database abstraction layer. This PR:

- Makes the models use a `DeclarativeBase` instead of `declarative_mixin`.
- Updates many of the models files to use `orm_models.<model>` directly.
- Removes usages of `PrefectDBInterface` in filters and sorting.

Related to #11795