### PR TITLE
rename `TaskServer` to `TaskWorker`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -796,7 +796,7 @@ See the PR for implementation details: https://github.com/PrefectHQ/prefect/pull
 - Pin uvicorn to < 0.29 — https://github.com/PrefectHQ/prefect/pull/12463
 
 ### Experimental
-- More robust error handling in `TaskServer` — https://github.com/PrefectHQ/prefect/pull/12382
+- More robust error handling in `TaskWorker` — https://github.com/PrefectHQ/prefect/pull/12382
 - Add `model_validate_json` to Pydantic compat layer — https://github.com/PrefectHQ/prefect/pull/12412
 - Add `model_dump_json` to Pydantic compat layer — https://github.com/PrefectHQ/prefect/pull/12406
 - Add hybrid `BaseModel` and public `pydantic` module — https://github.com/PrefectHQ/prefect/pull/12424

--- a/docs/3.0rc/guides/deferred-tasks.mdx
+++ b/docs/3.0rc/guides/deferred-tasks.mdx
@@ -62,11 +62,11 @@ The task worker will continually receive instructions to execute deferred tasks 
 
 **NOTE:** Task workers only run deferred tasks, not tasks you call directly as normal Python functions.
 
-You can run a task worker by passing tasks into the `prefect.task_server.serve()` method:
+You can run a task worker by passing tasks into the `prefect.task_worker.serve()` method:
 
 ```python tasks.py
 from prefect import task
-from prefect.task_server import serve
+from prefect.task_worker import serve
 
 
 @task
@@ -221,13 +221,13 @@ In this example, we'll start a task worker and run deferred tasks in the backgro
 
 To run tasks in a separate process or container, you'll need to start a task worker, similar to how you would run a Celery worker or an arq worker.
 The task worker will continually receive scheduled tasks to execute from Prefect's API, execute them, and report the results back to the API.
-You can run a task worker by passing tasks into the `prefect.task_server.serve()` method.
+You can run a task worker by passing tasks into the `prefect.task_worker.serve()` method.
 
-Step 1: Define the task and task worker in the file `task_server.py`
+Step 1: Define the task and task worker in the file `task_worker.py`
 
 ```python
 from prefect import task
-from prefect.task_server import serve
+from prefect.task_worker import serve
 
 
 @task
@@ -242,7 +242,7 @@ if __name__ == "__main__":
 Step 2: Start the task worker by running the script in the terminal.
 
 ```bash
-python task_server.py
+python task_worker.py
 ```
 
 The task worker is now waiting for runs of the `my_background_task` task.
@@ -281,7 +281,7 @@ Step 6: You can use multiple task workers to run tasks in parallel.
 Start another instance of the task worker. In another terminal run:
 
 ```bash
-python task_server.py
+python task_worker.py
 ```
 
 Step 7: Send multiple tasks to the task worker.

--- a/docs/3.0rc/guides/deferred-tasks.mdx
+++ b/docs/3.0rc/guides/deferred-tasks.mdx
@@ -1,11 +1,11 @@
 ---
 title: Deferred Tasks
-description: Examples of using Prefect tasks and the task server.
+description: Examples of using Prefect tasks and the task worker.
 ---
 
 ## Why use deferred tasks?
 
-Prefect tasks are a great way to quickly execute small, discrete units of work. _Deferred_ Prefect tasks run in a background process using a Prefect task server. Use deferred tasks to move work out of the foreground of your application and distribute concurrent execution across across multiple processes or machines.
+Prefect tasks are a great way to quickly execute small, discrete units of work. _Deferred_ Prefect tasks run in a background process using a Prefect task worker. Use deferred tasks to move work out of the foreground of your application and distribute concurrent execution across across multiple processes or machines.
 
 For example, if you have a web app, you can use deferred tasks to offload processes such as sending emails, processing images, or inserting data into a database.
 
@@ -17,7 +17,7 @@ Prefect tasks are Python functions that can be run immediately or deferred for b
 
 You define a task by adding the `@task` decorator to a Python function, after which you can use the `delay` method to run the task in the background.
 
-If you schedule the task for background execution, you'll run a task server in a separate process or container to execute the task. This process is similar to a Celery worker or an arq worker.
+If you schedule the task for background execution, you'll run a task worker in a separate process or container to execute the task. This process is similar to a Celery worker or an arq worker.
 
 ### Defining a task
 
