### PR TITLE
Remove stray warning about tasks that weren't originally `SCHEDULED`

### DIFF
--- a/src/prefect/server/services/task_scheduling.py
+++ b/src/prefect/server/services/task_scheduling.py
@@ -99,9 +99,8 @@ class TaskSchedulingTimeouts(LoopService):
                 if prior_scheduled_state.type == states.StateType.SCHEDULED:
                     break
             else:
-                self.logger.warning(
-                    "No prior scheduled state found for task run %s", task_run.id
-                )
+                # This wasn't originally a SCHEDULED background task, so we won't
+                # attempt to reschedule it.
                 continue
 
             rescheduled = states.Scheduled(


### PR DESCRIPTION
Background tasks used to be the only tasks that existed without a flow run, but
that is no longer true.  The `TaskSchedulingTimeouts`, when it's looking for
stuck `PENDING` tasks would warn when it encountered one that hadn't previously
been `SCHEDULED`.  These tasks can just be quietly skipped here, without warning.
