### PR TITLE
Fix issue with event loops being closed

### DIFF
--- a/src/prefect/server/database/migrations/env.py
+++ b/src/prefect/server/database/migrations/env.py
@@ -1,7 +1,6 @@
 # Originally generated from `alembic init`
 # https://alembic.sqlalchemy.org/en/latest/tutorial.html#creating-an-environment
 
-import asyncio
 import contextlib
 
 import sqlalchemy
@@ -11,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from prefect.server.database.configurations import SQLITE_BEGIN_MODE
 from prefect.server.database.dependencies import provide_database_interface
 from prefect.server.utilities.database import get_dialect
+from prefect.utilities.asyncutils import sync_compatible
 
 db_interface = provide_database_interface()
 config = context.config
@@ -157,6 +157,7 @@ def disable_sqlite_foreign_keys(context):
         context.execute("BEGIN IMMEDIATE")
 
 
+@sync_compatible
 async def apply_migrations() -> None:
     """
     Apply migrations to the database.
@@ -171,4 +172,4 @@ async def apply_migrations() -> None:
 if context.is_offline_mode():
     dry_run_migrations()
 else:
-    asyncio.run(apply_migrations())
+    apply_migrations()

--- a/src/prefect/server/database/migrations/env.py
+++ b/src/prefect/server/database/migrations/env.py
@@ -1,6 +1,7 @@
 # Originally generated from `alembic init`
 # https://alembic.sqlalchemy.org/en/latest/tutorial.html#creating-an-environment
 
+import asyncio
 import contextlib
 
 import sqlalchemy
@@ -10,7 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from prefect.server.database.configurations import SQLITE_BEGIN_MODE
 from prefect.server.database.dependencies import provide_database_interface
 from prefect.server.utilities.database import get_dialect
-from prefect.utilities.asyncutils import sync_compatible
 
 db_interface = provide_database_interface()
 config = context.config
@@ -157,7 +157,6 @@ def disable_sqlite_foreign_keys(context):
         context.execute("BEGIN IMMEDIATE")
 
 
-@sync_compatible
 async def apply_migrations() -> None:
     """
     Apply migrations to the database.
@@ -172,4 +171,4 @@ async def apply_migrations() -> None:
 if context.is_offline_mode():
     dry_run_migrations()
 else:
-    apply_migrations()
+    asyncio.run(apply_migrations())

--- a/src/prefect/server/events/models/automations.py
+++ b/src/prefect/server/events/models/automations.py
@@ -117,7 +117,9 @@ async def _notify(session: AsyncSession, automation: Automation, event: str):
             asyncio.run_coroutine_threadsafe(coro, loop=loop)
         except RuntimeError as exc:
             if "Event loop is closed" in str(exc):
-                asyncio.run(coro)
+                loop = asyncio.new_event_loop()
+                asyncio.run_coroutine_threadsafe(coro, loop=loop)
+                loop.close()
             else:
                 raise
 

--- a/src/prefect/server/events/models/automations.py
+++ b/src/prefect/server/events/models/automations.py
@@ -104,7 +104,11 @@ async def _notify(session: AsyncSession, automation: Automation, event: str):
     sync_session = session.sync_session
 
     def change_notification(session, **kwargs):
-        run_sync(automation_changed(automation.id, f"automation__{event}"))
+        try:
+            run_sync(automation_changed(automation.id, f"automation__{event}"))
+        except Exception:
+            # On exception, do not re-raise, just move on
+            pass
 
     sa.event.listen(sync_session, "after_commit", change_notification, once=True)
 

--- a/src/prefect/server/events/models/automations.py
+++ b/src/prefect/server/events/models/automations.py
@@ -107,8 +107,7 @@ async def _notify(session: AsyncSession, automation: Automation, event: str):
         """
         This function is called on a deferred basis, and in some race conditions
         (e.g. unit tests) the retrieved event loop may be closed by the time the
-        coro is actually run. In this case, we run the coro in a new loop via
-        asyncio.run.
+        coro is actually run. In this case, we run the coro in a new loop.
         """
         loop = asyncio.get_event_loop()
 


### PR DESCRIPTION
We are frequently seeing a unit test issue regarding event loops that are closed. Randomly (but frequently), tests will fail reporting a RunTimeError("Event loop is closed.")  

After tracking down (at least one) source, it appears to be a race condition involving this SQLAlchemy hook. The loop is loaded before the hook is created, and by the time the hook is called the loop has been closed -- I believe this might be exacerbated by single-purpose loops being created for e.g. run_sync calls.

I explored a few solutions - mainly try/except with a fallback to asyncio.run, but ultimately using `run_sync` encapsulated them all and seems to work...? This is just a nasty race condition which something in the new engine code is exacerbating, probably the use of run sync to make scoped loops which this function was picking up.

(merging directly into #13454 )