### PR TITLE
Add support for composite triggers

### DIFF
--- a/ui/src/components/AutomationWizard.vue
+++ b/ui/src/components/AutomationWizard.vue
@@ -26,13 +26,11 @@
 
 <script lang="ts" setup>
   import { PWizard, WizardStep } from '@prefecthq/prefect-design'
-  import { isAutomationTriggerEvent } from '@prefecthq/prefect-ui-library'
   import { computed, ref } from 'vue'
   import { useRouter } from 'vue-router'
   import AutomationWizardStepActions from '@/components/AutomationWizardStepActions.vue'
   import AutomationWizardStepDetails from '@/components/AutomationWizardStepDetails.vue'
   import AutomationWizardStepTrigger from '@/components/AutomationWizardStepTrigger.vue'
-  import { mapper } from '@/services/mapper'
   import { Automation, AutomationFormValues, IAutomation, isAutomationActionFormValues } from '@/types/automation'
 
   const props = defineProps<{

--- a/ui/src/components/AutomationWizardStepTrigger.vue
+++ b/ui/src/components/AutomationWizardStepTrigger.vue
@@ -22,7 +22,7 @@
 
 <script lang="ts" setup>
   import { useWizardStep } from '@prefecthq/prefect-design'
-  import { createTuple, stringify, withProps, AutomationTriggerEventInput, AutomationTrigger, AutomationTriggerResponse, getAutomationTriggerTemplate, getDefaultAutomationTriggerValue, isNullish } from '@prefecthq/prefect-ui-library'
+  import { createTuple, stringify, withProps, AutomationTriggerEventInput, AutomationTrigger, AutomationTriggerResponse, getAutomationTriggerTemplate, getDefaultAutomationTriggerValue, isNullish, AutomationTriggerCustomInput } from '@prefecthq/prefect-ui-library'
   import { useValidation, useValidationObserver } from '@prefecthq/vue-compositions'
   import { computed, ref, watch } from 'vue'
   import AutomationTriggerJsonInput from '@/components/AutomationTriggerJsonInput.vue'
@@ -125,11 +125,25 @@
 
     const trigger = automation.value.trigger ?? getDefaultAutomationTriggerValue(template.value)
 
-    return withProps(AutomationTriggerEventInput, {
-      template: template.value,
-      trigger,
-      'onUpdate:trigger': updateTrigger,
-    })
+    switch (trigger.type) {
+      case 'event':
+        return withProps(AutomationTriggerEventInput, {
+          template: template.value,
+          trigger,
+          'onUpdate:trigger': updateTrigger,
+        })
+      case 'compound':
+      case 'sequence':
+        return withProps(AutomationTriggerCustomInput, {
+          trigger,
+          'onUpdate:trigger': updateTrigger,
+        })
+
+      default:
+        const exhaustive: never = trigger
+        throw new Error(`AutomationWizardStepTrigger is missing case for trigger type ${(exhaustive as AutomationTrigger).type}`)
+    }
+
   })
 
   function updateTrigger(trigger: AutomationTrigger | undefined): void {


### PR DESCRIPTION
# Description
Adds support for composite type automation triggers. For now these types of triggers are considered "custom" triggers and are only editable via json. We may add a richer ui experience for these in the future. 

Implementation of https://github.com/PrefectHQ/prefect-ui-library/pull/2523 and https://github.com/PrefectHQ/prefect-ui-library/pull/2520

Closes https://github.com/PrefectHQ/prefect/issues/13936