### PR TITLE
Add filter on task_run.expected_start_time

### DIFF
--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -813,6 +813,27 @@ class TaskRunFilterStartTime(PrefectFilterBaseModel):
         return filters
 
 
+class TaskRunFilterExpectedStartTime(PrefectFilterBaseModel):
+    """Filter by `TaskRun.expected_start_time`."""
+
+    before_: Optional[DateTimeTZ] = Field(
+        default=None,
+        description="Only include task runs expected to start at or before this time",
+    )
+    after_: Optional[DateTimeTZ] = Field(
+        default=None,
+        description="Only include task runs expected to start at or after this time",
+    )
+
+    def _get_filter_list(self) -> List:
+        filters = []
+        if self.before_ is not None:
+            filters.append(orm_models.TaskRun.expected_start_time <= self.before_)
+        if self.after_ is not None:
+            filters.append(orm_models.TaskRun.expected_start_time >= self.after_)
+        return filters
+
+
 class TaskRunFilter(PrefectOperatorFilterBaseModel):
     """Filter task runs. Only task runs matching all criteria will be returned"""
 
@@ -830,6 +851,9 @@ class TaskRunFilter(PrefectOperatorFilterBaseModel):
     )
     start_time: Optional[TaskRunFilterStartTime] = Field(
         default=None, description="Filter criteria for `TaskRun.start_time`"
+    )
+    expected_start_time: Optional[TaskRunFilterExpectedStartTime] = Field(
+        default=None, description="Filter criteria for `TaskRun.expected_start_time`"
     )
     subflow_runs: Optional[TaskRunFilterSubFlowRuns] = Field(
         default=None, description="Filter criteria for `TaskRun.subflow_run`"
@@ -851,6 +875,8 @@ class TaskRunFilter(PrefectOperatorFilterBaseModel):
             filters.append(self.state.as_sql_filter())
         if self.start_time is not None:
             filters.append(self.start_time.as_sql_filter())
+        if self.expected_start_time is not None:
+            filters.append(self.expected_start_time.as_sql_filter())
         if self.subflow_runs is not None:
             filters.append(self.subflow_runs.as_sql_filter())
         if self.flow_run_id is not None:


### PR DESCRIPTION
Add the ability to filter on `task_run.expected_start_time`.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [x] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [x] This pull request includes helpful docstrings.
- [x] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
