### PR TITLE
Copy pared down `prefect-redis` to integrations

### DIFF
--- a/src/integrations/prefect-redis/LICENSE
+++ b/src/integrations/prefect-redis/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 Prefect Technologies, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/integrations/prefect-redis/MANIFEST.in
+++ b/src/integrations/prefect-redis/MANIFEST.in
@@ -1,0 +1,14 @@
+# Things to always exclude
+global-exclude .git*
+global-exclude .ipynb_checkpoints
+global-exclude *.py[co]
+global-exclude __pycache__/**
+
+# Top-level Config
+include versioneer.py
+include prefect_redis/_version.py
+include LICENSE
+include MANIFEST.in
+include setup.cfg
+include requirements.txt
+include requirements-dev.txt

--- a/src/integrations/prefect-redis/README.md
+++ b/src/integrations/prefect-redis/README.md
@@ -1,0 +1,1 @@
+# prefect-redis

--- a/src/integrations/prefect-redis/prefect_redis/__init__.py
+++ b/src/integrations/prefect-redis/prefect_redis/__init__.py
@@ -1,0 +1,6 @@
+from .filesystem import RedisFilesystem
+
+
+__all__ = [
+    "RedisFilesystem",
+]

--- a/src/integrations/prefect-redis/prefect_redis/filesystem.py
+++ b/src/integrations/prefect-redis/prefect_redis/filesystem.py
@@ -1,0 +1,157 @@
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator, Optional, Union
+
+import redis.asyncio as redis
+from pydantic import Field
+from pydantic.types import SecretStr
+from typing_extensions import Self
+
+from prefect.filesystems import WritableFileSystem
+
+
+class RedisFilesystem(WritableFileSystem):
+    """
+    Block used to interact with Redis as a filesystem
+
+    Attributes:
+        host (str): The value to store.
+        port (int): The value to store.
+        db (int): The value to store.
+        username (str): The value to store.
+        password (str): The value to store.
+        connection_string (str): The value to store.
+
+    Example:
+        Create a new block from hostname, username and password:
+        ```python
+        from prefect_redis import RedisFilesystem
+
+        block = RedisFilesystem.from_host(
+            host="myredishost.com", username="redis", password="SuperSecret")
+        block.save("BLOCK_NAME")
+        ```
+
+        Create a new block from a connection string
+        ```python
+        from prefect_redis import RedisFilesystem
+        block = RedisFilesystem.from_url(""redis://redis:SuperSecret@myredishost.com:6379")
+        block.save("BLOCK_NAME")
+        ```
+    """
+
+    _logo_url = "https://stprododpcmscdnendpoint.azureedge.net/assets/icons/redis.png"
+
+    host: Optional[str] = Field(default=None, description="Redis hostname")
+    port: int = Field(default=6379, description="Redis port")
+    db: int = Field(default=0, description="Redis DB index")
+    username: Optional[SecretStr] = Field(default=None, description="Redis username")
+    password: Optional[SecretStr] = Field(default=None, description="Redis password")
+    connection_string: Optional[SecretStr] = Field(
+        default=None, description="Redis connection string"
+    )
+
+    def block_initialization(self) -> None:
+        if self.connection_string:
+            return
+        if not self.host:
+            raise ValueError("Initialization error: 'host' is required but missing.")
+        if self.username and not self.password:
+            raise ValueError(
+                "Initialization error: 'username' is provided, but 'password' is missing. Both are required."
+            )
+
+    async def read_path(self, path: str):
+        """Read a redis key
+
+        Args:
+            path: Redis key to read from
+
+        Returns:
+            Contents at key as bytes
+        """
+        async with self._client() as client:
+            return await client.get(path)
+
+    async def write_path(self, path: str, content: bytes):
+        """Write to a redis key
+
+        Args:
+            path: Redis key to write to
+            content: Binary object to write
+        """
+
+        async with self._client() as client:
+            return await client.set(path, content)
+
+    @asynccontextmanager
+    async def _client(self) -> AsyncGenerator[redis.Redis, None]:
+        if self.connection_string:
+            client = redis.Redis.from_url(self.connection_string.get_secret_value())
+        else:
+            assert self.host
+            client = redis.Redis(
+                host=self.host,
+                port=self.port,
+                username=self.username.get_secret_value() if self.username else None,
+                password=self.password.get_secret_value() if self.password else None,
+                db=self.db,
+            )
+
+        try:
+            yield client
+        finally:
+            await client.aclose()
+
+    @classmethod
+    def from_host(
+        cls,
+        host: str,
+        port: int = 6379,
+        db: int = 0,
+        username: Union[None, str, SecretStr] = None,
+        password: Union[None, str, SecretStr] = None,
+    ) -> Self:
+        """Create block from hostname, username and password
+
+        Args:
+            host: Redis hostname
+            username: Redis username
+            password: Redis password
+            port: Redis port
+
+        Returns:
+            `RedisFilesystem` instance
+        """
+
+        username = SecretStr(username) if isinstance(username, str) else username
+        password = SecretStr(password) if isinstance(password, str) else password
+
+        return cls(host=host, port=port, db=db, username=username, password=password)
+
+    @classmethod
+    def from_connection_string(cls, connection_string: Union[str, SecretStr]) -> Self:
+        """Create block from a Redis connection string
+
+        Supports the following URL schemes:
+        - `redis://` creates a TCP socket connection
+        - `rediss://` creates a SSL wrapped TCP socket connection
+        - `unix://` creates a Unix Domain Socket connection
+
+        See [Redis docs](https://redis.readthedocs.io/en/stable/examples
+        /connection_examples.html#Connecting-to-Redis-instances-by-specifying-a-URL
+        -scheme.) for more info.
+
+        Args:
+            connection_string: Redis connection string
+
+        Returns:
+            `RedisFilesystem` instance
+        """
+
+        connection_string = (
+            SecretStr(connection_string)
+            if isinstance(connection_string, str)
+            else connection_string
+        )
+
+        return cls(connection_string=connection_string)

--- a/src/integrations/prefect-redis/pyproject.toml
+++ b/src/integrations/prefect-redis/pyproject.toml
@@ -1,0 +1,74 @@
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prefect-redis"
+description = "Prefect integrations for interacting with Redis as a filesystem"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache License 2.0" }
+keywords = ["prefect"]
+authors = [{ name = "Prefect Technologies, Inc.", email = "help@prefect.io" }]
+classifiers = [
+  "Natural Language :: English",
+  "Intended Audience :: Developers",
+  "Intended Audience :: System Administrators",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+  "prefect>=3.0.0rc1",
+  "redis>=5.0.1",
+]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+dev = [
+  "coverage",
+  "interrogate",
+  "mkdocs-gen-files",
+  "mkdocs-material",
+  "mkdocs",
+  "mkdocstrings[python]",
+  "mypy",
+  "pre-commit",
+  "pytest-asyncio",
+  "pytest",
+  "pytest-xdist",
+]
+
+[project.urls]
+Homepage = "https://github.com/PrefectHQ/prefect/tree/main/src/integrations/prefect-redis"
+
+[project.entry-points."prefect.collections"]
+prefect_redis = "prefect_redis"
+
+[tool.setuptools_scm]
+version_file = "prefect_redis/_version.py"
+root = "../../.."
+tag_regex = "^prefect-redis-(?P<version>\\d+\\.\\d+\\.\\d+(?:[a-zA-Z0-9]+(?:\\.[a-zA-Z0-9]+)*)?)$"
+fallback_version = "0.0.0"
+git_describe_command = 'git describe --dirty --tags --long --match "prefect-redis-*[0-9]*"'
+
+[tool.interrogate]
+ignore-init-module = true
+ignore_init_method = true
+exclude = ["prefect_redis/_version.py", "tests"]
+fail-under = 95
+omit-covered-files = true
+
+[tool.coverage.run]
+omit = ["tests/*", "prefect_redis/_version.py"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/src/integrations/prefect-redis/tests/test_filesystem.py
+++ b/src/integrations/prefect-redis/tests/test_filesystem.py
@@ -1,0 +1,66 @@
+import os
+from typing import Union
+
+import pytest
+from prefect_redis.filesystem import RedisFilesystem
+from pydantic.types import SecretStr
+
+
+@pytest.fixture
+async def redis_config() -> dict[str, Union[str, int, None]]:
+    return {
+        "host": os.environ.get("TEST_REDIS_HOST", "localhost"),
+        "port": int(os.environ.get("TEST_REDIS_PORT", 6379)),
+        "db": int(os.environ.get("TEST_REDIS_DB", 0)),
+        "username": os.environ.get("TEST_REDIS_USERNAME"),
+        "password": os.environ.get("TEST_REDIS_PASSWORD"),
+    }
+
+
+@pytest.fixture
+async def redis_from_host(redis_config: dict) -> RedisFilesystem:
+    return RedisFilesystem.from_host(**redis_config)
+
+
+@pytest.fixture
+async def redis_from_connection_string(redis_config: dict) -> RedisFilesystem:
+    connection_string = (
+        f"redis://{redis_config['host']}:{redis_config['port']}/{redis_config['db']}"
+    )
+    return RedisFilesystem.from_connection_string(connection_string)
+
+
+async def test_initialize_from_host(redis_config: dict):
+    redis = RedisFilesystem.from_host(**redis_config)
+
+    assert redis.host == redis_config["host"]
+    assert redis.port == redis_config["port"]
+    assert redis.db == redis_config["db"]
+    assert redis.username == redis_config["username"]
+    assert redis.password == redis_config["password"]
+
+
+async def test_initialize_without_host_fails():
+    with pytest.raises(ValueError, match="'host' is required"):
+        RedisFilesystem(host=None)
+
+
+async def test_initialize_with_username_but_no_password_fails():
+    with pytest.raises(
+        ValueError, match="'username' is provided, but 'password' is missing"
+    ):
+        RedisFilesystem(
+            host="localhost", username=SecretStr("test_user"), password=None
+        )
+
+
+async def test_read_write_path_from_host(redis_from_host: RedisFilesystem):
+    await redis_from_host.write_path("test_key", b"test_value")
+    assert await redis_from_host.read_path("test_key") == b"test_value"
+
+
+async def test_read_write_path_from_connection_string(
+    redis_from_connection_string: RedisFilesystem,
+):
+    await redis_from_connection_string.write_path("test_key", b"test_value")
+    assert await redis_from_connection_string.read_path("test_key") == b"test_value"


### PR DESCRIPTION
This copies over a pared down / refactored version of `prefect-redis` that only includes the filesystem capabilities and full test coverage. 

There are a couple things left for follow-up PRs:

- Fill in the README
- Copy / update the documentation