### PR TITLE
Remove unnecessary debug log in events API

### DIFF
--- a/src/prefect/server/api/events.py
+++ b/src/prefect/server/api/events.py
@@ -261,14 +261,6 @@ async def handle_event_count_request(
     time_unit: TimeUnit,
     time_interval: float,
 ) -> List[EventCount]:
-    logger.debug(
-        "countable %s, time_unit %s, time_interval %s, events filter: %s",
-        countable,
-        time_unit,
-        time_interval,
-        filter.model_dump_json(),
-    )
-
     try:
         return await database.count_events(
             session=session,


### PR DESCRIPTION
Should close a few code scanning alerts

- [Log Injection](https://github.com/PrefectHQ/prefect/security/code-scanning/2011)
- [Log Injection](https://github.com/PrefectHQ/prefect/security/code-scanning/2012)
- [Log Injection](https://github.com/PrefectHQ/prefect/security/code-scanning/2013)