### PR TITLE
Infer task result persistence from other settings

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -335,6 +335,11 @@ class Flow(Generic[P, R]):
                     "Disable validation or change the argument names."
                 ) from exc
 
+        # result persistence settings
+        if persist_result is None:
+            if result_storage is not None or result_serializer is not None:
+                persist_result = True
+
         self.persist_result = persist_result
         self.result_storage = result_storage
         self.result_serializer = result_serializer

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -268,7 +268,14 @@ class ResultFactory(BaseModel):
             if ctx and ctx.result_factory
             else get_default_result_serializer()
         )
-        persist_result = task.persist_result
+        if task.persist_result is None:
+            persist_result = (
+                ctx.result_factory.persist_result
+                if ctx and ctx.result_factory
+                else get_default_persist_setting()
+            )
+        else:
+            persist_result = task.persist_result
 
         cache_result_in_memory = task.cache_result_in_memory
 

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -50,7 +50,6 @@ from prefect.futures import PrefectDistributedFuture, PrefectFuture, PrefectFutu
 from prefect.logging.loggers import get_logger
 from prefect.results import ResultFactory, ResultSerializer, ResultStorage
 from prefect.settings import (
-    PREFECT_RESULTS_PERSIST_BY_DEFAULT,
     PREFECT_TASK_DEFAULT_RETRIES,
     PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS,
 )
@@ -399,10 +398,8 @@ class Task(Generic[P, R]):
                 ]
             ):
                 persist_result = True
-            else:
-                persist_result = PREFECT_RESULTS_PERSIST_BY_DEFAULT.value()
 
-        if not persist_result:
+        if persist_result is False:
             self.cache_policy = None if cache_policy is None else NONE
             if cache_policy and cache_policy is not NotSet and cache_policy != NONE:
                 logger.warning(
@@ -504,7 +501,7 @@ class Task(Generic[P, R]):
             Type[NotSet],
         ] = NotSet,
         retry_jitter_factor: Union[float, Type[NotSet]] = NotSet,
-        persist_result: Union[bool, Type[NotSet]] = None,
+        persist_result: Union[bool, Type[NotSet]] = NotSet,
         result_storage: Union[ResultStorage, Type[NotSet]] = NotSet,
         result_serializer: Union[ResultSerializer, Type[NotSet]] = NotSet,
         result_storage_key: Union[str, Type[NotSet]] = NotSet,
@@ -621,7 +618,9 @@ class Task(Generic[P, R]):
                 if retry_jitter_factor is not NotSet
                 else self.retry_jitter_factor
             ),
-            persist_result=persist_result,
+            persist_result=(
+                persist_result if persist_result is not NotSet else self.persist_result
+            ),
             result_storage=(
                 result_storage if result_storage is not NotSet else self.result_storage
             ),

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -504,7 +504,7 @@ class Task(Generic[P, R]):
             Type[NotSet],
         ] = NotSet,
         retry_jitter_factor: Union[float, Type[NotSet]] = NotSet,
-        persist_result: Union[bool, Type[NotSet]] = NotSet,
+        persist_result: Union[bool, Type[NotSet]] = None,
         result_storage: Union[ResultStorage, Type[NotSet]] = NotSet,
         result_serializer: Union[ResultSerializer, Type[NotSet]] = NotSet,
         result_storage_key: Union[str, Type[NotSet]] = NotSet,
@@ -621,9 +621,7 @@ class Task(Generic[P, R]):
                 if retry_jitter_factor is not NotSet
                 else self.retry_jitter_factor
             ),
-            persist_result=(
-                persist_result if persist_result is not NotSet else self.persist_result
-            ),
+            persist_result=persist_result,
             result_storage=(
                 result_storage if result_storage is not NotSet else self.result_storage
             ),

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -387,8 +387,23 @@ class Task(Generic[P, R]):
         self.cache_expiration = cache_expiration
         self.refresh_cache = refresh_cache
 
+        # result persistence settings
         if persist_result is None:
