### PR TITLE
Makes the OpenAPI docs generation more robust

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,9 +37,11 @@ repos:
         name: Generating OpenAPI docs for Mintlify
         language: system
         entry: ./scripts/generate_mintlify_openapi_docs.py
+        pass_filenames: false
         files: |
             (?x)^(
                 .pre-commit-config.yaml|
-                src/prefect/server/.*|
+                src/prefect/server/api/.*|
+                src/prefect/server/schemas/.*|
                 scripts/generate_mintlify_openapi_docs.py
             )$


### PR DESCRIPTION
I learned something new with `pre-commit`: when you use the default
`pass_filenames: true`, all of the affected files are split into chunks and sent
to many instances of your hook in parallel.  Running `mintlify-scrape` in
parallel is pretty flakey and has been giving people fits.  Since this hook
doesn't need the specific filenames, we can turn off that option so it will
just invoke the script once.

Additionally, I'm using a more robust way to install `mintlify-scrape` with
the `npx` command, which will install it to the right place in a way that
doesn't require installing it globally.
