### PR TITLE
Turn on task persistence by default

### DIFF
--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -78,7 +78,7 @@ async def _get_or_create_default_storage(block_document_slug: str) -> ResultStor
             return await Block.load(default_storage_name)
         except ValueError as e:
             if "Unable to find" not in str(e):
-                raise ValueError("How did we get here?") from e
+                raise e
 
         block_type_slug, name = default_storage_name.split("/")
         if block_type_slug == "local-file-system":

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -66,7 +66,7 @@ _default_storages: Dict[Tuple[str, str], WritableFileSystem] = {}
 
 async def _get_or_create_default_storage(block_document_slug: str) -> ResultStorage:
     """
-    Generate a default file system for background task parameter/result storage.
+    Generate a default file system for storage.
     """
     default_storage_name, storage_path = cache_key = (
         block_document_slug,
@@ -78,7 +78,7 @@ async def _get_or_create_default_storage(block_document_slug: str) -> ResultStor
             return await Block.load(default_storage_name)
         except ValueError as e:
             if "Unable to find" not in str(e):
-                raise e
+                raise ValueError("How did we get here?") from e
 
         block_type_slug, name = default_storage_name.split("/")
         if block_type_slug == "local-file-system":

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -38,7 +38,6 @@ from prefect.settings import (
     PREFECT_RESULTS_DEFAULT_SERIALIZER,
     PREFECT_RESULTS_PERSIST_BY_DEFAULT,
     PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK,
-    default_result_storage_block_name,
 )
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import sync_compatible
@@ -62,35 +61,15 @@ logger = get_logger("results")
 P = ParamSpec("P")
 R = TypeVar("R")
 
-
-@sync_compatible
-async def get_default_result_storage() -> ResultStorage:
-    """
-    Generate a default file system for result storage.
-    """
-    try:
-        return await Block.load(PREFECT_DEFAULT_RESULT_STORAGE_BLOCK.value())
-    except ValueError as e:
-        if "Unable to find" not in str(e):
-            raise e
-        elif (
-            PREFECT_DEFAULT_RESULT_STORAGE_BLOCK.value()
-            == default_result_storage_block_name()
-        ):
-            return LocalFileSystem(basepath=PREFECT_LOCAL_STORAGE_PATH.value())
-        else:
-            raise
+_default_storages: Dict[Tuple[str, str], WritableFileSystem] = {}
 
 
-_default_task_scheduling_storages: Dict[Tuple[str, str], WritableFileSystem] = {}
-
-
-async def get_or_create_default_task_scheduling_storage() -> ResultStorage:
+async def _get_or_create_default_storage(block_document_slug: str) -> ResultStorage:
     """
     Generate a default file system for background task parameter/result storage.
     """
     default_storage_name, storage_path = cache_key = (
-        PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK.value(),
+        block_document_slug,
         PREFECT_LOCAL_STORAGE_PATH.value(),
     )
 
@@ -105,8 +84,8 @@ async def get_or_create_default_task_scheduling_storage() -> ResultStorage:
         if block_type_slug == "local-file-system":
             block = LocalFileSystem(basepath=storage_path)
         else:
-            raise Exception(
-                "The default task storage block does not exist, but it is of type "
+            raise ValueError(
+                "The default storage block does not exist, but it is of type "
                 f"'{block_type_slug}' which cannot be created implicitly.  Please create "
                 "the block manually."
             )
@@ -123,11 +102,30 @@ async def get_or_create_default_task_scheduling_storage() -> ResultStorage:
         return block
 
     try:
-        return _default_task_scheduling_storages[cache_key]
+        return _default_storages[cache_key]
     except KeyError:
         storage = await get_storage()
-        _default_task_scheduling_storages[cache_key] = storage
+        _default_storages[cache_key] = storage
         return storage
+
+
+@sync_compatible
+async def get_or_create_default_result_storage() -> ResultStorage:
+    """
+    Generate a default file system for result storage.
+    """
+    return await _get_or_create_default_storage(
+        PREFECT_DEFAULT_RESULT_STORAGE_BLOCK.value()
+    )
+
+
+async def get_or_create_default_task_scheduling_storage() -> ResultStorage:
+    """
+    Generate a default file system for background task parameter/result storage.
+    """
+    return await _get_or_create_default_storage(
+        PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK.value()
+    )
 
 
 def get_default_result_serializer() -> ResultSerializer:
@@ -210,7 +208,9 @@ class ResultFactory(BaseModel):
                 kwargs.pop(key)
 
         # Apply defaults
-        kwargs.setdefault("result_storage", await get_default_result_storage())
+        kwargs.setdefault(
+            "result_storage", await get_or_create_default_result_storage()
+        )
         kwargs.setdefault("result_serializer", get_default_result_serializer())
         kwargs.setdefault("persist_result", get_default_persist_setting())
         kwargs.setdefault("cache_result_in_memory", True)
@@ -280,7 +280,9 @@ class ResultFactory(BaseModel):
         """
         Create a new result factory for a task.
         """
-        return await cls._from_task(task, get_default_result_storage, client=client)
+        return await cls._from_task(
+            task, get_or_create_default_result_storage, client=client
+        )
 
     @classmethod
     @inject_client

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -417,9 +417,7 @@ class TaskRunEngine(Generic[P, R]):
                     log_prints=log_prints,
                     task_run=self.task_run,
                     parameters=self.parameters,
-                    result_factory=run_coro_as_sync(
-                        ResultFactory.from_autonomous_task(self.task)
-                    ),  # type: ignore
+                    result_factory=run_coro_as_sync(ResultFactory.from_task(self.task)),  # type: ignore
                     client=client,
                 )
             )

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -380,7 +380,7 @@ class Task(Generic[P, R]):
         self.refresh_cache = refresh_cache
 
         if not persist_result:
