### PR TITLE
Add _sync flag to sync compatible fns

### DIFF
--- a/src/prefect/records/result_store.py
+++ b/src/prefect/records/result_store.py
@@ -16,10 +16,7 @@ class ResultFactoryStore(RecordStore):
     def exists(self, key: str) -> bool:
         try:
             result = self.read(key)
-            # need to pass result as self explicitly when calling .aio
-            run_coro_as_sync(
-                result.get.aio(result)
-            )  # loads and caches value on result object
+            result.get(_sync=True)
             self.cache = result
             return True
         except (ObjectNotFound, ValueError):

--- a/tests/utilities/test_asyncutils.py
+++ b/tests/utilities/test_asyncutils.py
@@ -279,6 +279,22 @@ def test_sync_compatible_allows_direct_access_to_async_fn():
     assert sync_compatible(foo).aio is foo
 
 
+def test_sync_compatible_allows_forced_behavior_sync():
+    async def foo():
+        return 42
+
+    assert sync_compatible(foo)(_sync=True) == 42
+
+
+async def test_sync_compatible_allows_forced_behavior_sync_and_async():
+    async def foo():
+        return 42
+
+    assert sync_compatible(foo)(_sync=True) == 42
+    assert await sync_compatible(foo)(_sync=False) == 42
+    assert await sync_compatible(foo)() == 42
+
+
 def test_sync_compatible_requires_async_function():
     with pytest.raises(TypeError, match="must be async"):
 


### PR DESCRIPTION
In the spirit of minimizing breaking changes and also giving ourselves and users escape hatches, this PR updates `sync_compatible` in two ways:
- returns an awaitable if there is a running event loop, otherwise runs the function synchronously
- exposes a flag `_sync: bool` that allows the caller to override any magic and pick how they want the function run

**cc:** @jlowin @zzstoatzz 