### PR TITLE
Save absolute paths with no block IDs by default

### DIFF
--- a/docs/3.0rc/api-ref/server/schema.json
+++ b/docs/3.0rc/api-ref/server/schema.json
@@ -22250,9 +22250,15 @@
                         "default": true
                     },
                     "PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK": {
-                        "type": "string",
-                        "title": "Prefect Task Scheduling Default Storage Block",
-                        "default": "local-file-system/prefect-task-scheduling"
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Prefect Task Scheduling Default Storage Block"
                     },
                     "PREFECT_TASK_SCHEDULING_DELETE_FAILED_SUBMISSIONS": {
                         "type": "boolean",

--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -114,10 +114,6 @@ class LocalFileSystem(WritableFileSystem, WritableDeploymentStorage):
             resolved_path = basepath / resolved_path
         else:
             resolved_path = resolved_path.resolve()
-            if basepath not in resolved_path.parents and (basepath != resolved_path):
-                raise ValueError(
-                    f"Provided path {resolved_path} is outside of the base path {basepath}."
-                )
 
         return resolved_path
 

--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -95,7 +95,7 @@ class LocalFileSystem(WritableFileSystem, WritableDeploymentStorage):
     def cast_pathlib(cls, value):
         return stringify_path(value)
 
-    def _resolve_path(self, path: str) -> Path:
+    def _resolve_path(self, path: str, validate: bool = False) -> Path:
         # Only resolve the base path at runtime, default to the current directory
         basepath = (
             Path(self.basepath).expanduser().resolve()
@@ -115,6 +115,11 @@ class LocalFileSystem(WritableFileSystem, WritableDeploymentStorage):
         else:
             resolved_path = resolved_path.resolve()
 
+        if validate:
+            if basepath not in resolved_path.parents and (basepath != resolved_path):
+                raise ValueError(
+                    f"Provided path {resolved_path} is outside of the base path {basepath}."
+                )
         return resolved_path
 
     @sync_compatible
@@ -180,7 +185,7 @@ class LocalFileSystem(WritableFileSystem, WritableDeploymentStorage):
         Defaults to copying the entire contents of the current working directory to the block's basepath.
         An `ignore_file` path may be provided that can include gitignore style expressions for filepaths to ignore.
         """
-        destination_path = self._resolve_path(to_path)
+        destination_path = self._resolve_path(to_path, validate=True)
 
         if not local_path:
             local_path = Path(".").absolute()

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -341,6 +341,11 @@ class Flow(Generic[P, R]):
                 persist_result = True
 
         self.persist_result = persist_result
+        if result_storage is not None:
+            if getattr(result_storage, "_block_document_id", None) is None:
+                raise TypeError(
+                    "Result storage must have a block document ID - save it first."
+                )
         self.result_storage = result_storage
         self.result_serializer = result_serializer
         self.cache_result_in_memory = cache_result_in_memory

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -187,7 +187,7 @@ class Flow(Generic[P, R]):
         timeout_seconds: Union[int, float, None] = None,
         validate_parameters: bool = True,
         persist_result: Optional[bool] = None,
-        result_storage: Optional[ResultStorage] = None,
+        result_storage: Optional[Union[ResultStorage, str]] = None,
         result_serializer: Optional[ResultSerializer] = None,
         cache_result_in_memory: bool = True,
         log_prints: Optional[bool] = None,
@@ -341,7 +341,7 @@ class Flow(Generic[P, R]):
                 persist_result = True
 
         self.persist_result = persist_result
-        if result_storage is not None:
+        if result_storage and not isinstance(result_storage, str):
             if getattr(result_storage, "_block_document_id", None) is None:
                 raise TypeError(
                     "Result storage must have a block document ID - save it first."

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -344,7 +344,8 @@ class Flow(Generic[P, R]):
         if result_storage and not isinstance(result_storage, str):
             if getattr(result_storage, "_block_document_id", None) is None:
                 raise TypeError(
-                    "Result storage must have a block document ID - save it first."
+                    "Result storage configuration must be persisted server-side."
+                    " Please call `.save()` on your block before passing it in."
                 )
         self.result_storage = result_storage
         self.result_serializer = result_serializer

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -28,7 +28,6 @@ from prefect.client.utilities import inject_client
 from prefect.exceptions import MissingResult, ObjectAlreadyExists
 from prefect.filesystems import (
     LocalFileSystem,
-    ReadableFileSystem,
     WritableFileSystem,
 )
 from prefect.logging import get_logger
@@ -111,13 +110,18 @@ async def _get_or_create_default_storage(block_document_slug: str) -> ResultStor
 
 
 @sync_compatible
-async def get_or_create_default_result_storage() -> ResultStorage:
+async def get_default_result_storage() -> ResultStorage:
     """
     Generate a default file system for result storage.
     """
-    return await _get_or_create_default_storage(
-        PREFECT_DEFAULT_RESULT_STORAGE_BLOCK.value()
-    )
+    default_block = PREFECT_DEFAULT_RESULT_STORAGE_BLOCK.value()
+
+    if default_block is not None:
+        return await Block.load(default_block)
+
+    # otherwise, use the local file system
+    basepath = PREFECT_LOCAL_STORAGE_PATH.value()
+    return LocalFileSystem(basepath=basepath)
 
 
 async def get_or_create_default_task_scheduling_storage() -> ResultStorage:
@@ -177,9 +181,7 @@ class ResultFactory(BaseModel):
                 kwargs.pop(key)
 
         # Apply defaults
-        kwargs.setdefault(
-            "result_storage", await get_or_create_default_result_storage()
-        )
+        kwargs.setdefault("result_storage", await get_default_result_storage())
         kwargs.setdefault("result_serializer", get_default_result_serializer())
         kwargs.setdefault("persist_result", get_default_persist_setting())
         kwargs.setdefault("cache_result_in_memory", True)
@@ -230,9 +232,7 @@ class ResultFactory(BaseModel):
         """
         Create a new result factory for a task.
         """
-        return await cls._from_task(
-            task, get_or_create_default_result_storage, client=client
-        )
+        return await cls._from_task(task, get_default_result_storage, client=client)
 
     @classmethod
     @inject_client
@@ -337,16 +337,7 @@ class ResultFactory(BaseModel):
                 # Avoid saving the block if it already has an identifier assigned
                 storage_block_id = storage_block._block_document_id
             else:
-                if persist_result:
-                    # TODO: Overwrite is true to avoid issues where the save collides with
-                    # a previously saved document with a matching hash
-                    storage_block_id = await storage_block._save(
-                        is_anonymous=True, overwrite=True, client=client
-                    )
-                else:
-                    # a None-type UUID on unpersisted storage should not matter
-                    # since the ID is generated on the server
-                    storage_block_id = None
+                storage_block_id = None
         elif isinstance(result_storage, str):
             storage_block = await Block.load(result_storage, client=client)
             storage_block_id = storage_block._block_document_id
@@ -419,9 +410,6 @@ class ResultFactory(BaseModel):
 
     @sync_compatible
     async def store_parameters(self, identifier: UUID, parameters: Dict[str, Any]):
-        assert (
-            self.storage_block_id is not None
-        ), "Unexpected storage block ID. Was it persisted?"
         data = self.serializer.dumps(parameters)
         blob = PersistedResultBlob(serializer=self.serializer, data=data)
         await self.storage_block.write_path(
@@ -430,9 +418,6 @@ class ResultFactory(BaseModel):
 
     @sync_compatible
     async def read_parameters(self, identifier: UUID) -> Dict[str, Any]:
-        assert (
-            self.storage_block_id is not None
-        ), "Unexpected storage block ID. Was it persisted?"
         blob = PersistedResultBlob.model_validate_json(
             await self.storage_block.read_path(f"parameters/{identifier}")
         )
@@ -535,8 +520,8 @@ class PersistedResult(BaseResult):
     type: str = "reference"
 
     serializer_type: str
-    storage_block_id: uuid.UUID
     storage_key: str
+    storage_block_id: Optional[uuid.UUID] = None
     expiration: Optional[DateTime] = None
 
     _should_cache_object: bool = PrivateAttr(default=True)
@@ -553,6 +538,17 @@ class PersistedResult(BaseResult):
         self._cache = obj
         self._storage_block = storage_block
         self._serializer = serializer
+
+    @inject_client
+    async def _get_storage_block(self, client: "PrefectClient") -> WritableFileSystem:
+        if self._storage_block is not None:
+            return self._storage_block
+        elif self.storage_block_id is not None:
+            block_document = await client.read_block_document(self.storage_block_id)
+            self._storage_block = Block._from_block_document(block_document)
+        else:
+            self._storage_block = await get_default_result_storage()
+        return self._storage_block
 
     @sync_compatible
     @inject_client
@@ -574,12 +570,8 @@ class PersistedResult(BaseResult):
 
     @inject_client
     async def _read_blob(self, client: "PrefectClient") -> "PersistedResultBlob":
-        assert (
-            self.storage_block_id is not None
-        ), "Unexpected storage block ID. Was it persisted?"
-        block_document = await client.read_block_document(self.storage_block_id)
-        storage_block: ReadableFileSystem = Block._from_block_document(block_document)
-        content = await storage_block.read_path(self.storage_key)
+        block = await self._get_storage_block(client=client)
+        content = await block.read_path(self.storage_key)
         blob = PersistedResultBlob.model_validate_json(content)
         return blob
 
@@ -614,10 +606,7 @@ class PersistedResult(BaseResult):
         obj = obj if obj is not NotSet else self._cache
 
         # next, the storage block
-        storage_block = self._storage_block
-        if storage_block is None:
-            block_document = await client.read_block_document(self.storage_block_id)
-            storage_block = Block._from_block_document(block_document)
+        storage_block = await self._get_storage_block(client=client)
 
         # finally, the serializer
         serializer = self._serializer
@@ -680,9 +669,9 @@ class PersistedResult(BaseResult):
         cls: "Type[PersistedResult]",
         obj: R,
         storage_block: WritableFileSystem,
-        storage_block_id: uuid.UUID,
         storage_key_fn: Callable[[], str],
         serializer: Serializer,
+        storage_block_id: Optional[uuid.UUID] = None,
         cache_object: bool = True,
         expiration: Optional[DateTime] = None,
         defer_persistence: bool = False,
@@ -693,10 +682,6 @@ class PersistedResult(BaseResult):
         The object will be serialized and written to the storage block under a unique
         key. It will then be cached on the returned result.
         """
-        assert (
-            storage_block_id is not None
-        ), "Unexpected storage block ID. Was it saved?"
-
         key = storage_key_fn()
         if not isinstance(key, str):
             raise TypeError(
@@ -711,6 +696,10 @@ class PersistedResult(BaseResult):
                 description += f" persisted to [{uri}]({uri})."
         else:
             description += f" persisted with storage block `{storage_block_id}`."
+
+        # in this case we store an absolute path
+        if storage_block_id is None and uri is not None:
+            key = str(uri)
 
         result = cls(
             serializer_type=serializer.type,

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -128,9 +128,14 @@ async def get_or_create_default_task_scheduling_storage() -> ResultStorage:
     """
     Generate a default file system for background task parameter/result storage.
     """
-    return await _get_or_create_default_storage(
-        PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK.value()
-    )
+    default_block = PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK.value()
+
+    if default_block is not None:
+        return await Block.load(default_block)
+
+    # otherwise, use the local file system
+    basepath = PREFECT_LOCAL_STORAGE_PATH.value()
+    return LocalFileSystem(basepath=basepath)
 
 
 def get_default_result_serializer() -> ResultSerializer:

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -42,7 +42,6 @@ dependent on the value of other settings or perform other dynamic effects.
 
 import logging
 import os
-import socket
 import string
 import warnings
 from contextlib import contextmanager
@@ -85,7 +84,6 @@ from prefect._internal.schemas.validators import validate_settings
 from prefect.exceptions import MissingProfileError
 from prefect.utilities.names import OBFUSCATED_PREFIX, obfuscate
 from prefect.utilities.pydantic import add_cloudpickle_reduction
-from prefect.utilities.slugify import slugify
 
 T = TypeVar("T")
 
@@ -402,18 +400,6 @@ def warn_on_misconfigured_api_url(values):
             warnings.warn("\n".join(warnings_list), stacklevel=2)
 
     return values
-
-
-def default_result_storage_block_name(
-    settings: Optional["Settings"] = None, value: Optional[str] = None
-):
-    """
-    `value_callback` for `PREFECT_DEFAULT_RESULT_STORAGE_BLOCK` that sets the default
-    value to the hostname of the machine.
-    """
-    if value is None:
-        return f"local-file-system/{slugify(socket.gethostname())}-storage"
-    return value
 
 
 def default_database_connection_url(settings, value):
@@ -1423,10 +1409,7 @@ PREFECT_API_SERVICES_TASK_SCHEDULING_ENABLED = Setting(bool, default=True)
 Whether or not to start the task scheduling service in the server application.
 """
 
-PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK = Setting(
-    str,
-    default="local-file-system/prefect-task-scheduling",
-)
+PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK = Setting(Optional[str], default=None)
 """The `block-type/block-document` slug of a block to use as the default storage
 for autonomous tasks."""
 
@@ -1479,7 +1462,8 @@ PREFECT_EXPERIMENTAL_ENABLE_SCHEDULE_CONCURRENCY = Setting(bool, default=False)
 # Defaults -----------------------------------------------------------------------------
 
 PREFECT_DEFAULT_RESULT_STORAGE_BLOCK = Setting(
-    Optional[str], default=None, value_callback=default_result_storage_block_name
+    Optional[str],
+    default=None,
 )
 """The `block-type/block-document` slug of a block to use as the default result storage."""
 

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -439,7 +439,7 @@ class Task(Generic[P, R]):
         self.retry_jitter_factor = retry_jitter_factor
         self.persist_result = persist_result
 
-        if result_storage is not None:
+        if result_storage and not isinstance(result_storage, str):
             if getattr(result_storage, "_block_document_id", None) is None:
                 raise TypeError(
                     "Result storage must have a block document ID - save it first."

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -442,7 +442,8 @@ class Task(Generic[P, R]):
         if result_storage and not isinstance(result_storage, str):
             if getattr(result_storage, "_block_document_id", None) is None:
                 raise TypeError(
-                    "Result storage must have a block document ID - save it first."
+                    "Result storage configuration must be persisted server-side."
+                    " Please call `.save()` on your block before passing it in."
                 )
 
         self.result_storage = result_storage

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -438,6 +438,13 @@ class Task(Generic[P, R]):
 
         self.retry_jitter_factor = retry_jitter_factor
         self.persist_result = persist_result
+
+        if result_storage is not None:
+            if getattr(result_storage, "_block_document_id", None) is None:
+                raise TypeError(
+                    "Result storage must have a block document ID - save it first."
+                )
+
         self.result_storage = result_storage
         self.result_serializer = result_serializer
         self.result_storage_key = result_storage_key

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -22,7 +22,7 @@ from prefect.records.result_store import ResultFactoryStore
 from prefect.results import (
     BaseResult,
     ResultFactory,
-    get_or_create_default_result_storage,
+    get_default_result_storage,
 )
 from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.collections import AutoEnum
@@ -297,7 +297,7 @@ def transaction(
                 }
             )
         else:
-            default_storage = get_or_create_default_result_storage(_sync=True)
+            default_storage = get_default_result_storage(_sync=True)
             if existing_factory:
                 new_factory = existing_factory.model_copy(
                     update={

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -152,7 +152,7 @@ async def test_background_task_state_changes(
     tmp_path,
 ):
     storage = LocalFileSystem(basepath=tmp_path)
-    storage.save("test")
+    await storage.save("test")
 
     @task(result_storage=storage)
     def foo():

--- a/tests/results/test_task_results.py
+++ b/tests/results/test_task_results.py
@@ -183,16 +183,19 @@ async def test_task_with_uncached_but_persisted_result_not_cached_during_flow(
 async def test_task_result_serializer(
     prefect_client, source, serializer, tmp_path: Path
 ):
+    storage = LocalFileSystem(basepath=tmp_path)
+    await storage.save("tmp-test")
+
     @flow(
         result_serializer=serializer if source == "parent" else None,
-        result_storage=LocalFileSystem(basepath=str(tmp_path)),
+        result_storage=storage,
     )
     def foo():
         return bar(return_state=True)
 
     @task(
         result_serializer=serializer if source == "child" else None,
-        result_storage=LocalFileSystem(basepath=str(tmp_path)),
+        result_storage=storage,
         persist_result=True,
     )
     def bar():
@@ -213,6 +216,7 @@ async def test_task_result_serializer(
 @pytest.mark.parametrize("source", ["child", "parent"])
 async def test_task_result_storage(prefect_client, source):
     storage = LocalFileSystem(basepath=PREFECT_HOME.value() / "test-storage")
+    await storage.save("tmp-test-storage")
 
     @flow(result_storage=storage if source == "parent" else None)
     def foo():
@@ -236,6 +240,7 @@ async def test_task_result_storage(prefect_client, source):
 
 async def test_task_result_static_storage_key(prefect_client, tmp_path):
     storage = LocalFileSystem(basepath=tmp_path / "test-storage")
+    await storage.save("tmp-test-storage")
 
     @flow
     def foo():
@@ -259,6 +264,7 @@ async def test_task_result_static_storage_key(prefect_client, tmp_path):
 
 async def test_task_result_parameter_formatted_storage_key(prefect_client, tmp_path):
     storage = LocalFileSystem(basepath=tmp_path / "test-storage")
+    await storage.save("tmp-test-storage-again")
 
     @flow
     def foo():
@@ -286,6 +292,7 @@ async def test_task_result_parameter_formatted_storage_key(prefect_client, tmp_p
 
 async def test_task_result_flow_run_formatted_storage_key(prefect_client, tmp_path):
     storage = LocalFileSystem(basepath=tmp_path / "test-storage")
+    await storage.save("tmp-test-storage-again")
 
     @flow
     def foo():
@@ -339,7 +346,6 @@ async def test_task_literal_result_is_handled_the_same(prefect_client, value):
     @task(
         persist_result=True,
         result_serializer="pickle",
-        result_storage=LocalFileSystem(basepath=PREFECT_HOME.value()),
     )
     def bar():
         return value

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -21,7 +21,6 @@ from prefect.server.api.task_runs import TaskQueue
 from prefect.server.schemas.core import TaskRun as ServerTaskRun
 from prefect.server.services.task_scheduling import TaskSchedulingTimeouts
 from prefect.settings import (
-    PREFECT_LOCAL_STORAGE_PATH,
     PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK,
     PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT,
     temporary_settings,
@@ -107,12 +106,10 @@ async def test_task_submission_with_parameters_reuses_default_storage_block(
     with temporary_settings(
         {
             PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK: "local-file-system/my-tasks",
-            PREFECT_LOCAL_STORAGE_PATH: tmp_path / "some-storage",
         }
     ):
-        # The block will not exist initially
-        with pytest.raises(ValueError, match="Unable to find block document"):
-            await Block.load("local-file-system/my-tasks")
+        block = LocalFileSystem(basepath=tmp_path / "some-storage")
+        await block.save("my-tasks", overwrite=True)
 
         foo_task_without_result_storage = foo_task.with_options(result_storage=None)
         task_run_future_a = foo_task_without_result_storage.apply_async((42,))

--- a/tests/test_filesystems.py
+++ b/tests/test_filesystems.py
@@ -67,11 +67,6 @@ class TestLocalFileSystem:
         assert (tmp_path / "folder").exists()
         assert (tmp_path / "folder" / "test.txt").read_text() == "hello"
 
-    async def test_write_outside_of_basepath(self, tmp_path):
-        fs = LocalFileSystem(basepath=str(tmp_path / "foo"))
-        with pytest.raises(ValueError, match="..."):
-            await fs.write_path(tmp_path / "bar" / "test.txt", content=b"hello")
-
     async def test_read_fails_for_directory(self, tmp_path):
         fs = LocalFileSystem(basepath=str(tmp_path))
         (tmp_path / "folder").mkdir()

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -9,7 +9,6 @@ import pytest
 
 from prefect import task
 from prefect.exceptions import FailedRun, MissingResult
-from prefect.filesystems import LocalFileSystem
 from prefect.futures import (
     PrefectConcurrentFuture,
     PrefectDistributedFuture,
@@ -194,14 +193,8 @@ class TestPrefectDistributedFuture:
         future.wait()
         assert future.state.is_completed()
 
-    async def test_result_with_final_state(self, tmp_path):
-        # TODO: The default result storage block gets deleted during the
-        # execution of this test when it's run in as a suite, so we have to load
-        # a specific block and pass it in manually as the task's result storage.
-        # But why does the result storage block get deleted in the first place?
-        storage = LocalFileSystem(basepath=tmp_path)
-
-        @task(persist_result=True, result_storage=storage)
+    async def test_result_with_final_state(self):
+        @task(persist_result=True)
         def my_task():
             return 42
 

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import random
 import time
 from datetime import timedelta
 from pathlib import Path
@@ -410,14 +411,12 @@ class TestTaskRunsAsync:
 
         assert "__parents__" not in tr.task_inputs
 
-    async def test_task_runs_respect_result_persistence(self, prefect_client, tmp_path):
-        fs = LocalFileSystem(basepath=tmp_path)
-
-        @task(persist_result=False, result_storage=fs)
+    async def test_task_runs_respect_result_persistence(self, prefect_client):
+        @task(persist_result=False)
         async def no_persist():
             return TaskRunContext.get().task_run.id
 
-        @task(persist_result=True, result_storage=fs)
+        @task(persist_result=True)
         async def persist():
             return TaskRunContext.get().task_run.id
 
@@ -436,7 +435,7 @@ class TestTaskRunsAsync:
 
         assert await api_state.result() == run_id
 
-    async def test_task_runs_respect_cache_key(self, tmp_path: Path):
+    async def test_task_runs_respect_cache_key(self):
         @task(cache_key_fn=lambda *args, **kwargs: "key", persist_result=True)
         async def first():
             return 42
@@ -445,10 +444,8 @@ class TestTaskRunsAsync:
         async def second():
             return 500
 
-        fs = LocalFileSystem(basepath=tmp_path)
-
-        one = await run_task_async(first.with_options(result_storage=fs))
-        two = await run_task_async(second.with_options(result_storage=fs))
+        one = await run_task_async(first)
+        two = await run_task_async(second)
 
         assert one == 42
         assert two == 42
@@ -606,16 +603,14 @@ class TestTaskRunsSync:
         assert "__parents__" in inner_run.task_inputs
         assert inner_run.task_inputs["__parents__"][0].id == b
 
-    async def test_task_runs_respect_result_persistence(self, prefect_client, tmp_path):
-        fs = LocalFileSystem(basepath=tmp_path)
-
-        @task(persist_result=False, result_storage=fs)
+    async def test_task_runs_respect_result_persistence(self, prefect_client):
+        @task(persist_result=False)
         def no_persist():
             ctx = TaskRunContext.get()
             assert ctx
             return ctx.task_run.id
 
-        @task(persist_result=True, result_storage=fs)
+        @task(persist_result=True)
         def persist():
             ctx = TaskRunContext.get()
             assert ctx
@@ -636,7 +631,7 @@ class TestTaskRunsSync:
 
         assert await api_state.result() == run_id
 
-    async def test_task_runs_respect_cache_key(self, tmp_path: Path):
+    async def test_task_runs_respect_cache_key(self):
         @task(cache_key_fn=lambda *args, **kwargs: "key", persist_result=True)
         def first():
             return 42
@@ -645,10 +640,8 @@ class TestTaskRunsSync:
         def second():
             return 500
 
-        fs = LocalFileSystem(basepath=tmp_path)
-
-        one = run_task_sync(first.with_options(result_storage=fs))
-        two = run_task_sync(second.with_options(result_storage=fs))
+        one = run_task_sync(first)
+        two = run_task_sync(second)
 
         assert one == 42
         assert two == 42
@@ -1074,16 +1067,14 @@ class TestPersistence:
         assert await state.result() == 42
 
     async def test_task_loads_result_if_exists_using_result_storage_key(
-        self, prefect_client, tmp_path
+        self, prefect_client
     ):
-        fs = LocalFileSystem(basepath=tmp_path)
-
         factory = await ResultFactory.default_factory(
-            client=prefect_client, persist_result=True, result_storage=fs
+            client=prefect_client, persist_result=True
         )
         await factory.create_result(-92, key="foo-bar")
 
-        @task(result_storage=fs, result_storage_key="foo-bar", persist_result=True)
+        @task(result_storage_key="foo-bar", persist_result=True)
         async def async_task():
             return 42
 
@@ -1093,12 +1084,31 @@ class TestPersistence:
         assert isinstance(state.data, PersistedResult)
         assert state.data.storage_key == "foo-bar"
 
+    async def test_task_result_persistence_references_absolute_path(
+        self, prefect_client
+    ):
+        @task(result_storage_key="test-absolute-path", persist_result=True)
+        async def async_task():
+            return 42
+
+        state = await run_task_async(async_task, return_type="state")
+        assert state.is_completed()
+        assert await state.result() == 42
+        assert isinstance(state.data, PersistedResult)
+
+        key_path = Path(state.data.storage_key)
+        assert key_path.is_absolute()
+        assert key_path.name == "test-absolute-path"
+
 
 class TestCachePolicy:
     async def test_result_stored_with_storage_key_if_no_policy_set(
         self, prefect_client
     ):
-        @task(persist_result=True, result_storage_key="foo-bar")
+        # avoid conflicts
+        key = f"foo-bar-{random.randint(0, 10000)}"
+
+        @task(persist_result=True, result_storage_key=key)
         async def async_task():
             return 1800
 
@@ -1106,22 +1116,15 @@ class TestCachePolicy:
 
         assert state.is_completed()
         assert await state.result() == 1800
-        assert state.data.storage_key == "foo-bar"
+        assert state.data.storage_key == key
 
-    async def test_cache_expiration_is_respected(
-        self, prefect_client, tmp_path, advance_time
-    ):
-        fs = LocalFileSystem(basepath=tmp_path)
-
+    async def test_cache_expiration_is_respected(self, prefect_client, advance_time):
         @task(
             persist_result=True,
             result_storage_key="expiring-foo-bar",
             cache_expiration=timedelta(seconds=1.0),
-            result_storage=fs,
         )
         async def async_task():
-            import random
-
             return random.randint(0, 10000)
 
         first_state = await async_task(return_state=True)
@@ -1146,6 +1149,7 @@ class TestCachePolicy:
 
     async def test_cache_expiration_expires(self, prefect_client, tmp_path):
         fs = LocalFileSystem(basepath=tmp_path)
+        await fs.save("test-once")
 
         @task(
             persist_result=True,
@@ -1154,8 +1158,6 @@ class TestCachePolicy:
             result_storage=fs,
         )
         async def async_task():
-            import random
-
             return random.randint(0, 10000)
 
         first_state = await async_task(return_state=True)
@@ -1183,6 +1185,8 @@ class TestCachePolicy:
 
     async def test_none_return_value_does_persist(self, prefect_client, tmp_path):
         fs = LocalFileSystem(basepath=tmp_path)
+        await fs.save("none-test")
+
         FIRST_RUN = True
 
         @task(
@@ -1210,6 +1214,7 @@ class TestCachePolicy:
 
     async def test_flow_parameter_caching(self, prefect_client, tmp_path):
         fs = LocalFileSystem(basepath=tmp_path)
+        await fs.save("param-test")
 
         @task(
             cache_policy=FLOW_PARAMETERS,
@@ -1217,8 +1222,6 @@ class TestCachePolicy:
             persist_result=True,
         )
         def my_random_task(x: int):
-            import random
-
             return random.randint(0, x)
 
         @flow
@@ -1247,6 +1250,7 @@ class TestCachePolicy:
 
     async def test_bad_api_result_references_cause_reruns(self, tmp_path: Path):
         fs = LocalFileSystem(basepath=tmp_path)
+        await fs.save("badapi")
 
         PAYLOAD = {"return": 42}
 

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -1116,7 +1116,7 @@ class TestCachePolicy:
 
         assert state.is_completed()
         assert await state.result() == 1800
-        assert state.data.storage_key == key
+        assert Path(state.data.storage_key).name == key
 
     async def test_cache_expiration_is_respected(self, prefect_client, advance_time):
         @task(

--- a/tests/test_task_worker.py
+++ b/tests/test_task_worker.py
@@ -2,6 +2,7 @@ import asyncio
 import signal
 import uuid
 from contextlib import contextmanager
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import anyio
@@ -369,9 +370,9 @@ class TestTaskWorkerTaskResults:
         assert await updated_task_run.state.result() == x
 
         if "foo" in storage_key:
-            assert updated_task_run.state.data.storage_key == storage_key
+            assert Path(updated_task_run.state.data.storage_key).name == storage_key
         else:
-            assert updated_task_run.state.data.storage_key == x
+            assert Path(updated_task_run.state.data.storage_key).name == x
 
     async def test_task_run_via_task_worker_with_complex_result_type(
         self, prefect_client

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1235,6 +1235,7 @@ class TestResultPersistence:
 
     def test_setting_result_storage_sets_persist_result_to_true(self, tmpdir):
         block = LocalFileSystem(basepath=str(tmpdir))
+        block.save("test-name", _sync=True)
 
         @task(result_storage=block)
         def my_task():
@@ -1647,7 +1648,7 @@ class TestTaskCaching:
     ):
         block = LocalFileSystem(basepath=str(tmpdir))
 
-        block.save("test-cache-key-fn-takes-precedence-over-cache-policy")
+        await block.save("test-cache-key-fn-takes-precedence-over-cache-policy")
 
         @task(
             cache_key_fn=lambda *_: "cache-hit-9",
@@ -3004,6 +3005,9 @@ class TestTaskWithOptions:
         def second_cache_key_fn(*_):
             return "second cache hit"
 
+        block = LocalFileSystem(basepath="foo")
+        block.save("foo-test", _sync=True)
+
         @task(
             name="Initial task",
             description="Task before with options",
@@ -3014,7 +3018,7 @@ class TestTaskWithOptions:
             retry_delay_seconds=5,
             persist_result=True,
             result_serializer="pickle",
-            result_storage=LocalFileSystem(basepath="foo"),
+            result_storage=block,
             cache_result_in_memory=False,
             timeout_seconds=None,
             refresh_cache=False,
@@ -3022,6 +3026,9 @@ class TestTaskWithOptions:
         )
         def initial_task():
             pass
+
+        new_block = LocalFileSystem(basepath="bar")
+        new_block.save("bar-test", _sync=True)
 
         task_with_options = initial_task.with_options(
             name="Copied task",
@@ -3033,7 +3040,7 @@ class TestTaskWithOptions:
             retry_delay_seconds=10,
             persist_result=False,
             result_serializer="json",
-            result_storage=LocalFileSystem(basepath="bar"),
+            result_storage=new_block,
             cache_result_in_memory=True,
             timeout_seconds=42,
             refresh_cache=True,
@@ -3049,7 +3056,7 @@ class TestTaskWithOptions:
         assert task_with_options.retry_delay_seconds == 10
         assert task_with_options.persist_result is False
         assert task_with_options.result_serializer == "json"
-        assert task_with_options.result_storage == LocalFileSystem(basepath="bar")
+        assert task_with_options.result_storage == new_block
         assert task_with_options.cache_result_in_memory is True
         assert task_with_options.timeout_seconds == 42
         assert task_with_options.refresh_cache is True
@@ -3060,6 +3067,7 @@ class TestTaskWithOptions:
             return "cache hit"
 
         storage = LocalFileSystem(basepath=tmp_path)
+        storage.save("another-passthrough", _sync=True)
 
         @task(
             name="Initial task",
@@ -3102,9 +3110,12 @@ class TestTaskWithOptions:
         assert task_with_options.result_storage_key == "test"
 
     def test_with_options_can_unset_result_options_with_none(self, tmp_path: Path):
+        result_storage = LocalFileSystem(basepath=tmp_path)
+        result_storage.save("test-yet-again", _sync=True)
+
         @task(
             result_serializer="json",
-            result_storage=LocalFileSystem(basepath=tmp_path),
+            result_storage=result_storage,
             refresh_cache=True,
             result_storage_key="test",
         )

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -7,7 +7,7 @@ from prefect.flows import flow
 from prefect.records import RecordStore
 from prefect.records.result_store import ResultFactoryStore
 from prefect.results import (
-    get_or_create_default_result_storage,
+    get_default_result_storage,
     get_or_create_default_task_scheduling_storage,
 )
 from prefect.settings import (
@@ -283,7 +283,7 @@ class TestDefaultTransactionStorage:
             # make sure we aren't using an anonymous block
             assert (
                 result.storage_block_id
-                == get_or_create_default_result_storage()._block_document_id
+                == get_default_result_storage()._block_document_id
             )
             return result
 


### PR DESCRIPTION
This PR avoids the unnecessary persistence of blocks, specifically local storage blocks. There's essentially no reason to store a local storage block as absolute paths are all that's needed to read and write locally.

This PR makes default storage local-file based without block references.