### PR TITLE
variable cli updates

### DIFF
--- a/src/prefect/cli/_types.py
+++ b/src/prefect/cli/_types.py
@@ -118,6 +118,7 @@ class PrefectTyper(typer.Typer):
 
     def command(
         self,
+        name: Optional[str] = None,
         *args,
         aliases: List[str] = None,
         deprecated: bool = False,
@@ -153,7 +154,9 @@ class PrefectTyper(typer.Typer):
                 fn = with_deprecated_message(self.deprecated_message)(fn)
 
             # register fn with its original name
-            command_decorator = super(PrefectTyper, self).command(*args, **kwargs)
+            command_decorator = super(PrefectTyper, self).command(
+                name=name, *args, **kwargs
+            )
             original_command = command_decorator(fn)
 
             # register fn for each alias, e.g. @marvin_app.command(aliases=["r"])

--- a/src/prefect/cli/variable.py
+++ b/src/prefect/cli/variable.py
@@ -124,6 +124,18 @@ async def _set(
         Optional[List[str]], typer.Option(help="Tag to associate with the variable.")
     ] = None,
 ):
+    """
+    Set a variable.
+
+    If the variable already exists, use `--overwrite` to update it.
+
+    Arguments:
+        name: the name of the variable to set
+        value: the value of the variable to set
+        --overwrite: overwrite the variable if it already exists
+        --tag: tag to associate with the variable (you may pass multiple)
+    """
+
     async with get_client() as client:
         variable = await client.read_variable_by_name(name)
         var_dict = {"name": name, "value": parse_value(value), "tags": tag or []}

--- a/src/prefect/cli/variable.py
+++ b/src/prefect/cli/variable.py
@@ -1,12 +1,17 @@
+import json
+from typing import Any, Dict, List, Optional, Union
+
 import pendulum
 import typer
 from rich.pretty import Pretty
 from rich.table import Table
+from typing_extensions import Annotated
 
 from prefect import get_client
 from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error, exit_with_success
 from prefect.cli.root import app
