### PR TITLE
Warn on deprecated `PREFECT_CLOUD_URL` instead of error

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -378,6 +378,21 @@ def warn_on_database_password_value_without_usage(values):
     return values
 
 
+def check_for_deprecated_cloud_url(settings, value):
+    deprecated_value = PREFECT_CLOUD_URL.value_from(settings, bypass_callback=True)
+    if deprecated_value is not None:
+        warnings.warn(
+            (
+                "`PREFECT_CLOUD_URL` is set and will be used instead of"
+                " `PREFECT_CLOUD_API_URL` for backwards compatibility."
+                " `PREFECT_CLOUD_URL` is deprecated, set `PREFECT_CLOUD_API_URL`"
+                " instead."
+            ),
+            DeprecationWarning,
+        )
+    return deprecated_value or value
+
+
 def warn_on_misconfigured_api_url(values):
     """
     Validator for settings warning if the API URL is misconfigured.
@@ -679,8 +694,21 @@ Defaults to `True`, ensuring CSRF protection is enabled by default.
 PREFECT_CLOUD_API_URL = Setting(
     str,
     default="https://api.prefect.cloud/api",
+    value_callback=check_for_deprecated_cloud_url,
 )
 """API URL for Prefect Cloud. Used for authentication."""
+
+PREFECT_CLOUD_URL = Setting(
+    Optional[str],
+    default=None,
+    deprecated=True,
+    deprecated_start_date="Dec 2022",
+    deprecated_end_date="Dec 2025",
+    deprecated_help="Use `PREFECT_CLOUD_API_URL` instead.",
+)
+"""
+DEPRECATED: Use `PREFECT_CLOUD_API_URL` instead.
+"""
 
 
 PREFECT_UI_URL = Setting(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -17,6 +17,7 @@ from prefect.settings import (
     PREFECT_CLIENT_RETRY_EXTRA_CODES,
     PREFECT_CLOUD_API_URL,
     PREFECT_CLOUD_UI_URL,
+    PREFECT_CLOUD_URL,
     PREFECT_DEBUG_MODE,
     PREFECT_HOME,
     PREFECT_LOGGING_EXTRA_LOGGERS,
@@ -401,6 +402,28 @@ class TestSettingAccess:
     def test_prefect_home_expands_tilde_in_path(self):
         settings = Settings(PREFECT_HOME="~/test")
         assert PREFECT_HOME.value_from(settings) == Path("~/test").expanduser()
+
+    def test_prefect_cloud_url_deprecated_on_set(self):
+        with temporary_settings({PREFECT_CLOUD_URL: "test"}):
+            with pytest.raises(
+                DeprecationWarning,
+                match=(
+                    "`PREFECT_CLOUD_URL` is set and will be used instead of"
+                    " `PREFECT_CLOUD_API_URL`"
+                ),
+            ):
+                PREFECT_CLOUD_API_URL.value()
+
+    def test_prefect_cloud_url_deprecated_on_access(self):
+        with pytest.raises(
+            DeprecationWarning,
+            match=(
+                "Setting 'PREFECT_CLOUD_URL' has been deprecated. "
+                "It will not be available after Jun 2023. "
+                "Use `PREFECT_CLOUD_API_URL` instead."
+            ),
+        ):
+            PREFECT_CLOUD_URL.value()
 
     @pytest.mark.parametrize(
         "api_url,ui_url",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -419,7 +419,7 @@ class TestSettingAccess:
             DeprecationWarning,
             match=(
                 "Setting 'PREFECT_CLOUD_URL' has been deprecated. "
-                "It will not be available after Jun 2023. "
+                "It will not be available after Dec 2025. "
                 "Use `PREFECT_CLOUD_API_URL` instead."
             ),
         ):


### PR DESCRIPTION
Adds extended deprecation period (3 years instead of 6 months)