### PR TITLE
Give `test_can_use_working_tree_as_context` its own contexts folder

### DIFF
--- a/tests/docker/contexts/tree-as-context/hello.txt
+++ b/tests/docker/contexts/tree-as-context/hello.txt
@@ -1,0 +1,1 @@
+Can't bear oceans.

--- a/tests/docker/test_image_builds.py
+++ b/tests/docker/test_image_builds.py
@@ -265,7 +265,9 @@ def test_copying_file_from_alternative_base(
 def test_can_use_working_tree_as_context(
     contexts: Path, docker: DockerClient, prefect_base_image: str
 ):
-    with ImageBuilder(prefect_base_image, context=contexts / "no-dockerfile") as image:
+    with ImageBuilder(
+        prefect_base_image, context=contexts / "tree-as-context"
+    ) as image:
         image.add_line("WORKDIR /tiny/")
         image.copy("hello.txt", "hello.txt")
         image.add_line('ENTRYPOINT [ "/bin/cat", "hello.txt" ]')


### PR DESCRIPTION
If `test_can_use_working_tree_as_context` and `test_generate_dockerfile_with_no_requirements` were picked up by different workers it was possible for them to interact as they used the same `contexts` folder. This copies that folder to give `test_can_use_working_tree_as_context` its own.