### PR TITLE
Rename `RedisFilesystem` to `RedisStorageContainer` to match naming semantics of other filesystem classes

### DIFF
--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -85,6 +85,13 @@ jobs:
           uv pip install --upgrade --system -e .[dev]
           uv pip install --upgrade --system ../../../
 
+      - name: Start redis
+        if: matrix.package == 'prefect-redis'
+        run: >
+          docker run
+          --detach
+          --publish 6379:6379
+          redis:latest
 
       - name: Run tests
         if: matrix.package != 'prefect-ray'

--- a/src/integrations/prefect-redis/prefect_redis/__init__.py
+++ b/src/integrations/prefect-redis/prefect_redis/__init__.py
@@ -1,6 +1,6 @@
-from .filesystem import RedisFilesystem
+from .filesystem import RedisStorageContainer
 
 
 __all__ = [
-    "RedisFilesystem",
+    "RedisStorageContainer",
 ]

--- a/src/integrations/prefect-redis/prefect_redis/filesystem.py
+++ b/src/integrations/prefect-redis/prefect_redis/filesystem.py
@@ -9,7 +9,7 @@ from typing_extensions import Self
 from prefect.filesystems import WritableFileSystem
 
 
-class RedisFilesystem(WritableFileSystem):
+class RedisStorageContainer(WritableFileSystem):
     """
     Block used to interact with Redis as a filesystem
 
@@ -24,17 +24,17 @@ class RedisFilesystem(WritableFileSystem):
     Example:
         Create a new block from hostname, username and password:
         ```python
-        from prefect_redis import RedisFilesystem
+        from prefect_redis import RedisStorageContainer
 
-        block = RedisFilesystem.from_host(
+        block = RedisStorageContainer.from_host(
             host="myredishost.com", username="redis", password="SuperSecret")
         block.save("BLOCK_NAME")
         ```
 
         Create a new block from a connection string
         ```python
-        from prefect_redis import RedisFilesystem
-        block = RedisFilesystem.from_url(""redis://redis:SuperSecret@myredishost.com:6379")
+        from prefect_redis import RedisStorageContainer
+        block = RedisStorageContainer.from_url(""redis://redis:SuperSecret@myredishost.com:6379")
         block.save("BLOCK_NAME")
         ```
     """
@@ -120,7 +120,7 @@ class RedisFilesystem(WritableFileSystem):
             port: Redis port
 
         Returns:
-            `RedisFilesystem` instance
+            `RedisStorageContainer` instance
         """
 
         username = SecretStr(username) if isinstance(username, str) else username
@@ -145,7 +145,7 @@ class RedisFilesystem(WritableFileSystem):
             connection_string: Redis connection string
 
         Returns:
-            `RedisFilesystem` instance
+            `RedisStorageContainer` instance
         """
 
         connection_string = (

--- a/src/integrations/prefect-redis/tests/test_filesystem.py
+++ b/src/integrations/prefect-redis/tests/test_filesystem.py
@@ -2,7 +2,7 @@ import os
 from typing import Union
 
 import pytest
-from prefect_redis.filesystem import RedisFilesystem
+from prefect_redis.filesystem import RedisStorageContainer
 from pydantic.types import SecretStr
 
 
@@ -18,20 +18,20 @@ async def redis_config() -> dict[str, Union[str, int, None]]:
 
 
 @pytest.fixture
-async def redis_from_host(redis_config: dict) -> RedisFilesystem:
-    return RedisFilesystem.from_host(**redis_config)
+async def redis_from_host(redis_config: dict) -> RedisStorageContainer:
+    return RedisStorageContainer.from_host(**redis_config)
 
 
 @pytest.fixture
-async def redis_from_connection_string(redis_config: dict) -> RedisFilesystem:
+async def redis_from_connection_string(redis_config: dict) -> RedisStorageContainer:
     connection_string = (
         f"redis://{redis_config['host']}:{redis_config['port']}/{redis_config['db']}"
     )
-    return RedisFilesystem.from_connection_string(connection_string)
+    return RedisStorageContainer.from_connection_string(connection_string)
 
 
 async def test_initialize_from_host(redis_config: dict):
-    redis = RedisFilesystem.from_host(**redis_config)
+    redis = RedisStorageContainer.from_host(**redis_config)
 
     assert redis.host == redis_config["host"]
     assert redis.port == redis_config["port"]
@@ -42,25 +42,25 @@ async def test_initialize_from_host(redis_config: dict):
 
 async def test_initialize_without_host_fails():
     with pytest.raises(ValueError, match="'host' is required"):
-        RedisFilesystem(host=None)
+        RedisStorageContainer(host=None)
 
 
 async def test_initialize_with_username_but_no_password_fails():
     with pytest.raises(
         ValueError, match="'username' is provided, but 'password' is missing"
     ):
-        RedisFilesystem(
+        RedisStorageContainer(
             host="localhost", username=SecretStr("test_user"), password=None
         )
 
 
-async def test_read_write_path_from_host(redis_from_host: RedisFilesystem):
+async def test_read_write_path_from_host(redis_from_host: RedisStorageContainer):
     await redis_from_host.write_path("test_key", b"test_value")
     assert await redis_from_host.read_path("test_key") == b"test_value"
 
 
 async def test_read_write_path_from_connection_string(
-    redis_from_connection_string: RedisFilesystem,
+    redis_from_connection_string: RedisStorageContainer,
 ):
     await redis_from_connection_string.write_path("test_key", b"test_value")
     assert await redis_from_connection_string.read_path("test_key") == b"test_value"


### PR DESCRIPTION
@desertaxle I think this naming brings it inline with the others, thoughts?

Related to #12249 