### PR TITLE
Give `redis` a non-conflicting name in datadog tests

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -211,7 +211,7 @@ jobs:
 
   run-tests-for-datadog:
     name: DataDog CI Visibility
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.event.head_commit.modified contains '.github/workflows/python-tests.yaml')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event.head_commit.modified contains '.github/workflows/python-tests.yaml'
     runs-on:
       group: oss-larger-runners
     strategy:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -211,7 +211,7 @@ jobs:
 
   run-tests-for-datadog:
     name: DataDog CI Visibility
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.event.head_commit.modified contains '.github/workflows/python-tests.yaml')
     runs-on:
       group: oss-larger-runners
     strategy:
@@ -319,7 +319,7 @@ jobs:
       - name: Start redis
         run: >
           docker run
-          --name "prefect-test-registry"
+          --name "redis"
           --detach
           --publish 6379:6379
           redis:latest


### PR DESCRIPTION
Redis had a copy/pasted name from the docker registry, renaming it to keep it from conflicting when running the datadog tests. This also includes a change to ensure we're running the datadog tests when we change the action yaml.