### PR TITLE
Fix code block formatting in automations concepts docs

### DIFF
--- a/docs/2.19.x/concepts/automations.mdx
+++ b/docs/2.19.x/concepts/automations.mdx
@@ -92,32 +92,30 @@ from prefect.events.schemas.automations import EventTrigger
 from prefect.server.events.actions import CancelFlowRun
 
 # creating an automation
-automation =
-  Automation(
+automation = Automation(
     name="woodchonk",
     trigger=EventTrigger(
-      expect={"animal.walked"},
-      match={
-        "genus": "Marmota",
-        "species": "monax",
+        expect={"animal.walked"},
+        match={
+            "genus": "Marmota",
+            "species": "monax",
         },
         posture="Reactive",
         threshold=3,
-        ),
-      actions=[CancelFlowRun()]
-        ).create()
+    ),
+    actions=[CancelFlowRun()]
+).create()
 print(automation)
 # name='woodchonk' description='' enabled=True trigger=EventTrigger(type='event', match=ResourceSpecification(__root__={'genus': 'Marmota', 'species': 'monax'}), match_related=ResourceSpecification(__root__={}), after=set(), expect={'animal.walked'}, for_each=set(), posture=Posture.Reactive, threshold=3, within=datetime.timedelta(seconds=10)) actions=[CancelFlowRun(type='cancel-flow-run')] actions_on_trigger=[] actions_on_resolve=[] owner_resource=None id=UUID('d641c552-775c-4dc6-a31e-541cb11137a6')
 
 # reading the automation
 
-automation = Automation.read(id ="d641c552-775c-4dc6-a31e-541cb11137a6")
-or
+automation = Automation.read(id="d641c552-775c-4dc6-a31e-541cb11137a6")
+# or
 automation = Automation.read("woodchonk")
 
 print(automation)
 # name='woodchonk' description='' enabled=True trigger=EventTrigger(type='event', match=ResourceSpecification(__root__={'genus': 'Marmota', 'species': 'monax'}), match_related=ResourceSpecification(__root__={}), after=set(), expect={'animal.walked'}, for_each=set(), posture=Posture.Reactive, threshold=3, within=datetime.timedelta(seconds=10)) actions=[CancelFlowRun(type='cancel-flow-run')] actions_on_trigger=[] actions_on_resolve=[] owner_resource=None id=UUID('d641c552-775c-4dc6-a31e-541cb11137a6')
-
 ```
 
 
@@ -276,21 +274,20 @@ from db import Table
 
 @flow
 def transform(table_name: str):
-  table = Table(table_name)
+    table = Table(table_name)
 
-  if not table.exists():
-    emit_event(
-        event="table-missing",
-        resource={"prefect.resource.id": "etl-events.transform"}
+    if not table.exists():
+        emit_event(
+            event="table-missing",
+            resource={"prefect.resource.id": "etl-events.transform"}
     )
-  elif table.is_empty():
-    emit_event(
-        event="table-empty",
-        resource={"prefect.resource.id": "etl-events.transform"}
-    )
-  else:
-    # transform data
-
+    elif table.is_empty():
+        emit_event(
+            event="table-empty",
+            resource={"prefect.resource.id": "etl-events.transform"}
+        )
+    else:
+        # transform data
 ```
 
 

--- a/docs/2.19.x/concepts/automations.mdx
+++ b/docs/2.19.x/concepts/automations.mdx
@@ -169,7 +169,7 @@ Both the `event` and `metric` triggers support matching events for specific reso
 
 Consider the `resource` and `related` fields on the following `prefect.flow-run.Completed` event, truncated for the sake of example. Its primary resource is a flow run, and since that flow run was started via a deployment, it is related to both its flow and its deployment:
 
