### PR TITLE
Only allow one worker to start the registry

### DIFF
--- a/tests/fixtures/docker.py
+++ b/tests/fixtures/docker.py
@@ -113,7 +113,7 @@ def prefect_base_image(pytestconfig: "pytest.Config", docker: DockerClient):
     return image_name
 
 
-def _wait_for_registry(url: str, timeout: int = 30) -> bool:
+def _wait_for_registry(url: str, timeout: int = 60) -> bool:
     start = time.time()
     while time.time() - start < timeout:
         try:


### PR DESCRIPTION
The issue this seems to have been running into was that all of the workers were trying to start the registry and all but the first one would be denied by docker itself. This led to the `registry` fixture throwing an exception and the tests relying on the fixture to fail.

This updates the `registry` fixture to only start the container if we're on `gw0` and all other workers will wait for the registry to be available before continuing. 