### PR TITLE
Fix bug where block documents are resolved in `job_variables` before saving server-side

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -461,7 +461,7 @@ async def _run_single_deploy(
     push_steps = deploy_config.get("push", actions.get("push")) or []
     pull_steps = deploy_config.get("pull", actions.get("pull")) or []
 
-    # Don't resolve references in job variables. That will happen when 
+    # Don't resolve references in job variables. That will happen when
     # preparing for a flow run.
     _job_variables = deploy_config["work_pool"].pop("job_variables", {})
     deploy_config = await resolve_block_document_references(deploy_config)

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -461,8 +461,8 @@ async def _run_single_deploy(
     push_steps = deploy_config.get("push", actions.get("push")) or []
     pull_steps = deploy_config.get("pull", actions.get("pull")) or []
 
-    # Don't resolve references in job variables. That will happen we preparing for
-    # a flow run.
+    # Don't resolve references in job variables. That will happen when 
+    # preparing for a flow run.
     _job_variables = deploy_config["work_pool"].pop("job_variables", {})
     deploy_config = await resolve_block_document_references(deploy_config)
     deploy_config = await resolve_variables(deploy_config)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
This PR skips formatting block documents in a `prefect.yaml`'s `work_pool.job_variables`. The worker that picks up a flow run for the created deployment will handle that resolution.

Closes https://github.com/PrefectHQ/prefect/issues/14088

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
- [x] This pull request references any related issue by including "closes `<link to issue>`"
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
