### PR TITLE
Remove is_state

### DIFF
--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -224,7 +224,7 @@ async def return_value_to_state(retval: R, result_factory: ResultFactory) -> Sta
     """
 
     if (
-        is_state(retval)
+        isinstance(retval, State)
         # Check for manual creation
         and not retval.state_details.flow_run_id
         and not retval.state_details.task_run_id
@@ -238,7 +238,7 @@ async def return_value_to_state(retval: R, result_factory: ResultFactory) -> Sta
         return state
 
     # Determine a new state from the aggregate of contained states
-    if is_state(retval) or is_state_iterable(retval):
+    if isinstance(retval, State) or is_state_iterable(retval):
         states = StateGroup(ensure_iterable(retval))
 
         # Determine the new state type
@@ -341,7 +341,7 @@ async def get_state_exception(state: State) -> BaseException:
     elif isinstance(result, str):
         return wrapper(result)
 
-    elif is_state(result):
+    elif isinstance(result, State):
         # Return the exception from the inner state
         return await get_state_exception(result)
 
@@ -373,23 +373,6 @@ async def raise_state_exception(state: State) -> None:
     raise await get_state_exception(state)
 
 
-def is_state(obj: Any) -> TypeGuard[State]:
-    """
-    Check if the given object is a state instance
-    """
-    # We may want to narrow this to client-side state types but for now this provides
-    # backwards compatibility
-    try:
-        from prefect.server.schemas.states import State as State_
-
-        classes_ = (State, State_)
-    except ImportError:
-        classes_ = State
-
-    # return isinstance(obj, (State, State_))
-    return isinstance(obj, classes_)
-
-
 def is_state_iterable(obj: Any) -> TypeGuard[Iterable[State]]:
     """
     Check if a the given object is an iterable of states types
@@ -408,7 +391,7 @@ def is_state_iterable(obj: Any) -> TypeGuard[Iterable[State]]:
         and isinstance(obj, (list, set, tuple))
         and obj
     ):
-        return all([is_state(o) for o in obj])
+        return all([isinstance(o, State) for o in obj])
     else:
         return False
 

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -56,7 +56,6 @@ from prefect.settings import (
 from prefect.states import (
     State,
     get_state_exception,
-    is_state,
 )
 from prefect.tasks import Task
 from prefect.utilities.annotations import allow_failure, quote
@@ -97,7 +96,7 @@ async def collect_task_run_inputs(expr: Any, max_depth: int = -1) -> Set[TaskRun
             # We need to wait for futures to be submitted before we can get the task
             # run id but we want to do so asynchronously
             futures.add(obj)
-        elif is_state(obj):
+        elif isinstance(obj, State):
             if obj.state_details.task_run_id:
                 inputs.add(TaskRunResult(id=obj.state_details.task_run_id))
         # Expressions inside quotes should not be traversed
@@ -142,7 +141,7 @@ def collect_task_run_inputs_sync(
     def add_futures_and_states_to_inputs(obj):
         if isinstance(obj, future_cls) and hasattr(obj, "task_run_id"):
             inputs.add(TaskRunResult(id=obj.task_run_id))
-        elif is_state(obj):
+        elif isinstance(obj, State):
             if obj.state_details.task_run_id:
                 inputs.add(TaskRunResult(id=obj.state_details.task_run_id))
         # Expressions inside quotes should not be traversed
@@ -270,7 +269,7 @@ async def resolve_inputs(
 
         if isinstance(expr, PrefectFuture):
             futures.add(expr)
-        if is_state(expr):
+        if isinstance(expr, State):
             states.add(expr)
 
         return expr
@@ -309,7 +308,7 @@ async def resolve_inputs(
 
         if isinstance(expr, PrefectFuture):
             state = expr._final_state
-        elif is_state(expr):
+        elif isinstance(expr, State):
             state = expr
         else:
             return expr
@@ -797,7 +796,7 @@ def resolve_to_final_result(expr, context):
     if isinstance(expr, NewPrefectFuture):
         expr.wait()
         state = expr.state
-    elif is_state(expr):
+    elif isinstance(expr, State):
         state = expr
     else:
         return expr

--- a/tests/results/test_flow_results.py
+++ b/tests/results/test_flow_results.py
@@ -15,7 +15,6 @@ from prefect.serializers import (
     PickleSerializer,
     Serializer,
 )
-from prefect.server import schemas
 from prefect.settings import (
     PREFECT_DEFAULT_RESULT_STORAGE_BLOCK,
     PREFECT_HOME,
@@ -419,41 +418,6 @@ async def test_flow_state_result_is_respected(persist_result, return_state):
 
     if return_state.data:
         assert await state.result(raise_on_failure=False) == return_state.data
-
-
-@pytest.mark.parametrize(
-    "return_state",
-    [
-        schemas.states.Completed(data="test"),
-        schemas.states.Cancelled(),
-        schemas.states.Failed(),
-    ],
-)
-@pytest.mark.parametrize("persist_result", [True, False])
-async def test_flow_server_state_schema_result_is_respected(
-    persist_result, return_state
-):
-    # Tests for backwards compatibility with server-side state return values
-    @flow(persist_result=persist_result)
-    def my_flow():
-        return return_state
-
-    with pytest.warns(DeprecationWarning, match="Use `prefect.states.State` instead"):
-        state = my_flow(return_state=True)
-
-    assert state.type == return_state.type
-
-    # id, timestamp, and state details must be excluded as they are copied from
-    # the API version of the state and will not match the state created for
-    # this test. Data must be excluded as it will have been updated to a
-    # result.
-    assert state.dict(
-        exclude={"id", "timestamp", "state_details", "data"}
-    ) == return_state.dict(exclude={"id", "timestamp", "state_details", "data"})
-
-    if return_state.data:
-        with pytest.warns(DeprecationWarning, match="use `prefect.states.State`"):
-            assert await state.result(raise_on_failure=False) == return_state.data
 
 
 async def test_root_flow_default_remote_storage(tmp_path: Path):

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -20,25 +20,11 @@ from prefect.states import (
     Running,
     State,
     StateGroup,
-    is_state,
     is_state_iterable,
     raise_state_exception,
     return_value_to_state,
 )
 from prefect.utilities.annotations import quote
-
-
-def test_is_state():
-    assert is_state(Completed())
-
-
-def test_is_not_state():
-    assert not is_state(None)
-    assert not is_state("test")
-
-
-def test_is_state_requires_instance():
-    assert not is_state(Completed)
 
 
 @pytest.mark.parametrize("iterable_type", [set, list, tuple])


### PR DESCRIPTION
The is_state utility exists for backwards-compatible checks of historic server-defined State objects, and is no longer needed. 

Due to threading, calling this function accounts for 7% of new task engine overhead (!)