### PR TITLE
Move and rename client page

### DIFF
--- a/docs/3.0rc/manage/interact-with-api.mdx
+++ b/docs/3.0rc/manage/interact-with-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: Manipulate run metadata in Python
+title: Manage run metadata in Python
 description: Learn how to use the `PrefectClient` to interact with the API.
 ---
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -105,7 +105,8 @@
             "3.0rc/develop/artifacts",
             "3.0rc/develop/variables",
             "3.0rc/develop/blocks",
-            "3.0rc/develop/interact-with-data"
+            "3.0rc/develop/interact-with-data",
+            "3.0rc/manage/interact-with-api"
           ]
         },
         {
@@ -199,8 +200,7 @@
           ]
         },
         "3.0rc/manage/self-host",
-        "3.0rc/manage/configure-client",
-        "3.0rc/manage/interact-with-api"
+        "3.0rc/manage/configure-client"
       ]
     },
     {


### PR DESCRIPTION
I think this page belongs in the "Manage state and configuration" section. Open to pushback

Shortens the title, which was wrapped in the sidebar