### PR TITLE
Allow block registration to use client schemas for server model creation

### DIFF
--- a/src/prefect/server/models/block_schemas.py
+++ b/src/prefect/server/models/block_schemas.py
@@ -19,7 +19,6 @@ from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.models.block_types import read_block_type_by_slug
 from prefect.server.schemas.actions import BlockSchemaCreate
 from prefect.server.schemas.core import BlockSchema, BlockSchemaReference, BlockType
-from prefect.settings import PREFECT_TEST_MODE
 
 if TYPE_CHECKING:
     from prefect.client.schemas.actions import (
@@ -53,14 +52,10 @@ async def create_block_schema(
     """
     from prefect.blocks.core import Block, _get_non_block_reference_definitions
 
-    # We take a shortcut in many unit tests to pass client models directly to
-    # this function.  We will support this (only in unit tests) by converting them
-    # to the appropriate server model.
+    # We take a shortcut in many unit tests and in block registration to pass client
+    # models directly to this function.  We will support this by converting them to
+    # the appropriate server model.
     if not isinstance(block_schema, schemas.actions.BlockSchemaCreate):
-        if not PREFECT_TEST_MODE.value():
-            raise ValueError(
-                f"block_schema must be a server model, got {type(block_schema)}"
-            )
         block_schema = schemas.actions.BlockSchemaCreate.model_validate(
             block_schema.model_dump(
                 mode="json",

--- a/src/prefect/server/models/block_types.py
+++ b/src/prefect/server/models/block_types.py
@@ -14,7 +14,6 @@ from prefect.server import schemas
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.database.orm_models import BlockSchema, BlockType
-from prefect.settings import PREFECT_TEST_MODE
 
 if TYPE_CHECKING:
     from prefect.client.schemas import BlockType as ClientBlockType
@@ -38,14 +37,10 @@ async def create_block_type(
     Returns:
         block_type: an ORM block type model
     """
-    # We take a shortcut in many unit tests to pass client models directly to
-    # this function.  We will support this (only in unit tests) by converting them
-    # to the appropriate server model.
+    # We take a shortcut in many unit tests and in block registration to pass client
+    # models directly to this function.  We will support this by converting them to
+    # the appropriate server model.
     if not isinstance(block_type, schemas.core.BlockType):
-        if not PREFECT_TEST_MODE.value():
-            raise ValueError(
-                f"block_type must be a server model, got {type(block_type)}"
-            )
         block_type = schemas.core.BlockType.model_validate(
             block_type.model_dump(mode="json")
         )
@@ -172,12 +167,10 @@ async def update_block_type(
         bool: True if the block type was updated
     """
 
-    # We take a shortcut in many unit tests to pass client models directly to
-    # this function.  We will support this (only in unit tests) by converting them
-    # to the appropriate server model.
+    # We take a shortcut in many unit tests and in block registration to pass client
+    # models directly to this function.  We will support this by converting them to
+    # the appropriate server model.
     if not isinstance(block_type, schemas.actions.BlockTypeUpdate):
-        if not PREFECT_TEST_MODE.value():
-            raise ValueError("block_type must be a server model")
         block_type = schemas.actions.BlockTypeUpdate.model_validate(
             block_type.model_dump(
                 mode="json",


### PR DESCRIPTION
We were originally allowing this only for unit tests, but we also use this
path via block autoregistration at server startup.  Now that we're past the
hump on Pydantic v2, we can remove the more aggressive exception here and just
transparently convert the type.
