### PR TITLE
raise helpful error when `task_worker` runs against ephemeral server

### DIFF
--- a/src/prefect/client/subscriptions.py
+++ b/src/prefect/client/subscriptions.py
@@ -23,10 +23,15 @@ class Subscription(Generic[S]):
         path: str,
         keys: List[str],
         client_id: Optional[str] = None,
+        base_url: Optional[str] = None,
     ):
         self.model = model
         self.client_id = client_id
-        base_url = PREFECT_API_URL.value().replace("http", "ws", 1)
+
+        if base_url is None:
+            base_url = PREFECT_API_URL.value()
+
+        base_url = base_url.replace("http", "ws", 1)
         self.subscription_url = f"{base_url}{path}"
 
         self.keys = keys

--- a/src/prefect/client/subscriptions.py
+++ b/src/prefect/client/subscriptions.py
@@ -9,7 +9,7 @@ from typing_extensions import Self
 
 from prefect._internal.schemas.bases import IDBaseModel
 from prefect.logging import get_logger
-from prefect.settings import PREFECT_API_KEY, PREFECT_API_URL
+from prefect.settings import PREFECT_API_KEY
 
 logger = get_logger(__name__)
 
@@ -27,10 +27,6 @@ class Subscription(Generic[S]):
     ):
         self.model = model
         self.client_id = client_id
-
-        if base_url is None:
-            base_url = PREFECT_API_URL.value()
-
         base_url = base_url.replace("http", "ws", 1)
         self.subscription_url = f"{base_url}{path}"
 

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -153,6 +153,7 @@ class TaskWorker:
             path="/task_runs/subscriptions/scheduled",
             keys=[task.task_key for task in self.tasks],
             client_id=self._client_id,
+            base_url=base_url,
         ):
             if self._limiter:
                 await self._limiter.acquire_on_behalf_of(task_run.id)

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -142,7 +142,7 @@ class TaskWorker:
         base_url = PREFECT_API_URL.value()
         if base_url is None:
             raise ValueError(
-                "PREFECT_API_URL must be set to use the task worker. "
+                "`PREFECT_API_URL` must be set to use the task worker. "
                 "Task workers are not compatible with the ephemeral API."
             )
         logger.info(

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -139,6 +139,12 @@ class TaskWorker:
         raise StopTaskWorker
 
     async def _subscribe_to_task_scheduling(self):
+        base_url = PREFECT_API_URL.value()
+        if base_url is None:
+            raise ValueError(
+                "PREFECT_API_URL must be set to use the task worker. "
+                "Task workers are not compatible with ephemeral api."
+            )
         logger.info(
             f"Subscribing to tasks: {' | '.join(t.task_key.split('.')[-1] for t in self.tasks)}"
         )

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -143,7 +143,7 @@ class TaskWorker:
         if base_url is None:
             raise ValueError(
                 "PREFECT_API_URL must be set to use the task worker. "
-                "Task workers are not compatible with ephemeral api."
+                "Task workers are not compatible with the ephemeral API."
             )
         logger.info(
             f"Subscribing to tasks: {' | '.join(t.task_key.split('.')[-1] for t in self.tasks)}"

--- a/tests/test_task_worker.py
+++ b/tests/test_task_worker.py
@@ -662,14 +662,13 @@ class TestTaskWorkerLimit:
         # only one should run at a time, so we'll move on after 1 second
         # to ensure that the second task hasn't started
         with anyio.move_on_after(1):
-            with temporary_settings({PREFECT_API_URL: "http://notarealurl:4200"}):
-                await task_worker.start()
+            await task_worker.start()
 
-                updated_task_run_1 = await prefect_client.read_task_run(task_run_1.id)
-                updated_task_run_2 = await prefect_client.read_task_run(task_run_2.id)
+        updated_task_run_1 = await prefect_client.read_task_run(task_run_1.id)
+        updated_task_run_2 = await prefect_client.read_task_run(task_run_2.id)
 
-                assert updated_task_run_1.state.is_completed()
-                assert updated_task_run_2.state.is_scheduled()
+        assert updated_task_run_1.state.is_completed()
+        assert updated_task_run_2.state.is_scheduled()
 
     async def test_tasks_execute_when_limit_is_none(
         self, mock_subscription, prefect_client
@@ -698,14 +697,13 @@ class TestTaskWorkerLimit:
         # both should run at the same time, so we'll move on after 1 second
         # to ensure that the second task has started
         with anyio.move_on_after(1):
-            with temporary_settings({PREFECT_API_URL: "http://notarealurl:4200"}):
-                await task_worker.start()
+            await task_worker.start()
 
-                updated_task_run_1 = await prefect_client.read_task_run(task_run_1.id)
-                updated_task_run_2 = await prefect_client.read_task_run(task_run_2.id)
+        updated_task_run_1 = await prefect_client.read_task_run(task_run_1.id)
+        updated_task_run_2 = await prefect_client.read_task_run(task_run_2.id)
 
-                assert updated_task_run_1.state.is_completed()
-                assert updated_task_run_2.state.is_completed()
+        assert updated_task_run_1.state.is_completed()
+        assert updated_task_run_2.state.is_completed()
 
     async def test_tasks_execute_when_capacity_frees_up(
         self, mock_subscription, prefect_client


### PR DESCRIPTION
closes:https://github.com/PrefectHQ/prefect/issues/13847

Previously running a task worker against the ephemeral api would error with:
```
17:32:07.345 | INFO    | prefect.task_worker - Starting task worker...
17:32:07.345 | INFO    | prefect.task_worker - Subscribing to tasks: my_background_task-7c388d0bf59fa4394379971e841498bc
17:32:07.347 | ERROR   | prefect.task_worker - Task worker stopped with 1 exception:
'NoneType' object has no attribute 'replace'
```

As of this PR it errors in the following way:
```
17:44:36.607 | INFO    | prefect.task_worker - Starting task worker...
17:44:36.609 | ERROR   | prefect.task_worker - Task worker stopped with 1 exception:
PREFECT_API_URL must be set to use the task worker. Task workers are not compatible with ephemeral api.
```
