### PR TITLE
Fix flaky `test_logs_message_when_submitted_tasks_end_in_pending` test

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -854,13 +854,17 @@ class TestTaskSubmit:
         """
 
         @task
-        def foo():
-            pass
+        def find_palindromes():
+            """This is a computationally expensive task that never ends,
+            allowing the flow to exit before the task is completed."""
+            num = 10
+            while True:
+                _ = str(num) == str(num)[::-1]
+                num += 1
 
         @flow
         def test_flow():
-            for _ in range(100):
-                foo.submit()
+            find_palindromes.submit()
 
         test_flow()
         assert (


### PR DESCRIPTION
This fixes the flaky `test_logs_message_when_submitted_tasks_end_in_pending` test. The original test was just queuing up 100 tasks that were no-ops, and sometimes those tasks were able to all complete before the flow fully exited. This version gives it a single, somewhat expensive, never ending, task that should never complete, allowing the flow to exit before the task finishes.

Closes #14225 