### PR TITLE
Fix some tests in `tests/cli/test_flow_run.py`

### DIFF
--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -1,7 +1,8 @@
-from datetime import datetime, timezone
+from datetime import timezone
 from uuid import UUID, uuid4
 
 import pytest
+from pendulum import now as pendulum_now
 
 import prefect.exceptions
 from prefect import flow
@@ -369,7 +370,7 @@ def flow_run_factory(prefect_client):
                 name="prefect.flow_runs",
                 level=20,
                 message=f"Log {i} from flow_run {flow_run.id}.",
-                timestamp=datetime.now(tz=timezone.utc),
+                timestamp=pendulum_now(tz=timezone.utc),
                 flow_run_id=flow_run.id,
             )
             for i in range(num_logs)

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -1,8 +1,7 @@
-from datetime import timezone
 from uuid import UUID, uuid4
 
 import pytest
-from pendulum import now as pendulum_now
+from pydantic_extra_types.pendulum_dt import DateTime
 
 import prefect.exceptions
 from prefect import flow
@@ -370,7 +369,7 @@ def flow_run_factory(prefect_client):
                 name="prefect.flow_runs",
                 level=20,
                 message=f"Log {i} from flow_run {flow_run.id}.",
-                timestamp=pendulum_now(tz=timezone.utc),
+                timestamp=DateTime.now(),
                 flow_run_id=flow_run.id,
             )
             for i in range(num_logs)


### PR DESCRIPTION
Fixes tests in `test_flow_run.py` file:
```bash
FAILED tests/cli/test_flow_run.py::TestFlowRunLogs::test_when_num_logs_smaller_than_page_size_then_no_pagination - pydantic_core._pydantic_core.ValidationError: 1 validation error for LogCreate
FAILED tests/cli/test_flow_run.py::TestFlowRunLogs::test_when_num_logs_greater_than_page_size_then_pagination - pydantic_core._pydantic_core.ValidationError: 1 validation error for LogCreate
FAILED tests/cli/test_flow_run.py::TestFlowRunLogs::test_when_num_logs_smaller_than_page_size_with_head_then_no_pagination - pydantic_core._pydantic_core.ValidationError: 1 validation error for LogCreate
FAILED tests/cli/test_flow_run.py::TestFlowRunLogs::test_when_num_logs_greater_than_page_size_with_head_then_pagination - pydantic_core._pydantic_core.ValidationError: 1 validation error for LogCreate
FAILED tests/cli/test_flow_run.py::TestFlowRunLogs::test_when_num_logs_greater_than_page_size_with_head_outputs_correct_num_logs - pydantic_core._pydantic_core.ValidationError: 1 validation error for LogCreate
FAILED tests/cli/test_flow_run.py::TestFlowRunLogs::test_default_head_returns_default_num_logs - pydantic_core._pydantic_core.ValidationError: 1 validation error for LogCreate
FAILED tests/cli/test_flow_run.py::TestFlowRunLogs::test_h_and_n_shortcuts_for_head_and_num_logs - pydantic_core._pydantic_core.ValidationError: 1 validation error for LogCreate
FAILED tests/cli/test_flow_run.py::TestFlowRunLogs::test_num_logs_passed_standalone_returns_num_logs - pydantic_core._pydantic_core.ValidationError: 1 validation error for LogCreate
FAILED tests/cli/test_flow_run.py::TestFlowRunLogs::test_when_num_logs_passed_with_reverse_param_and_num_logs - pydantic_core._pydantic_core.ValidationError: 1 validation error for LogCreate
FAILED tests/cli/test_flow_run.py::TestFlowRunLogs::test_passing_head_and_tail_raises - pydantic_core._pydantic_core.ValidationError: 1 validation error for LogCreate
FAILED tests/cli/test_flow_run.py::TestFlowRunLogs::test_default_tail_returns_default_num_logs - pydantic_core._pydantic_core.ValidationError: 1 validation error for LogCreate
FAILED tests/cli/test_flow_run.py::TestFlowRunLogs::test_reverse_tail_with_num_logs - pydantic_core._pydantic_core.ValidationError: 1 validation error for LogCreate
FAILED tests/cli/test_flow_run.py::TestFlowRunLogs::test_reverse_tail_returns_default_num_logs - pydantic_core._pydantic_core.ValidationError: 1 validation error for LogCreate
FAILED tests/cli/test_flow_run.py::TestFlowRunLogs::test_when_num_logs_greater_than_page_size_with_tail_outputs_correct_num_logs - pydantic_core._pydantic_core.ValidationError: 1 validation error for LogCreate
```

Will follow with fix for remaining tests:
```bash
FAILED tests/cli/test_flow_run.py::TestFlowRunExecute::test_execute_flow_run_via_argument - assert False
FAILED tests/cli/test_flow_run.py::TestFlowRunExecute::test_execute_flow_run_via_environment_variable - assert False
```