### PR TITLE
Fix title formatting of code sample scripts in serve docs

### DIFF
--- a/docs/3.0rc/deploy/run-flows-in-local-processes.mdx
+++ b/docs/3.0rc/deploy/run-flows-in-local-processes.mdx
@@ -12,7 +12,7 @@ The serve method creates a deployment for the flow and starts a long-running pro
 that monitors for work from the Prefect server.
 When work is found, it is executed within its own isolated subprocess.
 
-```python title="hello_world.py"
+```python hello_world.py
 from prefect import flow
 
 

--- a/docs/3.0rc/deploy/run-flows-in-local-processes.mdx
+++ b/docs/3.0rc/deploy/run-flows-in-local-processes.mdx
@@ -101,7 +101,7 @@ To execute remotely triggered or scheduled runs, your script with `flow.serve` m
 
 Serve multiple flows with the same process using the `serve` utility along with the `to_deployment` method of flows:
 
-```python
+```python serve_two_flows.py
 import time
 from prefect import flow, serve
 
@@ -159,13 +159,15 @@ You can retrieve flows from remote storage with the `flow.from_source` method.
 `flow.from_source` accepts a git repository URL and an entrypoint pointing to the 
 flow to load from the repository:
 
-```python title="load_from_url.py"
+```python load_from_url.py
 from prefect import flow
+
 
 my_flow = flow.from_source(
     source="https://github.com/PrefectHQ/prefect.git",
     entrypoint="flows/hello_world.py:hello"
 )
+
 
 if __name__ == "__main__":
     my_flow()
@@ -183,7 +185,7 @@ flow function separated by a colon.
 For additional configuration, such as specifying a private repository, 
 provide a `GitRepository` object instead of URL:
 
-```python title="load_from_storage.py"
+```python load_from_storage.py
 from prefect import flow
 from prefect.runner.storage import GitRepository
 from prefect.blocks.system import Secret
@@ -210,7 +212,7 @@ if __name__ == "__main__":
 
 You can serve a flow loaded from remote storage with the same [`serve`](#serving-a-flow) method as a local flow:
 
-```python title="serve_loaded_flow.py"
+```python serve_loaded_flow.py
 from prefect import flow
 
 


### PR DESCRIPTION
Fixes example code script title formatting.

Problematic formatting example:
![Screenshot 2024-07-12 at 4 02 44 PM](https://github.com/user-attachments/assets/635a5984-0d29-433e-9b5a-c708128f90f7)

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.


