### PR TITLE
Fix most `test_deployment_cli.py` tests

### DIFF
--- a/tests/cli/deployment/test_deployment_cli.py
+++ b/tests/cli/deployment/test_deployment_cli.py
@@ -5,8 +5,8 @@ import pytest
 
 from prefect import flow
 from prefect.client.orchestration import PrefectClient
-from prefect.server.schemas.filters import DeploymentFilter, DeploymentFilterId
-from prefect.server.schemas.schedules import IntervalSchedule
+from prefect.client.schemas.filters import DeploymentFilter, DeploymentFilterId
+from prefect.client.schemas.schedules import IntervalSchedule
 from prefect.settings import (
     PREFECT_API_SERVICES_TRIGGERS_ENABLED,
     temporary_settings,


### PR DESCRIPTION
Should fix: 
```bash
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_list_schedules - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_interval_without_anchor_date[commands0] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_interval_without_anchor_date[commands1] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_no_schedule[commands0] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_no_schedule[commands1] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_with_no_schedule_and_schedule_options_raises - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_with_too_many_schedule_options_raises[commands0-Exactly one of `--interval`, `--rrule`, `--cron` or `--no-schedule` must be provided] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_with_too_many_schedule_options_raises[commands1-Exactly one of `--interval`, `--rrule`, or `--cron` must be provided] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_with_no_schedule_options_raises[commands0-Exactly one of `--interval`, `--rrule`, `--cron` or `--no-schedule` must be provided] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_with_no_schedule_options_raises[commands1-Exactly one of `--interval`, `--rrule`, or `--cron` must be provided] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_json_rrule[commands0] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_json_rrule[commands1] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_json_rrule_has_timezone[commands0] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_json_rrule_has_timezone[commands1] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_json_rrule_with_timezone_arg[commands0] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_json_rrule_with_timezone_arg[commands1] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_json_rrule_with_timezone_arg_overrides_if_passed_explicitly[commands0] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_json_rrule_with_timezone_arg_overrides_if_passed_explicitly[commands1] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_str_literal_rrule[commands0] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_str_literal_rrule[commands1] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_str_literal_rrule_has_timezone[commands0] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_str_literal_rrule_has_timezone[commands1] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_str_literal_rrule_with_timezone_arg[commands0] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_str_literal_rrule_with_timezone_arg[commands1] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_str_literal_rrule_with_timezone_arg_overrides_if_passed_explicitly[commands0] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_str_literal_rrule_with_timezone_arg_overrides_if_passed_explicitly[commands1] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_updates_cron[commands0] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_updates_cron[commands1] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_deployment_not_found_raises[commands0] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_deployment_not_found_raises[commands1] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_pausing_and_resuming_schedules_with_pause_schedule - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_pausing_and_resuming_schedules_with_schedule_pause - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_pause_schedule_deployment_not_found_raises - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_schedule_pause_deployment_not_found_raises - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_pause_schedule_multiple_schedules_raises - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_updating_anchor_date_respected[commands0] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_updating_anchor_date_respected[commands1] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_updating_anchor_date_without_interval_raises[commands0-An anchor date can only be provided with an interval schedule] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_updating_anchor_date_without_interval_raises[commands1-An anchor date can only be provided with an interval schedule] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_invalid_interval_anchor_raises[commands0-The anchor date must be a valid date string.] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_set_schedule_invalid_interval_anchor_raises[commands1-The anchor date must be a valid date string.] - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_create_schedule_replace_replaces_existing_schedules_many - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_create_schedule_replace_replaces_existing_schedule - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_create_schedule_replace_seeks_confirmation - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_create_schedule_replace_accepts_confirmation - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_clear_schedule_deletes - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_clear_schedule_raises_if_deployment_does_not_exist - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_delete_schedule_deletes - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_delete_schedule_raises_if_schedule_does_not_exist - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
ERROR tests/cli/deployment/test_deployment_cli.py::TestDeploymentSchedules::test_delete_schedule_raises_if_deployment_does_not_exist - pydantic_core._pydantic_core.ValidationError: 4 validation errors for DeploymentCreate
```