### PR TITLE
Move docker registry lifecycle management out of pytest

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -422,6 +422,13 @@ jobs:
 
           echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
 
+      - name: Start docker registry
+        run: >
+          docker run
+          --name "prefect-test-registry"
+          --detach
+          --publish 5555:5000
+
         # Parallelize tests by scope to reduce expensive service fixture duplication
         # Do not allow the test suite to build images, as we want the prebuilt images to be tested
         # Do not run Kubernetes service tests, we do not have a cluster available

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -428,6 +428,7 @@ jobs:
           --name "prefect-test-registry"
           --detach
           --publish 5555:5000
+          registry:2
 
         # Parallelize tests by scope to reduce expensive service fixture duplication
         # Do not allow the test suite to build images, as we want the prebuilt images to be tested

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,8 @@ services:
       - postgres
       - -c
       - max_connections=250
+  registry:
+      image: registry:2
+      container_name: prefect-test-registry
+      ports:
+        - "5555:5000"

--- a/tests/fixtures/docker.py
+++ b/tests/fixtures/docker.py
@@ -1,9 +1,11 @@
 import sys
+import time
 from contextlib import contextmanager
 from typing import Generator
 
 import docker.errors as docker_errors
 import pytest
+import requests
 from typer.testing import CliRunner
 
 import prefect
@@ -19,7 +21,7 @@ from prefect.utilities.dockerutils import (
 
 with silence_docker_warnings():
     from docker import DockerClient
-    from docker.errors import APIError, ImageNotFound, NotFound
+    from docker.errors import APIError, ImageNotFound
     from docker.models.containers import Container
 
 
@@ -110,26 +112,28 @@ def prefect_base_image(pytestconfig: "pytest.Config", docker: DockerClient):
     return image_name
 
 
-@pytest.fixture(scope="module")
-def registry(docker: DockerClient) -> Generator[str, None, None]:
-    """Starts a Docker registry locally, returning its URL"""
-
-    with silence_docker_warnings():
-        # Clean up any previously-created registry:
+def _wait_for_registry(url: str, timeout: int = 30) -> bool:
+    start = time.time()
+    while time.time() - start < timeout:
         try:
-            preexisting: Container = docker.containers.get("orion-test-registry")
-            _safe_remove_container(preexisting)  # pragma: no cover
-        except NotFound:
+            response = requests.get(f"{url}/v2/")
+            if response.status_code == 200:
+                return True
+        except requests.ConnectionError:
             pass
+        time.sleep(1)
+    return False
 
-        container: Container = docker.containers.run(
-            "registry:2",
-            detach=True,
-            remove=True,
-            name="orion-test-registry",
-            ports={"5000/tcp": 5555},
+
+@pytest.fixture
+def registry() -> Generator[str, None, None]:
+    """Return the URL for the local Docker registry."""
+    registry_url = "http://localhost:5555"
+    if not _wait_for_registry(registry_url):
+        raise RuntimeError(
+            "Docker registry did not become ready in time. If you're running "
+            "the tests locally, make sure you have the registry running with "
+            "`docker compose up -d`."
         )
-        try:
-            yield "http://localhost:5555"
-        finally:
-            container.remove(force=True)
+
+    yield registry_url


### PR DESCRIPTION
The issue with our docker tests seems to have been that all of the workers were trying to start the registry and all but the first one would be denied by docker itself. This led to the `registry` fixture throwing an exception and the tests relying on the fixture to fail.

This moves the management of the docker registry out of pytest and into actions/docker-compose. 