### PR TITLE
Controls time in the task engine cache tests to avoid flakes

### DIFF
--- a/tests/fixtures/time.py
+++ b/tests/fixtures/time.py
@@ -1,7 +1,9 @@
-from typing import Optional, Union
+from datetime import timedelta
+from typing import Callable, Optional, Union
 
 import pendulum
 import pytest
+from pendulum import DateTime
 from pendulum.tz.timezone import Timezone
 
 
@@ -16,3 +18,27 @@ def frozen_time(monkeypatch: pytest.MonkeyPatch) -> pendulum.DateTime:
 
     monkeypatch.setattr(pendulum, "now", frozen_time)
     return frozen
+
+
+@pytest.fixture
+def advance_time(monkeypatch: pytest.MonkeyPatch) -> Callable[[timedelta], DateTime]:
+    clock = pendulum.now("UTC")
+
+    def advance(amount: timedelta):
+        nonlocal clock
+        clock += amount
+        return clock
+
+    def nowish(tz: Optional[Union[str, Timezone]] = None):
+        # each time this is called, advance by 1 microsecond so that time is moving
+        # forward bit-by-bit to avoid everything appearing to happen all at once
+        advance(timedelta(microseconds=1))
+
+        if tz is None:
+            return clock
+
+        return clock.in_timezone(tz)
+
+    monkeypatch.setattr(pendulum, "now", nowish)
+
+    return advance

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -1139,7 +1139,9 @@ class TestCachePolicy:
         assert await state.result() == 1800
         assert state.data.storage_key == "foo-bar"
 
-    async def test_cache_expiration_is_respected(self, prefect_client, tmp_path):
+    async def test_cache_expiration_is_respected(
+        self, prefect_client, tmp_path, advance_time
+    ):
         fs = LocalFileSystem(basepath=tmp_path)
 
         @task(
@@ -1164,7 +1166,7 @@ class TestCachePolicy:
         assert first_result == second_result, "Cache was not used"
 
         # let cache expire...
-        await asyncio.sleep(1.1)
+        advance_time(timedelta(seconds=1.1))
 
         third_state = await async_task(return_state=True)
         assert third_state.is_completed()


### PR DESCRIPTION
This introduces a new `advance_time` fixture that allows for arbitrarily
adjusting the return value of `pendulum.now` in tests.  It's similar to its
counterpart `frozen_time`, but the time will advance on its own with each call.
The function returned by the fixture allows advancing time by a specified amount
in tests.
