### PR TITLE
Type hint Fix

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/cloud/jobs.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/cloud/jobs.py
@@ -416,7 +416,7 @@ async def trigger_dbt_cloud_job_run_and_wait_for_completion(
 async def _build_trigger_job_run_options(
     dbt_cloud_credentials: DbtCloudCredentials,
     trigger_job_run_options: TriggerJobRunOptions,
-    run_id: str,
+    run_id: int,
     run_info: Dict[str, Any],
     job_info: Dict[str, Any],
 ):

--- a/src/prefect/cli/_prompts.py
+++ b/src/prefect/cli/_prompts.py
@@ -6,7 +6,7 @@ import os
 import shutil
 from datetime import timedelta
 from getpass import GetPassWarning
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import readchar
 from rich.console import Console, Group
@@ -97,7 +97,7 @@ def prompt_select_from_table(
     selected_row = None
     table_kwargs = table_kwargs or {}
 
-    def build_table() -> Table:
+    def build_table() -> Union[Table, Group]:
         """
         Generate a table of options. The `current_idx` will be highlighted.
         """

--- a/src/prefect/server/services/cancellation_cleanup.py
+++ b/src/prefect/server/services/cancellation_cleanup.py
@@ -133,7 +133,7 @@ class CancellationCleanup(LoopService):
 
     async def _cancel_subflow(
         self, db: PrefectDBInterface, flow_run: orm_models.FlowRun
-    ) -> None:
+    ) -> Optional[bool]:
         if not flow_run.parent_task_run_id:
             return False
 

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -558,7 +558,7 @@ def propose_state_sync(
         )
 
 
-def _dynamic_key_for_task_run(context: FlowRunContext, task: Task) -> int:
+def _dynamic_key_for_task_run(context: FlowRunContext, task: Task) -> Union[int, str]:
     if context.detached:  # this task is running on remote infrastructure
         return str(uuid4())
     elif context.flow_run is None:  # this is an autonomous task run


### PR DESCRIPTION
## Description
Fix type check warnings reported by Pyre@Google, which were outdated after code modifications.

## Detail
1. update the type hint of argument `run_id`  in function `_build_trigger_job_run_options` from `str` to `int`, since the `run_id` is used as an argument in `get_dbt_cloud_run_artifact.with_options` and should be `int` after the commit https://github.com/PrefectHQ/prefect/commit/839c3b02e007d14a2b7df6a01b208c724caffa4d
2. update the return value type of function `build_table` from `Table` to `Union[Table, Group]`, since it can return `Group` after commit https://github.com/PrefectHQ/prefect/commit/0429a61d5554233489a3cb6aefed3df9b11fd03c
3. update the return value type of function `_cancel_subflow` from `None` to `Optional[bool]`, since it can return `False` and `None` after commit https://github.com/PrefectHQ/prefect/commit/e938557a16e68289ddf49608eebbe949a24860ef
4. update the return value type of function `_dynamic_key_for_task_run` from `int` to `Union[int, str]`, since it can return `str(uuid4())` after commit https://github.com/PrefectHQ/prefect/commit/bb3d2c2d351602566b733c7a7264fb0cd44ee1bf