### PR TITLE
Fix flaky 2.x CI tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -596,7 +596,7 @@ def reset_sys_modules():
     importlib.invalidate_caches()
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=True, scope="module")
 def leaves_no_extraneous_files():
     """This fixture will fail a test if it seems to have left new files or directories
     in the root of the local working tree.  For performance, it only checks for changes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -596,7 +596,7 @@ def reset_sys_modules():
     importlib.invalidate_caches()
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(autouse=True, scope="session")
 def leaves_no_extraneous_files():
     """This fixture will fail a test if it seems to have left new files or directories
     in the root of the local working tree.  For performance, it only checks for changes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -596,7 +596,7 @@ def reset_sys_modules():
     importlib.invalidate_caches()
 
 
-@pytest.fixture(autouse=True, scope="module")
+@pytest.fixture(autouse=True, scope="function")
 def leaves_no_extraneous_files():
     """This fixture will fail a test if it seems to have left new files or directories
     in the root of the local working tree.  For performance, it only checks for changes

--- a/tests/results/test_flow_results.py
+++ b/tests/results/test_flow_results.py
@@ -357,8 +357,12 @@ async def test_child_flow_result_missing_with_null_return(prefect_client):
 
 @pytest.mark.parametrize("empty_type", [dict, list])
 @pytest.mark.parametrize("persist_result", [True, False])
-def test_flow_empty_result_is_retained(persist_result, empty_type):
-    @flow(persist_result=persist_result)
+def test_flow_empty_result_is_retained(
+    persist_result: bool, empty_type, tmp_path: Path
+):
+    storage = LocalFileSystem(basepath=tmp_path)
+
+    @flow(persist_result=persist_result, result_storage=storage)
     def my_flow():
         return empty_type()
 
@@ -377,13 +381,16 @@ def test_flow_empty_result_is_retained(persist_result, empty_type):
     ],
 )
 @pytest.mark.parametrize("persist_result", [True, False])
-def test_flow_resultlike_result_is_retained(persist_result, resultlike):
+def test_flow_resultlike_result_is_retained(
+    persist_result: bool, resultlike, tmp_path: Path
+):
     """
     Since Pydantic will coerce dictionaries into `BaseResult` types, we need to be sure
     that user dicts that look like a bit like results do not cause problems
     """
+    storage = LocalFileSystem(basepath=tmp_path)
 
-    @flow(persist_result=persist_result)
+    @flow(persist_result=persist_result, result_storage=storage)
     def my_flow():
         return resultlike
 
@@ -401,8 +408,12 @@ def test_flow_resultlike_result_is_retained(persist_result, resultlike):
     ],
 )
 @pytest.mark.parametrize("persist_result", [True, False])
-def test_flow_state_result_is_respected(persist_result, return_state):
-    @flow(persist_result=persist_result)
+def test_flow_state_result_is_respected(
+    persist_result: bool, return_state, tmp_path: Path
+):
+    storage = LocalFileSystem(basepath=tmp_path)
+
+    @flow(persist_result=persist_result, result_storage=storage)
     def my_flow():
         return return_state
 
@@ -430,9 +441,13 @@ def test_flow_state_result_is_respected(persist_result, return_state):
     ],
 )
 @pytest.mark.parametrize("persist_result", [True, False])
-def test_flow_server_state_schema_result_is_respected(persist_result, return_state):
+def test_flow_server_state_schema_result_is_respected(
+    persist_result: bool, return_state, tmp_path: Path
+):
+    storage = LocalFileSystem(basepath=tmp_path)
+
     # Tests for backwards compatibility with server-side state return values
-    @flow(persist_result=persist_result)
+    @flow(persist_result=persist_result, result_storage=storage)
     def my_flow():
         return return_state
 


### PR DESCRIPTION
This PR fixes a number of test flakes related to stray file cleanup. 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
 	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->