### PR TITLE
Add utilities to serialize context to a dictionary and hydrate context from a dictionary

### DIFF
--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -48,7 +48,7 @@ from prefect.exceptions import MissingContextError
 from prefect.futures import PrefectFuture
 from prefect.new_task_runners import TaskRunner
 from prefect.results import ResultFactory
-from prefect.settings import PREFECT_HOME, Profile, Settings, temporary_settings
+from prefect.settings import PREFECT_HOME, Profile, Settings
 from prefect.states import State
 from prefect.task_runners import BaseTaskRunner
 from prefect.utilities.asyncutils import run_sync
@@ -123,11 +123,11 @@ def hydrated_context(
                 )
                 stack.enter_context(task_run_context)
             # Set up tags context
-            if tags_context := serialized_context.get("tags"):
+            if tags_context := serialized_context.get("tags_context"):
                 stack.enter_context(tags(*tags_context["current_tags"]))
             # Set up settings context
-            if settings_context := serialized_context.get("settings"):
-                stack.enter_context(temporary_settings(**settings_context))
+            if settings_context := serialized_context.get("settings_context"):
+                stack.enter_context(SettingsContext(**settings_context))
         yield
 
 

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -10,7 +10,7 @@ import os
 import sys
 import warnings
 from collections import defaultdict
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from contextvars import ContextVar, Token
 from functools import update_wrapper
 from pathlib import Path
@@ -28,25 +28,30 @@ from typing import (
     TypeVar,
     Union,
 )
+from uuid import uuid4
 
+import anyio
+import anyio._backends._asyncio
 import anyio.abc
 import pendulum
 from pydantic.v1 import BaseModel, Field, PrivateAttr
+from sniffio import AsyncLibraryNotFoundError
 
 import prefect.logging
 import prefect.logging.configuration
 import prefect.settings
 from prefect._internal.schemas.fields import DateTimeTZ
-from prefect.client.orchestration import PrefectClient, SyncPrefectClient
+from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
 from prefect.client.schemas import FlowRun, TaskRun
 from prefect.events.worker import EventsWorker
 from prefect.exceptions import MissingContextError
 from prefect.futures import PrefectFuture
 from prefect.new_task_runners import TaskRunner
 from prefect.results import ResultFactory
-from prefect.settings import PREFECT_HOME, Profile, Settings
+from prefect.settings import PREFECT_HOME, Profile, Settings, temporary_settings
 from prefect.states import State
 from prefect.task_runners import BaseTaskRunner
+from prefect.utilities.asyncutils import run_sync
 from prefect.utilities.importtools import load_script_as_module
 
 T = TypeVar("T")
@@ -59,6 +64,71 @@ if TYPE_CHECKING:
 # This will be populated downstream but must be null here to facilitate loading the
 # default settings.
 GLOBAL_SETTINGS_CONTEXT = None
+
+
+def serialize_context() -> Dict[str, Any]:
+    """
+    Serialize the current context for use in a remote execution environment.
+    """
+
+    flow_run_context = EngineContext.get()
+    task_run_context = TaskRunContext.get()
+    tags_context = TagsContext.get()
+    settings_context = SettingsContext.get()
+
+    return {
+        "flow_run_context": flow_run_context.serialize() if flow_run_context else {},
+        "task_run_context": task_run_context.serialize() if task_run_context else {},
+        "tags_context": tags_context.serialize() if tags_context else {},
+        "settings_context": settings_context.serialize() if settings_context else {},
+    }
+
+
+@contextmanager
+def hydrated_context(
+    serialized_context: Optional[Dict[str, Any]] = None,
+    client: Union[PrefectClient, SyncPrefectClient, None] = None,
+):
+    if not client:
+        client = get_client(sync_client=True)
+    with ExitStack() as stack:
+        if serialized_context:
+            # Set up parent flow run context
+            # TODO: This task group isn't necessary in the new engine. Remove the background tasks
+            # attribute from FlowRunContext.
+            try:
+                task_group = anyio.create_task_group()
+            except AsyncLibraryNotFoundError:
+                task_group = anyio._backends._asyncio.TaskGroup()
+            if flow_run_context := serialized_context.get("flow_run_context"):
+                flow = flow_run_context["flow"]
+                flow_run_context = FlowRunContext(
+                    **flow_run_context,
+                    client=client,
+                    background_tasks=task_group,
+                    result_factory=run_sync(ResultFactory.from_flow(flow)),
+                    task_runner=flow.task_runner.duplicate(),
+                    detached=True,
+                )
+                stack.enter_context(flow_run_context)
+            # Set up parent task run context
+            if parent_task_run_context := serialized_context.get("task_run_context"):
+                parent_task = parent_task_run_context["task"]
+                task_run_context = TaskRunContext(
+                    **parent_task_run_context,
+                    client=client,
+                    result_factory=run_sync(
+                        ResultFactory.from_autonomous_task(parent_task)
+                    ),
+                )
+                stack.enter_context(task_run_context)
+            # Set up tags context
+            if tags_context := serialized_context.get("tags"):
+                stack.enter_context(tags(*tags_context["current_tags"]))
+            # Set up settings context
+            if settings_context := serialized_context.get("settings"):
+                stack.enter_context(temporary_settings(**settings_context))
+        yield
 
 
 class ContextModel(BaseModel):
