### PR TITLE
Allows us to run integration package unit tests by adding a PR label

### DIFF
--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "src/integrations/*/**"
+    types: [opened, reopened, synchronize, labeled]
   push:
     branches:
       - main
@@ -12,6 +13,9 @@ on:
 
 jobs:
   prepare-matrix:
+    # These tests will only run if the integration paths are affected, or someone has
+    # added the `integrations` label to the PR
+    if: github.event_name != 'labeled' || contains(github.event.pull_request.labels.*.name, 'integrations')
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -4,8 +4,8 @@ on:
   pull_request:
     paths:
       #- .github/workflows/integration-package-tests.yaml
-      - "src/*"
-      - "tests/*"
+      - "src/**"
+      - "tests/**"
     types: [opened, reopened, synchronize, labeled]
   push:
     branches:

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -16,7 +16,7 @@ jobs:
   prepare-matrix:
     # These tests will only run if the integration paths are affected, or someone has
     # added the `integrations` label to the PR
-    if: ${{ github.event_name != 'labeled' || contains(github.event.pull_request.labels.*.name, 'integrations') }}
+    if: ${{ github.event_name != 'labeled' || contains(github.event.pull_request.labels.*.name, 'test-all-integrations') }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -32,7 +32,7 @@ jobs:
       - name: Generate matrix
         id: set-matrix
         run: |
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'integrations') }}" == 'true' ]]; then
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'test-all-integrations') }}" == 'true' ]]; then
             # All of the integration packages were changed since 2.19.2, so this is a
             # standin for saying "all integrations"
             COMMIT_RANGE="2.19.2..${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -40,6 +40,15 @@ jobs:
           python scripts/generate_integration_package_tests_matrix.py "$COMMIT_RANGE" > matrix.json
           cat matrix.json
           echo "matrix=$(cat matrix.json)" >> $GITHUB_OUTPUT
+      - name: Generate matrix
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'integrations') }}
+        run: |
+          # All of the integration packages were changed since 2.19.2, so this is a
+          # standin for saying "all integrations"
+          COMMIT_RANGE="2.19.2..${{ github.event.pull_request.head.sha }}"
+          python scripts/generate_integration_package_tests_matrix.py "$COMMIT_RANGE" > matrix.json
+          cat matrix.json
+          echo "matrix=$(cat matrix.json)" >> $GITHUB_OUTPUT
 
   run-tests:
     timeout-minutes: 20

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -3,8 +3,8 @@ name: Integrations Packages Tests
 on:
   pull_request:
     paths:
-      # - .github/workflows/integration-package-tests.yaml
-      - "**/*.py"
+      - .github/workflows/integration-package-tests.yaml
+      - "src/**/*"
     types: [opened, reopened, synchronize, labeled]
   push:
     branches:

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -4,8 +4,7 @@ on:
   pull_request:
     paths:
       #- .github/workflows/integration-package-tests.yaml
-      - "src/**"
-      - "tests/**"
+      - "**/*.py"
     types: [opened, reopened, synchronize, labeled]
   push:
     branches:

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -32,20 +32,15 @@ jobs:
       - name: Generate matrix
         id: set-matrix
         run: |
-          if [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'integrations') }}" == 'true' ]]; then
+            # All of the integration packages were changed since 2.19.2, so this is a
+            # standin for saying "all integrations"
+            COMMIT_RANGE="2.19.2..${{ github.event.pull_request.head.sha }}"
+          else if [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
             COMMIT_RANGE="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
           else
             COMMIT_RANGE="${{ github.event.before }}..${{ github.event.after }}"
           fi
-          python scripts/generate_integration_package_tests_matrix.py "$COMMIT_RANGE" > matrix.json
-          cat matrix.json
-          echo "matrix=$(cat matrix.json)" >> $GITHUB_OUTPUT
-      - name: Generate matrix
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'integrations') }}
-        run: |
-          # All of the integration packages were changed since 2.19.2, so this is a
-          # standin for saying "all integrations"
-          COMMIT_RANGE="2.19.2..${{ github.event.pull_request.head.sha }}"
           python scripts/generate_integration_package_tests_matrix.py "$COMMIT_RANGE" > matrix.json
           cat matrix.json
           echo "matrix=$(cat matrix.json)" >> $GITHUB_OUTPUT

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -36,7 +36,7 @@ jobs:
             # All of the integration packages were changed since 2.19.2, so this is a
             # standin for saying "all integrations"
             COMMIT_RANGE="2.19.2..${{ github.event.pull_request.head.sha }}"
-          else if [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
+          elif [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
             COMMIT_RANGE="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
           else
             COMMIT_RANGE="${{ github.event.before }}..${{ github.event.after }}"

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -3,7 +3,7 @@ name: Integrations Packages Tests
 on:
   pull_request:
     paths:
-      #- .github/workflows/integration-package-tests.yaml
+      - .github/workflows/integration-package-tests.yaml
       - "**/*.py"
     types: [opened, reopened, synchronize, labeled]
   push:

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -5,7 +5,7 @@ on:
     paths:
       - .github/workflows/integration-package-tests.yaml
       - "src/**/*"
-    types: [opened, reopened, synchronize, labeled]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   push:
     branches:
       - main
@@ -16,7 +16,6 @@ jobs:
   prepare-matrix:
     # These tests will only run if the integration paths are affected, or someone has
     # added the `integrations` label to the PR
-    if: ${{ github.event_name != 'labeled' || contains(github.event.pull_request.labels.*.name, 'test-all-integrations') }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -15,7 +15,7 @@ jobs:
   prepare-matrix:
     # These tests will only run if the integration paths are affected, or someone has
     # added the `integrations` label to the PR
-    if: github.event_name != 'labeled' || contains(github.event.pull_request.labels.*.name, 'integrations')
+    if: ${{ github.event_name != 'labeled' || contains(github.event.pull_request.labels.*.name, 'integrations') }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -3,7 +3,9 @@ name: Integrations Packages Tests
 on:
   pull_request:
     paths:
-      - "src/integrations/*/**"
+      #- .github/workflows/integration-package-tests.yaml
+      - "src/*"
+      - "tests/*"
     types: [opened, reopened, synchronize, labeled]
   push:
     branches:

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -3,7 +3,7 @@ name: Integrations Packages Tests
 on:
   pull_request:
     paths:
-      - .github/workflows/integration-package-tests.yaml
+      # - .github/workflows/integration-package-tests.yaml
       - "**/*.py"
     types: [opened, reopened, synchronize, labeled]
   push:

--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -104,6 +104,3 @@ __all__ = [
     "resume_flow_run",
     "suspend_flow_run",
 ]
-
-
-# NO-OP CHANGE

--- a/src/prefect/__init__.py
+++ b/src/prefect/__init__.py
@@ -104,3 +104,6 @@ __all__ = [
     "resume_flow_run",
     "suspend_flow_run",
 ]
+
+
+# NO-OP CHANGE


### PR DESCRIPTION
There are times when we make changes to `prefect` that we suspect may affect
the integrations packages, but we don't want to run the full integrations test
suites on _every_ `prefect` change.  This lets us add a `test-all-integrations` label to
a PR to opt in to running those tests.
