### PR TITLE
Addressing a race condition with the automations integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -10,7 +10,7 @@ on:
       - ui/**
       - .nvmrc
       - Dockerfile
-      - flows/
+      - flows/*
   push:
     branches:
       - main

--- a/flows/automation-assessments.py
+++ b/flows/automation-assessments.py
@@ -62,7 +62,9 @@ async def create_or_replace_automation(
             response.raise_for_status()
 
 
-async def wait_for_event(event: str, resource_id: str) -> Event:
+async def wait_for_event(
+    listening: asyncio.Event, event: str, resource_id: str
+) -> Event:
     logger = get_run_logger()
 
     filter = EventFilter(
@@ -71,6 +73,7 @@ async def wait_for_event(event: str, resource_id: str) -> Event:
         resource=EventResourceFilter(id=[resource_id]),
     )
     async with get_events_subscriber(filter=filter) as subscriber:
+        listening.set()
         async for event in subscriber:
             logger.info(event)
             return event
@@ -94,12 +97,15 @@ async def assess_reactive_automation():
             "actions": [{"type": "do-nothing"}],
         }
     ) as automation:
+        listening = asyncio.Event()
         listener = asyncio.create_task(
             wait_for_event(
+                listening,
                 "prefect.automation.triggered",
                 f"prefect.automation.{automation['id']}",
             )
         )
+        await listening.wait()
 
         async with get_events_client() as events:
             for i in range(5):
@@ -113,8 +119,11 @@ async def assess_reactive_automation():
 
         # Wait until we see the automation triggered event, or fail if it takes longer
         # than 60 seconds.  The reactive trigger should fire almost immediately.
-        with anyio.fail_after(60):
-            await listener
+        try:
+            with anyio.fail_after(60):
+                await listener
+        except asyncio.TimeoutError:
+            raise Exception("Reactive automation did not trigger in 60s")
 
 
 @flow
@@ -136,12 +145,15 @@ async def assess_proactive_automation():
             "actions": [{"type": "do-nothing"}],
         }
     ) as automation:
+        listening = asyncio.Event()
         listener = asyncio.create_task(
             wait_for_event(
+                listening,
                 "prefect.automation.triggered",
                 f"prefect.automation.{automation['id']}",
             )
         )
+        await listening.wait()
 
         async with get_events_client() as events:
             for i in range(2):  # not enough events to close the automation
@@ -155,8 +167,11 @@ async def assess_proactive_automation():
 
         # Wait until we see the automation triggered event, or fail if it takes longer
         # than 60 seconds.  The proactive trigger should take a little over 15s to fire.
-        with anyio.fail_after(60):
-            await listener
+        try:
+            with anyio.fail_after(60):
+                await listener
+        except asyncio.TimeoutError:
+            raise Exception("Proactive automation did not trigger in 60s")
 
 
 @flow
@@ -189,12 +204,15 @@ async def assess_compound_automation():
             "actions": [{"type": "do-nothing"}],
         }
     ) as automation:
+        listening = asyncio.Event()
         listener = asyncio.create_task(
             wait_for_event(
+                listening,
                 "prefect.automation.triggered",
                 f"prefect.automation.{automation['id']}",
             )
         )
+        await listening.wait()
 
         async with get_events_client() as events:
             await events.emit(
@@ -212,8 +230,11 @@ async def assess_compound_automation():
 
         # Wait until we see the automation triggered event, or fail if it takes longer
         # than 60 seconds.  The compound trigger should fire almost immediately.
-        with anyio.fail_after(60):
-            await listener
+        try:
+            with anyio.fail_after(60):
+                await listener
+        except asyncio.TimeoutError:
+            raise Exception("Compound automation did not trigger in 60s")
 
 
 @flow
@@ -245,12 +266,15 @@ async def assess_sequence_automation():
             "actions": [{"type": "do-nothing"}],
         }
     ) as automation:
+        listening = asyncio.Event()
         listener = asyncio.create_task(
             wait_for_event(
+                listening,
                 "prefect.automation.triggered",
                 f"prefect.automation.{automation['id']}",
             )
         )
+        await listening.wait()
 
         first = uuid4()
         second = uuid4()
@@ -278,8 +302,11 @@ async def assess_sequence_automation():
 
         # Wait until we see the automation triggered event, or fail if it takes longer
         # than 60 seconds.  The compound trigger should fire almost immediately.
-        with anyio.fail_after(60):
-            await listener
+        try:
+            with anyio.fail_after(60):
+                await listener
+        except asyncio.TimeoutError:
+            raise Exception("Sequence automation did not trigger in 60s")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
One way that these automation tests could fail is if connecting to the websocket
to listen for the triggered event takes longer than it takes to emit the
events and trigger the automation.

By using an `asyncio.Event` to signal when the socket is connected, we can wait
for that signal before we proceed with the rest of the test.
