### PR TITLE
Replace our customized `Duration` types with plain `timedelta`s

### DIFF
--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -34,11 +34,12 @@ class PrefectBaseModel(BaseModel):
     _reset_fields: ClassVar[Set[str]] = set()
 
     model_config = ConfigDict(
+        ser_json_timedelta="float",
         extra=(
             "ignore"
             if os.getenv("PREFECT_TEST_MODE", "0").lower() not in ["true", "1"]
             else "forbid"
-        )
+        ),
     )
 
     def __eq__(self, other: Any) -> bool:

--- a/src/prefect/cli/_prompts.py
+++ b/src/prefect/cli/_prompts.py
@@ -205,7 +205,6 @@ def prompt_interval_schedule(console):
     Prompt the user for an interval in seconds.
     """
     default_seconds = 3600
-    # The interval value must be a timedelta object in order to pass validation as a `PositiveDuration` type in `IntervalSchedule`.
     default_duration = timedelta(seconds=default_seconds)
 
     # We show the default in the prompt message rather than enabling `show_default=True` here because `rich` displays timedeltas in hours

--- a/src/prefect/client/schemas/schedules.py
+++ b/src/prefect/client/schemas/schedules.py
@@ -18,7 +18,6 @@ from prefect._internal.schemas.validators import (
     validate_cron_string,
     validate_rrule_string,
 )
-from prefect.types import PositiveDuration
 
 MAX_ITERATIONS = 1000
 # approx. 1 years worth of RDATEs + buffer
@@ -56,7 +55,7 @@ class IntervalSchedule(PrefectBaseModel):
 
     model_config = ConfigDict(extra="forbid", exclude_none=True)
 
-    interval: PositiveDuration
+    interval: datetime.timedelta = Field(gt=datetime.timedelta(0))
     anchor_date: Annotated[DateTime, AfterValidator(default_anchor_date)] = Field(
         default_factory=lambda: pendulum.now("UTC"),
         examples=["2020-01-01T00:00:00Z"],

--- a/src/prefect/events/schemas/automations.py
+++ b/src/prefect/events/schemas/automations.py
@@ -24,7 +24,6 @@ from typing_extensions import Self, TypeAlias
 
 from prefect._internal.schemas.bases import PrefectBaseModel
 from prefect.events.actions import ActionTypes, RunDeployment
-from prefect.types import NonNegativeDuration
 from prefect.utilities.collections import AutoEnum
 
 from .events import ResourceSpecification
@@ -163,8 +162,9 @@ class EventTrigger(ResourceTrigger):
             "triggers)"
         ),
     )
-    within: NonNegativeDuration = Field(
+    within: timedelta = Field(
         timedelta(seconds=0),
+        ge=timedelta(seconds=0),
         description=(
             "The time period over which the events must occur.  For Reactive triggers, "
             "this may be as low as 0 seconds, but must be at least 10 seconds for "

--- a/src/prefect/server/events/schemas/automations.py
+++ b/src/prefect/server/events/schemas/automations.py
@@ -39,7 +39,6 @@ from prefect.server.events.schemas.events import (
 )
 from prefect.server.schemas.actions import ActionBaseModel
 from prefect.server.utilities.schemas import ORMBaseModel, PrefectBaseModel
-from prefect.types import NonNegativeDuration
 from prefect.utilities.collections import AutoEnum
 
 logger = get_logger(__name__)
@@ -305,8 +304,9 @@ class EventTrigger(ResourceTrigger):
             "triggers)"
         ),
     )
-    within: NonNegativeDuration = Field(
+    within: timedelta = Field(
         timedelta(seconds=0),
+        ge=timedelta(seconds=0),
         description=(
             "The time period over which the events must occur.  For Reactive triggers, "
             "this may be as low as 0 seconds, but must be at least 10 seconds for "

--- a/src/prefect/server/schemas/schedules.py
+++ b/src/prefect/server/schemas/schedules.py
@@ -20,7 +20,7 @@ from prefect._internal.schemas.validators import (
     validate_rrule_string,
 )
 from prefect.server.utilities.schemas.bases import PrefectBaseModel
-from prefect.types import PositiveDuration, TimeZone
+from prefect.types import TimeZone
 
 MAX_ITERATIONS = 1000
 
@@ -72,7 +72,7 @@ class IntervalSchedule(PrefectBaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    interval: PositiveDuration
+    interval: datetime.timedelta = Field(gt=datetime.timedelta(0))
     anchor_date: Annotated[DateTime, AfterValidator(default_anchor_date)] = Field(
         default_factory=lambda: pendulum.now("UTC"),
         examples=["2020-01-01T00:00:00Z"],

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -59,11 +59,12 @@ class PrefectBaseModel(BaseModel):
 
     _reset_fields: ClassVar[Set[str]] = set()
     model_config = ConfigDict(
+        ser_json_timedelta="float",
         extra=(
             "ignore"
             if os.getenv("PREFECT_TEST_MODE", "0").lower() not in ["true", "1"]
             else "forbid"
-        )
+        ),
     )
 
     def __eq__(self, other: Any) -> bool:

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -82,7 +82,6 @@ from typing_extensions import Literal
 from prefect._internal.compatibility.deprecated import generate_deprecation_message
 from prefect._internal.schemas.validators import validate_settings
 from prefect.exceptions import MissingProfileError
-from prefect.types import NonNegativeDuration, PositiveDuration
 from prefect.utilities.names import OBFUSCATED_PREFIX, obfuscate
 from prefect.utilities.pydantic import add_cloudpickle_reduction
 
@@ -1116,7 +1115,7 @@ this many scheduled runs, depending on the value of
 """
 
 PREFECT_API_SERVICES_SCHEDULER_MAX_SCHEDULED_TIME = Setting(
-    PositiveDuration,
+    timedelta,
     default=timedelta(days=100),
 )
 """The scheduler will create new runs up to this far in the
@@ -1127,7 +1126,7 @@ scheduled. Defaults to 100 days (`8640000` seconds).
 """
 
 PREFECT_API_SERVICES_SCHEDULER_MIN_SCHEDULED_TIME = Setting(
-    PositiveDuration,
+    timedelta,
     default=timedelta(hours=1),
 )
 """The scheduler will create new runs at least this far in the
@@ -1156,7 +1155,7 @@ this often. Defaults to `5`.
 """
 
 PREFECT_API_SERVICES_LATE_RUNS_AFTER_SECONDS = Setting(
-    PositiveDuration,
+    timedelta,
     default=timedelta(seconds=15),
 )
 """The late runs service will mark runs as late after they
@@ -1262,9 +1261,7 @@ Note: Enabling this setting requires corresponding support in the client for
 CSRF token management. See PREFECT_CLIENT_CSRF_SUPPORT_ENABLED for more.
 """
 
