### PR TITLE
retry `git_clone` pull step

### DIFF
--- a/src/prefect/_internal/retries.py
+++ b/src/prefect/_internal/retries.py
@@ -1,0 +1,62 @@
+import asyncio
+from functools import wraps
+from typing import Any, Callable, Optional, Tuple, Type
+
+from prefect.logging.loggers import get_logger
+from prefect.utilities.math import clamped_poisson_interval
+
+logger = get_logger("retries")
+
+
+def exponential_backoff_with_jitter(
+    attempt: int, base_delay: float, max_delay: float
+) -> float:
+    average_interval = min(base_delay * (2**attempt), max_delay)
+    return clamped_poisson_interval(average_interval, clamping_factor=0.3)
+
+
+def retry_async_fn(
+    max_attempts: int = 3,
+    backoff_strategy: Optional[Callable[[int, float, float], float]] = None,
+    base_delay: float = 1,
+    max_delay: float = 10,
+    retry_on_exceptions: Optional[Tuple[Type[Exception], ...]] = None,
+):
+    """A decorator for retrying an async function.
+
+    Args:
+        max_attempts: The maximum number of times to retry the function.
+        backoff_strategy: A function that takes in the number of attempts, the base
+            delay, and the maximum delay, and returns the delay to use for the next
+            attempt. Defaults to an exponential backoff with jitter.
+        base_delay: The base delay to use for the first attempt.
+        max_delay: The maximum delay to use for the last attempt.
+        retry_on_exceptions: A tuple of exception types to retry on. Defaults to
+            retrying on all exceptions.
+    """
+    if backoff_strategy is None:
+        backoff_strategy = exponential_backoff_with_jitter
+
+    if retry_on_exceptions is None:
+        retry_on_exceptions = (Exception,)
+
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            for attempt in range(max_attempts):
+                try:
+                    return await func(*args, **kwargs)
+                except retry_on_exceptions as e:
+                    if attempt == max_attempts - 1:
+                        logger.exception(f"Failed after {max_attempts} attempts")
+                        raise
+                    delay = backoff_strategy(attempt, base_delay, max_delay)
+                    logger.warning(
+                        f"Attempt {attempt + 1} failed with {type(e).__name__}. "
+                        f"Retrying in {delay:.2f} seconds..."
+                    )
+                    await asyncio.sleep(delay)
+
+        return wrapper
+
+    return decorator

--- a/src/prefect/deployments/steps/pull.py
+++ b/src/prefect/deployments/steps/pull.py
@@ -6,6 +6,8 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
+from tenacity import retry, stop_after_attempt, wait_exponential
+
 from prefect.logging.loggers import get_logger
 from prefect.runner.storage import BlockStorageAdapter, GitRepository, RemoteStorage
 from prefect.utilities.asyncutils import sync_compatible
@@ -14,6 +16,13 @@ deployment_logger = get_logger("deployment")
 
 if TYPE_CHECKING:
     from prefect.blocks.core import Block
+
+GIT_CLONE_RETRIES = 3
+GIT_CLONE_BACKOFF_STRATEGY = wait_exponential(
+    multiplier=1,
+    min=1,
+    max=10,
+)
 
 
 def set_working_directory(directory: str) -> dict:
@@ -31,6 +40,7 @@ def set_working_directory(directory: str) -> dict:
     return dict(directory=directory)
 
 
