### PR TITLE
Run integrations package test workflow only on Python file changes

### DIFF
--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
     paths:
-      - "src/integrations/*/**"
+      - "src/integrations/*/**.py"
 
 jobs:
   prepare-matrix:

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -4,13 +4,13 @@ on:
   pull_request:
     paths:
       - .github/workflows/integration-package-tests.yaml
-      - "src/**/*"
+      - "src/integrations/*/**.py"
     types: [opened, reopened, synchronize, labeled, unlabeled]
   push:
     branches:
       - main
     paths:
-      - "src/integrations/*/**"
+      - "src/integrations/*/**.py"
 
 jobs:
   prepare-matrix:

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -4,13 +4,13 @@ on:
   pull_request:
     paths:
       - .github/workflows/integration-package-tests.yaml
-      - "src/integrations/*/**.py"
+      - "src/**/*.py"
     types: [opened, reopened, synchronize, labeled, unlabeled]
   push:
     branches:
       - main
     paths:
-      - "src/integrations/*/**.py"
+      - "src/**/*.py"
 
 jobs:
   prepare-matrix:

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
     paths:
-      - "src/**/*.py"
+      - "src/integrations/*/**"
 
 jobs:
   prepare-matrix:


### PR DESCRIPTION
Ideally we'd only run on changes to `.py` files, rather than docs changes, for example.