### PR TITLE
Fix `ThreadPoolTaskRunner` concurrency by copying `max_workers` on duplication

### DIFF
--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -208,7 +208,7 @@ class ThreadPoolTaskRunner(TaskRunner[PrefectConcurrentFuture]):
         self._max_workers = max_workers
 
     def duplicate(self) -> "ThreadPoolTaskRunner":
-        return type(self)()
+        return type(self)(max_workers=self._max_workers)
 
     def submit(
         self,
@@ -287,6 +287,11 @@ class ThreadPoolTaskRunner(TaskRunner[PrefectConcurrentFuture]):
             self._executor.shutdown()
             self._executor = None
         super().__exit__(exc_type, exc_value, traceback)
+
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, ThreadPoolTaskRunner):
+            return False
+        return self._max_workers == value._max_workers
 
 
 # Here, we alias ConcurrentTaskRunner to ThreadPoolTaskRunner for backwards compatibility

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -60,10 +60,11 @@ class MockFuture(PrefectWrappedFuture):
 
 class TestThreadPoolTaskRunner:
     def test_duplicate(self):
-        runner = ThreadPoolTaskRunner()
+        runner = ThreadPoolTaskRunner(max_workers=100)
         duplicate_runner = runner.duplicate()
         assert isinstance(duplicate_runner, ThreadPoolTaskRunner)
         assert duplicate_runner is not runner
+        assert duplicate_runner == runner
 
     def test_runner_must_be_started(self):
         runner = ThreadPoolTaskRunner()


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
Fixes issue with `ThreadPoolTaskRunner` concurrency by copying `max_workers` on task runner duplication. Now the `max_workers` setting is respected, and users can increase the amount of concurrent execution if desired.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
Execute 100 tasks concurrently (this would execute in batches previously):
```python
from prefect import task, flow
from prefect.task_runners import ThreadPoolTaskRunner


@task
def sleepy_task(i):
    import time

    print(f"Sleepy task {i}")
    time.sleep(10)
    return i


@flow(task_runner=ThreadPoolTaskRunner(max_workers=100))
def test_flow():
    return sleepy_task.map(range(100))


if __name__ == "__main__":
    test_flow()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
 	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `mint.json` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `docs/mint.json` navigation.
