### PR TITLE
New engine logging

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -3721,7 +3721,7 @@ class SyncPrefectClient:
 
         return OrchestrationResult.parse_obj(response.json())
 
-    async def set_task_run_name(self, task_run_id: UUID, name: str):
+    def set_task_run_name(self, task_run_id: UUID, name: str):
         task_run_data = TaskRunUpdate(name=name)
         return self._client.patch(
             f"/task_runs/{task_run_id}",

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -3721,6 +3721,13 @@ class SyncPrefectClient:
 
         return OrchestrationResult.parse_obj(response.json())
 
+    async def set_task_run_name(self, task_run_id: UUID, name: str):
+        task_run_data = TaskRunUpdate(name=name)
+        return self._client.patch(
+            f"/task_runs/{task_run_id}",
+            json=task_run_data.dict(json_compatible=True, exclude_unset=True),
+        )
+
     def create_task_run(
         self,
         task: "TaskObject[P, R]",

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -350,12 +350,8 @@ class TaskRunEngine(Generic[P, R]):
             client=client,
         ):
             # set the logger to the task run logger
-            current_logger = self.logger
-            try:
-                self.logger = task_run_logger(task_run=self.task_run, task=self.task)  # type: ignore
-                yield
-            finally:
-                self.logger = current_logger
+            self.logger = task_run_logger(task_run=self.task_run, task=self.task)  # type: ignore
+            yield
 
     @contextmanager
     def start(

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -70,6 +70,7 @@ class TaskRunEngine(Generic[P, R]):
     wait_for: Optional[Iterable[PrefectFuture]] = None
     _is_started: bool = False
     _client: Optional[SyncPrefectClient] = None
+    _task_name_set: bool = False
 
     def __post_init__(self):
         if self.parameters is None:
@@ -381,7 +382,7 @@ class TaskRunEngine(Generic[P, R]):
             self.logger = task_run_logger(task_run=self.task_run, task=self.task)  # type: ignore
 
             # update the task run name if necessary
-            if self.task.task_run_name:
+            if not self._task_name_set and self.task.task_run_name:
                 task_run_name = _resolve_custom_task_run_name(
                     task=self.task, parameters=self.parameters
                 )
@@ -393,6 +394,7 @@ class TaskRunEngine(Generic[P, R]):
                     f"Renamed task run {self.task_run.name!r} to {task_run_name!r}"
                 )
                 self.task_run.name = task_run_name
+                self._task_name_set = True
             yield
 
     @contextmanager

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -485,6 +485,9 @@ def run_task_sync(
                         call_args, call_kwargs = parameters_to_args_kwargs(
                             task.fn, run.parameters or {}
                         )
+                        run.logger.debug(
+                            f"Executing flow {task.name!r} for flow run {run.task_run.name!r}..."
+                        )
                         result = cast(R, task.fn(*call_args, **call_kwargs))  # type: ignore
 
                     # If the task run is successful, finalize it.
@@ -532,6 +535,9 @@ async def run_task_async(
                     with timeout_async(seconds=run.task.timeout_seconds):
                         call_args, call_kwargs = parameters_to_args_kwargs(
                             task.fn, run.parameters or {}
+                        )
+                        run.logger.debug(
+                            f"Executing flow {task.name!r} for flow run {run.task_run.name!r}..."
                         )
                         result = cast(R, await task.fn(*call_args, **call_kwargs))  # type: ignore
 

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import gc
+import logging
 import uuid
 import warnings
 from contextlib import asynccontextmanager
@@ -77,7 +78,10 @@ async def database_engine(db: PrefectDBInterface):
         else:
             continue
 
-        await driver_connection.close()
+        try:
+            await driver_connection.close()
+        except Exception:
+            logging.exception("Exception closed while closing connection.")
 
     # Finally, free up all references to connections and clean up proactively so that
     # we don't have any lingering connections after this.  This should prevent

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -168,7 +168,6 @@ class TestTaskRunName:
             def my_task():
                 pass
 
-    @fails_with_new_engine
     def test_invalid_runtime_run_name(self):
         class InvalidTaskRunNameArg:
             def format(*args, **kwargs):
@@ -1585,7 +1584,6 @@ class TestCacheFunctionBuiltins:
 
 
 class TestTaskTimeouts:
-    @fails_with_new_engine
     async def test_task_timeouts_actually_timeout(self, timeout_test_flow):
         flow_state = timeout_test_flow(return_state=True)
         timed_out, _, _ = await flow_state.result(raise_on_failure=False)
@@ -1597,7 +1595,6 @@ class TestTaskTimeouts:
         timed_out, _, _ = await flow_state.result(raise_on_failure=False)
         assert timed_out.is_crashed() is False
 
-    @fails_with_new_engine
     async def test_task_timeouts_do_not_crash_flow_runs(self, timeout_test_flow):
         flow_state = timeout_test_flow(return_state=True)
         timed_out, _, _ = await flow_state.result(raise_on_failure=False)
@@ -3489,7 +3486,6 @@ async def test_task_run_name_is_set_with_function_using_runtime_context(prefect_
     assert task_run.name == "chris-wuz-here"
 
 
-@fails_with_new_engine
 async def test_task_run_name_is_set_with_function_not_returning_string(prefect_client):
     def generate_task_run_name():
         pass

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2585,7 +2585,9 @@ class TestTaskRunLogs:
 
         logs = await _wait_for_logs(prefect_client)
         assert logs, "There should be logs"
-        assert all([log.flow_run_id == flow_run_id for log in logs])
+        assert all([log.flow_run_id == flow_run_id for log in logs]), str(
+            [log.flow_run_id for log in logs]
+        )
         task_run_logs = [log for log in logs if log.task_run_id is not None]
         assert task_run_logs, f"There should be task run logs in {logs}"
         assert all([log.task_run_id == task_run_id for log in task_run_logs])

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3459,7 +3459,6 @@ async def test_task_run_name_is_set_with_function(prefect_client):
     assert task_run.name == "is-this-a-bird"
 
 
-@fails_with_new_engine
 async def test_task_run_name_is_set_with_function_using_runtime_context(prefect_client):
     def generate_task_run_name():
         params = task_run_ctx.parameters

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2586,7 +2586,7 @@ class TestTaskRunLogs:
         logs = await _wait_for_logs(prefect_client)
         assert logs, "There should be logs"
         assert all([log.flow_run_id == flow_run_id for log in logs]), str(
-            [log.flow_run_id for log in logs]
+            [log for log in logs]
         )
         task_run_logs = [log for log in logs if log.task_run_id is not None]
         assert task_run_logs, f"There should be task run logs in {logs}"

--- a/tests/utilities/test_templating.py
+++ b/tests/utilities/test_templating.py
@@ -253,7 +253,7 @@ class TestApplyValues:
 
 
 class TestResolveBlockDocumentReferences:
-    @pytest.fixture(scope="class")
+    @pytest.fixture()
     async def block_document_id(self):
         class ArbitraryBlock(Block):
             a: int

--- a/tests/utilities/test_templating.py
+++ b/tests/utilities/test_templating.py
@@ -259,7 +259,9 @@ class TestResolveBlockDocumentReferences:
             a: int
             b: str
 
-        return await ArbitraryBlock(a=1, b="hello").save(name="arbitrary-block")
+        return await ArbitraryBlock(a=1, b="hello").save(
+            name="arbitrary-block", overwrite=True
+        )
 
     async def test_resolve_block_document_references_with_no_block_document_references(
         self,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Adds logging for run creation and completion to the new engine so that it feels familiar and homey.

Also adds support for logging prints to the new engine.

Also fixes some issues with task run naming.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
For this flow:
```python
from prefect import flow, task


@flow(retries=3, log_prints=True)
def my_flow(foo: bool):
    my_other_flow(42)
    print("Hello, world!")
    return slow_task.submit()

@flow
def my_other_flow(bar: int):
    pass

@task(timeout_seconds=10, task_run_name="bloop")
def slow_task():
    print("Sleeping...")
    import time
    time.sleep(1)

if __name__ == "__main__":
    my_flow(foo=True)
```

Running will produce this output:
```
22:14:31.434 | INFO    | prefect.engine - Created flow run 'didactic-prawn' for flow 'my-flow'
22:14:31.437 | INFO    | prefect.engine - View at http://127.0.0.1:4200/flow-runs/flow-run/785b8466-010a-4338-8f68-b0e1e10d5649
22:14:32.088 | INFO    | Flow run 'didactic-prawn' - Created subflow run 'burrowing-finch' for flow 'my-other-flow'
22:14:32.090 | INFO    | prefect.engine - View at http://127.0.0.1:4200/flow-runs/flow-run/ae098ba9-e966-43e1-bdf3-910f8ad50b7a
22:14:32.172 | INFO    | Flow run 'burrowing-finch' - Finished in state Completed()
22:14:32.185 | INFO    | Flow run 'didactic-prawn' - Hello, world!
22:14:32.191 | INFO    | Flow run 'didactic-prawn' - Submitting task slow_task to thread pool executor...
22:14:32.209 | INFO    | prefect.engine - Created task run 'slow_task-0' for task 'slow_task'
22:14:32.242 | INFO    | Task run 'bloop' - Sleeping...
22:14:33.267 | INFO    | Task run 'bloop' - Finished in state Completed()
22:14:33.294 | INFO    | Flow run 'didactic-prawn' - Finished in state Completed('All states completed.')
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
