### PR TITLE
fix hydration for workspace variables for `2.x`

### DIFF
--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -250,6 +250,8 @@ async def update_deployment(
                 ctx = await HydrationContext.build(
                     session=session,
                     raise_on_error=True,
+                    render_jinja=True,
+                    render_workspace_variables=True,
                 )
                 parameters = hydrate(dehydrated_params, ctx)
                 deployment.parameters = parameters
@@ -617,7 +619,12 @@ async def create_flow_run_from_deployment(
         try:
             dehydrated_params = deployment.parameters
             dehydrated_params.update(flow_run.parameters or {})
-            ctx = await HydrationContext.build(session=session, raise_on_error=True)
+            ctx = await HydrationContext.build(
+                session=session,
+                raise_on_error=True,
+                render_jinja=True,
+                render_workspace_variables=True,
+            )
             parameters = hydrate(dehydrated_params, ctx)
         except HydrationError as exc:
             raise HTTPException(

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -372,7 +372,10 @@ async def resume_flow_run(
 
             try:
                 hydration_context = await schema_tools.HydrationContext.build(
-                    session=session, raise_on_error=True
+                    session=session,
+                    raise_on_error=True,
+                    render_jinja=True,
+                    render_workspace_variables=True,
                 )
                 run_input = schema_tools.hydrate(run_input, hydration_context) or {}
             except schema_tools.HydrationError as exc:

--- a/src/prefect/server/api/ui/schemas.py
+++ b/src/prefect/server/api/ui/schemas.py
@@ -36,7 +36,9 @@ async def validate_obj(
         )
 
     async with db.session_context() as session:
-        ctx = await HydrationContext.build(session=session)
+        ctx = await HydrationContext.build(
+            session=session, render_jinja=False, render_workspace_variables=True
+        )
 
     hydrated_values = hydrate(values, ctx)
     try:

--- a/tests/server/api/test_deployments.py
+++ b/tests/server/api/test_deployments.py
@@ -2894,7 +2894,7 @@ class TestCreateFlowRunFromDeployment:
         res = response.json()
         assert res["parameters"] == {"param": "3"}
 
-    async def test_create_flow_workspace_variable_prefect_kind(
+    async def test_create_flow_run_workspace_variable_prefect_kind(
         self,
         deployment,
         client,
@@ -2916,6 +2916,8 @@ class TestCreateFlowRunFromDeployment:
                 }
             },
         )
+        print("ASDMFASKDMFALSJDFASDf")
+        print(response.content)
         assert response.status_code == 201
         res = response.json()
         assert res["parameters"] == {"param": "my_value"}

--- a/tests/server/api/test_deployments.py
+++ b/tests/server/api/test_deployments.py
@@ -1524,6 +1524,7 @@ class TestUpdateDeployment:
             session,
             schemas.actions.VariableCreate(name="my_variable", value="my_value"),
         )
+        await session.commit()
 
         response = await client.patch(
             f"/deployments/{deployment.id}",
@@ -2904,6 +2905,7 @@ class TestCreateFlowRunFromDeployment:
             session,
             schemas.actions.VariableCreate(name="my_variable", value="my_value"),
         )
+        await session.commit()
 
         response = await client.post(
             f"/deployments/{deployment.id}/create_flow_run",

--- a/tests/server/api/test_deployments.py
+++ b/tests/server/api/test_deployments.py
@@ -2834,7 +2834,7 @@ class TestCreateFlowRunFromDeployment:
         assert "Validation failed for field 'person'" in response.text
         assert "Failure reason: 'name' is a required property" in response.text
 
-    async def test_schemas_v2_basic_parameters(
+    async def test_create_flow_run_basic_parameters(
         self,
         deployment,
         client,
@@ -2847,7 +2847,7 @@ class TestCreateFlowRunFromDeployment:
         res = response.json()
         assert res["parameters"] == {"param1": 1, "param2": 2}
 
-    async def test_schemas_v2_none_prefect_kind(
+    async def test_create_flow_run_none_prefect_kind(
         self,
         deployment,
         client,
@@ -2860,7 +2860,7 @@ class TestCreateFlowRunFromDeployment:
         res = response.json()
         assert res["parameters"] == {"param": 5}
 
-    async def test_schemas_v2_json_prefect_kind(
+    async def test_create_flow_run_json_prefect_kind(
         self,
         deployment,
         client,
@@ -2877,7 +2877,7 @@ class TestCreateFlowRunFromDeployment:
         assert response.status_code == 201
         assert response.json()["parameters"]["x"] == "str_of_json"
 
-    async def test_schemas_v2_jinja_prefect_kind(
+    async def test_create_flow_run_jinja_prefect_kind(
         self,
         deployment,
         client,
@@ -2894,7 +2894,7 @@ class TestCreateFlowRunFromDeployment:
         res = response.json()
         assert res["parameters"] == {"param": "3"}
 
-    async def test_schemas_v2_workspace_variable_prefect_kind(
+    async def test_create_flow_workspace_variable_prefect_kind(
         self,
         deployment,
         client,

--- a/tests/server/api/test_deployments.py
+++ b/tests/server/api/test_deployments.py
@@ -1536,7 +1536,7 @@ class TestUpdateDeployment:
                 }
             },
         )
-        assert response.status_code == 204
+        assert response.status_code == 204, str(response.content)
 
         response = await client.get(f"/deployments/{deployment.id}")
         assert response.json()["parameters"] == {"x": "my_value"}
@@ -2916,9 +2916,7 @@ class TestCreateFlowRunFromDeployment:
                 }
             },
         )
-        print("ASDMFASKDMFALSJDFASDf")
-        print(response.content)
-        assert response.status_code == 201
+        assert response.status_code == 201, str(response.content)
         res = response.json()
         assert res["parameters"] == {"param": "my_value"}
 

--- a/tests/server/api/test_flow_runs.py
+++ b/tests/server/api/test_flow_runs.py
@@ -1405,6 +1405,7 @@ class TestResumeFlowrun:
             session,
             schemas.actions.VariableCreate(name="my_variable", value="my_value"),
         )
+        await session.commit()
 
         response = await client.post(
             f"/flow_runs/{paused_flow_run_waiting_for_input_with_default.id}/resume",

--- a/tests/server/api/test_flow_runs.py
+++ b/tests/server/api/test_flow_runs.py
@@ -1417,7 +1417,7 @@ class TestResumeFlowrun:
                 }
             },
         )
-        assert response.status_code == 201
+        assert response.status_code == 201, str(response.content)
         assert response.json()["status"] == "ACCEPT"
 
         flow_run_input = await models.flow_run_input.read_flow_run_input(

--- a/tests/utilities/schema_tools/test_hydration.py
+++ b/tests/utilities/schema_tools/test_hydration.py
@@ -318,7 +318,9 @@ class TestHydrateWithWorkspaceVariablePrefectKind:
             ),
         ],
     )
-    def test_hydrate_with_null_prefect_kind(self, input_object, expected_output, ctx):
+    def test_hydrate_with_workspace_variable_prefect_kind(
+        self, input_object, expected_output, ctx
+    ):
         hydrated_value = hydrate(input_object, ctx)
         assert hydrated_value == expected_output
 


### PR DESCRIPTION
closes: https://github.com/PrefectHQ/prefect/issues/13541

There was an update to how `HydrationContext` worked specifically for `actions` that got made in cloud but not in OSS. When actions got ported over to OSS, it brought 80% of that pr, but not the parts in the deployment/flow run api.

This PR updates `HydrationContext.build` to use the correct parameters in those endpoints. It also brings over a bunch of tests that would have caught this had I added them earlier.