### PR TITLE
Default `anchor_date` to `now`

### DIFF
--- a/src/prefect/_internal/schemas/validators.py
+++ b/src/prefect/_internal/schemas/validators.py
@@ -375,8 +375,6 @@ def reconcile_paused_deployment(values):
 
 
 def default_anchor_date(v: DateTime) -> DateTime:
-    if v is None:
-        return pendulum.now("UTC")
     return pendulum.instance(v)
 
 

--- a/src/prefect/server/schemas/schedules.py
+++ b/src/prefect/server/schemas/schedules.py
@@ -74,9 +74,10 @@ class IntervalSchedule(PrefectBaseModel):
     model_config = ConfigDict(extra="forbid")
 
     interval: PositiveDuration
-    anchor_date: Optional[
-        Annotated[DateTime, AfterValidator(default_anchor_date)]
-    ] = Field(default=None, examples=["2020-01-01T00:00:00Z"])
+    anchor_date: Annotated[DateTime, AfterValidator(default_anchor_date)] = Field(
+        default_factory=lambda: pendulum.now("UTC"),
+        examples=["2020-01-01T00:00:00Z"],
+    )
     timezone: Optional[str] = Field(default=None, examples=["America/New_York"])
 
     @model_validator(mode="after")


### PR DESCRIPTION
The `default_anchor_date` validator wasn't getting called when no value was given to the schedule, so we just need a default factory to set the value on initialization. This also removes the `None` check from `default_anchor_date` as we don't expect, or want to handle, `IntervalSchedule(anchor_date=None)`.