### PR TITLE
Removing dependencies on `distutils` in VCS integrations

### DIFF
--- a/src/integrations/prefect-bitbucket/prefect_bitbucket/repository.py
+++ b/src/integrations/prefect-bitbucket/prefect_bitbucket/repository.py
@@ -36,7 +36,7 @@ private_bitbucket_block.save(name="my-private-bitbucket-block")
 """
 
 import io
-from distutils.dir_util import copy_tree
+import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Optional, Tuple, Union
@@ -197,4 +197,6 @@ class BitBucketRepository(ReadableDeploymentStorage):
                 dst_dir=local_path, src_dir=tmp_dir, sub_directory=from_path
             )
 
-            copy_tree(src=content_source, dst=content_destination)
+            shutil.copytree(
+                src=content_source, dst=content_destination, dirs_exist_ok=True
+            )

--- a/src/integrations/prefect-github/prefect_github/repository.py
+++ b/src/integrations/prefect-github/prefect_github/repository.py
@@ -9,8 +9,8 @@ GitHub query_repository* tasks and the GitHub storage block.
 
 import io
 import shlex
+import shutil
 from datetime import datetime
-from distutils.dir_util import copy_tree
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, Iterable, Optional, Tuple, Union
@@ -160,7 +160,9 @@ class GitHubRepository(ReadableDeploymentStorage):
                 dst_dir=local_path, src_dir=tmp_path_str, sub_directory=from_path
             )
 
-            copy_tree(src=content_source, dst=content_destination)
+            shutil.copytree(
+                src=content_source, dst=content_destination, dirs_exist_ok=True
+            )
 
 
 @task

--- a/src/integrations/prefect-gitlab/prefect_gitlab/repositories.py
+++ b/src/integrations/prefect-gitlab/prefect_gitlab/repositories.py
@@ -40,9 +40,10 @@ Examples:
     private_gitlab_block.save()
 ```
 """
+
 import io
+import shutil
 import urllib.parse
-from distutils.dir_util import copy_tree
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Optional, Tuple, Union
@@ -213,4 +214,6 @@ class GitLabRepository(ReadableDeploymentStorage):
                 dst_dir=local_path, src_dir=tmp_dir, sub_directory=from_path
             )
 
-            copy_tree(src=content_source, dst=content_destination)
+            shutil.copytree(
+                src=content_source, dst=content_destination, dirs_exist_ok=True
+            )


### PR DESCRIPTION
Our Github, Gitlab, and Bitbucket integrations had a dependency on `distutils`,
which was deprecated in Python 3.10 and removed in Python 3.12.  We were only
using them for a recursive copy utility, which is readily available in `shutil`.
