### PR TITLE
Fix `test_callables` tests

### DIFF
--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -721,7 +721,7 @@ class PersistedResultBlob(BaseModel):
     prefect_version: str = Field(default=prefect.__version__)
 
     def to_bytes(self) -> bytes:
-        return self.model_dump_json().encode()
+        return self.model_dump_json(serialize_as_any=True).encode()
 
 
 class UnknownResult(BaseResult):

--- a/tests/utilities/test_callables.py
+++ b/tests/utilities/test_callables.py
@@ -17,7 +17,7 @@ class TestFunctionToSchema:
             pass
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
             "properties": {},
             "title": "Parameters",
             "type": "object",
@@ -42,7 +42,7 @@ class TestFunctionToSchema:
             pass
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
             "title": "Parameters",
             "type": "object",
             "properties": {
@@ -79,7 +79,7 @@ class TestFunctionToSchema:
             pass
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
             "title": "Parameters",
             "type": "object",
             "properties": {"x": {"title": "x", "position": 0}},
@@ -92,7 +92,7 @@ class TestFunctionToSchema:
             pass
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
             "title": "Parameters",
             "type": "object",
             "properties": {"x": {"default": 42, "position": 0, "title": "x"}},
@@ -105,7 +105,7 @@ class TestFunctionToSchema:
             pass
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
             "title": "Parameters",
             "type": "object",
             "properties": {
@@ -125,7 +125,7 @@ class TestFunctionToSchema:
             pass
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
             "title": "Parameters",
             "type": "object",
             "properties": {
@@ -171,8 +171,9 @@ class TestFunctionToSchema:
                 },
             },
             "required": ["x"],
+            "definitions": {},
         }
-        assert schema.model_dump() == expected_schema
+        assert schema.model_dump_for_openapi() == expected_schema
 
     def test_function_with_enum_argument(self):
         class Color(Enum):
@@ -196,6 +197,7 @@ class TestFunctionToSchema:
                     "title": "x",
                 }
             },
+            "required": [],
             "definitions": {
                 "Color": {
                     "enum": ["RED", "GREEN", "BLUE"],
@@ -205,7 +207,7 @@ class TestFunctionToSchema:
             },
         }
 
-        assert schema.model_dump() == expected_schema
+        assert schema.model_dump_for_openapi() == expected_schema
 
     def test_function_with_generic_arguments(self):
         def f(
@@ -250,9 +252,10 @@ class TestFunctionToSchema:
                 },
             },
             "required": ["a", "b", "c", "d", "e"],
+            "definitions": {},
         }
 
-        assert schema.model_dump() == expected_schema
+        assert schema.model_dump_for_openapi() == expected_schema
 
     def test_function_with_user_defined_type(self):
         class Foo:
@@ -262,7 +265,8 @@ class TestFunctionToSchema:
             pass
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
+            "definitions": {},
             "title": "Parameters",
             "type": "object",
             "properties": {"x": {"title": "x", "position": 0}},
@@ -278,7 +282,7 @@ class TestFunctionToSchema:
             pass
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
             "definitions": {
                 "Foo": {
                     "properties": {
@@ -315,7 +319,7 @@ class TestFunctionToSchema:
             ...
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
             "title": "Parameters",
             "type": "object",
             "properties": {
@@ -326,6 +330,7 @@ class TestFunctionToSchema:
                     "title": "foo",
                 }
             },
+            "required": [],
             "definitions": {
                 "Foo": {
                     "properties": {"bar": {"title": "Bar", "type": "string"}},
@@ -393,7 +398,7 @@ class TestFunctionToSchema:
         enum_schema.pop("description")
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
             "title": "Parameters",
             "type": "object",
             "properties": {
@@ -450,7 +455,7 @@ class TestFunctionToSchema:
             pass
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
             "title": "Parameters",
             "type": "object",
             "properties": {
@@ -463,6 +468,7 @@ class TestFunctionToSchema:
                 },
             },
             "required": ["x"],
+            "definitions": {},
         }
 
     def test_function_with_v1_secretstr_from_compat_module(self):
@@ -472,19 +478,17 @@ class TestFunctionToSchema:
             pass
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
             "title": "Parameters",
             "type": "object",
             "properties": {
                 "x": {
                     "title": "x",
                     "position": 0,
-                    "format": "password",
-                    "type": "string",
-                    "writeOnly": True,
                 },
             },
             "required": ["x"],
+            "definitions": {},
         }
 
 
@@ -504,10 +508,12 @@ class TestMethodToSchema:
 
         for method in [Foo().f, Foo.g, Foo.h]:
             schema = callables.parameter_schema(method)
-            assert schema.model_dump() == {
+            assert schema.model_dump_for_openapi() == {
                 "properties": {},
                 "title": "Parameters",
                 "type": "object",
+                "required": [],
+                "definitions": {},
             }
 
     def test_methods_with_enum_arguments(self):
@@ -542,6 +548,7 @@ class TestMethodToSchema:
                         "title": "color",
                     }
                 },
+                "required": [],
                 "definitions": {
                     "Color": {
                         "enum": ["RED", "GREEN", "BLUE"],
@@ -551,7 +558,7 @@ class TestMethodToSchema:
                 },
             }
 
-            assert schema.model_dump() == expected_schema
+            assert schema.model_dump_for_openapi() == expected_schema
 
     def test_methods_with_complex_arguments(self):
         class Foo:
@@ -592,8 +599,9 @@ class TestMethodToSchema:
                     },
                 },
                 "required": ["x"],