+@retry(stop=stop_after_attempt(GIT_CLONE_RETRIES), wait=GIT_CLONE_BACKOFF_STRATEGY)
 @sync_compatible
 async def git_clone(
     repository: str,

--- a/src/prefect/deployments/steps/pull.py
+++ b/src/prefect/deployments/steps/pull.py
@@ -36,6 +36,7 @@ def set_working_directory(directory: str) -> dict:
     max_attempts=3,
     base_delay=1,
     max_delay=10,
+    retry_on_exceptions=(RuntimeError,),
 )
 @sync_compatible
 async def git_clone(

--- a/tests/_internal/test_retries.py
+++ b/tests/_internal/test_retries.py
@@ -1,0 +1,109 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from prefect._internal.retries import retry_async_fn
+
+
+@pytest.fixture(autouse=True)
+def mock_sleep():
+    with patch("asyncio.sleep", new_callable=AsyncMock) as mock:
+        yield mock
+
+
+class TestRetryAsyncFn:
+    async def test_successful_execution(self):
+        @retry_async_fn()
+        async def success_func():
+            return "Success"
+
+        result = await success_func()
+        assert result == "Success"
+
+    async def test_max_attempts(self, mock_sleep):
+        mock_func = AsyncMock(side_effect=ValueError("Test error"))
+
+        @retry_async_fn(max_attempts=3)
+        async def fail_func():
+            await mock_func()
+
+        with pytest.raises(ValueError, match="Test error"):
+            await fail_func()
+
+        assert mock_func.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    async def test_custom_backoff_strategy(self, mock_sleep):
+        custom_strategy = Mock(return_value=0.1)
+
+        @retry_async_fn(max_attempts=3, backoff_strategy=custom_strategy)
+        async def fail_func():
+            raise ValueError("Test error")
+
+        with pytest.raises(ValueError, match="Test error"):
+            await fail_func()
+
+        assert custom_strategy.call_count == 2  # Called for the 2nd and 3rd attempts
+        assert mock_sleep.call_count == 2
+        assert all(call.args[0] == 0.1 for call in mock_sleep.call_args_list)
+
+    async def test_specific_exception_retry(self, mock_sleep):
+        @retry_async_fn(max_attempts=3, retry_on_exceptions=(ValueError,))
+        async def mixed_fail_func():
+            if mixed_fail_func.calls == 0:
+                mixed_fail_func.calls += 1
+                raise ValueError("Retry this")
+            elif mixed_fail_func.calls == 1:
+                mixed_fail_func.calls += 1
+                raise TypeError("Don't retry this")
+            return "Success"
+
+        mixed_fail_func.calls = 0
+
+        with pytest.raises(TypeError, match="Don't retry this"):
+            await mixed_fail_func()
+
+        assert mixed_fail_func.calls == 2
+        assert mock_sleep.call_count == 1
+
+    async def test_logging(self, caplog, mock_sleep):
+        @retry_async_fn(max_attempts=2)
+        async def fail_func():
+            raise ValueError("Test error")
+
+        with pytest.raises(ValueError, match="Test error"), caplog.at_level("WARNING"):
+            await fail_func()
+
+        assert "Attempt 1 failed with ValueError. Retrying in" in caplog.text
+        assert "Failed after 2 attempts" in caplog.text
+        assert mock_sleep.call_count == 1
+
+    async def test_exponential_backoff_with_jitter(self, mock_sleep):
+        @retry_async_fn(max_attempts=4, base_delay=1, max_delay=10)
+        async def fail_func():
+            raise ValueError("Test error")
+
+        with pytest.raises(ValueError, match="Test error"):
+            await fail_func()
+
+        assert mock_sleep.call_count == 3
+        delays = [call.args[0] for call in mock_sleep.call_args_list]
+
+        # Check that delays are within expected ranges
+        assert 0.7 <= delays[0] <= 1.3  # 1 * 1.3
+        assert 1.4 <= delays[1] <= 2.6  # 2 * 1.3
+        assert 2.8 <= delays[2] <= 5.2  # 4 * 1.3
+
+    async def test_retry_successful_after_failures(self, mock_sleep):
+        mock_func = AsyncMock(
+            side_effect=[ValueError("Error 1"), ValueError("Error 2"), "Success"]
+        )
+
+        @retry_async_fn(max_attempts=4)
+        async def eventual_success_func():
+            return await mock_func()
+
+        result = await eventual_success_func()
+        assert result == "Success"
+        assert mock_func.call_count == 3
+        assert mock_sleep.call_count == 2

--- a/tests/_internal/test_retries.py
+++ b/tests/_internal/test_retries.py
@@ -74,8 +74,11 @@ class TestRetryAsyncFn:
         with pytest.raises(ValueError, match="Test error"), caplog.at_level("WARNING"):
             await fail_func()
 
-        assert "Attempt 1 failed with ValueError. Retrying in" in caplog.text
-        assert "Failed after 2 attempts" in caplog.text
+        assert (
+            "Attempt 1 of function 'fail_func' failed with ValueError. Retrying in"
+            in caplog.text
+        )
+        assert "'fail_func' failed after 2 attempts" in caplog.text
         assert mock_sleep.call_count == 1
 
     async def test_exponential_backoff_with_jitter(self, mock_sleep):

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -502,8 +502,8 @@ class TestGitCloneStep:
         mock_git_repo = MagicMock()
         mock_git_repo.return_value.pull_code = AsyncMock(
             side_effect=[
-                Exception("Error 1"),
-                Exception("Error 2"),
+                RuntimeError("Octocat went out to lunch"),
+                RuntimeError("Octocat is playing chess in the break room"),
                 None,  # Successful on third attempt
             ]
         )
@@ -512,7 +512,6 @@ class TestGitCloneStep:
             "prefect.deployments.steps.pull.GitRepository", mock_git_repo
         )
 
-        # Mock sleep to speed up test
         async def mock_sleep(seconds):
             pass
 
@@ -527,8 +526,8 @@ class TestGitCloneStep:
                 }
             )
 
-        assert "Attempt 1 failed with Exception. Retrying in " in caplog.text
-        assert "Attempt 2 failed with Exception. Retrying in " in caplog.text
+        assert "Attempt 1 failed with RuntimeError. Retrying in " in caplog.text
+        assert "Attempt 2 failed with RuntimeError. Retrying in " in caplog.text
 
         assert result == {"directory": "repo"}
 

--- a/tests/deployment/test_steps.py
+++ b/tests/deployment/test_steps.py
@@ -526,8 +526,14 @@ class TestGitCloneStep:
                 }
             )
 
-        assert "Attempt 1 failed with RuntimeError. Retrying in " in caplog.text
-        assert "Attempt 2 failed with RuntimeError. Retrying in " in caplog.text
+        assert (
+            "Attempt 1 of function 'git_clone' failed with RuntimeError. Retrying in "
+            in caplog.text
+        )
+        assert (
+            "Attempt 2 of function 'git_clone' failed with RuntimeError. Retrying in "
+            in caplog.text
+        )
 
         assert result == {"directory": "repo"}
 


### PR DESCRIPTION
this PR adds retries to `git_clone` to retry pulling code from github 

we discussed using `tenacity` internally and decided to avoid it for now, since we may want an opinionated retry primitive later, that we wouldn't necessarily want coupled to `tenacity`

instead, this PR implements an `_internal` `retry_async_fn` (explicitly for async functions 🙂) to accomplish what we need