### PR TITLE
Fix clicking "parent flow run" from a flow run with a grandparent navigates to the grandparent

### DIFF
--- a/ui/src/pages/FlowRun.vue
+++ b/ui/src/pages/FlowRun.vue
@@ -1,30 +1,30 @@
 <template>
-  <p-layout-default class="flow-run">
+  <p-layout-default v-if="flowRun" :key="flowRun.id" class="flow-run">
     <template #header>
-      <PageHeadingFlowRun v-if="flowRun" :flow-run-id="flowRun.id" @delete="goToRuns" />
+      <PageHeadingFlowRun :flow-run-id="flowRun.id" @delete="goToRuns" />
     </template>
 
-    <FlowRunGraphs v-if="flowRun && !isPending" :flow-run="flowRun" />
+    <FlowRunGraphs v-if="!isPending" :flow-run="flowRun" />
 
     <p-tabs v-model:selected="tab" :tabs="tabs">
       <template #details>
-        <FlowRunDetails v-if="flowRun" :flow-run="flowRun" />
+        <FlowRunDetails :flow-run="flowRun" />
       </template>
 
       <template #logs>
-        <FlowRunLogs v-if="flowRun" :flow-run="flowRun" />
+        <FlowRunLogs :flow-run="flowRun" />
       </template>
 
       <template #results>
-        <FlowRunResults v-if="flowRun" :flow-run="flowRun" />
+        <FlowRunResults :flow-run="flowRun" />
       </template>
 
       <template #artifacts>
-        <FlowRunArtifacts v-if="flowRun" :flow-run="flowRun" />
+        <FlowRunArtifacts :flow-run="flowRun" />
       </template>
 
       <template #task-runs>
-        <FlowRunTaskRuns v-if="flowRun" :flow-run-id="flowRun.id" />
+        <FlowRunTaskRuns :flow-run-id="flowRun.id" />
       </template>
 
       <template #subflow-runs>
@@ -32,13 +32,13 @@
       </template>
 
       <template #parameters>
-        <CopyableWrapper v-if="flowRun" :text-to-copy="parameters">
+        <CopyableWrapper :text-to-copy="parameters">
           <p-code-highlight lang="json" :text="parameters" class="flow-run__parameters" />
         </CopyableWrapper>
       </template>
 
       <template #job-variables>
-        <CopyableWrapper v-if="flowRun" :text-to-copy="jobVariables">
+        <CopyableWrapper :text-to-copy="jobVariables">
           <p-code-highlight lang="json" :text="jobVariables" class="flow-run__job-variables" />
         </CopyableWrapper>
       </template>


### PR DESCRIPTION
# Description
Narrowed down to some subscription sharing issue between nebula-ui/WorkspaceFlowRun.vue and ui-library/FlowRunParentFlowRun.vue

Ultimately the primary subscription in WorkspaceFlowRun would end up having the channel key/args for the parent flow run but the response for the grandparent flow run. This is likely the same issue as #2810 which was fixed by using a vue key to prevent component reuse. Moving that key to the root element seems to fix both issues.

Closes PrefectHQ/prefect#13817