+                "definitions": {},
             }
-            assert schema.model_dump() == expected_schema
+            assert schema.model_dump_for_openapi() == expected_schema
 
 
 class TestParseFlowDescriptionToSchema:
@@ -606,13 +614,14 @@ class TestParseFlowDescriptionToSchema:
             """
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
             "title": "Parameters",
             "type": "object",
             "properties": {
                 "x": {"title": "x", "description": "required argument x", "position": 0}
             },
             "required": ["x"],
+            "definitions": {},
         }
 
     def test_flow_without_docstring(self):
@@ -620,11 +629,12 @@ class TestParseFlowDescriptionToSchema:
             pass
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
             "title": "Parameters",
             "type": "object",
             "properties": {"x": {"title": "x", "position": 0}},
             "required": ["x"],
+            "definitions": {},
         }
 
     def test_flow_without_args_docstring(self):
@@ -632,11 +642,12 @@ class TestParseFlowDescriptionToSchema:
             """Function f."""
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
             "title": "Parameters",
             "type": "object",
             "properties": {"x": {"title": "x", "position": 0}},
             "required": ["x"],
+            "definitions": {},
         }
 
     def test_flow_with_complex_args_docstring(self):
@@ -655,7 +666,7 @@ class TestParseFlowDescriptionToSchema:
             """
 
         schema = callables.parameter_schema(f)
-        assert schema.model_dump() == {
+        assert schema.model_dump_for_openapi() == {
             "title": "Parameters",
             "type": "object",
             "properties": {

--- a/tests/utilities/test_callables.py
+++ b/tests/utilities/test_callables.py
@@ -21,6 +21,8 @@ class TestFunctionToSchema:
             "properties": {},
             "title": "Parameters",
             "type": "object",
+            "required": [],
+            "definitions": {},
         }
 
     def test_function_with_pydantic_base_model_collisions(self):
@@ -69,6 +71,7 @@ class TestFunctionToSchema:
                 "validate",
                 "foo",
             ],
+            "definitions": {},
         }
 
     def test_function_with_one_required_argument(self):
@@ -81,6 +84,7 @@ class TestFunctionToSchema:
             "type": "object",
             "properties": {"x": {"title": "x", "position": 0}},
             "required": ["x"],
+            "definitions": {},
         }
 
     def test_function_with_one_optional_argument(self):
@@ -91,7 +95,9 @@ class TestFunctionToSchema:
         assert schema.model_dump() == {
             "title": "Parameters",
             "type": "object",
-            "properties": {"x": {"title": "x", "default": 42, "position": 0}},
+            "properties": {"x": {"default": 42, "position": 0, "title": "x"}},
+            "required": [],
+            "definitions": {},
         }
 
     def test_function_with_one_optional_annotated_argument(self):
@@ -103,8 +109,15 @@ class TestFunctionToSchema:
             "title": "Parameters",
             "type": "object",
             "properties": {
-                "x": {"title": "x", "default": 42, "type": "integer", "position": 0}
+                "x": {
+                    "default": 42,
+                    "position": 0,
+                    "title": "x",
+                    "type": "integer",
+                }
             },
+            "required": [],
+            "definitions": {},
         }
 
     def test_function_with_two_arguments(self):
