### PR TITLE
Get `parameters` from flow definition if none are given otherwise

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -10,9 +10,6 @@ from prefect.exceptions import (
 from prefect.logging.loggers import (
     get_logger,
 )
-from prefect.utilities.asyncutils import (
-    run_coro_as_sync,
-)
 
 engine_logger = get_logger("engine")
 
@@ -35,11 +32,7 @@ if __name__ == "__main__":
         )
 
         flow_run, flow = load_flow_and_flow_run(flow_run_id=flow_run_id)
-        # run the flow
-        if flow.isasync:
-            run_coro_as_sync(run_flow(flow, flow_run=flow_run))
-        else:
-            run_flow(flow, flow_run=flow_run)
+        run_flow(flow, flow_run=flow_run)
     except Abort as exc:
         engine_logger.info(
             f"Engine execution of flow run '{flow_run_id}' aborted by orchestrator:"

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -31,16 +31,15 @@ if __name__ == "__main__":
     try:
         from prefect.flow_engine import (
             load_flow_and_flow_run,
-            run_flow_async,
-            run_flow_sync,
+            run_flow,
         )
 
         flow_run, flow = load_flow_and_flow_run(flow_run_id=flow_run_id)
         # run the flow
         if flow.isasync:
-            run_coro_as_sync(run_flow_async(flow, flow_run=flow_run))
+            run_coro_as_sync(run_flow(flow, flow_run=flow_run))
         else:
-            run_flow_sync(flow, flow_run=flow_run)
+            run_flow(flow, flow_run=flow_run)
     except Abort as exc:
         engine_logger.info(
             f"Engine execution of flow run '{flow_run_id}' aborted by orchestrator:"

--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -10,6 +10,9 @@ from prefect.exceptions import (
 from prefect.logging.loggers import (
     get_logger,
 )
+from prefect.utilities.asyncutils import (
+    run_coro_as_sync,
+)
 
 engine_logger = get_logger("engine")
 
@@ -32,7 +35,12 @@ if __name__ == "__main__":
         )
 
         flow_run, flow = load_flow_and_flow_run(flow_run_id=flow_run_id)
-        run_flow(flow, flow_run=flow_run)
+        # run the flow
+        if flow.isasync:
+            run_coro_as_sync(run_flow(flow, flow_run=flow_run))
+        else:
+            run_flow(flow, flow_run=flow_run)
+
     except Abort as exc:
         engine_logger.info(
             f"Engine execution of flow run '{flow_run_id}' aborted by orchestrator:"

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -737,6 +737,15 @@ def run_flow(
 def _flow_parameters(
     flow: Flow[P, R], flow_run: Optional[FlowRun], parameters: Optional[Dict[str, Any]]
 ) -> Dict[str, Any]:
-    parameters = (flow_run.parameters if flow_run else parameters) or {}
-    args, kwargs = parameters_to_args_kwargs(flow.fn, parameters)
-    return get_call_parameters(flow.fn, args, kwargs)
+    if parameters:
+        # This path is taken when a flow is being called directly with
+        # parameters, in that case just return the parameters as-is.
+        return parameters
+
+    # Otherwise the flow is being executed indirectly and we may need to grab
+    # the parameters from the flow run. We also need to resolve any default
+    # parameters that are defined on the flow function itself.
+
+    parameters = flow_run.parameters if flow_run else {}
+    call_args, call_kwargs = parameters_to_args_kwargs(flow.fn, parameters)
+    return get_call_parameters(flow.fn, call_args, call_kwargs)

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -737,9 +737,6 @@ def run_flow(
 def _flow_parameters(
     flow: Flow[P, R], flow_run: Optional[FlowRun], parameters: Optional[Dict[str, Any]]
 ) -> Dict[str, Any]:
-    if flow_run and flow_run.parameters:
-        return flow_run.parameters
-    elif parameters:
-        return parameters
-    else:
-        return get_call_parameters(flow.fn, (), {})
+    parameters = (flow_run.parameters if flow_run else parameters) or {}
+    args, kwargs = parameters_to_args_kwargs(flow.fn, parameters)
+    return get_call_parameters(flow.fn, args, kwargs)

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -51,7 +51,11 @@ from prefect.states import (
     return_value_to_state,
 )
 from prefect.utilities.asyncutils import run_coro_as_sync
-from prefect.utilities.callables import call_with_parameters, parameters_to_args_kwargs
+from prefect.utilities.callables import (
+    call_with_parameters,
+    get_call_parameters,
+    parameters_to_args_kwargs,
+)
 from prefect.utilities.collections import visit_collection
 from prefect.utilities.engine import (
     _get_hook_name,
@@ -595,10 +599,11 @@ def run_flow_sync(
     wait_for: Optional[Iterable[PrefectFuture]] = None,
     return_type: Literal["state", "result"] = "result",
 ) -> Union[R, State, None]:
-    parameters = flow_run.parameters if flow_run else parameters
-
     engine = FlowRunEngine[P, R](
-        flow=flow, parameters=parameters, flow_run=flow_run, wait_for=wait_for
+        flow=flow,
+        parameters=parameters,
+        flow_run=flow_run,
+        wait_for=wait_for,
     )
 
     with engine.start():
@@ -616,8 +621,6 @@ async def run_flow_async(
     wait_for: Optional[Iterable[PrefectFuture]] = None,
     return_type: Literal["state", "result"] = "result",
 ) -> Union[R, State, None]:
-    parameters = flow_run.parameters if flow_run else parameters
-
     engine = FlowRunEngine[P, R](
         flow=flow, parameters=parameters, flow_run=flow_run, wait_for=wait_for
     )
@@ -714,10 +717,13 @@ def run_flow(
     kwargs = dict(
         flow=flow,
         flow_run=flow_run,
-        parameters=parameters,
+        parameters=_flow_parameters(
+            flow=flow, flow_run=flow_run, parameters=parameters
+        ),
         wait_for=wait_for,
         return_type=return_type,
     )
+
     if flow.isasync and flow.isgenerator:
         return run_generator_flow_async(**kwargs)
     elif flow.isgenerator:
@@ -726,3 +732,14 @@ def run_flow(
         return run_flow_async(**kwargs)
     else:
         return run_flow_sync(**kwargs)
+
+
+def _flow_parameters(
+    flow: Flow[P, R], flow_run: Optional[FlowRun], parameters: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
+    if flow_run and flow_run.parameters:
+        return flow_run.parameters
+    elif parameters:
+        return parameters
+    else:
+        return get_call_parameters(flow.fn, (), {})

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -128,12 +128,12 @@ class TestFlowRunsAsync:
             y: str
 
         @flow
-        async def bar(model: TheModel = {"x": 42, "y": "nate"}):  # type: ignore
-            return model.x, model.y
+        async def bar(required: str, model: TheModel = {"x": 42, "y": "nate"}):  # type: ignore
+            return required, model.x, model.y
 
-        result = await run_flow(bar)
+        result = await run_flow(bar, parameters={"required": "hello"})
 
-        assert result == (42, "nate")
+        assert result == ("hello", 42, "nate")
 
     async def test_with_param_validation(self):
         @flow
@@ -294,12 +294,12 @@ class TestFlowRunsSync:
             y: str
 
         @flow
-        def bar(model: TheModel = {"x": 42, "y": "nate"}):  # type: ignore
-            return model.x, model.y
+        def bar(required: str, model: TheModel = {"x": 42, "y": "nate"}):  # type: ignore
+            return required, model.x, model.y
 
-        result = run_flow(bar)
+        result = run_flow(bar, parameters={"required": "hello"})
 
-        assert result == (42, "nate")
+        assert result == ("hello", 42, "nate")
 
     async def test_with_param_validation(self):
         @flow
@@ -1552,11 +1552,11 @@ class TestGenerators:
             x: list[int]
 
         @flow
-        async def g(model: TheModel = {"x": [1, 2, 3]}):  # type: ignore
+        async def g(required: str, model: TheModel = {"x": [1, 2, 3]}):  # type: ignore
             for i in model.x:
                 yield i
 
-        assert [i async for i in run_flow(g)] == [1, 2, 3]
+        assert [i async for i in g("hello")] == [1, 2, 3]
 
 
 class TestAsyncGenerators:
@@ -1711,8 +1711,9 @@ class TestAsyncGenerators:
             x: list[int]
 
         @flow
-        def g(model: TheModel = {"x": [1, 2, 3]}):  # type: ignore
+        def g(required: str, model: TheModel = {"x": [1, 2, 3]}):  # type: ignore
+            yield required
             for i in model.x:
                 yield i
 
-        assert [i for i in run_flow(g)] == [1, 2, 3]
+        assert [i for i in g("hello")] == ["hello", 1, 2, 3]

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -122,7 +122,9 @@ class TestFlowRunsAsync:
 
         assert result == (42, "nate")
 
-    async def test_with_default_pydantic_model_dict_params(self):
+    async def test_with_default_pydantic_model_dict_params(
+        self, prefect_client: PrefectClient
+    ):
         class TheModel(pydantic.BaseModel):
             x: int
             y: str
@@ -131,8 +133,10 @@ class TestFlowRunsAsync:
         async def bar(required: str, model: TheModel = {"x": 42, "y": "nate"}):  # type: ignore
             return required, model.x, model.y
 
-        result = await run_flow(bar, parameters={"required": "hello"})
-
+        flow_run = await prefect_client.create_flow_run(
+            bar, parameters={"required": "hello"}
+        )
+        result = await run_flow(flow=bar, flow_run=flow_run)
         assert result == ("hello", 42, "nate")
 
     async def test_with_param_validation(self):
@@ -288,7 +292,9 @@ class TestFlowRunsSync:
 
         assert result == (42, "nate")
 
-    async def test_with_default_pydantic_model_dict_params(self):
+    async def test_with_default_pydantic_model_dict_params(
+        self, prefect_client: PrefectClient
+    ):
         class TheModel(pydantic.BaseModel):
             x: int
             y: str
@@ -297,8 +303,10 @@ class TestFlowRunsSync:
         def bar(required: str, model: TheModel = {"x": 42, "y": "nate"}):  # type: ignore
             return required, model.x, model.y
 
-        result = run_flow(bar, parameters={"required": "hello"})
-
+        flow_run = await prefect_client.create_flow_run(
+            bar, parameters={"required": "hello"}
+        )
+        result = run_flow(flow=bar, flow_run=flow_run)
         assert result == ("hello", 42, "nate")
 
     async def test_with_param_validation(self):


### PR DESCRIPTION
This ensures that when we start a flow run that we pull the parameters from the flow function definition if no parameters are provided via the flow run or passed into the `run_flow` method itself.

This also changes the entrypoint in the engine to use `run_flow` instead of `run_flow_sync` and `run_flow_async`.

Closes #13273 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
- [x] This pull request references any related issue by including "closes `<link to issue>`"
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
