### PR TITLE
Add ability to limit concurrent runs for a task server

### DIFF
--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -23,6 +23,7 @@ import pendulum
 from typing_extensions import ParamSpec
 
 from prefect import Task
+from prefect._internal.concurrency.api import create_call, from_sync
 from prefect.client.orchestration import SyncPrefectClient
 from prefect.client.schemas import TaskRun
 from prefect.client.schemas.objects import State, TaskRunInput
@@ -532,7 +533,9 @@ class TaskRunEngine(Generic[P, R]):
 
                     # flush all logs if this is not a "top" level run
                     if not (FlowRunContext.get() or TaskRunContext.get()):
-                        run_coro_as_sync(APILogHandler.aflush(), wait_for_result=False)
+                        from_sync.call_soon_in_loop_thread(
+                            create_call(APILogHandler.aflush)
+                        )
 
                     self._is_started = False
                     self._client = None

--- a/src/prefect/task_server.py
+++ b/src/prefect/task_server.py
@@ -251,6 +251,8 @@ class TaskServer:
     async def execute_task_run(self, task_run: TaskRun):
         """Execute a task run in the task server."""
         async with self if not self.started else asyncnullcontext():
+            if self._limitter:
+                await self._limitter.acquire_on_behalf_of(task_run.id)
             await self._submit_scheduled_task_run(task_run)
 
     async def __aenter__(self):

--- a/src/prefect/task_server.py
+++ b/src/prefect/task_server.py
@@ -7,7 +7,7 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import AsyncExitStack
 from contextvars import copy_context
-from typing import List
+from typing import List, Optional
 
 import anyio
 import anyio.abc
@@ -61,11 +61,14 @@ class TaskServer:
     Args:
         - tasks: A list of tasks to serve. These tasks will be submitted to the engine
             when a scheduled task run is found.
+        - limit: The maximum number of tasks that can be run concurrently. Defaults to 10.
+            Pass `None` to remove the limit.
     """
 
     def __init__(
         self,
         *tasks: Task,
+        limit: Optional[int] = 10,
     ):
         self.tasks: List[Task] = tasks
 
@@ -82,6 +85,7 @@ class TaskServer:
 
         self._runs_task_group: anyio.abc.TaskGroup = anyio.create_task_group()
         self._executor = ThreadPoolExecutor()
+        self._limitter = anyio.CapacityLimiter(limit) if limit else None
 
     @property
     def _client_id(self) -> str:
@@ -142,6 +146,8 @@ class TaskServer:
             keys=[task.task_key for task in self.tasks],
             client_id=self._client_id,
         ):
+            if self._limitter:
+                await self._limitter.acquire_on_behalf_of(task_run.id)
             logger.info(f"Received task run: {task_run.id} - {task_run.name}")
             self._runs_task_group.start_soon(self._submit_scheduled_task_run, task_run)
 
@@ -239,6 +245,8 @@ class TaskServer:
                 return_type="state",
             )
             await asyncio.wrap_future(future)
+        if self._limitter:
+            self._limitter.release_on_behalf_of(task_run.id)
 
     async def execute_task_run(self, task_run: TaskRun):
         """Execute a task run in the task server."""
@@ -265,7 +273,7 @@ class TaskServer:
 
 
 @sync_compatible
-async def serve(*tasks: Task):
+async def serve(*tasks: Task, limit: Optional[int] = 10):
     """Serve the provided tasks so that their runs may be submitted to and executed.
     in the engine. Tasks do not need to be within a flow run context to be submitted.
     You must `.submit` the same task object that you pass to `serve`.
@@ -273,6 +281,8 @@ async def serve(*tasks: Task):
     Args:
         - tasks: A list of tasks to serve. When a scheduled task run is found for a
             given task, the task run will be submitted to the engine for execution.
