### PR TITLE
More test prep

### DIFF
--- a/tests/deployment/test_flow_runs.py
+++ b/tests/deployment/test_flow_runs.py
@@ -96,7 +96,7 @@ class TestRunDeployment:
         flow_run = await prefect_client.read_flow_run(flow_run.id)
         assert flow_run.job_variables == job_vars
 
-    def test_returns_flow_run_on_timeout(
+    async def test_returns_flow_run_on_timeout(
         self,
         test_deployment,
         use_hosted_api_server,
@@ -122,7 +122,7 @@ class TestRunDeployment:
                 )
             )
 
-            flow_run = run_deployment(
+            flow_run = await run_deployment(
                 f"foo/{deployment.name}", timeout=1, poll_interval=0
             )
             assert len(flow_polls.calls) > 0
@@ -162,7 +162,7 @@ class TestRunDeployment:
             assert len(flow_polls.calls) == 0
             assert flow_run.state.is_scheduled()
 
-    def test_polls_indefinitely(
+    async def test_polls_indefinitely(
         self,
         test_deployment,
         use_hosted_api_server,
@@ -197,16 +197,16 @@ class TestRunDeployment:
                 "GET", re.compile(PREFECT_API_URL.value() + "/flow_runs/.*")
             ).mock(side_effect=side_effects)
 
-            run_deployment(f"foo/{deployment.name}", timeout=None, poll_interval=0)
+            await run_deployment(f"foo/{deployment.name}", timeout=None, poll_interval=0)
             assert len(flow_polls.calls) == 100
 
-    def test_schedules_immediately_by_default(
+    async def test_schedules_immediately_by_default(
         self, test_deployment, use_hosted_api_server
     ):
         deployment = test_deployment
 
         scheduled_time = pendulum.now("UTC")
-        flow_run = run_deployment(
+        flow_run = await run_deployment(
             f"foo/{deployment.name}",
             timeout=0,
             poll_interval=0,
@@ -214,13 +214,13 @@ class TestRunDeployment:
 
         assert (flow_run.expected_start_time - scheduled_time).total_seconds() < 1
 
-    def test_accepts_custom_scheduled_time(
+    async def test_accepts_custom_scheduled_time(
         self, test_deployment, use_hosted_api_server
     ):
         deployment = test_deployment
 
         scheduled_time = pendulum.now("UTC") + pendulum.Duration(minutes=5)
-        flow_run = run_deployment(
+        flow_run = await run_deployment(
             f"foo/{deployment.name}",
             scheduled_time=scheduled_time,
             timeout=0,
@@ -229,10 +229,10 @@ class TestRunDeployment:
 
         assert (flow_run.expected_start_time - scheduled_time).total_seconds() < 1
 
-    def test_custom_flow_run_names(self, test_deployment, use_hosted_api_server):
+    async def test_custom_flow_run_names(self, test_deployment, use_hosted_api_server):
         deployment = test_deployment
 
-        flow_run = run_deployment(
+        flow_run = await run_deployment(
             f"foo/{deployment.name}",
             flow_run_name="a custom flow run name",
             timeout=0,
@@ -241,10 +241,10 @@ class TestRunDeployment:
 
         assert flow_run.name == "a custom flow run name"
 
-    def test_accepts_tags(self, test_deployment):
+    async def test_accepts_tags(self, test_deployment):
         deployment = test_deployment
 
-        flow_run = run_deployment(
+        flow_run = await run_deployment(
             f"foo/{deployment.name}",
             tags=["I", "love", "prefect"],
             timeout=0,
@@ -253,17 +253,17 @@ class TestRunDeployment:
 
         assert sorted(flow_run.tags) == ["I", "love", "prefect"]
 
-    def test_accepts_idempotency_key(self, test_deployment):
+    async def test_accepts_idempotency_key(self, test_deployment):
         deployment = test_deployment
 
-        flow_run_a = run_deployment(
+        flow_run_a = await run_deployment(
             f"foo/{deployment.name}",
             idempotency_key="12345",
             timeout=0,
             poll_interval=0,
         )
 
-        flow_run_b = run_deployment(
+        flow_run_b = await run_deployment(
             f"foo/{deployment.name}",
             idempotency_key="12345",
             timeout=0,

--- a/tests/deployment/test_flow_runs.py
+++ b/tests/deployment/test_flow_runs.py
@@ -197,7 +197,9 @@ class TestRunDeployment:
                 "GET", re.compile(PREFECT_API_URL.value() + "/flow_runs/.*")
             ).mock(side_effect=side_effects)
 
-            await run_deployment(f"foo/{deployment.name}", timeout=None, poll_interval=0)
+            await run_deployment(
+                f"foo/{deployment.name}", timeout=None, poll_interval=0
+            )
             assert len(flow_polls.calls) == 100
 
     async def test_schedules_immediately_by_default(

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -25,7 +25,6 @@ from prefect.settings import (
     temporary_settings,
 )
 from prefect.task_server import TaskServer
-from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.hashing import hash_objects
 
 if TYPE_CHECKING:
@@ -103,7 +102,9 @@ async def test_task_submission_with_parameters_uses_default_storage(foo_task):
 
     result_factory = await result_factory_from_task(foo_task)
 
-    await result_factory.read_parameters(task_run.state.state_details.task_parameters_id)
+    await result_factory.read_parameters(
+        task_run.state.state_details.task_parameters_id
+    )
 
 
 async def test_task_submission_with_parameters_reuses_default_storage_block(
@@ -141,7 +142,9 @@ async def test_task_submission_with_parameters_reuses_default_storage_block(
         ) == {"x": 24}
 
 
-async def test_task_submission_creates_a_scheduled_task_run(foo_task_with_result_storage):
+async def test_task_submission_creates_a_scheduled_task_run(
+    foo_task_with_result_storage,
+):
     task_run = foo_task_with_result_storage.submit(42)
     assert task_run.state.is_scheduled()
 

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -32,7 +32,6 @@ if TYPE_CHECKING:
     from prefect.client.orchestration import PrefectClient
 
 
-@sync_compatible
 async def result_factory_from_task(task) -> ResultFactory:
     return await ResultFactory.from_autonomous_task(task)
 
@@ -98,16 +97,16 @@ def async_foo_task_with_result_storage(async_foo_task, local_filesystem):
     return async_foo_task.with_options(result_storage=local_filesystem)
 
 
-def test_task_submission_with_parameters_uses_default_storage(foo_task):
+async def test_task_submission_with_parameters_uses_default_storage(foo_task):
     foo_task_without_result_storage = foo_task.with_options(result_storage=None)
     task_run = foo_task_without_result_storage.submit(42)
 
-    result_factory = result_factory_from_task(foo_task)
+    result_factory = await result_factory_from_task(foo_task)
 
-    result_factory.read_parameters(task_run.state.state_details.task_parameters_id)
+    await result_factory.read_parameters(task_run.state.state_details.task_parameters_id)
 
 
-def test_task_submission_with_parameters_reuses_default_storage_block(
+async def test_task_submission_with_parameters_reuses_default_storage_block(
     foo_task: Task, tmp_path: Path
 ):
     with temporary_settings(
@@ -118,37 +117,37 @@ def test_task_submission_with_parameters_reuses_default_storage_block(
     ):
         # The block will not exist initially
         with pytest.raises(ValueError, match="Unable to find block document"):
-            Block.load("local-file-system/my-tasks")
+            await Block.load("local-file-system/my-tasks")
 
         foo_task_without_result_storage = foo_task.with_options(result_storage=None)
         task_run_a = foo_task_without_result_storage.submit(42)
 
-        storage_before = Block.load("local-file-system/my-tasks")
+        storage_before = await Block.load("local-file-system/my-tasks")
         assert isinstance(storage_before, LocalFileSystem)
         assert storage_before.basepath == str(tmp_path / "some-storage")
 
         foo_task_without_result_storage = foo_task.with_options(result_storage=None)
         task_run_b = foo_task_without_result_storage.submit(24)
 
-        storage_after = Block.load("local-file-system/my-tasks")
+        storage_after = await Block.load("local-file-system/my-tasks")
         assert isinstance(storage_after, LocalFileSystem)
 
-        result_factory = result_factory_from_task(foo_task)
-        assert result_factory.read_parameters(
+        result_factory = await result_factory_from_task(foo_task)
+        assert await result_factory.read_parameters(
             task_run_a.state.state_details.task_parameters_id
         ) == {"x": 42}
-        assert result_factory.read_parameters(
+        assert await result_factory.read_parameters(
             task_run_b.state.state_details.task_parameters_id
         ) == {"x": 24}
 
 
-def test_task_submission_creates_a_scheduled_task_run(foo_task_with_result_storage):
+async def test_task_submission_creates_a_scheduled_task_run(foo_task_with_result_storage):
     task_run = foo_task_with_result_storage.submit(42)
     assert task_run.state.is_scheduled()
 
-    result_factory = result_factory_from_task(foo_task_with_result_storage)
+    result_factory = await result_factory_from_task(foo_task_with_result_storage)
 
-    parameters = result_factory.read_parameters(
+    parameters = await result_factory.read_parameters(
         task_run.state.state_details.task_parameters_id
     )
 


### PR DESCRIPTION
More test updates in preparation for switching to the new engine by default. Note that async functions called outside of flow/task run contexts _must_ be awaited in the new world.