### PR TITLE
Adds warning when `cache_key_fn` and `cache_policy` are both provided to a task

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -368,7 +368,11 @@ class Task(Generic[P, R]):
 
             self.task_key = f"{self.fn.__qualname__}-{task_origin_hash}"
 
-        # TODO: warn of precedence of cache policies and cache key fn if both provided?
+        if cache_policy is not NotSet and cache_key_fn is not None:
+            logger.warning(
+                f"Both `cache_policy` and `cache_key_fn` are set on task {self}. `cache_key_fn` will be used."
+            )
+
         if cache_key_fn:
             cache_policy = CachePolicy.from_cache_key_fn(cache_key_fn)
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1471,12 +1471,17 @@ class TestTaskCaching:
         assert await s3.result() == 6
         assert await s4.result() == 6
 
-    async def test_cache_key_fn_takes_precedence_over_cache_policy(self, caplog):
-        # TODO: remove the need to set persist_result=True
+    async def test_cache_key_fn_takes_precedence_over_cache_policy(
+        self, caplog, tmpdir
+    ):
+        block = LocalFileSystem(basepath=str(tmpdir))
+
+        block.save("test-cache-key-fn-takes-precedence-over-cache-policy")
+
         @task(
             cache_key_fn=lambda *_: "cache-hit-9",
             cache_policy=INPUTS,
-            persist_result=True,
+            result_storage=block,
         )
         def foo(x):
             return x

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1472,7 +1472,12 @@ class TestTaskCaching:
         assert await s4.result() == 6
 
     async def test_cache_key_fn_takes_precedence_over_cache_policy(self, caplog):
-        @task(cache_key_fn=lambda *_: "cache-hit-9", cache_policy=INPUTS)
+        # TODO: remove the need to set persist_result=True
+        @task(
+            cache_key_fn=lambda *_: "cache-hit-9",
+            cache_policy=INPUTS,
+            persist_result=True,
+        )
         def foo(x):
             return x
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1476,11 +1476,8 @@ class TestTaskCaching:
         def foo(x):
             return x
 
-        @flow
-        def bar():
-            return foo(1, return_state=True), foo(2, return_state=True)
-
-        first_state, second_state = bar()
+        first_state = foo(1, return_state=True)
+        second_state = foo(2, return_state=True)
         assert first_state.name == "Completed"
         assert second_state.name == "Cached"
         assert await second_state.result() == await first_state.result()
@@ -1491,13 +1488,10 @@ class TestTaskCaching:
         def foo(x):
             return x
 
-        @flow
-        def bar():
-            return foo(1, return_state=True), foo.with_options(
-                result_storage_key="after"
-            )(2, return_state=True)
-
-        first_state, second_state = bar()
+        first_state = foo(1, return_state=True)
+        second_state = foo.with_options(result_storage_key="after")(
+            2, return_state=True
+        )
         assert first_state.name == "Completed"
         assert second_state.name == "Completed"
         assert await first_state.result() == 1


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
This PR adds a warning when `cache_key_fn` and `cache_policy` are both provided to a task informing the user that `cache_key_fn` takes precedence.

It also adds a test recording that the cache is busted when the `result_storage_key` on a task changes. This will be true until we implement a transaction record store separate from result storage.

Related to https://github.com/PrefectHQ/prefect/issues/13800

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
 	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->

For documentation changes:

- [ ] This pull request includes redirect settings in `mint.json` for files that are removed or renamed.

For new functions or classes in the Python SDK:

- [ ] This pull request includes helpful docstrings.
- [ ] If a new Python file was added, this pull request contains a stub page in the Python SDK docs and an entry in `docs/mint.json` navigation.