@@ -114,6 +184,14 @@ class ContextModel(BaseModel):
         new = super().copy(**kwargs)
         new._token = None
         return new
+
+    def serialize(self) -> Dict[str, Any]:
+        """
+        Serialize the context model to a dictionary that can be pickled with cloudpickle.
+        """
+        return self.dict(
+            exclude_unset=True,
+        )
 
 
 class PrefectObjectRegistry(ContextModel):
@@ -210,6 +288,12 @@ class RunContext(ContextModel):
     input_keyset: Optional[Dict[str, Dict[str, str]]] = None
     client: Union[PrefectClient, SyncPrefectClient]
 
+    def serialize(self):
+        return self.dict(
+            include={"start_time", "input_keyset"},
+            exclude_unset=True,
+        )
+
 
 class EngineContext(RunContext):
     """
@@ -235,11 +319,25 @@ class EngineContext(RunContext):
     log_prints: bool = False
     parameters: Optional[Dict[str, Any]] = None
 
+    # Flag signaling if the flow run context has been serialized and sent
+    # to remote infrastructure.
+    detached: bool = False
+
     # Result handling
     result_factory: ResultFactory
 
     # Counter for task calls allowing unique
     task_run_dynamic_keys: Dict[str, int] = Field(default_factory=dict)
+
+    def get_dynamic_key_for_task_run(self, task: "Task"):
+        if self.detached:
+            return uuid4()
+        elif task.task_key not in self.task_run_dynamic_keys:
+            self.task_run_dynamic_keys[task.task_key] = 0
+        else:
+            self.task_run_dynamic_keys[task.task_key] += 1
+
+        return self.task_run_dynamic_keys[task.task_key]
 
     # Counter for flow pauses
     observed_flow_pauses: Dict[str, int] = Field(default_factory=dict)
@@ -262,6 +360,19 @@ class EngineContext(RunContext):
     events: Optional[EventsWorker] = None
 
     __var__ = ContextVar("flow_run")
+
+    def serialize(self):
+        return self.dict(
+            include={
+                "flow_run",
+                "flow",
+                "parameters",
+                "log_prints",
+                "start_time",
+                "input_keyset",
+            },
+            exclude_unset=True,
+        )
 
 
 FlowRunContext = EngineContext  # for backwards compatibility
@@ -286,6 +397,19 @@ class TaskRunContext(RunContext):
     result_factory: ResultFactory
 
     __var__ = ContextVar("task_run")
+
+    def serialize(self):
+        return self.dict(
+            include={
+                "task_run",
+                "task",
+                "parameters",
+                "log_prints",
+                "start_time",
+                "input_keyset",
+            },
+            exclude_unset=True,
+        )
 
 
 class TagsContext(ContextModel):

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -28,7 +28,6 @@ from typing import (
     TypeVar,
     Union,
 )
-from uuid import uuid4
 
 import anyio
 import anyio._backends._asyncio
@@ -328,16 +327,6 @@ class EngineContext(RunContext):
 
     # Counter for task calls allowing unique
     task_run_dynamic_keys: Dict[str, int] = Field(default_factory=dict)
-
-    def get_dynamic_key_for_task_run(self, task: "Task"):
-        if self.detached:
-            return uuid4()
-        elif task.task_key not in self.task_run_dynamic_keys:
-            self.task_run_dynamic_keys[task.task_key] = 0
-        else:
-            self.task_run_dynamic_keys[task.task_key] += 1
-
-        return self.task_run_dynamic_keys[task.task_key]
 
     # Counter for flow pauses
     observed_flow_pauses: Dict[str, int] = Field(default_factory=dict)

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -523,6 +523,7 @@ class Task(Generic[P, R]):
     ) -> TaskRun:
         from prefect.engine import NUM_CHARS_DYNAMIC_KEY
         from prefect.utilities.engine import (
+            _dynamic_key_for_task_run,
             collect_task_run_inputs_sync,
         )
 
@@ -534,7 +535,7 @@ class Task(Generic[P, R]):
             parameters = {}
 
         if flow_run_context:
-            dynamic_key = flow_run_context.get_dynamic_key_for_task_run(self)
+            dynamic_key = _dynamic_key_for_task_run(context=flow_run_context, task=self)
         else:
             dynamic_key = uuid4().hex
 

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -523,7 +523,6 @@ class Task(Generic[P, R]):
     ) -> TaskRun:
         from prefect.engine import NUM_CHARS_DYNAMIC_KEY
         from prefect.utilities.engine import (
-            _dynamic_key_for_task_run,
             collect_task_run_inputs_sync,
         )
 
@@ -535,7 +534,7 @@ class Task(Generic[P, R]):
             parameters = {}
 
         if flow_run_context:
-            dynamic_key = _dynamic_key_for_task_run(context=flow_run_context, task=self)
+            dynamic_key = flow_run_context.get_dynamic_key_for_task_run(self)
         else:
             dynamic_key = uuid4().hex
 

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -562,7 +562,9 @@ def propose_state_sync(
 
 
 def _dynamic_key_for_task_run(context: FlowRunContext, task: Task) -> int:
-    if context.flow_run is None:  # this is an autonomous task run
+    if context.detached:  # this task is running on remote infrastructure
+        return str(uuid4())
+    elif context.flow_run is None:  # this is an autonomous task run
         context.task_run_dynamic_keys[task.task_key] = getattr(
             task, "dynamic_key", str(uuid4())
         )

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -13,13 +13,18 @@ from prefect.context import (
     ContextModel,
     FlowRunContext,
     SettingsContext,
+    TagsContext,
     TaskRunContext,
     get_run_context,
     get_settings_context,
+    hydrated_context,
     root_settings_context,
+    serialize_context,
+    tags,
     use_profile,
 )
 from prefect.exceptions import MissingContextError
+from prefect.new_task_runners import ThreadPoolTaskRunner
 from prefect.results import ResultFactory
 from prefect.settings import (
     DEFAULT_PROFILES_PATH,
@@ -394,3 +399,201 @@ class TestSettingsContext:
             result = portal.call(get_settings_context)
 
         assert result == GLOBAL_SETTINGS_CONTEXT
+
+
+class TestSerializeContext:
+    def test_empty(self):
+        serialized = serialize_context()
+        assert serialized == {
+            "flow_run_context": {},
+            "task_run_context": {},
+            "tags_context": {},
+            "settings_context": SettingsContext.get().serialize(),
+        }
+
+    async def test_with_flow_run_context(self, prefect_client):
+        @flow
+        def foo():
+            pass
+
+        test_task_runner = ThreadPoolTaskRunner()
+        flow_run = await prefect_client.create_flow_run(foo)
+        result_factory = await ResultFactory.from_flow(foo)
+
+        async with anyio.create_task_group() as task_group:
+            with FlowRunContext(
+                flow=foo,
+                flow_run=flow_run,
+                client=prefect_client,
+                task_runner=test_task_runner,
+                result_factory=result_factory,
+                background_tasks=task_group,
+                parameters={"x": "y"},
+            ) as flow_run_context:
+                serialized = serialize_context()
+                assert serialized == {
+                    "flow_run_context": flow_run_context.serialize(),
+                    "task_run_context": {},
+                    "tags_context": {},
+                    "settings_context": SettingsContext.get().serialize(),
+                }
+
+    async def test_with_task_run_context(self, prefect_client, flow_run):
+        @task
+        def bar():
+            pass
+
+        task_run = await prefect_client.create_task_run(
+            bar, flow_run.id, dynamic_key=""
+        )
+
+        with TaskRunContext(
+            task=bar,
+            task_run=task_run,
+            client=prefect_client,
+            result_factory=await ResultFactory.from_task(bar, client=prefect_client),
+            parameters={"foo": "bar"},
+        ) as task_ctx:
+            serialized = serialize_context()
+            assert serialized == {
+                "flow_run_context": {},
+                "task_run_context": task_ctx.serialize(),
+                "tags_context": {},
+                "settings_context": SettingsContext.get().serialize(),
+            }
+
+    def test_with_tags_context(self):
+        with tags("a", "b") as current_tags:
+            serialized = serialize_context()
+            assert serialized == {
+                "flow_run_context": {},
+                "task_run_context": {},
+                "tags_context": {"current_tags": current_tags},
+                "settings_context": SettingsContext.get().serialize(),
+            }
+
+    def test_with_multiple_contexts(self):
+        with tags("a", "b") as current_tags:
+            with temporary_settings(
+                updates={PREFECT_API_KEY: "test", PREFECT_API_URL: "test"}
+            ):
+                serialized = serialize_context()
+                assert serialized == {
+                    "flow_run_context": {},
+                    "task_run_context": {},
+                    "tags_context": {"current_tags": current_tags},
+                    "settings_context": SettingsContext.get().serialize(),
+                }
+                assert (
+                    serialized["settings_context"]["settings"]["PREFECT_API_KEY"]
+                    == "test"
+                )
+                assert (
+                    serialized["settings_context"]["settings"]["PREFECT_API_URL"]
+                    == "test"
+                )
+
+
+class TestHydratedContext:
+    def test_empty(self):
+        initial_settings_context = SettingsContext.get()
+        with hydrated_context({}):
+            assert FlowRunContext.get() is None
+            assert TaskRunContext.get() is None
+            assert TagsContext.get().current_tags == set()
+            assert SettingsContext.get() == initial_settings_context
+
+    async def test_with_flow_run_context(self, prefect_client):
+        @flow
+        def foo():
+            pass
+
+        test_task_runner = ThreadPoolTaskRunner()
+        flow_run = await prefect_client.create_flow_run(foo)
+        result_factory = await ResultFactory.from_flow(foo)
+        async with anyio.create_task_group() as task_group:
+            flow_run_context = FlowRunContext(
+                flow=foo,
+                flow_run=flow_run,
+                client=prefect_client,
+                task_runner=test_task_runner,
+                result_factory=result_factory,
+                background_tasks=task_group,
+                parameters={"x": "y"},
+            )
+
+        with hydrated_context(
+            {
+                "flow_run_context": flow_run_context.serialize(),
+            }
+        ):
+            hydrated_flow_run_context = FlowRunContext.get()
+            assert hydrated_flow_run_context.flow is foo
+            assert hydrated_flow_run_context.flow_run == flow_run
+            assert (
+                hydrated_flow_run_context.client is not None
+            )  # this won't be the same object as the original client
+            assert (
+                hydrated_flow_run_context.task_runner is not None
+            )  # this won't be the same object as the original task runner
+            assert (
+                hydrated_flow_run_context.result_factory is not None
+            )  # this won't be the same object as the original result factory
+            assert (
+                hydrated_flow_run_context.background_tasks is not None
+            )  # this won't be the same object as the original background tasks
+            assert isinstance(hydrated_flow_run_context.start_time, DateTime)
+            assert hydrated_flow_run_context.parameters == {"x": "y"}
+
+    async def test_with_task_run_context(self, prefect_client, flow_run):
+        @task
+        def bar():
+            pass
+
+        task_run = await prefect_client.create_task_run(
+            bar, flow_run.id, dynamic_key=""
+        )
+        task_ctx = TaskRunContext(
+            task=bar,
+            task_run=task_run,
+            client=prefect_client,
+            result_factory=await ResultFactory.from_task(bar, client=prefect_client),
+            parameters={"foo": "bar"},
+        )
+
+        with hydrated_context(
+            {
+                "task_run_context": task_ctx.serialize(),
+            }
+        ):
+            hydrated_task_ctx = TaskRunContext.get()
+            assert hydrated_task_ctx.task is bar
+            assert hydrated_task_ctx.task_run == task_run
+            assert hydrated_task_ctx.result_factory is not None
+            assert isinstance(hydrated_task_ctx.start_time, DateTime)
+            assert hydrated_task_ctx.parameters == {"foo": "bar"}
+
+    def test_with_tags_context(self):
+        with hydrated_context(
+            {
+                "tags_context": {"current_tags": {"a", "b"}},
+            }
+        ):
+            assert TagsContext.get().current_tags == {"a", "b"}
+
+    def test_with_settings_context(self):
+        with hydrated_context(
+            {
+                "settings_context": {
+                    "profile": {"name": "test", "settings": {}, "source": None},
+                    "settings": {"PREFECT_API_KEY": "test", "PREFECT_API_URL": "test"},
+                },
+            }
+        ):
+            assert SettingsContext.get().profile == Profile(
+                name="test",
+                settings={},
+                source=None,
+            )
+            assert SettingsContext.get().settings.PREFECT_API_KEY == "test"
+            assert SettingsContext.get().settings.PREFECT_API_URL == "test"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
When running tasks on remote infrastructure like Dask and Ray with the task engine, we lose some of the context surrounding the current task run. This makes it difficult to link the task run back to its parent run. This can also make it difficult to ensure the correct settings are propagated to the remote infrastructure.

This PR introduces two mirror utilities: `serialize_context` and `hydrated_context`. When used in conjunction, we can serialize the current context to a pickleable dictionary, send it to the remote infrastructure, and recreate it. This helps to make the task engine highly portable and helps us maintain consistent dependency tracking.

The task run engine has been updated to accept a `context` kwargs, which consumes the output of `serialize_context`.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Submit a task to Dask with the current context:
```python
from uuid import uuid4

from distributed import Client

from prefect import flow, task
from prefect.context import serialize_context


@task
def square(x):
    return x**2


@flow
def my_flow():
    context = serialize_context()
    with Client() as client:
        future = client.submit(
            run_task,
            square,
            parameters={"x": 42},
            context=context,
        )
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `netlify.toml` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `mkdocs.yml` navigation.
