### PR TITLE
Remove remaining references to `SequentialTaskRunner` in 3.x docs

### DIFF
--- a/docs/2.19.x/concepts/flows.mdx
+++ b/docs/2.19.x/concepts/flows.mdx
@@ -123,6 +123,7 @@ from prefect.task_runners import SequentialTaskRunner
 @flow(
     name="My Flow",
     description="My flow using SequentialTaskRunner",
+    task_runner=SequentialTaskRunner())
 )
 def my_flow():
     return

--- a/docs/2.19.x/concepts/flows.mdx
+++ b/docs/2.19.x/concepts/flows.mdx
@@ -120,9 +120,10 @@ For example, you can provide a `name` value for the flow. Here we've also used t
 from prefect import flow
 from prefect.task_runners import SequentialTaskRunner
 
-@flow(name="My Flow",
-      description="My flow using SequentialTaskRunner",
-      task_runner=SequentialTaskRunner())
+@flow(
+    name="My Flow",
+    description="My flow using SequentialTaskRunner",
+)
 def my_flow():
     return
 
@@ -132,8 +133,10 @@ def my_flow():
 You can also provide the description as the docstring on the flow function.
 
 ```python
-@flow(name="My Flow",
-      task_runner=SequentialTaskRunner())
+@flow(
+    name="My Flow",
+    task_runner=SequentialTaskRunner()
+)
 def my_flow():
     """My flow using SequentialTaskRunner"""
     return

--- a/docs/3.0rc/develop/observe-workflows/logging.mdx
+++ b/docs/3.0rc/develop/observe-workflows/logging.mdx
@@ -17,7 +17,6 @@ see an example of the log messages created automatically by Prefect:
 ```bash
 16:45:44.534 | INFO    | prefect.engine - Created flow run 'gray-dingo' for flow
 'hello-flow'
-16:45:44.534 | INFO    | Flow run 'gray-dingo' - Using task runner 'SequentialTaskRunner'
 16:45:44.598 | INFO    | Flow run 'gray-dingo' - Created task run 'hello-task-54135dc1-0'
 for task 'hello-task'
 Hello world!

--- a/docs/3.0rc/develop/write-workflows/index.mdx
+++ b/docs/3.0rc/develop/write-workflows/index.mdx
@@ -333,11 +333,13 @@ and a non-default task runner.
 
 ```python
 from prefect import flow
-from prefect.task_runners import SequentialTaskRunner
 
-@flow(name="My Flow",
-      description="My flow using SequentialTaskRunner",
-      task_runner=SequentialTaskRunner())
+@flow(
+    name="My Flow",
+    description="My flow with retries and linear backoff",
+    retries=3,
+    retry_delay_seconds=[10, 20, 30],
+)
 def my_flow():
     return
 ```
@@ -345,10 +347,13 @@ def my_flow():
 You can also provide the description as the docstring on the flow function.
 
 ```python
-@flow(name="My Flow",
-      task_runner=SequentialTaskRunner())
+@flow(
+    name="My Flow",
+    retries=3,
+    retry_delay_seconds=[10, 20, 30],
+)
 def my_flow():
-    """My flow using SequentialTaskRunner"""
+    """My flow with retries and linear backoff"""
     return
 ```
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1686,7 +1686,7 @@ def load_flow_from_entrypoint(
         FlowScriptError: If an exception is encountered while running the script
         MissingFlowError: If the flow function specified in the entrypoint does not exist
     """
-    with PrefectObjectRegistry(
+    with PrefectObjectRegistry(  # type: ignore
         block_code_execution=True,
         capture_failures=True,
     ):
@@ -1711,7 +1711,7 @@ def load_flow_from_entrypoint(
         return flow
 
 
-def load_flow_from_text(script_contents: AnyStr, flow_name: str):
+def load_flow_from_text(script_contents: AnyStr, flow_name: str) -> Flow:
     """
     Load a flow from a text script.
 
@@ -1742,7 +1742,7 @@ async def serve(
     print_starting_message: bool = True,
     limit: Optional[int] = None,
     **kwargs,
-):
+) -> NoReturn:
     """
     Serve the provided list of deployments.
 
@@ -1832,7 +1832,7 @@ async def load_flow_from_flow_run(
     flow_run: "FlowRun",
     ignore_storage: bool = False,
     storage_base_path: Optional[str] = None,
-) -> "Flow":
+) -> Flow:
     """
     Load a flow from the location/script provided in a deployment's storage document.
 
@@ -1886,7 +1886,9 @@ async def load_flow_from_flow_run(
         await storage_block.get_directory(from_path=from_path, local_path=".")
 
     if deployment.pull_steps:
-        run_logger.debug(f"Running {len(deployment.pull_steps)} deployment pull steps")
+        run_logger.debug(
+            f"Running {len(deployment.pull_steps)} deployment pull step(s)"
+        )
         output = await run_steps(deployment.pull_steps)
         if output.get("directory"):
             run_logger.debug(f"Changing working directory to {output['directory']!r}")


### PR DESCRIPTION
closes #13955

note we keep one reference to it in the task runners page to let people know that its gone now (should they come looking for it)