### PR TITLE
Remove `PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING` flag

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -578,7 +578,7 @@ def create_app(
         if prefect.settings.PREFECT_API_SERVICES_FOREMAN_ENABLED.value():
             service_instances.append(services.foreman.Foreman())
 
-        if prefect.settings.PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING.value():
+        if prefect.settings.PREFECT_API_SERVICES_TASK_SCHEDULING_ENABLED.value():
             service_instances.append(services.task_scheduling.TaskSchedulingTimeouts())
 
         if prefect.settings.PREFECT_API_SERVICES_TRIGGERS_ENABLED.value():

--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -33,7 +33,6 @@ from prefect.server.schemas import core, filters, states
 from prefect.server.schemas.states import StateType
 from prefect.server.task_queue import TaskQueue
 from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
     PREFECT_TASK_RUN_TAG_CONCURRENCY_SLOT_WAIT_SECONDS,
 )
 from prefect.utilities.math import clamped_poisson_interval
@@ -485,10 +484,6 @@ class EnqueueScheduledTasks(BaseOrchestrationRule):
         validated_state: Optional[states.State],
         context: TaskOrchestrationContext,
     ) -> None:
-        if not PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING.value():
-            # Only if task scheduling is enabled
-            return
-
         if not validated_state:
             # Only if the transition was valid
             return

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1486,6 +1486,11 @@ PREFECT_WORKER_WEBSERVER_PORT = Setting(
 The port the worker's webserver should bind to.
 """
 
+PREFECT_API_SERVICES_TASK_SCHEDULING_ENABLED = Setting(bool, default=True)
+"""
+Whether or not to start the task scheduling service in the server application.
+"""
+
 PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK = Setting(
     str,
     default="local-file-system/prefect-task-scheduling",
@@ -1550,11 +1555,6 @@ Whether or not to enable the experimental workspace dashboard.
 PREFECT_EXPERIMENTAL_WARN_WORKSPACE_DASHBOARD = Setting(bool, default=False)
 """
 Whether or not to warn when the experimental workspace dashboard is enabled.
-"""
-
-PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING = Setting(bool, default=False)
-"""
-Whether or not to enable experimental task scheduling.
 """
 
 PREFECT_EXPERIMENTAL_ENABLE_WORK_QUEUE_STATUS = Setting(bool, default=True)

--- a/src/prefect/task_server.py
+++ b/src/prefect/task_server.py
@@ -22,7 +22,6 @@ from prefect.logging.loggers import get_logger
 from prefect.results import ResultFactory
 from prefect.settings import (
     PREFECT_API_URL,
-    PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
     PREFECT_TASK_SCHEDULING_DELETE_FAILED_SUBMISSIONS,
 )
 from prefect.states import Pending
@@ -293,12 +292,6 @@ async def serve(*tasks: Task):
             serve(say, yell)
         ```
     """
-    if not PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING.value():
-        raise RuntimeError(
-            "To enable task scheduling, set PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING"
-            " to True."
-        )
-
     task_server = TaskServer(*tasks)
     try:
         await task_server.start()

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -44,7 +44,6 @@ from prefect.futures import PrefectFuture
 from prefect.logging.loggers import get_logger
 from prefect.results import ResultFactory, ResultSerializer, ResultStorage
 from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
     PREFECT_TASK_DEFAULT_RETRIES,
     PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS,
 )
@@ -1017,7 +1016,7 @@ class Task(Generic[P, R]):
                 "`task.map()` is not currently supported by `flow.visualize()`"
             )
 
-        if PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING.value() and not flow_run_context:
+        if not flow_run_context:
             # TODO: Should we split out background task mapping into a separate method
             # like we do for the `submit`/`apply_async` split?
             parameters_list = expand_mapping_parameters(self.fn, parameters)
