### PR TITLE
Put `AwsCredentials` first to match default factory

### DIFF
--- a/src/integrations/prefect-aws/prefect_aws/s3.py
+++ b/src/integrations/prefect-aws/prefect_aws/s3.py
@@ -5,19 +5,20 @@ import io
 import os
 import uuid
 from pathlib import Path
-from typing import Any, BinaryIO, Dict, List, Optional, Union
+from typing import Any, BinaryIO, Dict, List, Optional, Union, get_args
 
 import boto3
 from botocore.paginate import PageIterator
 from botocore.response import StreamingBody
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from prefect import task
-from prefect.blocks.abstract import ObjectStorageBlock
+from prefect.blocks.abstract import CredentialsBlock, ObjectStorageBlock
 from prefect.filesystems import WritableDeploymentStorage, WritableFileSystem
 from prefect.logging import get_run_logger
 from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
 from prefect.utilities.filesystem import filter_files
+from prefect.utilities.pydantic import lookup_type
 from prefect_aws import AwsCredentials, MinIOCredentials
 from prefect_aws.client_parameters import AwsClientParameters
 
@@ -408,7 +409,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
 
     bucket_name: str = Field(default=..., description="Name of your bucket.")
 
-    credentials: Union[AwsCredentials, MinIOCredentials] = Field(
+    credentials: Union[MinIOCredentials, AwsCredentials] = Field(
         default_factory=AwsCredentials,
         description="A block containing your credentials to AWS or MinIO.",
     )
@@ -420,6 +421,42 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
             "for reading and writing objects."
         ),
     )
+
+    @field_validator("credentials", mode="before")
+    def validate_credentials(cls, value, field):
+        if isinstance(value, dict):
+            # There is an issue with pydantic and nested blocks with union
+            # types, in this case credentials is affected by it. What happens
+            # is that the credentials block appears to be correctly initialized
+            # but when it's attached to the parent block it's an
+            # _uninitialized_ instance without the field attributes.
+
+            # This validator is a workaround to check for the correct type
+            # or fallback to iterating over the possible credential types
+            # and trying to initialize them.
+
+            block_type_slug = value.pop("block_type_slug", None)
+            if block_type_slug:
+                credential_classes = (
+                    lookup_type(CredentialsBlock, dispatch_key=block_type_slug),
+                )
+            else:
+                credential_classes = get_args(
+                    cls.model_fields["credentials"].annotation
+                )
+
+            for credentials_cls in credential_classes:
+                try:
+                    return credentials_cls(**value)  # type: ignore
+                except ValueError:
+                    pass
+
+            valid_classes = ", ".join(c.__name__ for c in credential_classes)
+            raise ValueError(
+                f"Invalid credentials data: does not match any credential type. Valid types: {valid_classes}"
+            )
+
+        return value
 
     # Property to maintain compatibility with storage block based deployments
     @property

--- a/src/integrations/prefect-aws/prefect_aws/s3.py
+++ b/src/integrations/prefect-aws/prefect_aws/s3.py
@@ -408,7 +408,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
 
     bucket_name: str = Field(default=..., description="Name of your bucket.")
 
-    credentials: Union[MinIOCredentials, AwsCredentials] = Field(
+    credentials: Union[AwsCredentials, MinIOCredentials] = Field(
         default_factory=AwsCredentials,
         description="A block containing your credentials to AWS or MinIO.",
     )

--- a/src/integrations/prefect-aws/tests/test_s3.py
+++ b/src/integrations/prefect-aws/tests/test_s3.py
@@ -1102,3 +1102,12 @@ class TestS3Bucket:
             to_bucket=to_bucket,
         )
         assert key == expected_path
+
+    def test_round_trip_default_credentials(self):
+        # Regression test for
+        # https://github.com/PrefectHQ/prefect/issues/13349
+        S3Bucket(bucket_name="round-trip-bucket").save("round-tripper")
+        loaded = S3Bucket.load("round-tripper")
+        assert hasattr(
+            loaded.credentials, "aws_access_key_id"
+        ), "`credentials` were not properly initialized"


### PR DESCRIPTION
The issue as written isn't particularly accurate. What's actually going on here is that `S3Bucket` has a default_factory for `credentials`, which is just `AwsCredentials`, when the code in the issue is doing `overwrite=True` that's causing it to overwrite the credentials assigned in the UI. That all makes sense, what _didn't_ make sense was the error that was being thrown.

The error in the issue was `TypeError: unhashable type: 'dict'`, so my goal here was to get a more useful `botocore.exceptions.NoCredentialsError` that would hint at the credentials being missing. That led me down a rabbit hole where there seems to be some incompatibility between pydantic and nested blocks with Union types. With `MinIOCredentials` as the first thing in the Union loading fails, but it fails in a way that the resulting `AwsCredentials` block that's attached to the `credentials` attribute of the `S3Bucket` is _uninitialized_, meaning that the field attributes like `aws_access_key_id` aren't actually present. If we put `AwsCredentials` first then we can never get a `MinIOCredentials` block as `AwsCredentials` doesn't have any real validation, it just accepts whatever you throw at it.

The fix in this PR is to add a `field_validator` to explicitly instantiate the correct credentials class avoiding the internals of pydantic that are, seemingly, attaching it incorrectly.

Closes #13349