-            self.cache_policy = NONE
+            self.cache_policy = None if cache_policy is None else NONE
             if cache_policy and cache_policy is not NotSet and cache_policy != NONE:
                 logger.warning(
                     "Ignoring `cache_policy` because `persist_result` is False"

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -381,11 +381,11 @@ class Task(Generic[P, R]):
 
         if not persist_result:
             self.cache_policy = NONE
-            if cache_policy:
+            if cache_policy and cache_policy is not NotSet and cache_policy != NONE:
                 logger.warning(
                     "Ignoring `cache_policy` because `persist_result` is False"
                 )
-        if cache_policy is NotSet and result_storage_key is None:
+        elif cache_policy is NotSet and result_storage_key is None:
             self.cache_policy = DEFAULT
         elif result_storage_key:
             # TODO: handle this situation with double storage

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -44,7 +44,7 @@ from prefect.context import (
 )
 from prefect.futures import PrefectDistributedFuture, PrefectFuture
 from prefect.logging.loggers import get_logger
-from prefect.records.cache_policies import DEFAULT, CachePolicy
+from prefect.records.cache_policies import DEFAULT, NONE, CachePolicy
 from prefect.results import ResultFactory, ResultSerializer, ResultStorage
 from prefect.settings import (
     PREFECT_TASK_DEFAULT_RETRIES,
@@ -218,10 +218,8 @@ class Task(Generic[P, R]):
             cannot exceed 50.
         retry_jitter_factor: An optional factor that defines the factor to which a retry
             can be jittered in order to avoid a "thundering herd".
-        persist_result: An optional toggle indicating whether the result of this task
-            should be persisted to result storage. Defaults to `None`, which indicates
-            that Prefect should choose whether the result should be persisted depending on
-            the features being used.
+        persist_result: An toggle indicating whether the result of this task
+            should be persisted to result storage. Defaults to `True`.
         result_storage: An optional block to use to persist the result of this task.
             Defaults to the value set in the flow the task is called in.
         result_storage_key: An optional key to store the result in storage at when persisted.
@@ -273,7 +271,7 @@ class Task(Generic[P, R]):
             ]
         ] = None,
         retry_jitter_factor: Optional[float] = None,
-        persist_result: Optional[bool] = None,
+        persist_result: bool = True,
         result_storage: Optional[ResultStorage] = None,
         result_serializer: Optional[ResultSerializer] = None,
         result_storage_key: Optional[str] = None,
@@ -381,6 +379,12 @@ class Task(Generic[P, R]):
         self.cache_expiration = cache_expiration
         self.refresh_cache = refresh_cache
 
+        if not persist_result:
+            self.cache_policy = NONE
+            if cache_policy:
+                logger.warning(
+                    "Ignoring `cache_policy` because `persist_result` is False"
+                )
         if cache_policy is NotSet and result_storage_key is None:
             self.cache_policy = DEFAULT
         elif result_storage_key:
