### PR TITLE
returning cursor result from ex/exmany

### DIFF
--- a/src/integrations/prefect-sqlalchemy/prefect_sqlalchemy/database.py
+++ b/src/integrations/prefect-sqlalchemy/prefect_sqlalchemy/database.py
@@ -609,7 +609,7 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
         **execution_options: Dict[str, Any],
-    ) -> None:
+    ) -> CursorResult:
         """
         Executes an operation on the database. This method is intended to be used
         for operations that do not return data, such as INSERT, UPDATE, or DELETE.
@@ -636,13 +636,14 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
             ```
         """  # noqa
         async with self._manage_connection(begin=False) as connection:
-            await self._async_sync_execute(
+            result = await self._async_sync_execute(
                 connection,
                 text(operation),
                 parameters,
                 execution_options=execution_options,
             )
         self.logger.info(f"Executed the operation, {operation!r}")
+        return result
 
     @sync_compatible
     async def execute_many(

--- a/src/integrations/prefect-sqlalchemy/prefect_sqlalchemy/database.py
+++ b/src/integrations/prefect-sqlalchemy/prefect_sqlalchemy/database.py
@@ -650,7 +650,7 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         operation: str,
         seq_of_parameters: List[Dict[str, Any]],
         **execution_options: Dict[str, Any],
-    ) -> None:
+    ) -> CursorResult:
         """
         Executes many operations on the database. This method is intended to be used
         for operations that do not return data, such as INSERT, UPDATE, or DELETE.
@@ -681,7 +681,7 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
             ```
         """  # noqa
         async with self._manage_connection(begin=False) as connection:
-            await self._async_sync_execute(
+            result = await self._async_sync_execute(
                 connection,
                 text(operation),
                 seq_of_parameters,
@@ -690,6 +690,7 @@ class SqlAlchemyConnector(CredentialsBlock, DatabaseBlock):
         self.logger.info(
             f"Executed {len(seq_of_parameters)} operations based off {operation!r}."
         )
+        return result
 
     async def __aenter__(self):
         """

--- a/src/integrations/prefect-sqlalchemy/tests/test_database.py
+++ b/src/integrations/prefect-sqlalchemy/tests/test_database.py
@@ -12,6 +12,7 @@ from prefect_sqlalchemy.database import (
 )
 from sqlalchemy import __version__ as SQLALCHEMY_VERSION
 from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.engine.cursor import CursorResult
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
 
 from prefect import flow, task
@@ -163,7 +164,7 @@ class TestSqlAlchemyConnector:
             "INSERT INTO customers (name, address) VALUES (:name, :address);",
             parameters={"name": "Marvin", "address": "Highway 42"},
         )
-        await credentials.execute_many(
+        many_result = await credentials.execute_many(
             "INSERT INTO customers (name, address) VALUES (:name, :address);",
             seq_of_parameters=[
                 {"name": "Ford", "address": "Highway 42"},
@@ -171,6 +172,7 @@ class TestSqlAlchemyConnector:
                 {"name": "Me", "address": "Myway 88"},
             ],
         )
+        assert isinstance(many_result, CursorResult)
         yield credentials
 
     @pytest.fixture(params=[True, False])

--- a/src/integrations/prefect-sqlalchemy/tests/test_database.py
+++ b/src/integrations/prefect-sqlalchemy/tests/test_database.py
@@ -157,10 +157,10 @@ class TestSqlAlchemyConnector:
             ),
             fetch_size=2,
         )
-        await credentials.execute(
+        create_result = await credentials.execute(
             "CREATE TABLE IF NOT EXISTS customers (name varchar, address varchar);"
         )
-        await credentials.execute(
+        insert_result = await credentials.execute(
             "INSERT INTO customers (name, address) VALUES (:name, :address);",
             parameters={"name": "Marvin", "address": "Highway 42"},
         )
@@ -173,6 +173,8 @@ class TestSqlAlchemyConnector:
             ],
         )
         assert isinstance(many_result, CursorResult)
+        assert isinstance(insert_result, CursorResult)
+        assert isinstance(create_result, CursorResult)
         yield credentials
 
     @pytest.fixture(params=[True, False])


### PR DESCRIPTION
Closes #14232 

Returns a CursorResult object when using execute / executemany.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
- [x] This pull request references any related issue by including "closes `<link to issue>`"
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
