### PR TITLE
Use `NotFound` exception from `docker.errors`

### DIFF
--- a/tests/fixtures/docker.py
+++ b/tests/fixtures/docker.py
@@ -20,7 +20,7 @@ from prefect.utilities.dockerutils import (
 
 with silence_docker_warnings():
     from docker import DockerClient
-    from docker.errors import APIError, ImageNotFound
+    from docker.errors import APIError, ImageNotFound, NotFound
     from docker.models.containers import Container
 
 
@@ -70,7 +70,7 @@ def cleanup_all_new_docker_objects(docker: DockerClient, worker_id: str):
             for image in docker.images.list(filters=filters):
                 for tag in image.tags:
                     docker.images.remove(tag, force=True)
-        except docker.errors.NotFound:
+        except NotFound:
             logger.warning("Failed to clean up Docker objects")
 
 


### PR DESCRIPTION
The docker tests [failed in main](https://github.com/PrefectHQ/prefect/actions/runs/9323639698/job/25667269799) with an error when trying to cleanup created containers:

```
tests/fixtures/docker.py:73: in cleanup_all_new_docker_objects
    except docker.errors.NotFound:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <docker.client.DockerClient object at 0x7f8450f44d90>, name = 'errors'

    def __getattr__(self, name):
        s = [f"'DockerClient' object has no attribute '{name}'"]
        # If a user calls a method on APIClient, they
        if hasattr(APIClient, name):
            s.append("In Docker SDK for Python 2.0, this method is now on the "
                     "object APIClient. See the low-level API section of the "
                     "documentation for more details.")
>       raise AttributeError(' '.join(s))
E       AttributeError: 'DockerClient' object has no attribute 'errors'
```

This fixes that up by importing the Exception and not using the 'shadow' `docker` that is actually the client.