### PR TITLE
Pin requests to <2.32.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,7 +25,7 @@ pytest-timeout
 pytest-xdist < 3.4.0 # 3.5.0 introduces some flakiness. Need to investigate and resolve.
 pytkdocs >= 0.14.2
 pyyaml
-requests
+requests<2.32.0  # `requests` renamed `get_connection` to `_get_connection`, which is a method docker-py monkeypatches. See https://github.com/docker/docker-py/issues/3256 Should be able to un-pin when docker-py hotfix is out.
 setuptools
 vermin
 virtualenv


### PR DESCRIPTION
A new version of `requests` was released a couple hours ago that broke compatibility with `docker-py`. Pinning while they get a hotfix together.

More details: https://github.com/docker/docker-py/issues/3256
