### PR TITLE
Move community pages to contribute tab

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -32,7 +32,7 @@
     },
     {
       "name": "Contribute",
-      "url": "3.0rc/community"
+      "url": "community"
     }
   ],
   "api": {


### PR DESCRIPTION
We accidentally moved the contribute content to the documentation menu. Removing the parent directory should fix that.