### PR TITLE
More docs style improvements from Vale

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -20,3 +20,15 @@ Google.Exclamation = NO
 
 [formats]
 mdx = md
+
+Exclude = rest-api/**
+Exlcude = assets/** 
+Exclude = images/**
+Exclude = logos/** 
+Exclude = styles/** 
+Exclude = *.json 
+Exclude = *.js 
+Exclude = *.css
+Exclude = *.jpg
+Exclude = *.png
+Exclude = 3.0rc/**

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -13,22 +13,15 @@ Vocab = prose
 
 Vale.Spelling = NO
 Google.Will = NO
-Google.We = NO
 Google.Quotes = NO
 Google.OptionalPlurals = NO
+
+# All of the following would be helpful in some cases but get really noisy
 Google.Exclamation = NO
+Google.Headings = NO
+Google.We = NO
 
 [formats]
 mdx = md
 
-Exclude = rest-api/**
-Exlcude = assets/** 
-Exclude = images/**
-Exclude = logos/** 
-Exclude = styles/** 
-Exclude = *.json 
-Exclude = *.js 
-Exclude = *.css
-Exclude = *.jpg
-Exclude = *.png
-Exclude = 3.0rc/**
+# vale --glob='!{*.mdx,*.js,*.json,*.png,*.jpg,*.css,*.yml,*.svg,3.0rc/api-ref/*.md}' ./3.0rc

--- a/docs/3.0rc/deploy/infrastructure-concepts/prefect-yaml.mdx
+++ b/docs/3.0rc/deploy/infrastructure-concepts/prefect-yaml.mdx
@@ -524,7 +524,7 @@ The above command deploys:
 Because a `prefect.yaml` file is a standard YAML file, you can use [YAML aliases](https://yaml.org/spec/1.2.2/#71-alias-nodes) 
 to reuse configuration across deployments.
 
-This functionality allows multiple deployments to share the work pool configuration, deployment actions, or other 
+This capability allows multiple deployments to share the work pool configuration, deployment actions, or other 
 configurations.
 
 Declare a YAML alias with the `&{alias_name}` syntax and insert that alias elsewhere in the file with the `*{alias_name}` 

--- a/docs/3.0rc/deploy/infrastructure-concepts/work-pools.mdx
+++ b/docs/3.0rc/deploy/infrastructure-concepts/work-pools.mdx
@@ -336,7 +336,7 @@ Learn more about [overriding job variables](/3.0rc/deploy/infrastructure-concept
     Advanced customization is useful anytime the underlying infrastructure supports a high degree of customization. 
     In these scenarios a work pool job template allows you to expose a minimal and easy-to-digest set of options to deployment authors. 
     Additionally, these options are the _only_ customizable aspects for deployment infrastructure, which are useful for restricting 
-    functionality in secure environments. For example, the `kubernetes` worker type allows users to specify a custom job template  
+    capabilities in secure environments. For example, the `kubernetes` worker type allows users to specify a custom job template  
     to configure the manifest that workers use to create jobs for flow execution.
 
     For more information and advanced configuration examples, see the [Kubernetes Worker](https://prefecthq.github.io/prefect-kubernetes/worker/) 
@@ -765,7 +765,7 @@ build namespace is set to the URL of the repository.
 While the default namespace is set, any images you build without specifying a registry or username/organization 
 are pushed to the repository.
 
-To use this functionality, write your deploy script like this:
+To use this capability, write your deploy script like this:
 
 ```python example_deploy_script.py
 from prefect import flow                                                       

--- a/docs/3.0rc/deploy/infrastructure-examples/serverless.mdx
+++ b/docs/3.0rc/deploy/infrastructure-examples/serverless.mdx
@@ -303,7 +303,7 @@ run this command for your particular cloud provider:
         While the default namespace is set, any images you build without specifying a registry or username/organization 
         are pushed to the registry.
 
-        To use this functionality, write your deploy scripts like this:
+        To use this capability, write your deploy scripts like this:
 
         ```python example_deploy_script.py
         from prefect import flow
@@ -388,7 +388,7 @@ Created work pool 'my-cloud-run-pool'!
     While the default namespace is set, any images you build without specifying a registry or username/organization 
     are pushed to the repository.
 
-    To use this functionality, write your deploy scripts like this:
+    To use this capability, write your deploy scripts like this:
 
     ```python example_deploy_script.py
     from prefect import flow                                                       

--- a/docs/3.0rc/develop/blocks.mdx
+++ b/docs/3.0rc/develop/blocks.mdx
@@ -7,7 +7,7 @@ description: Prefect blocks package configuration storage, infrastructure, and s
 
 Prefect blocks store configuration and provide an interface for interacting with external systems.
 
-Blocks expose methods that provide functionality specific to these systems.
+Blocks expose methods that provide capabilities specific to these systems.
 For example, you can use blocks to:
 
 - Download data from, or upload data to, an S3 bucket
@@ -217,7 +217,7 @@ class Cube(Block):
     edge_length_inches: float
 ```
 
-You can include methods on a block to provide functionality. 
+You can add methods to a block to provide additional actions. 
 Here's the same cube block with methods to calculate the volume and surface area of the cube:
 
 ```python
@@ -255,7 +255,7 @@ if __name__ == "__main__":
 All block values are encrypted before being stored.
 If you have values that you would not like visible in the UI or in logs, 
 use the `SecretStr` field type provided by Pydantic to automatically obfuscate those values.
-You can use this functionality for fields that store credentials such as passwords and API tokens.
+You can use this capability for fields that store credentials such as passwords and API tokens.
 
 Here's an example of an `AWSCredentials` block that uses `SecretStr`:
 
@@ -288,7 +288,7 @@ print(aws_credentials_block)
 
 Prefect's `SecretDict` field type allows you to add a dictionary field to your block 
 that automatically obfuscates values at all levels in the UI or in logs.
-This functionality is useful for blocks where typing or structure of secret fields is not known until configuration time.
+This capability is useful for blocks where typing or structure of secret fields is not known until configuration time.
 
 Here's an example of a block that uses `SecretDict`:
 
@@ -344,7 +344,7 @@ Available metadata fields include:
 ### Nested blocks
 
 Blocks are composable: a block can be used within other blocks.
-You can create a block type that uses functionality from another block type by declaring it as an attribute.
+You can create a block type that uses capabilities from another block type by declaring it as an attribute.
 
 Nestable blocks are loosely coupled, and configuration can be changed for each block independently. 
 This allows sharing configuration across multiple use cases.

--- a/docs/3.0rc/develop/blocks.mdx
+++ b/docs/3.0rc/develop/blocks.mdx
@@ -217,7 +217,7 @@ class Cube(Block):
     edge_length_inches: float
 ```
 
-You can add methods to a block to provide additional actions. 
+You can add methods to a block to provide additional capabilities. 
 Here's the same cube block with methods to calculate the volume and surface area of the cube:
 
 ```python

--- a/docs/3.0rc/develop/deferred-tasks.mdx
+++ b/docs/3.0rc/develop/deferred-tasks.mdx
@@ -282,7 +282,7 @@ The URL will look like this:
 
 Substitute your UUID at the end of the URL.
 
-#### Step 6: Use multiple task workers to run tasks in parallel.
+#### Step 6: Use multiple task workers to run tasks in parallel
 
 Start another instance of the task worker. In another terminal run:
 
@@ -305,7 +305,7 @@ if __name__ == "__main__":
 
 Run the file to see the work get distributed across both task workers.
 
-#### Step 8: Shut down the task workers with *control* + *c*.
+#### Step 8: Shut down the task workers with *control* + *c*
 
 This guide showed you how to send tasks to multiple Prefect task workers running in the background.
 This allows you to observe these tasks executing in parallel and very quickly with web sockets, with no polling required.

--- a/docs/3.0rc/develop/interact-with-data.mdx
+++ b/docs/3.0rc/develop/interact-with-data.mdx
@@ -158,7 +158,7 @@ This example uses Python code.
   <Tab title="AWS">
 
     Note that the `S3Bucket` block is not the same as the `S3` block that ships with Prefect. 
-    The `S3Bucket` block used in this example is part of the `prefect-aws` library and provides additional functionality. 
+    The `S3Bucket` block used in this example is part of the `prefect-aws` library and provides additional capabilities. 
 
     Next, reference the credentials block created above.
 
@@ -176,14 +176,14 @@ This example uses Python code.
   <Tab title="Azure">
 
     Note that the `AzureBlobStorageCredentials` block is not the same as the Azure block that ships with Prefect. 
-    The `AzureBlobStorageCredentials` block used in this example is part of the `prefect-azure` library and provides additional functionality. 
+    The `AzureBlobStorageCredentials` block used in this example is part of the `prefect-azure` library and provides additional capabilities. 
 
     Azure blob storage doesn't require a separate block. The connection string used in the `AzureBlobStorageCredentials` block can encode the information needed. 
   </Tab>
   <Tab title="GCP">
 
     Note that the `GcsBucket` block is not the same as the `GCS` block that ships with Prefect. 
-    The `GcsBucket` block is part of the `prefect-gcp` library and provides additional functionality.
+    The `GcsBucket` block is part of the `prefect-gcp` library and provides additional capabilities.
 
     Next, reference the credentials block created above.
 

--- a/docs/3.0rc/develop/pause-resume.mdx
+++ b/docs/3.0rc/develop/pause-resume.mdx
@@ -12,7 +12,7 @@ When a flow run is suspended, code execution is stopped and so is the process.
 ### Pause a flow run
 
 Prefect enables pausing an in-progress flow run for manual approval.
-Prefect exposes this functionality with the [`pause_flow_run`](https://prefect-python-sdk-docs.netlify.app/prefect/engine/#prefect.engine.pause_flow_run) 
+Prefect exposes this capability with the [`pause_flow_run`](https://prefect-python-sdk-docs.netlify.app/prefect/engine/#prefect.engine.pause_flow_run) 
 and [`resume_flow_run`](https://prefect-python-sdk-docs.netlify.app/prefect/engine/#prefect.engine.resume_flow_run) functions.
 
 <Note>
@@ -103,7 +103,7 @@ This means you can suspend flow runs to save costs instead of paying for long-ru
 However, when the flow run resumes, the flow code will execute again from the beginning of the flow. 
 We recommend using [tasks](/3.0rc/develop/write-tasks/) and [task caching](/3.0rc/develop/task-caching) to avoid recomputing expensive operations.
 
-Prefect exposes this functionality through the [`suspend_flow_run`](https://prefect-python-sdk-docs.netlify.app/prefect/engine/#prefect.engine.suspend_flow_run) and 
+Prefect exposes this capability through the [`suspend_flow_run`](https://prefect-python-sdk-docs.netlify.app/prefect/engine/#prefect.engine.suspend_flow_run) and 
 [`resume_flow_run`](https://prefect-python-sdk-docs.netlify.app/prefect/engine/#prefect.engine.resume_flow_run) functions, as well as the Prefect UI.
 
 When called inside of a flow, `suspend_flow_run` immediately suspends execution of the flow run.

--- a/docs/3.0rc/develop/write-tasks.mdx
+++ b/docs/3.0rc/develop/write-tasks.mdx
@@ -22,7 +22,7 @@ Flows and tasks share some common features:
 (see all [task settings](/3.0rc/develop/write-tasks/#task-arguments) and 
 [flow settings](/3.0rc/develop/write-flows/#flow-settings))
 - They can have a name, description, and tags for organization and bookkeeping
-- They provide functionality for retries, timeouts, and other hooks to handle failure and completion events
+- They provide retries, timeouts, and other hooks to handle failure and completion events
 
 ## Example task
 

--- a/docs/3.0rc/get-started/install.mdx
+++ b/docs/3.0rc/get-started/install.mdx
@@ -46,7 +46,7 @@ Review the `pip install` output messages for the `Scripts` folder path on your s
 
 The `prefect-client` library is a minimal installation of Prefect designed for interacting with Prefect Cloud or a remote self-hosted server instance.
 
-`prefect-client` enables a subset of Prefect's functionality with a smaller installation size, making it ideal for use in lightweight, resource-constrained, or ephemeral environments.
+`prefect-client` enables a subset of Prefect's capabilities with a smaller installation size, making it ideal for use in lightweight, resource-constrained, or ephemeral environments.
 It omits all CLI and server components found in the `prefect` library.
 
 To install the latest release of `prefect-client`, run:

--- a/docs/3.0rc/get-started/quickstart.mdx
+++ b/docs/3.0rc/get-started/quickstart.mdx
@@ -46,7 +46,7 @@ Connect to the Prefect API, either Prefect Cloud hosted by us, or a local Prefec
 
 1. Choose **Log in with a web browser** and click the **Authorize** button in the browser window that opens.
 
-Your CLI is now authenticated with your Prefect Cloud account through a locally-stored API key that expires in 30 days.
+Your CLI is now authenticated with your Prefect Cloud account through a locally stored API key that expires in 30 days.
 
 If you have any issues with browser-based authentication, you can [authenticate with a manually created API key](/3.0rc/manage/cloud/manage-users/api-keys/) instead.
   </Tab>

--- a/docs/3.0rc/manage/cloud/index.mdx
+++ b/docs/3.0rc/manage/cloud/index.mdx
@@ -33,7 +33,7 @@ As an account Admin, you will also have access to account settings from the Acco
 
 As an account Admin you can create a [workspace](#workspaces) and invite other individuals to your workspace.
 
-Upgrading from a Prefect Cloud Free tier plan to a Pro or Enterprise tier plan enables additional functionality for adding workspaces, managing teams, and running higher volume workloads.
+Upgrading from a Prefect Cloud Free tier plan to a Pro or Enterprise tier plan enables additional capabilities for adding workspaces, managing teams, and running higher volume workloads.
 
 Workspace Admins for Pro tier plans have the ability to set [role-based access controls (RBAC)](#roles-and-custom-permissions), view [Audit Logs](#audit-log), and configure [service accounts](#service-accounts).
 

--- a/docs/3.0rc/manage/cloud/manage-users/manage-roles.mdx
+++ b/docs/3.0rc/manage/cloud/manage-users/manage-roles.mdx
@@ -8,7 +8,7 @@ access to the appropriate level within specific workspaces.
 
 Role-based access controls (RBAC) enable you to assign users granular permissions to perform certain activities.
 
-Enterprise account Admins can create custom roles for users to give users access to functionality 
+Enterprise account Admins can create custom roles for users to give users access to capabilities 
 beyond the scope of Prefect’s built-in workspace roles.
 
 ## Built-in roles
@@ -50,11 +50,11 @@ specific permissions within a workspace.
 
 Custom roles can inherit permissions from a built-in role.
 This enables tweaks to the role to meet your team’s needs, while ensuring users still benefit 
-from Prefect’s default workspace role permission curation as new functionality becomes available.
+from Prefect’s default workspace role permission curation as new capabilities becomes available.
 
 You can create custom workspace roles independently of Prefect’s built-in roles. This option gives 
-workspace admins full control of user access to workspace functionality. However, for non-inherited custom roles, 
-the workspace admin takes on the responsibility for monitoring and setting permissions for new functionality as it is released.
+workspace admins full control of user access to workspace capabilities. However, for non-inherited custom roles, 
+the workspace admin takes on the responsibility for monitoring and setting permissions for new capabilities as it is released.
 
 See [Role permissions](#workspace-role-permissions) for details of permissions you may set for custom roles.
 
@@ -68,10 +68,9 @@ custom role from a set of initial permissions associated with a built-in Prefect
 You can add additional permissions to the custom role. Permissions included in the inherited role cannot be removed.
 
 Custom roles created from an inherited role follow Prefect's default workspace role permission curation as 
-new functionality becomes available.
+new capabilities becomes available.
 
-To configure an inherited role alongside a custom role, select the **Inherit permission from a default role** 
-check box, then select the role from which the new role should inherit permissions.
+To configure an inherited role alongside a custom role, select **Inherit permission from a default role**, then select the role from which the new role should inherit permissions.
 
 ## Workspace role permissions
 

--- a/docs/3.0rc/manage/cloud/workspaces.mdx
+++ b/docs/3.0rc/manage/cloud/workspaces.mdx
@@ -62,7 +62,7 @@ Workspace transfer retains existing workspace configuration and flow run history
 <Note>
 **Workspace transfer permissions**
 
-You must have admin privileges to initiate or approve a workspace transfer.
+You must have administrator privileges to initiate or approve a workspace transfer.
 
 To initiate a workspace transfer between personal accounts, contact [support@prefect.io](mailto:support@prefect.io).
 </Note>

--- a/docs/3.0rc/resources/upgrade-agents-to-workers.mdx
+++ b/docs/3.0rc/resources/upgrade-agents-to-workers.mdx
@@ -317,13 +317,16 @@ if __name__ == "__main__":
         parameters=dict(name="Marvin"),
     )
 ```
-
+<!-- vale Google.Spacing = NO -->
 <Note>
 When using `flow.from_source(...).deploy(...)` with a remote
 `source` (like a `GitHub` block or `str` URL like https://github.com/me/myrepo.git),
 the flow you're deploying does not need to be available locally before running your script.
 See the [SDK reference](https://prefect-python-sdk-docs.netlify.app/prefect/#prefect.Flow.from_source) for more info on `from_source`.
+
 </Note>
+<!-- vale Google.Spacing = YES -->
+
 
 #### Deploying via a Docker image
 

--- a/docs/3.0rc/resources/upgrade-prefect-3.mdx
+++ b/docs/3.0rc/resources/upgrade-prefect-3.mdx
@@ -228,7 +228,7 @@ Prefect 2 uses Pydantic V1 to validate data, particularly for blocks and work po
 Prefect 3 uses Pydantic V2. This upgrade does not require changes for any built-in Prefect interfaces or supported integrations. 
 However, if you have registered custom blocks with a self-hosted Prefect Server, type enforcement for those block schemas must be upgraded to Pydantic V2 to work with Prefect 3. 
 
-See the the [Pydantic migration guide](https://docs.pydantic.dev/latest/migration/) for more information.
+See the [Pydantic migration guide](https://docs.pydantic.dev/latest/migration/) for more information.
 
 ## Workers replace agents
 

--- a/docs/contribute/styles-practices.mdx
+++ b/docs/contribute/styles-practices.mdx
@@ -285,7 +285,7 @@ Versions are composed of three parts: MAJOR.MINOR.PATCH. For example, the versio
 of 5, and patch version of 0.
 
 Occasionally, we add a suffix to the version such as `rc`, `a`, or `b`. These indicate pre-release versions that users can 
-opt into to test functionality before it is ready for release.
+opt into for testing and experimentation prior to a generally available release.
 
 Each release will increase one of the version numbers. If we increase a number other than the patch version, the versions to the 
 right of it reset to zero.
@@ -304,7 +304,7 @@ Prefect increases the patch version when:
 
 *   Making enhancements to existing features
 *   Fixing behavior in existing features
-*   Adding new functionality to existing concepts
+*   Adding new capabilities to existing concepts
 *   Updating dependencies
 
 ## Deprecation
@@ -319,7 +319,7 @@ Prefect will sometimes include changes to behavior to fix a bug. These changes a
 
 When running a Prefect server, you are in charge of ensuring the version is compatible with those of the clients that are 
 using the server. Prefect aims to maintain backwards compatibility with old clients for each server release. In contrast, 
-sometimes you cannot use new clients with an old server. The new client may expect the server to support functionality that 
+sometimes you cannot use new clients with an old server. The new client may expect the server to support capabilities that 
 it does not yet include. For this reason, we recommend that all clients are the same version as the server or older.
 
 For example, you can use a client on 2.1.0 with a server on 2.5.0. You cannot use a client on 2.5.0 with a server on 2.1.0.

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -100,7 +100,7 @@ For more information about these environment variables, see the [cURL documentat
 
 The `prefect-client` library is a minimal installation of Prefect designed for interacting with Prefect Cloud or a remote self-hosted server instance.
 
-`prefect-client` enables a subset of Prefect's functionality with a smaller installation size, making it ideal for use in lightweight, resource-constrained, or ephemeral environments. It omits all CLI and server components found in the `prefect` library.
+`prefect-client` enables a subset of Prefect's capabilities with a smaller installation size, making it ideal for use in lightweight, resource-constrained, or ephemeral environments. It omits all CLI and server components found in the `prefect` library.
 
 Install the latest version with:
 
@@ -114,7 +114,7 @@ By default, a local Prefect server instance uses SQLite as the backing database.
 
 <Info>
 
-If you install the [`prefect-client`](https://pypi.org/project/prefect-client/) library that provides a limited set of the full Prefect library's functionality, you do not need SQLite installed.
+If you install the [`prefect-client`](https://pypi.org/project/prefect-client/) library that provides a limited set of the full Prefect library's capabilities, you do not need SQLite installed.
 </Info>
 
 ### Install SQLite on RHEL

--- a/docs/integrations/prefect-azure/index.mdx
+++ b/docs/integrations/prefect-azure/index.mdx
@@ -32,7 +32,7 @@ Install or update to the latest version of the prefect-azure library and depende
 
 If necessary, see [additional installation options for Blob Storage, Cosmos DB, and ML Datastore](#additional-installation-options).
 
-To install with all additional functionality, use the following command:
+To install with all additional capabilities, use the following command:
 
 Install or update to the latest version of the prefect-aws library and dependencies.
 

--- a/docs/integrations/prefect-dbt/index.mdx
+++ b/docs/integrations/prefect-dbt/index.mdx
@@ -33,7 +33,7 @@ Install or update to the latest version of the prefect-dbt library and dependenc
 
 If necessary, see [additional installation options for dbt Core with BigQuery, Snowflake, and Postgres](#additional-installation-options).
 
-To install with all additional functionality, use the following command:
+To install with all additional capabilities, use the following command:
 
 
 ```bash
@@ -326,7 +326,7 @@ Refer to the `prefect-dbt` API documentation linked in the sidebar to explore al
 
 Additional installation options for dbt Core with BigQuery, Snowflake, and Postgres are shown below.
 
-#### Additional functionality for dbt Core and Snowflake profiles
+#### Additional capabilities for dbt Core and Snowflake profiles
 
 To install for Prefect 3, include the `--pre` flag.
 
@@ -336,7 +336,7 @@ pip install -U "prefect-dbt[snowflake]"
 ```
 
 
-#### Additional functionality for dbt Core and BigQuery profiles
+#### Additional capabilities for dbt Core and BigQuery profiles
 
 
 ```bash
@@ -344,7 +344,7 @@ pip install -U "prefect-dbt[bigquery]"
 ```
 
 
-#### Additional functionality for dbt Core and Postgres profiles
+#### Additional capabilities for dbt Core and Postgres profiles
 
 
 ```bash

--- a/docs/integrations/prefect-gcp/index.mdx
+++ b/docs/integrations/prefect-gcp/index.mdx
@@ -33,7 +33,7 @@ Install or update to the latest version of the prefect-gcp library and dependenc
 
 If using BigQuery, Cloud Storage, Secret Manager, or Vertex AI, see [additional installation options](#additional-installation-options).
 
-To install with all additional functionality, use the following command:
+To install with all additional capabilities, use the following command:
 
 
 ```bash


### PR DESCRIPTION
This PR brings the 3.0rc repo and other docs files to 0 errors and 53 warnings. Does not include the Server API docs.

From the docs folder, run with:

```vale --glob='!{*.mdx,*.js,*.json,*.png,*.jpg,*.css,*.yml,*.svg,3.0rc/api-ref/*.md}' ./3.0rc```

It runs quickly locally.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
