### PR TITLE
handle join edge case in `ParameterTypeError.from_validation_error`

### DIFF
--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -178,7 +178,10 @@ class ParameterTypeError(PrefectException):
 
     @classmethod
     def from_validation_error(cls, exc: ValidationError) -> Self:
-        bad_params = [f'{".".join(err["loc"])}: {err["msg"]}' for err in exc.errors()]
+        bad_params = [
+            f'{".".join(str(item) for item in err["loc"])}: {err["msg"]}'
+            for err in exc.errors()
+        ]
         msg = "Flow run received invalid parameters:\n - " + "\n - ".join(bad_params)
         return cls(msg)
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -30,7 +30,7 @@ class TestParameterTypeError:
         ):
             Foo(**{"num": "not an int", "string": [1, 2]})
 
-    def test_construction_with_list_of_Model_type_inputs(self):
+    def test_construction_with_list_of_model_type_inputs(self):
         """regression test for https://github.com/PrefectHQ/prefect/issues/14406"""
 
         errored = False


### PR DESCRIPTION
closes #14406

handles the case where an `loc` item might be an `int`, when you are referring an index in a list input type
```python
  File "/home/nmclean/.cache/pypoetry/virtualenvs/global-calculator-UYA1GDje-py3.11/lib/python3.11/site-packages/prefect/exceptions.py", line 181, in <listcomp>
    bad_params = [f'{".".join(err["loc"])}: {err["msg"]}' for err in exc.errors()]
                     ^^^^^^^^^^^^^^^^^^^^
TypeError: sequence item 1: expected str instance, int found
```