### PR TITLE
Add helpful warning about decorator order

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1505,6 +1505,9 @@ def flow(
         >>>     pass
     """
     if __fn:
+        if isinstance(__fn, (classmethod, staticmethod)):
+            method_decorator = type(__fn).__name__
+            raise TypeError(f"@{method_decorator} should be applied on top of @flow")
         return cast(
             Flow[P, R],
             Flow(

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1480,6 +1480,9 @@ def task(
     """
 
     if __fn:
+        if isinstance(__fn, (classmethod, staticmethod)):
+            method_decorator = type(__fn).__name__
+            raise TypeError(f"@{method_decorator} should be applied on top of @task")
         return cast(
             Task[P, R],
             Task(

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -900,6 +900,28 @@ class TestFlowCall:
         assert Foo.static_method() == "static"
         assert isinstance(Foo.static_method, Flow)
 
+    def test_error_message_if_decorate_classmethod(self):
+        with pytest.raises(
+            TypeError, match="@classmethod should be applied on top of @flow"
+        ):
+
+            class Foo:
+                @flow
+                @classmethod
+                def bar(cls):
+                    pass
+
+    def test_error_message_if_decorate_staticmethod(self):
+        with pytest.raises(
+            TypeError, match="@staticmethod should be applied on top of @flow"
+        ):
+
+            class Foo:
+                @flow
+                @staticmethod
+                def bar():
+                    pass
+
 
 class TestSubflowCalls:
     async def test_subflow_call_with_no_tasks(self):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -369,6 +369,28 @@ class TestTaskCall:
         assert Foo.static_method() == "static"
         assert isinstance(Foo.static_method, Task)
 
+    def test_error_message_if_decorate_classmethod(self):
+        with pytest.raises(
+            TypeError, match="@classmethod should be applied on top of @task"
+        ):
+
+            class Foo:
+                @task
+                @classmethod
+                def bar():
+                    pass
+
+    def test_error_message_if_decorate_staticmethod(self):
+        with pytest.raises(
+            TypeError, match="@staticmethod should be applied on top of @task"
+        ):
+
+            class Foo:
+                @task
+                @staticmethod
+                def bar():
+                    pass
+
 
 class TestTaskRun:
     async def test_sync_task_run_inside_sync_flow(self):


### PR DESCRIPTION
Follow up from #13944. It's not obvious what order to stack decorators, but the `@task` or `@flow` decorator needs to go *under* [be applied before] the `@classmethod` or `@staticmethod`. This is because the classmethod/staticmethod  decorator outputs are not recognized as callable objects and therefore create errors in a lot of Prefect's attempts to set up the flow/task.

This PR adds a clear error message, as the one you get today is `TypeError: 'bar' must be callable` which is very confusing.

```python
class Foo:
    
    # this is the WRONG order
    @task
    @classmethod
    def bar(cls, x):
        pass


    # this is the RIGHT order
    @staticmethod
    @task
    def baz(x):
        pass
```