-```python
+```json
 "resource": {
   "prefect.resource.id": "prefect.flow-run.925eacce-7fe5-4753-8f02-77f1511543db",
   "prefect.resource.name": "cute-kittiwake"
@@ -194,7 +194,7 @@ There are a number of valid ways to select the above event for evaluation, and t
 
 The following configuration will filter for any events whose primary resource is a flow run, _and_ that flow run has a name starting with `cute-` or `radical-`.
 
-```python
+```json
 "match": {
   "prefect.resource.id": "prefect.flow-run.*",
   "prefect.resource.name": ["cute-*", "radical-*"]
@@ -207,7 +207,7 @@ The following configuration will filter for any events whose primary resource is
 
 This configuration, on the other hand, will filter for any events for which this specific deployment is a related resource.
 
-```
+```json
 "match": {},
 "match_related": {
   "prefect.resource.id": "prefect.deployment.37ca4a08-e2d9-4628-a310-cc15a323378e"
@@ -219,7 +219,7 @@ This configuration, on the other hand, will filter for any events for which this
 
 Both of the above approaches will select the example `prefect.flow-run.Completed` event, but will permit additional, possibly undesired events through the filter as well. `match` and `match_related` can be combined for more restrictive filtering:
 
-```
+```json
 "match": {
   "prefect.resource.id": "prefect.flow-run.*",
   "prefect.resource.name": ["cute-*", "radical-*"]
@@ -251,7 +251,7 @@ This configuration informs the trigger to evaluate _only_ `prefect.flow-run.Comp
 
 `threshold` decides the quantity of `expect`ed events needed to satisfy the trigger. Increasing the `threshold` above 1 will also require use of `within` to define a range of time in which multiple events are seen. The following configuration will expect two occurrences of `prefect.flow-run.Completed` within 60 seconds.
 
-```python
+```json
 "expect": [
   "prefect.flow-run.Completed"
 ],
@@ -299,7 +299,7 @@ The following configuration uses `after` to prevent this automation from firing 
 Note how `match` and `match_related` are used to ensure the trigger only evaluates events that are relevant to its purpose.
 </Tip>
 
-```python
+```json
 "match": {
   "prefect.resource.id": [
     "prefect.flow-run.*",
@@ -327,7 +327,7 @@ All of the previous examples were designed around a reactive `posture` - that is
 
 The following trigger will fire if a `prefect.flow-run.Completed` event is not seen within 60 seconds after a `prefect.flow-run.Running` event is seen.
 
-```python
+```json
 {
   "match": {
     "prefect.resource.id": "prefect.flow-run.*"
@@ -350,7 +350,7 @@ The following trigger will fire if a `prefect.flow-run.Completed` event is not s
 
 However, without `for_each`, a `prefect.flow-run.Completed` event from a _different_ flow run than the one that started this trigger with its `prefect.flow-run.Running` event could satisfy the condition. Adding a `for_each` of `prefect.resource.id` will cause this trigger to be evaluated separately for each flow run id associated with these events.
 
-```python
+```json
 {
   "match": {
     "prefect.resource.id": "prefect.flow-run.*"
@@ -410,7 +410,7 @@ And the `MetricTriggerQuery` query is defined as:
 
 For example, to fire when flow runs tagged `production` in your workspace are failing at a rate of 10% or worse for the last hour (in other words, your success rate is below 90%), create this trigger:
 
-```python
+```json
 {
   "type": "metric",
   "match": {
@@ -434,7 +434,7 @@ For example, to fire when flow runs tagged `production` in your workspace are fa
 
 To detect when the average lateness of your Kubernetes workloads (running on a work pool named `kubernetes`) in the last day exceeds 5 minutes late, and that number hasn't gotten better for the last 10 minutes, use a trigger like this:
 
-```python
+```json
 {
   "type": "metric",
   "match": {
@@ -462,7 +462,7 @@ To create a trigger from multiple kinds of events and metrics, use a `compound` 
 
 For example, if you want to run a deployment only after three different flows in your workspace have written their results to a remote filesystem, combine them with a 'compound' trigger:
 
-```python
+```json
 {
   "type": "compound",
   "require": "all",
@@ -505,7 +505,7 @@ This trigger will fire once it sees at least one of each of the underlying event
 
 If you want a flow run to complete prior to starting to watch for those three events, you can combine the entire previous trigger as the second part of a sequence of two triggers:
 
-```python
+```json
 {
   // the outer trigger is now a "sequence" trigger
   "type": "sequence",
@@ -568,7 +568,7 @@ The `within` parameter for compound and sequence triggers constrains how close i
 
 Any type of trigger may be composed into higher-order composite triggers, including proactive event triggers and metric triggers. In the following example, the compound trigger will fire if any of the following events occur: a flow run stuck in `Pending`, a work pool becoming unready, or the average amount of `Late` work in your workspace going over 10 minutes:
 
-```python
+```json
 {
   "type": "compound",
   "require": "any",
@@ -642,7 +642,7 @@ Trigger definitions for deployments are supported in `prefect.yaml`, `.serve`, a
 
 A list of triggers can be included directly on any deployment in a `prefect.yaml` file:
 
-```python
+```yaml
 deployments:
   - name: my-deployment
     entrypoint: path/to/flow.py:decorated_fn
@@ -663,7 +663,7 @@ deployments:
 
 This deployment will create a flow run when an `external.resource.pinged` event _and_ an `external.resource.replied` event have been seen from `my.external.resource`:
 
-```python
+```yaml
 deployments:
   - name: my-deployment
     entrypoint: path/to/flow.py:decorated_fn
@@ -769,7 +769,7 @@ if __name__=="__main__":
 
 You can pass one or more `--trigger` arguments to `prefect deploy`, which can be either a JSON string or a path to a `.yaml` or `.json` file.
 
-```python
+```sh
 # Pass a trigger as a JSON string
 prefect deploy -n test-deployment \
   --trigger '{
@@ -789,7 +789,7 @@ prefect deploy -n test-deployment --trigger my_stuff/triggers.json
 
 For example, a `triggers.yaml` file could have many triggers defined:
 
-```python
+```yaml
 triggers:
   - enabled: true
     match:


### PR DESCRIPTION
This PR includes minor tweaks to code blocks within the concepts/automations docs page.
- fixes indentation/formatting in python blocks
- specifies `json`/`yaml` for code fences where relevant rather than `python`