@@ -54,15 +54,15 @@ my_background_task.delay("Agrajag")
 
 For documentation on the features available for tasks, refer to the [Prefect Tasks documentation](https://docs-3.prefect.io/3.0rc/tutorial/tasks).
 
-### Executing deferred tasks with a task server
+### Executing deferred tasks with a task worker
 
-To run tasks in a separate process or container, start a task server.
+To run tasks in a separate process or container, start a task worker.
 
-The task server will continually receive instructions to execute deferred tasks from Prefect's API, execute them, and report the results back to the API.
+The task worker will continually receive instructions to execute deferred tasks from Prefect's API, execute them, and report the results back to the API.
 
-**NOTE:** Task servers only run deferred tasks, not tasks you call directly.
+**NOTE:** Task workers only run deferred tasks, not tasks you call directly as normal Python functions.
 
-You can run a task server by passing tasks into the `prefect.task_server.serve()` method:
+You can run a task worker by passing tasks into the `prefect.task_server.serve()` method:
 
 ```python tasks.py
 from prefect import task
@@ -76,29 +76,29 @@ def my_background_task(name: str):
 
 
 if __name__ == "__main__":
-    # NOTE: The serve() function accepts multiple tasks. The Task Server 
+    # NOTE: The serve() function accepts multiple tasks. The Task worker 
     # will listen for scheduled task runs for all tasks passed in.
     serve(my_background_task)
 ```
 
-Run this script to start the task server.
+Run this script to start the task worker.
 
-The task server should begin listening for scheduled tasks. If tasks were scheduled before the task server started, it will begin processing them.
+The task worker should begin listening for scheduled tasks. If tasks were scheduled before the task worker started, it will begin processing them.
 
-You can also use the helper CLI command `prefect task serve` to start a task server.
+You can also use the helper CLI command `prefect task serve` to start a task worker.
 
 ```bash
 prefect task serve my_task.py:my_background_task
 ```
 
 
-## Guided exploration of deferred tasks and task servers in Prefect
+## Guided exploration of deferred tasks and task workers in Prefect
 
-Below we explore increasingly realistic examples of using deferred tasks and task servers in Prefect.
+Below we explore increasingly realistic examples of using deferred tasks and task workers in Prefect.
 
 We'll start by running a Prefect task in the foreground by calling it.
 
-Next we'll start a task server and defer tasks so that they run in the background. We'll see how we can use multiple task servers to run tasks in parallel.
+Next we'll start a task worker and defer tasks so that they run in the background. We'll see how we can use multiple task workers to run tasks in parallel.
 
 Then we'll create a basic FastAPI application that defers tasks when you hit an endpoint.
 
@@ -132,7 +132,7 @@ Step 3: Connect to Prefect Cloud or a local Prefect server instance (if not set 
 
 You can use either Prefect Cloud or a local Prefect server instance for these examples.
 
-You need to have `PREFECT_API_URL` set to send tasks to task servers.
+You need to have `PREFECT_API_URL` set to send tasks to task workers.
 
 If you're using a local Prefect server instance with a SQLite backing database (the default database), you can save this value to your active Prefect Profile by running the following command in your terminal.
 
@@ -213,17 +213,17 @@ You can scroll down to see your most recent task runs or filter for them.
 Hit the refresh button for updates, if needed.
 
 
-### Example 2: Start a task server and run deferred tasks in the background
+### Example 2: Start a task worker and run deferred tasks in the background
 
 <summary>Expand</summary>
 
-In this example, we'll start a task server and run deferred tasks in the background.  
+In this example, we'll start a task worker and run deferred tasks in the background.  
 
-To run tasks in a separate process or container, you'll need to start a task server, similar to how you would run a Celery worker or an arq worker.
-The task server will continually receive scheduled tasks to execute from Prefect's API, execute them, and report the results back to the API.
-You can run a task server by passing tasks into the `prefect.task_server.serve()` method.
+To run tasks in a separate process or container, you'll need to start a task worker, similar to how you would run a Celery worker or an arq worker.
+The task worker will continually receive scheduled tasks to execute from Prefect's API, execute them, and report the results back to the API.
+You can run a task worker by passing tasks into the `prefect.task_server.serve()` method.
 
-Step 1: Define the task and task server in the file `task_server.py`
+Step 1: Define the task and task worker in the file `task_server.py`
 
 ```python
 from prefect import task
@@ -239,13 +239,13 @@ if __name__ == "__main__":
     serve(my_background_task)
 ```
 
-Step 2: Start the task server by running the script in the terminal.
+Step 2: Start the task worker by running the script in the terminal.
 
 ```bash
 python task_server.py
 ```
 
-The task server is now waiting for runs of the `my_background_task` task.
+The task worker is now waiting for runs of the `my_background_task` task.
 Let's give it some task runs.
 
 Step 3: Create a file named `task_scheduler.py` and save the following code in it.
@@ -276,17 +276,17 @@ The URL will look like this:
 Substitute your UUID at the end of the URL.
 Note that the UI navigation experience for task runs will be improved soon.
 
-Step 6: You can use multiple task servers to run tasks in parallel.
+Step 6: You can use multiple task workers to run tasks in parallel.
 
-Start another instance of the task server. In another terminal run:
+Start another instance of the task worker. In another terminal run:
 
 ```bash
 python task_server.py
 ```
 
-Step 7: Send multiple tasks to the task server.
+Step 7: Send multiple tasks to the task worker.
 
-Modify the `task_scheduler.py` file to send multiple tasks to the task server with different inputs:
+Modify the `task_scheduler.py` file to send multiple tasks to the task worker with different inputs:
 
 ```python
 from tasks import my_background_task
@@ -297,11 +297,11 @@ if __name__ == "__main__":
     my_background_task.delay("Slartibartfast")
 ```
 
-Run the file and watch the work get distributed across both task servers!
+Run the file and watch the work get distributed across both task workers!
 
-Step 8: Shut down the task servers with *control* + *c*.
+Step 8: Shut down the task workers with *control* + *c*.
 
-Alright, you're able to send tasks to multiple Prefect task servers running in the background!
+Alright, you're able to send tasks to multiple Prefect task workers running in the background!
 This is cool because we can observe these tasks executing in parallel and very quickly with web sockets - no polling required.
 
 See additional examples in the [deferred tasks github repository](https://github.com/PrefectHQ/prefect-background-task-examples.git).

--- a/docs/3.0rc/guides/index.mdx
+++ b/docs/3.0rc/guides/index.mdx
@@ -22,7 +22,7 @@ description: Learn how to do common workflows with Prefect.
 | [Specifying Upstream Dependencies](/3.0rc/develop/write-tasks/upstream-dependencies/) | Run tasks in a desired order. |
 | [Third-party Secrets](/3.0rc/guides/secrets/) | Use credentials stored in a secrets manager in your workflows. |
 | [Prefect Recipes](/3.0rc/recipes/recipes/) |  Common, extensible examples for setting up Prefect. |
-| [Using Deferred Tasks](/3.0rc/guides/deferred-tasks.mdx/) |  Examples of using Prefect tasks and the task server. |
+| [Using Deferred Tasks](/3.0rc/guides/deferred-tasks.mdx/) |  Examples of using Prefect tasks and the task worker. |
 
 ## Execution
 

--- a/src/prefect/cli/task.py
+++ b/src/prefect/cli/task.py
@@ -5,7 +5,7 @@ import typer
 from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error
 from prefect.cli.root import app
-from prefect.task_server import serve as task_serve
+from prefect.task_worker import serve as task_serve
 from prefect.utilities.importtools import import_object
 
 task_app = PrefectTyper(name="task", help="Commands for working with task scheduling.")

--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -149,7 +149,7 @@ class PrefectDistributedFuture(PrefectFuture):
     Represents the result of a computation happening anywhere.
 
     This class is typically used to interact with the result of a task run
-    scheduled to run in a Prefect task server but can be used to interact with
+    scheduled to run in a Prefect task worker but can be used to interact with
     any task run scheduled in Prefect's API.
     """
 

--- a/src/prefect/server/task_queue.py
+++ b/src/prefect/server/task_queue.py
@@ -1,5 +1,5 @@
 """
-Implements an in-memory task queue for delivering background task runs to TaskServers.
+Implements an in-memory task queue for delivering background task runs to TaskWorkers.
 """
 
 import asyncio

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1530,9 +1530,9 @@ PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT = Setting(
     default=timedelta(seconds=30),
 )
 """
-How long before a PENDING task are made available to another task server.  In practice,
-a task server should move a task from PENDING to RUNNING very quickly, so runs stuck in
-PENDING for a while is a sign that the task server may have crashed.
+How long before a PENDING task are made available to another task worker.  In practice,
+a task worker should move a task from PENDING to RUNNING very quickly, so runs stuck in
+PENDING for a while is a sign that the task worker may have crashed.
 """
 
 PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS = Setting(bool, default=False)

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -325,11 +325,11 @@ class PrefectTaskRunner(TaskRunner[PrefectDistributedFuture]):
         flow_run_ctx = FlowRunContext.get()
         if flow_run_ctx:
             get_run_logger(flow_run_ctx).info(
-                f"Submitting task {task.name} to for execution by a Prefect task server..."
+                f"Submitting task {task.name} to for execution by a Prefect task worker..."
             )
         else:
             self.logger.info(
-                f"Submitting task {task.name} to for execution by a Prefect task server..."
+                f"Submitting task {task.name} to for execution by a Prefect task worker..."
             )
 
         return task.apply_async(

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -32,11 +32,11 @@ from prefect.utilities.asyncutils import asyncnullcontext, sync_compatible
 from prefect.utilities.engine import emit_task_run_state_change_event, propose_state
 from prefect.utilities.processutils import _register_signal
 
-logger = get_logger("task_server")
+logger = get_logger("task_worker")
 
 
-class StopTaskServer(Exception):
-    """Raised when the task server is stopped."""
+class StopTaskWorker(Exception):
+    """Raised when the task worker is stopped."""
 
     pass
 
@@ -51,11 +51,11 @@ def should_try_to_read_parameters(task: Task, task_run: TaskRun) -> bool:
     return new_enough_state_details and task_accepts_parameters
 
 
-class TaskServer:
+class TaskWorker:
     """This class is responsible for serving tasks that may be executed in the background
     by a task runner via the traditional engine machinery.
 
-    When `start()` is called, the task server will open a websocket connection to a
+    When `start()` is called, the task worker will open a websocket connection to a
     server-side queue of scheduled task runs. When a scheduled task run is found, the
     scheduled task run is submitted to the engine for execution with a minimal `EngineContext`
     so that the task run can be governed by orchestration rules.
@@ -82,7 +82,7 @@ class TaskServer:
 
         if not asyncio.get_event_loop().is_running():
             raise RuntimeError(
-                "TaskServer must be initialized within an async context."
+                "TaskWorker must be initialized within an async context."
             )
 
         self._runs_task_group: anyio.abc.TaskGroup = anyio.create_task_group()
@@ -95,7 +95,7 @@ class TaskServer:
 
     def handle_sigterm(self, signum, frame):
         """
-        Shuts down the task server when a SIGTERM is received.
+        Shuts down the task worker when a SIGTERM is received.
         """
         logger.info("SIGTERM received, initiating graceful shutdown...")
         from_sync.call_in_loop_thread(create_call(self.stop))
@@ -105,12 +105,12 @@ class TaskServer:
     @sync_compatible
     async def start(self) -> None:
         """
-        Starts a task server, which runs the tasks provided in the constructor.
+        Starts a task worker, which runs the tasks provided in the constructor.
         """
         _register_signal(signal.SIGTERM, self.handle_sigterm)
 
         async with asyncnullcontext() if self.started else self:
-            logger.info("Starting task server...")
+            logger.info("Starting task worker...")
             try:
                 await self._subscribe_to_task_scheduling()
             except InvalidStatusCode as exc:
@@ -126,17 +126,17 @@ class TaskServer:
 
     @sync_compatible
     async def stop(self):
-        """Stops the task server's polling cycle."""
+        """Stops the task worker's polling cycle."""
         if not self.started:
             raise RuntimeError(
-                "Task server has not yet started. Please start the task server by"
+                "Task worker has not yet started. Please start the task worker by"
                 " calling .start()"
             )
 
         self.started = False
         self.stopping = True
 
-        raise StopTaskServer
+        raise StopTaskWorker
 
     async def _subscribe_to_task_scheduling(self):
         logger.info(
@@ -163,7 +163,7 @@ class TaskServer:
         if not task:
             if PREFECT_TASK_SCHEDULING_DELETE_FAILED_SUBMISSIONS:
                 logger.warning(
-                    f"Task {task_run.name!r} not found in task server registry."
+                    f"Task {task_run.name!r} not found in task worker registry."
                 )
                 await self._client._client.delete(f"/task_runs/{task_run.id}")  # type: ignore
 
@@ -262,14 +262,14 @@ class TaskServer:
             self._limiter.release_on_behalf_of(task_run.id)
 
     async def execute_task_run(self, task_run: TaskRun):
-        """Execute a task run in the task server."""
+        """Execute a task run in the task worker."""
         async with self if not self.started else asyncnullcontext():
             if self._limiter:
                 await self._limiter.acquire_on_behalf_of(task_run.id)
             await self._submit_scheduled_task_run(task_run)
 
     async def __aenter__(self):
-        logger.debug("Starting task server...")
+        logger.debug("Starting task worker...")
 
         if self._client._closed:
             self._client = get_client()
@@ -282,7 +282,7 @@ class TaskServer:
         return self
 
     async def __aexit__(self, *exc_info):
-        logger.debug("Stopping task server...")
+        logger.debug("Stopping task worker...")
         self.started = False
         await self._exit_stack.__aexit__(*exc_info)
 
@@ -302,7 +302,7 @@ async def serve(*tasks: Task, limit: Optional[int] = 10):
     Example:
         ```python
         from prefect import task
-        from prefect.task_server import serve
+        from prefect.task_worker import serve
 
         @task(log_prints=True)
         def say(message: str):
@@ -317,21 +317,21 @@ async def serve(*tasks: Task, limit: Optional[int] = 10):
             serve(say, yell)
         ```
     """
-    task_server = TaskServer(*tasks, limit=limit)
+    task_worker = TaskWorker(*tasks, limit=limit)
 
     try:
-        await task_server.start()
+        await task_worker.start()
 
     except BaseExceptionGroup as exc:  # novermin
         exceptions = exc.exceptions
         n_exceptions = len(exceptions)
         logger.error(
-            f"Task server stopped with {n_exceptions} exception{'s' if n_exceptions != 1 else ''}:"
+            f"Task worker stopped with {n_exceptions} exception{'s' if n_exceptions != 1 else ''}:"
             f"\n" + "\n".join(str(e) for e in exceptions)
         )
 
-    except StopTaskServer:
-        logger.info("Task server stopped.")
+    except StopTaskWorker:
+        logger.info("Task worker stopped.")
 
     except (asyncio.CancelledError, KeyboardInterrupt):
-        logger.info("Task server interrupted, stopping...")
+        logger.info("Task worker interrupted, stopping...")

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -601,7 +601,7 @@ class Task(Generic[P, R]):
             else:
                 state = Pending()
 
-            # store parameters for background tasks so that task servers
+            # store parameters for background tasks so that task worker
             # can retrieve them at runtime
             if deferred and (parameters or wait_for):
                 parameters_id = uuid4()
@@ -1084,7 +1084,7 @@ class Task(Generic[P, R]):
         dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
     ) -> PrefectDistributedFuture:
         """
-        Create a pending task run for a task server to execute.
+        Create a pending task run for a task worker to execute.
 
         Args:
             args: Arguments to run the task with
@@ -1223,7 +1223,7 @@ class Task(Generic[P, R]):
 
             >>> my_task.serve()
         """
-        from prefect.task_server import serve
+        from prefect.task_worker import serve
 
         serve(self)
 

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -4,7 +4,7 @@ from prefect.client.schemas.objects import State
 from prefect.events.clients import AssertingEventsClient
 from prefect.events.worker import EventsWorker
 from prefect.filesystems import LocalFileSystem
-from prefect.task_server import TaskWorker
+from prefect.task_worker import TaskWorker
 
 
 async def test_task_state_change_happy_path(

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -4,7 +4,7 @@ from prefect.client.schemas.objects import State
 from prefect.events.clients import AssertingEventsClient
 from prefect.events.worker import EventsWorker
 from prefect.filesystems import LocalFileSystem
-from prefect.task_server import TaskServer
+from prefect.task_server import TaskWorker
 
 
 async def test_task_state_change_happy_path(
@@ -151,7 +151,7 @@ async def test_background_task_state_changes(
     task_run_future = foo.apply_async()
     task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-    await TaskServer(foo).execute_task_run(task_run)
+    await TaskWorker(foo).execute_task_run(task_run)
 
     task_run_states = await prefect_client.read_task_run_states(
         task_run_future.task_run_id

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -26,7 +26,7 @@ from prefect.settings import (
     PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT,
     temporary_settings,
 )
-from prefect.task_server import TaskServer
+from prefect.task_server import TaskWorker
 from prefect.utilities.hashing import hash_objects
 
 if TYPE_CHECKING:
@@ -283,8 +283,8 @@ async def test_stuck_pending_tasks_are_reenqueued(
     task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
     assert task_run.state.is_scheduled()
 
-    # now we simulate a stuck task by having the TaskServer try to run it but fail
-    server = TaskServer(foo_task_with_result_storage)
+    # now we simulate a stuck task by having the TaskWorker try to run it but fail
+    server = TaskWorker(foo_task_with_result_storage)
 
     def assert_exception(exc_group: ExceptionGroup):
         assert len(exc_group.exceptions) == 1

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -26,7 +26,7 @@ from prefect.settings import (
     PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT,
     temporary_settings,
 )
-from prefect.task_server import TaskWorker
+from prefect.task_worker import TaskWorker
 from prefect.utilities.hashing import hash_objects
 
 if TYPE_CHECKING:
@@ -293,7 +293,7 @@ async def test_stuck_pending_tasks_are_reenqueued(
 
     with catch({ValueError: assert_exception}):
         with mock.patch(
-            "prefect.task_server.run_task_sync",
+            "prefect.task_worker.run_task_sync",
             side_effect=ValueError("woops"),
         ):
             await server.execute_task_run(task_run)

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -12,7 +12,7 @@ from prefect.futures import PrefectFuture, PrefectWrappedFuture
 from prefect.results import _default_task_scheduling_storages
 from prefect.states import Completed, Running
 from prefect.task_runners import PrefectTaskRunner, ThreadPoolTaskRunner
-from prefect.task_server import serve
+from prefect.task_worker import serve
 from prefect.tasks import task
 
 
@@ -184,7 +184,7 @@ class TestPrefectTaskRunner:
         _default_task_scheduling_storages.clear()
 
     @pytest.fixture
-    async def task_server(self, use_hosted_api_server):
+    async def task_worker(self, use_hosted_api_server):
         call = from_async.call_soon_in_new_thread(
             create_call(
                 serve,
@@ -210,7 +210,7 @@ class TestPrefectTaskRunner:
         with pytest.raises(RuntimeError, match="Task runner is not started"):
             runner.submit(my_test_task, {})
 
-    @pytest.mark.usefixtures("task_server")
+    @pytest.mark.usefixtures("task_worker")
     def test_submit_sync_task(self):
         with PrefectTaskRunner() as runner:
             parameters = {"param1": 1, "param2": 2}
@@ -220,7 +220,7 @@ class TestPrefectTaskRunner:
 
             assert future.result(timeout=10) == (1, 2)
 
-    @pytest.mark.usefixtures("task_server")
+    @pytest.mark.usefixtures("task_worker")
     def test_submit_async_task(self):
         with PrefectTaskRunner() as runner:
             parameters = {"param1": 1, "param2": 2}
@@ -230,7 +230,7 @@ class TestPrefectTaskRunner:
 
             assert future.result(timeout=10) == (1, 2)
 
-    @pytest.mark.usefixtures("task_server")
+    @pytest.mark.usefixtures("task_worker")
     def test_submit_sync_task_receives_context(self):
         with tags("tag1", "tag2"):
             with PrefectTaskRunner() as runner:
@@ -240,7 +240,7 @@ class TestPrefectTaskRunner:
 
                 assert future.result(timeout=10) == {"tag1", "tag2"}
 
-    @pytest.mark.usefixtures("task_server")
+    @pytest.mark.usefixtures("task_worker")
     def test_submit_async_task_receives_context(self):
         with tags("tag1", "tag2"):
             with PrefectTaskRunner() as runner:
@@ -250,7 +250,7 @@ class TestPrefectTaskRunner:
 
                 assert future.result(timeout=10) == {"tag1", "tag2"}
 
-    @pytest.mark.usefixtures("task_server")
+    @pytest.mark.usefixtures("task_worker")
     def test_map_sync_task(self):
         with PrefectTaskRunner() as runner:
             parameters = {"param1": [1, 2, 3], "param2": [4, 5, 6]}
@@ -262,7 +262,7 @@ class TestPrefectTaskRunner:
             results = [future.result(timeout=10) for future in futures]
             assert results == [(1, 4), (2, 5), (3, 6)]
 
-    @pytest.mark.usefixtures("task_server")
+    @pytest.mark.usefixtures("task_worker")
     def test_map_async_task(self):
         with PrefectTaskRunner() as runner:
             parameters = {"param1": [1, 2, 3], "param2": [4, 5, 6]}
@@ -274,7 +274,7 @@ class TestPrefectTaskRunner:
             results = [future.result(timeout=10) for future in futures]
             assert results == [(1, 4), (2, 5), (3, 6)]
 
-    @pytest.mark.usefixtures("task_server")
+    @pytest.mark.usefixtures("task_worker")
     def test_map_sync_task_with_context(self):
         with tags("tag1", "tag2"):
             with PrefectTaskRunner() as runner:
@@ -287,7 +287,7 @@ class TestPrefectTaskRunner:
                 results = [future.result(timeout=10) for future in futures]
                 assert results == [{"tag1", "tag2"}] * 3
 
-    @pytest.mark.usefixtures("task_server")
+    @pytest.mark.usefixtures("task_worker")
     def test_map_async_task_with_context(self):
         with tags("tag1", "tag2"):
             with PrefectTaskRunner() as runner:
@@ -300,7 +300,7 @@ class TestPrefectTaskRunner:
                 results = [future.result(timeout=10) for future in futures]
                 assert results == [{"tag1", "tag2"}] * 3
 
-    @pytest.mark.usefixtures("task_server")
+    @pytest.mark.usefixtures("task_worker")
     def test_map_with_future_resolved_to_list(self):
         with PrefectTaskRunner() as runner:
             future = MockFuture(data=[1, 2, 3])

--- a/tests/test_task_worker.py
+++ b/tests/test_task_worker.py
@@ -12,7 +12,7 @@ from prefect.exceptions import MissingResult
 from prefect.filesystems import LocalFileSystem
 from prefect.futures import PrefectDistributedFuture
 from prefect.states import Running
-from prefect.task_server import TaskWorker, serve
+from prefect.task_worker import TaskWorker, serve
 from prefect.tasks import task_input_hash
 
 
@@ -63,9 +63,9 @@ def bar_task():
 
 
 @pytest.fixture
-def mock_task_server_start(monkeypatch):
+def mock_task_worker_start(monkeypatch):
     monkeypatch.setattr(
-        "prefect.task_server.TaskWorker.start", mock_start := AsyncMock()
+        "prefect.task_worker.TaskWorker.start", mock_start := AsyncMock()
     )
     return mock_start
 
@@ -73,7 +73,7 @@ def mock_task_server_start(monkeypatch):
 @pytest.fixture
 def mock_create_subscription(monkeypatch):
     monkeypatch.setattr(
-        "prefect.task_server.TaskWorker._subscribe_to_task_scheduling",
+        "prefect.task_worker.TaskWorker._subscribe_to_task_scheduling",
         create_subscription := AsyncMock(),
     )
     return create_subscription
@@ -82,51 +82,51 @@ def mock_create_subscription(monkeypatch):
 @pytest.fixture
 def mock_subscription(monkeypatch):
     monkeypatch.setattr(
-        "prefect.task_server.Subscription", mock_subscription := MagicMock()
+        "prefect.task_worker.Subscription", mock_subscription := MagicMock()
     )
     return mock_subscription
 
 
-async def test_task_server_basic_context_management():
-    async with TaskWorker(...) as task_server:
-        assert task_server.started is True
-        assert (await task_server._client.hello()).status_code == 200
+async def test_task_worker_basic_context_management():
+    async with TaskWorker(...) as task_worker:
+        assert task_worker.started is True
+        assert (await task_worker._client.hello()).status_code == 200
 
-    assert task_server.started is False
+    assert task_worker.started is False
     with pytest.raises(RuntimeError, match="client has been closed"):
-        await task_server._client.hello()
+        await task_worker._client.hello()
 
 
 async def test_handle_sigterm(mock_create_subscription):
-    task_server = TaskWorker(...)
+    task_worker = TaskWorker(...)
 
     with patch("sys.exit") as mock_exit, patch.object(
-        task_server, "stop", new_callable=AsyncMock
+        task_worker, "stop", new_callable=AsyncMock
     ) as mock_stop:
-        await task_server.start()
+        await task_worker.start()
 
         mock_create_subscription.assert_called_once()
 
-        task_server.handle_sigterm(signal.SIGTERM, None)
+        task_worker.handle_sigterm(signal.SIGTERM, None)
 
         mock_exit.assert_called_once_with(0)
         mock_stop.assert_called_once()
 
 
-async def test_task_server_client_id_is_set():
+async def test_task_worker_client_id_is_set():
     with patch("socket.gethostname", return_value="foo"), patch(
         "os.getpid", return_value=42
     ):
-        task_server = TaskWorker(...)
-        task_server._client = MagicMock(api_url="http://localhost:4200")
+        task_worker = TaskWorker(...)
+        task_worker._client = MagicMock(api_url="http://localhost:4200")
 
-        assert task_server._client_id == "foo-42"
+        assert task_worker._client_id == "foo-42"
 
 
-async def test_task_server_handles_aborted_task_run_submission(
+async def test_task_worker_handles_aborted_task_run_submission(
     foo_task, prefect_client, caplog
 ):
-    task_server = TaskWorker(foo_task)
+    task_worker = TaskWorker(foo_task)
 
     task_run_future = foo_task.apply_async((42,))
 
@@ -140,33 +140,33 @@ async def test_task_server_handles_aborted_task_run_submission(
 
     task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-    await task_server.execute_task_run(task_run)
+    await task_worker.execute_task_run(task_run)
 
     assert "in a RUNNING state and cannot transition to a PENDING state." in caplog.text
 
 
-async def test_task_server_handles_deleted_task_run_submission(
+async def test_task_worker_handles_deleted_task_run_submission(
     foo_task, prefect_client, caplog
 ):
-    task_server = TaskWorker(foo_task)
+    task_worker = TaskWorker(foo_task)
 
     task_run_future = foo_task.apply_async((42,))
     task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
     await prefect_client.delete_task_run(task_run_future.task_run_id)
 
-    await task_server.execute_task_run(task_run)
+    await task_worker.execute_task_run(task_run)
 
     assert (
         f"Task run {task_run.id!r} not found. It may have been deleted." in caplog.text
     )
 
 
-@pytest.mark.usefixtures("mock_task_server_start")
+@pytest.mark.usefixtures("mock_task_worker_start")
 class TestServe:
-    async def test_serve_basic_sync_task(self, foo_task, mock_task_server_start):
+    async def test_serve_basic_sync_task(self, foo_task, mock_task_worker_start):
         await serve(foo_task)
-        mock_task_server_start.assert_called_once()
+        mock_task_worker_start.assert_called_once()
 
         task_run_future = foo_task.apply_async((42,))
 
@@ -174,9 +174,9 @@ class TestServe:
 
         assert task_run_future.state.is_scheduled()
 
-    async def test_serve_basic_async_task(self, async_foo_task, mock_task_server_start):
+    async def test_serve_basic_async_task(self, async_foo_task, mock_task_worker_start):
         await serve(async_foo_task)
-        mock_task_server_start.assert_called_once()
+        mock_task_worker_start.assert_called_once()
 
         task_run_future = async_foo_task.apply_async((42,))
 
@@ -185,15 +185,15 @@ class TestServe:
         assert task_run_future.state.is_scheduled()
 
 
-async def test_task_server_can_execute_a_single_async_single_task_run(
+async def test_task_worker_can_execute_a_single_async_single_task_run(
     async_foo_task, prefect_client
 ):
-    task_server = TaskWorker(async_foo_task)
+    task_worker = TaskWorker(async_foo_task)
 
     task_run_future = async_foo_task.apply_async((42,))
     task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-    await task_server.execute_task_run(task_run)
+    await task_worker.execute_task_run(task_run)
 
     updated_task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
@@ -202,15 +202,15 @@ async def test_task_server_can_execute_a_single_async_single_task_run(
     assert await updated_task_run.state.result() == 42
 
 
-async def test_task_server_can_execute_a_single_sync_single_task_run(
+async def test_task_worker_can_execute_a_single_sync_single_task_run(
     foo_task, prefect_client
 ):
-    task_server = TaskWorker(foo_task)
+    task_worker = TaskWorker(foo_task)
 
     task_run_future = foo_task.apply_async((42,))
     task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-    await task_server.execute_task_run(task_run)
+    await task_worker.execute_task_run(task_run)
 
     updated_task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
@@ -220,7 +220,7 @@ async def test_task_server_can_execute_a_single_sync_single_task_run(
 
 
 class TestTaskWorkerTaskRunRetries:
-    async def test_task_run_via_task_server_respects_retry_policy(self, prefect_client):
+    async def test_task_run_via_task_worker_respects_retry_policy(self, prefect_client):
         count = 0
 
         @task(retries=1, persist_result=True)
@@ -232,12 +232,12 @@ class TestTaskWorkerTaskRunRetries:
             count += 1
             return count
 
-        task_server = TaskWorker(task_with_retry)
+        task_worker = TaskWorker(task_with_retry)
 
         task_run_future = task_with_retry.apply_async()
         task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-        await task_server.execute_task_run(task_run)
+        await task_worker.execute_task_run(task_run)
 
         updated_task_run = await prefect_client.read_task_run(
             task_run_future.task_run_id
@@ -254,7 +254,7 @@ class TestTaskWorkerTaskRunRetries:
         [lambda task, task_run, state: True, lambda task, task_run, state: False],
         ids=["will_retry", "wont_retry"],
     )
-    async def test_task_run_via_task_server_respects_retry_condition_fn(
+    async def test_task_run_via_task_worker_respects_retry_condition_fn(
         self, should_retry, prefect_client
     ):
         count = 0
@@ -274,12 +274,12 @@ class TestTaskWorkerTaskRunRetries:
             count += 1
             return count
 
-        task_server = TaskWorker(task_with_retry_condition_fn)
+        task_worker = TaskWorker(task_with_retry_condition_fn)
 
         task_run_future = task_with_retry_condition_fn.apply_async()
         task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-        await task_server.execute_task_run(task_run)
+        await task_worker.execute_task_run(task_run)
 
         updated_task_run = await prefect_client.read_task_run(
             task_run_future.task_run_id
@@ -292,19 +292,19 @@ class TestTaskWorkerTaskRunRetries:
 
 class TestTaskWorkerTaskResults:
     @pytest.mark.parametrize("persist_result", [True, False], ids=["persisted", "not"])
-    async def test_task_run_via_task_server_respects_persist_result(
+    async def test_task_run_via_task_worker_respects_persist_result(
         self, persist_result, prefect_client
     ):
         @task(persist_result=persist_result)
         def some_task():
             return 42
 
-        task_server = TaskWorker(some_task)
+        task_worker = TaskWorker(some_task)
 
         task_run_future = some_task.apply_async()
         task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-        await task_server.execute_task_run(task_run)
+        await task_worker.execute_task_run(task_run)
 
         updated_task_run = await prefect_client.read_task_run(
             task_run_future.task_run_id
@@ -324,19 +324,19 @@ class TestTaskWorkerTaskResults:
     @pytest.mark.parametrize(
         "storage_key", ["foo", "{parameters[x]}"], ids=["static", "dynamic"]
     )
-    async def test_task_run_via_task_server_respects_result_storage_key(
+    async def test_task_run_via_task_worker_respects_result_storage_key(
         self, storage_key, prefect_client
     ):
         @task(persist_result=True, result_storage_key=storage_key)
         def some_task(x):
             return x
 
-        task_server = TaskWorker(some_task)
+        task_worker = TaskWorker(some_task)
 
         task_run_future = some_task.apply_async(kwargs={"x": "foo"})
         task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-        await task_server.execute_task_run(task_run)
+        await task_worker.execute_task_run(task_run)
 
         updated_task_run = await prefect_client.read_task_run(
             task_run_future.task_run_id
@@ -348,7 +348,7 @@ class TestTaskWorkerTaskResults:
 
         assert updated_task_run.state.data.storage_key == "foo"
 
-    async def test_task_run_via_task_server_with_complex_result_type(
+    async def test_task_run_via_task_worker_with_complex_result_type(
         self, prefect_client
     ):
         @task(persist_result=True)
@@ -361,12 +361,12 @@ class TestTaskWorkerTaskResults:
                 ),
             )
 
-        task_server = TaskWorker(americas_third_largest_city)
+        task_worker = TaskWorker(americas_third_largest_city)
 
         task_run_future = americas_third_largest_city.apply_async()
         task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-        await task_server.execute_task_run(task_run)
+        await task_worker.execute_task_run(task_run)
 
         updated_task_run = await prefect_client.read_task_run(
             task_run_future.task_run_id
@@ -382,7 +382,7 @@ class TestTaskWorkerTaskResults:
             ),
         )
 
-    async def test_task_run_via_task_server_respects_caching(
+    async def test_task_run_via_task_worker_respects_caching(
         self, async_foo_task, prefect_client, caplog
     ):
         count = 0
@@ -393,12 +393,12 @@ class TestTaskWorkerTaskResults:
             count += 1
             return count
 
-        task_server = TaskWorker(task_with_cache)
+        task_worker = TaskWorker(task_with_cache)
 
         task_run_future = task_with_cache.apply_async((42,))
         task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-        await task_server.execute_task_run(task_run)
+        await task_worker.execute_task_run(task_run)
 
         updated_task_run = await prefect_client.read_task_run(
             task_run_future.task_run_id
@@ -412,7 +412,7 @@ class TestTaskWorkerTaskResults:
         task_run = await prefect_client.read_task_run(new_task_run_future.task_run_id)
 
         with caplog.at_level("INFO"):
-            await task_server.execute_task_run(task_run)
+            await task_worker.execute_task_run(task_run)
 
         new_updated_task_run = await prefect_client.read_task_run(
             task_run_future.task_run_id
@@ -424,7 +424,7 @@ class TestTaskWorkerTaskResults:
 
         assert count == 1
 
-    async def test_task_run_via_task_server_receives_result_of_task_dependency(
+    async def test_task_run_via_task_worker_receives_result_of_task_dependency(
         self, prefect_client, foo_task, bar_task
     ):
         """
@@ -433,7 +433,7 @@ class TestTaskWorkerTaskResults:
         foo = foo_task.with_options(persist_result=True)
         bar = bar_task.with_options(persist_result=True)
 
-        task_server = TaskWorker(foo, bar)
+        task_worker = TaskWorker(foo, bar)
 
         foo_task_run_future = foo.apply_async((42,))
         foo_task_run = await prefect_client.read_task_run(
@@ -444,19 +444,19 @@ class TestTaskWorkerTaskResults:
             bar_task_run_future.task_run_id
         )
 
-        await task_server.execute_task_run(foo_task_run)
+        await task_worker.execute_task_run(foo_task_run)
         assert foo_task_run_future.result() == 42
 
-        await task_server.execute_task_run(bar_task_run)
+        await task_worker.execute_task_run(bar_task_run)
         assert bar_task_run_future.result() == 43
 
-    async def test_task_run_via_task_server_handles_mix_of_args_and_task_dependencies(
+    async def test_task_run_via_task_worker_handles_mix_of_args_and_task_dependencies(
         self, foo_task, bar_task, prefect_client
     ):
         foo = foo_task.with_options(persist_result=True)
         bar = bar_task.with_options(persist_result=True)
 
-        task_server = TaskWorker(foo, bar)
+        task_worker = TaskWorker(foo, bar)
 
         foo_task_run_future = foo.apply_async((42,))
         foo_task_run = await prefect_client.read_task_run(
@@ -467,27 +467,27 @@ class TestTaskWorkerTaskResults:
             bar_task_run_future.task_run_id
         )
 
-        await task_server.execute_task_run(foo_task_run)
+        await task_worker.execute_task_run(foo_task_run)
         assert foo_task_run_future.result() == 42
 
-        await task_server.execute_task_run(bar_task_run)
+        await task_worker.execute_task_run(bar_task_run)
         assert bar_task_run_future.result() == 47
 
 
 class TestTaskWorkerTaskTags:
-    async def test_task_run_via_task_server_respects_tags(
+    async def test_task_run_via_task_worker_respects_tags(
         self, async_foo_task, prefect_client
     ):
         @task(tags=["foo", "bar"])
         async def task_with_tags(x):
             return x
 
-        task_server = TaskWorker(task_with_tags)
+        task_worker = TaskWorker(task_with_tags)
 
         task_run_future = task_with_tags.apply_async((42,))
         task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-        await task_server.execute_task_run(task_run)
+        await task_worker.execute_task_run(task_run)
 
         updated_task_run = await prefect_client.read_task_run(
             task_run_future.task_run_id
@@ -499,19 +499,19 @@ class TestTaskWorkerTaskTags:
 
 
 class TestTaskWorkerCustomTaskRunName:
-    async def test_task_run_via_task_server_respects_custom_task_run_name(
+    async def test_task_run_via_task_worker_respects_custom_task_run_name(
         self, async_foo_task, prefect_client
     ):
         async_foo_task_with_custom_name = async_foo_task.with_options(
             task_run_name="{x}"
         )
 
-        task_server = TaskWorker(async_foo_task_with_custom_name)
+        task_worker = TaskWorker(async_foo_task_with_custom_name)
 
         task_run_future = async_foo_task_with_custom_name.apply_async((42,))
         task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-        await task_server.execute_task_run(task_run)
+        await task_worker.execute_task_run(task_run)
 
         updated_task_run = await prefect_client.read_task_run(
             task_run_future.task_run_id
@@ -523,7 +523,7 @@ class TestTaskWorkerCustomTaskRunName:
 
 
 class TestTaskWorkerTaskStateHooks:
-    async def test_task_run_via_task_server_runs_on_completion_hook(
+    async def test_task_run_via_task_worker_runs_on_completion_hook(
         self, async_foo_task, prefect_client, capsys
     ):
         async_foo_task_with_on_completion_hook = async_foo_task.with_options(
@@ -532,12 +532,12 @@ class TestTaskWorkerTaskStateHooks:
             ]
         )
 
-        task_server = TaskWorker(async_foo_task_with_on_completion_hook)
+        task_worker = TaskWorker(async_foo_task_with_on_completion_hook)
 
         task_run_future = async_foo_task_with_on_completion_hook.apply_async((42,))
         task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-        await task_server.execute_task_run(task_run)
+        await task_worker.execute_task_run(task_run)
 
         updated_task_run = await prefect_client.read_task_run(
             task_run_future.task_run_id
@@ -547,7 +547,7 @@ class TestTaskWorkerTaskStateHooks:
 
         assert "Running on_completion hook" in capsys.readouterr().out
 
-    async def test_task_run_via_task_server_runs_on_failure_hook(
+    async def test_task_run_via_task_worker_runs_on_failure_hook(
         self, prefect_client, capsys
     ):
         @task(
@@ -556,12 +556,12 @@ class TestTaskWorkerTaskStateHooks:
         def task_that_fails():
             raise ValueError("I failed")
 
-        task_server = TaskWorker(task_that_fails)
+        task_worker = TaskWorker(task_that_fails)
 
         task_run_future = task_that_fails.apply_async()
         task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-        await task_server.execute_task_run(task_run)
+        await task_worker.execute_task_run(task_run)
 
         updated_task_run = await prefect_client.read_task_run(
             task_run_future.task_run_id
@@ -573,7 +573,7 @@ class TestTaskWorkerTaskStateHooks:
 
 
 class TestTaskWorkerNestedTasks:
-    async def test_nested_task_run_via_task_server(self, prefect_client):
+    async def test_nested_task_run_via_task_worker(self, prefect_client):
         @task
         def inner_task(x):
             return x
@@ -582,12 +582,12 @@ class TestTaskWorkerNestedTasks:
         def outer_task(x):
             return inner_task(x)
 
-        task_server = TaskWorker(outer_task)
+        task_worker = TaskWorker(outer_task)
 
         task_run_future = outer_task.apply_async((42,))
         task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-        await task_server.execute_task_run(task_run)
+        await task_worker.execute_task_run(task_run)
 
         updated_task_run = await prefect_client.read_task_run(
             task_run_future.task_run_id
@@ -597,7 +597,7 @@ class TestTaskWorkerNestedTasks:
 
         assert await updated_task_run.state.result() == 42
 
-    async def test_nested_flow_run_via_task_server(self, prefect_client):
+    async def test_nested_flow_run_via_task_worker(self, prefect_client):
         @flow
         def inner_flow(x):
             return x
@@ -606,12 +606,12 @@ class TestTaskWorkerNestedTasks:
         def background_task(x):
             return inner_flow(x)
 
-        task_server = TaskWorker(background_task)
+        task_worker = TaskWorker(background_task)
 
         task_run_future = background_task.apply_async((42,))
         task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
-        await task_server.execute_task_run(task_run)
+        await task_worker.execute_task_run(task_run)
 
         updated_task_run = await prefect_client.read_task_run(
             task_run_future.task_run_id
@@ -628,14 +628,14 @@ class TestTaskWorkerLimit:
         """Register LocalFileSystem before running tests to avoid race conditions."""
         await LocalFileSystem.register_type_and_schema()
 
-    async def test_task_server_respects_limit(self, mock_subscription, prefect_client):
+    async def test_task_worker_respects_limit(self, mock_subscription, prefect_client):
         @task
         def slow_task():
             import time
 
             time.sleep(1)
 
-        task_server = TaskWorker(slow_task, limit=1)
+        task_worker = TaskWorker(slow_task, limit=1)
 
         task_run_future_1 = slow_task.apply_async()
         task_run_1 = await prefect_client.read_task_run(task_run_future_1.task_run_id)
@@ -653,7 +653,7 @@ class TestTaskWorkerLimit:
         # only one should run at a time, so we'll move on after 1 second
         # to ensure that the second task hasn't started
         with anyio.move_on_after(1):
-            await task_server.start()
+            await task_worker.start()
 
         updated_task_run_1 = await prefect_client.read_task_run(task_run_1.id)
         updated_task_run_2 = await prefect_client.read_task_run(task_run_2.id)
@@ -670,7 +670,7 @@ class TestTaskWorkerLimit:
 
             time.sleep(1)
 
-        task_server = TaskWorker(slow_task, limit=None)
+        task_worker = TaskWorker(slow_task, limit=None)
 
         task_run_future_1 = slow_task.apply_async()
         task_run_1 = await prefect_client.read_task_run(task_run_future_1.task_run_id)
@@ -688,7 +688,7 @@ class TestTaskWorkerLimit:
         # both should run at the same time, so we'll move on after 1 second
         # to ensure that the second task has started
         with anyio.move_on_after(1):
-            await task_server.start()
+            await task_worker.start()
 
         updated_task_run_1 = await prefect_client.read_task_run(task_run_1.id)
         updated_task_run_2 = await prefect_client.read_task_run(task_run_2.id)
@@ -708,7 +708,7 @@ class TestTaskWorkerLimit:
                 raise ValueError("Something went wrong! This event should not be set.")
             event.set()
 
-        task_server = TaskWorker(slow_task, limit=1)
+        task_worker = TaskWorker(slow_task, limit=1)
 
         task_run_future_1 = slow_task.apply_async()
         task_run_1 = await prefect_client.read_task_run(task_run_future_1.task_run_id)
@@ -723,7 +723,7 @@ class TestTaskWorkerLimit:
 
         mock_subscription.return_value = mock_iter()
 
-        server_task = asyncio.create_task(task_server.start())
+        server_task = asyncio.create_task(task_worker.start())
         await event.wait()
         updated_task_run_1 = await prefect_client.read_task_run(task_run_1.id)
         updated_task_run_2 = await prefect_client.read_task_run(task_run_2.id)
@@ -749,7 +749,7 @@ class TestTaskWorkerLimit:
 
             time.sleep(1)
 
-        task_server = TaskWorker(slow_task, limit=1)
+        task_worker = TaskWorker(slow_task, limit=1)
 
         task_run_future_1 = slow_task.apply_async()
         task_run_1 = await prefect_client.read_task_run(task_run_future_1.task_run_id)
@@ -758,11 +758,11 @@ class TestTaskWorkerLimit:
 
         try:
             with anyio.move_on_after(1):
-                # start task server first to avoid race condition between two execute_task_run calls
-                async with task_server:
+                # start task worker first to avoid race condition between two execute_task_run calls
+                async with task_worker:
                     await asyncio.gather(
-                        task_server.execute_task_run(task_run_1),
-                        task_server.execute_task_run(task_run_2),
+                        task_worker.execute_task_run(task_run_1),
+                        task_worker.execute_task_run(task_run_2),
                     )
         except asyncio.exceptions.CancelledError:
             # We want to cancel the second task run, so this is expected


### PR DESCRIPTION
this PR actualizes internal discussion around "worker" being the best word for what you get when you start a process to listen for / execute task runs

this is obviously a significant breaking change, but one i think we're aligned on