-            persist_result = PREFECT_RESULTS_PERSIST_BY_DEFAULT.value()
+            if cache_policy and cache_policy != NONE:
+                persist_result = True
+            elif cache_key_fn is not None:
+                persist_result = True
+            elif any(
+                [
+                    result_storage_key is not None,
+                    result_storage is not None,
+                    result_serializer is not None,
+                ]
+            ):
+                persist_result = True
+            else:
+                persist_result = PREFECT_RESULTS_PERSIST_BY_DEFAULT.value()
+
         if not persist_result:
             self.cache_policy = None if cache_policy is None else NONE
             if cache_policy and cache_policy is not NotSet and cache_policy != NONE:

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -389,7 +389,7 @@ class Task(Generic[P, R]):
 
         # result persistence settings
         if persist_result is None:
-            if cache_policy and cache_policy != NONE:
+            if cache_policy and cache_policy != NONE and cache_policy != NotSet:
                 persist_result = True
             elif cache_key_fn is not None:
                 persist_result = True

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -389,12 +389,10 @@ class Task(Generic[P, R]):
 
         # result persistence settings
         if persist_result is None:
-            if cache_policy and cache_policy != NONE and cache_policy != NotSet:
-                persist_result = True
-            elif cache_key_fn is not None:
-                persist_result = True
-            elif any(
+            if any(
                 [
+                    cache_policy and cache_policy != NONE and cache_policy != NotSet,
+                    cache_key_fn is not None,
                     result_storage_key is not None,
                     result_storage is not None,
                     result_serializer is not None,

--- a/tests/results/test_result_factory.py
+++ b/tests/results/test_result_factory.py
@@ -178,7 +178,7 @@ def test_root_flow_custom_serializer_by_type_string():
 
 
 def test_root_flow_custom_serializer_by_instance(default_persistence_off):
-    @flow(result_serializer=JSONSerializer(jsonlib="orjson"))
+    @flow(persist_result=False, result_serializer=JSONSerializer(jsonlib="orjson"))
     def foo():
         return get_run_context().result_factory
 
@@ -198,7 +198,7 @@ async def test_root_flow_custom_storage_by_slug(tmp_path, default_persistence_of
         return get_run_context().result_factory
 
     result_factory = foo()
-    assert result_factory.persist_result is False
+    assert result_factory.persist_result is True  # inferred from the storage
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_factory.storage_block, storage)
     assert result_factory.storage_block_id == storage_id
@@ -215,7 +215,7 @@ async def test_root_flow_custom_storage_by_instance_presaved(
         return get_run_context().result_factory
 
     result_factory = foo()
-    assert result_factory.persist_result is False
+    assert result_factory.persist_result is True  # inferred from the storage
     assert result_factory.serializer == DEFAULT_SERIALIZER()
     assert result_factory.storage_block == storage
     assert result_factory.storage_block._is_anonymous is False
@@ -370,7 +370,7 @@ def test_child_flow_can_opt_out_of_result_persistence_when_parent_uses_feature(
 
 
 def test_child_flow_inherits_custom_serializer(default_persistence_off):
-    @flow(result_serializer="json")
+    @flow(persist_result=False, result_serializer="json")
     def foo():
         return get_run_context().result_factory, bar()
 
@@ -404,23 +404,6 @@ async def test_child_flow_inherits_custom_storage(tmp_path, default_persistence_
     assert child_factory.storage_block_id == storage_id
 
 
-def test_child_flow_custom_serializer(default_persistence_off):
-    @flow
-    def foo():
-        return get_run_context().result_factory, bar()
-
-    @flow(result_serializer="json")
-    def bar():
-        return get_run_context().result_factory
-
-    parent_factory, child_factory = foo()
-    assert parent_factory.serializer == DEFAULT_SERIALIZER()
-    assert child_factory.persist_result is False
-    assert child_factory.serializer == JSONSerializer()
-    assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert child_factory.storage_block_id is not None
-
-
 async def test_child_flow_custom_storage(tmp_path, default_persistence_off):
     storage = LocalFileSystem(basepath=tmp_path / "test")
     storage_id = await storage.save("test")
@@ -435,7 +418,7 @@ async def test_child_flow_custom_storage(tmp_path, default_persistence_off):
 
     parent_factory, child_factory = foo()
     assert_blocks_equal(parent_factory.storage_block, DEFAULT_STORAGE())
-    assert child_factory.persist_result is False
+    assert child_factory.persist_result is True  # inferred from the storage
     assert child_factory.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(child_factory.storage_block, storage)
     assert child_factory.storage_block_id == storage_id

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -267,6 +267,53 @@ class TestDecorator:
                 pass
 
 
+class TestResultPersistence:
+    @pytest.mark.parametrize("persist_result", [True, False])
+    def test_persist_result_set_to_bool(self, persist_result):
+        @flow(persist_result=persist_result)
+        def my_flow():
+            pass
+
+        @flow
+        def base():
+            pass
+
+        new_flow = base.with_options(persist_result=persist_result)
+
+        assert my_flow.persist_result is persist_result
+        assert new_flow.persist_result is persist_result
+
+    def test_setting_result_storage_sets_persist_result_to_true(self, tmpdir):
+        block = LocalFileSystem(basepath=str(tmpdir))
+
+        @flow(result_storage=block)
+        def my_flow():
+            pass
+
+        @flow
+        def base():
+            pass
+
+        new_flow = base.with_options(result_storage=block)
+
+        assert my_flow.persist_result is True
+        assert new_flow.persist_result is True
+
+    def test_setting_result_serializer_sets_persist_result_to_true(self):
+        @flow(result_serializer="json")
+        def my_flow():
+            pass
+
+        @flow
+        def base():
+            pass
+
+        new_flow = base.with_options(result_serializer="json")
+
+        assert my_flow.persist_result is True
+        assert new_flow.persist_result is True
+
+
 class TestFlowWithOptions:
     def test_with_options_allows_override_of_flow_settings(self):
         @flow(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1192,7 +1192,14 @@ class TestResultPersistence:
         def my_task():
             pass
 
+        @task
+        def base():
+            pass
+
+        new_task = base.with_options(persist_result=persist_result)
+
         assert my_task.persist_result is persist_result
+        assert new_task.persist_result is persist_result
 
     @pytest.mark.parametrize(
         "cache_policy",
@@ -1203,14 +1210,28 @@ class TestResultPersistence:
         def my_task():
             pass
 
+        @task
+        def base():
+            pass
+
+        new_task = base.with_options(cache_policy=cache_policy)
+
         assert my_task.persist_result is True
+        assert new_task.persist_result is True
 
     def test_setting_cache_key_fn_sets_persist_result_to_true(self):
         @task(cache_key_fn=lambda *_: "test-key")
         def my_task():
             pass
 
+        @task
+        def base():
+            pass
+
+        new_task = base.with_options(cache_key_fn=lambda *_: "test-key")
+
         assert my_task.persist_result is True
+        assert new_task.persist_result is True
 
     def test_setting_result_storage_sets_persist_result_to_true(self, tmpdir):
         block = LocalFileSystem(basepath=str(tmpdir))
@@ -1219,21 +1240,42 @@ class TestResultPersistence:
         def my_task():
             pass
 
+        @task
+        def base():
+            pass
+
+        new_task = base.with_options(result_storage=block)
+
         assert my_task.persist_result is True
+        assert new_task.persist_result is True
 
     def test_setting_result_serializer_sets_persist_result_to_true(self):
         @task(result_serializer="json")
         def my_task():
             pass
 
+        @task
+        def base():
+            pass
+
+        new_task = base.with_options(result_serializer="json")
+
         assert my_task.persist_result is True
+        assert new_task.persist_result is True
 
     def test_setting_result_storage_key_sets_persist_result_to_true(self):
         @task(result_storage_key="test-key")
         def my_task():
             pass
 
+        @task
+        def base():
+            pass
+
+        new_task = base.with_options(result_storage_key="test-key")
+
         assert my_task.persist_result is True
+        assert new_task.persist_result is True
 
 
 class TestTaskCaching:


### PR DESCRIPTION
Right now, users have to explicitly set `persist_result=True` in their task inits, _or_ set the global `PREFECT_RESULTS_PERSIST_BY_DEFAULT`.  This is overly conservative; when a user sets other settings such as cache key policies, they are clearly opting into result persistence so we can improve the DX here by making that inference on users' behalf.

In addition, this PR adds similar logic to flow init and allows settings configured at the flow level to become defaults for tasks if they are not otherwise set on the task.