### PR TITLE
Fix `DeploymentCreate` validation error for `schedules` field

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -90,6 +90,7 @@ from prefect.client.schemas.objects import (
     FlowRunNotificationPolicy,
     FlowRunPolicy,
     Log,
+    MinimalDeploymentSchedule,
     Parameter,
     QueueFilter,
     TaskRunPolicy,
@@ -1558,7 +1559,9 @@ class PrefectClient:
         name: str,
         version: Optional[str] = None,
         schedule: Optional[SCHEDULE_TYPES] = None,
-        schedules: Optional[List[DeploymentScheduleCreate]] = None,
+        schedules: Optional[
+            List[Union[DeploymentScheduleCreate, MinimalDeploymentSchedule]]
+        ] = None,
         parameters: Optional[Dict[str, Any]] = None,
         description: Optional[str] = None,
         work_queue_name: Optional[str] = None,
@@ -1600,7 +1603,6 @@ class PrefectClient:
         Returns:
             the ID of the deployment in the backend
         """
-
         deployment_create = DeploymentCreate(
             flow_id=flow_id,
             name=name,

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -17,7 +17,11 @@ from prefect._internal.schemas.validators import (
     validate_name_present_on_nonanonymous_blocks,
     validate_schedule_max_scheduled_runs,
 )
-from prefect.client.schemas.objects import StateDetails, StateType
+from prefect.client.schemas.objects import (
+    MinimalDeploymentSchedule,
+    StateDetails,
+    StateType,
+)
 from prefect.client.schemas.schedules import SCHEDULE_TYPES
 from prefect.settings import PREFECT_DEPLOYMENT_SCHEDULE_MAX_SCHEDULED_RUNS
 from prefect.types import (
@@ -164,7 +168,7 @@ class DeploymentCreate(ActionBaseModel):
     flow_id: UUID = Field(..., description="The ID of the flow to deploy.")
     is_schedule_active: Optional[bool] = Field(None)
     paused: Optional[bool] = Field(None)
-    schedules: List[DeploymentScheduleCreate] = Field(
+    schedules: List[Union[DeploymentScheduleCreate, MinimalDeploymentSchedule]] = Field(
         default_factory=list,
         description="A list of schedules for the deployment.",
     )

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -267,7 +267,6 @@ class RunnerDeployment(BaseModel):
         Returns:
             The ID of the created deployment.
         """
-
         work_pool_name = work_pool_name or self.work_pool_name
 
         if image and not work_pool_name:

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -267,6 +267,7 @@ class RunnerDeployment(BaseModel):
         Returns:
             The ID of the created deployment.
         """
+
         work_pool_name = work_pool_name or self.work_pool_name
 
         if image and not work_pool_name:


### PR DESCRIPTION
Fixes tests in `tests/cli/test_flow.py`:
```bash
FAILED tests/cli/test_flow.py::TestFlowServe::test_flow_serve_cli_accepts_interval - prefect.deployments.runner.DeploymentApplyError: Error while applying deployment: 1 validation error for DeploymentCreate
FAILED tests/cli/test_flow.py::TestFlowServe::test_flow_serve_cli_accepts_cron - prefect.deployments.runner.DeploymentApplyError: Error while applying deployment: 1 validation error for DeploymentCreate
FAILED tests/cli/test_flow.py::TestFlowServe::test_flow_serve_cli_accepts_rrule - prefect.deployments.runner.DeploymentApplyError: Error while applying deployment: 1 validation error for DeploymentCreate
```
and test in `tests/cli/test_shell.py`
```bash
FAILED tests/cli/test_shell.py::test_shell_serve_options - prefect.deployments.runner.DeploymentApplyError: Error while applying deployment: 1 validation error for DeploymentCreate
```