### PR TITLE
Allow uvicorn > 0.29.0 (2.x)

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -32,7 +32,7 @@ sniffio >=1.3.0, < 2.0.0
 toml >= 0.10.0
 typing_extensions >= 4.5.0, < 5.0.0
 ujson >= 5.8.0, < 6.0.0
-uvicorn >= 0.14.0, < 0.29.0
+uvicorn >= 0.14.0, !=0.29.0
 websockets >= 10.4, < 13.0
 
 # additional dependencies of starlette, which we're currently vendoring

--- a/src/prefect/cli/cloud/__init__.py
+++ b/src/prefect/cli/cloud/__init__.py
@@ -131,9 +131,6 @@ async def serve_login_api(cancel_scope, task_status):
         cause = exc.__context__  # Hide the system exit
         traceback.print_exception(type(cause), value=cause, tb=cause.__traceback__)
         cancel_scope.cancel()
-    except KeyboardInterrupt:
-        # `uvicorn.serve` can raise `KeyboardInterrupt` when it's done serving.
-        cancel_scope.cancel()
     else:
         # Exit if we are done serving the API
         # Uvicorn overrides signal handlers so without this Ctrl-C is broken
@@ -274,9 +271,8 @@ async def login_with_browser() -> str:
             app.console.print("Waiting for response...")
             await result_event.wait()
 
-        # Uvicorn installs signal handlers, this is the cleanest way to shutdown the
-        # login API
-        raise_signal(signal.SIGINT)
+        # Shut down the background uvicorn server
+        tg.cancel_scope.cancel()
 
     result = login_api.extra.get("result")
     if not result:

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -553,33 +553,43 @@ def create_app(
         service_instances = []
 
         if prefect.settings.PREFECT_API_SERVICES_SCHEDULER_ENABLED.value():
-            service_instances.append(services.scheduler.Scheduler())
-            service_instances.append(services.scheduler.RecentDeploymentsScheduler())
+            service_instances.append(services.scheduler.Scheduler(handle_signals=False))
+            service_instances.append(
+                services.scheduler.RecentDeploymentsScheduler(handle_signals=False)
+            )
 
         if prefect.settings.PREFECT_API_SERVICES_LATE_RUNS_ENABLED.value():
-            service_instances.append(services.late_runs.MarkLateRuns())
+            service_instances.append(
+                services.late_runs.MarkLateRuns(handle_signals=False)
+            )
 
         if prefect.settings.PREFECT_API_SERVICES_PAUSE_EXPIRATIONS_ENABLED.value():
-            service_instances.append(services.pause_expirations.FailExpiredPauses())
+            service_instances.append(
+                services.pause_expirations.FailExpiredPauses(handle_signals=False)
+            )
 
         if prefect.settings.PREFECT_API_SERVICES_CANCELLATION_CLEANUP_ENABLED.value():
             service_instances.append(
-                services.cancellation_cleanup.CancellationCleanup()
+                services.cancellation_cleanup.CancellationCleanup(handle_signals=False)
             )
 
         if prefect.settings.PREFECT_SERVER_ANALYTICS_ENABLED.value():
-            service_instances.append(services.telemetry.Telemetry())
+            service_instances.append(services.telemetry.Telemetry(handle_signals=False))
 
         if prefect.settings.PREFECT_API_SERVICES_FLOW_RUN_NOTIFICATIONS_ENABLED.value():
             service_instances.append(
-                services.flow_run_notifications.FlowRunNotifications()
+                services.flow_run_notifications.FlowRunNotifications(
+                    handle_signals=False
+                )
             )
 
         if prefect.settings.PREFECT_API_SERVICES_FOREMAN_ENABLED.value():
-            service_instances.append(services.foreman.Foreman())
+            service_instances.append(services.foreman.Foreman(handle_signals=False))
 
         if prefect.settings.PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING.value():
-            service_instances.append(services.task_scheduling.TaskSchedulingTimeouts())
+            service_instances.append(
+                services.task_scheduling.TaskSchedulingTimeouts(handle_signals=False)
+            )
 
         if (
             prefect.settings.PREFECT_EXPERIMENTAL_EVENTS.value()
@@ -592,7 +602,7 @@ def create_app(
             and prefect.settings.PREFECT_API_SERVICES_TRIGGERS_ENABLED.value()
         ):
             service_instances.append(ReactiveTriggers())
-            service_instances.append(ProactiveTriggers())
+            service_instances.append(ProactiveTriggers(handle_signals=False))
             service_instances.append(Actions())
 
         if (


### PR DESCRIPTION
This is the 2.x side of https://github.com/PrefectHQ/prefect/pull/14361 

In this version we're manually setting `handle_signals=False` in the fastapi factory instead of changing the default value, keeping the, possibly, breaking change in the 3.x line.

Related to #14318 