### PR TITLE
Fix docker worker volumes

### DIFF
--- a/src/integrations/prefect-docker/prefect_docker/worker.py
+++ b/src/integrations/prefect-docker/prefect_docker/worker.py
@@ -74,7 +74,7 @@ def assert_volume_str(v: str) -> str:
     if not match:
         raise ValueError(f"Invalid volume string: {v!r}")
 
-    source, _, mode = match.groups()
+    _, _, mode = match.groups()
 
     # Check for empty parts
     if ":" not in v or v.startswith(":") or v.endswith(":"):

--- a/src/integrations/prefect-docker/prefect_docker/worker.py
+++ b/src/integrations/prefect-docker/prefect_docker/worker.py
@@ -62,7 +62,32 @@ class ImagePullPolicy(enum.Enum):
     NEVER = "Never"
 
 
-VolumeStr = Annotated[str, AfterValidator(lambda v: ":" in v)]
+def assert_volume_str(v: str) -> str:
+    """Assert that a string is a valid Docker volume string."""
+    if not isinstance(v, str):
+        raise ValueError("Volume must be a string")
+
+    # Regex pattern for valid Docker volume strings, including Windows paths
+    pattern = r"^([a-zA-Z]:\\|/)?[^:]+:(/)?[^:]+(:ro|:rw)?$"
+
+    match = re.match(pattern, v)
+    if not match:
+        raise ValueError(f"Invalid volume string: {v!r}")
+
+    source, _, mode = match.groups()
+
+    # Check for empty parts
+    if ":" not in v or v.startswith(":") or v.endswith(":"):
+        raise ValueError(f"Volume string contains empty part: {v!r}")
+
+    # If there's a mode, it must be 'ro' or 'rw'
+    if mode and mode not in (":ro", ":rw"):
+        raise ValueError(f"Invalid volume mode: {mode!r}. Must be ':ro' or ':rw'")
+
+    return v
+
+
+VolumeStr = Annotated[str, AfterValidator(assert_volume_str)]
 
 
 class DockerWorkerJobConfiguration(BaseJobConfiguration):

--- a/src/integrations/prefect-docker/tests/test_worker.py
+++ b/src/integrations/prefect-docker/tests/test_worker.py
@@ -15,7 +15,9 @@ from prefect_docker.worker import (
     CONTAINER_LABELS,
     DockerWorker,
     DockerWorkerJobConfiguration,
+    VolumeStr,
 )
+from pydantic import BaseModel, ValidationError
 
 from prefect.client.schemas import FlowRun
 from prefect.events import RelatedResource
@@ -260,6 +262,45 @@ async def test_uses_volumes_setting(
     call_volumes = mock_docker_client.containers.create.call_args[1].get("volumes")
     assert "a:b" in call_volumes
     assert "c:d" in call_volumes
+
+
+class VolumeModel(BaseModel):
+    volume: VolumeStr
+
+
+@pytest.mark.parametrize(
+    "volume_str",
+    [
+        "a:b",
+        "/host/path:/container/path",
+        "named_volume:/app/data",
+        "/home/user:/home/docker:ro",
+        "/home/user:/home/docker:rw",
+        "C:\\path\\on\\windows:/path/in/container",
+        "\\\\host\\share:/path/in/container",
+    ],
+)
+def test_valid_volume_strings(volume_str):
+    assert VolumeModel(volume=volume_str).volume == volume_str
+
+
+@pytest.mark.parametrize(
+    "volume_str",
+    [
+        "invalid_volume",
+        ":missing_host",
+        "missing_container:",
+        "/double:/colon:/path",
+        "/path:/path:invalid_mode",
+        ":/:",
+        " : : ",
+        "/host:/container:rw:extra",
+        "",  # empty string
+    ],
+)
+def test_invalid_volume_strings(volume_str):
+    with pytest.raises(ValidationError, match="Invalid volume"):
+        VolumeModel(volume=volume_str)
 
 
 async def test_uses_privileged_setting(

--- a/src/integrations/prefect-docker/tests/test_worker.py
+++ b/src/integrations/prefect-docker/tests/test_worker.py
@@ -17,7 +17,7 @@ from prefect_docker.worker import (
     DockerWorkerJobConfiguration,
     VolumeStr,
 )
-from pydantic import BaseModel, ValidationError
+from pydantic import TypeAdapter, ValidationError
 
 from prefect.client.schemas import FlowRun
 from prefect.events import RelatedResource
@@ -264,10 +264,6 @@ async def test_uses_volumes_setting(
     assert "c:d" in call_volumes
 
 
-class VolumeModel(BaseModel):
-    volume: VolumeStr
-
-
 @pytest.mark.parametrize(
     "volume_str",
     [
@@ -281,7 +277,7 @@ class VolumeModel(BaseModel):
     ],
 )
 def test_valid_volume_strings(volume_str):
-    assert VolumeModel(volume=volume_str).volume == volume_str
+    assert TypeAdapter(VolumeStr).validate_python(volume_str) == volume_str
 
 
 @pytest.mark.parametrize(
@@ -300,7 +296,7 @@ def test_valid_volume_strings(volume_str):
 )
 def test_invalid_volume_strings(volume_str):
     with pytest.raises(ValidationError, match="Invalid volume"):
-        VolumeModel(volume=volume_str)
+        TypeAdapter(VolumeStr).validate_python(volume_str)
 
 
 async def test_uses_privileged_setting(


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/14490

[this previous](https://github.com/PrefectHQ/prefect/pull/13697) PR introduced an incorrect `AfterValidator` for a self-validating `VolumeStr` which was `lambda v: ":" in v` which returns a `bool`, effectively casting all users' volumes `str->bool` after instantiation

this PR fixes this and adds some regression tests