### PR TITLE
2.x - Fix prefect deploy with dynamic @flow decorator args

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -106,7 +106,7 @@ from prefect.utilities.callables import (
 )
 from prefect.utilities.collections import listrepr
 from prefect.utilities.hashing import file_hash
-from prefect.utilities.importtools import import_object
+from prefect.utilities.importtools import import_object, safe_load_namespace
 from prefect.utilities.visualization import (
     FlowVisualizationError,
     GraphvizExecutableNotFoundError,
@@ -1850,11 +1850,33 @@ def load_flow_argument_from_entrypoint(
         ):
             for keyword in decorator.keywords:
                 if keyword.arg == arg:
-                    return (
-                        keyword.value.value
-                    )  # Return the string value of the argument
+                    if isinstance(keyword.value, ast.Constant):
+                        return (
+                            keyword.value.value
+                        )  # Return the string value of the argument
+
+                    # if the arg value is not a raw str (i.e. a variable or expression),
+                    # then attempt to evaluate it
+                    namespace = safe_load_namespace(source_code)
+                    literal_arg_value = ast.get_source_segment(
+                        source_code, keyword.value
+                    )
+                    try:
+                        evaluated_value = eval(literal_arg_value, namespace)  # type: ignore
+                    except Exception as e:
+                        logger.info(
+                            "Failed to parse @flow argument: `%s=%s` due to the following error. Ignoring and falling back to default behavior.",
+                            arg,
+                            literal_arg_value,
+                            exc_info=e,
+                        )
+                        # ignore the decorator arg and fallback to default behavior
+                        break
+                    return str(evaluated_value)
 
     if arg == "name":
         return func_name.replace(
             "_", "-"
         )  # If no matching decorator or keyword argument is found
+
+    return None


### PR DESCRIPTION
Port of https://github.com/PrefectHQ/prefect/pull/13967 for 2.x.

> Closes https://github.com/PrefectHQ/prefect/issues/13895 and https://github.com/PrefectHQ/prefect/issues/13950.
> 
> https://github.com/PrefectHQ/prefect/pull/13315 helped solve https://github.com/PrefectHQ/prefect/issues/9512 but in doing so introduced some regressions when using non-str type values for @flow arguments like name/description.
> 
> The key difference from changes introduced there is that we parse the flow name/description using an AST and as-is, args are expected to be raw str values and variables/expressions don't get evaluated correctly. This PR changes this by attempting to eval() when the value is not a constant.
> 
> If an arg is using a dependency that's not available in the current environment, then a message is logged to the user and the decorator arg is skipped, falling back to default behavior as if one was not supplied at all.
> 
> Note
> 
> Resolving relative imports for use here within the @flow decorator remains a bit tricky and should constitute a separate issue should that functionality be needed.