### PR TITLE
Ignore `.coverage` files when checking for extraneous files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -604,6 +604,15 @@ def leaves_no_extraneous_files():
     yield
     after = set(Path(".").iterdir())
     new_files = after - before
+
+    ignored_file_prefixes = {".coverage"}
+
+    new_files = {
+        f
+        for f in new_files
+        if not any(f.name.startswith(prefix) for prefix in ignored_file_prefixes)
+    }
+
     if new_files:
         raise AssertionError(
             "One of the tests in this module left new files in the "


### PR DESCRIPTION
I had the [Datadog tests fail](https://github.com/PrefectHQ/prefect/actions/runs/9386164402/job/25846053054) because there were `.coverage` files on the filesystem, this is expected as the datadog tests collect and report coverage. This PR ensures that these files are ignored for the purposes of checking for extraneous files.