+from prefect.client.schemas.actions import VariableCreate, VariableUpdate
 from prefect.exceptions import ObjectNotFound
 
 variable_app = PrefectTyper(
@@ -46,7 +51,7 @@ async def list_variables(
         for variable in sorted(variables, key=lambda x: f"{x.name}"):
             table.add_row(
                 variable.name,
-                variable.value,
+                json.dumps(variable.value),
                 pendulum.instance(variable.created).diff_for_humans(),
                 pendulum.instance(variable.updated).diff_for_humans(),
             )
@@ -75,15 +80,74 @@ async def inspect(
         app.console.print(Pretty(variable))
 
 
-@variable_app.command("delete")
-async def delete(
+@variable_app.command("get")
+async def get(
     name: str,
 ):
     """
-    Delete a variable.
+    Get a variable's value.
 
     Arguments:
-        name: the name of the variable to delete
+        name: the name of the variable to get
+    """
+
+    async with get_client() as client:
+        variable = await client.read_variable_by_name(
+            name=name,
+        )
+        if variable:
+            app.console.print(json.dumps(variable.value))
+        else:
+            exit_with_error(f"Variable {name!r} not found.")
+
+
+def parse_value(
+    value: str,
+) -> Union[str, int, float, bool, None, Dict[str, Any], List[str]]:
+    try:
+        parsed_value = json.loads(value)
+    except json.JSONDecodeError:
+        parsed_value = value
+    return parsed_value
+
+
+@variable_app.command("set")
+async def _set(
+    name: str,
+    value: str,
+    overwrite: bool = typer.Option(
+        False,
+        "--overwrite",
+        help="Overwrite the variable if it already exists.",
+    ),
+    tag: Annotated[
+        Optional[List[str]], typer.Option(help="Tag to associate with the variable.")
+    ] = None,
+):
+    async with get_client() as client:
+        variable = await client.read_variable_by_name(name)
+        var_dict = {"name": name, "value": parse_value(value), "tags": tag or []}
+        if variable:
+            if not overwrite:
+                exit_with_error(
+                    f"Variable {name!r} already exists. Use `--overwrite` to update it."
+                )
+            await client.update_variable(VariableUpdate(**var_dict))
+        else:
+            await client.create_variable(VariableCreate(**var_dict))
+
+        exit_with_success(f"Set variable {name!r}.")
+
+
+@variable_app.command("unset", aliases=["delete"])
+async def unset(
+    name: str,
+):
+    """
+    Unset a variable.
+
+    Arguments:
+        name: the name of the variable to unset
     """
 
     async with get_client() as client:
@@ -94,4 +158,4 @@ async def delete(
         except ObjectNotFound:
             exit_with_error(f"Variable {name!r} not found.")
 
-        exit_with_success(f"Deleted variable {name!r}.")
+        exit_with_success(f"Unset variable {name!r}.")

--- a/tests/cli/test_variable.py
+++ b/tests/cli/test_variable.py
@@ -94,9 +94,88 @@ def test_delete_variable_doesnt_exist():
     )
 
 
+def test_get_variable(variable):
+    invoke_and_assert(
+        ["variable", "get", variable.name],
+        expected_output_contains=variable.value,
+        expected_code=0,
+    )
+
+
+def test_get_variable_doesnt_exist(variable):
+    invoke_and_assert(
+        ["variable", "get", "doesnt_exist"],
+        expected_output_contains="Variable 'doesnt_exist' not found",
+        expected_code=1,
+    )
+
+
+def test_set_variable():
+    invoke_and_assert(
+        [
+            "variable",
+            "set",
+            "my_variable",
+            "my-value",
+            "--tag",
+            "tag1",
+            "--tag",
+            "tag2",
+        ],
+        expected_output_contains="Set variable 'my_variable'.",
+        expected_code=0,
+    )
+    invoke_and_assert(
+        ["variable", "inspect", "my_variable"],
+        expected_output_contains=[
+            "name='my_variable'",
+            "value='my-value'",
+            "tags=['tag1', 'tag2']",
+        ],
+        expected_code=0,
+    )
+
+
+def test_set_existing_variable_without_overwrite(variable):
+    invoke_and_assert(
+        ["variable", "set", variable.name, "new-value"],
+        expected_output_contains="already exists. Use `--overwrite` to update it.",
+        expected_code=1,
+    )
+
+
+def test_set_overwrite_variable(variable):
+    invoke_and_assert(
+        ["variable", "set", variable.name, "new-value", "--overwrite"],
+        expected_output_contains=f"Set variable {variable.name!r}",
+        expected_code=0,
+    )
+    invoke_and_assert(
+        ["variable", "get", variable.name],
+        expected_output_contains="new-value",
+        expected_code=0,
+    )
+
+
+def test_unset_variable_doesnt_exist():
+    invoke_and_assert(
+        ["variable", "unset", "doesnt_exist"],
+        expected_output_contains="Variable 'doesnt_exist' not found",
+        expected_code=1,
+    )
+
+
+def test_unset_variable(variable):
+    invoke_and_assert(
+        ["variable", "unset", variable.name],
+        expected_output_contains=f"Unset variable {variable.name!r}.",
+        expected_code=0,
+    )
+
+
 def test_delete_variable(variable):
     invoke_and_assert(
         ["variable", "delete", variable.name],
-        expected_output_contains=f"Deleted variable {variable.name!r}.",
+        expected_output_contains=f"Unset variable {variable.name!r}.",
         expected_code=0,
     )


### PR DESCRIPTION
This PR expands the `prefect variable ...` CLI to include a couple more commands.
- `prefect variable get` - to get the value of a variable
- `prefect variable set` - to set a variable (create or update, if you update you must pass `--overwrite`
- `prefect variable unset` - to delete a variable. This leaves the `delete` alias in place
- this pr fixes an issue with listing variables now that they are not always strings

### Example
```bash
➜ prefect variable set foo_bar_var '{"foo": "bar"}' --tag foo --tag bar
Set variable 'foo_bar_var'.
➜ prefect variable get foo_bar_var
{"foo": "bar"}
➜ prefect variable ls             
                                 Variables                                  
┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
┃ Name        ┃ Value                    ┃ Created        ┃ Updated        ┃
┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━┩
│ my_new_var  │ {"foo": "bar"}           │ 53 seconds ago │ 53 seconds ago │
└─────────────┴──────────────────────────┴────────────────┴────────────────┘
                 List Variables using `prefect variable ls`                 
➜ prefect variable unset foo_bar_var
Unset variable 'foo_bar_var'.
```