### PR TITLE
Update the v3 docs homepage

### DIFF
--- a/docs/3.0rc/get-started/index.mdx
+++ b/docs/3.0rc/get-started/index.mdx
@@ -44,7 +44,7 @@ if __name__ == "__main__":
     Write and observe workflows, create tasks, and build interactive workflows.
   </Card>
   <Card title="Deploy" icon="rocket" href="/3.0rc/deploy/serve-flows/deploy-a-flow">
-    Serve workflows on long lived infrastructure or scale to zero by deploying workflows to dynamically provisioned infrastructure,.
+    Serve workflows on long lived infrastructure or scale to zero by deploying workflows to dynamically provisioned infrastructure.
   </Card>
   <Card title="React" icon="eyes" href="/3.0rc/automate/events/automations-triggers">
     Enable workflows to react to their environment with events, automations, and webhooks.


### PR DESCRIPTION
The landing page of the 3.0 docs needs to be aligned with the new IA.

Closes https://github.com/PrefectHQ/prefect/issues/13994

### Example

![image 2](https://github.com/PrefectHQ/prefect/assets/186715/92fa5c19-3d91-4407-a3bc-736845cb0fe7)

### TODO

- [x] The **Prefect Cloud**, **Upgrade to Prefect 3**, **Develop**, **Deploy**, and **React** cards don't link to anything yet (they map to section titles, but you can't link to a section title)
- [x] The **Sign up** and **API reference buttons** have a blue bottom border which is inherited from a parent with the `.prose` class, and I'm not sure how to remove it without resorting to custom CSS. Any ideas @discdiver?
- [x] I feel like it would be cleaner to have a single class for turning a link into a primary (or secondary) button instead of having to assign ~10 individual tailwind classes to each `<a>` tag.
- [x] The code block is a bit large, and I think we should either simplify it, or else position it to the right of the buttons so that it doesn't take up so much vertical screen space.