@@ -1330,7 +1334,7 @@ def task(
         Callable[[int], List[float]],
     ] = 0,
     retry_jitter_factor: Optional[float] = None,
-    persist_result: Optional[bool] = None,
+    persist_result: bool = True,
     result_storage: Optional[ResultStorage] = None,
     result_storage_key: Optional[str] = None,
     result_serializer: Optional[ResultSerializer] = None,
@@ -1362,7 +1366,7 @@ def task(
         float, int, List[float], Callable[[int], List[float]], None
     ] = None,
     retry_jitter_factor: Optional[float] = None,
-    persist_result: Optional[bool] = None,
+    persist_result: bool = True,
     result_storage: Optional[ResultStorage] = None,
     result_storage_key: Optional[str] = None,
     result_serializer: Optional[ResultSerializer] = None,
@@ -1408,10 +1412,8 @@ def task(
             cannot exceed 50.
         retry_jitter_factor: An optional factor that defines the factor to which a retry
             can be jittered in order to avoid a "thundering herd".
-        persist_result: An optional toggle indicating whether the result of this task
-            should be persisted to result storage. Defaults to `None`, which indicates
-            that Prefect should choose whether the result should be persisted depending on
-            the features being used.
+        persist_result: An toggle indicating whether the result of this task
+            should be persisted to result storage. Defaults to `True`.
         result_storage: An optional block to use to persist the result of this task.
             Defaults to the value set in the flow the task is called in.
         result_storage_key: An optional key to store the result in storage at when persisted.

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -15,8 +15,11 @@ from typing_extensions import Self
 from prefect.context import ContextModel, FlowRunContext, TaskRunContext
 from prefect.records import RecordStore
 from prefect.records.result_store import ResultFactoryStore
-from prefect.results import BaseResult, ResultFactory, get_default_result_storage
-from prefect.settings import PREFECT_DEFAULT_RESULT_STORAGE_BLOCK
+from prefect.results import (
+    BaseResult,
+    ResultFactory,
+    get_or_create_default_result_storage,
+)
 from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.collections import AutoEnum
 
@@ -265,12 +268,7 @@ def transaction(
                 }
             )
         else:
-            default_storage = get_default_result_storage(_sync=True)
-            if not default_storage._block_document_id:
-                default_name = PREFECT_DEFAULT_RESULT_STORAGE_BLOCK.value().split("/")[
-                    -1
-                ]
-                default_storage.save(default_name, overwrite=True, _sync=True)
+            default_storage = get_or_create_default_result_storage(_sync=True)
             if existing_factory:
                 new_factory = existing_factory.model_copy(
                     update={

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -29,11 +29,16 @@ async def test_task_state_change_happy_path(
 
     await asserting_events_worker.drain()
     assert isinstance(asserting_events_worker._client, AssertingEventsClient)
-    assert len(task_run_states) == len(asserting_events_worker._client.events) == 3
+    events = [
+        event
+        for event in asserting_events_worker._client.events
+        if event.event.startswith("prefect.task-run.")
+    ]
+    assert len(task_run_states) == len(events) == 3
 
     last_state = None
     for i, task_run_state in enumerate(task_run_states):
-        event = asserting_events_worker._client.events[i]
+        event = events[i]
 
         assert event.id == task_run_state.id
         assert event.occurred == task_run_state.timestamp
@@ -93,11 +98,16 @@ async def test_task_state_change_task_failure(
 
     await asserting_events_worker.drain()
     assert isinstance(asserting_events_worker._client, AssertingEventsClient)
-    assert len(task_run_states) == len(asserting_events_worker._client.events) == 3
+    events = [
+        event
+        for event in asserting_events_worker._client.events
+        if event.event.startswith("prefect.task-run.")
+    ]
+    assert len(task_run_states) == len(events) == 3
 
     last_state = None
     for i, task_run_state in enumerate(task_run_states):
-        event = asserting_events_worker._client.events[i]
+        event = events[i]
 
         assert event.id == task_run_state.id
         assert event.occurred == task_run_state.timestamp
@@ -160,6 +170,7 @@ async def test_background_task_state_changes(
     await asserting_events_worker.drain()
 
     events = sorted(asserting_events_worker._client.events, key=lambda e: e.occurred)
+    events = [e for e in events if e.event.startswith("prefect.task-run.")]
 
     assert len(task_run_states) == len(events) == 4
 

--- a/tests/fixtures/storage.py
+++ b/tests/fixtures/storage.py
@@ -12,6 +12,7 @@ import pytest
 from fastapi import Body, FastAPI, status
 from fastapi.exceptions import RequestValidationError
 
+import prefect.results
 from prefect.filesystems import LocalFileSystem
 from prefect.server.api.server import validation_exception_handler
 
@@ -27,6 +28,13 @@ async def local_filesystem(tmp_path):
     block = LocalFileSystem(basepath=tmp_path)
     await block._save(is_anonymous=True)
     return block
+
+
+@pytest.fixture(autouse=True)
+async def clear_cached_filesystems():
+    prefect.results._default_storages.clear()
+    yield
+    prefect.results._default_storages.clear()
 
 
 # Key-value storage API ----------------------------------------------------------------

--- a/tests/results/test_flow_results.py
+++ b/tests/results/test_flow_results.py
@@ -439,11 +439,13 @@ async def test_root_flow_nonexistent_default_storage_block_fails():
     with temporary_settings(
         {
             PREFECT_RESULTS_PERSIST_BY_DEFAULT: True,
-            PREFECT_DEFAULT_RESULT_STORAGE_BLOCK: "local-file-system/my-result-storage",
+            PREFECT_DEFAULT_RESULT_STORAGE_BLOCK: "fake-block-type-slug/my-result-storage",
         }
     ):
         with pytest.raises(
-            ValueError, match="Unable to find block document named my-result-storage"
+            ValueError,
+            match="The default storage block does not exist, but it is of type"
+            " 'fake-block-type-slug' which cannot be created implicitly",
         ):
             await foo()
 

--- a/tests/results/test_result_factory.py
+++ b/tests/results/test_result_factory.py
@@ -57,7 +57,7 @@ def test_root_flow_default_result_factory():
     assert result_factory.cache_result_in_memory is True
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
-    assert result_factory.storage_block_id is None
+    assert result_factory.storage_block_id is not None
 
 
 def test_root_flow_default_result_serializer_can_be_overriden_by_setting():
@@ -105,7 +105,7 @@ def test_root_flow_custom_persist_setting(toggle):
     if toggle:
         assert isinstance(result_factory.storage_block_id, uuid.UUID)
     else:
-        assert result_factory.storage_block_id is None
+        assert result_factory.storage_block_id is not None
 
 
 @pytest.mark.parametrize("options", [{"cache_result_in_memory": False}])
@@ -134,7 +134,7 @@ def test_root_flow_can_opt_out_of_persistence_when_flow_uses_feature(options):
     assert result_factory.persist_result is False
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
-    assert result_factory.storage_block_id is None
+    assert result_factory.storage_block_id is not None
 
 
 @pytest.mark.parametrize("toggle", [True, False])
@@ -153,7 +153,7 @@ def test_root_flow_custom_cache_setting(toggle):
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
 
     if toggle:
-        assert result_factory.storage_block_id is None
+        assert result_factory.storage_block_id is not None
     else:
         assert isinstance(result_factory.storage_block_id, uuid.UUID)
 
@@ -167,7 +167,7 @@ def test_root_flow_custom_serializer_by_type_string():
     assert result_factory.persist_result is False
     assert result_factory.serializer == JSONSerializer()
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
-    assert result_factory.storage_block_id is None
+    assert result_factory.storage_block_id is not None
 
 
 def test_root_flow_custom_serializer_by_instance():
@@ -179,7 +179,7 @@ def test_root_flow_custom_serializer_by_instance():
     assert result_factory.persist_result is False
     assert result_factory.serializer == JSONSerializer(jsonlib="orjson")
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
-    assert result_factory.storage_block_id is None
+    assert result_factory.storage_block_id is not None
 
 
 async def test_root_flow_custom_storage_by_slug(tmp_path):
@@ -251,7 +251,7 @@ def test_child_flow_inherits_default_result_settings():
     assert child_factory.persist_result is False
     assert child_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert child_factory.storage_block_id is None
+    assert child_factory.storage_block_id is not None
 
 
 def test_child_flow_default_result_serializer_can_be_overriden_by_setting():
@@ -337,10 +337,7 @@ def test_child_flow_custom_cache_setting(toggle):
     assert child_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
 
-    if toggle:
-        assert child_factory.storage_block_id is None
-    else:
-        assert isinstance(child_factory.storage_block_id, uuid.UUID)
+    assert isinstance(child_factory.storage_block_id, uuid.UUID)
 
 
 @pytest.mark.parametrize("options", [{"retries": 3}])
@@ -375,7 +372,7 @@ def test_child_flow_can_opt_out_of_result_persistence_when_parent_uses_feature()
     assert child_factory.persist_result is False
     assert child_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert child_factory.storage_block_id is None
+    assert child_factory.storage_block_id is not None
 
 
 @pytest.mark.parametrize("options", [{"cache_result_in_memory": False}])
@@ -415,7 +412,7 @@ def test_child_flow_can_opt_out_of_result_persistence_when_child_uses_feature():
     assert child_factory.cache_result_in_memory is False
     assert child_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert child_factory.storage_block_id is None
+    assert child_factory.storage_block_id is not None
 
 
 def test_child_flow_inherits_custom_serializer():
@@ -431,7 +428,7 @@ def test_child_flow_inherits_custom_serializer():
     assert child_factory.persist_result is False
     assert child_factory.serializer == parent_factory.serializer
     assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert child_factory.storage_block_id is None
+    assert child_factory.storage_block_id is not None
 
 
 async def test_child_flow_inherits_custom_storage(tmp_path):
@@ -467,7 +464,7 @@ def test_child_flow_custom_serializer():
     assert child_factory.persist_result is False
     assert child_factory.serializer == JSONSerializer()
     assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert child_factory.storage_block_id is None
+    assert child_factory.storage_block_id is not None
 
 
 async def test_child_flow_custom_storage(tmp_path):
@@ -540,7 +537,7 @@ def test_task_inherits_default_result_settings():
     assert task_factory.persist_result is False
     assert task_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
-    assert task_factory.storage_block_id is None
+    assert task_factory.storage_block_id is not None
 
 
 def test_task_default_result_serializer_can_be_overriden_by_setting():
@@ -612,7 +609,7 @@ def test_task_custom_cache_setting(toggle):
     assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
 
     if toggle:
-        assert task_factory.storage_block_id is None
+        assert task_factory.storage_block_id is not None
     else:
         assert isinstance(task_factory.storage_block_id, uuid.UUID)
 
@@ -669,7 +666,7 @@ def test_task_can_opt_out_of_result_persistence_when_flow_uses_feature():
     assert task_factory.persist_result is False
     assert task_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
-    assert task_factory.storage_block_id is None
+    assert task_factory.storage_block_id is not None
 
 
 def test_task_can_opt_out_when_persist_result_default_is_overriden_by_setting():
@@ -700,7 +697,7 @@ def test_task_inherits_custom_serializer():
     assert task_factory.persist_result is False
     assert task_factory.serializer == flow_factory.serializer
     assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
-    assert task_factory.storage_block_id is None
+    assert task_factory.storage_block_id is not None
 
 
 async def test_task_inherits_custom_storage(tmp_path):
@@ -736,7 +733,7 @@ def test_task_custom_serializer():
     assert task_factory.persist_result is False
     assert task_factory.serializer == JSONSerializer()
     assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
-    assert task_factory.storage_block_id is None
+    assert task_factory.storage_block_id is not None
 
 
 async def test_task_custom_storage(tmp_path):
@@ -826,7 +823,7 @@ async def _verify_default_storage_creation_without_persistence(
     # verify storage settings are correctly set
     assert not result_factory.storage_block._is_anonymous
     assert result_factory.persist_result is False
-    assert result_factory.storage_block_id is None
+    assert result_factory.storage_block_id is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/results/test_result_factory.py
+++ b/tests/results/test_result_factory.py
@@ -534,23 +534,19 @@ def test_task_inherits_default_result_settings():
         return get_run_context().result_factory
 
     _, task_factory = foo()
-    assert task_factory.persist_result is False
+    assert task_factory.persist_result
     assert task_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
     assert task_factory.storage_block_id is not None
 
 
 def test_task_default_result_serializer_can_be_overriden_by_setting():
-    @flow
-    def foo():
-        return get_run_context().result_factory, bar()
-
-    @task
+    @task(persist_result=False)
     def bar():
         return get_run_context().result_factory
 
     with temporary_settings({PREFECT_RESULTS_DEFAULT_SERIALIZER: "json"}):
-        _, task_factory = foo()
+        task_factory = bar()
 
     assert task_factory.serializer == JSONSerializer()
 
@@ -603,7 +599,7 @@ def test_task_custom_cache_setting(toggle):
 
     flow_factory = foo()
     assert flow_factory.cache_result_in_memory is True
-    assert task_factory.persist_result is not toggle  # Persistence toggled on
+    assert task_factory.persist_result  # Persistence on unless explicitly turned off
     assert task_factory.cache_result_in_memory is toggle
     assert task_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
@@ -713,7 +709,7 @@ async def test_task_inherits_custom_storage(tmp_path):
         return get_run_context().result_factory
 
     flow_factory, task_factory = foo()
-    assert task_factory.persist_result is False
+    assert task_factory.persist_result
     assert task_factory.serializer == DEFAULT_SERIALIZER()
     assert task_factory.storage_block == flow_factory.storage_block
     assert task_factory.storage_block_id == storage_id
@@ -882,7 +878,7 @@ async def test_default_storage_creation_for_task_with_persistence_features(
 
 
 async def test_default_storage_creation_for_task_without_persistence_features():
-    @task
+    @task(persist_result=False)
     def my_task():
         return get_run_context().result_factory
 

--- a/tests/results/test_task_results.py
+++ b/tests/results/test_task_results.py
@@ -311,7 +311,7 @@ async def test_task_result_flow_run_formatted_storage_key(prefect_client, tmp_pa
     assert task_state.data.storage_key == "foo__bar"
 
 
-async def test_task_result_missing_with_null_return(prefect_client):
+async def test_task_result_with_null_return(prefect_client):
     @flow
     def foo():
         return bar(return_state=True)
@@ -327,8 +327,7 @@ async def test_task_result_missing_with_null_return(prefect_client):
     api_state = (
         await prefect_client.read_task_run(task_state.state_details.task_run_id)
     ).state
-    with pytest.raises(MissingResult):
-        await api_state.result()
+    assert await api_state.result() is None
 
 
 @pytest.mark.parametrize("value", [True, False, None])

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -53,9 +53,9 @@ async def clear_scheduled_task_queues():
 
 @pytest.fixture(autouse=True)
 async def clear_cached_filesystems():
-    prefect.results._default_task_scheduling_storages.clear()
+    prefect.results._default_storages.clear()
     yield
-    prefect.results._default_task_scheduling_storages.clear()
+    prefect.results._default_storages.clear()
 
 
 @pytest.fixture

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -1200,8 +1200,8 @@ class TestCachePolicy:
             await first_state.result() != await second_state.result()
         ), "Cache did not expire"
 
-    async def test_none_policy_doesnt_persist(self, prefect_client):
-        @task(cache_policy=None, result_storage_key=None)
+    async def test_none_policy_with_persist_result_false(self, prefect_client):
+        @task(cache_policy=None, result_storage_key=None, persist_result=False)
         async def async_task():
             return 1800
 
@@ -1385,7 +1385,7 @@ class TestGenerators:
         Test that a generator can timeout
         """
 
-        @task(timeout_seconds=0.1)
+        @task(timeout_seconds=1)
         def g():
             yield 1
             time.sleep(2)

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -9,7 +9,7 @@ import pytest
 from prefect._internal.concurrency.api import create_call, from_async
 from prefect.context import TagsContext, tags
 from prefect.futures import PrefectFuture, PrefectWrappedFuture
-from prefect.results import _default_task_scheduling_storages
+from prefect.results import _default_storages
 from prefect.states import Completed, Running
 from prefect.task_runners import PrefectTaskRunner, ThreadPoolTaskRunner
 from prefect.task_worker import serve
@@ -186,7 +186,7 @@ class TestThreadPoolTaskRunner:
 class TestPrefectTaskRunner:
     @pytest.fixture(autouse=True)
     def clear_cache(self):
-        _default_task_scheduling_storages.clear()
+        _default_storages.clear()
 
     @pytest.fixture
     async def task_worker(self, use_hosted_api_server):

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -8,8 +8,14 @@ import pytest
 
 from prefect._internal.concurrency.api import create_call, from_async
 from prefect.context import TagsContext, tags
+from prefect.filesystems import LocalFileSystem
 from prefect.futures import PrefectFuture, PrefectWrappedFuture
 from prefect.results import _default_storages
+from prefect.settings import (
+    PREFECT_DEFAULT_RESULT_STORAGE_BLOCK,
+    PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK,
+    temporary_settings,
+)
 from prefect.states import Completed, Running
 from prefect.task_runners import PrefectTaskRunner, ThreadPoolTaskRunner
 from prefect.task_worker import serve
@@ -59,6 +65,18 @@ class MockFuture(PrefectWrappedFuture):
 
 
 class TestThreadPoolTaskRunner:
+    @pytest.fixture(autouse=True)
+    def default_storage_setting(self, tmp_path):
+        name = str(uuid.uuid4())
+        LocalFileSystem(basepath=tmp_path).save(name)
+        with temporary_settings(
+            {
+                PREFECT_DEFAULT_RESULT_STORAGE_BLOCK: f"local-file-system/{name}",
+                PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK: f"local-file-system/{name}",
+            }
+        ):
+            yield
+
     def test_duplicate(self):
         runner = ThreadPoolTaskRunner(max_workers=100)
         duplicate_runner = runner.duplicate()

--- a/tests/test_task_worker.py
+++ b/tests/test_task_worker.py
@@ -8,7 +8,6 @@ import anyio
 import pytest
 from pydantic import BaseModel
 
-import prefect.results
 from prefect import flow, task
 from prefect.exceptions import MissingResult
 from prefect.filesystems import LocalFileSystem
@@ -19,13 +18,6 @@ from prefect.task_worker import TaskWorker, serve
 from prefect.tasks import task_input_hash
 
 pytestmark = pytest.mark.usefixtures("use_hosted_api_server")
-
-
-@pytest.fixture(autouse=True)
-async def clear_cached_filesystems():
-    prefect.results._default_task_scheduling_storages.clear()
-    yield
-    prefect.results._default_task_scheduling_storages.clear()
 
 
 # model defined outside of the test function to avoid pickling issues

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1597,7 +1597,7 @@ class TestTaskCaching:
         def foo(x):
             return x
 
-        assert foo.cache_policy == NONE
+        assert foo.cache_policy == cache_policy
 
         assert (
             "Ignoring `cache_policy` because `persist_result` is False"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3688,12 +3688,14 @@ async def test_sets_run_name_once():
 
 
 async def test_sets_run_name_once_per_call():
+    task_calls = 0
     generate_task_run_name = MagicMock(return_value="some-string")
-    mocked_task_method = MagicMock()
 
-    decorated_task_method = task(task_run_name=generate_task_run_name)(
-        mocked_task_method
-    )
+    def test_task():
+        nonlocal task_calls
+        task_calls += 1
+
+    decorated_task_method = task(task_run_name=generate_task_run_name)(test_task)
 
     @flow
     def my_flow(name):
@@ -3705,7 +3707,7 @@ async def test_sets_run_name_once_per_call():
     state = my_flow(name="some-name", return_state=True)
 
     assert state.type == StateType.COMPLETED
-    assert mocked_task_method.call_count == 2
+    assert task_calls == 2
     assert generate_task_run_name.call_count == 2
 
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -7,7 +7,7 @@ from prefect.flows import flow
 from prefect.records import RecordStore
 from prefect.records.result_store import ResultFactoryStore
 from prefect.results import (
-    get_default_result_storage,
+    get_or_create_default_result_storage,
     get_or_create_default_task_scheduling_storage,
 )
 from prefect.settings import (
@@ -283,7 +283,7 @@ class TestDefaultTransactionStorage:
             # make sure we aren't using an anonymous block
             assert (
                 result.storage_block_id
-                == get_default_result_storage()._block_document_id
+                == get_or_create_default_result_storage()._block_document_id
             )
             return result
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
To ensure we get idempotency for tasks out of the box, we need to ensure that tasks persist their results by default. With this PR, `persist_result` will default to `True` for all tasks. If `persist_result` is set to false, then the `cache_policy` will be ignored.

To facilitate writing results by default, we will attempt to load a default storage block matching the default storage block configured with `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK`. If that block doesn't exist (defaults to `{hostname}-storage`), we will create and save that block for the user. That block will be reused for subsequent runs.

Closes https://github.com/PrefectHQ/prefect/issues/14087

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
- [x] This pull request references any related issue by including "closes `<link to issue>`"
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
