### PR TITLE
Ensure events-worker app is ephemeral; run ephemeral migrations only once

### DIFF
--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -168,7 +168,7 @@ class PrefectEphemeralEventsClient(EventsClient):
             )
         from prefect.server.api.server import create_app
 
-        app = create_app()
+        app = create_app(ephemeral=True)
 
         self._http_client = PrefectHttpxAsyncClient(
             transport=httpx.ASGITransport(app=app, raise_app_exceptions=False),

--- a/src/prefect/utilities/asyncutils.py
+++ b/src/prefect/utilities/asyncutils.py
@@ -376,8 +376,8 @@ def sync_compatible(async_fn: T, force_sync: bool = False) -> T:
 
 
 @asynccontextmanager
-async def asyncnullcontext():
-    yield
+async def asyncnullcontext(value=None):
+    yield value
 
 
 def sync(__async_fn: Callable[P, Awaitable[T]], *args: P.args, **kwargs: P.kwargs) -> T:

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -21,6 +21,7 @@ from pydantic_extra_types.pendulum_dt import DateTime
 import prefect.client.schemas as client_schemas
 import prefect.context
 import prefect.exceptions
+import prefect.server.api
 from prefect import flow, tags
 from prefect.client.constants import SERVER_API_VERSION
 from prefect.client.orchestration import (
@@ -503,13 +504,21 @@ class TestClientContextManager:
 
 
 @pytest.mark.parametrize("enabled", [True, False])
-async def test_client_runs_migrations_for_ephemeral_app(enabled, monkeypatch):
+async def test_client_runs_migrations_for_ephemeral_app_only_once(enabled, monkeypatch):
     with temporary_settings(updates={PREFECT_API_DATABASE_MIGRATE_ON_START: enabled}):
+        # turn on lifespan for this test; it turns off after its run once per process
+        monkeypatch.setattr(prefect.server.api.server, "RUN_LIFESPAN", True)
+
         app = create_app(ephemeral=True, ignore_cache=True)
         mock = AsyncMock()
         monkeypatch.setattr(
             "prefect.server.database.interface.PrefectDBInterface.create_db", mock
         )
+        async with PrefectClient(app):
+            if enabled:
+                mock.assert_awaited_once_with()
+
+        # run a second time, but the mock should not be called again
         async with PrefectClient(app):
             if enabled:
                 mock.assert_awaited_once_with()


### PR DESCRIPTION
I'm trying to find the source of a performance issue and while this PR doesn't solve it, I did come across these two issues:

- the ephemeral events worker client doesn't create an ephemeral app, which means background services on the app are enabled. Now this doesn't matter in practice because the client is a low-level client that doesn't invoke the app lifespan, but if that changed it would have bad consequences. So I set the flag for using an ephemeral app (which will mean it can reuse the app from other clients without creating a new one).

- relatedly, ephemeral lifespans -- including creating/migrating the database and registering blocks -- are run multiple times, as the hooks are called whenever a new app is created. This is almost certainly unnecessary to do more than once per running process, so I've added a global flag to disable the lifespan hooks if they've already been run.