### PR TITLE
remove invalid kwarg and catch exception groups

### DIFF
--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -544,7 +544,7 @@ class TaskRunEngine(Generic[P, R]):
         return task_run.state.is_running() or task_run.state.is_scheduled()
 
     async def wait_until_ready(self):
-        """Waits for scheduled time if set."""
+        """Waits until the scheduled time (if its the future), then enters Running."""
         if scheduled_time := self.state.state_details.scheduled_time:
             self.logger.info(
                 f"Waiting for scheduled time {scheduled_time} for task {self.task.name!r}"

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -63,7 +63,6 @@ from prefect.utilities.importtools import to_qualified_name
 if TYPE_CHECKING:
     from prefect.client.orchestration import PrefectClient
     from prefect.context import TaskRunContext
-    from prefect.task_runners import BaseTaskRunner
     from prefect.transactions import Transaction
 
 T = TypeVar("T")  # Generic type var for capturing the inner return type of async funcs
@@ -1200,7 +1199,7 @@ class Task(Generic[P, R]):
         """
         return self.apply_async(args=args, kwargs=kwargs)
 
-    def serve(self, task_runner: Optional["BaseTaskRunner"] = None) -> "Task":
+    def serve(self) -> "Task":
         """Serve the task using the provided task runner. This method is used to
         establish a websocket connection with the Prefect server and listen for
         submitted task runs to execute.
@@ -1219,7 +1218,7 @@ class Task(Generic[P, R]):
         """
         from prefect.task_server import serve
 
-        serve(self, task_runner=task_runner)
+        serve(self)
 
 
 @overload


### PR DESCRIPTION
this PR
- stops allowing `serve` to accept a `task_runner` as `TaskServer` no longer expects one
- catches any `BaseExceptionGroup` that `TaskServer(...).start()` might throw
- removes db fixture section that [has flaked](https://github.com/PrefectHQ/prefect/actions/runs/9391770315/job/25868658763?pr=13821#step:9:2200) (@chrisguidry seems to have foretold this 🧙‍♂️ )