### PR TITLE
Enable the automations API even when the triggers service is disabled

### DIFF
--- a/src/prefect/server/api/automations.py
+++ b/src/prefect/server/api/automations.py
@@ -24,25 +24,14 @@ from prefect.server.events.schemas.automations import (
 )
 from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.utilities.server import PrefectRouter
-from prefect.settings import PREFECT_API_SERVICES_TRIGGERS_ENABLED
 from prefect.utilities.schema_tools.validation import (
     ValidationError as JSONSchemaValidationError,
 )
 
-
-def automations_enabled() -> bool:
-    if not PREFECT_API_SERVICES_TRIGGERS_ENABLED:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Automations are not enabled. Please enable the"
-            " PREFECT_API_SERVICES_TRIGGERS_ENABLED setting.",
-        )
-
-
 router = PrefectRouter(
     prefix="/automations",
     tags=["Automations"],
-    dependencies=[Depends(automations_enabled)],
+    dependencies=[],
 )
 
 

--- a/tests/events/server/test_automations_api.py
+++ b/tests/events/server/test_automations_api.py
@@ -178,29 +178,6 @@ async def create_objects_for_automation(
 
 
 @pytest.mark.parametrize(
-    "settings",
-    [
-        {
-            PREFECT_API_SERVICES_TRIGGERS_ENABLED: False,
-        },
-    ],
-)
-async def test_returns_404_when_automations_are_disabled(
-    client: AsyncClient,
-    settings: Dict,
-    automations_url: str,
-    automation_to_create: AutomationCreate,
-):
-    with temporary_settings(settings):
-        response = await client.post(
-            f"{automations_url}/",
-            json=automation_to_create.model_dump(mode="json"),
-        )
-
-    assert response.status_code == 404, response.content
-
-
-@pytest.mark.parametrize(
     "invalid_time",
     [
         timedelta(seconds=-10),


### PR DESCRIPTION
This was originally in place as part of the feature flagging mechanism for
events and automations, but is probably too aggressive for 3.0.  Similarly to
managing deployments even if `PREFECT_API_SERVICES_SCHEDULER_ENABLED` is turned
off, we can allow people to turn off triggers but still manage automations.
