### PR TITLE
Fix flaky `test_without_disable_logger` test.

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1372,7 +1372,7 @@ def test_without_disable_logger(caplog):
 
     function_with_logging(logger)
     assert not logger.disabled
-    assert caplog.record_tuples == [("griffe.agents.nodes", 50, "it's enabled!")]
+    assert ("griffe.agents.nodes", 50, "it's enabled!") in caplog.record_tuples
 
 
 def test_disable_logger(caplog):


### PR DESCRIPTION
This test flaked by asserting that the caplog tuples exactly match and have no other records. This PR changes the test to assert that the expected log is in the tuples and not that it's all of the tuples.

```
_________________________ test_without_disable_logger __________________________
[gw0] linux -- Python 3.11.9 /opt/hostedtoolcache/Python/3.11.9/x64/bin/python3

caplog = <_pytest.logging.LogCaptureFixture object at 0x7f3c90173990>

    def test_without_disable_logger(caplog):
        """
        Sanity test to double check whether caplog actually works
        so can be more confident in the asserts in test_disable_logger.
        """
        logger = logging.getLogger("griffe.agents.nodes")

        def function_with_logging(logger):
            assert not logger.disabled
            logger.critical("it's enabled!")
            return 42

        function_with_logging(logger)
        assert not logger.disabled
>       assert caplog.record_tuples == [("griffe.agents.nodes", 50, "it's enabled!")]
E       assert [('prefect._i...'s enabled!")] == [('griffe.age...'s enabled!")]
E         At index 0 diff: ('prefect._internal.concurrency', 10, "<WatcherThreadCancelScope, name='get' COMPLETED, runtime=0.00> exited") != ('griffe.agents.nodes', 50, "it's enabled!")
E         Left contains one more item: ('griffe.agents.nodes', 50, "it's enabled!")
E         Full diff:
E           [
E         +  ('prefect._internal.concurrency',
E         +   10,
E         +   "<WatcherThreadCancelScope, name='get' COMPLETED, runtime=0.00> exited"),
E            ('griffe.agents.nodes',
E             50,
E             "it's enabled!"),
E           ]

tests/test_logging.py:1375: AssertionError
```

https://github.com/PrefectHQ/prefect/actions/runs/9386685509/job/25847854356
