### PR TITLE
Add support for instance/class/static methods

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -365,11 +365,11 @@ class Flow(Generic[P, R]):
         if instance is None:
             return self
 
-        # if the flow is being accessed on an instance, bind the instance to the __self__ attribute
+        # if the flow is being accessed on an instance, bind the instance to the __prefect_self__ attribute
         # of the flow's function. This will allow it to be automatically added to the flow's parameters
         else:
             bound_flow = copy(self)
-            bound_flow.fn.__self__ = instance
+            bound_flow.fn.__prefect_self__ = instance
             return bound_flow
 
     def with_options(

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -354,6 +354,10 @@ class Flow(Generic[P, R]):
 
         self._entrypoint = f"{module}:{fn.__name__}"
 
+    @property
+    def ismethod(self) -> bool:
+        return hasattr(self.fn, "__prefect_self__")
+
     def __get__(self, instance, owner):
         """
         Implement the descriptor protocol so that the flow can be used as an instance method.
@@ -573,6 +577,9 @@ class Flow(Generic[P, R]):
         """
         serialized_parameters = {}
         for key, value in parameters.items():
+            # do not serialize the bound self object
+            if self.ismethod and value is self.fn.__prefect_self__:
+                continue
             try:
                 serialized_parameters[key] = jsonable_encoder(value)
             except (TypeError, ValueError):

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -378,11 +378,11 @@ class Task(Generic[P, R]):
         if instance is None:
             return self
 
-        # if the task is being accessed on an instance, bind the instance to the __self__ attribute
+        # if the task is being accessed on an instance, bind the instance to the __prefect_self__ attribute
         # of the task's function. This will allow it to be automatically added to the task's parameters
         else:
             bound_task = copy(self)
-            bound_task.fn.__self__ = instance
+            bound_task.fn.__prefect_self__ = instance
             return bound_task
 
     def with_options(

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -367,6 +367,10 @@ class Task(Generic[P, R]):
         self.retry_condition_fn = retry_condition_fn
         self.viz_return_value = viz_return_value
 
+    @property
+    def ismethod(self) -> bool:
+        return hasattr(self.fn, "__prefect_self__")
+
     def __get__(self, instance, owner):
         """
         Implement the descriptor protocol so that the task can be used as an instance method.

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -8,7 +8,7 @@ import datetime
 import inspect
 import os
 from copy import copy
-from functools import partial, update_wrapper, wraps
+from functools import partial, update_wrapper
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -378,23 +378,11 @@ class Task(Generic[P, R]):
         if instance is None:
             return self
 
-        # if the task is being accessed on an instance, bind the instance to the task's fn
+        # if the task is being accessed on an instance, bind the instance to the __self__ attribute
+        # of the task's function. This will allow it to be automatically added to the task's parameters
         else:
-            # create a wrapper that calls the task function with the instance as the first argument
-            @wraps(self.fn)
-            def _instance_wrapper(*args, **kwargs):
-                return self.fn(instance, *args, **kwargs)
-
-            # remove the first (bound) argument from the wrapped function signature
-            # so that validation works as expected
-            signature = inspect.signature(self.fn)
-            _instance_wrapper.__signature__ = signature.replace(
-                parameters=list(signature.parameters.values())[1:]
-            )
-
             bound_task = copy(self)
-            bound_task.fn = _instance_wrapper
-            update_wrapper(bound_task, _instance_wrapper)
+            bound_task.fn.__self__ = instance
             return bound_task
 
     def with_options(

--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -42,23 +42,24 @@ def get_call_parameters(
     call_args: Tuple[Any, ...],
     call_kwargs: Dict[str, Any],
     apply_defaults: bool = True,
-    include_self: bool = True,
 ) -> Dict[str, Any]:
     """
-    Bind a call to a function to get parameter/value mapping. Default values on the
-    signature will be included if not overridden.
+    Bind a call to a function to get parameter/value mapping. Default values on
+    the signature will be included if not overridden.
 
-    If include_self is True and fn is a bound method, fn.__self__ will be
-    explicitly included as the first parameter. This allows Prefect to work with
-    bound methods in a way that is consistent with how Python handles them (i.e.
-    users don't have to pass the instance to the method) while still making the
-    implicit self argument visible to all of Prefect's parameter machinery (such as
-    cache key functions).
+    If the function has a `__prefect_self__` attribute, it will be included as
+    the first parameter. This attribute is set when Prefect decorates a bound
+    method, so this approach allows Prefect to work with bound methods in a way
+    that is consistent with how Python handles them (i.e. users don't have to
+    pass the instance argument to the method) while still making the implicit self
+    argument visible to all of Prefect's parameter machinery (such as cache key
+    functions).
 
-    Raises a ParameterBindError if the arguments/kwargs are not valid for the function
+    Raises a ParameterBindError if the arguments/kwargs are not valid for the
+    function
     """
-    if include_self and hasattr(fn, "__self__"):
-        call_args = (fn.__self__,) + call_args
+    if hasattr(fn, "__prefect_self__"):
+        call_args = (fn.__prefect_self__,) + call_args
 
     try:
         bound_signature = inspect.signature(fn).bind(*call_args, **call_kwargs)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -856,6 +856,42 @@ class TestFlowCall:
         assert Foo.static_method() == "static"
         assert isinstance(Foo.static_method, Flow)
 
+    def test_flow_supports_instance_methods_with_basemodel(self):
+        class Foo(pydantic.BaseModel):
+            model_config = pydantic.ConfigDict(ignored_types=(Flow,))
+            x: int = 5
+
+            @flow
+            def instance_method(self):
+                return self.x
+
+        assert Foo().instance_method() == 5
+        assert isinstance(Foo().instance_method, Flow)
+
+    def test_flow_supports_class_methods_with_basemodel(self):
+        class Foo(pydantic.BaseModel):
+            model_config = pydantic.ConfigDict(ignored_types=(Flow,))
+
+            @classmethod
+            @flow
+            def class_method(cls):
+                return cls.__name__
+
+        assert Foo.class_method() == "Foo"
+        assert isinstance(Foo.class_method, Flow)
+
+    def test_flow_supports_static_methods_with_basemodel(self):
+        class Foo(pydantic.BaseModel):
+            model_config = pydantic.ConfigDict(ignored_types=(Flow,))
+
+            @staticmethod
+            @flow
+            def static_method():
+                return "static"
+
+        assert Foo.static_method() == "static"
+        assert isinstance(Foo.static_method, Flow)
+
 
 class TestSubflowCalls:
     async def test_subflow_call_with_no_tasks(self):

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -816,6 +816,46 @@ class TestFlowCall:
         assert flow_state.is_cancelled()
         assert flow_state.message == "1/1 states cancelled."
 
+    def test_flow_supports_instance_methods(self):
+        class Foo:
+            def __init__(self, x):
+                self.x = x
+
+            @flow
+            def instance_method(self):
+                return self.x
+
+        f = Foo(1)
+        assert Foo(5).instance_method() == 5
+        assert f.instance_method() == 1
+        assert isinstance(Foo(10).instance_method, Flow)
+
+    def test_flow_supports_class_methods(self):
+        class Foo:
+            def __init__(self, x):
+                self.x = x
+
+            @classmethod
+            @flow
+            def class_method(cls):
+                return cls.__name__
+
+        assert Foo.class_method() == "Foo"
+        assert isinstance(Foo.class_method, Flow)
+
+    def test_flow_supports_static_methods(self):
+        class Foo:
+            def __init__(self, x):
+                self.x = x
+
+            @staticmethod
+            @flow
+            def static_method():
+                return "static"
+
+        assert Foo.static_method() == "static"
+        assert isinstance(Foo.static_method, Flow)
+
 
 class TestSubflowCalls:
     async def test_subflow_call_with_no_tasks(self):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -324,6 +324,48 @@ class TestTaskCall:
 
         assert bar() == "ahellob"
 
+    def test_task_supports_instance_methods(self):
+        class Foo:
+            def __init__(self, x):
+                self.x = x
+
+            @task
+            def instance_method(self):
+                return self.x
+
+        f = Foo(1)
+        assert Foo(5).instance_method() == 5
+        # ensure the instance binding is not global
+        assert f.instance_method() == 1
+
+        assert isinstance(Foo(10).instance_method, Task)
+
+    def test_task_supports_class_methods(self):
+        class Foo:
+            def __init__(self, x):
+                self.x = x
+
+            @classmethod
+            @task
+            def class_method(cls):
+                return cls.__name__
+
+        assert Foo.class_method() == "Foo"
+        assert isinstance(Foo.class_method, Task)
+
+    def test_task_supports_static_methods(self):
+        class Foo:
+            def __init__(self, x):
+                self.x = x
+
+            @staticmethod
+            @task
+            def static_method():
+                return "static"
+
+        assert Foo.static_method() == "static"
+        assert isinstance(Foo.static_method, Task)
+
 
 class TestTaskRun:
     async def test_sync_task_run_inside_sync_flow(self):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2831,10 +2831,12 @@ class TestTaskWithOptions:
 
 
 class TestTaskMap:
+    @staticmethod
     @task
     async def add_one(x):
         return x + 1
 
+    @staticmethod
     @task
     def add_together(x, y):
         return x + y
@@ -2931,10 +2933,12 @@ class TestTaskMap:
         task_states = my_flow()
         assert [await state.result() for state in task_states] == [2, 3, 4]
 
+    @staticmethod
     @task
     def echo(x):
         return x
 
+    @staticmethod
     @task
     def numbers():
         return [1, 2, 3]


### PR DESCRIPTION
This PR adds support for decorating instance/class/static methods as @flows or @tasks.

Today, methods aren't supported because of how Prefect handles the implicit `self` argument; you'll get an error like `ParameterBindError: Error binding parameters for function 'instance_method': missing a required argument: 'self'.
Function 'instance_method' has signature 'self' but received args: () and kwargs: [].`.

This is because the function signature (used for validating parameters) demands an explicit `self` call arg that will never be supplied by the user.

The solution (for both flows and tasks) has two parts:
1. Implement the descriptor protocol on `Flows` and `Tasks` by adding a `__get__` method. When an instance method is accessed on its parent instance, the `__get__` method is called with the instance as its first argument. It is expected to return the bound method. We use that arg to create and return a copy of the Flow object which has that instance bound to its own `fn` as a `__prefect_self__` attribute. 
2. Modify Prefect's `get_call_parameters` function (which transforms user-supplied arguments into a full set of callargs) to look for `__prefect_self__` and, if found, prepend it to the front of the callargs.

This solution means:
1. Users never have to supply an implicit bound instance, just like normal Python
2. Prefect receives the implicit instance as a "normal" parameter, meaning that all input-based systems, such as caching, respect its existance.