### PR TITLE
Remove `PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS` flag

### DIFF
--- a/docs/3.0rc/api-ref/rest-api/server/schema.json
+++ b/docs/3.0rc/api-ref/rest-api/server/schema.json
@@ -22279,11 +22279,6 @@
                         "title": "Prefect Task Scheduling Pending Task Timeout",
                         "default": "PT0S"
                     },
-                    "PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS": {
-                        "type": "boolean",
-                        "title": "Prefect Experimental Enable Extra Runner Endpoints",
-                        "default": false
-                    },
                     "PREFECT_EXPERIMENTAL_DISABLE_SYNC_COMPAT": {
                         "type": "boolean",
                         "title": "Prefect Experimental Disable Sync Compat",

--- a/src/prefect/runner/submit.py
+++ b/src/prefect/runner/submit.py
@@ -14,7 +14,6 @@ from prefect.context import FlowRunContext
 from prefect.flows import Flow
 from prefect.logging import get_logger
 from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS,
     PREFECT_RUNNER_PROCESS_LIMIT,
     PREFECT_RUNNER_SERVER_HOST,
     PREFECT_RUNNER_SERVER_PORT,
@@ -129,13 +128,6 @@ async def submit_to_runner(
     if not isinstance(prefect_callable, (Flow, Task)):
         raise TypeError(
             "The `submit_to_runner` utility only supports submitting flows and tasks."
-        )
-
-    if not PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS.value():
-        raise ValueError(
-            "The `submit_to_runner` utility requires the `Runner` webserver to be"
-            " running and built with extra endpoints enabled. To enable this, set the"
-            " `PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS` setting to `True`."
         )
 
     parameters = parameters or {}

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1437,11 +1437,6 @@ a task worker should move a task from PENDING to RUNNING very quickly, so runs s
 PENDING for a while is a sign that the task worker may have crashed.
 """
 
-PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS = Setting(bool, default=False)
-"""
-Whether or not to enable experimental worker webserver endpoints.
-"""
-
 PREFECT_EXPERIMENTAL_DISABLE_SYNC_COMPAT = Setting(bool, default=False)
 """
 Whether or not to disable the sync_compatible decorator utility.

--- a/tests/runner/test_submit.py
+++ b/tests/runner/test_submit.py
@@ -9,7 +9,6 @@ from prefect import flow
 from prefect.client.schemas.objects import FlowRun
 from prefect.runner import submit_to_runner
 from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS,
     PREFECT_RUNNER_SERVER_ENABLE,
     temporary_settings,
 )
@@ -61,24 +60,9 @@ def runner_settings():
     with temporary_settings(
         {
             PREFECT_RUNNER_SERVER_ENABLE: True,
-            PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS: True,
         }
     ):
         yield
-
-
-async def test_submission_raises_if_extra_endpoints_not_enabled(mock_webserver):
-    with temporary_settings(
-        {PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS: False}
-    ):
-        with pytest.raises(
-            ValueError,
-            match=(
-                "The `submit_to_runner` utility requires the `Runner` webserver to be"
-                " running and built with extra endpoints enabled."
-            ),
-        ):
-            await submit_to_runner(identity, {"whatever": 42})
 
 
 @pytest.mark.parametrize("prefect_callable", [identity, async_identity])

--- a/tests/runner/test_webserver.py
+++ b/tests/runner/test_webserver.py
@@ -12,7 +12,6 @@ from prefect.client.schemas.objects import FlowRun
 from prefect.runner import Runner
 from prefect.runner.server import build_server
 from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS,
     PREFECT_RUNNER_SERVER_HOST,
     PREFECT_RUNNER_SERVER_PORT,
     temporary_settings,
@@ -48,7 +47,6 @@ def a_non_flow_function():
 def tmp_runner_settings():
     with temporary_settings(
         updates={
-            PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS: True,
             PREFECT_RUNNER_SERVER_HOST: "0.0.0.0",
             PREFECT_RUNNER_SERVER_PORT: 0,
         }
@@ -82,21 +80,6 @@ class TestWebserverSettings:
 
 
 class TestWebserverDeploymentRoutes:
-    async def test_deployment_router_not_added_if_experimental_flag_is_false(
-        self,
-        runner: Runner,
-    ):
-        with temporary_settings(
-            updates={PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS: False}
-        ):
-            webserver = await build_server(runner)
-            deployment_routes = [
-                r
-                for r in webserver.routes
-                if r.path.startswith("/deployment") and r.path.endswith("/run")
-            ]
-            assert len(deployment_routes) == 0
-
     async def test_runners_deployment_run_routes_exist(self, runner: Runner):
         deployment_ids = [
             await create_deployment(runner, simple_flow) for _ in range(3)
@@ -176,17 +159,6 @@ class TestWebserverDeploymentRoutes:
 
 
 class TestWebserverFlowRoutes:
-    async def test_flow_router_not_added_if_experimental_flag_is_false(
-        self,
-        runner: Runner,
-    ):
-        with temporary_settings(
-            updates={PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS: False}
-        ):
-            webserver = await build_server(runner)
-            flow_routes = [r for r in webserver.routes if r.path == "/flow/run"]
-            assert len(flow_routes) == 0
-
     async def test_flow_router_runs_managed_flow(self, runner: Runner):
         await create_deployment(runner, simple_flow)
         webserver = await build_server(runner)


### PR DESCRIPTION
Removes the `PREFECT_EXPERIMENTAL_ENABLE_EXTRA_RUNNER_ENDPOINTS` flag and related code.

Closes #14212 