### PR TITLE
Require a `PREFECT_API_URL` to start a worker

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -42,8 +42,10 @@ from prefect.exceptions import (
 from prefect.logging.loggers import PrefectLogAdapter, flow_run_logger, get_logger
 from prefect.plugins import load_prefect_collections
 from prefect.settings import (
+    PREFECT_API_URL,
     PREFECT_EXPERIMENTAL_WARN,
     PREFECT_EXPERIMENTAL_WARN_ENHANCED_CANCELLATION,
+    PREFECT_TEST_MODE,
     PREFECT_WORKER_HEARTBEAT_SECONDS,
     PREFECT_WORKER_PREFETCH_SECONDS,
     get_current_settings,
@@ -521,6 +523,10 @@ class BaseWorker(abc.ABC):
         self._limiter = (
             anyio.CapacityLimiter(self._limit) if self._limit is not None else None
         )
+
+        if not PREFECT_TEST_MODE and not PREFECT_API_URL.value():
+            raise ValueError("`PREFECT_API_URL` must be set to start a Worker.")
+
         self._client = get_client()
         await self._client.__aenter__()
         await self._runs_task_group.__aenter__()


### PR DESCRIPTION
When there's no `PREFECT_API_URL` set, calls to `get_client` will start the
ephemeral server transparently for the user.  This works amazingly well for
running single flows and tasks for demos and testing.  In the default
configuration, you can share a SQLite database across several Prefect processes,
like a server and a worker, and things will generally appear to work.

However, when we start to get into more advanced infrastructure like `Worker`
and `TaskWorker`, it doesn't make sense to run these ephemerally without a
Prefect server.  Event-driven workflows and background task scheduling require
a running server, and we should be explicit about that fact to avoid the
possibility for confusion (like events not being emitted, or automations not
running as expected).

Fixes #13876
