### PR TITLE
Adds a private status endpoint to `TaskWorker`

### DIFF
--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -387,6 +387,7 @@ async def serve(
     """
     task_worker = TaskWorker(*tasks, limit=limit)
 
+    status_server_task = None
     if status_server_port is not None:
         server = uvicorn.Server(
             uvicorn.Config(

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -91,7 +91,9 @@ class TaskWorker:
         self._executor = ThreadPoolExecutor(max_workers=limit if limit else None)
         self._limiter = anyio.CapacityLimiter(limit) if limit else None
 
-        self.in_flight_task_runs = {task.task_key: set() for task in self.tasks}
+        self.in_flight_task_runs = {
+            task.task_key: set() for task in self.tasks if isinstance(task, Task)
+        }
 
     @property
     def client_id(self) -> str:

--- a/tests/test_task_worker.py
+++ b/tests/test_task_worker.py
@@ -131,7 +131,7 @@ async def test_task_worker_client_id_is_set():
         task_worker = TaskWorker(...)
         task_worker._client = MagicMock(api_url="http://localhost:4200")
 
-        assert task_worker._client_id == "foo-42"
+        assert task_worker.client_id == "foo-42"
 
 
 async def test_task_worker_handles_aborted_task_run_submission(


### PR DESCRIPTION
This endpoint, at `http://127.0.0.1:4422/status` reports the current state of
the `TaskWorker`, including what its limiting parameters look like and which
task runs of each key are currently in-flight.  This is a rough-and-ready
monitoring endpoint that we can flesh out with more info and tests as we go, but
for now, we need it for load testing and reliability troubleshooting.