-PREFECT_SERVER_CSRF_TOKEN_EXPIRATION = Setting(
-    PositiveDuration, default=timedelta(hours=1)
-)
+PREFECT_SERVER_CSRF_TOKEN_EXPIRATION = Setting(timedelta, default=timedelta(hours=1))
 """
 Specifies the duration for which a CSRF token remains valid after being issued
 by the server.
@@ -1521,7 +1518,7 @@ The maximum number of retries to queue for submission.
 """
 
 PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT = Setting(
-    NonNegativeDuration,
+    timedelta,
     default=timedelta(seconds=30),
 )
 """
@@ -1660,16 +1657,12 @@ PREFECT_API_SERVICES_TRIGGERS_ENABLED = Setting(bool, default=True)
 Whether or not to start the triggers service in the server application.
 """
 
-PREFECT_EVENTS_EXPIRED_BUCKET_BUFFER = Setting(
-    PositiveDuration, default=timedelta(seconds=60)
-)
+PREFECT_EVENTS_EXPIRED_BUCKET_BUFFER = Setting(timedelta, default=timedelta(seconds=60))
 """
 The amount of time to retain expired automation buckets
 """
 
-PREFECT_EVENTS_PROACTIVE_GRANULARITY = Setting(
-    PositiveDuration, default=timedelta(seconds=5)
-)
+PREFECT_EVENTS_PROACTIVE_GRANULARITY = Setting(timedelta, default=timedelta(seconds=5))
 """
 How frequently proactive automations are evaluated
 """
