### PR TITLE
Handle multi-line dynamic flow names

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1925,8 +1925,12 @@ def load_flow_argument_from_entrypoint(
                     literal_arg_value = ast.get_source_segment(
                         source_code, keyword.value
                     )
+                    cleaned_value = (
+                        literal_arg_value.replace("\n", "") if literal_arg_value else ""
+                    )
+
                     try:
-                        evaluated_value = eval(literal_arg_value, namespace)  # type: ignore
+                        evaluated_value = eval(cleaned_value, namespace)  # type: ignore
                     except Exception as e:
                         logger.info(
                             "Failed to parse @flow argument: `%s=%s` due to the following error. Ignoring and falling back to default behavior.",

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -4531,6 +4531,36 @@ class TestLoadFlowArgumentFromEntrypoint:
         assert result == "flow-function"
         assert "Failed to parse @flow argument: `name=get_name()`" in caplog.text
 
+    def test_load_flow_name_from_entrypoint_dynamic_name_fstring_multiline(
+        self, tmp_path: Path
+    ):
+        flow_source = dedent(
+            """
+
+        from prefect import flow
+
+        flow_base_name = "flow-function"
+        version = "1.0"
+
+        @flow(
+            name=(
+                f"{flow_base_name}-"
+                f"{version}"
+            )
+        )
+        def flow_function(name: str) -> str:
+            return name
+        """
+        )
+
+        tmp_path.joinpath("flow.py").write_text(flow_source)
+
+        entrypoint = f"{tmp_path.joinpath('flow.py')}:flow_function"
+
+        result = load_flow_argument_from_entrypoint(entrypoint, "name")
+
+        assert result == "flow-function-1.0"
+
     def test_load_async_flow_from_entrypoint_no_name(self, tmp_path: Path):
         flow_source = dedent(
             """


### PR DESCRIPTION
This fixes an issue where splitting a dynamic flow name across multiple lines would result in an error when it was `eval`'ed.

Closes #14025 