### PR TITLE
Point to `main` for migration script in upgrade doc

### DIFF
--- a/docs/3.0rc/resources/upgrade-prefect-3.mdx
+++ b/docs/3.0rc/resources/upgrade-prefect-3.mdx
@@ -18,7 +18,7 @@ All previous and future Prefect 2 releases will continue to work with Prefect Cl
 
 Some modules have been renamed, reorganized, or removed for clarity. 
 Objects imported from changed modules will continue to work until their six month deprecation period ends, but will raise deprecation warnings. 
-See the [migration script](https://github.com/PrefectHQ/prefect/blob/f767724ab28278446456b024b5c1c73f76ebcbb5/src/prefect/_internal/compatibility/migration.py#L22) for the full list of modules that have been moved and removed.
+See the [migration script](https://github.com/PrefectHQ/prefect/blob/main/src/prefect/_internal/compatibility/migration.py#L22) for the full list of modules that have been moved and removed.
 
 ## Integrations must be upgraded
 


### PR DESCRIPTION
The link to the migration script in the upgrade doc was pointed at a commit, when it should probably just be pointed at main so the latest changes are there.