### PR TITLE
Enabling `PREFECT_TEST_MODE` for integrations tests

### DIFF
--- a/.github/workflows/api-compatibility-tests.yaml
+++ b/.github/workflows/api-compatibility-tests.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/setup-python@v5
         id: setup_python
         with:
-          python-version: 3.12
+          python-version: "3.12"
 
       - name: UV Cache
         # Manually cache the uv cache directory

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -88,6 +88,7 @@ jobs:
       - name: Run tests
         if: matrix.package != 'prefect-ray'
         env:
+          PREFECT_TEST_MODE: "True"
           PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///./orion-tests.db"
         working-directory: src/integrations/${{ matrix.package }}
         run: >
@@ -100,6 +101,7 @@ jobs:
       - name: Run tests for prefect-ray
         if: matrix.package == 'prefect-ray'
         env:
+          PREFECT_TEST_MODE: "True"
           PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///./orion-tests.db"
         working-directory: src/integrations/${{ matrix.package }}
         run: >

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -5,12 +5,13 @@ on:
     paths:
       - .github/workflows/integration-package-tests.yaml
       - "src/**/*.py"
+      - "src/integrations/**/*"
     types: [opened, reopened, synchronize, labeled, unlabeled]
   push:
     branches:
       - main
     paths:
-      - "src/integrations/*/**.py"
+      - "src/integrations/**/*"
 
 jobs:
   prepare-matrix:

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -88,7 +88,6 @@ jobs:
       - name: Run tests
         if: matrix.package != 'prefect-ray'
         env:
-          PREFECT_TEST_MODE: "True"
           PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///./orion-tests.db"
         working-directory: src/integrations/${{ matrix.package }}
         run: >
@@ -101,7 +100,6 @@ jobs:
       - name: Run tests for prefect-ray
         if: matrix.package == 'prefect-ray'
         env:
-          PREFECT_TEST_MODE: "True"
           PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///./orion-tests.db"
         working-directory: src/integrations/${{ matrix.package }}
         run: >

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-python@v5
         id: setup_python
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: UV Cache
         # Manually cache the uv cache directory

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-python@v5
         id: setup_python
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: UV Cache
         # Manually cache the uv cache directory

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-python@v5
         id: setup_python
         with:
-          python-version: "3.10"
+          python-version: "3.9.18"
 
       - name: UV Cache
         # Manually cache the uv cache directory

