### PR TITLE
Task Hook decorators

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -2272,10 +2272,10 @@ async def _run_task_hooks(task: Task, task_run: TaskRun, state: State) -> None:
     catch and log any errors that occur.
     """
     hooks = None
-    if state.is_failed() and task.on_failure:
-        hooks = task.on_failure
-    elif state.is_completed() and task.on_completion:
-        hooks = task.on_completion
+    if state.is_failed() and task.on_failure_hooks:
+        hooks = task.on_failure_hooks
+    elif state.is_completed() and task.on_completion_hooks:
+        hooks = task.on_completion_hooks
 
     if hooks:
         logger = task_run_logger(task_run)

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -125,10 +125,10 @@ class TaskRunEngine(Generic[P, R]):
             raise ValueError("Task run is not set")
 
         hooks = None
-        if state.is_failed() and task.on_failure:
-            hooks = task.on_failure
-        elif state.is_completed() and task.on_completion:
-            hooks = task.on_completion
+        if state.is_failed() and task.on_failure_hooks:
+            hooks = task.on_failure_hooks
+        elif state.is_completed() and task.on_completion_hooks:
+            hooks = task.on_completion_hooks
 
         for hook in hooks or []:
             hook_name = _get_hook_name(hook)

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -233,8 +233,6 @@ class Task(Generic[P, R]):
         hook_names = ["on_completion", "on_failure"]
         for hooks, hook_name in zip(hook_categories, hook_names):
             if hooks is not None:
-                if not hooks:
-                    raise ValueError(f"Empty list passed for '{hook_name}'")
                 try:
                     hooks = list(hooks)
                 except TypeError:
@@ -242,8 +240,8 @@ class Task(Generic[P, R]):
                         f"Expected iterable for '{hook_name}'; got"
                         f" {type(hooks).__name__} instead. Please provide a list of"
                         f" hooks to '{hook_name}':\n\n"
-                        f"@flow({hook_name}=[hook1, hook2])\ndef"
-                        " my_flow():\n\tpass"
+                        f"@task({hook_name}=[hook1, hook2])\ndef"
+                        " my_task():\n\tpass"
                     )
 
                 for hook in hooks:
@@ -252,8 +250,8 @@ class Task(Generic[P, R]):
                             f"Expected callables in '{hook_name}'; got"
                             f" {type(hook).__name__} instead. Please provide a list of"
                             f" hooks to '{hook_name}':\n\n"
-                            f"@flow({hook_name}=[hook1, hook2])\ndef"
-                            " my_flow():\n\tpass"
+                            f"@task({hook_name}=[hook1, hook2])\ndef"
+                            " my_task():\n\tpass"
                         )
 
         if not callable(fn):
@@ -333,8 +331,8 @@ class Task(Generic[P, R]):
         self.result_storage_key = result_storage_key
         self.cache_result_in_memory = cache_result_in_memory
         self.timeout_seconds = float(timeout_seconds) if timeout_seconds else None
-        self.on_completion_hooks = on_completion
-        self.on_failure_hooks = on_failure
+        self.on_completion_hooks = on_completion or []
+        self.on_failure_hooks = on_failure or []
 
         # retry_condition_fn must be a callable or None. If it is neither, raise a TypeError
         if retry_condition_fn is not None and not (callable(retry_condition_fn)):
@@ -510,6 +508,18 @@ class Task(Generic[P, R]):
             retry_condition_fn=retry_condition_fn or self.retry_condition_fn,
             viz_return_value=viz_return_value or self.viz_return_value,
         )
+
+    def on_completion(
+        self, fn: Callable[["Task", TaskRun, State], None]
+    ) -> Callable[["Task", TaskRun, State], None]:
+        self.on_completion_hooks.append(fn)
+        return fn
+
+    def on_failure(
+        self, fn: Callable[["Task", TaskRun, State], None]
+    ) -> Callable[["Task", TaskRun, State], None]:
+        self.on_failure_hooks.append(fn)
+        return fn
 
     async def create_run(
         self,

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -333,8 +333,8 @@ class Task(Generic[P, R]):
         self.result_storage_key = result_storage_key
         self.cache_result_in_memory = cache_result_in_memory
         self.timeout_seconds = float(timeout_seconds) if timeout_seconds else None
-        self.on_completion = on_completion
-        self.on_failure = on_failure
+        self.on_completion_hooks = on_completion
+        self.on_failure_hooks = on_failure
 
         # retry_condition_fn must be a callable or None. If it is neither, raise a TypeError
         if retry_condition_fn is not None and not (callable(retry_condition_fn)):
@@ -505,8 +505,8 @@ class Task(Generic[P, R]):
             refresh_cache=(
                 refresh_cache if refresh_cache is not NotSet else self.refresh_cache
             ),
-            on_completion=on_completion or self.on_completion,
-            on_failure=on_failure or self.on_failure,
+            on_completion=on_completion or self.on_completion_hooks,
+            on_failure=on_failure or self.on_failure_hooks,
             retry_condition_fn=retry_condition_fn or self.retry_condition_fn,
             viz_return_value=viz_return_value or self.viz_return_value,
         )


### PR DESCRIPTION
This PR exposes a new pattern for specifying state change hooks while preserving the current syntax; specifically, for tasks, it allows hooks to be specified as follows:

```python
@task
def my_task():
    pass

@my_task.on_completion
def my_hook(t, tr, s):
    pass

@my_task.on_failure
def my_other_hook(t, tr, s):
    pass
```

This PR also removes the unnecessary constraint that prevents empty lists in hook specification.

Assuming this passes muster, I'll follow up by exposing this same pattern for flows as well.