@@ -120,6 +133,7 @@ class TestFunctionToSchema:
                 "y": {"title": "y", "default": 5.0, "type": "number", "position": 1},
             },
             "required": ["x"],
+            "definitions": {},
         }
 
     def test_function_with_datetime_arguments(self):
@@ -657,6 +671,7 @@ class TestParseFlowDescriptionToSchema:
                 },
             },
             "required": ["x", "y"],
+            "definitions": {},
         }
 
 


### PR DESCRIPTION
This PR updates the tests to use the `model_dump_for_openapi` method that we used to replace the `dict` method we had on the `ParameterSchema` class. It also adds `required` and `definitions` fields to the expected schema as they no longer default to `None`.

Fixes currently failing tests:
<details>
<pre>
_______________________________________________________________________ TestParseFlowDescriptionToSchema.test_flow_with_complex_args_docstring _______________________________________________________________________

self = <tests.utilities.test_callables.TestParseFlowDescriptionToSchema object at 0x125274490>

    def test_flow_with_complex_args_docstring(self):
        def f(x, y):
            """Function f.
    
            Second line of docstring.
    
            Args:
                x: required argument x
                y (str): required typed argument y
                  with second line
    
            Returns:
                None: nothing
            """
    
        schema = callables.parameter_schema(f)
>       assert schema.model_dump() == {
            "title": "Parameters",
            "type": "object",
            "properties": {
                "x": {
                    "title": "x",
                    "description": "required argument x",
                    "position": 0,
                },
                "y": {
                    "title": "y",
                    "description": "required typed argument y\nwith second line",
                    "position": 1,
                },
            },
            "required": ["x", "y"],
        }
E       AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'description': 'required argument x', 'position': 0, 'title': 'x'}, 'y': {'description': 'required typed argument y\nwith second line', 'position': 1, 'title': 'y'}}, 'required': ['x', 'y'], 'definitions': {}} == {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'title': 'x', 'description': 'required argument x', 'position': 0}, 'y': {'title': 'y', 'description': 'required typed argument y\nwith second line', 'position': 1}}, 'required': ['x', 'y']}
E         Common items:
E         {'properties': {'x': {'description': 'required argument x',
E                               'position': 0,
E                               'title': 'x'},
E                         'y': {'description': 'required typed argument y\n'
E                                              'with second line',
E                               'position': 1,
E                               'title': 'y'}},
E          'required': ['x', 'y'],
E          'title': 'Parameters',
E          'type': 'object'}
E         Left contains 1 more item:
E         {'definitions': {}}
E         Full diff:
E           {
E         +  'definitions': {},
E            'properties': {'x': {'description': 'required argument x',
E                                 'position': 0,
E                                 'title': 'x'},
E                           'y': {'description': 'required typed argument y\n'
E                                                'with second line',
E                                 'position': 1,
E                                 'title': 'y'}},
E            'required': ['x',
E                         'y'],
E            'title': 'Parameters',
E            'type': 'object',
E           }

