### PR TITLE
conditionally log retryable errors

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -237,13 +237,13 @@ async def custom_internal_exception_handler(request: Request, exc: Exception):
 
     Send 503 for errors clients can retry on.
     """
-    logger.error("Encountered exception in request:", exc_info=True)
-
     if is_client_retryable_exception(exc):
         return JSONResponse(
             content={"exception_message": "Service Unavailable"},
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
+
+    logger.error("Encountered exception in request:", exc_info=True)
 
     return JSONResponse(
         content={"exception_message": "Internal Server Error"},

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -238,11 +238,6 @@ async def custom_internal_exception_handler(request: Request, exc: Exception):
     Send 503 for errors clients can retry on.
     """
     if is_client_retryable_exception(exc):
-        logger.info(
-            "Encountered retryable exception in request. Returning retryable status code:",
-            exc_info=True,
-        )
-
         return JSONResponse(
             content={"exception_message": "Service Unavailable"},
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -238,6 +238,11 @@ async def custom_internal_exception_handler(request: Request, exc: Exception):
     Send 503 for errors clients can retry on.
     """
     if is_client_retryable_exception(exc):
+        logger.info(
+            "Encountered retryable exception in request. Returning retryable status code:",
+            exc_info=True,
+        )
+
         return JSONResponse(
             content={"exception_message": "Service Unavailable"},
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -44,6 +44,7 @@ from prefect.server.utilities.database import get_dialect
 from prefect.server.utilities.server import method_paths_from_routes
 from prefect.settings import (
     PREFECT_API_DATABASE_CONNECTION_URL,
+    PREFECT_API_LOG_RETRYABLE_ERRORS,
     PREFECT_DEBUG_MODE,
     PREFECT_MEMO_STORE_PATH,
     PREFECT_MEMOIZE_BLOCK_AUTO_REGISTRATION,
@@ -238,6 +239,9 @@ async def custom_internal_exception_handler(request: Request, exc: Exception):
     Send 503 for errors clients can retry on.
     """
     if is_client_retryable_exception(exc):
+        if PREFECT_API_LOG_RETRYABLE_ERRORS.value():
+            logger.error("Encountered retryable exception in request:", exc_info=True)
+
         return JSONResponse(
             content={"exception_message": "Service Unavailable"},
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -923,7 +923,7 @@ async def mark_deployments_ready(
         return
 
     async with db.session_context(
-        begin_transaction=True, with_for_update=True
+        begin_transaction=True,
     ) as session:
         result = await session.execute(
             select(orm_models.Deployment.id).where(
@@ -977,7 +977,7 @@ async def mark_deployments_not_ready(
         return
 
     async with db.session_context(
-        begin_transaction=True, with_for_update=True
+        begin_transaction=True,
     ) as session:
         result = await session.execute(
             select(orm_models.Deployment.id).where(

--- a/src/prefect/server/services/loop_service.py
+++ b/src/prefect/server/services/loop_service.py
@@ -9,6 +9,7 @@ import anyio
 import pendulum
 
 from prefect.logging import get_logger
+from prefect.server.api.server import is_client_retryable_exception
 from prefect.server.database.dependencies import inject_db
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.utilities.processutils import _register_signal
@@ -83,7 +84,10 @@ class LoopService:
 
             # if an error is raised, log and continue
             except Exception as exc:
-                self.logger.error(f"Unexpected error in: {repr(exc)}", exc_info=True)
+                if not is_client_retryable_exception(exc):
+                    self.logger.error(
+                        f"Unexpected error in: {repr(exc)}", exc_info=True
+                    )
 
             end_time = pendulum.now("UTC")
 

--- a/src/prefect/server/services/loop_service.py
+++ b/src/prefect/server/services/loop_service.py
@@ -9,7 +9,6 @@ import anyio
 import pendulum
 
 from prefect.logging import get_logger
-from prefect.server.api.server import is_client_retryable_exception
 from prefect.server.database.dependencies import inject_db
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.utilities.processutils import _register_signal
@@ -84,6 +83,9 @@ class LoopService:
 
             # if an error is raised, log and continue
             except Exception as exc:
+                # avoid circular import
+                from prefect.server.api.server import is_client_retryable_exception
+
                 if not is_client_retryable_exception(exc):
                     self.logger.error(
                         f"Unexpected error in: {repr(exc)}", exc_info=True

--- a/src/prefect/server/services/loop_service.py
+++ b/src/prefect/server/services/loop_service.py
@@ -11,6 +11,7 @@ import pendulum
 from prefect.logging import get_logger
 from prefect.server.database.dependencies import inject_db
 from prefect.server.database.interface import PrefectDBInterface
+from prefect.settings import PREFECT_API_LOG_RETRYABLE_ERRORS
 from prefect.utilities.processutils import _register_signal
 
 
@@ -86,7 +87,10 @@ class LoopService:
                 # avoid circular import
                 from prefect.server.api.server import is_client_retryable_exception
 
-                if not is_client_retryable_exception(exc):
+                retryable_error = is_client_retryable_exception(exc)
+                if not retryable_error or (
+                    retryable_error and PREFECT_API_LOG_RETRYABLE_ERRORS.value()
+                ):
                     self.logger.error(
                         f"Unexpected error in: {repr(exc)}", exc_info=True
                     )

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1208,6 +1208,9 @@ PREFECT_API_SERVICES_FOREMAN_WORK_QUEUE_LAST_POLLED_TIMEOUT_SECONDS = Setting(
 """The number of seconds before a work queue is marked as not ready if it has not been
 polled."""
 
+PREFECT_API_LOG_RETRYABLE_ERRORS = Setting(bool, default=False)
+"""If `True`, log retryable errors in the API and it's services."""
+
 
 PREFECT_API_DEFAULT_LIMIT = Setting(
     int,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ from prefect.logging.configuration import setup_logging
 from prefect.settings import (
     PREFECT_API_BLOCKS_REGISTER_ON_START,
     PREFECT_API_DATABASE_CONNECTION_URL,
+    PREFECT_API_LOG_RETRYABLE_ERRORS,
     PREFECT_API_SERVICES_CANCELLATION_CLEANUP_ENABLED,
     PREFECT_API_SERVICES_EVENT_PERSISTER_ENABLED,
     PREFECT_API_SERVICES_FLOW_RUN_NOTIFICATIONS_ENABLED,
@@ -327,6 +328,7 @@ def pytest_sessionstart(session):
             PREFECT_API_SERVICES_PAUSE_EXPIRATIONS_ENABLED: False,
             PREFECT_API_SERVICES_CANCELLATION_CLEANUP_ENABLED: False,
             PREFECT_API_SERVICES_FOREMAN_ENABLED: False,
+            PREFECT_API_LOG_RETRYABLE_ERRORS: True,
             # Disable block auto-registration memoization
             PREFECT_MEMOIZE_BLOCK_AUTO_REGISTRATION: False,
             # Disable auto-registration of block types as they can conflict


### PR DESCRIPTION
When running the prefect server (ephemeral or otherwise), there a number of known expected exceptions that a user will hit. 

This is particularly true with SQLite:
- A requirement of our existing server side orchestration is that 1 client is orchestrating 1 run at a time. Cloud has it's own implementation to enforce this. OSS Postgres locks the row.
- To improve sqlite transaction behavior we implemented the following: https://github.com/PrefectHQ/prefect/pull/9594, where we can conditionally and explicitly lock the DB for certain actions (if you want to understand the real WHY we need to do this, I'd really recommend looking at that pr and the code comments in it)
- These locked db errors are sent with a retryable status code by the server, with the expectation that the client will try again. 

This is particularly visible when using the ephemeral api:
- When the ephemeral api is running in the same process as the flow/task run all errors are bundled together

This PR adds a setting `PREFECT_API_LOG_RETRYABLE_ERRORS` that defaults to False, that controls whether these retryable errors are logged.


