### PR TITLE
Expose `receive_input` and `send_input` from `prefect.input`

### DIFF
--- a/src/prefect/input/__init__.py
+++ b/src/prefect/input/__init__.py
@@ -12,6 +12,8 @@ from .run_input import (
     RunInputMetadata,
     keyset_from_base_key,
     keyset_from_paused_state,
+    receive_input,
+    send_input,
 )
 
 __all__ = [
@@ -26,4 +28,6 @@ __all__ = [
     "keyset_from_base_key",
     "keyset_from_paused_state",
     "read_flow_run_input",
+    "receive_input",
+    "send_input",
 ]


### PR DESCRIPTION
These methods were only in `prefect.input.run_input` which doesn't match with everything else that's exposed at `prefect.input`.