--- a/README.md
+++ b/README.md
@@ -114,8 +114,3 @@ Prefect is made possible by the fastest growing community of thousands of friend
 See our [documentation on contributing to Prefect](https://docs.prefect.io/contributing/overview/).
 
 Thanks for being part of the mission to build a new kind of workflow system and, of course, <i>**happy engineering!**</i>
-
-
-
-
-NO OP CHANGE DON'T MERGE ME

--- a/README.md
+++ b/README.md
@@ -114,3 +114,8 @@ Prefect is made possible by the fastest growing community of thousands of friend
 See our [documentation on contributing to Prefect](https://docs.prefect.io/contributing/overview/).
 
 Thanks for being part of the mission to build a new kind of workflow system and, of course, <i>**happy engineering!**</i>
+
+
+
+
+NO OP CHANGE DON'T MERGE ME

--- a/docs/2.19.x/how-to-guides/development/ci-cd.mdx
+++ b/docs/2.19.x/how-to-guides/development/ci-cd.mdx
@@ -144,7 +144,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Prefect Deploy
         env:
@@ -221,7 +221,7 @@ The `prefect.yaml` file in each project folder depends on environment variables 
   │   └── project_2
   └── cicd-example-workspaces-stg  # staging bucket
       ├── project_1
-      └── project_2  
+      └── project_2
 
 ```
 

--- a/docs/3.0rc/deploy/dynamic-infra/deploy-ci-cd.mdx
+++ b/docs/3.0rc/deploy/dynamic-infra/deploy-ci-cd.mdx
@@ -10,57 +10,57 @@ search:
 ---
 
 Many organizations deploy Prefect workflows through their CI/CD process.
-Each organization has their own unique CI/CD setup, but a common pattern is to use CI/CD to manage 
+Each organization has their own unique CI/CD setup, but a common pattern is to use CI/CD to manage
 Prefect [deployments](/3.0rc/deploy/serve-workflows).
-Combining Prefect's deployment features with CI/CD tools enables efficient management of flow code 
+Combining Prefect's deployment features with CI/CD tools enables efficient management of flow code
 updates, scheduling changes, and container builds.
-This guide uses [GitHub Actions](https://docs.github.com/en/actions) to implement a CI/CD process, 
+This guide uses [GitHub Actions](https://docs.github.com/en/actions) to implement a CI/CD process,
 but these concepts are generally applicable across many CI/CD tools.
 
-Note that Prefect's primary ways for creating deployments, a `.deploy` flow method or a `prefect.yaml` 
+Note that Prefect's primary ways for creating deployments, a `.deploy` flow method or a `prefect.yaml`
 configuration file, are both designed for building and pushing images to a Docker registry.
 
 ## Get started with GitHub Actions and Prefect
 
-In this example, you'll write a GitHub Actions workflow that runs each time you push to your repository's 
+In this example, you'll write a GitHub Actions workflow that runs each time you push to your repository's
 `main` branch. This workflow builds and pushes a Docker image containing your flow code to Docker Hub, then deploys the flow to Prefect Cloud.
 
 ### Repository secrets
 
 Your CI/CD process must be able to authenticate with Prefect in order to deploy flows.
 
-Deploy flows securely and non-interactively in your CI/CD process by saving your `PREFECT_API_URL` and 
+Deploy flows securely and non-interactively in your CI/CD process by saving your `PREFECT_API_URL` and
 `PREFECT_API_KEY` [as secrets in your repository's settings](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions). This allows them to be accessed in your CI/CD runner's environment without exposing them in any scripts or configuration files.
 
-In this scenario, deploying flows involves building and pushing Docker images, so add `DOCKER_USERNAME` 
+In this scenario, deploying flows involves building and pushing Docker images, so add `DOCKER_USERNAME`
 and `DOCKER_PASSWORD` as secrets to your repository as well.
 
-Create secrets for GitHub Actions in your repository under 
+Create secrets for GitHub Actions in your repository under
 **Settings -> Secrets and variables -> Actions -> New repository secret**:
 
 ![Creating a GitHub Actions secret](/3.0rc/img/guides/github-secrets.png)
 
 ### Write a GitHub workflow
 
-To deploy your flow through GitHub Actions, you need a workflow YAML file. GitHub looks for workflow 
-YAML files in the `.github/workflows/` directory in the root of your repository. In their simplest form, 
+To deploy your flow through GitHub Actions, you need a workflow YAML file. GitHub looks for workflow
+YAML files in the `.github/workflows/` directory in the root of your repository. In their simplest form,
 GitHub workflow files are made up of triggers and jobs.
 
 The `on:` trigger is set to run the workflow each time a push occurs on the `main` branch of the repository.
 
 The `deploy` job is comprised of four `steps`:
 
-- **`Checkout`** clones your repository into the GitHub Actions runner so you can reference files or 
+- **`Checkout`** clones your repository into the GitHub Actions runner so you can reference files or
 run scripts from your repository in later steps.
-- **`Log in to Docker Hub`** authenticates to DockerHub so your image can be pushed to the Docker 
-registry in your DockerHub account. [docker/login-action](https://github.com/docker/login-action) is an 
-existing GitHub action maintained by Docker. `with:` passes values into the Action, similar to passing 
+- **`Log in to Docker Hub`** authenticates to DockerHub so your image can be pushed to the Docker
+registry in your DockerHub account. [docker/login-action](https://github.com/docker/login-action) is an
+existing GitHub action maintained by Docker. `with:` passes values into the Action, similar to passing
 parameters to a function.
 - **`Setup Python`** installs your selected version of Python.
-- **`Prefect Deploy`** installs the dependencies used in your flow, then deploys your flow. `env:` makes 
+- **`Prefect Deploy`** installs the dependencies used in your flow, then deploys your flow. `env:` makes
 the `PREFECT_API_KEY` and `PREFECT_API_URL` secrets from your repository available as environment variables during this step's execution.
 
-For reference, the examples below live in their respective branches of 
+For reference, the examples below live in their respective branches of
 [this repository](https://github.com/prefecthq/cicd-example).
 
 <Tabs>
@@ -120,7 +120,7 @@ For reference, the examples below live in their respective branches of
           - name: Setup Python
             uses: actions/setup-python@v5
             with:
-              python-version: '3.11'
+              python-version: "3.11"
 
           - name: Prefect Deploy
             env:
@@ -213,7 +213,7 @@ For reference, the examples below live in their respective branches of
           - name: Setup Python
             uses: actions/setup-python@v5
             with:
-              python-version: '3.11'
+              python-version: "3.11"
 
           - name: Prefect Deploy
             env:
@@ -228,12 +228,12 @@ For reference, the examples below live in their respective branches of
 
 ### Run a GitHub workflow
 
-After pushing commits to your repository, GitHub automatically triggers a run of your workflow. 
+After pushing commits to your repository, GitHub automatically triggers a run of your workflow.
 Monitor the status of running and completed workflows from the **Actions** tab of your repository.
 
 ![A GitHub Action triggered via push](/3.0rc/img/guides/github-actions-trigger.png)
 
-View the logs from each workflow step as they run. The `Prefect Deploy` step includes output about 
+View the logs from each workflow step as they run. The `Prefect Deploy` step includes output about
 your image build and push, and the creation/update of your deployment.
 
 <div class="terminal">
@@ -256,19 +256,19 @@ Successfully created/updated all deployments!
 
 ## Advanced example
 
-In more complex scenarios, CI/CD processes often need to accommodate several additional 
+In more complex scenarios, CI/CD processes often need to accommodate several additional
 considerations to enable a smooth development workflow:
 
 - Making code available in different environments as it advances through stages of development
 - Handling independent deployment of distinct groupings of work, as in a monorepo
 - Efficiently using build time to avoid repeated work
 
-This [example repository](https://github.com/prefecthq/cicd-example-workspaces) addresses each of these 
+This [example repository](https://github.com/prefecthq/cicd-example-workspaces) addresses each of these
 considerations with a combination of Prefect's and GitHub's capabilities.
 
 ### Deploy to multiple workspaces
 
-The deployment processes to run are automatically selected when changes are pushed, depending on 
+The deployment processes to run are automatically selected when changes are pushed, depending on
 two conditions:
 
 ```yaml
@@ -281,15 +281,15 @@ on:
       - "project_1/**"
 ```
 
-- **`branches:`** - which branch has changed. This ultimately selects which Prefect workspace a 
-deployment is created or updated in. In this example, changes on the `stg` branch deploy flows to a 
+- **`branches:`** - which branch has changed. This ultimately selects which Prefect workspace a
+deployment is created or updated in. In this example, changes on the `stg` branch deploy flows to a
 staging workspace, and changes on the `main` branch deploy flows to a production workspace.
-- **`paths:`** - which project folders' files have changed. Since each project folder contains its own flows, 
-dependencies, and `prefect.yaml`, it represents a complete set of logic and configuration that can deploy 
+- **`paths:`** - which project folders' files have changed. Since each project folder contains its own flows,
+dependencies, and `prefect.yaml`, it represents a complete set of logic and configuration that can deploy
 independently. Each project in this repository gets its own GitHub Actions workflow YAML file.
 
-The `prefect.yaml` file in each project folder depends on environment variables dictated by the 
-selected job in each CI/CD workflow; enabling external code storage for Prefect deployments that is clearly 
+The `prefect.yaml` file in each project folder depends on environment variables dictated by the
+selected job in each CI/CD workflow; enabling external code storage for Prefect deployments that is clearly
 separated across projects and environments.
 
 ```
@@ -299,19 +299,19 @@ separated across projects and environments.
   │   └── project_2
   └── cicd-example-workspaces-stg  # staging bucket
       ├── project_1
-      └── project_2  
+      └── project_2
 ```
 
-Deployments in this example use S3 for code storage. So it's important that push steps place flow files 
-in separate locations depending upon their respective environment and project—so no deployment overwrites another 
+Deployments in this example use S3 for code storage. So it's important that push steps place flow files
+in separate locations depending upon their respective environment and project—so no deployment overwrites another
 deployment's files.
 
 ### Caching build dependencies
 
-Since building Docker images and installing Python dependencies are essential parts of the deployment process, 
+Since building Docker images and installing Python dependencies are essential parts of the deployment process,
 it's useful to rely on caching to skip repeated build steps.
 
-The `setup-python` action offers [caching options](https://github.com/actions/setup-python#caching-packages-dependencies) 
+The `setup-python` action offers [caching options](https://github.com/actions/setup-python#caching-packages-dependencies)
 so Python packages do not have to be downloaded on repeat workflow runs.
 
 ```yaml
@@ -327,9 +327,9 @@ Using cached prefect-2.16.1-py3-none-any.whl (2.9 MB)
 Using cached prefect_aws-0.4.10-py3-none-any.whl (61 kB)
 ```
 
-The `build-push-action` for building Docker images also offers 
-[caching options for GitHub Actions](https://docs.docker.com/build/cache/backends/gha/). 
-If you are not using GitHub, other remote [cache backends](https://docs.docker.com/build/cache/backends/) 
+The `build-push-action` for building Docker images also offers
+[caching options for GitHub Actions](https://docs.docker.com/build/cache/backends/gha/).
+If you are not using GitHub, other remote [cache backends](https://docs.docker.com/build/cache/backends/)
 are available as well.
 
 ```yaml
@@ -363,10 +363,10 @@ CACHED
 
 ## Prefect GitHub Actions
 
-Prefect provides its own GitHub Actions for [authentication](https://github.com/PrefectHQ/actions-prefect-auth) 
-and [deployment creation](https://github.com/PrefectHQ/actions-prefect-deploy). 
-These actions simplify deploying with CI/CD when using `prefect.yaml`, 
-especially in cases where a repository contains flows used in multiple deployments across multiple 
+Prefect provides its own GitHub Actions for [authentication](https://github.com/PrefectHQ/actions-prefect-auth)
+and [deployment creation](https://github.com/PrefectHQ/actions-prefect-deploy).
+These actions simplify deploying with CI/CD when using `prefect.yaml`,
+especially in cases where a repository contains flows used in multiple deployments across multiple
 Prefect Cloud workspaces.
 
 Here's an example of integrating these actions into the workflow above:
@@ -416,8 +416,8 @@ jobs:
 
 The `docker/login-action` GitHub Action supports pushing images to a wide variety of image registries.
 
-For example, if you are storing Docker images in AWS Elastic Container Registry, you can add your ECR 
-registry URL to the `registry` key in the `with:` part of the action and use an `AWS_ACCESS_KEY_ID` and 
+For example, if you are storing Docker images in AWS Elastic Container Registry, you can add your ECR
+registry URL to the `registry` key in the `with:` part of the action and use an `AWS_ACCESS_KEY_ID` and
 `AWS_SECRET_ACCESS_KEY` as your `username` and `password`.
 
 ```yaml
@@ -431,5 +431,5 @@ registry URL to the `registry` key in the `with:` part of the action and use an 
 
 ## See also
 
-Check out the [Prefect Cloud Terraform provider](https://registry.terraform.io/providers/PrefectHQ/prefect/latest/docs/guides/getting-started) 
+Check out the [Prefect Cloud Terraform provider](https://registry.terraform.io/providers/PrefectHQ/prefect/latest/docs/guides/getting-started)
 if you're using Terraform to manage your infrastructure.

--- a/src/integrations/prefect-aws/pyproject.toml
+++ b/src/integrations/prefect-aws/pyproject.toml
@@ -86,3 +86,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-aws/pyproject.toml
+++ b/src/integrations/prefect-aws/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
   "pytest",
   "pytest-asyncio >= 0.18.2, != 0.22.0, < 0.23.0", # Cannot override event loop in 0.23.0. See https://github.com/pytest-dev/pytest-asyncio/issues/706 for more details.
   "pytest-cov",
+  "pytest-env",
   "pytest-xdist",
   "types-boto3 >= 1.0.2",
 ]

--- a/src/integrations/prefect-azure/pyproject.toml
+++ b/src/integrations/prefect-azure/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
   "pre-commit",
   "pytest-asyncio",
   "pytest",
+  "pytest-env",
   "pytest-xdist",
 ]
 

--- a/src/integrations/prefect-azure/pyproject.toml
+++ b/src/integrations/prefect-azure/pyproject.toml
@@ -85,3 +85,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-bitbucket/pyproject.toml
+++ b/src/integrations/prefect-bitbucket/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
   "pre-commit",
   "pytest-asyncio",
   "pytest",
+  "pytest-env",
   "pytest-xdist",
 ]
 

--- a/src/integrations/prefect-bitbucket/pyproject.toml
+++ b/src/integrations/prefect-bitbucket/pyproject.toml
@@ -75,3 +75,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-dask/pyproject.toml
+++ b/src/integrations/prefect-dask/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
   "pre-commit",
   "pytest-asyncio >= 0.18.2, != 0.22.0, < 0.23.0",
   "pytest",
+  "pytest-env",
   "pytest-xdist",
 ]
 

--- a/src/integrations/prefect-dask/pyproject.toml
+++ b/src/integrations/prefect-dask/pyproject.toml
@@ -76,3 +76,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-databricks/pyproject.toml
+++ b/src/integrations/prefect-databricks/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
   "pre-commit",
   "pytest-asyncio",
   "pytest",
+  "pytest-env",
   "pytest-xdist",
   "respx",
 ]

--- a/src/integrations/prefect-databricks/pyproject.toml
+++ b/src/integrations/prefect-databricks/pyproject.toml
@@ -71,3 +71,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-dbt/pyproject.toml
+++ b/src/integrations/prefect-dbt/pyproject.toml
@@ -93,3 +93,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-dbt/pyproject.toml
+++ b/src/integrations/prefect-dbt/pyproject.toml
@@ -58,9 +58,10 @@ dev = [
   "prefect-gcp[bigquery]>=0.6.0rc1",
   "prefect-snowflake>=0.28.0rc1",
   "prefect-sqlalchemy>=0.5.0rc1",
-  "pytest-asyncio",
-  "pytest-xdist",
   "pytest",
+  "pytest-asyncio",
+  "pytest-env",
+  "pytest-xdist",
   "respx",
 ]
 

--- a/src/integrations/prefect-docker/pyproject.toml
+++ b/src/integrations/prefect-docker/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
   "pre-commit",
   "pytest-asyncio",
   "pytest",
+  "pytest-env",
   "pytest-xdist",
 ]
 

--- a/src/integrations/prefect-docker/pyproject.toml
+++ b/src/integrations/prefect-docker/pyproject.toml
@@ -75,3 +75,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-email/pyproject.toml
+++ b/src/integrations/prefect-email/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
   "pre-commit",
   "pytest-asyncio",
   "pytest",
+  "pytest-env",
   "pytest-xdist",
 ]
 

--- a/src/integrations/prefect-email/pyproject.toml
+++ b/src/integrations/prefect-email/pyproject.toml
@@ -71,3 +71,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-gcp/pyproject.toml
+++ b/src/integrations/prefect-gcp/pyproject.toml
@@ -61,9 +61,10 @@ dev = [
   "pillow",
   "pre-commit",
   "pyarrow",
-  "pytest-asyncio",
-  "pytest-xdist",
   "pytest",
+  "pytest-asyncio",
+  "pytest-env",
+  "pytest-xdist",
 ]
 
 [project.urls]

--- a/src/integrations/prefect-gcp/pyproject.toml
+++ b/src/integrations/prefect-gcp/pyproject.toml
@@ -95,7 +95,9 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-
+env = [
+  "PREFECT_TEST_MODE=1",
+]
 filterwarnings = [
   "ignore:Type google._upb._message.* uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14:DeprecationWarning",
 ]

--- a/src/integrations/prefect-github/pyproject.toml
+++ b/src/integrations/prefect-github/pyproject.toml
@@ -73,3 +73,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-github/pyproject.toml
+++ b/src/integrations/prefect-github/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
   "pre-commit",
   "pytest-asyncio",
   "pytest",
+  "pytest-env",
   "pytest-xdist",
 ]
 

--- a/src/integrations/prefect-gitlab/pyproject.toml
+++ b/src/integrations/prefect-gitlab/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
   "pre-commit",
   "pytest-asyncio",
   "pytest",
+  "pytest-env",
   "pytest-xdist",
 ]
 

--- a/src/integrations/prefect-gitlab/pyproject.toml
+++ b/src/integrations/prefect-gitlab/pyproject.toml
@@ -75,3 +75,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-kubernetes/pyproject.toml
+++ b/src/integrations/prefect-kubernetes/pyproject.toml
@@ -76,3 +76,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-kubernetes/pyproject.toml
+++ b/src/integrations/prefect-kubernetes/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
   "pre-commit",
   "pytest-asyncio",
   "pytest",
+  "pytest-env",
   "pytest-xdist",
 ]
 

--- a/src/integrations/prefect-ray/pyproject.toml
+++ b/src/integrations/prefect-ray/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
   "pytest-asyncio",
   "pytest",
   "pytest-asyncio>=0.18.2,!=0.22.0,<0.23.0",
+  "pytest-env",
   "pytest-xdist",
 ]
 

--- a/src/integrations/prefect-ray/pyproject.toml
+++ b/src/integrations/prefect-ray/pyproject.toml
@@ -75,3 +75,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-shell/pyproject.toml
+++ b/src/integrations/prefect-shell/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
   "pre-commit",
   "pytest-asyncio",
   "pytest",
+  "pytest-env",
   "pytest-xdist",
 ]
 

--- a/src/integrations/prefect-shell/pyproject.toml
+++ b/src/integrations/prefect-shell/pyproject.toml
@@ -71,3 +71,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-slack/pyproject.toml
+++ b/src/integrations/prefect-slack/pyproject.toml
@@ -74,3 +74,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-slack/pyproject.toml
+++ b/src/integrations/prefect-slack/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
   "pre-commit",
   "pytest-asyncio",
   "pytest",
+  "pytest-env",
   "pytest-xdist",
 ]
 

--- a/src/integrations/prefect-snowflake/pyproject.toml
+++ b/src/integrations/prefect-snowflake/pyproject.toml
@@ -73,3 +73,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-snowflake/pyproject.toml
+++ b/src/integrations/prefect-snowflake/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
   "pre-commit",
   "pytest-asyncio",
   "pytest",
+  "pytest-env",
   "pytest-xdist",
 ]
 

--- a/src/integrations/prefect-sqlalchemy/pyproject.toml
+++ b/src/integrations/prefect-sqlalchemy/pyproject.toml
@@ -76,3 +76,6 @@ show_missing = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+  "PREFECT_TEST_MODE=1",
+]

--- a/src/integrations/prefect-sqlalchemy/pyproject.toml
+++ b/src/integrations/prefect-sqlalchemy/pyproject.toml
@@ -42,9 +42,10 @@ dev = [
   "pillow",
   "pre-commit",
   "psycopg2",
-  "pytest-asyncio",
-  "pytest-xdist",
   "pytest",
+  "pytest-asyncio",
+  "pytest-env",
+  "pytest-xdist",
 ]
 
 [project.urls]

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -524,7 +524,6 @@ class BaseWorker(abc.ABC):
             anyio.CapacityLimiter(self._limit) if self._limit is not None else None
         )
 
-        # TODO: no-op change to trigger CI, remove me before merging, please
         if not PREFECT_TEST_MODE and not PREFECT_API_URL.value():
             raise ValueError("`PREFECT_API_URL` must be set to start a Worker.")
 

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -524,6 +524,7 @@ class BaseWorker(abc.ABC):
             anyio.CapacityLimiter(self._limit) if self._limit is not None else None
         )
 
+        # TODO: no-op change to trigger CI, remove me before merging, please
         if not PREFECT_TEST_MODE and not PREFECT_API_URL.value():
             raise ValueError("`PREFECT_API_URL` must be set to start a Worker.")
 


### PR DESCRIPTION
In a [prior change](https://github.com/PrefectHQ/prefect/pull/13942), we make it required that a worker have a `PREFECT_API_URL` set (with an exception for unit tests by looking at `PREFECT_TEST_MODE`).  We weren't setting `PREFECT_TEST_MODE` for the integrations package tests, so any ones that tested workers were failing.