### PR TITLE
Refactors event causal ordering to be reusable by multiple consumers

### DIFF
--- a/src/prefect/server/database/migrations/versions/postgresql/2024_07_15_145240_7495a5013e7e_adding_scope_to_followers.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2024_07_15_145240_7495a5013e7e_adding_scope_to_followers.py
@@ -17,12 +17,6 @@ depends_on = None
 
 
 def upgrade():
-    op.create_index(
-        op.f("ix_artifact_collection__updated"),
-        "artifact_collection",
-        ["updated"],
-        unique=False,
-    )
     op.add_column(
         "automation_event_follower", sa.Column("scope", sa.String(), nullable=False)
     )

--- a/src/prefect/server/database/migrations/versions/postgresql/2024_07_15_145240_7495a5013e7e_adding_scope_to_followers.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2024_07_15_145240_7495a5013e7e_adding_scope_to_followers.py
@@ -1,0 +1,59 @@
+"""Adding scope to followers
+
+Revision ID: 7495a5013e7e
+Revises: 94622c1663e8
+Create Date: 2024-07-15 14:52:40.850932
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "7495a5013e7e"
+down_revision = "94622c1663e8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        op.f("ix_artifact_collection__updated"),
+        "artifact_collection",
+        ["updated"],
+        unique=False,
+    )
+    op.add_column(
+        "automation_event_follower", sa.Column("scope", sa.String(), nullable=False)
+    )
+    op.drop_constraint(
+        "uq_automation_event_follower__follower_event_id",
+        "automation_event_follower",
+        type_="unique",
+    )
+    op.create_index(
+        op.f("ix_automation_event_follower__scope"),
+        "automation_event_follower",
+        ["scope"],
+        unique=False,
+    )
+    op.create_index(
+        "uq_follower_for_scope",
+        "automation_event_follower",
+        ["scope", "follower_event_id"],
+        unique=True,
+    )
+
+
+def downgrade():
+    op.drop_index("uq_follower_for_scope", table_name="automation_event_follower")
+    op.drop_index(
+        op.f("ix_automation_event_follower__scope"),
+        table_name="automation_event_follower",
+    )
+    op.create_unique_constraint(
+        "uq_automation_event_follower__follower_event_id",
+        "automation_event_follower",
+        ["follower_event_id"],
+    )
+    op.drop_column("automation_event_follower", "scope")

--- a/src/prefect/server/database/migrations/versions/sqlite/2024_07_15_145350_354f1ede7e9f_adding_scope_to_followers.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2024_07_15_145350_354f1ede7e9f_adding_scope_to_followers.py
@@ -1,0 +1,40 @@
+"""Adding scope to followers
+
+Revision ID: 354f1ede7e9f
+Revises: 2ac65f1758c2
+Create Date: 2024-07-15 14:53:50.718831
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "354f1ede7e9f"
+down_revision = "2ac65f1758c2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("automation_event_follower", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("scope", sa.String(), nullable=False))
+        batch_op.drop_constraint(
+            "uq_automation_event_follower__follower_event_id", type_="unique"
+        )
+        batch_op.create_index(
+            batch_op.f("ix_automation_event_follower__scope"), ["scope"], unique=False
+        )
+        batch_op.create_index(
+            "uq_follower_for_scope", ["scope", "follower_event_id"], unique=True
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("automation_event_follower", schema=None) as batch_op:
+        batch_op.drop_index("uq_follower_for_scope")
+        batch_op.drop_index(batch_op.f("ix_automation_event_follower__scope"))
+        batch_op.create_unique_constraint(
+            "uq_automation_event_follower__follower_event_id", ["follower_event_id"]
+        )
+        batch_op.drop_column("scope")

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -1430,8 +1430,17 @@ class CompositeTriggerChildFiring(Base):
 
 
 class AutomationEventFollower(Base):
+    __table_args__ = (
+        sa.Index(
+            "uq_follower_for_scope",
+            "scope",
+            "follower_event_id",
+            unique=True,
+        ),
+    )
+    scope = sa.Column(sa.String, nullable=False, default="", index=True)
     leader_event_id = sa.Column(UUID(), nullable=False, index=True)
-    follower_event_id = sa.Column(UUID(), nullable=False, unique=True)
+    follower_event_id = sa.Column(UUID(), nullable=False)
     received = sa.Column(Timestamp(), nullable=False, index=True)
     follower = sa.Column(Pydantic(ReceivedEvent), nullable=False)
 

--- a/src/prefect/server/events/ordering.py
+++ b/src/prefect/server/events/ordering.py
@@ -1,0 +1,206 @@
+"""
+Manages the partial causal ordering of events for a particular consumer.  This module
+maintains a buffer of events to be processed, aiming to process them in the order they
+occurred causally.
+"""
+
+from collections import defaultdict
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from typing import (
+    List,
+    Mapping,
+    MutableMapping,
+    Protocol,
+    Union,
+)
+from uuid import UUID
+
+import pendulum
+import sqlalchemy as sa
+from cachetools import TTLCache
+from typing_extensions import Self
+
+from prefect.logging import get_logger
+from prefect.server.database.dependencies import db_injector
+from prefect.server.database.interface import PrefectDBInterface
+from prefect.server.database.orm_models import AutomationEventFollower
+from prefect.server.events.schemas.events import Event, ReceivedEvent
+
+logger = get_logger(__name__)
+
+# How long we'll retain preceding events (to aid with ordering)
+PRECEDING_EVENT_LOOKBACK = timedelta(minutes=15)
+
+# How long we'll retain events we've processed (to prevent re-processing an event)
+PROCESSED_EVENT_LOOKBACK = timedelta(minutes=30)
+
+# How long we'll remember that we've seen an event
+SEEN_EXPIRATION = max(PRECEDING_EVENT_LOOKBACK, PROCESSED_EVENT_LOOKBACK)
+
+# How deep we'll allow the recursion to go when processing events
+MAX_DEPTH_OF_PRECEDING_EVENT = 20
+
+
+class EventArrivedEarly(Exception):
+    def __init__(self, event: ReceivedEvent):
+        self.event = event
+
+
+class MaxDepthExceeded(Exception):
+    def __init__(self, event: ReceivedEvent):
+        self.event = event
+
+
+class event_handler(Protocol):
+    async def __call__(self, event: ReceivedEvent, depth: int = 0):
+        ...  # pragma: no cover
+
+
+class CausalOrdering:
+    _seen_events: Mapping[str, MutableMapping[UUID, bool]] = defaultdict(
+        lambda: TTLCache(maxsize=10000, ttl=SEEN_EXPIRATION.total_seconds())
+    )
+
+    scope: str
+
+    def __init__(self, scope: str):
+        self.scope = scope
+
+    async def event_has_been_seen(self, event: Union[UUID, Event]) -> bool:
+        id = event.id if isinstance(event, Event) else event
+        return self._seen_events[self.scope].get(id, False)
+
+    async def record_event_as_seen(self, event: ReceivedEvent) -> None:
+        self._seen_events[self.scope][event.id] = True
+
+    @db_injector
+    async def record_follower(db: PrefectDBInterface, self: Self, event: ReceivedEvent):
+        """Remember that this event is waiting on another event to arrive"""
+        assert event.follows
+
+        async with db.session_context(begin_transaction=True) as session:
+            await session.execute(
+                sa.insert(AutomationEventFollower).values(
+                    scope=self.scope,
+                    leader_event_id=event.follows,
+                    follower_event_id=event.id,
+                    received=event.received,
+                    follower=event,
+                )
+            )
+
+    @db_injector
+    async def forget_follower(
+        db: PrefectDBInterface, self: Self, follower: ReceivedEvent
+    ):
+        """Forget that this event is waiting on another event to arrive"""
+        assert follower.follows
+
+        async with db.session_context(begin_transaction=True) as session:
+            await session.execute(
+                sa.delete(AutomationEventFollower).where(
+                    AutomationEventFollower.scope == self.scope,
+                    AutomationEventFollower.follower_event_id == follower.id,
+                )
+            )
+
+    @db_injector
+    async def get_followers(
+        db: PrefectDBInterface, self: Self, leader: ReceivedEvent
+    ) -> List[ReceivedEvent]:
+        """Returns events that were waiting on this leader event to arrive"""
+        async with db.session_context() as session:
+            query = sa.select(AutomationEventFollower.follower).where(
+                AutomationEventFollower.scope == self.scope,
+                AutomationEventFollower.leader_event_id == leader.id,
+            )
+            result = await session.execute(query)
+            followers = result.scalars().all()
+            return sorted(followers, key=lambda e: e.occurred)
+
+    @db_injector
+    async def get_lost_followers(db: PrefectDBInterface, self) -> List[ReceivedEvent]:
+        """Returns events that were waiting on a leader event that never arrived"""
+        earlier = pendulum.now("UTC") - PRECEDING_EVENT_LOOKBACK
+
+        async with db.session_context(begin_transaction=True) as session:
+            query = sa.select(AutomationEventFollower.follower).where(
+                AutomationEventFollower.scope == self.scope,
+                AutomationEventFollower.received < earlier,
+            )
+            result = await session.execute(query)
+            followers = result.scalars().all()
+
+            # forget these followers, since they are never going to see their leader event
+
+            await session.execute(
+                sa.delete(AutomationEventFollower).where(
+                    AutomationEventFollower.scope == self.scope,
+                    AutomationEventFollower.received < earlier,
+                )
+            )
+
+            return sorted(followers, key=lambda e: e.occurred)
+
+    @asynccontextmanager
+    async def preceding_event_confirmed(
+        self, handler: event_handler, event: ReceivedEvent, depth: int = 0
+    ):
+        """Events may optionally declare that they logically follow another event, so that
+        we can preserve important event orderings in the face of unreliable delivery and
+        ordering of messages from the queues.
+
+        This function keeps track of the ID of each event that this shard has successfully
+        processed going back to the PRECEDING_EVENT_LOOKBACK period.  If an event arrives
+        that must follow another one, confirm that we have recently seen and processed that
+        event before proceeding.
+
+        Args:
+        event (ReceivedEvent): The event to be processed. This object should include metadata indicating
+            if and what event it follows.
+        depth (int, optional): The current recursion depth, used to prevent infinite recursion due to
+            cyclic dependencies between events. Defaults to 0.
+
+
+        Raises EventArrivedEarly if the current event shouldn't be processed yet."""
+
+        if depth > MAX_DEPTH_OF_PRECEDING_EVENT:
+            logger.exception(
+                "Event %r (%s) for %r has exceeded the maximum recursion depth of %s",
+                event.event,
+                event.id,
+                event.resource.id,
+                MAX_DEPTH_OF_PRECEDING_EVENT,
+            )
+            raise MaxDepthExceeded(event)
+
+        if event.follows:
+            if not await self.event_has_been_seen(event.follows):
+                age = pendulum.now("UTC") - event.received
+                if age < PRECEDING_EVENT_LOOKBACK:
+                    logger.debug(
+                        "Event %r (%s) for %r arrived before the event it follows %s",
+                        event.event,
+                        event.id,
+                        event.resource.id,
+                        event.follows,
+                    )
+
+                    # record this follower for safe-keeping
+                    await self.record_follower(event)
+                    raise EventArrivedEarly(event)
+
+        yield
+
+        await self.record_event_as_seen(event)
+
+        # we have just processed an event that other events were waiting on, so let's
+        # react to them now in the order they occurred
+        for waiter in await self.get_followers(event):
+            await handler(waiter, depth + 1)
+
+        # if this event was itself waiting on something, let's consider it as resolved now
+        # that it has been processed
+        if event.follows:
+            await self.forget_follower(event)

--- a/tests/events/server/test_ordering.py
+++ b/tests/events/server/test_ordering.py
@@ -1,0 +1,277 @@
+from datetime import timedelta
+from typing import Sequence
+from uuid import uuid4
+
+import pendulum
+import pytest
+
+from prefect.server.events.ordering import (
+    MAX_DEPTH_OF_PRECEDING_EVENT,
+    CausalOrdering,
+    EventArrivedEarly,
+    MaxDepthExceeded,
+)
+from prefect.server.events.schemas.events import ReceivedEvent, Resource
+
+pytestmark = pytest.mark.usefixtures("cleared_automations")
+
+
+@pytest.fixture
+def resource() -> Resource:
+    return Resource({"prefect.resource.id": "any.thing"})
+
+
+@pytest.fixture
+def event_one(
+    start_of_test: pendulum.DateTime,
+    resource: Resource,
+) -> ReceivedEvent:
+    return ReceivedEvent(
+        resource=resource,
+        event="event.one",
+        occurred=start_of_test + timedelta(seconds=1),
+        received=start_of_test + timedelta(seconds=1),
+        id=uuid4(),
+        follows=None,
+    )
+
+
+@pytest.fixture
+def event_two(event_one: ReceivedEvent) -> ReceivedEvent:
+    return ReceivedEvent(
+        event="event.two",
+        id=uuid4(),
+        follows=event_one.id,
+        resource=event_one.resource,
+        occurred=event_one.occurred + timedelta(seconds=1),
+        received=event_one.received + timedelta(seconds=1, milliseconds=1),
+    )
+
+
+@pytest.fixture
+def event_three_a(event_two: ReceivedEvent) -> ReceivedEvent:
+    return ReceivedEvent(
+        event="event.three.a",
+        id=uuid4(),
+        follows=event_two.id,
+        resource=event_two.resource,
+        occurred=event_two.occurred + timedelta(seconds=1),
+        received=event_two.received + timedelta(seconds=1, milliseconds=1),
+    )
+
+
+@pytest.fixture
+def event_three_b(event_two: ReceivedEvent) -> ReceivedEvent:
+    return ReceivedEvent(
+        event="event.three.b",
+        id=uuid4(),
+        follows=event_two.id,
+        resource=event_two.resource,
+        occurred=event_two.occurred + timedelta(seconds=2),
+        received=event_two.received + timedelta(seconds=2, milliseconds=1),
+    )
+
+
+@pytest.fixture
+def in_proper_order(
+    event_one: ReceivedEvent,
+    event_two: ReceivedEvent,
+    event_three_a: ReceivedEvent,
+    event_three_b: ReceivedEvent,
+) -> Sequence[ReceivedEvent]:
+    return [event_one, event_two, event_three_a, event_three_b]
+
+
+@pytest.fixture
+def in_jumbled_order(
+    event_one: ReceivedEvent,
+    event_two: ReceivedEvent,
+    event_three_a: ReceivedEvent,
+    event_three_b: ReceivedEvent,
+) -> Sequence[ReceivedEvent]:
+    return [event_two, event_three_a, event_one, event_three_b]
+
+
+@pytest.fixture
+def backwards(
+    event_one: ReceivedEvent,
+    event_two: ReceivedEvent,
+    event_three_a: ReceivedEvent,
+    event_three_b: ReceivedEvent,
+) -> Sequence[ReceivedEvent]:
+    return [event_three_b, event_three_a, event_two, event_one]
+
+
+@pytest.fixture(params=["in_proper_order", "in_jumbled_order", "backwards"])
+def example(request: pytest.FixtureRequest) -> Sequence[ReceivedEvent]:
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture
+def causal_ordering() -> CausalOrdering:
+    return CausalOrdering(scope="unit-tests")
+
+
+async def test_ordering_is_correct(
+    causal_ordering: CausalOrdering,
+    in_proper_order: Sequence[ReceivedEvent],
+    example: Sequence[ReceivedEvent],
+):
+    processed = []
+
+    async def evaluate(event: ReceivedEvent, depth: int = 0) -> None:
+        async with causal_ordering.preceding_event_confirmed(
+            evaluate, event, depth=depth
+        ):
+            processed.append(event)
+
+    example = list(example)
+    while example:
+        try:
+            await evaluate(example.pop(0))
+        except EventArrivedEarly:
+            continue
+
+    assert processed == in_proper_order
+
+
+@pytest.fixture
+def worst_case(event_one: ReceivedEvent) -> list[ReceivedEvent]:
+    causal_order = []
+
+    # The worst case scenario for exceeding the depth of the preceding event is to have
+    # a long chain of events that are all linked to the same preceding event and then
+    # for that sequence to arrive in reverse order.  The depth of resolving followers
+    # will be the length of that chain.  It's +1 here so that we go over the limit.
+
+    previous = event_one
+
+    for i in range(MAX_DEPTH_OF_PRECEDING_EVENT + 1):
+        this_one = ReceivedEvent(
+            event=f"event.{i}",
+            resource=previous.resource,
+            occurred=previous.occurred + timedelta(seconds=1),
+            id=uuid4(),
+            follows=previous.id,
+        )
+
+        causal_order.append(this_one)
+        previous = this_one
+
+    return list(reversed(causal_order))
+
+
+async def test_recursion_is_contained(
+    causal_ordering: CausalOrdering,
+    event_one: ReceivedEvent,
+    worst_case: list[ReceivedEvent],
+):
+    async def evaluate(event: ReceivedEvent, depth: int = 0) -> None:
+        async with causal_ordering.preceding_event_confirmed(
+            evaluate, event, depth=depth
+        ):
+            pass
+
+    while worst_case:
+        try:
+            await evaluate(worst_case.pop(0))
+        except EventArrivedEarly:
+            continue
+
+    with pytest.raises(MaxDepthExceeded):
+        await evaluate(event_one)
+
+
+async def test_only_looks_to_a_certain_horizon(
+    causal_ordering: CausalOrdering,
+    event_one: ReceivedEvent,
+    event_two: ReceivedEvent,
+):
+    # backdate the events so they happened before the lookback period
+    event_one.received -= timedelta(days=1)
+    event_two.received -= timedelta(days=1)
+
+    processed = []
+
+    async def evaluate(event: ReceivedEvent, depth: int = 0) -> None:
+        async with causal_ordering.preceding_event_confirmed(
+            evaluate, event, depth=depth
+        ):
+            processed.append(event)
+
+    # will not raise EventArrivedEarly because we're outside the range we can look back
+    await evaluate(event_two)
+    await evaluate(event_one)
+
+    assert processed == [event_two, event_one]
+
+
+async def test_returns_lost_followers_in_occurred_order(
+    causal_ordering: CausalOrdering,
+    event_two: ReceivedEvent,
+    event_three_a: ReceivedEvent,
+    event_three_b: ReceivedEvent,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    processed = []
+
+    async def evaluate(event: ReceivedEvent, depth: int = 0) -> None:
+        async with causal_ordering.preceding_event_confirmed(
+            evaluate, event, depth=depth
+        ):
+            processed.append(event)
+
+    example = [event_three_a, event_three_b, event_two]
+    while example:
+        try:
+            await evaluate(example.pop(0))
+        except EventArrivedEarly:
+            continue
+
+    assert processed == []
+
+    # setting to a negative duration here simulates moving into the future
+    monkeypatch.setattr(
+        "prefect.server.events.ordering.PRECEDING_EVENT_LOOKBACK",
+        timedelta(minutes=-1),
+    )
+
+    # because event one never arrived, these are all lost followers
+    lost_followers = await causal_ordering.get_lost_followers()
+    assert lost_followers == [event_two, event_three_a, event_three_b]
+
+
+async def test_two_instances_do_not_interfere(
+    event_one: ReceivedEvent,
+    event_two: ReceivedEvent,
+):
+    # A partial test that two instances of the same class do not interfere with each
+    # other.  This does not test every piece of functionality, but illustrates that
+    # prefixes are used.
+
+    ordering_one = CausalOrdering(scope="one")
+    ordering_two = CausalOrdering(scope="two")
+
+    await ordering_one.record_event_as_seen(event_one)
+    assert await ordering_one.event_has_been_seen(event_one)
+    assert not await ordering_two.event_has_been_seen(event_one)
+
+    await ordering_two.record_event_as_seen(event_one)
+    assert await ordering_one.event_has_been_seen(event_one)
+    assert await ordering_two.event_has_been_seen(event_one)
+
+    await ordering_one.record_follower(event_two)
+    assert await ordering_one.get_followers(event_one) == [event_two]
+    assert await ordering_two.get_followers(event_one) == []
+
+    await ordering_two.record_follower(event_two)
+    assert await ordering_one.get_followers(event_one) == [event_two]
+    assert await ordering_two.get_followers(event_one) == [event_two]
+
+    await ordering_one.forget_follower(event_two)
+    assert await ordering_one.get_followers(event_one) == []
+    assert await ordering_two.get_followers(event_one) == [event_two]
+
+    await ordering_two.forget_follower(event_two)
+    assert await ordering_one.get_followers(event_one) == []
+    assert await ordering_two.get_followers(event_one) == []

--- a/tests/events/server/triggers/test_service.py
+++ b/tests/events/server/triggers/test_service.py
@@ -365,7 +365,8 @@ async def test_only_processes_event_once(
         },
     )
 
-    reactive_evaluation.side_effect = triggers.record_event_as_seen
+    causal_ordering = triggers.causal_ordering()
+    reactive_evaluation.side_effect = causal_ordering.record_event_as_seen
 
     await asyncio.gather(*[message_handler(message) for _ in range(50)])
 


### PR DESCRIPTION
For the triggers system, we keep track of out-of-order messages and attempt to
replay them in causal order (where an event is processed after the event that
it declares it `follows`).  This change extracts this logic to a class and
separates the bookkeeping records so that multiple consumers can keep separate
track of events.

This is largely a port of the changes in Prefect Cloud that we made last week.

Closes #14577