@@ -1139,13 +1138,6 @@ class Task(Generic[P, R]):
 
             >>> my_task.serve()
         """
-
-        if not PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING:
-            raise ValueError(
-                "Task's `serve` method is an experimental feature and must be enabled with "
-                "`prefect config set PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING=True`"
-            )
-
         from prefect.task_server import serve
 
         serve(self, task_runner=task_runner)

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -1,22 +1,10 @@
-import pytest
-
 from prefect import flow, task
 from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.objects import State
 from prefect.events.clients import AssertingEventsClient
 from prefect.events.worker import EventsWorker
 from prefect.filesystems import LocalFileSystem
-from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
-    temporary_settings,
-)
 from prefect.task_server import TaskServer
-
-
-@pytest.fixture
-def enable_task_scheduling():
-    with temporary_settings({PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING: True}):
-        yield
 
 
 async def test_task_state_change_happy_path(
@@ -151,7 +139,6 @@ async def test_background_task_state_changes(
     asserting_events_worker: EventsWorker,
     reset_worker_events,
     prefect_client,
-    enable_task_scheduling,
     tmp_path,
 ):
     storage = LocalFileSystem(basepath=tmp_path)

--- a/tests/server/orchestration/api/test_task_run_subscriptions.py
+++ b/tests/server/orchestration/api/test_task_run_subscriptions.py
@@ -15,24 +15,10 @@ from prefect.server import models
 from prefect.server.api import task_runs
 from prefect.server.schemas import states as server_states
 from prefect.server.schemas.core import TaskRun as ServerTaskRun
-from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
-    temporary_settings,
-)
 
 
 @pytest.fixture
-def task_scheduling_enabled() -> Generator[None, None, None]:
-    with temporary_settings(
-        {
-            PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING: True,
-        }
-    ):
-        yield
-
-
-@pytest.fixture
-def reset_task_queues(task_scheduling_enabled) -> Generator[None, None, None]:
+def reset_task_queues() -> Generator[None, None, None]:
     task_runs.TaskQueue.reset()
 
     yield

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -21,7 +21,6 @@ from prefect.server.api.task_runs import TaskQueue
 from prefect.server.schemas.core import TaskRun as ServerTaskRun
 from prefect.server.services.task_scheduling import TaskSchedulingTimeouts
 from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
     PREFECT_LOCAL_STORAGE_PATH,
     PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK,
     PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT,
@@ -43,16 +42,6 @@ def local_filesystem(tmp_path):
     block = LocalFileSystem(basepath=tmp_path)
     block.save("test-fs", overwrite=True)
     return block
-
-
-@pytest.fixture(autouse=True)
-def allow_experimental_task_scheduling():
-    with temporary_settings(
-        {
-            PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING: True,
-        }
-    ):
-        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_task_server.py
+++ b/tests/test_task_server.py
@@ -8,23 +8,9 @@ import prefect.results
 from prefect import flow, get_client, task
 from prefect.client.schemas.objects import TaskRun
 from prefect.exceptions import MissingResult
-from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
-    temporary_settings,
-)
 from prefect.states import Running
 from prefect.task_server import TaskServer, serve
 from prefect.tasks import task_input_hash
-
-
-@pytest.fixture(autouse=True)
-def mock_settings():
-    with temporary_settings(
-        {
-            PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING: True,
-        }
-    ):
-        yield
 
 
 @pytest.fixture(autouse=True)
@@ -163,14 +149,6 @@ async def test_task_server_handles_deleted_task_run_submission(
 
 @pytest.mark.usefixtures("mock_task_server_start")
 class TestServe:
-    async def test_serve_raises_if_task_scheduling_not_enabled(self, foo_task):
-        with temporary_settings({PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING: False}):
-            with pytest.raises(
-                RuntimeError,
-                match="set PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING to True",
-            ):
-                await serve(foo_task)
-
     async def test_serve_basic_sync_task(self, foo_task, mock_task_server_start):
         await serve(foo_task)
         mock_task_server_start.assert_called_once()


### PR DESCRIPTION
This removes the `PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING` flag and related code. It also adds in a `PREFECT_API_SERVICES_TASK_SCHEDULING_ENABLED` setting, that's enabled by default, to enable/disable starting the service when starting prefect.