### PR TITLE
Allowing clients to provide TaskRun ids

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -73,7 +73,6 @@ jobs:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql-config.yml
           queries: security-extended
-          setup-python-dependencies: false
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -302,11 +302,6 @@ class FlowRunUpdate(ActionBaseModel):
 class TaskRunCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a task run"""
 
-    id: Optional[UUID] = Field(
-        default=None,
-        description="The ID to use for the task run. If not provided, a random UUID will be generated.",
-    )
-
     # TaskRunCreate states must be provided as StateCreate objects
     state: Optional[StateCreate] = Field(
         default=None, description="The state of the task run to create"

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -302,6 +302,11 @@ class FlowRunUpdate(ActionBaseModel):
 class TaskRunCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a task run"""
 
+    id: Optional[UUID] = Field(
+        default=None,
+        description="The ID to use for the task run. If not provided, a random UUID will be generated.",
+    )
+
     # TaskRunCreate states must be provided as StateCreate objects
     state: Optional[StateCreate] = Field(
         default=None, description="The state of the task run to create"

--- a/src/prefect/server/api/task_runs.py
+++ b/src/prefect/server/api/task_runs.py
@@ -56,8 +56,12 @@ async def create_task_run(
 
     If no state is provided, the task run will be created in a PENDING state.
     """
+
     # hydrate the input model into a full task run / state model
-    task_run = schemas.core.TaskRun(**task_run.dict())
+    task_run_dict = task_run.dict()
+    if not task_run_dict.get("id"):
+        task_run_dict.pop("id", None)
+    task_run = schemas.core.TaskRun(**task_run_dict)
 
     if not task_run.state:
         task_run.state = schemas.states.Pending()

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -421,6 +421,11 @@ class StateCreate(ActionBaseModel):
 class TaskRunCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a task run"""
 
+    id: Optional[UUID] = Field(
+        default=None,
+        description="The ID to use for the task run. If not provided, a random UUID will be generated.",
+    )
+
     # TaskRunCreate states must be provided as StateCreate objects
     state: Optional[StateCreate] = Field(
         default=None, description="The state of the task run to create"

--- a/tests/results/test_flow_results.py
+++ b/tests/results/test_flow_results.py
@@ -357,8 +357,12 @@ async def test_child_flow_result_missing_with_null_return(prefect_client):
 
 @pytest.mark.parametrize("empty_type", [dict, list])
 @pytest.mark.parametrize("persist_result", [True, False])
-def test_flow_empty_result_is_retained(persist_result, empty_type):
-    @flow(persist_result=persist_result)
+def test_flow_empty_result_is_retained(
+    persist_result: bool, empty_type, tmp_path: Path
+):
+    storage = LocalFileSystem(basepath=tmp_path)
+
+    @flow(persist_result=persist_result, result_storage=storage)
     def my_flow():
         return empty_type()
 
@@ -377,13 +381,16 @@ def test_flow_empty_result_is_retained(persist_result, empty_type):
     ],
 )
 @pytest.mark.parametrize("persist_result", [True, False])
-def test_flow_resultlike_result_is_retained(persist_result, resultlike):
+def test_flow_resultlike_result_is_retained(
+    persist_result: bool, resultlike, tmp_path: Path
+):
     """
     Since Pydantic will coerce dictionaries into `BaseResult` types, we need to be sure
     that user dicts that look like a bit like results do not cause problems
     """
+    storage = LocalFileSystem(basepath=tmp_path)
 
-    @flow(persist_result=persist_result)
+    @flow(persist_result=persist_result, result_storage=storage)
     def my_flow():
         return resultlike
 
@@ -401,8 +408,12 @@ def test_flow_resultlike_result_is_retained(persist_result, resultlike):
     ],
 )
 @pytest.mark.parametrize("persist_result", [True, False])
-def test_flow_state_result_is_respected(persist_result, return_state):
-    @flow(persist_result=persist_result)
+def test_flow_state_result_is_respected(
+    persist_result: bool, return_state, tmp_path: Path
+):
+    storage = LocalFileSystem(basepath=tmp_path)
+
+    @flow(persist_result=persist_result, result_storage=storage)
     def my_flow():
         return return_state
 
@@ -430,9 +441,13 @@ def test_flow_state_result_is_respected(persist_result, return_state):
     ],
 )
 @pytest.mark.parametrize("persist_result", [True, False])
-def test_flow_server_state_schema_result_is_respected(persist_result, return_state):
+def test_flow_server_state_schema_result_is_respected(
+    persist_result: bool, return_state, tmp_path: Path
+):
+    storage = LocalFileSystem(basepath=tmp_path)
+
     # Tests for backwards compatibility with server-side state return values
-    @flow(persist_result=persist_result)
+    @flow(persist_result=persist_result, result_storage=storage)
     def my_flow():
         return return_state
 


### PR DESCRIPTION
Though we aren't using this client-side in 2.x, having support for it will allow
3.x clients to work with 2.x servers (as with Prefect Cloud)
