### PR TITLE
Use `serialize_as_any` when calling `model_dump_json` in `to_bytes` method of `PersistedResultBlob`

### DIFF
--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -721,7 +721,7 @@ class PersistedResultBlob(BaseModel):
     prefect_version: str = Field(default=prefect.__version__)
 
     def to_bytes(self) -> bytes:
-        return self.model_dump_json().encode()
+        return self.model_dump_json(serialize_as_any=True).encode()
 
 
 class UnknownResult(BaseResult):


### PR DESCRIPTION
More info here: https://docs.pydantic.dev/latest/concepts/serialization/#serializing-with-duck-typing

Fixes: `tests/results/test_persisted_result.py`

Before:
```bash
    async def test_result_reference_create_uses_serializer(storage_block):
        serializer = PickleSerializer(picklelib="pickle")
    
        result = await PersistedResult.create(
            "test",
            storage_block_id=storage_block._block_document_id,
            storage_block=storage_block,
            storage_key_fn=DEFAULT_STORAGE_KEY_FN,
            serializer=serializer,
        )
    
        assert result.serializer_type == serializer.type
        contents = await storage_block.read_path(result.storage_key)
        blob = PersistedResultBlob.parse_raw(contents)
>       assert blob.serializer == serializer
E       AssertionError: assert PickleSerializer(type='pickle', picklelib='cloudpickle', picklelib_version=None) == PickleSerializer(type='pickle', picklelib='pickle', picklelib_version=None)
E         Full diff:
E         - PickleSerializer(type='pickle', picklelib='pickle', picklelib_version=None)
E         + PickleSerializer(type='pickle', picklelib='cloudpickle', picklelib_version=None)
E         ?                                            +++++

tests/results/test_persisted_result.py:82: AssertionError
----------------------------------------------------------------------------------------------------------------------------- Captured stderr setup ------------------------------------------------------------------------------------------------------------------------------
16:33:27.006 | DEBUG   | prefect.client - Using ephemeral application with database at sqlite+aiosqlite:////var/folders/w4/979gp2bx3td2207pd3fd_vsm0000gn/T/tmp4nrgznl0/prefect.db
16:33:27.006 | DEBUG   | MainThread   | prefect._internal.concurrency - <function Block.register_type_and_schema at 0x105920e00> --> return coroutine for user await
------------------------------------------------------------------------------------------------------------------------------- Captured log setup -------------------------------------------------------------------------------------------------------------------------------
DEBUG    prefect.client:orchestration.py:3244 Using ephemeral application with database at sqlite+aiosqlite:////var/folders/w4/979gp2bx3td2207pd3fd_vsm0000gn/T/tmp4nrgznl0/prefect.db
------------------------------------------------------------------------------------------------------------------------------ Captured stderr call ------------------------------------------------------------------------------------------------------------------------------
16:33:27.106 | DEBUG   | MainThread   | prefect._internal.concurrency - <function PersistedResult.create at 0x105a004a0> --> return coroutine for user await
16:33:27.107 | DEBUG   | MainThread   | prefect._internal.concurrency - <function LocalFileSystem.write_path at 0x1059ae160> --> return coroutine for user await
16:33:27.108 | DEBUG   | MainThread   | prefect._internal.concurrency - <function LocalFileSystem.read_path at 0x1059aca40> --> return coroutine for user await
============================================================================================================================ short test summary info =============================================================================================================================
FAILED tests/results/test_persisted_result.py::test_result_reference_create_uses_serializer - AssertionError: assert PickleSerializer(type='pickle', picklelib='cloudpickle', picklelib_version=None) == PickleSerializer(type='pickle', picklelib='pickle', picklelib_version=None)
```