### PR TITLE
Reduces the lockiness of automations database access

### DIFF
--- a/src/prefect/server/events/models/automations.py
+++ b/src/prefect/server/events/models/automations.py
@@ -25,9 +25,9 @@ if TYPE_CHECKING:
 @asynccontextmanager
 @db_injector
 async def automations_session(
-    db: PrefectDBInterface,
+    db: PrefectDBInterface, begin_transaction: bool = False
 ) -> AsyncGenerator[AsyncSession, None]:
-    async with db.session_context(begin_transaction=True) as session:
+    async with db.session_context(begin_transaction=begin_transaction) as session:
         yield session
 
 

--- a/src/prefect/server/events/triggers.py
+++ b/src/prefect/server/events/triggers.py
@@ -433,7 +433,7 @@ async def reactive_evaluation(event: ReceivedEvent, depth: int = 0):
 
             bucketing_key = trigger.bucketing_key(event)
 
-            async with automations_session() as session:
+            async with automations_session(begin_transaction=True) as session:
                 try:
                     bucket: Optional["ORMAutomationBucket"] = None
 


### PR DESCRIPTION
When porting automations from Prefect Cloud, the default is to begin a
transaction for every automations session.  This isn't strictly necessary in
most cases, and with SQLite, it exacerbates the `database is locked` issues.
