### PR TITLE
Removes the extra CODEOWNERS entry for events

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,17 +12,6 @@
 mkdocs.yml                           @PrefectHQ/docs
 mkdocs.insiders.yml                  @PrefectHQ/docs
 
-# orchestration rules / policies
-/src/prefect/server/orchestration     @PrefectHQ/open-source
-
-# database configuration / models
-/src/prefect/server/database          @PrefectHQ/open-source
-
-# the events subsystem, while it's being ported
-/src/prefect/events                   @chrisguidry
-/src/prefect/server/events            @chrisguidry
-/tests/events                         @chrisguidry
-
 # imports
 /src/prefect/__init__.py              @aaazzam @chrisguidry
 /src/prefect/main.py                  @aaazzam @chrisguidry


### PR DESCRIPTION
Now that events are all cooked in 3.0, these can just be treated normally.  I
also noticed we had some legacy rules that are no-ops as well, so I removed
those too.
