### PR TITLE
Update persistence setting to mirror internal logic

### DIFF
--- a/docs/3.0rc/api-ref/server/schema.json
+++ b/docs/3.0rc/api-ref/server/schema.json
@@ -21947,7 +21947,7 @@
                     "PREFECT_RESULTS_PERSIST_BY_DEFAULT": {
                         "type": "boolean",
                         "title": "Prefect Results Persist By Default",
-                        "default": false
+                        "default": true
                     },
                     "PREFECT_TASKS_REFRESH_CACHE": {
                         "type": "boolean",

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -142,38 +142,6 @@ def get_default_persist_setting() -> bool:
     return PREFECT_RESULTS_PERSIST_BY_DEFAULT.value()
 
 
-def flow_features_require_result_persistence(flow: "Flow") -> bool:
-    """
-    Returns `True` if the given flow uses features that require its result to be
-    persisted.
-    """
-    if not flow.cache_result_in_memory:
-        return True
-    return False
-
-
-def flow_features_require_child_result_persistence(flow: "Flow") -> bool:
-    """
-    Returns `True` if the given flow uses features that require child flow and task
-    runs to persist their results.
-    """
-    if flow and flow.retries:
-        return True
-    return False
-
-
-def task_features_require_result_persistence(task: "Task") -> bool:
-    """
-    Returns `True` if the given task uses features that require its result to be
-    persisted.
-    """
-    if task.cache_key_fn:
-        return True
-    if not task.cache_result_in_memory:
-        return True
-    return False
-
-
 def _format_user_supplied_storage_key(key: str) -> str:
     # Note here we are pinning to task runs since flow runs do not support storage keys
     # yet; we'll need to split logic in the future or have two separate functions
@@ -235,17 +203,7 @@ class ResultFactory(BaseModel):
                 result_storage=flow.result_storage or ctx.result_factory.storage_block,
                 result_serializer=flow.result_serializer
                 or ctx.result_factory.serializer,
-                persist_result=(
-                    flow.persist_result
-                    if flow.persist_result is not None
-                    # !! Child flows persist their result by default if the it or the
-                    #    parent flow uses a feature that requires it
-                    else (
-                        flow_features_require_result_persistence(flow)
-                        or flow_features_require_child_result_persistence(ctx.flow)
-                        or get_default_persist_setting()
-                    )
-                ),
+                persist_result=flow.persist_result,
                 cache_result_in_memory=flow.cache_result_in_memory,
                 storage_key_fn=DEFAULT_STORAGE_KEY_FN,
                 client=client,
@@ -258,16 +216,7 @@ class ResultFactory(BaseModel):
                 client=client,
                 result_storage=flow.result_storage,
                 result_serializer=flow.result_serializer,
-                persist_result=(
-                    flow.persist_result
-                    if flow.persist_result is not None
-                    # !! Flows persist their result by default if uses a feature that
-                    #    requires it
-                    else (
-                        flow_features_require_result_persistence(flow)
-                        or get_default_persist_setting()
-                    )
-                ),
+                persist_result=flow.persist_result,
                 cache_result_in_memory=flow.cache_result_in_memory,
                 storage_key_fn=DEFAULT_STORAGE_KEY_FN,
             )
@@ -318,21 +267,7 @@ class ResultFactory(BaseModel):
             if ctx and ctx.result_factory
             else get_default_result_serializer()
         )
-        persist_result = (
-            task.persist_result
-            if task.persist_result is not None
-            # !! Tasks persist their result by default if their parent flow uses a
-            #    feature that requires it or the task uses a feature that requires it
-            else (
-                (
-                    flow_features_require_child_result_persistence(ctx.flow)
-                    if ctx
-                    else False
-                )
-                or task_features_require_result_persistence(task)
-                or get_default_persist_setting()
-            )
-        )
+        persist_result = task.persist_result
 
         cache_result_in_memory = task.cache_result_in_memory
 
@@ -355,11 +290,14 @@ class ResultFactory(BaseModel):
         cls: Type[Self],
         result_storage: ResultStorage,
         result_serializer: ResultSerializer,
