### PR TITLE
remove dynamic key from non-flow task run name

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -588,7 +588,7 @@ class Task(Generic[P, R]):
         async with client:
             if not flow_run_context:
                 dynamic_key = f"{self.task_key}-{str(uuid4().hex)}"
-                task_run_name = f"{self.name}-{dynamic_key[:NUM_CHARS_DYNAMIC_KEY]}"
+                task_run_name = self.name
             else:
                 dynamic_key = _dynamic_key_for_task_run(
                     context=flow_run_context, task=self


### PR DESCRIPTION
If I have task called `my_background_task`, when I run it inside of a flow, the task run's name is `my_background_task-0`. When I run it independently (via `.delay` or directly) it's name is `my_background_task-my_backg` as it tries to append the first 8 characters of the dynamic key. If the function name is > 8 chars, this suffix will always be the same. It seems better UX to just have the task run name

