### PR TITLE
Bumping to latest uvicorn

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -34,5 +34,5 @@ sniffio >=1.3.0, < 2.0.0
 toml >= 0.10.0
 typing_extensions >= 4.5.0, < 5.0.0
 ujson >= 5.8.0, < 6.0.0
-uvicorn >= 0.14.0, < 0.29.0
+uvicorn >= 0.30.1
 websockets >= 10.4, < 13.0


### PR DESCRIPTION
Dependabot wanted to bump this version, but it would have left it as a `<`,
so I'm making it a `>=`.
