### PR TITLE
Pin requests to <2.32.0 for `2.x`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,7 +29,7 @@ pytest-timeout
 pytest-xdist < 3.4.0 # 3.5.0 introduces some flakiness. Need to investigate and resolve.
 pytkdocs >= 0.14.2
 pyyaml
-requests
+requests<2.32.0  # `requests` renamed `get_connection` to `_get_connection`, which is a method docker-py monkeypatches. See https://github.com/docker/docker-py/issues/3256 Should be able to un-pin when docker-py hotfix is out.
 setuptools != 60.9.0; python_version < '3.8'
 vermin
 virtualenv


### PR DESCRIPTION
Clone of https://github.com/PrefectHQ/prefect/pull/13474 for `2.x`