+        - limit: The maximum number of tasks that can be run concurrently. Defaults to 10.
+            Pass `None` to remove the limit.
 
     Example:
         ```python
@@ -292,7 +302,8 @@ async def serve(*tasks: Task):
             serve(say, yell)
         ```
     """
-    task_server = TaskServer(*tasks)
+    task_server = TaskServer(*tasks, limit=limit)
+
     try:
         await task_server.start()
 

--- a/tests/test_task_server.py
+++ b/tests/test_task_server.py
@@ -664,7 +664,7 @@ class TestTaskServerLimit:
         updated_task_run_2 = await prefect_client.read_task_run(task_run_2.id)
 
         assert updated_task_run_1.state.is_completed()
-        assert updated_task_run_2.state.is_running()
+        assert not updated_task_run_2.state.is_completed()
 
         # clear the event to allow the second task to complete
         event.clear()

--- a/tests/test_task_server.py
+++ b/tests/test_task_server.py
@@ -2,6 +2,7 @@ import asyncio
 import signal
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import anyio
 import pytest
 from pydantic import BaseModel
 
@@ -9,6 +10,7 @@ import prefect.results
 from prefect import flow, get_client, task
 from prefect.client.schemas.objects import TaskRun
 from prefect.exceptions import MissingResult
+from prefect.filesystems import LocalFileSystem
 from prefect.states import Running
 from prefect.task_server import TaskServer, serve
 from prefect.tasks import task_input_hash
@@ -209,24 +211,6 @@ async def test_task_server_can_execute_a_single_sync_single_task_run(
     assert updated_task_run.state.is_completed()
 
     assert await updated_task_run.state.result() == 42
-
-
-async def test_task_server_respects_limit(foo_task, mock_subscription):
-    task_server = TaskServer(foo_task, limit=1)
-
-    task_run_1 = foo_task.apply_async((42,))
-    task_run_2 = foo_task.apply_async((43,))
-
-    async def mock_iter():
-        yield task_run_1
-        yield task_run_2
-        await asyncio.sleep(1)
-
-    mock_subscription.return_value = mock_iter()
-
-    await task_server.start()
-
-    assert mock_subscription.call_count == 1
 
 
 class TestTaskServerTaskRunRetries:
@@ -577,3 +561,148 @@ class TestTaskServerNestedTasks:
         assert updated_task_run.state.is_completed()
 
         assert await updated_task_run.state.result() == 42
+
+
+class TestTaskServerLimit:
+    @pytest.fixture(autouse=True)
+    async def register_localfilesystem(self):
+        """Register LocalFileSystem before running tests to avoid race conditions."""
+        await LocalFileSystem.register_type_and_schema()
+
+    async def test_task_server_respects_limit(self, mock_subscription, prefect_client):
+        @task
+        def slow_task():
+            import time
+
+            time.sleep(1)
+
+        task_server = TaskServer(slow_task, limit=1)
+
+        task_run_1 = slow_task.apply_async()
+        task_run_2 = slow_task.apply_async()
+
+        async def mock_iter():
+            yield task_run_1
+            yield task_run_2
+            # sleep for a second to ensure that task execution starts
+            await asyncio.sleep(1)
+
+        mock_subscription.return_value = mock_iter()
+
+        # only one should run at a time, so we'll move on after 1 second
+        # to ensure that the second task hasn't started
+        with anyio.move_on_after(1):
+            await task_server.start()
+
+        updated_task_run_1 = await prefect_client.read_task_run(task_run_1.id)
+        updated_task_run_2 = await prefect_client.read_task_run(task_run_2.id)
+
+        assert updated_task_run_1.state.is_completed()
+        assert updated_task_run_2.state.is_scheduled()
+
+    async def test_tasks_execute_when_limit_is_none(
+        self, mock_subscription, prefect_client
+    ):
+        @task
+        def slow_task():
+            import time
+
+            time.sleep(1)
+
+        task_server = TaskServer(slow_task, limit=None)
+
+        task_run_1 = slow_task.apply_async()
+        task_run_2 = slow_task.apply_async()
+
+        async def mock_iter():
+            yield task_run_1
+            yield task_run_2
+            # sleep for a second to ensure that task execution starts
+            await asyncio.sleep(1)
+
+        mock_subscription.return_value = mock_iter()
+
+        # both should run at the same time, so we'll move on after 1 second
+        # to ensure that the second task has started
+        with anyio.move_on_after(1):
+            await task_server.start()
+
+        updated_task_run_1 = await prefect_client.read_task_run(task_run_1.id)
+        updated_task_run_2 = await prefect_client.read_task_run(task_run_2.id)
+
+        assert updated_task_run_1.state.is_completed()
+        assert updated_task_run_2.state.is_completed()
+
+    async def test_tasks_execute_when_capacity_frees_up(
+        self, mock_subscription, prefect_client
+    ):
+        event = asyncio.Event()
+
+        @task
+        async def slow_task():
+            await asyncio.sleep(1)
+            if event.is_set():
+                raise ValueError("Something went wrong! This event should not be set.")
+            event.set()
+
+        task_server = TaskServer(slow_task, limit=1)
+
+        task_run_1 = slow_task.apply_async()
+        task_run_2 = slow_task.apply_async()
+
+        async def mock_iter():
+            yield task_run_1
+            yield task_run_2
+            # sleep for a second to ensure that task execution starts
+            await asyncio.sleep(1)
+
+        mock_subscription.return_value = mock_iter()
+
+        server_task = asyncio.create_task(task_server.start())
+        await event.wait()
+        updated_task_run_1 = await prefect_client.read_task_run(task_run_1.id)
+        updated_task_run_2 = await prefect_client.read_task_run(task_run_2.id)
+
+        assert updated_task_run_1.state.is_completed()
+        assert updated_task_run_2.state.is_running()
+
+        # clear the event to allow the second task to complete
+        event.clear()
+
+        await event.wait()
+        updated_task_run_2 = await prefect_client.read_task_run(task_run_2.id)
+
+        assert updated_task_run_2.state.is_completed()
+
+        server_task.cancel()
+        await server_task
+
+    async def test_execute_task_run_respects_limit(self, prefect_client):
+        @task
+        def slow_task():
+            import time
+
+            time.sleep(1)
+
+        task_server = TaskServer(slow_task, limit=1)
+
+        task_run_1 = slow_task.apply_async()
+        task_run_2 = slow_task.apply_async()
+
+        try:
+            with anyio.move_on_after(1):
+                # start task server first to avoid race condition between two execute_task_run calls
+                async with task_server:
+                    await asyncio.gather(
+                        task_server.execute_task_run(task_run_1),
+                        task_server.execute_task_run(task_run_2),
+                    )
+        except asyncio.exceptions.CancelledError:
+            # We want to cancel the second task run, so this is expected
+            pass
+
+        updated_task_run_1 = await prefect_client.read_task_run(task_run_1.id)
+        updated_task_run_2 = await prefect_client.read_task_run(task_run_2.id)
+
+        assert updated_task_run_1.state.is_completed()
+        assert updated_task_run_2.state.is_scheduled()


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Adds a `limit` argument to `TaskServer` to limit the number of concurrent runs for a given task server. Task servers will stop receiving runs from the sbuscription when the limit is reached. Once one or more active task runs completes, the server will begin pulling runs from the subscription again until the limit is reached. If `limit` is set to `None`, now limiting of concurrent runs is enforced.

Closes https://github.com/PrefectHQ/prefect/issues/12325

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Given the following script:
```python
from prefect import task
from prefect.task_server import serve


@task
def slow_task():
    import time

    time.sleep(5)
    return 42


async def main():
    for _ in range(10):
        slow_task.apply_async()

    await serve(slow_task, limit=2)


if __name__ == "__main__":
    import asyncio

    asyncio.run(main())
```
the received runs will be executed in groups of two:
```
14:06:34.579 | INFO    | prefect.task_server - Starting task server...
14:06:34.580 | INFO    | prefect.task_server - Subscribing to tasks: slow_task-541ab05a929b32acb2d77ba3aa0291b1
14:06:34.590 | INFO    | prefect.task_server - Received task run: 95e4be3b-f62b-4a95-9b34-6c06c32d4473 - slow_task-slow_tas
14:06:34.595 | INFO    | prefect.task_server - Received task run: 3df7b6c1-1706-4b08-b73e-c129e52be258 - slow_task-slow_tas
14:06:39.934 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:06:39.938 | INFO    | prefect.task_server - Received task run: 97e3e9d4-c73b-4899-b247-16c1ae2cfb5d - slow_task-slow_tas
14:06:39.947 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:06:39.951 | INFO    | prefect.task_server - Received task run: ccf1b9ca-4875-4f24-be31-3ad93c90bf75 - slow_task-slow_tas
14:06:45.060 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:06:45.066 | INFO    | prefect.task_server - Received task run: 679f51d4-8e7b-4851-b3a5-51d24717af3b - slow_task-slow_tas
14:06:45.079 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:06:45.083 | INFO    | prefect.task_server - Received task run: 934924ea-9970-4dcf-92d4-541ddb997f3c - slow_task-slow_tas
14:06:50.232 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:06:50.235 | INFO    | prefect.task_server - Received task run: c87986f2-e32d-4160-b632-9908d5aacff9 - slow_task-slow_tas
14:06:50.254 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:06:50.256 | INFO    | prefect.task_server - Received task run: 7a2f93d0-3a4c-4fd4-abd9-3a26bf23a3f6 - slow_task-slow_tas
14:06:55.374 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:06:55.378 | INFO    | prefect.task_server - Received task run: c3abf996-7698-4d3b-92a2-fdbc07dcb384 - slow_task-slow_tas
14:06:55.386 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:06:55.391 | INFO    | prefect.task_server - Received task run: f41e878e-97de-44a3-bfaa-c9e8d40ec496 - slow_task-slow_tas
14:07:00.511 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:07:00.530 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
```

The equivalent output without a limit:
```
14:09:02.307 | INFO    | prefect.task_server - Starting task server...
14:09:02.308 | INFO    | prefect.task_server - Subscribing to tasks: slow_task-541ab05a929b32acb2d77ba3aa0291b1
14:09:02.310 | INFO    | prefect.task_server - Received task run: 8dda8696-3977-4f49-9641-300a4a4ad922 - slow_task-slow_tas
14:09:02.316 | INFO    | prefect.task_server - Received task run: cded3c6d-c097-4dfb-ac83-bcc88b28ec45 - slow_task-slow_tas
14:09:02.320 | INFO    | prefect.task_server - Received task run: f68e853f-692f-4afb-b643-bd0886fb5f2f - slow_task-slow_tas
14:09:02.325 | INFO    | prefect.task_server - Received task run: 97633822-3927-4b9a-97c9-fcf0fe90f63c - slow_task-slow_tas
14:09:02.330 | INFO    | prefect.task_server - Received task run: 2d31e8c7-f13a-4d51-9b7a-715db0a5e51f - slow_task-slow_tas
14:09:02.336 | INFO    | prefect.task_server - Received task run: 4e1e01d2-fd95-4288-8f5b-dbdb3a5e6868 - slow_task-slow_tas
14:09:02.342 | INFO    | prefect.task_server - Received task run: 24584a0c-43d2-49ec-87e7-d47ca8e63c43 - slow_task-slow_tas
14:09:02.377 | INFO    | prefect.task_server - Received task run: 62153b42-44df-4758-adb5-7a7b41999ddc - slow_task-slow_tas
14:09:02.384 | INFO    | prefect.task_server - Received task run: 1f4225b2-9a88-4721-925e-b81f03ed0515 - slow_task-slow_tas
14:09:02.392 | INFO    | prefect.task_server - Received task run: 571d6d3e-a79a-4eb8-9afc-7b23cb4cc83c - slow_task-slow_tas
14:09:07.738 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:09:07.770 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:09:07.778 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:09:07.784 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:09:07.802 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:09:07.810 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:09:07.819 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:09:07.825 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:09:07.842 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
14:09:07.854 | INFO    | Task run 'slow_task-slow_tas' - Finished in state Completed()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
 	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `mint.json` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `docs/mint.json` navigation.
