### PR TITLE
[UI] Fix missing work pools nav item

### DIFF
--- a/ui/src/components/ContextSidebar.vue
+++ b/ui/src/components/ContextSidebar.vue
@@ -50,7 +50,7 @@
   import { routes } from '@/router'
 
   const can = useCan()
-  const canSeeWorkPools = computed(() => can.access.work_pools && can.read.work_pool)
+  const canSeeWorkPools = computed(() => can.read.work_pool)
 
   const { showModal: showJoinCommunityModal, open: openJoinCommunityModal } = useShowModal()
   const { value: joinTheCommunityModalDismissed } = useStorage('local', 'join-the-community-modal-dismissed', false)

--- a/ui/src/maps/featureFlag.ts
+++ b/ui/src/maps/featureFlag.ts
@@ -7,8 +7,6 @@ export const mapFlagResponseToFeatureFlag: MapFunction<FlagResponse, FeatureFlag
   switch (source) {
     case 'workers':
       return 'access:workers'
-    case 'work_pools':
-      return 'access:work_pools'
     case 'artifacts':
       return 'access:artifacts'
     case 'deployment_status':

--- a/ui/src/pages/Dashboard.vue
+++ b/ui/src/pages/Dashboard.vue
@@ -5,7 +5,7 @@
         <template v-if="!empty" #actions>
           <div class="workspace-dashboard__header-actions">
             <div class="workspace-dashboard__subflows-toggle">
-                <p-toggle v-model="filter.hideSubflows" append="Hide subflows" />
+              <p-toggle v-model="filter.hideSubflows" append="Hide subflows" />
             </div>
             <FlowRunTagsInput v-model:selected="filter.tags" empty-message="All tags" />
             <DateRangeSelect v-model="filter.range" class="workspace-dashboard__date-select" />

--- a/ui/src/types/flagResponse.ts
+++ b/ui/src/types/flagResponse.ts
@@ -1,6 +1,5 @@
 export type FlagResponse =
 | 'workers'
-| 'work_pools'
 | 'artifacts'
 | 'deployment_status'
 | 'work_queue_status'

--- a/ui/src/utilities/permissions.ts
+++ b/ui/src/utilities/permissions.ts
@@ -3,7 +3,6 @@ import { InjectionKey } from 'vue'
 
 const featureFlags = [
   'access:workers',
-  'access:work_pools',
   'access:artifacts',
   'access:deploymentStatus',
   'access:workQueueStatus',


### PR DESCRIPTION
https://github.com/PrefectHQ/prefect/pull/13144 removed the `PREFECT_EXPERIMENTAL_ENABLE_WORK_POOLS` setting which the UI was still using as a feature flag despite it having shifted over to `default=True` behavior some time ago. By removing this setting, the UI guards incorrectly see the flag is being turned off now. 