### PR TITLE
Remove announce dismiss in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,7 +40,6 @@ theme:
     custom_dir: docs/overrides
     favicon: img/favicon.png
     features:
-        - announce.dismiss
         - content.action.edit
         - content.code.copy
         - navigation.tabs.sticky


### PR DESCRIPTION
Attempting to get 3.x docs bar to show.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