tests/utilities/test_callables.py:644: AssertionError
============================================================================================== short test summary info ===============================================================================================
FAILED tests/utilities/test_callables.py::TestFunctionToSchema::test_simple_function_with_no_arguments - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {}, 'required': [], 'definitions': {}} == {'properties': {}, 'title': 'Parameters', 'type': 'object'}
FAILED tests/utilities/test_callables.py::TestFunctionToSchema::test_function_with_pydantic_base_model_collisions - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'json': {'position': 0, 'title': 'json'}, 'copy': {'position': 1, 'title': 'copy'}, 'parse_obj': {'position': 2, 'title': 'parse_...
FAILED tests/utilities/test_callables.py::TestFunctionToSchema::test_function_with_one_required_argument - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'position': 0, 'title': 'x'}}, 'required': ['x'], 'definitions': {}} == {'title': 'Parameters', 'type': 'object', 'properti...
FAILED tests/utilities/test_callables.py::TestFunctionToSchema::test_function_with_one_optional_argument - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'default': 42, 'position': 0, 'title': 'x'}}, 'required': [], 'definitions': {}} == {'title': 'Parameters', 'type': 'object...
FAILED tests/utilities/test_callables.py::TestFunctionToSchema::test_function_with_one_optional_annotated_argument - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'default': 42, 'position': 0, 'title': 'x', 'type': 'integer'}}, 'required': [], 'definitions': {}} == {'title': 'Parameter...
FAILED tests/utilities/test_callables.py::TestFunctionToSchema::test_function_with_two_arguments - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'position': 0, 'title': 'x', 'type': 'integer'}, 'y': {'default': 5.0, 'position': 1, 'title': 'y', 'type': 'number'}}, 're...
FAILED tests/utilities/test_callables.py::TestFunctionToSchema::test_function_with_datetime_arguments - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'format': 'date-time', 'position': 0, 'title': 'x', 'type': 'string'}, 'y': {'default': '2025-01-01T00:00:00Z', 'format': '...
FAILED tests/utilities/test_callables.py::TestFunctionToSchema::test_function_with_enum_argument - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'allOf': [{'$ref': '#/definitions/Color'}], 'default': 'RED', 'position': 0, 'title': 'x'}}, 'required': [], 'definitions':...
FAILED tests/utilities/test_callables.py::TestFunctionToSchema::test_function_with_generic_arguments - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'a': {'items': {'type': 'string'}, 'position': 0, 'title': 'a', 'type': 'array'}, 'b': {'position': 1, 'title': 'b', 'type': 'obj...
FAILED tests/utilities/test_callables.py::TestFunctionToSchema::test_function_with_user_defined_type - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'position': 0, 'title': 'x'}}, 'required': ['x'], 'definitions': {}} == {'title': 'Parameters', 'type': 'object', 'properti...
FAILED tests/utilities/test_callables.py::TestFunctionToSchema::test_function_with_pydantic_model_default_across_v1_and_v2 - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'foo': {'allOf': [{'$ref': '#/definitions/Foo'}], 'default': {'bar': 'baz'}, 'position': 0, 'title': 'foo'}}, 'required': [], 'de...
FAILED tests/utilities/test_callables.py::TestFunctionToSchema::test_function_with_secretstr - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'format': 'password', 'position': 0, 'title': 'x', 'type': 'string', 'writeOnly': True}}, 'required': ['x'], 'definitions':...
FAILED tests/utilities/test_callables.py::TestFunctionToSchema::test_function_with_v1_secretstr_from_compat_module - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'position': 0, 'title': 'x'}}, 'required': ['x'], 'definitions': {}} == {'title': 'Parameters', 'type': 'object', 'properti...
FAILED tests/utilities/test_callables.py::TestMethodToSchema::test_methods_with_no_arguments - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {}, 'required': [], 'definitions': {}} == {'properties': {}, 'title': 'Parameters', 'type': 'object'}
FAILED tests/utilities/test_callables.py::TestMethodToSchema::test_methods_with_enum_arguments - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'color': {'allOf': [{'$ref': '#/definitions/Color'}], 'default': 'RED', 'position': 0, 'title': 'color'}}, 'required': [], 'defin...
FAILED tests/utilities/test_callables.py::TestMethodToSchema::test_methods_with_complex_arguments - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'format': 'date-time', 'position': 0, 'title': 'x', 'type': 'string'}, 'y': {'default': 42, 'position': 1, 'title': 'y', 't...
FAILED tests/utilities/test_callables.py::TestParseFlowDescriptionToSchema::test_flow_with_args_docstring - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'description': 'required argument x', 'position': 0, 'title': 'x'}}, 'required': ['x'], 'definitions': {}} == {'title': 'Pa...
FAILED tests/utilities/test_callables.py::TestParseFlowDescriptionToSchema::test_flow_without_docstring - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'position': 0, 'title': 'x'}}, 'required': ['x'], 'definitions': {}} == {'title': 'Parameters', 'type': 'object', 'properti...
FAILED tests/utilities/test_callables.py::TestParseFlowDescriptionToSchema::test_flow_without_args_docstring - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'position': 0, 'title': 'x'}}, 'required': ['x'], 'definitions': {}} == {'title': 'Parameters', 'type': 'object', 'properti...
FAILED tests/utilities/test_callables.py::TestParseFlowDescriptionToSchema::test_flow_with_complex_args_docstring - AssertionError: assert {'title': 'Parameters', 'type': 'object', 'properties': {'x': {'description': 'required argument x', 'position': 0, 'title': 'x'}, 'y': {'description': 'required typed argument y\nwith s...
=========================================================================================== 20 failed, 14 passed in 7.63s ============================================================================================
</pre>
</details>