### PR TITLE
Startup the docker registry when running datadog tests

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -308,6 +308,14 @@ jobs:
 
           echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
 
+      - name: Start docker registry
+        run: >
+          docker run
+          --name "prefect-test-registry"
+          --detach
+          --publish 5555:5000
+          registry:2
+
       - name: Start redis
         run: >
           docker run


### PR DESCRIPTION
We moved the lifecycle management of the docker registry for the docker tests out of pytest and into the action. We missed that the datadog suite was also running these tests and also needs the registry running.