### PR TITLE
Ensure lifespan runs for each app

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -58,7 +58,7 @@ UI_TITLE = "Prefect Prefect REST API UI"
 API_VERSION = prefect.__version__
 # migrations should run only once per app start; the ephemeral API can potentially
 # create multiple apps in a single process
-RUN_LIFESPAN = True
+LIFESPAN_RAN_FOR_APP = set()
 
 logger = get_logger("server")
 
@@ -622,13 +622,12 @@ def create_app(
 
     @asynccontextmanager
     async def lifespan(app):
-        global RUN_LIFESPAN
-        if RUN_LIFESPAN:
+        if app not in LIFESPAN_RAN_FOR_APP:
             try:
                 await run_migrations()
                 await add_block_types()
                 await start_services()
-                RUN_LIFESPAN = False
+                LIFESPAN_RAN_FOR_APP.add(app)
                 yield
             finally:
                 await stop_services()

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -507,7 +507,7 @@ class TestClientContextManager:
 async def test_client_runs_migrations_for_ephemeral_app_only_once(enabled, monkeypatch):
     with temporary_settings(updates={PREFECT_API_DATABASE_MIGRATE_ON_START: enabled}):
         # turn on lifespan for this test; it turns off after its run once per process
-        monkeypatch.setattr(prefect.server.api.server, "RUN_LIFESPAN", True)
+        monkeypatch.setattr(prefect.server.api.server, "LIFESPAN_RAN_FOR_APP", set())
 
         app = create_app(ephemeral=True, ignore_cache=True)
         mock = AsyncMock()
@@ -522,6 +522,34 @@ async def test_client_runs_migrations_for_ephemeral_app_only_once(enabled, monke
         async with PrefectClient(app):
             if enabled:
                 mock.assert_awaited_once_with()
+
+        if not enabled:
+            mock.assert_not_awaited()
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+async def test_client_runs_migrations_for_two_different_ephemeral_apps(
+    enabled, monkeypatch
+):
+    with temporary_settings(updates={PREFECT_API_DATABASE_MIGRATE_ON_START: enabled}):
+        # turn on lifespan for this test; it turns off after its run once per process
+        monkeypatch.setattr(prefect.server.api.server, "LIFESPAN_RAN_FOR_APP", set())
+
+        app = create_app(ephemeral=True, ignore_cache=True)
+        app2 = create_app(ephemeral=True, ignore_cache=True)
+
+        mock = AsyncMock()
+        monkeypatch.setattr(
+            "prefect.server.database.interface.PrefectDBInterface.create_db", mock
+        )
+        async with PrefectClient(app):
+            if enabled:
+                mock.assert_awaited_once_with()
+
+        # run a second time, but the mock should not be called again
+        async with PrefectClient(app2):
+            if enabled:
+                assert mock.await_count == 2
 
         if not enabled:
             mock.assert_not_awaited()

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -546,7 +546,7 @@ async def test_client_runs_migrations_for_two_different_ephemeral_apps(
             if enabled:
                 mock.assert_awaited_once_with()
 
-        # run a second time, but the mock should not be called again
+        # run a second time, and mock should be called again because it's a different app
         async with PrefectClient(app2):
             if enabled:
                 assert mock.await_count == 2


### PR DESCRIPTION
Quick follow up to #13838 -- that PR prevented lifespan events (like db migrations) running once they had already been run once, but set the flag globally. That might be too heavy handed, as two different apps could each want their own lifecycle governance. In practice this is unlikely because while `create_app()` will allow multiple apps to be created, they all inherit the same settings; nonetheless this is probably a more permissive design.