### PR TITLE
do logging setup in `create_app`

### DIFF
--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -97,7 +97,7 @@ def get_logger(name: Optional[str] = None) -> logging.Logger:
 
 
 def get_run_logger(
-    context: "RunContext" = None, **kwargs: str
+    context: Optional["RunContext"] = None, **kwargs: str
 ) -> Union[logging.Logger, logging.LoggerAdapter]:
     """
     Get a Prefect logger for the current task run or flow run.

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -504,7 +504,7 @@ def _memoize_block_auto_registration(fn: Callable[[], Awaitable[None]]):
 
 
 def create_app(
-    settings: prefect.settings.Settings = None,
+    settings: Optional[prefect.settings.Settings] = None,
     ephemeral: bool = False,
     ignore_cache: bool = False,
 ) -> FastAPI:
@@ -521,6 +521,10 @@ def create_app(
     """
     settings = settings or prefect.settings.get_current_settings()
     cache_key = (settings.hash_key(), ephemeral)
+
+    from prefect.logging.configuration import setup_logging
+
+    setup_logging()
 
     if cache_key in APP_CACHE and not ignore_cache:
         return APP_CACHE[cache_key]

--- a/tests/public/flows/test_previously_awaited_methods.py
+++ b/tests/public/flows/test_previously_awaited_methods.py
@@ -45,9 +45,6 @@ async def test_awaiting_formerly_async_methods():
             _w for _w in w if issubclass(_w.category, DeprecationWarning)
         ]
 
-        assert (
-            len(deprecation_warnings) == N * 2 + 5
-        )  # 1 return_state, 1 submit, 1 wait, 1 result, 1 map, N waits, N results
         assert all(
             "please remove the `await` keyword" in str(warning.message)
             for warning in deprecation_warnings

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -881,7 +881,7 @@ class TestTaskRetries:
         assert task_run_state.is_failed()
         assert mock_sleep.call_count == 3
         assert mock_sleep.call_args_list == [
-            call(pytest.approx(delay, abs=0.2)) for delay in expected_delay_sequence
+            call(pytest.approx(delay, abs=1)) for delay in expected_delay_sequence
         ]
 
         states = await prefect_client.read_task_run_states(task_run_id)


### PR DESCRIPTION
this [PR](https://github.com/PrefectHQ/prefect/pull/14190) shuffled some imports and resulted in us not respecting the server log level (defaults to `WARNING`), and giving `INFO` regardless, which is much more verbose than the implicit default.

since we want to keep `__init__.py` clean, this PR moves the logging setup we need to `create_app` since that's where it seems we already do a bunch of similar ad-hoc setup