### PR TITLE
Ensure label on PRs for release notes

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -27,7 +27,13 @@ jobs:
         done
 
         if [ "$LABEL_FOUND" = false ]; then
-          echo "This pull request must have one of the following labels: ${REQUIRED_LABELS[*]}"
+          echo "##[error]This pull request must have one of the following labels:"
+          echo " - docs"
+          echo " - integrations"
+          echo " - fix"
+          echo " - enhancement"
+          echo " - feature"
+          echo " - maintenance"
           exit 1
         fi
 

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,0 +1,36 @@
+# For automated releases, we should ensure we don't have PRs in the Uncategorized section. 
+# Uncategorized PRs can be prevented by adding the necessary label.
+
+name: Ensure PR Label
+
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled]
+
+jobs:
+  ensure-label:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check for required labels
+      id: label-check
+      run: |
+        LABELS=$(jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH")
+        REQUIRED_LABELS=("docs" "integrations" "fix" "enhancement" "feature" "maintenance")
+        LABEL_FOUND=false
+
+        for label in "${REQUIRED_LABELS[@]}"; do
+          if echo "$LABELS" | grep -q "$label"; then
+            LABEL_FOUND=true
+            break
+          fi
+        done
+
+        if [ "$LABEL_FOUND" = false ]; then
+          echo "This pull request must have one of the following labels: ${REQUIRED_LABELS[*]}"
+          exit 1
+        fi
+
+    - name: Fail the PR if no required label is found
+      if: steps.label-check.outputs.LABEL_FOUND == 'false'
+      run: exit 1

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -27,13 +27,14 @@ jobs:
         done
 
         if [ "$LABEL_FOUND" = false ]; then
-          echo "##[error]This pull request must have one of the following labels:"
+          echo "##[error]This pull request must have one of the following labels to help with sorting for release notes:"
           echo " - docs"
+          echo " - maintenance"
+          echo " - deprecation"
           echo " - integrations"
           echo " - fix"
           echo " - enhancement"
           echo " - feature"
-          echo " - maintenance"
           exit 1
         fi
 


### PR DESCRIPTION
It would be useful to ensure we don't have uncategorized PRs, when it comes to release notes.

![Screenshot 2024-07-03 at 12 11 13 PM](https://github.com/PrefectHQ/prefect/assets/42048900/16c42a37-53a1-4277-bc90-542edfeccb79)
![Screenshot 2024-07-03 at 12 11 20 PM](https://github.com/PrefectHQ/prefect/assets/42048900/8410e9e9-41f5-44cc-b792-b67af9c12b57)
