### PR TITLE
Add `prefect task serve` CLI command to start task server

### DIFF
--- a/docs/3.0rc/api-ref/prefect/cli/task.mdx
+++ b/docs/3.0rc/api-ref/prefect/cli/task.mdx
@@ -1,0 +1,9 @@
+---
+description: Prefect command line interface for interacting with the task server
+tags:
+    - Python API
+    - CLI
+    - Tasks
+---
+
+::: prefect.cli.task

--- a/src/prefect/cli/__init__.py
+++ b/src/prefect/cli/__init__.py
@@ -21,6 +21,7 @@ import prefect.cli.flow_run
 import prefect.cli.global_concurrency_limit
 import prefect.cli.profile
 import prefect.cli.server
+import prefect.cli.task
 import prefect.cli.variable
 import prefect.cli.work_pool
 import prefect.cli.work_queue

--- a/src/prefect/cli/task.py
+++ b/src/prefect/cli/task.py
@@ -3,6 +3,7 @@ from typing import List
 import typer
 
 from prefect.cli._types import PrefectTyper
+from prefect.cli._utilities import exit_with_error
 from prefect.cli.root import app
 from prefect.task_server import serve as task_serve
 from prefect.utilities.importtools import import_object
@@ -31,22 +32,19 @@ async def serve(
 
     for entrypoint in entrypoints:
         if ".py:" not in entrypoint:
-            app.console.print(
+            exit_with_error(
                 (
                     f"Error: Invalid entrypoint format {entrypoint!r}. It "
                     "must be of the form `./path/to/file.py:task_func_name`."
-                ),
-                style="red",
+                )
             )
-            raise typer.Exit(1)
 
         try:
             tasks.append(import_object(entrypoint))
         except Exception:
             module, task_name = entrypoint.split(":")
-            app.console.print(
+            exit_with_error(
                 f"Error: {module!r} has no function {task_name!r}.", style="red"
             )
-            raise typer.Exit(1)
 
     await task_serve(*tasks)

--- a/src/prefect/cli/task.py
+++ b/src/prefect/cli/task.py
@@ -19,9 +19,8 @@ async def serve(
     ),
 ):
     """
-    Starts a task server that runs scheduled tasks.
-
-    This command initiates a task server which will monitor and execute the specified tasks.
+    Serve the provided tasks so that their runs may be submitted to and
+    executed in the engine.
 
     Args:
         entrypoints: List of strings representing the paths to one or more

--- a/src/prefect/cli/task.py
+++ b/src/prefect/cli/task.py
@@ -1,0 +1,53 @@
+from typing import List
+
+import typer
+
+from prefect.cli._types import PrefectTyper
+from prefect.cli.root import app
+from prefect.task_server import serve as task_serve
+from prefect.utilities.importtools import import_object
+
+task_app = PrefectTyper(name="task", help="Commands for working with task scheduling.")
+app.add_typer(task_app, aliases=["task"])
+
+
+@task_app.command()
+async def serve(
+    entrypoints: List[str] = typer.Argument(
+        ...,
+        help="The paths to one or more tasks, in the form of `./path/to/file.py:task_func_name`.",
+    ),
+):
+    """
+    Starts a task server that runs scheduled tasks.
+
+    This command initiates a task server which will monitor and execute the specified tasks.
+
+    Args:
+        entrypoints: List of strings representing the paths to one or more
+            tasks. Each path should be in the format
+            `./path/to/file.py:task_func_name`.
+    """
+    tasks = []
+
+    for entrypoint in entrypoints:
+        if ".py:" not in entrypoint:
+            app.console.print(
+                (
+                    f"Error: Invalid entrypoint format {entrypoint!r}. It "
+                    "must be of the form `./path/to/file.py:task_func_name`."
+                ),
+                style="red",
+            )
+            raise typer.Exit(1)
+
+        try:
+            tasks.append(import_object(entrypoint))
+        except Exception:
+            module, task_name = entrypoint.split(":")
+            app.console.print(
+                f"Error: {module!r} has no function {task_name!r}.", style="red"
+            )
+            raise typer.Exit(1)
+
+    await task_serve(*tasks)

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -1,0 +1,82 @@
+from unittest import mock
+
+from prefect import __development_base_path__
+from prefect.testing.cli import invoke_and_assert
+from prefect.utilities.asyncutils import run_sync_in_worker_thread
+
+TEST_PROJECTS_DIR = __development_base_path__ / "tests" / "test-projects"
+
+
+async def test_invalid_entrypoint():
+    await run_sync_in_worker_thread(
+        invoke_and_assert,
+        [
+            "task",
+            "serve",
+            "file.py",
+        ],
+        expected_code=1,
+        expected_output_contains=[
+            (
+                "Error: Invalid entrypoint format 'file.py'. It "
+                "must be of the form `./path/to/file.py:task_func_name`."
+            )
+        ],
+    )
+
+
+async def test_import_failure():
+    await run_sync_in_worker_thread(
+        invoke_and_assert,
+        [
+            "task",
+            "serve",
+            "file.py:nope_not_a_chance",
+        ],
+        expected_code=1,
+        expected_output_contains=[
+            "Error: 'file.py' has no function 'nope_not_a_chance'."
+        ],
+    )
+
+
+async def test_single_entrypoint():
+    with mock.patch(
+        "prefect.cli.task.task_serve", new_callable=mock.AsyncMock
+    ) as task_serve:
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            [
+                "task",
+                "serve",
+                f"{TEST_PROJECTS_DIR}/tasks/household.py:do_the_dishes",
+            ],
+            expected_code=0,
+        )
+
+        task_serve.assert_awaited_once()
+        served_tasks = task_serve.call_args_list[0][0]
+        assert len(served_tasks) == 1
+        assert served_tasks[0].name == "do_the_dishes"
+
+
+async def test_multiple_entrypoints():
+    with mock.patch(
+        "prefect.cli.task.task_serve", new_callable=mock.AsyncMock
+    ) as task_serve:
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            [
+                "task",
+                "serve",
+                f"{TEST_PROJECTS_DIR}/tasks/household.py:do_the_dishes",
+                f"{TEST_PROJECTS_DIR}/tasks/space.py:spacewalk",
+            ],
+            expected_code=0,
+        )
+
+        task_serve.assert_awaited_once()
+        served_tasks = task_serve.call_args_list[0][0]
+        assert len(served_tasks) == 2
+        assert served_tasks[0].name == "do_the_dishes"
+        assert served_tasks[1].name == "spacewalk"

--- a/tests/test-projects/tasks/household.py
+++ b/tests/test-projects/tasks/household.py
@@ -1,0 +1,6 @@
+from prefect import task
+
+
+@task
+def do_the_dishes():
+    return "The dishes are :sparkles: clean!"

--- a/tests/test-projects/tasks/space.py
+++ b/tests/test-projects/tasks/space.py
@@ -1,0 +1,6 @@
+from prefect import task
+
+
+@task
+def spacewalk():
+    return "Houston, I have a bad feeling about this mission."


### PR DESCRIPTION
This adds a `prefect task serve` CLI command that takes a list of entrypoints and starts a task server that will serve the tasks at those entrypoints.

Closes #12245 