### PR TITLE
Remove extra log flushes

### DIFF
--- a/src/prefect/new_flow_engine.py
+++ b/src/prefect/new_flow_engine.py
@@ -33,7 +33,6 @@ from prefect.client.schemas.sorting import FlowRunSort
 from prefect.context import FlowRunContext, TagsContext
 from prefect.exceptions import Abort, Pause, PrefectException, UpstreamTaskError
 from prefect.flows import Flow, load_flow_from_entrypoint, load_flow_from_flow_run
-from prefect.logging.handlers import APILogHandler
 from prefect.logging.loggers import (
     flow_run_logger,
     get_logger,
@@ -548,10 +547,6 @@ class FlowRunEngine(Generic[P, R]):
                     level=logging.INFO if self.state.is_completed() else logging.ERROR,
                     msg=f"Finished in state {display_state}",
                 )
-
-                maybe_awaitable = APILogHandler.flush()
-                if inspect.isawaitable(maybe_awaitable):
-                    run_sync(maybe_awaitable)
 
                 self._is_started = False
                 self._client = None

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -30,7 +30,6 @@ from prefect.client.schemas.objects import State, TaskRunInput
 from prefect.context import FlowRunContext, TaskRunContext, hydrated_context
 from prefect.events.schemas.events import Event
 from prefect.exceptions import Abort, Pause, PrefectException, UpstreamTaskError
-from prefect.logging.handlers import APILogHandler
 from prefect.logging.loggers import get_logger, patch_print, task_run_logger
 from prefect.new_futures import PrefectFuture
 from prefect.results import ResultFactory
@@ -484,10 +483,6 @@ class TaskRunEngine(Generic[P, R]):
                         else logging.ERROR,
                         msg=f"Finished in state {display_state}",
                     )
-
-                    maybe_awaitable = APILogHandler.flush()
-                    if inspect.isawaitable(maybe_awaitable):
-                        run_sync(maybe_awaitable)
 
                     self._is_started = False
                     self._client = None

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1683,7 +1683,8 @@ class TestFlowRunLogs:
 
         my_flow()
 
-        await asyncio.sleep(2)  # Allow logs chance to flush
+        await _wait_for_logs(prefect_client, expected_num_logs=3)
+
         logs = await prefect_client.read_logs()
         assert "Hello world!" in {log.message for log in logs}
 
@@ -1709,8 +1710,8 @@ class TestFlowRunLogs:
                 logger.error("There was an issue", exc_info=True)
 
         my_flow()
+        await _wait_for_logs(prefect_client, expected_num_logs=3)
 
-        await asyncio.sleep(2)  # Allow logs chance to flush
         logs = await prefect_client.read_logs()
         error_logs = "\n".join([log.message for log in logs if log.level == 40])
         assert "Traceback" in error_logs
@@ -1787,7 +1788,7 @@ class TestSubflowRunLogs:
         flow_run_id = state.state_details.flow_run_id
         subflow_run_id = (await state.result()).state_details.flow_run_id
 
-        await asyncio.sleep(2)  # Allow logs chance to flush
+        await _wait_for_logs(prefect_client, expected_num_logs=3)
 
         logs = await prefect_client.read_logs()
         log_messages = [log.message for log in logs]

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1683,7 +1683,7 @@ class TestFlowRunLogs:
 
         my_flow()
 
-        await asyncio.sleep(0.5)  # needed for new engine for some reason
+        await asyncio.sleep(2)  # Allow logs chance to flush
         logs = await prefect_client.read_logs()
         assert "Hello world!" in {log.message for log in logs}
 
@@ -1710,7 +1710,7 @@ class TestFlowRunLogs:
 
         my_flow()
 
-        await asyncio.sleep(0.5)  # needed for new engine for some reason
+        await asyncio.sleep(2)  # Allow logs chance to flush
         logs = await prefect_client.read_logs()
         error_logs = "\n".join([log.message for log in logs if log.level == 40])
         assert "Traceback" in error_logs
@@ -1786,6 +1786,8 @@ class TestSubflowRunLogs:
         state = my_flow(return_state=True)
         flow_run_id = state.state_details.flow_run_id
         subflow_run_id = (await state.result()).state_details.flow_run_id
+
+        await asyncio.sleep(2)  # Allow logs chance to flush
 
         logs = await prefect_client.read_logs()
         log_messages = [log.message for log in logs]


### PR DESCRIPTION
Part of performance profiling - these blocking calls add 20% overhead to the new engine. 