### PR TITLE
Add extra info to pydantic error to help users recover

### DIFF
--- a/src/prefect/flow_runs.py
+++ b/src/prefect/flow_runs.py
@@ -340,7 +340,7 @@ async def suspend_flow_run(
     already started will run until completion. When resumed, the flow run will
     be rescheduled to finish execution. In order suspend a flow run in this
     way, the flow needs to have an associated deployment and results need to be
-    configured with the `persist_results` option.
+    configured with the `persist_result` option.
 
     Args:
         flow_run_id: a flow run id. If supplied, this function will attempt to

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -621,7 +621,10 @@ class PersistedResult(BaseResult):
         try:
             data = serializer.dumps(obj)
         except Exception as exc:
-            extra_info = ""
+            extra_info = (
+                'You can try a different serializer (e.g. result_serializer="json") '
+                "or disabling persistence (persist_result=False) for this flow or task."
+            )
             # check if this is a known issue with cloudpickle and pydantic
             # and add extra information to help the user recover
 

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -639,15 +639,18 @@ class PersistedResult(BaseResult):
                     if get_ipython() is not None:
                         extra_info = inspect.cleandoc(
                             """
-                        This is a known issue in Pydantic that prevents models
-                        from being serialized by cloudpickle in IPython/Jupyter
-                        environments. Please see
-                        https://github.com/pydantic/pydantic/issues/8232 for
-                        more information. To fix the issue, either use the JSON
-                        serializer (`result_serializer="json"`) or disable
-                        result persistence (`persist_result=False`) when
-                        creating this flow or task.
-                        """
+                            This is a known issue in Pydantic that prevents
+                            locally-defined (non-imported) models from being
+                            serialized by cloudpickle in IPython/Jupyter
+                            environments. Please see
+                            https://github.com/pydantic/pydantic/issues/8232 for
+                            more information. To fix the issue, either: (1) move
+                            your Pydantic class definition to an importable
+                            location, (2) use the JSON serializer for your flow
+                            or task (`result_serializer="json"`), or (3)
+                            disable result persistence for your flow or task
+                            (`persist_result=False`).
+                            """
                         ).replace("\n", " ")
                 except ImportError:
                     pass


### PR DESCRIPTION
There is a longstanding issue with pickling locally-defined Pydantic models that is suddenly biting a lot of users (including myself 😅 ) now that we are optimistically persisting results by default for the transactional layer. A user testing ControlFlow immediately ran into this last night. We can take steps in CF proactively because we know what the user is trying to do, but I'm not sure how heavy-handed we can be in Prefect proper. For example, I do not think we can automatically select a different serializer at this point. Instead, this PR adds an explanation to what is otherwise a very cryptic error (`TypeError: cannot pickle 'sqlite3.Connection' object`), which we reraise.