### PR TITLE
Ensure a coro is returned from run_sync

### DIFF
--- a/src/prefect/utilities/asyncutils.py
+++ b/src/prefect/utilities/asyncutils.py
@@ -234,8 +234,7 @@ def sync_compatible(async_fn: T, force_sync: bool = False) -> T:
         if force_sync:
             return run_sync(ctx_call())
         elif RUN_ASYNC_FLAG.get() or is_async:
-            context = copy_context()
-            return context.run(ctx_call)
+            return ctx_call
         else:
             return run_sync(ctx_call())
 

--- a/src/prefect/utilities/asyncutils.py
+++ b/src/prefect/utilities/asyncutils.py
@@ -234,7 +234,7 @@ def sync_compatible(async_fn: T, force_sync: bool = False) -> T:
         if force_sync:
             return run_sync(ctx_call())
         elif RUN_ASYNC_FLAG.get() or is_async:
-            return ctx_call
+            return ctx_call()
         else:
             return run_sync(ctx_call())
 


### PR DESCRIPTION
When run_sync is called on a coro in an async frame, it wraps the coro in `context.run()` and returns it. However, `context.run()` is a synchronous function, so what ends up happening is the coro is _never_ awaited.

Coros always load contextvars from their parent frame, so i believe it should be fine to simply return the coro to be awaited by the async caller.

I observed a small number of calls reporting "coroutine not awaited" and believe this is the culprit.