### PR TITLE
respect `--ui`/`--no-ui` flag on `prefect server start`

### DIFF
--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -184,6 +184,7 @@ async def start(
     server_env["PREFECT_SERVER_ANALYTICS_ENABLED"] = str(analytics)
     server_env["PREFECT_API_SERVICES_LATE_RUNS_ENABLED"] = str(late_runs)
     server_env["PREFECT_API_SERVICES_UI"] = str(ui)
+    server_env["PREFECT_UI_ENABLED"] = str(ui)
     server_env["PREFECT_LOGGING_SERVER_LEVEL"] = log_level
 
     base_url = f"http://{host}:{port}"


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/14476

previously, whether or not the dashboard was build only depended on `PREFECT_UI_ENABLED`, where that should be starting place that can be overridden or not by the `ui`/ `no-ui` flag on `prefect server start`

## test changes
```bash
docker build . -t test

docker run -p 4200:4200 --rm test -- prefect server start --host 0.0.0.0 --ui # correctly builds dashboard

docker run -p 4200:4200 --rm test -- prefect server start --host 0.0.0.0 --no-ui # correctly skips dashboard
```