### PR TITLE
Remove `PREFECT_EXPERIMENTAL_ENABLE_SCHEDULE_CONCURRENCY` flag

### DIFF
--- a/docs/3.0rc/api-ref/server/schema.json
+++ b/docs/3.0rc/api-ref/server/schema.json
@@ -22289,11 +22289,6 @@
                         "title": "Prefect Experimental Disable Sync Compat",
                         "default": false
                     },
-                    "PREFECT_EXPERIMENTAL_ENABLE_SCHEDULE_CONCURRENCY": {
-                        "type": "boolean",
-                        "title": "Prefect Experimental Enable Schedule Concurrency",
-                        "default": false
-                    },
                     "PREFECT_DEFAULT_RESULT_STORAGE_BLOCK": {
                         "anyOf": [
                             {

--- a/src/prefect/cli/_prompts.py
+++ b/src/prefect/cli/_prompts.py
@@ -35,9 +35,6 @@ from prefect.deployments.base import (
 )
 from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound
 from prefect.flows import load_flow_from_entrypoint
-from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_SCHEDULE_CONCURRENCY,
-)
 from prefect.utilities import urls
 from prefect.utilities.processutils import get_sys_executable, run_process
 from prefect.utilities.slugify import slugify
@@ -394,13 +391,12 @@ def prompt_schedules(console) -> List[DeploymentScheduleCreate]:
                 "active": is_schedule_active,
             }
 
-            if PREFECT_EXPERIMENTAL_ENABLE_SCHEDULE_CONCURRENCY:
-                max_active_runs = prompt_for_schedule_max_active_runs(console)
-                catchup = prompt_for_schedule_catchup(console)
+            max_active_runs = prompt_for_schedule_max_active_runs(console)
+            catchup = prompt_for_schedule_catchup(console)
 
-                minimal_schedule_kwargs.update(
-                    {"max_active_runs": max_active_runs, "catchup": catchup}
-                )
+            minimal_schedule_kwargs.update(
+                {"max_active_runs": max_active_runs, "catchup": catchup}
+            )
 
             schedules.append(DeploymentScheduleCreate(**minimal_schedule_kwargs))
 

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1447,8 +1447,6 @@ PREFECT_EXPERIMENTAL_DISABLE_SYNC_COMPAT = Setting(bool, default=False)
 Whether or not to disable the sync_compatible decorator utility.
 """
 
-PREFECT_EXPERIMENTAL_ENABLE_SCHEDULE_CONCURRENCY = Setting(bool, default=False)
-
 # Defaults -----------------------------------------------------------------------------
 
 PREFECT_DEFAULT_RESULT_STORAGE_BLOCK = Setting(

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -51,7 +51,6 @@ from prefect.server.schemas.actions import (
 )
 from prefect.settings import (
     PREFECT_DEFAULT_WORK_POOL_NAME,
-    PREFECT_EXPERIMENTAL_ENABLE_SCHEDULE_CONCURRENCY,
     PREFECT_UI_URL,
     temporary_settings,
 )
@@ -61,12 +60,6 @@ from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.filesystem import tmpchdir
 
 TEST_PROJECTS_DIR = prefect.__development_base_path__ / "tests" / "test-projects"
-
-
-@pytest.fixture
-def enable_schedule_concurrency():
-    with temporary_settings({PREFECT_EXPERIMENTAL_ENABLE_SCHEDULE_CONCURRENCY: True}):
-        yield
 
 
 @pytest.fixture
@@ -2665,7 +2658,7 @@ class TestSchedules:
         assert deployment_schedule.schedule.cron == "0 4 * * *"
         assert deployment_schedule.schedule.timezone == "America/Chicago"
 
-    @pytest.mark.usefixtures("project_dir", "enable_schedule_concurrency")
+    @pytest.mark.usefixtures("project_dir")
     async def test_deploy_with_max_active_runs_and_catchup_provided_for_schedule(
         self, work_pool, prefect_client
     ):
@@ -2704,9 +2697,7 @@ class TestSchedules:
         assert deployment.schedules[0].max_active_runs == 5
         assert deployment.schedules[0].catchup is True
 
-    @pytest.mark.usefixtures(
-        "project_dir", "interactive_console", "enable_schedule_concurrency"
-    )
+    @pytest.mark.usefixtures("project_dir", "interactive_console")
     async def test_deploy_with_max_active_runs_and_catchup_interactive(
         self, work_pool, prefect_client
     ):


### PR DESCRIPTION
Removes the `PREFECT_EXPERIMENTAL_ENABLE_SCHEDULE_CONCURRENCY` flag and related code.

Closes #14213 