### PR TITLE
Fix syntax issue in `python-tests.yaml` action.

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -211,7 +211,7 @@ jobs:
 
   run-tests-for-datadog:
     name: DataDog CI Visibility
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event.head_commit.modified contains '.github/workflows/python-tests.yaml'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, '.github/workflows/python-tests.yaml'))
     runs-on:
       group: oss-larger-runners
     strategy:


### PR DESCRIPTION
Fun fact, if you mess up a yaml GitHub doesn't count that as a failed check.