### PR TITLE
Add types to hashing utils

### DIFF
--- a/src/prefect/utilities/hashing.py
+++ b/src/prefect/utilities/hashing.py
@@ -2,9 +2,9 @@ import hashlib
 import sys
 from functools import partial
 from pathlib import Path
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
-import cloudpickle
+import cloudpickle  # type: ignore
 
 from prefect.serializers import JSONSerializer
 
@@ -14,7 +14,9 @@ else:
     _md5 = hashlib.md5
 
 
-def stable_hash(*args: Union[str, bytes], hash_algo=_md5) -> str:
+def stable_hash(
+    *args: Union[str, bytes], hash_algo: Callable[..., hashlib._Hash] = _md5
+) -> str:  # type: ignore
     """Given some arguments, produces a stable 64-bit hash of their contents.
 
     Supports bytes and strings. Strings will be UTF-8 encoded.
@@ -34,7 +36,7 @@ def stable_hash(*args: Union[str, bytes], hash_algo=_md5) -> str:
     return h.hexdigest()
 
 
-def file_hash(path: str, hash_algo=_md5) -> str:
+def file_hash(path: str, hash_algo: Callable[..., hashlib._Hash] = _md5) -> str:  # type: ignore
     """Given a path to a file, produces a stable hash of the file contents.
 
     Args:
@@ -48,7 +50,9 @@ def file_hash(path: str, hash_algo=_md5) -> str:
     return stable_hash(contents, hash_algo=hash_algo)
 
 
-def hash_objects(*args, hash_algo=_md5, **kwargs) -> Optional[str]:
+def hash_objects(
+    *args, hash_algo: Callable[..., hashlib._Hash] = _md5, **kwargs
+) -> Optional[str]:  # type: ignore
     """
     Attempt to hash objects by dumping to JSON or serializing with cloudpickle.
     On failure of both, `None` will be returned
@@ -60,7 +64,7 @@ def hash_objects(*args, hash_algo=_md5, **kwargs) -> Optional[str]:
         pass
 
     try:
-        return stable_hash(cloudpickle.dumps((args, kwargs)), hash_algo=hash_algo)
+        return stable_hash(cloudpickle.dumps((args, kwargs)), hash_algo=hash_algo)  # type: ignore
     except Exception:
         pass
 

--- a/src/prefect/utilities/hashing.py
+++ b/src/prefect/utilities/hashing.py
@@ -15,7 +15,8 @@ else:
 
 
 def stable_hash(
-    *args: Union[str, bytes], hash_algo: Callable[..., hashlib._Hash] = _md5
+    *args: Union[str, bytes],
+    hash_algo: Callable[..., hashlib._Hash] = _md5,  # type: ignore
 ) -> str:  # type: ignore
     """Given some arguments, produces a stable 64-bit hash of their contents.
 

--- a/src/prefect/utilities/hashing.py
+++ b/src/prefect/utilities/hashing.py
@@ -1,8 +1,9 @@
+# pyright: reportPrivateUsage=false
 import hashlib
 import sys
 from functools import partial
 from pathlib import Path
-from typing import Callable, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import cloudpickle  # type: ignore
 
@@ -16,7 +17,7 @@ else:
 
 def stable_hash(
     *args: Union[str, bytes],
-    hash_algo: Callable[..., hashlib._Hash] = _md5,  # type: ignore
+    hash_algo: Callable[..., hashlib._Hash] = _md5,  # type: ignore[no-private-members]
 ) -> str:  # type: ignore
     """Given some arguments, produces a stable 64-bit hash of their contents.
 
@@ -37,7 +38,7 @@ def stable_hash(
     return h.hexdigest()
 
 
-def file_hash(path: str, hash_algo: Callable[..., hashlib._Hash] = _md5) -> str:  # type: ignore
+def file_hash(path: str, hash_algo: Callable[..., hashlib._Hash] = _md5) -> str:
     """Given a path to a file, produces a stable hash of the file contents.
 
     Args:
@@ -52,8 +53,8 @@ def file_hash(path: str, hash_algo: Callable[..., hashlib._Hash] = _md5) -> str:
 
 
 def hash_objects(
-    *args, hash_algo: Callable[..., hashlib._Hash] = _md5, **kwargs
-) -> Optional[str]:  # type: ignore
+    *args: Any, hash_algo: Callable[..., "hashlib._Hash"] = _md5, **kwargs: Any
+) -> Optional[str]:
     """
     Attempt to hash objects by dumping to JSON or serializing with cloudpickle.
     On failure of both, `None` will be returned


### PR DESCRIPTION
getting nerdnsiped one utility at a time

lowlight: hashlib exposes their Hash type as a private type. Given that it's a core library I'm fine with this but welcome any pushback. 
