### PR TITLE
Resolving an infinite loop distributing events to a websocket subscriber

### DIFF
--- a/src/prefect/server/api/events.py
+++ b/src/prefect/server/api/events.py
@@ -73,7 +73,6 @@ async def stream_workspace_events_out(
     websocket: WebSocket,
 ) -> None:
     """Open a WebSocket to stream Events"""
-
     websocket = await subscriptions.accept_prefect_socket(
         websocket,
     )
@@ -120,6 +119,11 @@ async def stream_workspace_events_out(
 
             # ...before resuming the ongoing stream of events
             async for event in event_stream:
+                if not event:
+                    if await subscriptions.still_connected(websocket):
+                        continue
+                    break
+
                 if wants_backfill and event.id in backfilled_ids:
                     backfilled_ids.remove(event.id)
                     continue

--- a/src/prefect/server/events/stream.py
+++ b/src/prefect/server/events/stream.py
@@ -47,7 +47,7 @@ async def events(
                 # forever waiting for a message to be put on the queue, and never notice
                 # that their client (like a websocket) has actually disconnected.
                 try:
-                    event = await asyncio.wait_for(queue.get(), timeout=2)
+                    event = await asyncio.wait_for(queue.get(), timeout=1)
                 except asyncio.TimeoutError:
                     # If the queue is empty, we'll yield to the caller with a None in
                     # order to give it control over what happens next.  This helps with

--- a/src/prefect/server/events/stream.py
+++ b/src/prefect/server/events/stream.py
@@ -37,19 +37,25 @@ async def subscribed(
 @asynccontextmanager
 async def events(
     filter: EventFilter,
-) -> AsyncGenerator[AsyncIterable[ReceivedEvent], None]:
+) -> AsyncGenerator[AsyncIterable[Optional[ReceivedEvent]], None]:
     async with subscribed(filter) as queue:
 
-        async def consume() -> AsyncGenerator[ReceivedEvent, None]:
+        async def consume() -> AsyncGenerator[Optional[ReceivedEvent], None]:
             while True:
                 # Use a brief timeout to allow for cancellation, especially when a
                 # client disconnects.  Without a timeout here, a consumer may block
                 # forever waiting for a message to be put on the queue, and never notice
                 # that their client (like a websocket) has actually disconnected.
                 try:
-                    event = await asyncio.wait_for(queue.get(), timeout=5)
+                    event = await asyncio.wait_for(queue.get(), timeout=2)
                 except asyncio.TimeoutError:
+                    # If the queue is empty, we'll yield to the caller with a None in
+                    # order to give it control over what happens next.  This helps with
+                    # the outbound websocket, where we want to check if the client is
+                    # still connected periodically.
+                    yield None
                     continue
+
                 yield event
 
         yield consume()
@@ -119,6 +125,10 @@ class Distributor:
 
     async def start(self):
         await start_distributor()
+        try:
+            await _distributor_task
+        except asyncio.CancelledError:
+            pass
 
     async def stop(self):
         await stop_distributor()

--- a/src/prefect/server/utilities/subscriptions.py
+++ b/src/prefect/server/utilities/subscriptions.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Optional
 
 from fastapi import (
@@ -40,3 +41,21 @@ async def accept_prefect_socket(websocket: WebSocket) -> Optional[WebSocket]:
     except NORMAL_DISCONNECT_EXCEPTIONS:
         # it's fine if a client disconnects either normally or abnormally
         return None
+
+
+async def still_connected(websocket: WebSocket) -> bool:
+    """Checks that a client websocket still seems to be connected during a period where
+    the server is expected to be sending messages."""
+    try:
+        await asyncio.wait_for(websocket.receive(), timeout=0.1)
+        return True  # this should never happen, but if it does, we're still connected
+    except asyncio.TimeoutError:
+        # The fact that we timed out rather than getting another kind of error
+        # here means we're still connected to our client, so we can continue to send
+        # events.
+        return True
+    except RuntimeError:
+        # starlette raises this if we test a client that's disconnected
+        return False
+    except NORMAL_DISCONNECT_EXCEPTIONS:
+        return False


### PR DESCRIPTION
The outward signs of this manifest as the Prefect server not stopping in
response to an interrupt after a websocket subscriber has connected once.  The
specific scenario that caused that was:

* Subscriber connects and start listening for events from the server
* The server opens a queue with the distributor and starts the loop to check for
  new events, periodically yielding back control
* If no events ever arrive for that subscriber (due to a restrictive filter or
  just an absence of events), the loop will just continue indefinitely _even if
  the subscriber disconnects_
* This leads to there being an unfinished task on the event loop, preventing the
  server from shutting itself down cleanly

The ideal solution here would be to send a `ping` message down the wire to the
client, but we don't have access to those lower-level protocol messages from the
Starlette layer (they are handled by the webserver, like uvicorn in our case).
The solution here is twofold:

1. Actually yield control all the way back to the caller of the `stream.events()`
   by `yield`ing a `None` when there's no new event for a while
2. When getting that control passed back to the socket endpoint, it can perform
   a (mildly hacky) test by attempting to `receive` from the socket (knowing
   that the client isn't expected to `send` anything); this works as a
   functional "are you still there?" test that we can perform without needing to
   introduce a client-side acknowledgement to the streaming protocol

Fixes #13868
