### PR TITLE
Add more direct recommendations to worker upgrade guide

### DIFF
--- a/docs/3.0rc/resources/upgrade-agents-to-workers.mdx
+++ b/docs/3.0rc/resources/upgrade-agents-to-workers.mdx
@@ -223,7 +223,7 @@ if __name__ == "__main__":
 You can then start a worker to execute scheduled runs, pulling the flow code from `example.py`:
 
 ```bash
-# starts a worker and creates `local` work pool if it doesn't exist
+# starts a worker and creates `local` Process work pool if it doesn't exist
 prefect worker start --pool local
 ```
 

--- a/docs/3.0rc/resources/upgrade-agents-to-workers.mdx
+++ b/docs/3.0rc/resources/upgrade-agents-to-workers.mdx
@@ -322,7 +322,7 @@ if __name__ == "__main__":
 When using `flow.from_source(...).deploy(...)` with a remote
 `source` (like a `GitHub` block or `str` URL like https://github.com/me/myrepo.git),
 the flow you're deploying does not need to be available locally before running your script.
-See the [API reference](https://prefect-python-sdk-docs.netlify.app/prefect/#prefect.Flow.from_source) for more info on `from_source`.
+See the [SDK reference](https://prefect-python-sdk-docs.netlify.app/prefect/#prefect.Flow.from_source) for more info on `from_source`.
 </Note>
 
 #### Deploying via a Docker image

--- a/docs/3.0rc/resources/upgrade-agents-to-workers.mdx
+++ b/docs/3.0rc/resources/upgrade-agents-to-workers.mdx
@@ -320,7 +320,7 @@ if __name__ == "__main__":
 
 <Note>
 When using `flow.from_source(...).deploy(...)` with a remote
-`source` (like a `GitHub` block or `str` url like https://github.com/me/myrepo.git),
+`source` (like a `GitHub` block or `str` URL like https://github.com/me/myrepo.git),
 the flow you're deploying does not need to be available locally before running your script.
 See the [API reference](https://prefect-python-sdk-docs.netlify.app/prefect/#prefect.Flow.from_source) for more info on `from_source`.
 </Note>

--- a/docs/3.0rc/resources/upgrade-agents-to-workers.mdx
+++ b/docs/3.0rc/resources/upgrade-agents-to-workers.mdx
@@ -164,8 +164,8 @@ using `prefect deploy`.
 
 ### `flow.deploy`
 
-If you have a Python script that uses `Deployment.build_from_flow`, you can replace it with 
-`flow.deploy`.
+If you have a Python script that uses `Deployment.build_from_flow` to create a deployment, you
+can replace it with `flow.deploy`.
 
 You can translate most arguments to `Deployment.build_from_flow` directly to `flow.deploy`, 
 but here are some possible changes you may need:
@@ -178,11 +178,11 @@ but here are some possible changes you may need:
   - `flow.from_source` loads your flow from a remote storage location and makes it deployable. 
   You can pass your existing storage block to the `source` argument of `flow.from_source`.
 
-Below are some examples of how to translate `Deployment.build_from_flow` to `flow.deploy`.
+Below are some examples of how to translate `Deployment.build_from_flow` into `flow.deploy`.
 
-#### Deploying without any blocks
+#### Deploying from a local file
 
-If you aren't using any blocks:
+Using agents and `Deployment.build_from_flow` to deploy a flow from a local file looked like:
 
 ```python
 from prefect import flow
@@ -199,9 +199,10 @@ if __name__ == "__main__":
     )
 ```
 
-You can replace `Deployment.build_from_flow` with `flow.serve` :
+When using workers, you can accomplish the same local-storage deployment with `flow.deploy`:
 
-```python
+```python example.py
+from pathlib import Path
 from prefect import flow
 
 @flow(log_prints=True)
@@ -209,14 +210,26 @@ def my_flow(name: str = "world"):
     print(f"Hello {name}! I'm a flow from a Python script!")
 
 if __name__ == "__main__":
-    my_flow.serve(
+    my_flow.from_source(
+        source=str(Path(__file__).parent),
+        entrypoint="example.py:my_flow",
+    ).deploy(
         name="my-deployment",
         parameters=dict(name="Marvin"),
+        work_pool_name="local",
     )
 ```
 
-This starts a process that serves your flow and executes any flow runs that are scheduled 
-to start.
+You can then start a worker to execute scheduled runs, pulling the flow code from `example.py`:
+
+```bash
+# starts a worker and creates `local` work pool if it doesn't exist
+prefect worker start --pool local
+```
+
+<Note>
+If you'd like to immediately serve this flow as a deployment without running a worker or using work pools, you can [use `flow.serve`](/3.0rc/deploy/run-flows-in-local-processes/).
+</Note>
 
 #### Deploying using a storage block
 
@@ -239,10 +252,10 @@ if __name__ == "__main__":
     )
 ```
 
-You can use `flow.from_source` to load your flow from the same location and `flow.serve` to 
+You can use `flow.from_source` to load your flow from the same location and `flow.deploy` to 
 create a deployment:
 
-```python
+```python example.py
 from prefect import flow
 from prefect.storage import GitHub
 
@@ -250,15 +263,12 @@ if __name__ == "__main__":
     flow.from_source(
         source=GitHub.load("demo-repo"),
         entrypoint="example.py:my_flow"
-    ).serve(
+    ).deploy(
         name="my-deployment",
         parameters=dict(name="Marvin"),
+        work_pool_name="local", # or the name of your work pool
     )
 ```
-
-This allows you to execute scheduled flow runs without starting a worker. Additionally, 
-the process serving your flow regularly checks for updates to your flow code, and automatically 
-updates the flow if it detects any changes to the code.
 
 #### Deploying using an infrastructure and storage block
 
@@ -266,7 +276,7 @@ For the code below, you need to create a work pool from your infrastructure bloc
 `flow.deploy` as the `work_pool_name` argument. You also need to pass your storage block to 
 `flow.from_source` as the `source` argument.
 
-```python
+```python example.py
 from prefect import flow
 from prefect.deployments import Deployment
 from prefect.filesystems import GitHub
@@ -292,7 +302,7 @@ if __name__ == "__main__":
 
 The equivalent deployment code using `flow.deploy` should look like this:
 
-```python
+```python example.py
 from prefect import flow
 from prefect.storage import GitHub
 
@@ -309,8 +319,10 @@ if __name__ == "__main__":
 ```
 
 <Note>
-When using `flow.from_source(...).deploy(...)`, the flow you're deploying does not 
-need to be available locally before running your script.
+When using `flow.from_source(...).deploy(...)` with a remote
+`source` (like a `GitHub` block or `str` url like https://github.com/me/myrepo.git),
+the flow you're deploying does not need to be available locally before running your script.
+See the [API reference](https://prefect-python-sdk-docs.netlify.app/prefect/#prefect.Flow.from_source) for more info on `from_source`.
 </Note>
 
 #### Deploying via a Docker image

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -971,6 +971,29 @@ class Flow(Generic[P, R]):
 
             my_flow()
             ```
+
+            Load a flow from a local directory:
+
+            ``` python
+            # from_local_source.py
+
+            from pathlib import Path
+            from prefect import flow
+
+            @flow(log_prints=True)
+            def my_flow(name: str = "world"):
+                print(f"Hello {name}! I'm a flow from a Python script!")
+
+            if __name__ == "__main__":
+                my_flow.from_source(
+                    source=str(Path(__file__).parent),
+                    entrypoint="from_local_source.py:my_flow",
+                ).deploy(
+                    name="my-deployment",
+                    parameters=dict(name="Marvin"),
+                    work_pool_name="local",
+                )
+            ```
         """
 
         from prefect.runner.storage import (
@@ -999,7 +1022,7 @@ class Flow(Generic[P, R]):
             await storage.pull_code()
 
             full_entrypoint = str(storage.destination / entrypoint)
-            flow: "Flow" = await from_async.wait_for_call_in_new_thread(
+            flow: Flow = await from_async.wait_for_call_in_new_thread(
                 create_call(load_flow_from_entrypoint, full_entrypoint)
             )
             flow._storage = storage
@@ -1126,7 +1149,13 @@ class Flow(Generic[P, R]):
                 )
             ```
         """
-        work_pool_name = work_pool_name or PREFECT_DEFAULT_WORK_POOL_NAME.value()
+        if not (
+            work_pool_name := work_pool_name or PREFECT_DEFAULT_WORK_POOL_NAME.value()
+        ):
+            raise ValueError(
+                "No work pool name provided. Please provide a `work_pool_name` or set the"
+                " `PREFECT_DEFAULT_WORK_POOL_NAME` environment variable."
+            )
 
         try:
             async with get_client() as client:


### PR DESCRIPTION
the current version of the [guide has a section titled `flow.deploy`](https://docs-3.prefect.io/3.0rc/resources/upgrade-agents-to-workers#flow-deploy) and means to help people off `Deployment.build_from_flow`, but the first couple examples use `flow.serve`.

`flow.serve` is not a direct replacement for `Deployment.build_from_flow` because no one who was using the latter ever got a blocking process that serves their flow as a deployment. `flow.deploy` is the direct analogue and the subject of the section and seems like it should be used in the examples.

i keep a link to the main docs on `serve`
