### PR TITLE
Expose `limit` in `prefect task serve`

### DIFF
--- a/src/prefect/cli/task.py
+++ b/src/prefect/cli/task.py
@@ -18,6 +18,10 @@ async def serve(
         ...,
         help="The paths to one or more tasks, in the form of `./path/to/file.py:task_func_name`.",
     ),
+    limit: int = typer.Option(
+        10,
+        help="The maximum number of tasks that can be run concurrently. Defaults to 10.",
+    ),
 ):
     """
     Serve the provided tasks so that their runs may be submitted to and
@@ -27,6 +31,7 @@ async def serve(
         entrypoints: List of strings representing the paths to one or more
             tasks. Each path should be in the format
             `./path/to/file.py:task_func_name`.
+        limit: The maximum number of tasks that can be run concurrently.
     """
     tasks = []
 
@@ -47,4 +52,4 @@ async def serve(
                 f"Error: {module!r} has no function {task_name!r}.", style="red"
             )
 
-    await task_serve(*tasks)
+    await task_serve(*tasks, limit=limit)

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -54,7 +54,7 @@ async def test_single_entrypoint():
             expected_code=0,
         )
 
-        task_serve.assert_awaited_once()
+        task_serve.assert_awaited_once_with(mock.ANY, limit=10)
         served_tasks = task_serve.call_args_list[0][0]
         assert len(served_tasks) == 1
         assert served_tasks[0].name == "do_the_dishes"
@@ -75,7 +75,7 @@ async def test_multiple_entrypoints():
             expected_code=0,
         )
 
-        task_serve.assert_awaited_once()
+        task_serve.assert_awaited_once_with(mock.ANY, mock.ANY, limit=10)
         served_tasks = task_serve.call_args_list[0][0]
         assert len(served_tasks) == 2
         assert served_tasks[0].name == "do_the_dishes"


### PR DESCRIPTION
Following on from https://github.com/PrefectHQ/prefect/pull/13662 this exposes the `limit` in the CLI.