### PR TITLE
Bumping `pytest-xdist`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ pytest-benchmark
 pytest-env
 pytest-flakefinder
 pytest-timeout
-pytest-xdist < 3.4.0 # 3.5.0 introduces some flakiness. Need to investigate and resolve.
+pytest-xdist >= 3.7
 pytkdocs >= 0.14.2
 pyyaml
 redis>=5.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ pytest-benchmark
 pytest-env
 pytest-flakefinder
 pytest-timeout
-pytest-xdist >= 3.7
+pytest-xdist >= 3.6.1
 pytkdocs >= 0.14.2
 pyyaml
 redis>=5.0.1


### PR DESCRIPTION
Dependabot wanted to bump this for us, but it would have left it as a `<`
requirement, as well as retaining this stray comment in the requirements file.
Here I just bump it to a `>=`, since it should be working now.
