### PR TITLE
Adds `wait` utility for `PrefectFutures`

### DIFF
--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -333,7 +333,7 @@ def wait(futures: List[PrefectFuture], timeout=None) -> DoneAndNotDoneFutures:
         return DoneAndNotDoneFutures(done, not_done)
     try:
         with timeout_context(timeout):
-            for future in not_done:
+            for future in not_done.copy():
                 future.wait()
                 done.add(future)
                 not_done.remove(future)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->
Adds a `wait`utility function that mirrors that of `concurrent.futures.wait`. 
Closes #14240


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ x ] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
- [ x ] This pull request references any related issue by including "closes `<link to issue>`"
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ x ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ x ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ x ] If this pull request adds functions or classes, it includes helpful docstrings.
