### PR TITLE
Pin Griffe < 0.48.0

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -8,7 +8,7 @@ exceptiongroup >= 1.0.0
 fastapi >= 0.111.0, < 1.0.0
 fsspec >= 2022.5.0
 graphviz >= 0.20.1
-griffe >= 0.20.0
+griffe >= 0.20.0, <0.48.0
 httpcore >=1.0.5, < 2.0.0
 httpx[http2] >= 0.23, != 0.23.2
 importlib_metadata >= 4.4; python_version < '3.10'


### PR DESCRIPTION
Today's release of Griffe, which we use for docstring parsing, deprecates a variety of methods we currently use as they push to a 1.0 release. They encourage pinning. We can reevaluate our use of Griffe to see if the juice is worth the squeeze for version 1.0, but until then this just pins it. 