### PR TITLE
Chdir on test to prevent file writes

### DIFF
--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -792,7 +792,9 @@ class TestPipInstallRequirements:
 
 class TestPullWithBlock:
     @pytest.fixture
-    async def test_block(self):
+    async def test_block(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(str(tmp_path))  # ensures never writes to active directory
+
         class FakeStorageBlock(Block):
             _block_type_slug = "fake-storage-block"
 


### PR DESCRIPTION
Thanks to @chrisguidry's new test utility that errors on new file creation, I believe I've found the culprit of many of our file creation errors.