### PR TITLE
Enhancement: Cloud CTA dark mode button

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -42,7 +42,7 @@
   },
   "topbarCtaButton": {
     "name": "TRY PREFECT CLOUD",
-    "url": "https://app.prefect.cloud/auth/login"
+    "url": "https://app.prefect.cloud/"
   },
   "anchors": [
     {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,23 +1,21 @@
-#topbar-cta-button a {
-  display: flex;
-  align-items: center;
-  padding: 0.8rem 1.1rem !important; /* Increase the vertical padding */
-  gap: 0.5rem;
+#topbar-cta-button > a > span {
   background-color: #2D6DF6;
-  color: #fff !important;
   border-radius: 0.25rem;
+}
+
+#topbar-cta-button > a {
+  padding: 0.5rem 1rem;
+}
+
+#topbar-cta-button > a div > span {
   font-weight: 400;
   letter-spacing: 0.4px;
 }
 
-#topbar-cta-button span.z-10 {
-  color: inherit !important; /* This will override the text color set by the classes */
+#topbar-cta-button>a div>span,
+#topbar-cta-button > a div > svg {
+  color: #fff;
 }
-
-#topbar-cta-button span.z-10.dark\:text-primary-light {
-  color: inherit !important; /* This will override the dark mode text color */
-}
-
 
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');


### PR DESCRIPTION
Before (note the faint weird border inside the button): 

<img width="1481" alt="Screenshot 2024-07-12 at 2 08 12 PM" src="https://github.com/user-attachments/assets/04b88045-b487-41c2-b7d9-4de9c19df702">

After: 

<img width="1481" alt="Screenshot 2024-07-12 at 2 13 30 PM" src="https://github.com/user-attachments/assets/90a71986-459d-435f-b4ef-c45d5a618bed">
