### PR TITLE
Remove divider from runs page

### DIFF
--- a/ui/src/pages/Runs.vue
+++ b/ui/src/pages/Runs.vue
@@ -12,8 +12,6 @@
         <p-content>
           <FlowRunsFilterGroup v-model:nameSearch="flowRunNameLike" :filter="dashboardFilter" @update:filter="setDashboardFilter" />
 
-          <p-divider />
-
           <p-tabs-root v-model="tab" :default-value="tabs[0]">
             <p-tabs-list>
               <p-tabs-trigger value="flow-runs">
@@ -179,8 +177,8 @@
   const tab = useRouteQueryParam('tab', 'flow-runs')
   const tabs = ['flow-runs', 'task-runs']
 
-  const flowRunsCountAllSubscription = useSubscription(api.flowRuns.getFlowRunsCount, [{}])
-  const taskRunsCountAllSubscription = useSubscription(api.taskRuns.getTaskRunsCount, [{}])
+  const flowRunsCountAllSubscription = useSubscription(api.flowRuns.getFlowRunsCount)
+  const taskRunsCountAllSubscription = useSubscription(api.taskRuns.getTaskRunsCount)
 
   const loaded = computed(() => flowRunsCountAllSubscription.executed && taskRunsCountAllSubscription.executed)
   const empty = computed(() => flowRunsCountAllSubscription.response === 0 && taskRunsCountAllSubscription.response === 0)


### PR DESCRIPTION
# Description
Removing the divider since it doesn't offer much and takes up a lot of space

**before**
<img width="906" alt="image" src="https://github.com/PrefectHQ/nebula-ui/assets/6200442/35a46d10-68ee-4925-82b9-ab835d9b9913">

**after**
<img width="910" alt="image" src="https://github.com/PrefectHQ/nebula-ui/assets/6200442/86217858-9d9f-47b7-86f5-58e8f53161ba">