-        persist_result: bool,
+        persist_result: Optional[bool],
         cache_result_in_memory: bool,
         storage_key_fn: Callable[[], str],
         client: "PrefectClient",
     ) -> Self:
+        if persist_result is None:
+            persist_result = get_default_persist_setting()
+
         storage_block_id, storage_block = await cls.resolve_storage_block(
             result_storage, client=client, persist_result=persist_result
         )
@@ -680,7 +618,13 @@ class PersistedResult(BaseResult):
             # this could error if the serializer requires kwargs
             serializer = Serializer(type=self.serializer_type)
 
-        data = serializer.dumps(obj)
+        try:
+            data = serializer.dumps(obj)
+        except Exception as exc:
+            raise ValueError(
+                f"Failed to serialize object of type {type(obj).__name__!r} with "
+                f"serializer {serializer.type!r}."
+            ) from exc
         blob = PersistedResultBlob(
             serializer=serializer, data=data, expiration=self.expiration
         )

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -749,7 +749,7 @@ PREFECT_RESULTS_DEFAULT_SERIALIZER = Setting(
 
 PREFECT_RESULTS_PERSIST_BY_DEFAULT = Setting(
     bool,
-    default=False,
+    default=True,
 )
 """
 The default setting for persisting results when not otherwise specified. If enabled,

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -47,6 +47,7 @@ from prefect.logging.loggers import get_logger
 from prefect.records.cache_policies import DEFAULT, NONE, CachePolicy
 from prefect.results import ResultFactory, ResultSerializer, ResultStorage
 from prefect.settings import (
+    PREFECT_RESULTS_PERSIST_BY_DEFAULT,
     PREFECT_TASK_DEFAULT_RETRIES,
     PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS,
 )
@@ -218,8 +219,10 @@ class Task(Generic[P, R]):
             cannot exceed 50.
         retry_jitter_factor: An optional factor that defines the factor to which a retry
             can be jittered in order to avoid a "thundering herd".
-        persist_result: An toggle indicating whether the result of this task
-            should be persisted to result storage. Defaults to `True`.
+        persist_result: A toggle indicating whether the result of this task
+            should be persisted to result storage. Defaults to `None`, which
+            indicates that the global default should be used (which is `True` by
+            default).
         result_storage: An optional block to use to persist the result of this task.
             Defaults to the value set in the flow the task is called in.
         result_storage_key: An optional key to store the result in storage at when persisted.
@@ -271,7 +274,7 @@ class Task(Generic[P, R]):
             ]
         ] = None,
         retry_jitter_factor: Optional[float] = None,
-        persist_result: bool = True,
+        persist_result: Optional[bool] = None,
         result_storage: Optional[ResultStorage] = None,
         result_serializer: Optional[ResultSerializer] = None,
         result_storage_key: Optional[str] = None,
@@ -379,6 +382,8 @@ class Task(Generic[P, R]):
         self.cache_expiration = cache_expiration
         self.refresh_cache = refresh_cache
 
+        if persist_result is None:
+            persist_result = PREFECT_RESULTS_PERSIST_BY_DEFAULT.value()
         if not persist_result:
             self.cache_policy = None if cache_policy is None else NONE
             if cache_policy and cache_policy is not NotSet and cache_policy != NONE:
@@ -1334,7 +1339,7 @@ def task(
         Callable[[int], List[float]],
     ] = 0,
     retry_jitter_factor: Optional[float] = None,
-    persist_result: bool = True,
+    persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_storage_key: Optional[str] = None,
     result_serializer: Optional[ResultSerializer] = None,
@@ -1366,7 +1371,7 @@ def task(
         float, int, List[float], Callable[[int], List[float]], None
     ] = None,
     retry_jitter_factor: Optional[float] = None,
-    persist_result: bool = True,
+    persist_result: Optional[bool] = None,
     result_storage: Optional[ResultStorage] = None,
     result_storage_key: Optional[str] = None,
     result_serializer: Optional[ResultSerializer] = None,
@@ -1412,8 +1417,10 @@ def task(
             cannot exceed 50.
         retry_jitter_factor: An optional factor that defines the factor to which a retry
             can be jittered in order to avoid a "thundering herd".
-        persist_result: An toggle indicating whether the result of this task
-            should be persisted to result storage. Defaults to `True`.
+        persist_result: A toggle indicating whether the result of this task
+            should be persisted to result storage. Defaults to `None`, which
+            indicates that the global default should be used (which is `True` by
+            default).
         result_storage: An optional block to use to persist the result of this task.
             Defaults to the value set in the flow the task is called in.
         result_storage_key: An optional key to store the result in storage at when persisted.

--- a/tests/results/test_result_factory.py
+++ b/tests/results/test_result_factory.py
@@ -28,6 +28,16 @@ def DEFAULT_STORAGE():
 
 
 @pytest.fixture
+def default_persistence_off():
+    """
+    Many tests return result factories, which aren't serialiable.
+    When we switched the default persistence setting to True, this caused tests to fail.
+    """
+    with temporary_settings({PREFECT_RESULTS_PERSIST_BY_DEFAULT: False}):
+        yield
+
+
+@pytest.fixture
 async def factory(prefect_client):
     return await ResultFactory.default_factory(
         client=prefect_client, persist_result=True
@@ -53,7 +63,7 @@ def test_root_flow_default_result_factory():
         return get_run_context().result_factory
 
     result_factory = foo()
-    assert result_factory.persist_result is False
+    assert result_factory.persist_result is True
     assert result_factory.cache_result_in_memory is True
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
@@ -61,7 +71,7 @@ def test_root_flow_default_result_factory():
 
 
 def test_root_flow_default_result_serializer_can_be_overriden_by_setting():
-    @flow
+    @flow(persist_result=False)
     def foo():
         return get_run_context().result_factory
 
@@ -138,7 +148,7 @@ def test_root_flow_can_opt_out_of_persistence_when_flow_uses_feature(options):
 
 
 @pytest.mark.parametrize("toggle", [True, False])
-def test_root_flow_custom_cache_setting(toggle):
+def test_root_flow_custom_cache_setting(toggle, default_persistence_off):
     result_factory = None
 
     @flow(cache_result_in_memory=toggle)
@@ -147,7 +157,6 @@ def test_root_flow_custom_cache_setting(toggle):
         result_factory = get_run_context().result_factory
 
     foo()
-    assert result_factory.persist_result is not toggle  # Persistence toggled on
     assert result_factory.cache_result_in_memory is toggle
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
@@ -159,7 +168,7 @@ def test_root_flow_custom_cache_setting(toggle):
 
 
 def test_root_flow_custom_serializer_by_type_string():
-    @flow(result_serializer="json")
+    @flow(result_serializer="json", persist_result=False)
     def foo():
         return get_run_context().result_factory
 
@@ -170,7 +179,7 @@ def test_root_flow_custom_serializer_by_type_string():
     assert result_factory.storage_block_id is not None
 
 
-def test_root_flow_custom_serializer_by_instance():
+def test_root_flow_custom_serializer_by_instance(default_persistence_off):
     @flow(result_serializer=JSONSerializer(jsonlib="orjson"))
     def foo():
         return get_run_context().result_factory
@@ -182,7 +191,7 @@ def test_root_flow_custom_serializer_by_instance():
     assert result_factory.storage_block_id is not None
 
 
-async def test_root_flow_custom_storage_by_slug(tmp_path):
+async def test_root_flow_custom_storage_by_slug(tmp_path, default_persistence_off):
     storage = LocalFileSystem(basepath=tmp_path / "test")
     storage_id = await storage.save("test")
 
@@ -197,7 +206,9 @@ async def test_root_flow_custom_storage_by_slug(tmp_path):
     assert result_factory.storage_block_id == storage_id
 
 
-async def test_root_flow_custom_storage_by_instance_presaved(tmp_path):
+async def test_root_flow_custom_storage_by_instance_presaved(
+    tmp_path, default_persistence_off
+):
     storage = LocalFileSystem(basepath=tmp_path / "test")
     storage_id = await storage.save("test")
 
@@ -238,7 +249,7 @@ async def test_root_flow_custom_storage_by_instance_unsaved(prefect_client, tmp_
     )
 
 
-def test_child_flow_inherits_default_result_settings():
+def test_child_flow_inherits_default_result_settings(default_persistence_off):
     @flow
     def foo():
         return get_run_context().result_factory, bar()
@@ -254,7 +265,9 @@ def test_child_flow_inherits_default_result_settings():
     assert child_factory.storage_block_id is not None
 
 
-def test_child_flow_default_result_serializer_can_be_overriden_by_setting():
+def test_child_flow_default_result_serializer_can_be_overriden_by_setting(
+    default_persistence_off,
+):
     @flow
     def foo():
         return get_run_context().result_factory, bar()
@@ -299,7 +312,7 @@ def test_child_flow_can_opt_out_when_persist_result_default_is_overriden_by_sett
     assert child_factory.persist_result is False
 
 
-def test_child_flow_custom_persist_setting():
+def test_child_flow_custom_persist_setting(default_persistence_off):
     @flow
     def foo():
         return get_run_context().result_factory, bar()
@@ -317,7 +330,7 @@ def test_child_flow_custom_persist_setting():
 
 
 @pytest.mark.parametrize("toggle", [True, False])
-def test_child_flow_custom_cache_setting(toggle):
+def test_child_flow_custom_cache_setting(toggle, default_persistence_off):
     child_factory = None
 
     @flow
@@ -332,7 +345,6 @@ def test_child_flow_custom_cache_setting(toggle):
 
     parent_factory = foo()
     assert parent_factory.cache_result_in_memory is True
-    assert child_factory.persist_result is not toggle  # Persistence toggled on
     assert child_factory.cache_result_in_memory is toggle
     assert child_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
@@ -340,25 +352,9 @@ def test_child_flow_custom_cache_setting(toggle):
     assert isinstance(child_factory.storage_block_id, uuid.UUID)
 
 
-@pytest.mark.parametrize("options", [{"retries": 3}])
-def test_child_flow_persists_result_when_parent_uses_feature(options):
-    @flow(**options)
-    def foo():
-        return get_run_context().result_factory, bar()
-
-    @flow
-    def bar():
-        return get_run_context().result_factory
-
-    parent_factory, child_factory = foo()
-    assert parent_factory.persist_result is False
-    assert child_factory.persist_result is True
-    assert child_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(child_factory.storage_block_id, uuid.UUID)
-
-
-def test_child_flow_can_opt_out_of_result_persistence_when_parent_uses_feature():
+def test_child_flow_can_opt_out_of_result_persistence_when_parent_uses_feature(
+    default_persistence_off,
+):
     @flow(retries=3)
     def foo():
         return get_run_context().result_factory, bar()
@@ -375,47 +371,7 @@ def test_child_flow_can_opt_out_of_result_persistence_when_parent_uses_feature()
     assert child_factory.storage_block_id is not None
 
 
-@pytest.mark.parametrize("options", [{"cache_result_in_memory": False}])
-def test_child_flow_persists_result_when_child_uses_feature(options):
-    @flow
-    def foo():
-        return get_run_context().result_factory, bar()
-
-    @flow(**options)
-    def bar():
-        return get_run_context().result_factory
-
-    parent_factory, child_factory = foo()
-    assert parent_factory.persist_result is False
-    assert child_factory.persist_result is True
-    assert child_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(child_factory.storage_block_id, uuid.UUID)
-
-
-def test_child_flow_can_opt_out_of_result_persistence_when_child_uses_feature():
-    child_factory = None
-
-    @flow
-    def foo():
-        bar(return_state=True)
-        return get_run_context().result_factory
-
-    @flow(persist_result=False, cache_result_in_memory=False)
-    def bar():
-        nonlocal child_factory
-        child_factory = get_run_context().result_factory
-
-    parent_factory = foo()
-    assert parent_factory.persist_result is False
-    assert child_factory.persist_result is False
-    assert child_factory.cache_result_in_memory is False
-    assert child_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert child_factory.storage_block_id is not None
-
-
-def test_child_flow_inherits_custom_serializer():
+def test_child_flow_inherits_custom_serializer(default_persistence_off):
     @flow(result_serializer="json")
     def foo():
         return get_run_context().result_factory, bar()
@@ -431,7 +387,7 @@ def test_child_flow_inherits_custom_serializer():
     assert child_factory.storage_block_id is not None
 
 
-async def test_child_flow_inherits_custom_storage(tmp_path):
+async def test_child_flow_inherits_custom_storage(tmp_path, default_persistence_off):
     storage = LocalFileSystem(basepath=tmp_path / "test")
     storage_id = await storage.save("test")
 
@@ -450,7 +406,7 @@ async def test_child_flow_inherits_custom_storage(tmp_path):
     assert child_factory.storage_block_id == storage_id
 
 
-def test_child_flow_custom_serializer():
+def test_child_flow_custom_serializer(default_persistence_off):
     @flow
     def foo():
         return get_run_context().result_factory, bar()
@@ -467,7 +423,7 @@ def test_child_flow_custom_serializer():
     assert child_factory.storage_block_id is not None
 
 
-async def test_child_flow_custom_storage(tmp_path):
+async def test_child_flow_custom_storage(tmp_path, default_persistence_off):
     storage = LocalFileSystem(basepath=tmp_path / "test")
     storage_id = await storage.save("test")
 
@@ -571,13 +527,13 @@ def test_task_custom_persist_setting():
     def foo():
         return get_run_context().result_factory, bar()
 
-    @flow(persist_result=True)
+    @flow(persist_result=False)
     def bar():
         return get_run_context().result_factory
 
     flow_factory, task_factory = foo()
-    assert flow_factory.persist_result is False
-    assert task_factory.persist_result is True
+    assert flow_factory.persist_result is True
+    assert task_factory.persist_result is False
     assert task_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
     assert isinstance(task_factory.storage_block_id, uuid.UUID)
@@ -610,45 +566,9 @@ def test_task_custom_cache_setting(toggle):
         assert isinstance(task_factory.storage_block_id, uuid.UUID)
 
 
-@pytest.mark.parametrize("options", [{"retries": 3}])
-def test_task_persists_result_when_flow_uses_feature(options):
-    @flow(**options)
-    def foo():
-        return get_run_context().result_factory, bar()
-
-    @task
-    def bar():
-        return get_run_context().result_factory
-
-    flow_factory, task_factory = foo()
-    assert flow_factory.persist_result is False
-    assert task_factory.persist_result is True
-    assert task_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(task_factory.storage_block_id, uuid.UUID)
-
-
-@pytest.mark.parametrize(
-    "options", [{"cache_key_fn": lambda *_: "foo"}, {"cache_result_in_memory": False}]
-)
-def test_task_persists_result_when_task_uses_feature(options):
-    @flow
-    def foo():
-        return get_run_context().result_factory, bar()
-
-    @task(**options)
-    def bar():
-        return get_run_context().result_factory
-
-    flow_factory, task_factory = foo()
-    assert flow_factory.persist_result is False
-    assert task_factory.persist_result is True
-    assert task_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
-    assert isinstance(task_factory.storage_block_id, uuid.UUID)
-
-
-def test_task_can_opt_out_of_result_persistence_when_flow_uses_feature():
+def test_task_can_opt_out_of_result_persistence_when_flow_uses_feature(
+    default_persistence_off,
+):
     @flow(retries=3)
     def foo():
         return get_run_context().result_factory, bar()
@@ -680,8 +600,8 @@ def test_task_can_opt_out_when_persist_result_default_is_overriden_by_setting():
     assert task_factory.persist_result is False
 
 
-def test_task_inherits_custom_serializer():
-    @flow(result_serializer="json")
+def test_task_inherits_custom_serializer(default_persistence_off):
+    @flow(result_serializer="json", persist_result=False)
     def foo():
         return get_run_context().result_factory, bar()
 
@@ -715,12 +635,12 @@ async def test_task_inherits_custom_storage(tmp_path):
     assert task_factory.storage_block_id == storage_id
 
 
-def test_task_custom_serializer():
+def test_task_custom_serializer(default_persistence_off):
     @flow
     def foo():
         return get_run_context().result_factory, bar()
 
-    @flow(result_serializer="json")
+    @flow(result_serializer="json", persist_result=False)
     def bar():
         return get_run_context().result_factory
 
@@ -747,7 +667,7 @@ async def test_task_custom_storage(tmp_path):
     flow_factory, task_factory = foo()
     assert_blocks_equal(flow_factory.storage_block, DEFAULT_STORAGE())
     assert_blocks_equal(task_factory.storage_block, storage)
-    assert task_factory.persist_result is False
+    assert task_factory.persist_result is True
     assert task_factory.serializer == DEFAULT_SERIALIZER()
     assert task_factory.storage_block_id == storage_id
 
@@ -839,7 +759,7 @@ async def test_default_storage_creation_for_flow_with_persistence_features(
 
 
 async def test_default_storage_creation_for_flow_without_persistence_features():
-    @flow()
+    @flow(persist_result=False)
     def foo():
         return get_run_context().result_factory
 

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -990,7 +990,7 @@ class TestPauseFlowRun:
         class FlowInput(RunInput):
             x: int
 
-        @flow
+        @flow(persist_result=False)
         async def pausing_flow():
             nonlocal flow_run_id
             context = FlowRunContext.get()
@@ -1273,7 +1273,7 @@ class TestSuspendFlowRun:
         class FlowInput(RunInput):
             x: int
 
-        @flow()
+        @flow(persist_result=False)
         async def suspending_flow():
             nonlocal flow_run_id
             context = get_run_context()

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -409,7 +409,6 @@ class TestFlowWithOptions:
 
     def test_with_options_can_unset_result_options_with_none(self, tmp_path: Path):
         @flow(
-            persist_result=True,
             result_serializer="json",
             result_storage=LocalFileSystem(basepath=tmp_path),
         )
@@ -417,11 +416,9 @@ class TestFlowWithOptions:
             pass
 
         flow_with_options = initial_flow.with_options(
-            persist_result=None,
             result_serializer=None,
             result_storage=None,
         )
-        assert flow_with_options.persist_result is None
         assert flow_with_options.result_serializer is None
         assert flow_with_options.result_storage is None
 

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -140,17 +140,19 @@ class TestReturnValueToState:
         state = Completed(data="hello!")
         assert await return_value_to_state(state, factory) is state
 
-    async def test_returns_single_state_with_null_data(self, factory):
+    async def test_returns_single_state_with_null_data_and_persist_off(
+        self, prefect_client
+    ):
+        factory = await ResultFactory.default_factory(
+            client=prefect_client, persist_result=False
+        )
         state = Completed(data=None)
         result_state = await return_value_to_state(state, factory)
         assert result_state is state
         assert isinstance(result_state.data, UnpersistedResult)
         assert await result_state.result() is None
 
-    async def test_returns_single_state_with_data_to_persist(self, prefect_client):
-        factory = await ResultFactory.default_factory(
-            client=prefect_client, persist_result=True
-        )
+    async def test_returns_single_state_with_data_to_persist(self, factory):
         state = Completed(data=1)
         result_state = await return_value_to_state(state, factory)
         assert result_state is state

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2988,7 +2988,6 @@ class TestTaskWithOptions:
 
     def test_with_options_can_unset_result_options_with_none(self, tmp_path: Path):
         @task(
-            persist_result=True,
             result_serializer="json",
             result_storage=LocalFileSystem(basepath=tmp_path),
             refresh_cache=True,
@@ -2998,13 +2997,11 @@ class TestTaskWithOptions:
             pass
 
         task_with_options = initial_task.with_options(
-            persist_result=None,
             result_serializer=None,
             result_storage=None,
             refresh_cache=None,
             result_storage_key=None,
         )
-        assert task_with_options.persist_result is None
         assert task_with_options.result_serializer is None
         assert task_with_options.result_storage is None
         assert task_with_options.refresh_cache is None


### PR DESCRIPTION
Sets `PREFECT_RESULTS_PERSIST_BY_DEFAULT` to `True` by default