### PR TITLE
Retries retrieval of persisted results from storage

### DIFF
--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import sys
 import traceback
@@ -22,11 +23,14 @@ from prefect.exceptions import (
     TerminationSignal,
     UnfinishedRun,
 )
+from prefect.logging.loggers import get_logger
 from prefect.results import BaseResult, R, ResultFactory
 from prefect.settings import PREFECT_ASYNC_FETCH_STATE_RESULT
 from prefect.utilities.annotations import BaseAnnotation
 from prefect.utilities.asyncutils import in_async_main_thread, sync_compatible
 from prefect.utilities.collections import ensure_iterable
+
+logger = get_logger("states")
 
 
 def get_state_result(
@@ -61,6 +65,33 @@ def get_state_result(
         return _get_state_result(state, raise_on_failure=raise_on_failure)
 
 
+RESULT_READ_MAXIMUM_ATTEMPTS = 10
+RESULT_READ_RETRY_DELAY = 0.25
+
+
+async def _get_state_result_data_with_retries(state: State[R]) -> R:
+    # Results may be written asynchronously, possibly after their corresponding
+    # state has been written and events have been emitted, so we should give some
+    # grace here about missing results.  The exception below could come in the form
+    # of a missing file, a short read, or other types of errors depending on the
+    # result storage backend.
+    print("in _get_state_result_data_with_retries", repr(state))
+    for i in range(1, RESULT_READ_MAXIMUM_ATTEMPTS + 1):
+        try:
+            return await state.data.get()
+        except Exception as e:
+            if i == RESULT_READ_MAXIMUM_ATTEMPTS:
+                raise
+            logger.debug(
+                "Exception %r while reading result, retry %s/%s in %ss...",
+                e,
+                i,
+                RESULT_READ_MAXIMUM_ATTEMPTS,
+                RESULT_READ_RETRY_DELAY,
+            )
+            await asyncio.sleep(RESULT_READ_RETRY_DELAY)
+
+
 @sync_compatible
 async def _get_state_result(state: State[R], raise_on_failure: bool) -> R:
     """
@@ -81,7 +112,8 @@ async def _get_state_result(state: State[R], raise_on_failure: bool) -> R:
         raise await get_state_exception(state)
 
     if isinstance(state.data, BaseResult):
-        result = await state.data.get()
+        result = await _get_state_result_data_with_retries(state)
+
     elif state.data is None:
         if state.is_failed() or state.is_crashed() or state.is_cancelled():
             return await get_state_exception(state)
@@ -352,7 +384,7 @@ async def get_state_exception(state: State) -> BaseException:
         raise ValueError(f"Expected failed or crashed state got {state!r}.")
 
     if isinstance(state.data, BaseResult):
-        result = await state.data.get()
+        result = await _get_state_result_data_with_retries(state)
     elif state.data is None:
         result = None
     else:

--- a/tests/results/test_persisted_result.py
+++ b/tests/results/test_persisted_result.py
@@ -1,10 +1,13 @@
 import json
+import time
 import uuid
+from unittest import mock
 
 import pendulum
 import pytest
 
-from prefect.filesystems import LocalFileSystem
+import prefect.results
+from prefect.filesystems import LocalFileSystem, WritableFileSystem
 from prefect.results import DEFAULT_STORAGE_KEY_FN, PersistedResult, PersistedResultBlob
 from prefect.serializers import JSONSerializer, PickleSerializer
 
@@ -236,3 +239,96 @@ async def test_lifecycle_of_defer_persistence(storage_block):
     await result.write()
     blob = await result._read_blob()
     assert blob.load() == "test-defer"
+
+
+@pytest.fixture
+def shorter_result_retries(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(prefect.results, "RESULT_READ_RETRIES", 3)
+    monkeypatch.setattr(prefect.results, "RESULT_READ_RETRY_DELAY", 0.01)
+
+
+@pytest.fixture
+async def a_real_result(storage_block: WritableFileSystem) -> PersistedResult:
+    return await PersistedResult.create(
+        "test-graceful-retry",
+        storage_block_id=storage_block._block_document_id,
+        storage_block=storage_block,
+        storage_key_fn=lambda: "test-graceful-retry-path",
+        serializer=JSONSerializer(),
+        defer_persistence=True,
+    )
+
+
+async def test_graceful_retries_are_finite_while_retrieving_missing_results(
+    shorter_result_retries: None,
+    a_real_result: PersistedResult,
+):
+    now = time.monotonic()
+
+    # it should raise if the result has not been written
+    with pytest.raises(ValueError, match="does not exist"):
+        await a_real_result._read_blob()
+
+    # it should have taken ~3 retries for this to raise
+    expected_sleep = (
+        prefect.results.RESULT_READ_RETRIES * prefect.results.RESULT_READ_RETRY_DELAY
+    )
+    assert expected_sleep <= time.monotonic() - now <= expected_sleep * 5
+
+
+async def test_graceful_retries_reraise_last_error_while_retrieving_missing_results(
+    shorter_result_retries: None,
+    a_real_result: PersistedResult,
+):
+    # if it strikes out 3 times, we should re-raise
+    now = time.monotonic()
+    with pytest.raises(FileNotFoundError):
+        with mock.patch(
+            "prefect.filesystems.LocalFileSystem.read_path",
+            new=mock.AsyncMock(
+                side_effect=[
+                    OSError,
+                    TimeoutError,
+                    FileNotFoundError,
+                ]
+            ),
+        ) as m:
+            await a_real_result._read_blob()
+
+    # the loop should have failed three times, sleeping 0.01s per error
+    assert m.call_count == prefect.results.RESULT_READ_RETRIES
+    expected_sleep = (
+        prefect.results.RESULT_READ_RETRIES * prefect.results.RESULT_READ_RETRY_DELAY
+    )
+    assert expected_sleep <= time.monotonic() - now <= expected_sleep * 5
+
+
+async def test_graceful_retries_eventually_succeed_while(
+    shorter_result_retries: None,
+    a_real_result: PersistedResult,
+):
+    # now write the result so it's available
+    await a_real_result.write()
+    expected_blob = await a_real_result._read_blob()
+
+    # even if it misses a couple times, it will eventually return the data
+    now = time.monotonic()
+    with mock.patch(
+        "prefect.filesystems.LocalFileSystem.read_path",
+        new=mock.AsyncMock(
+            side_effect=[
+                FileNotFoundError,
+                TimeoutError,
+                expected_blob.model_dump_json().encode(),
+            ]
+        ),
+    ) as m:
+        blob = await a_real_result._read_blob()
+        assert blob.load() == "test-graceful-retry"
+
+    # the loop should have failed twice, then succeeded, sleeping 0.01s per failure
+    assert m.call_count == prefect.results.RESULT_READ_RETRIES
+    expected_sleep = 2 * prefect.results.RESULT_READ_RETRY_DELAY
+    assert expected_sleep <= time.monotonic() - now <= expected_sleep * 5

--- a/tests/results/test_state_result.py
+++ b/tests/results/test_state_result.py
@@ -2,11 +2,18 @@
 Generic tests for `State.result`
 """
 
+import time
+from unittest import mock
+
 import pytest
 
+import prefect.states
 from prefect.exceptions import UnfinishedRun
-from prefect.results import UnpersistedResult
+from prefect.filesystems import LocalFileSystem, WritableFileSystem
+from prefect.results import PersistedResult, PersistedResultBlob, UnpersistedResult
+from prefect.serializers import JSONSerializer
 from prefect.states import State, StateType
+from prefect.utilities.annotations import NotSet
 
 
 @pytest.mark.parametrize(
@@ -33,3 +40,120 @@ async def test_finished_states_allow_result_retrieval(state_type: StateType):
     state = State(type=state_type, data=await UnpersistedResult.create("test"))
 
     assert await state.result(raise_on_failure=False) == "test"
+
+
+@pytest.fixture
+def shorter_result_retries(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(prefect.states, "RESULT_READ_MAXIMUM_ATTEMPTS", 3)
+    monkeypatch.setattr(prefect.states, "RESULT_READ_RETRY_DELAY", 0.01)
+
+
+@pytest.fixture
+async def storage_block(tmp_path):
+    block = LocalFileSystem(basepath=tmp_path)
+    await block._save(is_anonymous=True)
+    return block
+
+
+@pytest.fixture
+async def a_real_result(storage_block: WritableFileSystem) -> PersistedResult:
+    return await PersistedResult.create(
+        "test-graceful-retry",
+        storage_block_id=storage_block._block_document_id,
+        storage_block=storage_block,
+        storage_key_fn=lambda: "test-graceful-retry-path",
+        serializer=JSONSerializer(),
+        defer_persistence=True,
+    )
+
+
+@pytest.fixture
+def completed_state(a_real_result: PersistedResult) -> State[str]:
+    assert a_real_result.has_cached_object()
+
+    result_copy = a_real_result.model_copy()
+    result_copy._cache = NotSet
+    assert not result_copy.has_cached_object()
+
+    return State(type=StateType.COMPLETED, data=result_copy)
+
+
+async def test_graceful_retries_are_finite_while_retrieving_missing_results(
+    shorter_result_retries: None,
+    completed_state: State[str],
+):
+    now = time.monotonic()
+
+    # it should raise if the result has not been written
+    with pytest.raises(ValueError, match="does not exist"):
+        await completed_state.result()
+
+    # it should have taken ~3 retries for this to raise
+    expected_sleep = (
+        prefect.states.RESULT_READ_MAXIMUM_ATTEMPTS
+        * prefect.states.RESULT_READ_RETRY_DELAY
+    )
+    elapsed = time.monotonic() - now
+    assert elapsed >= expected_sleep
+
+
+async def test_graceful_retries_reraise_last_error_while_retrieving_missing_results(
+    shorter_result_retries: None,
+    completed_state: State[str],
+):
+    # if it strikes out 3 times, we should re-raise
+    now = time.monotonic()
+    with pytest.raises(FileNotFoundError):
+        with mock.patch(
+            "prefect.filesystems.LocalFileSystem.read_path",
+            new=mock.AsyncMock(
+                side_effect=[
+                    OSError,
+                    TimeoutError,
+                    FileNotFoundError,
+                ]
+            ),
+        ) as m:
+            await completed_state.result()
+
+    # the loop should have failed three times, sleeping 0.01s per error
+    assert m.call_count == prefect.states.RESULT_READ_MAXIMUM_ATTEMPTS
+    expected_sleep = (
+        prefect.states.RESULT_READ_MAXIMUM_ATTEMPTS
+        * prefect.states.RESULT_READ_RETRY_DELAY
+    )
+    elapsed = time.monotonic() - now
+    assert elapsed >= expected_sleep
+
+
+async def test_graceful_retries_eventually_succeed_while(
+    shorter_result_retries: None,
+    a_real_result: PersistedResult,
+    completed_state: State[str],
+):
+    # now write the result so it's available
+    await a_real_result.write()
+    expected_blob = await a_real_result._read_blob()
+    assert isinstance(expected_blob, PersistedResultBlob)
+
+    # even if it misses a couple times, it will eventually return the data
+    now = time.monotonic()
+    with mock.patch(
+        "prefect.filesystems.LocalFileSystem.read_path",
+        new=mock.AsyncMock(
+            side_effect=[
+                FileNotFoundError,
+                TimeoutError,
+                expected_blob.model_dump_json().encode(),
+            ]
+        ),
+    ) as m:
+        assert await completed_state.result() == "test-graceful-retry"
+
+    # the loop should have failed twice, then succeeded, sleeping 0.01s per failure
+    assert m.call_count == prefect.states.RESULT_READ_MAXIMUM_ATTEMPTS
+    expected_sleep = 2 * prefect.states.RESULT_READ_RETRY_DELAY
+    elapsed = time.monotonic() - now
+    assert elapsed >= expected_sleep


### PR DESCRIPTION
With some recent changes to transactions, we are now emitting events slightly
before we write results to their storage backend.  While we should undertake a
fuller refactoring to uncouple transaction storage from individual results, we
can also get by with a few built-in graceful retries here.  This should smooth
over the issue with the race condition, as well as help with transient network
issues on remote filesystems.

Part of #14189
