### PR TITLE
pin `pydantic>=2.7` for `Secret`

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -19,7 +19,7 @@ packaging >= 21.3, < 24.3
 pathspec >= 0.8.0
 pendulum >= 3.0.0, <4
 # the version constraints for pydantic are merged with those from fastapi 0.103.2
-pydantic >= 2.4, < 3.0.0
+pydantic >= 2.7, < 3.0.0
 pydantic_core >= 2.12.0, < 3.0.0
 pydantic_extra_types
 pydantic_settings

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -18,7 +18,7 @@ orjson >= 3.7, < 4.0
 packaging >= 21.3, < 24.3
 pathspec >= 0.8.0
 pendulum >= 3.0.0, <4
-# the version constraints for pydantic are merged with those from fastapi 0.103.2
+# 2024/05/28: we had same as fastapi 0.103.2 -> pydantic 2.4 but for `Secret` we need 2.7
 pydantic >= 2.7, < 3.0.0
 pydantic_core >= 2.12.0, < 3.0.0
 pydantic_extra_types


### PR DESCRIPTION
we currently use [pydantic's `Secret`](https://docs.pydantic.dev/latest/examples/secrets/#serialize-secretstr-and-secretbytes-as-plain-text) in `main` when it is only available after 2.7