### PR TITLE
Mark tasks as being `deferred` when using `apply_async`

### DIFF
--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -136,6 +136,7 @@ class StateDetails(PrefectBaseModel):
     scheduled_time: Optional[DateTime] = None
     cache_key: Optional[str] = None
     cache_expiration: Optional[DateTime] = None
+    deferred: Optional[bool] = None
     untrackable_result: bool = False
     pause_timeout: Optional[DateTime] = None
     pause_reschedule: bool = False

--- a/src/prefect/server/orchestration/core_policy.py
+++ b/src/prefect/server/orchestration/core_policy.py
@@ -492,6 +492,10 @@ class EnqueueScheduledTasks(BaseOrchestrationRule):
             # Only for autonomous tasks
             return
 
+        if not validated_state.state_details.deferred:
+            # Only for tasks that are deferred
+            return
+
         task_run: core.TaskRun = core.TaskRun.model_validate(context.run)
         queue: TaskQueue = TaskQueue.for_key(task_run.task_key)
 

--- a/src/prefect/server/schemas/states.py
+++ b/src/prefect/server/schemas/states.py
@@ -76,6 +76,7 @@ class StateDetails(PrefectBaseModel):
     scheduled_time: Optional[DateTime] = None
     cache_key: Optional[str] = None
     cache_expiration: Optional[DateTime] = None
+    deferred: Optional[bool] = False
     untrackable_result: bool = False
     pause_timeout: Optional[DateTime] = None
     pause_reschedule: bool = False

--- a/src/prefect/server/services/task_scheduling.py
+++ b/src/prefect/server/services/task_scheduling.py
@@ -104,9 +104,11 @@ class TaskSchedulingTimeouts(LoopService):
                 )
                 continue
 
-            rescheduled = states.Scheduled()
-            rescheduled.state_details.task_parameters_id = (
-                prior_scheduled_state.state_details.task_parameters_id
+            rescheduled = states.Scheduled(
+                state_details={
+                    "deferred": True,
+                    "task_parameters_id": prior_scheduled_state.state_details.task_parameters_id,
+                }
             )
 
             await models.task_runs.set_task_run_state(

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -549,6 +549,7 @@ class Task(Generic[P, R]):
         parent_task_run_context: Optional[TaskRunContext] = None,
         wait_for: Optional[Iterable[PrefectFuture]] = None,
         extra_task_inputs: Optional[Dict[str, Set[TaskRunInput]]] = None,
+        deferred: bool = False,
     ) -> TaskRun:
         from prefect.utilities.engine import (
             _dynamic_key_for_task_run,
@@ -589,6 +590,9 @@ class Task(Generic[P, R]):
 
                 factory = await ResultFactory.from_autonomous_task(self, client=client)
                 await factory.store_parameters(parameters_id, parameters)
+
+            if deferred:
+                state.state_details.deferred = True
 
             # collect task inputs
             task_inputs = {
@@ -1119,7 +1123,7 @@ class Task(Generic[P, R]):
         # Convert the call args/kwargs to a parameter dict
         parameters = get_call_parameters(self.fn, args, kwargs)
 
-        return run_coro_as_sync(self.create_run(parameters=parameters))
+        return run_coro_as_sync(self.create_run(parameters=parameters, deferred=True))
 
     def serve(self, task_runner: Optional["BaseTaskRunner"] = None) -> "Task":
         """Serve the task using the provided task runner. This method is used to

--- a/tests/server/orchestration/api/test_task_run_subscriptions.py
+++ b/tests/server/orchestration/api/test_task_run_subscriptions.py
@@ -242,7 +242,7 @@ async def preexisting_runs(session: AsyncSession, reset_task_queues) -> List[Tas
                 flow_run_id=None,
                 task_key="mytasks.taskA",
                 dynamic_key="mytasks.taskA-1",
-                state=server_states.Scheduled(),
+                state=server_states.Scheduled(state_details={"deferred": True}),
             ),
         )
     )
@@ -254,7 +254,7 @@ async def preexisting_runs(session: AsyncSession, reset_task_queues) -> List[Tas
                 flow_run_id=None,
                 task_key="mytasks.taskA",
                 dynamic_key="mytasks.taskA-2",
-                state=server_states.Scheduled(),
+                state=server_states.Scheduled(state_details={"deferred": True}),
             ),
         )
     )


### PR DESCRIPTION
This updates `apply_async` to mark task runs it creates as being `deferred`. It also updates the `EnqueueScheduledTasks` core policy to only enqueue tasks that are `deferred=True`. This keeps tasks that are executed in other ways from also being executed by the task server.

Closes #13674 