### PR TITLE
Disables server-side `PENDING` task rescheduling by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,6 @@ repos:
         files: |
             (?x)^(
                 .pre-commit-config.yaml|
-                src/prefect/server/|
+                src/prefect/server/.*|
                 scripts/generate_mintlify_openapi_docs.py
             )$

--- a/docs/3.0rc/api-ref/server/schema.json
+++ b/docs/3.0rc/api-ref/server/schema.json
@@ -22524,7 +22524,7 @@
                         "type": "string",
                         "format": "duration",
                         "title": "Prefect Task Scheduling Pending Task Timeout",
-                        "default": "PT30S"
+                        "default": "PT0S"
                     },
                     "PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS": {
                         "type": "boolean",

--- a/src/prefect/server/services/task_scheduling.py
+++ b/src/prefect/server/services/task_scheduling.py
@@ -35,6 +35,9 @@ class TaskSchedulingTimeouts(LoopService):
         """
         Periodically reschedules pending task runs that have been pending for too long.
         """
+        if not PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT:
+            return
+
         async with db.session_context(begin_transaction=True) as session:
             if self._first_run:
                 await self.restore_scheduled_tasks_if_necessary(session)

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1541,7 +1541,7 @@ The maximum number of retries to queue for submission.
 
 PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT = Setting(
     timedelta,
-    default=timedelta(seconds=30),
+    default=timedelta(0),
 )
 """
 How long before a PENDING task are made available to another task worker.  In practice,

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -235,6 +235,7 @@ async def prefect_client() -> AsyncGenerator["PrefectClient", None]:
         yield client
 
 
+@pytest.fixture
 def enabled_task_scheduling_pending_task_timeout():
     with temporary_settings({PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT: 30}):
         yield


### PR DESCRIPTION
During my load testing, it became clear that this feature won't work as-is on
such a short timescale.  Because tasks remain `PENDING` until all of their
dependencies are resolved, it's possible that a long period of time may elapse
before those `PENDING` tasks can actually move on to `RUNNING`, and in a system
with deep dependencies, this can put the task workers in a position where they
can't keep up and are constantly getting redelivered tasks.

Rather than defaulting this to on, we should let the user opt-in to the behavior
for now, based on their workload.
