### PR TITLE
Ensure that workers drain before the test dir is deleted

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -359,12 +359,15 @@ def pytest_sessionstart(session):
     setup_logging()
 
 
-@pytest.hookimpl(hookwrapper=True)
-def pytest_sessionfinish(session):
-    # Allow all other finish fixture to complete first
+# def pytest_sessionfinish(session, exitstatus):
+@pytest.fixture(scope="session", autouse=True)
+def cleanup(drain_log_workers, drain_events_workers):
+    # this fixture depends on other fixtures with important cleanup steps like
+    # draining workers to ensure that the home directory is not deleted before
+    # these steps are completed
     yield
 
-    # Then, delete the temporary directory
+    # delete the temporary directory
     if TEST_PREFECT_HOME is not None:
         shutil.rmtree(TEST_PREFECT_HOME)
 

--- a/tests/fixtures/events.py
+++ b/tests/fixtures/events.py
@@ -1,5 +1,6 @@
 import pytest
 
+from prefect.events.worker import EventsWorker
 from prefect.server.events.clients import AssertingEventsClient
 
 
@@ -29,3 +30,12 @@ def workspace_events_client(
         "prefect.server.models.deployments.PrefectServerEventsClient",
         AssertingEventsClient,
     )
+
+
+@pytest.fixture(scope="session", autouse=True)
+async def drain_events_workers():
+    """
+    Ensure that all workers have finished before the test session ends.
+    """
+    yield
+    await EventsWorker.drain_all()

--- a/tests/fixtures/logging.py
+++ b/tests/fixtures/logging.py
@@ -1,6 +1,6 @@
 import pytest
 
-from prefect.logging.handlers import APILogHandler
+from prefect.logging.handlers import APILogHandler, APILogWorker
 from prefect.settings import PREFECT_LOGGING_TO_API_ENABLED, temporary_settings
 
 
@@ -31,3 +31,12 @@ def enable_api_log_handler_if_marked(request):
             yield True
     else:
         yield False
+
+
+@pytest.fixture(scope="session", autouse=True)
+async def drain_log_workers():
+    """
+    Ensure that all workers have finished before the test session ends.
+    """
+    yield
+    await APILogWorker.drain_all()


### PR DESCRIPTION
Tests are extremely noisy lately with two common errors:
- logs not being written due to files being closed
- events db records not being written due to the file being unavailable

(Note these usually don't seem to actually fail tests, but they show up in test failure outputs - see https://github.com/PrefectHQ/prefect/actions/runs/9391385621/job/25863415303. The same errors *do* sometimes show up as test failures but I'm not sure why yet)


I believe this is because the log/events workers have outstanding items to process when test directory is cleaned up. This PR makes the following changes:
- explicit fixtures to drain all logs and events workers
- a session fixture to delete the temp directory after the worker fixtures complete. In theory the hook implementation should have ensured that the directory was deleted after all fixtures, but empirically it didn't work. I also tried `pytest_sessionfinish` which is supposed to be the very last hook called, but it didn't work either. 

Testing this is quite difficult but the failures are nondeterministic. I tested it locally using a test that reliably (but not always) created the bad situation. 


---

Edit: by coincidence, a test on another branch just failed that gives me some confidence this is the issue. Here's the traceback:

```
                                                                                                                                                [100%]/Users/jlowin/Developer/prefect/.venv/lib/python3.12/site-packages/_pytest/main.py:306: PluggyTeardownRaisedWarning: A plugin raised an exception during an old-style hookwrapper teardown.
Plugin: /Users/jlowin/Developer/prefect/tests/conftest.py, Hook: pytest_sessionfinish
FileNotFoundError: [Errno 2] No such file or directory: 'prefect.db-wal'
For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning
  config.hook.pytest_sessionfinish(
--- Logging error ---
Traceback (most recent call last):
  File "/Users/jlowin/Developer/prefect/.venv/bin/pytest", line 8, in <module>
    sys.exit(console_main())
             ^^^^^^^^^^^^^^
  File "/Users/jlowin/Developer/prefect/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py", line 192, in console_main
    code = main()
           ^^^^^^
  File "/Users/jlowin/Developer/prefect/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py", line 169, in main
    ret: Union[ExitCode, int] = config.hook.pytest_cmdline_main(
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jlowin/Developer/prefect/.venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jlowin/Developer/prefect/.venv/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jlowin/Developer/prefect/.venv/lib/python3.12/site-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/Users/jlowin/Developer/prefect/.venv/lib/python3.12/site-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jlowin/Developer/prefect/.venv/lib/python3.12/site-packages/_pytest/main.py", line 318, in pytest_cmdline_main
    return wrap_session(config, _main)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jlowin/Developer/prefect/.venv/lib/python3.12/site-packages/_pytest/main.py", line 306, in wrap_session
    config.hook.pytest_sessionfinish(
  File "/Users/jlowin/Developer/prefect/.venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 513, in __call__
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1271, in emit
    self.flush()
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1251, in flush
    self.stream.flush()
ValueError: I/O operation on closed file.
```

Notice this error was raised in/by the `pytest_sessionfinish` hook -- based on my exploration, my guess is that this hook is tearing down all threads, which forces a final flush, but the directory delete is happening in a way that the final flush comes immediately after. So the hook wrapper that delete the directory is somehow getting out of expected order. The change in this PR should fix that.