### PR TITLE
Fix docs formatting in integrations page

### DIFF
--- a/docs/integrations/integrations.mdx
+++ b/docs/integrations/integrations.mdx
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     run_dbt_job_flow()
 ```
 
-## Creat a custom block for use in an integration
+## Create a custom block for use in an integration
 
 Prefect welcomes community contributions of integration libraries.
 
@@ -104,13 +104,13 @@ class Secret(Block):
         value: A string value that should be kept secret.
 
     Example:
-        ```python
+        (wrap in tripple backticsk and *python* to render correctly in the docs)
         from prefect.blocks.system import Secret
         secret_block = Secret.load("BLOCK_NAME")
 
         # Access the stored secret
         secret_block.get()
-        ```
+        
     """
 
     _logo_url = "https://example.com/logo.png"
@@ -144,9 +144,11 @@ To fix an issue or add a feature to any Prefect-maintained ntegrations, please [
 1. [Fork the repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo#forking-a-repository)
 2. [Clone the forked repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo#cloning-your-forked-repository)
 3. Install the repository and its dependencies:
+
 ```
 pip install -e ".[dev]"
 ```
+
 4. Make desired changes
 5. Add tests
 6. Insert an entry to the Integration's CHANGELOG.md


### PR DESCRIPTION
Didn't like triple backticks inside triple backticks and fixes a typo.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
 	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [X] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `mint.json` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `docs/mint.json` navigation.
