### PR TITLE
Resolves two log injection security alerts

### DIFF
--- a/src/prefect/server/api/validation.py
+++ b/src/prefect/server/api/validation.py
@@ -36,6 +36,7 @@ Note some important details:
 """
 
 from typing import Any, Dict, Optional, Tuple, Union
+from uuid import UUID
 
 import pydantic
 from fastapi import HTTPException, status
@@ -117,23 +118,29 @@ async def _resolve_default_reference(
     }
     """
     if not isinstance(variable, dict):
-        return
+        return None
 
     if "$ref" not in variable:
-        return
+        return None
 
     reference_data = variable.get("$ref", {})
-    if (block_doc_id := reference_data.get("block_document_id")) is None:
-        return
+    if (provided_block_document_id := reference_data.get("block_document_id")) is None:
+        return None
+
+    if not isinstance(provided_block_document_id, UUID):
+        try:
+            block_document_id = UUID(provided_block_document_id)
+        except ValueError:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Block not found.")
 
     try:
         block_document = await models.block_documents.read_block_document_by_id(
-            session, block_doc_id
+            session, block_document_id
         )
     except pydantic.ValidationError:
         # It's possible to get an invalid UUID here because the block document ID is
         # not validated by our schemas.
-        logger.info("Could not find block document with ID %s", block_doc_id)
+        logger.info("Could not find block document with ID %s", block_document_id)
         block_document = None
 
     if not block_document:

--- a/src/prefect/server/api/validation.py
+++ b/src/prefect/server/api/validation.py
@@ -127,7 +127,9 @@ async def _resolve_default_reference(
     if (provided_block_document_id := reference_data.get("block_document_id")) is None:
         return None
 
-    if not isinstance(provided_block_document_id, UUID):
+    if isinstance(provided_block_document_id, UUID):
+        block_document_id = provided_block_document_id
+    else:
         try:
             block_document_id = UUID(provided_block_document_id)
         except ValueError:


### PR DESCRIPTION
Code scanning alerts [2014](https://github.com/PrefectHQ/prefect/security/code-scanning/2014) and [2015](https://github.com/PrefectHQ/prefect/security/code-scanning/2015) point out that we're using a potentially user-provided value in a log message.
I also noticed that, becuase we aren't validating that the given block document
ID was a UUID, we were also passing a user-provided value through the models
layer.  Parsing the given string to a UUID resolves both issues.