@@ -1689,9 +1682,7 @@ PREFECT_API_SERVICES_EVENT_PERSISTER_FLUSH_INTERVAL = Setting(float, default=5, 
 The maximum number of seconds between flushes of the event persister.
 """
 
-PREFECT_EVENTS_RETENTION_PERIOD = Setting(
-    NonNegativeDuration, default=timedelta(days=7)
-)
+PREFECT_EVENTS_RETENTION_PERIOD = Setting(timedelta, default=timedelta(days=7))
 """
 The amount of time to retain events in the database.
 """
@@ -1702,7 +1693,7 @@ Whether or not to allow streaming events out of via websockets.
 """
 
 PREFECT_API_EVENTS_RELATED_RESOURCE_CACHE_TTL = Setting(
-    PositiveDuration, default=timedelta(minutes=5)
+    timedelta, default=timedelta(minutes=5)
 )
 """
 How long to cache related resource data for emitting server-side vents

--- a/src/prefect/types/__init__.py
+++ b/src/prefect/types/__init__.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, ClassVar, Dict, List, Type, Union
+from typing import Annotated, Any, Dict, List, Union
 import orjson
 import pydantic
 
@@ -10,9 +10,7 @@ from pydantic import (
     StrictInt,
     StrictStr,
 )
-from datetime import timedelta
 from zoneinfo import available_timezones
-from pydantic_core import core_schema
 
 MAX_VARIABLE_NAME_LENGTH = 255
 MAX_VARIABLE_VALUE_LENGTH = 5000
@@ -23,53 +21,6 @@ NonNegativeInteger = Annotated[int, Field(ge=0)]
 PositiveInteger = Annotated[int, Field(gt=0)]
 NonNegativeFloat = Annotated[float, Field(ge=0.0)]
 TimeZone = Annotated[str, Field(default="UTC", pattern="|".join(timezone_set))]
-
-
-class Duration(timedelta):
-    schema: ClassVar = core_schema.timedelta_schema(
-        serialization=core_schema.plain_serializer_function_ser_schema(
-            timedelta.total_seconds, when_used="json-unless-none"
-        ),
-    )
-
-    @classmethod
-    def __get_pydantic_core_schema__(
-        cls, source: Type[Any], handler: Any
-    ) -> core_schema.CoreSchema:
-        # Allows us to parse numeric and string representations of durations
-        def parse_duration(value: Any) -> timedelta:
-            if isinstance(value, (float, int)):
-                return timedelta(seconds=value)
-            elif isinstance(value, str):
-                try:
-                    return timedelta(seconds=float(value))
-                except ValueError:
-                    return value  # type: ignore
-            return value
-
-        return core_schema.no_info_before_validator_function(parse_duration, cls.schema)
-
-
-class NonNegativeDuration(Duration):
-    """A timedelta that must be greater than or equal to 0."""
-
-    schema: ClassVar = core_schema.timedelta_schema(
-        ge=timedelta(seconds=0),
-        serialization=core_schema.plain_serializer_function_ser_schema(
-            timedelta.total_seconds, when_used="json-unless-none"
-        ),
-    )
-
-
-class PositiveDuration(Duration):
-    """A timedelta that must be greater than 0."""
-
-    schema: ClassVar = core_schema.timedelta_schema(
-        gt=timedelta(seconds=0),
-        serialization=core_schema.plain_serializer_function_ser_schema(
-            timedelta.total_seconds, when_used="json-unless-none"
-        ),
-    )
 
 
 BANNED_CHARACTERS = ["/", "%", "&", ">", "<"]
@@ -132,8 +83,6 @@ __all__ = [
     "NonNegativeInteger",
     "PositiveInteger",
     "NonNegativeFloat",
-    "NonNegativeDuration",
-    "PositiveDuration",
     "Name",
     "NameOrEmpty",
     "NonEmptyishName",

--- a/tests/types/test_self_validating_types.py
+++ b/tests/types/test_self_validating_types.py
@@ -1,12 +1,8 @@
-from datetime import timedelta
-
 import pytest
 from pydantic import BaseModel, ValidationError
 
 from prefect.types import (
-    NonNegativeDuration,
     NonNegativeInteger,
-    PositiveDuration,
     PositiveInteger,
 )
 
@@ -36,36 +32,6 @@ class TestConstrainedIntegers:
     def test_invalid_integer(self, integer_type, invalid_value):
         class Model(BaseModel):
             value: integer_type
-
-        with pytest.raises(ValidationError):
-            Model(value=invalid_value)
-
-
-class TestConstrainedDurations:
-    @pytest.mark.parametrize(
-        "duration_type,valid_value",
-        [
-            (PositiveDuration, timedelta(seconds=1)),
-            (NonNegativeDuration, timedelta(seconds=0)),
-        ],
-    )
-    def test_valid_duration(self, duration_type, valid_value):
-        class Model(BaseModel):
-            value: duration_type
-
-        m = Model(value=valid_value)
-        assert m.value == valid_value
-
-    @pytest.mark.parametrize(
-        "duration_type,invalid_value",
-        [
-            (PositiveDuration, timedelta(seconds=0)),
-            (NonNegativeDuration, timedelta(seconds=-1)),
-        ],
-    )
-    def test_invalid_duration(self, duration_type, invalid_value):
-        class Model(BaseModel):
-            value: duration_type
 
         with pytest.raises(ValidationError):
             Model(value=invalid_value)


### PR DESCRIPTION
As I was trying to reconcile the schemas between OSS and Cloud, I discovered
that there's a model configuration called `ser_json_timedelta` where we can
easily toggle the original behavior of serializing to floats.  No need for
custom types at all.
