### PR TITLE
Mute 3.12.2 error

### DIFF
--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -108,8 +108,8 @@ class APILogHandler(logging.Handler):
                 )
 
             # Not ideal, but this method is called by the stdlib and cannot return a
-            # coroutine so we just schedule the drain in a new thread and continue
-            from_sync.call_soon_in_new_thread(create_call(APILogWorker.drain_all))
+            # coroutine so we just schedule the drain in the global loop thread and continue
+            from_sync.call_soon_in_loop_thread(create_call(APILogWorker.drain_all))
             return None
         else:
             # We set a timeout of 5s because we don't want to block forever if the worker

--- a/src/prefect/server/models/logs.py
+++ b/src/prefect/server/models/logs.py
@@ -42,7 +42,17 @@ async def create_logs(
     Returns:
         None
     """
-    await session.execute(db.insert(db.Log).values([log.model_dump() for log in logs]))
+    try:
+        await session.execute(
+            db.insert(db.Log).values([log.model_dump() for log in logs])
+        )
+    except RuntimeError as exc:
+        if "can't create new thread at interpreter shutdown" in str(exc):
+            # Background logs sometimes fail to write when the interpreter is shutting down.
+            # This is a known issue in Python 3.12.2 that can be ignored and is fixed in Python 3.12.3.
+            pass
+        else:
+            raise
 
 
 @inject_db

--- a/src/prefect/server/models/logs.py
+++ b/src/prefect/server/models/logs.py
@@ -50,6 +50,7 @@ async def create_logs(
         if "can't create new thread at interpreter shutdown" in str(exc):
             # Background logs sometimes fail to write when the interpreter is shutting down.
             # This is a known issue in Python 3.12.2 that can be ignored and is fixed in Python 3.12.3.
+            # see e.g. https://github.com/python/cpython/issues/113964
             pass
         else:
             raise


### PR DESCRIPTION
Python 3.12.2 introduced an issue that our background log handlers sometimes hit when writing logs while the system is tearing down (which happens very frequently in CI and interactive runs). The issue appears to be [fixed](https://github.com/python/cpython/issues/113964) in Python 3.12.3. If the problem happens, there is no recourse and it is classified as a Python bug, not a Prefect bug, so muting this specific error will hopefully save devs from the red herring rabbit hole I spent the last day in. 

