### PR TITLE
Break `TaskRunEngine` into Sync and Async classes

### DIFF
--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -10,12 +10,13 @@ import os
 import sys
 import warnings
 import weakref
-from contextlib import ExitStack, contextmanager
+from contextlib import ExitStack, asynccontextmanager, contextmanager
 from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    AsyncGenerator,
     Dict,
     Generator,
     Mapping,
@@ -211,6 +212,22 @@ class ClientContext(ContextModel):
         self._httpx_settings = httpx_settings
         self._context_stack = 0
 
+    async def __aenter__(self):
+        self._context_stack += 1
+        if self._context_stack == 1:
+            self.sync_client.__enter__()
+            await self.async_client.__aenter__()
+            return super().__enter__()
+        else:
+            return self
+
+    async def __aexit__(self, *exc_info):
+        self._context_stack -= 1
+        if self._context_stack == 0:
+            self.sync_client.__exit__(*exc_info)
+            await self.async_client.__aexit__(*exc_info)
+            return super().__exit__(*exc_info)
+
     def __enter__(self):
         self._context_stack += 1
         if self._context_stack == 1:
@@ -235,6 +252,16 @@ class ClientContext(ContextModel):
             yield ctx
         else:
             with ClientContext() as ctx:
+                yield ctx
+
+    @classmethod
+    @asynccontextmanager
+    async def async_get_or_create(cls) -> AsyncGenerator["ClientContext", None]:
+        ctx = ClientContext.get()
+        if ctx:
+            yield ctx
+        else:
+            async with ClientContext() as ctx:
                 yield ctx
 
 

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -3,7 +3,7 @@ import logging
 import threading
 import time
 from asyncio import CancelledError
-from contextlib import ExitStack, contextmanager
+from contextlib import ExitStack, asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
 from textwrap import dedent
 from typing import (
@@ -30,7 +30,7 @@ import pendulum
 from typing_extensions import ParamSpec
 
 from prefect import Task
-from prefect.client.orchestration import SyncPrefectClient
+from prefect.client.orchestration import PrefectClient, SyncPrefectClient
 from prefect.client.schemas import TaskRun
 from prefect.client.schemas.objects import State, TaskRunInput
 from prefect.context import (
@@ -68,13 +68,14 @@ from prefect.states import (
 )
 from prefect.transactions import Transaction, transaction
 from prefect.utilities.annotations import NotSet
-from prefect.utilities.asyncutils import run_coro_as_sync
+from prefect.utilities.asyncutils import RUNNING_IN_ASYNC_TASK_ENGINE, run_coro_as_sync
 from prefect.utilities.callables import call_with_parameters, parameters_to_args_kwargs
 from prefect.utilities.collections import visit_collection
 from prefect.utilities.engine import (
     _get_hook_name,
     emit_task_run_state_change_event,
     link_state_to_result,
+    propose_state,
     propose_state_sync,
     resolve_to_final_result,
 )
@@ -84,13 +85,15 @@ from prefect.utilities.timeout import timeout, timeout_async
 P = ParamSpec("P")
 R = TypeVar("R")
 
+BACKOFF_MAX = 10
+
 
 class TaskRunTimeoutError(TimeoutError):
     """Raised when a task run exceeds its timeout."""
 
 
 @dataclass
-class TaskRunEngine(Generic[P, R]):
+class BaseTaskRunEngine(Generic[P, R]):
     task: Union[Task[P, R], Task[P, Coroutine[Any, Any, R]]]
     logger: logging.Logger = field(default_factory=lambda: get_logger("engine"))
     parameters: Optional[Dict[str, Any]] = None
@@ -104,19 +107,12 @@ class TaskRunEngine(Generic[P, R]):
     _raised: Union[Exception, Type[NotSet]] = NotSet
     _initial_run_context: Optional[TaskRunContext] = None
     _is_started: bool = False
-    _client: Optional[SyncPrefectClient] = None
     _task_name_set: bool = False
     _last_event: Optional[PrefectEvent] = None
 
     def __post_init__(self):
         if self.parameters is None:
             self.parameters = {}
-
-    @property
-    def client(self) -> SyncPrefectClient:
-        if not self._is_started or self._client is None:
-            raise RuntimeError("Engine has not started.")
-        return self._client
 
     @property
     def state(self) -> State:
@@ -157,41 +153,6 @@ class TaskRunEngine(Generic[P, R]):
         ):
             return self.context["cancel_event"].is_set()
         return False
-
-    def call_hooks(self, state: Optional[State] = None):
-        if state is None:
-            state = self.state
-        task = self.task
-        task_run = self.task_run
-
-        if not task_run:
-            raise ValueError("Task run is not set")
-
-        if state.is_failed() and task.on_failure_hooks:
-            hooks = task.on_failure_hooks
-        elif state.is_completed() and task.on_completion_hooks:
-            hooks = task.on_completion_hooks
-        else:
-            hooks = None
-
-        for hook in hooks or []:
-            hook_name = _get_hook_name(hook)
-
-            try:
-                self.logger.info(
-                    f"Running hook {hook_name!r} in response to entering state"
-                    f" {state.name!r}"
-                )
-                result = hook(task, task_run, state)
-                if inspect.isawaitable(result):
-                    run_coro_as_sync(result)
-            except Exception:
-                self.logger.error(
-                    f"An error was encountered while running hook {hook_name!r}",
-                    exc_info=True,
-                )
-            else:
-                self.logger.info(f"Hook {hook_name!r} finished running successfully")
 
     def compute_transaction_key(self) -> Optional[str]:
         key = None
@@ -252,6 +213,58 @@ class TaskRunEngine(Generic[P, R]):
             context={"current_task_run": self.task_run, "current_task": self.task},
         )
 
+    def is_running(self) -> bool:
+        """Whether or not the engine is currently running a task."""
+        if (task_run := getattr(self, "task_run", None)) is None:
+            return False
+        return task_run.state.is_running() or task_run.state.is_scheduled()
+
+
+@dataclass
+class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
+    _client: Optional[SyncPrefectClient] = None
+
+    @property
+    def client(self) -> SyncPrefectClient:
+        if not self._is_started or self._client is None:
+            raise RuntimeError("Engine has not started.")
+        return self._client
+
+    def call_hooks(self, state: Optional[State] = None):
+        if state is None:
+            state = self.state
+        task = self.task
+        task_run = self.task_run
+
+        if not task_run:
+            raise ValueError("Task run is not set")
+
+        if state.is_failed() and task.on_failure_hooks:
+            hooks = task.on_failure_hooks
+        elif state.is_completed() and task.on_completion_hooks:
+            hooks = task.on_completion_hooks
+        else:
+            hooks = None
+
+        for hook in hooks or []:
+            hook_name = _get_hook_name(hook)
+
+            try:
+                self.logger.info(
+                    f"Running hook {hook_name!r} in response to entering state"
+                    f" {state.name!r}"
+                )
+                result = hook(task, task_run, state)
+                if inspect.isawaitable(result):
+                    run_coro_as_sync(result)
+            except Exception:
+                self.logger.error(
+                    f"An error was encountered while running hook {hook_name!r}",
+                    exc_info=True,
+                )
+            else:
+                self.logger.info(f"Hook {hook_name!r} finished running successfully")
+
     def begin_run(self):
         try:
             self._resolve_parameters()
@@ -281,7 +294,6 @@ class TaskRunEngine(Generic[P, R]):
             except Exception:
                 state = self.set_state(new_state, force=True)
 
-        BACKOFF_MAX = 10
         backoff_count = 0
 
         # TODO: Could this listen for state change events instead of polling?
@@ -507,7 +519,7 @@ class TaskRunEngine(Generic[P, R]):
         self,
         task_run_id: Optional[UUID] = None,
         dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
-    ) -> Generator["TaskRunEngine", Any, Any]:
+    ) -> Generator["SyncTaskRunEngine", Any, Any]:
         """
         Enters a client context and creates a task run if needed.
         """
@@ -601,12 +613,6 @@ class TaskRunEngine(Generic[P, R]):
                     self._is_started = False
                     self._client = None
 
-    def is_running(self) -> bool:
-        """Whether or not the engine is currently running a task."""
-        if (task_run := getattr(self, "task_run", None)) is None:
-            return False
-        return task_run.state.is_running() or task_run.state.is_scheduled()
-
     async def wait_until_ready(self):
         """Waits until the scheduled time (if its the future), then enters Running."""
         if scheduled_time := self.state.state_details.scheduled_time:
@@ -684,24 +690,495 @@ class TaskRunEngine(Generic[P, R]):
         task is async.
         """
         parameters = self.parameters or {}
-        if self.task.isasync:
-
-            async def _call_task_fn():
-                if transaction.is_committed():
-                    result = transaction.read()
-                else:
-                    result = await call_with_parameters(self.task.fn, parameters)
-                self.handle_success(result, transaction=transaction)
-                return result
-
-            return _call_task_fn()
+        if transaction.is_committed():
+            result = transaction.read()
         else:
+            result = call_with_parameters(self.task.fn, parameters)
+        self.handle_success(result, transaction=transaction)
+        return result
+
+
+@dataclass
+class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
+    _client: Optional[PrefectClient] = None
+
+    @property
+    def client(self) -> PrefectClient:
+        if not self._is_started or self._client is None:
+            raise RuntimeError("Engine has not started.")
+        return self._client
+
+    async def call_hooks(self, state: Optional[State] = None):
+        if state is None:
+            state = self.state
+        task = self.task
+        task_run = self.task_run
+
+        if not task_run:
+            raise ValueError("Task run is not set")
+
+        if state.is_failed() and task.on_failure_hooks:
+            hooks = task.on_failure_hooks
+        elif state.is_completed() and task.on_completion_hooks:
+            hooks = task.on_completion_hooks
+        else:
+            hooks = None
+
+        for hook in hooks or []:
+            hook_name = _get_hook_name(hook)
+
+            try:
+                self.logger.info(
+                    f"Running hook {hook_name!r} in response to entering state"
+                    f" {state.name!r}"
+                )
+                result = hook(task, task_run, state)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                self.logger.error(
+                    f"An error was encountered while running hook {hook_name!r}",
+                    exc_info=True,
+                )
+            else:
+                self.logger.info(f"Hook {hook_name!r} finished running successfully")
+
+    async def begin_run(self):
+        try:
+            self._resolve_parameters()
+            self._wait_for_dependencies()
+        except UpstreamTaskError as upstream_exc:
+            state = await self.set_state(
+                Pending(
+                    name="NotReady",
+                    message=str(upstream_exc),
+                ),
+                # if orchestrating a run already in a pending state, force orchestration to
+                # update the state name
+                force=self.state.is_pending(),
+            )
+            return
+
+        new_state = Running()
+        state = await self.set_state(new_state)
+
+        # TODO: this is temporary until the API stops rejecting state transitions
+        # and the client / transaction store becomes the source of truth
+        # this is a bandaid caused by the API storing a Completed state with a bad
+        # result reference that no longer exists
+        if state.is_completed():
+            try:
+                await state.result(retry_result_failure=False)
+            except Exception:
+                state = await self.set_state(new_state, force=True)
+
+        backoff_count = 0
+
+        # TODO: Could this listen for state change events instead of polling?
+        while state.is_pending() or state.is_paused():
+            if backoff_count < BACKOFF_MAX:
+                backoff_count += 1
+            interval = clamped_poisson_interval(
+                average_interval=backoff_count, clamping_factor=0.3
+            )
+            time.sleep(interval)
+            state = await self.set_state(new_state)
+
+    async def set_state(self, state: State, force: bool = False) -> State:
+        last_state = self.state
+        if not self.task_run:
+            raise ValueError("Task run is not set")
+        try:
+            new_state = await propose_state(
+                self.client, state, task_run_id=self.task_run.id, force=force
+            )
+        except Pause as exc:
+            # We shouldn't get a pause signal without a state, but if this happens,
+            # just use a Paused state to assume an in-process pause.
+            new_state = exc.state if exc.state else Paused()
+            if new_state.state_details.pause_reschedule:
+                # If we're being asked to pause and reschedule, we should exit the
+                # task and expect to be resumed later.
+                raise
+
+        # currently this is a hack to keep a reference to the state object
+        # that has an in-memory result attached to it; using the API state
+
+        # could result in losing that reference
+        self.task_run.state = new_state
+        # emit a state change event
+        self._last_event = emit_task_run_state_change_event(
+            task_run=self.task_run,
+            initial_state=last_state,
+            validated_state=self.task_run.state,
+            follows=self._last_event,
+        )
+        return new_state
+
+    async def result(self, raise_on_failure: bool = True) -> "Union[R, State, None]":
+        if self._return_value is not NotSet:
+            # if the return value is a BaseResult, we need to fetch it
+            if isinstance(self._return_value, BaseResult):
+                _result = self._return_value.get()
+                if inspect.isawaitable(_result):
+                    _result = await _result
+                return _result
+
+            # otherwise, return the value as is
+            return self._return_value
+
+        if self._raised is not NotSet:
+            # if the task raised an exception, raise it
+            if raise_on_failure:
+                raise self._raised
+
+            # otherwise, return the exception
+            return self._raised
+
+    async def handle_success(self, result: R, transaction: Transaction) -> R:
+        result_factory = getattr(TaskRunContext.get(), "result_factory", None)
+        if result_factory is None:
+            raise ValueError("Result factory is not set")
+
+        if self.task.cache_expiration is not None:
+            expiration = pendulum.now("utc") + self.task.cache_expiration
+        else:
+            expiration = None
+
+        terminal_state = await return_value_to_state(
+            result,
+            result_factory=result_factory,
+            key=transaction.key,
+            expiration=expiration,
+            # defer persistence to transaction commit
+            defer_persistence=True,
+        )
+        transaction.stage(
+            terminal_state.data,
+            on_rollback_hooks=self.task.on_rollback_hooks,
+            on_commit_hooks=self.task.on_commit_hooks,
+        )
+        if transaction.is_committed():
+            terminal_state.name = "Cached"
+        await self.set_state(terminal_state)
+        self._return_value = result
+        return result
+
+    async def handle_retry(self, exc: Exception) -> bool:
+        """Handle any task run retries.
+
+        - If the task has retries left, and the retry condition is met, set the task to retrying and return True.
+          - If the task has a retry delay, place in AwaitingRetry state with a delayed scheduled time.
+        - If the task has no retries left, or the retry condition is not met, return False.
+        """
+        if self.retries < self.task.retries and self.can_retry:
+            if self.task.retry_delay_seconds:
+                delay = (
+                    self.task.retry_delay_seconds[
+                        min(self.retries, len(self.task.retry_delay_seconds) - 1)
+                    ]  # repeat final delay value if attempts exceed specified delays
+                    if isinstance(self.task.retry_delay_seconds, Sequence)
+                    else self.task.retry_delay_seconds
+                )
+                new_state = AwaitingRetry(
+                    scheduled_time=pendulum.now("utc").add(seconds=delay)
+                )
+            else:
+                delay = None
+                new_state = Retrying()
+
+            self.logger.info(
+                "Task run failed with exception: %r - " "Retry %s/%s will start %s",
+                exc,
+                self.retries + 1,
+                self.task.retries,
+                str(delay) + " second(s) from now" if delay else "immediately",
+            )
+
+            await self.set_state(new_state, force=True)
+            self.retries = self.retries + 1
+            return True
+        elif self.retries >= self.task.retries:
+            self.logger.error(
+                "Task run failed with exception: %r - Retries are exhausted",
+                exc,
+                exc_info=True,
+            )
+            return False
+
+        return False
+
+    async def handle_exception(self, exc: Exception) -> None:
+        # If the task fails, and we have retries left, set the task to retrying.
+        if not await self.handle_retry(exc):
+            # If the task has no retries left, or the retry condition is not met, set the task to failed.
+            context = TaskRunContext.get()
+            state = await exception_to_failed_state(
+                exc,
+                message="Task run encountered an exception",
+                result_factory=getattr(context, "result_factory", None),
+            )
+            await self.set_state(state)
+            self._raised = exc
+
+    async def handle_timeout(self, exc: TimeoutError) -> None:
+        if not await self.handle_retry(exc):
+            if isinstance(exc, TaskRunTimeoutError):
+                message = f"Task run exceeded timeout of {self.task.timeout_seconds} second(s)"
+            else:
+                message = f"Task run failed due to timeout: {exc!r}"
+            self.logger.error(message)
+            state = Failed(
+                data=exc,
+                message=message,
+                name="TimedOut",
+            )
+            await self.set_state(state)
+            self._raised = exc
+
+    async def handle_crash(self, exc: BaseException) -> None:
+        state = await exception_to_crashed_state(exc)
+        self.logger.error(f"Crash detected! {state.message}")
+        self.logger.debug("Crash details:", exc_info=exc)
+        await self.set_state(state, force=True)
+        self._raised = exc
+
+    @asynccontextmanager
+    async def setup_run_context(self, client: Optional[PrefectClient] = None):
+        from prefect.utilities.engine import (
+            _resolve_custom_task_run_name,
+            should_log_prints,
+        )
+
+        if client is None:
+            client = self.client
+        if not self.task_run:
+            raise ValueError("Task run is not set")
+
+        self.task_run = await client.read_task_run(self.task_run.id)
+        with ExitStack() as stack:
+            if log_prints := should_log_prints(self.task):
+                stack.enter_context(patch_print())
+            stack.enter_context(
+                TaskRunContext(
+                    task=self.task,
+                    log_prints=log_prints,
+                    task_run=self.task_run,
+                    parameters=self.parameters,
+                    result_factory=await ResultFactory.from_task(self.task),  # type: ignore
+                    client=client,
+                )
+            )
+            # set the logger to the task run logger
+            self.logger = task_run_logger(task_run=self.task_run, task=self.task)  # type: ignore
+
+            # update the task run name if necessary
+            if not self._task_name_set and self.task.task_run_name:
+                task_run_name = _resolve_custom_task_run_name(
+                    task=self.task, parameters=self.parameters
+                )
+                await self.client.set_task_run_name(
+                    task_run_id=self.task_run.id, name=task_run_name
+                )
+                self.logger.extra["task_run_name"] = task_run_name
+                self.logger.debug(
+                    f"Renamed task run {self.task_run.name!r} to {task_run_name!r}"
+                )
+                self.task_run.name = task_run_name
+                self._task_name_set = True
+            yield
+
+    @asynccontextmanager
+    async def initialize_run(
+        self,
+        task_run_id: Optional[UUID] = None,
+        dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
+    ) -> AsyncGenerator["AsyncTaskRunEngine", Any]:
+        """
+        Enters a client context and creates a task run if needed.
+        """
+        with hydrated_context(self.context):
+            async with ClientContext.async_get_or_create() as client_ctx:
+                self._client = client_ctx.async_client
+                self._is_started = True
+                try:
+                    if not self.task_run:
+                        self.task_run = await self.task.create_run(
+                            id=task_run_id,
+                            parameters=self.parameters,
+                            flow_run_context=FlowRunContext.get(),
+                            parent_task_run_context=TaskRunContext.get(),
+                            wait_for=self.wait_for,
+                            extra_task_inputs=dependencies,
+                        )
+                    # Emit an event to capture that the task run was in the `PENDING` state.
+                    self._last_event = emit_task_run_state_change_event(
+                        task_run=self.task_run,
+                        initial_state=None,
+                        validated_state=self.task_run.state,
+                    )
+
+                    async with self.setup_run_context():
+                        # setup_run_context might update the task run name, so log creation here
+                        self.logger.info(
+                            f"Created task run {self.task_run.name!r} for task {self.task.name!r}"
+                        )
+                        yield self
+
+                except TerminationSignal as exc:
+                    # TerminationSignals are caught and handled as crashes
+                    await self.handle_crash(exc)
+                    raise exc
+
+                except Exception:
+                    # regular exceptions are caught and re-raised to the user
+                    raise
+                except (Pause, Abort) as exc:
+                    # Do not capture internal signals as crashes
+                    if isinstance(exc, Abort):
+                        self.logger.error("Task run was aborted: %s", exc)
+                    raise
+                except GeneratorExit:
+                    # Do not capture generator exits as crashes
+                    raise
+                except BaseException as exc:
+                    # BaseExceptions are caught and handled as crashes
+                    await self.handle_crash(exc)
+                    raise
+                finally:
+                    # If debugging, use the more complete `repr` than the usual `str` description
+                    display_state = (
+                        repr(self.state) if PREFECT_DEBUG_MODE else str(self.state)
+                    )
+                    level = logging.INFO if self.state.is_completed() else logging.ERROR
+                    msg = f"Finished in state {display_state}"
+                    if self.state.is_pending():
+                        msg += (
+                            "\nPlease wait for all submitted tasks to complete"
+                            " before exiting your flow by calling `.wait()` on the "
+                            "`PrefectFuture` returned from your `.submit()` calls."
+                        )
+                        msg += dedent(
+                            """
+
+                            Example:
+
+                            from prefect import flow, task
+
+                            @task
+                            def say_hello(name):
+                                print f"Hello, {name}!"
+
+                            @flow
+                            def example_flow():
+                                future = say_hello.submit(name="Marvin)
+                                future.wait()
+
+                            example_flow()
+                                      """
+                        )
+                    self.logger.log(
+                        level=level,
+                        msg=msg,
+                    )
+
+                    self._is_started = False
+                    self._client = None
+
+    async def wait_until_ready(self):
+        """Waits until the scheduled time (if its the future), then enters Running."""
+        if scheduled_time := self.state.state_details.scheduled_time:
+            sleep_time = (scheduled_time - pendulum.now("utc")).total_seconds()
+            await anyio.sleep(sleep_time if sleep_time > 0 else 0)
+            await self.set_state(
+                Retrying() if self.state.name == "AwaitingRetry" else Running(),
+                force=True,
+            )
+
+    # --------------------------
+    #
+    # The following methods compose the main task run loop
+    #
+    # --------------------------
+
+    @asynccontextmanager
+    async def start(
+        self,
+        task_run_id: Optional[UUID] = None,
+        dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
+    ) -> AsyncGenerator[None, None]:
+        async with self.initialize_run(
+            task_run_id=task_run_id, dependencies=dependencies
+        ):
+            # Set the global flag to indicate that we are running in the async
+            # task engine to ensure that downstream sync tasks are run in a
+            # separate thread to avoid blocking the event loop.
+            token = RUNNING_IN_ASYNC_TASK_ENGINE.set(True)
+            await self.begin_run()
+            try:
+                yield
+            finally:
+                await self.call_hooks()
+                RUNNING_IN_ASYNC_TASK_ENGINE.reset(token)
+
+    @asynccontextmanager
+    async def transaction_context(self) -> AsyncGenerator[Transaction, None]:
+        result_factory = getattr(TaskRunContext.get(), "result_factory", None)
+
+        # refresh cache setting is now repurposes as overwrite transaction record
+        overwrite = (
+            self.task.refresh_cache
+            if self.task.refresh_cache is not None
+            else PREFECT_TASKS_REFRESH_CACHE.value()
+        )
+        with transaction(
+            key=self.compute_transaction_key(),
+            store=ResultFactoryStore(result_factory=result_factory),
+            overwrite=overwrite,
+            logger=self.logger,
+        ) as txn:
+            yield txn
+
+    @asynccontextmanager
+    async def run_context(self):
+        timeout_context = timeout_async if self.task.isasync else timeout
+        # reenter the run context to ensure it is up to date for every run
+        async with self.setup_run_context():
+            try:
+                with timeout_context(
+                    seconds=self.task.timeout_seconds,
+                    timeout_exc_type=TaskRunTimeoutError,
+                ):
+                    self.logger.debug(
+                        f"Executing task {self.task.name!r} for task run {self.task_run.name!r}..."
+                    )
+                    if self.is_cancelled():
+                        raise CancelledError("Task run cancelled by the task runner")
+
+                    yield self
+            except TimeoutError as exc:
+                await self.handle_timeout(exc)
+            except Exception as exc:
+                await self.handle_exception(exc)
+
+    async def call_task_fn(
+        self, transaction: Transaction
+    ) -> Union[R, Coroutine[Any, Any, R]]:
+        """
+        Convenience method to call the task function. Returns a coroutine if the
+        task is async.
+        """
+        parameters = self.parameters or {}
+
+        async def _call_task_fn():
             if transaction.is_committed():
                 result = transaction.read()
             else:
-                result = call_with_parameters(self.task.fn, parameters)
-            self.handle_success(result, transaction=transaction)
+                result = await call_with_parameters(self.task.fn, parameters)
+            await self.handle_success(result, transaction=transaction)
             return result
+
+        return await _call_task_fn()
 
 
 def run_task_sync(
@@ -714,7 +1191,7 @@ def run_task_sync(
     dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
     context: Optional[Dict[str, Any]] = None,
 ) -> Union[R, State, None]:
-    engine = TaskRunEngine[P, R](
+    engine = SyncTaskRunEngine[P, R](
         task=task,
         parameters=parameters,
         task_run=task_run,
@@ -741,7 +1218,7 @@ async def run_task_async(
     dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
     context: Optional[Dict[str, Any]] = None,
 ) -> Union[R, State, None]:
-    engine = TaskRunEngine[P, R](
+    engine = AsyncTaskRunEngine[P, R](
         task=task,
         parameters=parameters,
         task_run=task_run,
@@ -749,13 +1226,13 @@ async def run_task_async(
         context=context,
     )
 
-    with engine.start(task_run_id=task_run_id, dependencies=dependencies):
+    async with engine.start(task_run_id=task_run_id, dependencies=dependencies):
         while engine.is_running():
             await engine.wait_until_ready()
-            with engine.run_context(), engine.transaction_context() as txn:
+            async with engine.run_context(), engine.transaction_context() as txn:
                 await engine.call_task_fn(txn)
 
-    return engine.state if return_type == "state" else engine.result()
+    return engine.state if return_type == "state" else await engine.result()
 
 
 def run_generator_task_sync(
@@ -771,7 +1248,7 @@ def run_generator_task_sync(
     if return_type != "result":
         raise ValueError("The return_type for a generator task must be 'result'")
 
-    engine = TaskRunEngine[P, R](
+    engine = SyncTaskRunEngine[P, R](
         task=task,
         parameters=parameters,
         task_run=task_run,
@@ -825,7 +1302,7 @@ async def run_generator_task_async(
 ) -> AsyncGenerator[R, None]:
     if return_type != "result":
         raise ValueError("The return_type for a generator task must be 'result'")
-    engine = TaskRunEngine[P, R](
+    engine = AsyncTaskRunEngine[P, R](
         task=task,
         parameters=parameters,
         task_run=task_run,
@@ -833,10 +1310,10 @@ async def run_generator_task_async(
         context=context,
     )
 
-    with engine.start(task_run_id=task_run_id, dependencies=dependencies):
+    async with engine.start(task_run_id=task_run_id, dependencies=dependencies):
         while engine.is_running():
             await engine.wait_until_ready()
-            with engine.run_context(), engine.transaction_context() as txn:
+            async with engine.run_context(), engine.transaction_context() as txn:
                 # TODO: generators should default to commit_mode=OFF
                 # because they are dynamic by definition
                 # for now we just prevent this branch explicitly
@@ -860,13 +1337,13 @@ async def run_generator_task_async(
                             link_state_to_result(engine.state, gen_result)
                             yield gen_result
                     except (StopAsyncIteration, GeneratorExit) as exc:
-                        engine.handle_success(None, transaction=txn)
+                        await engine.handle_success(None, transaction=txn)
                         if isinstance(exc, GeneratorExit):
                             gen.throw(exc)
 
     # async generators can't return, but we can raise failures here
     if engine.state.is_failed():
-        engine.result()
+        await engine.result()
 
 
 def run_task(

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -3,7 +3,7 @@ import logging
 import threading
 import time
 from asyncio import CancelledError
-from contextlib import ExitStack, asynccontextmanager, contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
 from textwrap import dedent
 from typing import (
@@ -19,7 +19,6 @@ from typing import (
     Optional,
     Sequence,
     Set,
-    Tuple,
     Type,
     TypeVar,
     Union,
@@ -31,7 +30,7 @@ import pendulum
 from typing_extensions import ParamSpec
 
 from prefect import Task
-from prefect.client.orchestration import PrefectClient, SyncPrefectClient
+from prefect.client.orchestration import SyncPrefectClient
 from prefect.client.schemas import TaskRun
 from prefect.client.schemas.objects import State, TaskRunInput
 from prefect.context import (
@@ -49,11 +48,7 @@ from prefect.exceptions import (
     UpstreamTaskError,
 )
 from prefect.futures import PrefectFuture
-from prefect.logging.loggers import (
-    get_logger,
-    patch_print,
-    task_run_logger,
-)
+from prefect.logging.loggers import get_logger, patch_print, task_run_logger
 from prefect.records.result_store import ResultFactoryStore
 from prefect.results import BaseResult, ResultFactory, _format_user_supplied_storage_key
 from prefect.settings import (
@@ -73,14 +68,13 @@ from prefect.states import (
 )
 from prefect.transactions import Transaction, transaction
 from prefect.utilities.annotations import NotSet
-from prefect.utilities.asyncutils import RUNNING_IN_ASYNC_TASK_ENGINE, run_coro_as_sync
+from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.callables import call_with_parameters, parameters_to_args_kwargs
 from prefect.utilities.collections import visit_collection
 from prefect.utilities.engine import (
     _get_hook_name,
     emit_task_run_state_change_event,
     link_state_to_result,
-    propose_state,
     propose_state_sync,
     resolve_to_final_result,
 )
@@ -90,15 +84,13 @@ from prefect.utilities.timeout import timeout, timeout_async
 P = ParamSpec("P")
 R = TypeVar("R")
 
-BACKOFF_MAX = 10
-
 
 class TaskRunTimeoutError(TimeoutError):
     """Raised when a task run exceeds its timeout."""
 
 
 @dataclass
-class BaseTaskRunEngine(Generic[P, R]):
+class TaskRunEngine(Generic[P, R]):
     task: Union[Task[P, R], Task[P, Coroutine[Any, Any, R]]]
     logger: logging.Logger = field(default_factory=lambda: get_logger("engine"))
     parameters: Optional[Dict[str, Any]] = None
@@ -112,6 +104,7 @@ class BaseTaskRunEngine(Generic[P, R]):
     _raised: Union[Exception, Type[NotSet]] = NotSet
     _initial_run_context: Optional[TaskRunContext] = None
     _is_started: bool = False
+    _client: Optional[SyncPrefectClient] = None
     _task_name_set: bool = False
     _last_event: Optional[PrefectEvent] = None
 
@@ -120,8 +113,15 @@ class BaseTaskRunEngine(Generic[P, R]):
             self.parameters = {}
 
     @property
+    def client(self) -> SyncPrefectClient:
+        if not self._is_started or self._client is None:
+            raise RuntimeError("Engine has not started.")
+        return self._client
+
+    @property
     def state(self) -> State:
-        self._ensure_task_run()
+        if not self.task_run:
+            raise ValueError("Task run is not set")
         return self.task_run.state
 
     @property
@@ -129,9 +129,8 @@ class BaseTaskRunEngine(Generic[P, R]):
         retry_condition: Optional[
             Callable[[Task[P, Coroutine[Any, Any, R]], TaskRun, State], bool]
         ] = self.task.retry_condition_fn
-
-        self._ensure_task_run()
-
+        if not self.task_run:
+            raise ValueError("Task run is not set")
         try:
             self.logger.debug(
                 f"Running `retry_condition_fn` check {retry_condition!r} for task"
@@ -158,6 +157,41 @@ class BaseTaskRunEngine(Generic[P, R]):
         ):
             return self.context["cancel_event"].is_set()
         return False
+
+    def call_hooks(self, state: Optional[State] = None):
+        if state is None:
+            state = self.state
+        task = self.task
+        task_run = self.task_run
+
+        if not task_run:
+            raise ValueError("Task run is not set")
+
+        if state.is_failed() and task.on_failure_hooks:
+            hooks = task.on_failure_hooks
+        elif state.is_completed() and task.on_completion_hooks:
+            hooks = task.on_completion_hooks
+        else:
+            hooks = None
+
+        for hook in hooks or []:
+            hook_name = _get_hook_name(hook)
+
+            try:
+                self.logger.info(
+                    f"Running hook {hook_name!r} in response to entering state"
+                    f" {state.name!r}"
+                )
+                result = hook(task, task_run, state)
+                if inspect.isawaitable(result):
+                    run_coro_as_sync(result)
+            except Exception:
+                self.logger.error(
+                    f"An error was encountered while running hook {hook_name!r}",
+                    exc_info=True,
+                )
+            else:
+                self.logger.info(f"Hook {hook_name!r} finished running successfully")
 
     def compute_transaction_key(self) -> Optional[str]:
         key = None
@@ -218,42 +252,57 @@ class BaseTaskRunEngine(Generic[P, R]):
             context={"current_task_run": self.task_run, "current_task": self.task},
         )
 
-    def _resolve_and_wait_for_dependencies(self) -> Union[State, None]:
+    def begin_run(self):
         try:
             self._resolve_parameters()
             self._wait_for_dependencies()
         except UpstreamTaskError as upstream_exc:
-            return Pending(name="NotReady", message=str(upstream_exc))
+            state = self.set_state(
+                Pending(
+                    name="NotReady",
+                    message=str(upstream_exc),
+                ),
+                # if orchestrating a run already in a pending state, force orchestration to
+                # update the state name
+                force=self.state.is_pending(),
+            )
+            return
 
-    def _calculate_backoff(self, backoff_count: int) -> Tuple[float, int]:
-        if backoff_count < BACKOFF_MAX:
-            backoff_count += 1
+        new_state = Running()
+        state = self.set_state(new_state)
 
-        interval = clamped_poisson_interval(
-            average_interval=backoff_count, clamping_factor=0.3
-        )
+        # TODO: this is temporary until the API stops rejecting state transitions
+        # and the client / transaction store becomes the source of truth
+        # this is a bandaid caused by the API storing a Completed state with a bad
+        # result reference that no longer exists
+        if state.is_completed():
+            try:
+                state.result(retry_result_failure=False, _sync=True)
+            except Exception:
+                state = self.set_state(new_state, force=True)
 
-        return interval, backoff_count
+        BACKOFF_MAX = 10
+        backoff_count = 0
 
-    def _handle_state_change(self, new_state: State):
+        # TODO: Could this listen for state change events instead of polling?
+        while state.is_pending() or state.is_paused():
+            if backoff_count < BACKOFF_MAX:
+                backoff_count += 1
+            interval = clamped_poisson_interval(
+                average_interval=backoff_count, clamping_factor=0.3
+            )
+            time.sleep(interval)
+            state = self.set_state(new_state)
+
+    def set_state(self, state: State, force: bool = False) -> State:
         last_state = self.state
-
-        # currently this is a hack to keep a reference to the state object
-        # that has an in-memory result attached to it; using the API state
-
-        # could result in losing that reference
-        self.task_run.state = new_state
-
-        # emit a state change event
-        self._last_event = emit_task_run_state_change_event(
-            task_run=self.task_run,
-            initial_state=last_state,
-            validated_state=self.task_run.state,
-            follows=self._last_event,
-        )
-
-    def _handle_propose_state_exception(self, exc: Exception):
-        if isinstance(exc, Pause):
+        if not self.task_run:
+            raise ValueError("Task run is not set")
+        try:
+            new_state = propose_state_sync(
+                self.client, state, task_run_id=self.task_run.id, force=force
+            )
+        except Pause as exc:
             # We shouldn't get a pause signal without a state, but if this happens,
             # just use a Paused state to assume an in-process pause.
             new_state = exc.state if exc.state else Paused()
@@ -261,76 +310,31 @@ class BaseTaskRunEngine(Generic[P, R]):
                 # If we're being asked to pause and reschedule, we should exit the
                 # task and expect to be resumed later.
                 raise
-        else:
-            raise exc
 
-    def _task_cache_expiration_datetime(self) -> Union[pendulum.DateTime, None]:
-        if self.task.cache_expiration is not None:
-            return pendulum.now("utc") + self.task.cache_expiration
-        else:
-            return None
+        # currently this is a hack to keep a reference to the state object
+        # that has an in-memory result attached to it; using the API state
 
-    def _ensure_task_run(self) -> TaskRun:
-        if not self.task_run:
-            raise ValueError("Task run is not set")
-
-        return self.task_run
-
-    def _ensure_result_factory(self) -> ResultFactory:
-        result_factory = getattr(TaskRunContext.get(), "result_factory", None)
-        if result_factory is None:
-            raise ValueError("Result factory is not set")
-
-        return result_factory
-
-    def _task_run_logger(self) -> logging.Logger:
-        task_run = self._ensure_task_run()
-        return task_run_logger(task_run=task_run, task=self.task)  # type: ignore
-
-    def is_running(self) -> bool:
-        """Whether or not the engine is currently running a task."""
-        if (task_run := getattr(self, "task_run", None)) is None:
-            return False
-        return task_run.state.is_running() or task_run.state.is_scheduled()
-
-    @contextmanager
-    def transaction_context(self) -> Generator[Transaction, None, None]:
-        result_factory = self._ensure_result_factory()
-
-        # refresh cache setting is now repurposes as overwrite transaction record
-        overwrite = (
-            self.task.refresh_cache
-            if self.task.refresh_cache is not None
-            else PREFECT_TASKS_REFRESH_CACHE.value()
+        # could result in losing that reference
+        self.task_run.state = new_state
+        # emit a state change event
+        self._last_event = emit_task_run_state_change_event(
+            task_run=self.task_run,
+            initial_state=last_state,
+            validated_state=self.task_run.state,
+            follows=self._last_event,
         )
-        with transaction(
-            key=self.compute_transaction_key(),
-            store=ResultFactoryStore(result_factory=result_factory),
-            overwrite=overwrite,
-            logger=self.logger,
-        ) as txn:
-            yield txn
+        return new_state
 
-    def _hooks(
-        self, task: Task, state: State
-    ) -> Generator[Tuple[str, Callable], None, None]:
-        task = self.task
-
-        if state.is_failed() and task.on_failure_hooks:
-            hooks = task.on_failure_hooks
-        elif state.is_completed() and task.on_completion_hooks:
-            hooks = task.on_completion_hooks
-        else:
-            hooks = []
-
-        for hook in hooks:
-            yield (_get_hook_name(hook), hook)
-
-    def _result_from_non_base_result(
-        self, raise_on_failure: bool
-    ) -> "Union[R, State, None]":
+    def result(self, raise_on_failure: bool = True) -> "Union[R, State, None]":
         if self._return_value is not NotSet:
-            # return the value as is
+            # if the return value is a BaseResult, we need to fetch it
+            if isinstance(self._return_value, BaseResult):
+                _result = self._return_value.get()
+                if inspect.isawaitable(_result):
+                    _result = run_coro_as_sync(_result)
+                return _result
+
+            # otherwise, return the value as is
             return self._return_value
 
         if self._raised is not NotSet:
@@ -341,15 +345,44 @@ class BaseTaskRunEngine(Generic[P, R]):
             # otherwise, return the exception
             return self._raised
 
-    def _retry_state(self, exc: Exception) -> Union[State, None]:
-        """Return the proper state for a task run retry.
+    def handle_success(self, result: R, transaction: Transaction) -> R:
+        result_factory = getattr(TaskRunContext.get(), "result_factory", None)
+        if result_factory is None:
+            raise ValueError("Result factory is not set")
 
-        - If the task has retries left, and the retry condition is met, return `Retrying` state.
-        - If the task has a retry delay, return `AwaitingRetry` state with a delayed scheduled time.
-        - If the task has no retries left, or the retry condition is not met, return None.
+        if self.task.cache_expiration is not None:
+            expiration = pendulum.now("utc") + self.task.cache_expiration
+        else:
+            expiration = None
+
+        terminal_state = run_coro_as_sync(
+            return_value_to_state(
+                result,
+                result_factory=result_factory,
+                key=transaction.key,
+                expiration=expiration,
+                # defer persistence to transaction commit
+                defer_persistence=True,
+            )
+        )
+        transaction.stage(
+            terminal_state.data,
+            on_rollback_hooks=self.task.on_rollback_hooks,
+            on_commit_hooks=self.task.on_commit_hooks,
+        )
+        if transaction.is_committed():
+            terminal_state.name = "Cached"
+        self.set_state(terminal_state)
+        self._return_value = result
+        return result
+
+    def handle_retry(self, exc: Exception) -> bool:
+        """Handle any task run retries.
+
+        - If the task has retries left, and the retry condition is met, set the task to retrying and return True.
+          - If the task has a retry delay, place in AwaitingRetry state with a delayed scheduled time.
+        - If the task has no retries left, or the retry condition is not met, return False.
         """
-        new_state = None
-
         if self.retries < self.task.retries and self.can_retry:
             if self.task.retry_delay_seconds:
                 delay = (
@@ -374,183 +407,16 @@ class BaseTaskRunEngine(Generic[P, R]):
                 str(delay) + " second(s) from now" if delay else "immediately",
             )
 
+            self.set_state(new_state, force=True)
             self.retries = self.retries + 1
-            return new_state
+            return True
         elif self.retries >= self.task.retries:
             self.logger.error(
                 "Task run failed with exception: %r - Retries are exhausted",
                 exc,
                 exc_info=True,
             )
-
-        return None
-
-    def _log_task_run_timeout(self, exc: Exception) -> str:
-        if isinstance(exc, TaskRunTimeoutError):
-            message = (
-                f"Task run exceeded timeout of {self.task.timeout_seconds} second(s)"
-            )
-        else:
-            message = f"Task run failed due to timeout: {exc!r}"
-
-        self.logger.error(message)
-
-        return message
-
-    def _log_task_run_crashed(self, state: State, exc: BaseException) -> None:
-        self.logger.error(f"Crash detected! {state.message}")
-        self.logger.debug("Crash details:", exc_info=exc)
-
-    @contextmanager
-    def setup_run_context(
-        self,
-        result_factory: ResultFactory,
-        client: Union[PrefectClient, SyncPrefectClient],
-    ):
-        from prefect.utilities.engine import should_log_prints
-
-        with ExitStack() as stack:
-            if log_prints := should_log_prints(self.task):
-                stack.enter_context(patch_print())
-            stack.enter_context(
-                TaskRunContext(
-                    task=self.task,
-                    log_prints=log_prints,
-                    task_run=self.task_run,
-                    parameters=self.parameters,
-                    result_factory=result_factory,  # type: ignore
-                    client=client,
-                )
-            )
-            yield
-
-
-@dataclass
-class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
-    _client: Optional[SyncPrefectClient] = None
-
-    @property
-    def client(self) -> SyncPrefectClient:
-        if not self._is_started or self._client is None:
-            raise RuntimeError("Engine has not started.")
-        return self._client
-
-    def call_hooks(self, state: Optional[State] = None):
-        if state is None:
-            state = self.state
-
-        self._ensure_task_run()
-
-        for hook_name, hook in self._hooks(task=self.task, state=state):
-            try:
-                self.logger.info(
-                    f"Running hook {hook_name!r} in response to entering state"
-                    f" {state.name!r}"
-                )
-                result = hook(self.task, self.task_run, state)
-                if inspect.isawaitable(result):
-                    run_coro_as_sync(result)
-            except Exception:
-                self.logger.error(
-                    f"An error was encountered while running hook {hook_name!r}",
-                    exc_info=True,
-                )
-            else:
-                self.logger.info(f"Hook {hook_name!r} finished running successfully")
-
-    def begin_run(self):
-        if not_ready_state := self._resolve_and_wait_for_dependencies():
-            self.set_state(not_ready_state, force=self.state.is_pending())
-            return
-
-        self.task_run = self.client.read_task_run(self.task_run.id)
-
-        new_state = Running()
-        state = self.set_state(new_state)
-
-        # TODO: this is temporary until the API stops rejecting state transitions
-        # and the client / transaction store becomes the source of truth
-        # this is a bandaid caused by the API storing a Completed state with a bad
-        # result reference that no longer exists
-        if state.is_completed():
-            try:
-                state.result(retry_result_failure=False, _sync=True)
-            except Exception:
-                state = self.set_state(new_state, force=True)
-
-        backoff_count = 0
-
-        # TODO: Could this listen for state change events instead of polling?
-        while state.is_pending() or state.is_paused():
-            interval, backoff_count = self._calculate_backoff(backoff_count)
-            time.sleep(interval)
-            state = self.set_state(new_state)
-
-    def set_state(self, state: State, force: bool = False) -> State:
-        self._ensure_task_run()
-
-        try:
-            new_state = propose_state_sync(
-                self.client, state, task_run_id=self.task_run.id, force=force
-            )
-        except Exception as exc:
-            self._handle_propose_state_exception(exc)
-
-        self._handle_state_change(new_state)
-
-        return new_state
-
-    def result(self, raise_on_failure: bool = True) -> "Union[R, State, None]":
-        if self._return_value is not NotSet and isinstance(
-            self._return_value, BaseResult
-        ):
-            # if the return value is a BaseResult, we need to fetch it
-            _result = self._return_value.get()
-            if inspect.isawaitable(_result):
-                _result = run_coro_as_sync(_result)
-            return _result
-
-        return self._result_from_non_base_result(raise_on_failure=raise_on_failure)
-
-    def handle_success(self, result: R, transaction: Transaction) -> R:
-        result_factory = self._ensure_result_factory()
-        expiration = self._task_cache_expiration_datetime()
-
-        terminal_state = run_coro_as_sync(
-            return_value_to_state(
-                result,
-                result_factory=result_factory,
-                key=transaction.key,
-                expiration=expiration,
-                # defer persistence to transaction commit
-                defer_persistence=True,
-            )
-        )
-        transaction.stage(
-            terminal_state.data,
-            on_rollback_hooks=self.task.on_rollback_hooks,
-            on_commit_hooks=self.task.on_commit_hooks,
-        )
-        if transaction.is_committed():
-            terminal_state.name = "Cached"
-
-        self.set_state(terminal_state)
-
-        self._return_value = result
-
-        return result
-
-    def handle_retry(self, exc: Exception) -> bool:
-        """
-        Handle any task run retries.
-
-        - If the task has retries left, set retrying state and return True.
-        - If the task has no retries left, or the retry condition is not met, return False.
-        """
-
-        if retry_state := self._retry_state(exc):
-            self.set_state(retry_state, force=True)
-            return True
+            return False
 
         return False
 
@@ -571,8 +437,11 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
     def handle_timeout(self, exc: TimeoutError) -> None:
         if not self.handle_retry(exc):
-            message = self._log_task_run_timeout(exc)
-
+            if isinstance(exc, TaskRunTimeoutError):
+                message = f"Task run exceeded timeout of {self.task.timeout_seconds} second(s)"
+            else:
+                message = f"Task run failed due to timeout: {exc!r}"
+            self.logger.error(message)
             state = Failed(
                 data=exc,
                 message=message,
@@ -581,30 +450,64 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             self.set_state(state)
             self._raised = exc
 
-    def set_task_run_name(self):
-        from prefect.utilities.engine import _resolve_custom_task_run_name
+    def handle_crash(self, exc: BaseException) -> None:
+        state = run_coro_as_sync(exception_to_crashed_state(exc))
+        self.logger.error(f"Crash detected! {state.message}")
+        self.logger.debug("Crash details:", exc_info=exc)
+        self.set_state(state, force=True)
+        self._raised = exc
 
-        task_run = self._ensure_task_run()
+    @contextmanager
+    def setup_run_context(self, client: Optional[SyncPrefectClient] = None):
+        from prefect.utilities.engine import (
+            _resolve_custom_task_run_name,
+            should_log_prints,
+        )
 
-        # Update the task run name.
-        if not self._task_name_set and self.task.task_run_name:
-            task_run_name = _resolve_custom_task_run_name(
-                task=self.task, parameters=self.parameters
+        if client is None:
+            client = self.client
+        if not self.task_run:
+            raise ValueError("Task run is not set")
+
+        self.task_run = client.read_task_run(self.task_run.id)
+        with ExitStack() as stack:
+            if log_prints := should_log_prints(self.task):
+                stack.enter_context(patch_print())
+            stack.enter_context(
+                TaskRunContext(
+                    task=self.task,
+                    log_prints=log_prints,
+                    task_run=self.task_run,
+                    parameters=self.parameters,
+                    result_factory=run_coro_as_sync(ResultFactory.from_task(self.task)),  # type: ignore
+                    client=client,
+                )
             )
-            self.client.set_task_run_name(task_run_id=task_run.id, name=task_run_name)
-            self.logger.extra["task_run_name"] = task_run_name
-            self.logger.debug(
-                f"Renamed task run {task_run.name!r} to {task_run_name!r}"
-            )
-            task_run.name = task_run_name
-            self._task_name_set = True
+            # set the logger to the task run logger
+            self.logger = task_run_logger(task_run=self.task_run, task=self.task)  # type: ignore
+
+            # update the task run name if necessary
+            if not self._task_name_set and self.task.task_run_name:
+                task_run_name = _resolve_custom_task_run_name(
+                    task=self.task, parameters=self.parameters
+                )
+                self.client.set_task_run_name(
+                    task_run_id=self.task_run.id, name=task_run_name
+                )
+                self.logger.extra["task_run_name"] = task_run_name
+                self.logger.debug(
+                    f"Renamed task run {self.task_run.name!r} to {task_run_name!r}"
+                )
+                self.task_run.name = task_run_name
+                self._task_name_set = True
+            yield
 
     @contextmanager
     def initialize_run(
         self,
         task_run_id: Optional[UUID] = None,
         dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
-    ) -> Generator["SyncTaskRunEngine", Any, Any]:
+    ) -> Generator["TaskRunEngine", Any, Any]:
         """
         Enters a client context and creates a task run if needed.
         """
@@ -624,24 +527,19 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                                 extra_task_inputs=dependencies,
                             )
                         )
-
-                    self.logger = self._task_run_logger()
-
-                    # Capture initial state of the task run, usually `PENDING` or `SCHEDULED`.
+                    # Emit an event to capture that the task run was in the `PENDING` state.
                     self._last_event = emit_task_run_state_change_event(
                         task_run=self.task_run,
                         initial_state=None,
                         validated_state=self.task_run.state,
                     )
 
-                    with self.configured_run_context():
-                        self.set_task_run_name()
-
-                    self.logger.info(
-                        f"Created task run {self.task_run.name!r} for task {self.task.name!r}"
-                    )
-
-                    yield self
+                    with self.setup_run_context():
+                        # setup_run_context might update the task run name, so log creation here
+                        self.logger.info(
+                            f"Created task run {self.task_run.name!r} for task {self.task.name!r}"
+                        )
+                        yield self
 
                 except TerminationSignal as exc:
                     # TerminationSignals are caught and handled as crashes
@@ -703,6 +601,12 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                     self._is_started = False
                     self._client = None
 
+    def is_running(self) -> bool:
+        """Whether or not the engine is currently running a task."""
+        if (task_run := getattr(self, "task_run", None)) is None:
+            return False
+        return task_run.state.is_running() or task_run.state.is_scheduled()
+
     async def wait_until_ready(self):
         """Waits until the scheduled time (if its the future), then enters Running."""
         if scheduled_time := self.state.state_details.scheduled_time:
@@ -713,31 +617,11 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 force=True,
             )
 
-    def handle_crash(self, exc: BaseException) -> None:
-        state = run_coro_as_sync(exception_to_crashed_state(exc))
-        self._log_task_run_crashed(state, exc)
-        self.set_state(state, force=True)
-        self._raised = exc
-
     # --------------------------
     #
     # The following methods compose the main task run loop
     #
     # --------------------------
-
-    @contextmanager
-    def configured_run_context(self) -> Generator[None, None, None]:
-        result_factory = run_coro_as_sync(ResultFactory.from_task(self.task))
-        self.task_run = self.client.read_task_run(self.task_run.id)
-
-        try:
-            with self.setup_run_context(
-                result_factory=result_factory,
-                client=self.client,
-            ):
-                yield
-        finally:
-            pass
 
     @contextmanager
     def start(
@@ -753,10 +637,30 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 self.call_hooks()
 
     @contextmanager
+    def transaction_context(self) -> Generator[Transaction, None, None]:
+        result_factory = getattr(TaskRunContext.get(), "result_factory", None)
+
+        # refresh cache setting is now repurposes as overwrite transaction record
+        overwrite = (
+            self.task.refresh_cache
+            if self.task.refresh_cache is not None
+            else PREFECT_TASKS_REFRESH_CACHE.value()
+        )
+        with transaction(
+            key=self.compute_transaction_key(),
+            store=ResultFactoryStore(result_factory=result_factory),
+            overwrite=overwrite,
+            logger=self.logger,
+        ) as txn:
+            yield txn
+
+    @contextmanager
     def run_context(self):
-        with self.configured_run_context():
+        timeout_context = timeout_async if self.task.isasync else timeout
+        # reenter the run context to ensure it is up to date for every run
+        with self.setup_run_context():
             try:
-                with timeout(
+                with timeout_context(
                     seconds=self.task.timeout_seconds,
                     timeout_exc_type=TaskRunTimeoutError,
                 ):
@@ -772,377 +676,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             except Exception as exc:
                 self.handle_exception(exc)
 
-    def call_task_fn(self, transaction: Transaction) -> R:
-        """
-        Convenience method to call the task function.
-        """
-        parameters = self.parameters or {}
-        if transaction.is_committed():
-            result = transaction.read()
-        else:
-            result = call_with_parameters(self.task.fn, parameters)
-        self.handle_success(result, transaction=transaction)
-        return result
-
-
-@dataclass
-class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
-    _client: Optional[PrefectClient] = None
-
-    @property
-    def client(self) -> PrefectClient:
-        if not self._is_started or self._client is None:
-            raise RuntimeError("Engine has not started.")
-        return self._client
-
-    async def call_hooks(self, state: Optional[State] = None):
-        if state is None:
-            state = self.state
-
-        self._ensure_task_run()
-
-        for hook_name, hook in self._hooks(task=self.task, state=state):
-            try:
-                self.logger.info(
-                    f"Running hook {hook_name!r} in response to entering state"
-                    f" {state.name!r}"
-                )
-                result = hook(self.task, self.task_run, state)
-                if inspect.isawaitable(result):
-                    await result
-            except Exception:
-                self.logger.error(
-                    f"An error was encountered while running hook {hook_name!r}",
-                    exc_info=True,
-                )
-            else:
-                self.logger.info(f"Hook {hook_name!r} finished running successfully")
-
-    async def begin_run(self):
-        if not_ready_state := self._resolve_and_wait_for_dependencies():
-            await self.set_state(not_ready_state, force=self.state.is_pending())
-            return
-
-        self.task_run = await self.client.read_task_run(self.task_run.id)
-
-        new_state = Running()
-        state = await self.set_state(new_state)
-
-        # TODO: this is temporary until the API stops rejecting state transitions
-        # and the client / transaction store becomes the source of truth
-        # this is a bandaid caused by the API storing a Completed state with a bad
-        # result reference that no longer exists
-        if state.is_completed():
-            try:
-                await state.result(retry_result_failure=False)
-            except Exception:
-                state = await self.set_state(new_state, force=True)
-
-        backoff_count = 0
-
-        # TODO: Could this listen for state change events instead of polling?
-        while state.is_pending() or state.is_paused():
-            interval, backoff_count = self._calculate_backoff(backoff_count)
-            await anyio.sleep(interval)
-            state = await self.set_state(new_state)
-
-    async def set_state(self, state: State, force: bool = False) -> State:
-        self._ensure_task_run()
-
-        try:
-            new_state = await propose_state(
-                self.client, state, task_run_id=self.task_run.id, force=force
-            )
-        except Exception as exc:
-            self._handle_propose_state_exception(exc)
-
-        self._handle_state_change(new_state)
-
-        return new_state
-
-    async def result(self, raise_on_failure: bool = True) -> "Union[R, State, None]":
-        if self._return_value is not NotSet and isinstance(
-            self._return_value, BaseResult
-        ):
-            # if the return value is a BaseResult, we need to fetch it
-            _result = self._return_value.get()
-            if inspect.isawaitable(_result):
-                _result = await _result
-            return _result
-
-        return self._result_from_non_base_result(raise_on_failure=raise_on_failure)
-
-    async def handle_success(self, result: R, transaction: Transaction) -> R:
-        result_factory = self._ensure_result_factory()
-        expiration = self._task_cache_expiration_datetime()
-
-        terminal_state = await return_value_to_state(
-            result,
-            result_factory=result_factory,
-            key=transaction.key,
-            expiration=expiration,
-            # defer persistence to transaction commit
-            defer_persistence=True,
-        )
-
-        transaction.stage(
-            terminal_state.data,
-            on_rollback_hooks=self.task.on_rollback_hooks,
-            on_commit_hooks=self.task.on_commit_hooks,
-        )
-        if transaction.is_committed():
-            terminal_state.name = "Cached"
-
-        await self.set_state(terminal_state)
-
-        self._return_value = result
-
-        return result
-
-    async def handle_retry(self, exc: Exception) -> bool:
-        """
-        Handle any task run retries.
-
-        - If the task has retries left, set retrying state and return True.
-        - If the task has no retries left, or the retry condition is not met, return False.
-        """
-
-        if retry_state := self._retry_state(exc):
-            await self.set_state(retry_state, force=True)
-            return True
-
-        return False
-
-    async def handle_exception(self, exc: Exception) -> None:
-        # If the task fails, and we have retries left, set the task to retrying.
-        if not await self.handle_retry(exc):
-            # If the task has no retries left, or the retry condition is not met, set the task to failed.
-            context = TaskRunContext.get()
-            state = await exception_to_failed_state(
-                exc,
-                message="Task run encountered an exception",
-                result_factory=getattr(context, "result_factory", None),
-            )
-            await self.set_state(state)
-            self._raised = exc
-
-    async def handle_timeout(self, exc: TimeoutError) -> None:
-        if not await self.handle_retry(exc):
-            message = self._log_task_run_timeout(exc)
-
-            state = Failed(
-                data=exc,
-                message=message,
-                name="TimedOut",
-            )
-            await self.set_state(state)
-            self._raised = exc
-
-    async def handle_crash(self, exc: BaseException) -> None:
-        state = await exception_to_crashed_state(exc)
-        self._log_task_run_crashed(state, exc)
-        await self.set_state(state, force=True)
-        self._raised = exc
-
-    async def set_task_run_name(self):
-        from prefect.utilities.engine import _resolve_custom_task_run_name
-
-        task_run = self._ensure_task_run()
-
-        # Update the task run name.
-        if not self._task_name_set and self.task.task_run_name:
-            task_run_name = _resolve_custom_task_run_name(
-                task=self.task, parameters=self.parameters
-            )
-            await self.client.set_task_run_name(
-                task_run_id=task_run.id, name=task_run_name
-            )
-            self.logger.extra["task_run_name"] = task_run_name
-            self.logger.debug(
-                f"Renamed task run {task_run.name!r} to {task_run_name!r}"
-            )
-            task_run.name = task_run_name
-            self._task_name_set = True
-
-    @asynccontextmanager
-    async def initialize_run(
-        self,
-        task_run_id: Optional[UUID] = None,
-        dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
-    ) -> AsyncGenerator["AsyncTaskRunEngine", Any]:
-        """
-        Enters a client context and creates a task run if needed.
-        """
-        with hydrated_context(self.context):
-            async with ClientContext.async_get_or_create() as client_ctx:
-                self._client = client_ctx.async_client
-                self._is_started = True
-                try:
-                    if not self.task_run:
-                        self.task_run = await self.task.create_run(
-                            client=self._client,
-                            id=task_run_id,
-                            parameters=self.parameters,
-                            flow_run_context=FlowRunContext.get(),
-                            parent_task_run_context=TaskRunContext.get(),
-                            wait_for=self.wait_for,
-                            extra_task_inputs=dependencies,
-                        )
-
-                    self.logger = self._task_run_logger()
-
-                    # Capture initial state of the task run, usually `PENDING` or `SCHEDULED`.
-                    self._last_event = emit_task_run_state_change_event(
-                        task_run=self.task_run,
-                        initial_state=None,
-                        validated_state=self.task_run.state,
-                    )
-
-                    async with self.configured_run_context():
-                        # Some tasks may rely on the run context to set the task
-                        # run name.
-                        await self.set_task_run_name()
-
-                    self.logger.info(
-                        f"Created task run {self.task_run.name!r} for task {self.task.name!r}"
-                    )
-
-                    yield self
-
-                except TerminationSignal as exc:
-                    # TerminationSignals are caught and handled as crashes
-                    await self.handle_crash(exc)
-                    raise exc
-
-                except Exception:
-                    # regular exceptions are caught and re-raised to the user
-                    raise
-                except (Pause, Abort) as exc:
-                    # Do not capture internal signals as crashes
-                    if isinstance(exc, Abort):
-                        self.logger.error("Task run was aborted: %s", exc)
-                    raise
-                except GeneratorExit:
-                    # Do not capture generator exits as crashes
-                    raise
-                except BaseException as exc:
-                    # BaseExceptions are caught and handled as crashes
-                    await self.handle_crash(exc)
-                    raise
-                finally:
-                    # If debugging, use the more complete `repr` than the usual `str` description
-                    display_state = (
-                        repr(self.state) if PREFECT_DEBUG_MODE else str(self.state)
-                    )
-                    level = logging.INFO if self.state.is_completed() else logging.ERROR
-                    msg = f"Finished in state {display_state}"
-                    if self.state.is_pending():
-                        msg += (
-                            "\nPlease wait for all submitted tasks to complete"
-                            " before exiting your flow by calling `.wait()` on the "
-                            "`PrefectFuture` returned from your `.submit()` calls."
-                        )
-                        msg += dedent(
-                            """
-
-                            Example:
-
-                            from prefect import flow, task
-
-                            @task
-                            def say_hello(name):
-                                print f"Hello, {name}!"
-
-                            @flow
-                            def example_flow():
-                                future = say_hello.submit(name="Marvin)
-                                future.wait()
-
-                            example_flow()
-                                      """
-                        )
-                    self.logger.log(
-                        level=level,
-                        msg=msg,
-                    )
-
-                    self._is_started = False
-                    self._client = None
-
-    async def wait_until_ready(self):
-        """Waits until the scheduled time (if its the future), then enters Running."""
-        if scheduled_time := self.state.state_details.scheduled_time:
-            sleep_time = (scheduled_time - pendulum.now("utc")).total_seconds()
-            await anyio.sleep(sleep_time if sleep_time > 0 else 0)
-            await self.set_state(
-                Retrying() if self.state.name == "AwaitingRetry" else Running(),
-                force=True,
-            )
-
-    # --------------------------
-    #
-    # The following methods compose the main task run loop
-    #
-    # --------------------------
-
-    @asynccontextmanager
-    async def configured_run_context(self) -> AsyncGenerator[None, None]:
-        result_factory = await ResultFactory.from_task(self.task)
-        self.task_run = await self.client.read_task_run(self.task_run.id)
-
-        try:
-            with self.setup_run_context(
-                result_factory=result_factory,
-                client=self.client,
-            ):
-                yield
-        finally:
-            pass
-
-    @asynccontextmanager
-    async def start(
-        self,
-        task_run_id: Optional[UUID] = None,
-        dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
-    ) -> AsyncGenerator[None, None]:
-        async with self.initialize_run(
-            task_run_id=task_run_id,
-            dependencies=dependencies,
-        ):
-            # Set a context variable to indicate that the task is running in
-            # the async task engine to ensure that if this task has sync tasks
-            # in it the SyncTaskRunEngine spins up a new thread for async
-            # operations.
-            token = RUNNING_IN_ASYNC_TASK_ENGINE.set(True)
-
-            await self.begin_run()
-            try:
-                yield
-            finally:
-                await self.call_hooks()
-                RUNNING_IN_ASYNC_TASK_ENGINE.reset(token)
-
-    @asynccontextmanager
-    async def run_context(self):
-        async with self.configured_run_context():
-            try:
-                with timeout_async(
-                    seconds=self.task.timeout_seconds,
-                    timeout_exc_type=TaskRunTimeoutError,
-                ):
-                    self.logger.debug(
-                        f"Executing task {self.task.name!r} for task run {self.task_run.name!r}..."
-                    )
-                    if self.is_cancelled():
-                        raise CancelledError("Task run cancelled by the task runner")
-
-                    yield self
-            except TimeoutError as exc:
-                await self.handle_timeout(exc)
-            except Exception as exc:
-                await self.handle_exception(exc)
-
-    async def call_task_fn(
+    def call_task_fn(
         self, transaction: Transaction
     ) -> Union[R, Coroutine[Any, Any, R]]:
         """
@@ -1150,12 +684,24 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
         task is async.
         """
         parameters = self.parameters or {}
-        if transaction.is_committed():
-            result = transaction.read()
+        if self.task.isasync:
+
+            async def _call_task_fn():
+                if transaction.is_committed():
+                    result = transaction.read()
+                else:
+                    result = await call_with_parameters(self.task.fn, parameters)
+                self.handle_success(result, transaction=transaction)
+                return result
+
+            return _call_task_fn()
         else:
-            result = await call_with_parameters(self.task.fn, parameters)
-        await self.handle_success(result, transaction=transaction)
-        return result
+            if transaction.is_committed():
+                result = transaction.read()
+            else:
+                result = call_with_parameters(self.task.fn, parameters)
+            self.handle_success(result, transaction=transaction)
+            return result
 
 
 def run_task_sync(
@@ -1168,7 +714,7 @@ def run_task_sync(
     dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
     context: Optional[Dict[str, Any]] = None,
 ) -> Union[R, State, None]:
-    engine = SyncTaskRunEngine[P, R](
+    engine = TaskRunEngine[P, R](
         task=task,
         parameters=parameters,
         task_run=task_run,
@@ -1195,7 +741,7 @@ async def run_task_async(
     dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
     context: Optional[Dict[str, Any]] = None,
 ) -> Union[R, State, None]:
-    engine = AsyncTaskRunEngine[P, R](
+    engine = TaskRunEngine[P, R](
         task=task,
         parameters=parameters,
         task_run=task_run,
@@ -1203,14 +749,13 @@ async def run_task_async(
         context=context,
     )
 
-    async with engine.start(task_run_id=task_run_id, dependencies=dependencies):
+    with engine.start(task_run_id=task_run_id, dependencies=dependencies):
         while engine.is_running():
             await engine.wait_until_ready()
-            async with engine.run_context():
-                with engine.transaction_context() as txn:
-                    await engine.call_task_fn(txn)
+            with engine.run_context(), engine.transaction_context() as txn:
+                await engine.call_task_fn(txn)
 
-    return engine.state if return_type == "state" else await engine.result()
+    return engine.state if return_type == "state" else engine.result()
 
 
 def run_generator_task_sync(
@@ -1226,7 +771,7 @@ def run_generator_task_sync(
     if return_type != "result":
         raise ValueError("The return_type for a generator task must be 'result'")
 
-    engine = SyncTaskRunEngine[P, R](
+    engine = TaskRunEngine[P, R](
         task=task,
         parameters=parameters,
         task_run=task_run,
@@ -1280,7 +825,7 @@ async def run_generator_task_async(
 ) -> AsyncGenerator[R, None]:
     if return_type != "result":
         raise ValueError("The return_type for a generator task must be 'result'")
-    engine = AsyncTaskRunEngine[P, R](
+    engine = TaskRunEngine[P, R](
         task=task,
         parameters=parameters,
         task_run=task_run,
@@ -1288,41 +833,40 @@ async def run_generator_task_async(
         context=context,
     )
 
-    async with engine.start(task_run_id=task_run_id, dependencies=dependencies):
+    with engine.start(task_run_id=task_run_id, dependencies=dependencies):
         while engine.is_running():
             await engine.wait_until_ready()
-            async with engine.run_context():
-                with engine.transaction_context() as txn:
-                    # TODO: generators should default to commit_mode=OFF
-                    # because they are dynamic by definition
-                    # for now we just prevent this branch explicitly
-                    if False and txn.is_committed():
-                        txn.read()
-                    else:
-                        call_args, call_kwargs = parameters_to_args_kwargs(
-                            task.fn, engine.parameters or {}
-                        )
-                        gen = task.fn(*call_args, **call_kwargs)
-                        try:
-                            while True:
-                                # can't use anext in Python < 3.10
-                                gen_result = await gen.__anext__()
-                                # link the current state to the result for dependency tracking
-                                #
-                                # TODO: this could grow the task_run_result
-                                # dictionary in an unbounded way, so finding a
-                                # way to periodically clean it up (using
-                                # weakrefs or similar) would be good
-                                link_state_to_result(engine.state, gen_result)
-                                yield gen_result
-                        except (StopAsyncIteration, GeneratorExit) as exc:
-                            await engine.handle_success(None, transaction=txn)
-                            if isinstance(exc, GeneratorExit):
-                                gen.throw(exc)
+            with engine.run_context(), engine.transaction_context() as txn:
+                # TODO: generators should default to commit_mode=OFF
+                # because they are dynamic by definition
+                # for now we just prevent this branch explicitly
+                if False and txn.is_committed():
+                    txn.read()
+                else:
+                    call_args, call_kwargs = parameters_to_args_kwargs(
+                        task.fn, engine.parameters or {}
+                    )
+                    gen = task.fn(*call_args, **call_kwargs)
+                    try:
+                        while True:
+                            # can't use anext in Python < 3.10
+                            gen_result = await gen.__anext__()
+                            # link the current state to the result for dependency tracking
+                            #
+                            # TODO: this could grow the task_run_result
+                            # dictionary in an unbounded way, so finding a
+                            # way to periodically clean it up (using
+                            # weakrefs or similar) would be good
+                            link_state_to_result(engine.state, gen_result)
+                            yield gen_result
+                    except (StopAsyncIteration, GeneratorExit) as exc:
+                        engine.handle_success(None, transaction=txn)
+                        if isinstance(exc, GeneratorExit):
+                            gen.throw(exc)
 
     # async generators can't return, but we can raise failures here
     if engine.state.is_failed():
-        await engine.result()
+        engine.result()
 
 
 def run_task(

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -1,9 +1,10 @@
+import asyncio
 import inspect
 import logging
 import threading
 import time
 from asyncio import CancelledError
-from contextlib import ExitStack, contextmanager
+from contextlib import ExitStack, asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
 from textwrap import dedent
 from typing import (
@@ -30,7 +31,7 @@ import pendulum
 from typing_extensions import ParamSpec
 
 from prefect import Task
-from prefect.client.orchestration import SyncPrefectClient
+from prefect.client.orchestration import PrefectClient, SyncPrefectClient
 from prefect.client.schemas import TaskRun
 from prefect.client.schemas.objects import State, TaskRunInput
 from prefect.context import (
@@ -48,7 +49,11 @@ from prefect.exceptions import (
     UpstreamTaskError,
 )
 from prefect.futures import PrefectFuture
-from prefect.logging.loggers import get_logger, patch_print, task_run_logger
+from prefect.logging.loggers import (
+    get_logger,
+    patch_print,
+    task_run_logger,
+)
 from prefect.records.result_store import ResultFactoryStore
 from prefect.results import BaseResult, ResultFactory, _format_user_supplied_storage_key
 from prefect.settings import (
@@ -68,13 +73,14 @@ from prefect.states import (
 )
 from prefect.transactions import Transaction, transaction
 from prefect.utilities.annotations import NotSet
-from prefect.utilities.asyncutils import run_coro_as_sync
+from prefect.utilities.asyncutils import RUNNING_IN_ASYNC_TASK_ENGINE, run_coro_as_sync
 from prefect.utilities.callables import call_with_parameters, parameters_to_args_kwargs
 from prefect.utilities.collections import visit_collection
 from prefect.utilities.engine import (
     _get_hook_name,
     emit_task_run_state_change_event,
     link_state_to_result,
+    propose_state,
     propose_state_sync,
     resolve_to_final_result,
 )
@@ -84,13 +90,15 @@ from prefect.utilities.timeout import timeout, timeout_async
 P = ParamSpec("P")
 R = TypeVar("R")
 
+BACKOFF_MAX = 10
+
 
 class TaskRunTimeoutError(TimeoutError):
     """Raised when a task run exceeds its timeout."""
 
 
 @dataclass
-class TaskRunEngine(Generic[P, R]):
+class BaseTaskRunEngine(Generic[P, R]):
     task: Union[Task[P, R], Task[P, Coroutine[Any, Any, R]]]
     logger: logging.Logger = field(default_factory=lambda: get_logger("engine"))
     parameters: Optional[Dict[str, Any]] = None
@@ -104,7 +112,6 @@ class TaskRunEngine(Generic[P, R]):
     _raised: Union[Exception, Type[NotSet]] = NotSet
     _initial_run_context: Optional[TaskRunContext] = None
     _is_started: bool = False
-    _client: Optional[SyncPrefectClient] = None
     _task_name_set: bool = False
     _last_event: Optional[PrefectEvent] = None
 
@@ -113,15 +120,8 @@ class TaskRunEngine(Generic[P, R]):
             self.parameters = {}
 
     @property
-    def client(self) -> SyncPrefectClient:
-        if not self._is_started or self._client is None:
-            raise RuntimeError("Engine has not started.")
-        return self._client
-
-    @property
     def state(self) -> State:
-        if not self.task_run:
-            raise ValueError("Task run is not set")
+        self._ensure_task_run()
         return self.task_run.state
 
     @property
@@ -129,8 +129,9 @@ class TaskRunEngine(Generic[P, R]):
         retry_condition: Optional[
             Callable[[Task[P, Coroutine[Any, Any, R]], TaskRun, State], bool]
         ] = self.task.retry_condition_fn
-        if not self.task_run:
-            raise ValueError("Task run is not set")
+
+        self._ensure_task_run()
+
         try:
             self.logger.debug(
                 f"Running `retry_condition_fn` check {retry_condition!r} for task"
@@ -157,41 +158,6 @@ class TaskRunEngine(Generic[P, R]):
         ):
             return self.context["cancel_event"].is_set()
         return False
-
-    def call_hooks(self, state: Optional[State] = None):
-        if state is None:
-            state = self.state
-        task = self.task
-        task_run = self.task_run
-
-        if not task_run:
-            raise ValueError("Task run is not set")
-
-        if state.is_failed() and task.on_failure_hooks:
-            hooks = task.on_failure_hooks
-        elif state.is_completed() and task.on_completion_hooks:
-            hooks = task.on_completion_hooks
-        else:
-            hooks = None
-
-        for hook in hooks or []:
-            hook_name = _get_hook_name(hook)
-
-            try:
-                self.logger.info(
-                    f"Running hook {hook_name!r} in response to entering state"
-                    f" {state.name!r}"
-                )
-                result = hook(task, task_run, state)
-                if inspect.isawaitable(result):
-                    run_coro_as_sync(result)
-            except Exception:
-                self.logger.error(
-                    f"An error was encountered while running hook {hook_name!r}",
-                    exc_info=True,
-                )
-            else:
-                self.logger.info(f"Hook {hook_name!r} finished running successfully")
 
     def compute_transaction_key(self) -> Optional[str]:
         key = None
@@ -252,64 +218,22 @@ class TaskRunEngine(Generic[P, R]):
             context={"current_task_run": self.task_run, "current_task": self.task},
         )
 
-    def begin_run(self):
+    def _resolve_and_wait_for_dependencies(self) -> Union[State, None]:
         try:
             self._resolve_parameters()
             self._wait_for_dependencies()
         except UpstreamTaskError as upstream_exc:
-            state = self.set_state(
-                Pending(
-                    name="NotReady",
-                    message=str(upstream_exc),
-                ),
-                # if orchestrating a run already in a pending state, force orchestration to
-                # update the state name
-                force=self.state.is_pending(),
-            )
-            return
+            return Pending(name="NotReady", message=str(upstream_exc))
 
-        new_state = Running()
-        state = self.set_state(new_state)
+    def _calculate_backoff(self, backoff_count: int) -> float:
+        if backoff_count < BACKOFF_MAX:
+            backoff_count += 1
+        return clamped_poisson_interval(
+            average_interval=backoff_count, clamping_factor=0.3
+        )
 
-        # TODO: this is temporary until the API stops rejecting state transitions
-        # and the client / transaction store becomes the source of truth
-        # this is a bandaid caused by the API storing a Completed state with a bad
-        # result reference that no longer exists
-        if state.is_completed():
-            try:
-                state.result(retry_result_failure=False, _sync=True)
-            except Exception:
-                state = self.set_state(new_state, force=True)
-
-        BACKOFF_MAX = 10
-        backoff_count = 0
-
-        # TODO: Could this listen for state change events instead of polling?
-        while state.is_pending() or state.is_paused():
-            if backoff_count < BACKOFF_MAX:
-                backoff_count += 1
-            interval = clamped_poisson_interval(
-                average_interval=backoff_count, clamping_factor=0.3
-            )
-            time.sleep(interval)
-            state = self.set_state(new_state)
-
-    def set_state(self, state: State, force: bool = False) -> State:
+    def _handle_state_change(self, new_state: State) -> State:
         last_state = self.state
-        if not self.task_run:
-            raise ValueError("Task run is not set")
-        try:
-            new_state = propose_state_sync(
-                self.client, state, task_run_id=self.task_run.id, force=force
-            )
-        except Pause as exc:
-            # We shouldn't get a pause signal without a state, but if this happens,
-            # just use a Paused state to assume an in-process pause.
-            new_state = exc.state if exc.state else Paused()
-            if new_state.state_details.pause_reschedule:
-                # If we're being asked to pause and reschedule, we should exit the
-                # task and expect to be resumed later.
-                raise
 
         # currently this is a hack to keep a reference to the state object
         # that has an in-memory result attached to it; using the API state
@@ -323,18 +247,83 @@ class TaskRunEngine(Generic[P, R]):
             validated_state=self.task_run.state,
             follows=self._last_event,
         )
-        return new_state
 
-    def result(self, raise_on_failure: bool = True) -> "Union[R, State, None]":
+    def _handle_propose_state_exception(self, exc: Exception):
+        if isinstance(exc, Pause):
+            # We shouldn't get a pause signal without a state, but if this happens,
+            # just use a Paused state to assume an in-process pause.
+            new_state = exc.state if exc.state else Paused()
+            if new_state.state_details.pause_reschedule:
+                # If we're being asked to pause and reschedule, we should exit the
+                # task and expect to be resumed later.
+                raise
+        else:
+            raise exc
+
+    def _task_cache_expiration_datetime(self) -> Union[pendulum.DateTime, None]:
+        if self.task.cache_expiration is not None:
+            return pendulum.now("utc") + self.task.cache_expiration
+        else:
+            return None
+
+    def _ensure_task_run(self) -> TaskRun:
+        if not self.task_run:
+            raise ValueError("Task run is not set")
+
+        return self.task_run
+
+    def _ensure_result_factory(self) -> ResultFactory:
+        result_factory = getattr(TaskRunContext.get(), "result_factory", None)
+        if result_factory is None:
+            raise ValueError("Result factory is not set")
+
+        return result_factory
+
+    def _task_run_logger(self) -> logging.Logger:
+        task_run = self._ensure_task_run()
+        return task_run_logger(task_run=task_run, task=self.task)  # type: ignore
+
+    def is_running(self) -> bool:
+        """Whether or not the engine is currently running a task."""
+        if (task_run := getattr(self, "task_run", None)) is None:
+            return False
+        return task_run.state.is_running() or task_run.state.is_scheduled()
+
+    @contextmanager
+    def transaction_context(self) -> Generator[Transaction, None, None]:
+        result_factory = self._ensure_result_factory()
+
+        # refresh cache setting is now repurposes as overwrite transaction record
+        overwrite = (
+            self.task.refresh_cache
+            if self.task.refresh_cache is not None
+            else PREFECT_TASKS_REFRESH_CACHE.value()
+        )
+        with transaction(
+            key=self.compute_transaction_key(),
+            store=ResultFactoryStore(result_factory=result_factory),
+            overwrite=overwrite,
+            logger=self.logger,
+        ) as txn:
+            yield txn
+
+    def _get_hooks(self, task: Task, state: State) -> dict[str, Callable]:
+        task = self.task
+
+        if state.is_failed() and task.on_failure_hooks:
+            hooks = task.on_failure_hooks
+        elif state.is_completed() and task.on_completion_hooks:
+            hooks = task.on_completion_hooks
+        else:
+            hooks = []
+
+        return {_get_hook_name(hook): hook for hook in hooks}
+
+    def _result_from_non_base_result(
+        self, raise_on_failure: bool
+    ) -> "Union[R, State, None]":
         if self._return_value is not NotSet:
-            # if the return value is a BaseResult, we need to fetch it
-            if isinstance(self._return_value, BaseResult):
-                _result = self._return_value.get()
-                if inspect.isawaitable(_result):
-                    _result = run_coro_as_sync(_result)
-                return _result
-
-            # otherwise, return the value as is
+            # return the value as is
             return self._return_value
 
         if self._raised is not NotSet:
@@ -345,44 +334,15 @@ class TaskRunEngine(Generic[P, R]):
             # otherwise, return the exception
             return self._raised
 
-    def handle_success(self, result: R, transaction: Transaction) -> R:
-        result_factory = getattr(TaskRunContext.get(), "result_factory", None)
-        if result_factory is None:
-            raise ValueError("Result factory is not set")
+    def _retry_state(self, exc: Exception) -> Union[State, None]:
+        """Return the proper state for a task run retry.
 
-        if self.task.cache_expiration is not None:
-            expiration = pendulum.now("utc") + self.task.cache_expiration
-        else:
-            expiration = None
-
-        terminal_state = run_coro_as_sync(
-            return_value_to_state(
-                result,
-                result_factory=result_factory,
-                key=transaction.key,
-                expiration=expiration,
-                # defer persistence to transaction commit
-                defer_persistence=True,
-            )
-        )
-        transaction.stage(
-            terminal_state.data,
-            on_rollback_hooks=self.task.on_rollback_hooks,
-            on_commit_hooks=self.task.on_commit_hooks,
-        )
-        if transaction.is_committed():
-            terminal_state.name = "Cached"
-        self.set_state(terminal_state)
-        self._return_value = result
-        return result
-
-    def handle_retry(self, exc: Exception) -> bool:
-        """Handle any task run retries.
-
-        - If the task has retries left, and the retry condition is met, set the task to retrying and return True.
-          - If the task has a retry delay, place in AwaitingRetry state with a delayed scheduled time.
-        - If the task has no retries left, or the retry condition is not met, return False.
+        - If the task has retries left, and the retry condition is met, return `Retrying` state.
+        - If the task has a retry delay, return `AwaitingRetry` state with a delayed scheduled time.
+        - If the task has no retries left, or the retry condition is not met, return None.
         """
+        new_state = None
+
         if self.retries < self.task.retries and self.can_retry:
             if self.task.retry_delay_seconds:
                 delay = (
@@ -407,16 +367,181 @@ class TaskRunEngine(Generic[P, R]):
                 str(delay) + " second(s) from now" if delay else "immediately",
             )
 
-            self.set_state(new_state, force=True)
             self.retries = self.retries + 1
-            return True
+            return new_state
         elif self.retries >= self.task.retries:
             self.logger.error(
                 "Task run failed with exception: %r - Retries are exhausted",
                 exc,
                 exc_info=True,
             )
-            return False
+
+        return None
+
+    def _log_task_run_timeout(self, exc: Exception) -> str:
+        if isinstance(exc, TaskRunTimeoutError):
+            message = (
+                f"Task run exceeded timeout of {self.task.timeout_seconds} second(s)"
+            )
+        else:
+            message = f"Task run failed due to timeout: {exc!r}"
+
+        self.logger.error(message)
+
+        return message
+
+    def _log_task_run_crashed(self, state: State, exc: BaseException) -> None:
+        self.logger.error(f"Crash detected! {state.message}")
+        self.logger.debug("Crash details:", exc_info=exc)
+
+    @contextmanager
+    def setup_run_context(
+        self,
+        result_factory: ResultFactory,
+        client: Union[PrefectClient, SyncPrefectClient],
+    ):
+        from prefect.utilities.engine import should_log_prints
+
+        with ExitStack() as stack:
+            if log_prints := should_log_prints(self.task):
+                stack.enter_context(patch_print())
+            stack.enter_context(
+                TaskRunContext(
+                    task=self.task,
+                    log_prints=log_prints,
+                    task_run=self.task_run,
+                    parameters=self.parameters,
+                    result_factory=result_factory,  # type: ignore
+                    client=client,
+                )
+            )
+            yield
+
+
+@dataclass
+class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
+    _client: Optional[SyncPrefectClient] = None
+
+    @property
+    def client(self) -> SyncPrefectClient:
+        if not self._is_started or self._client is None:
+            raise RuntimeError("Engine has not started.")
+        return self._client
+
+    def call_hooks(self, state: Optional[State] = None):
+        if state is None:
+            state = self.state
+
+        self._ensure_task_run()
+
+        for hook_name, hook in self._get_hooks(task=self.task, state=state).items():
+            try:
+                self.logger.info(
+                    f"Running hook {hook_name!r} in response to entering state"
+                    f" {state.name!r}"
+                )
+                result = hook(self.task, self.task_run, state)
+                if inspect.isawaitable(result):
+                    run_coro_as_sync(result)
+            except Exception:
+                self.logger.error(
+                    f"An error was encountered while running hook {hook_name!r}",
+                    exc_info=True,
+                )
+            else:
+                self.logger.info(f"Hook {hook_name!r} finished running successfully")
+
+    def begin_run(self):
+        if not_ready_state := self._resolve_and_wait_for_dependencies():
+            self.set_state(not_ready_state, force=self.state.is_pending())
+            return
+
+        new_state = Running()
+        state = self.set_state(new_state)
+
+        # TODO: this is temporary until the API stops rejecting state transitions
+        # and the client / transaction store becomes the source of truth
+        # this is a bandaid caused by the API storing a Completed state with a bad
+        # result reference that no longer exists
+        if state.is_completed():
+            try:
+                state.result(retry_result_failure=False, _sync=True)
+            except Exception:
+                state = self.set_state(new_state, force=True)
+
+        backoff_count = 0
+
+        # TODO: Could this listen for state change events instead of polling?
+        while state.is_pending() or state.is_paused():
+            interval = self._calculate_backoff(backoff_count)
+            time.sleep(interval)
+            state = self.set_state(new_state)
+
+    def set_state(self, state: State, force: bool = False) -> State:
+        self._ensure_task_run()
+
+        try:
+            new_state = propose_state_sync(
+                self.client, state, task_run_id=self.task_run.id, force=force
+            )
+        except Exception as exc:
+            self._handle_propose_state_exception(exc)
+
+        self._handle_state_change(new_state)
+
+        return new_state
+
+    def result(self, raise_on_failure: bool = True) -> "Union[R, State, None]":
+        if self._return_value is not NotSet and isinstance(
+            self._return_value, BaseResult
+        ):
+            # if the return value is a BaseResult, we need to fetch it
+            _result = self._return_value.get()
+            if inspect.isawaitable(_result):
+                _result = run_coro_as_sync(_result)
+            return _result
+
+        return self._result_from_non_base_result(raise_on_failure=raise_on_failure)
+
+    def handle_success(self, result: R, transaction: Transaction) -> R:
+        result_factory = self._ensure_result_factory()
+        expiration = self._task_cache_expiration_datetime()
+
+        terminal_state = run_coro_as_sync(
+            return_value_to_state(
+                result,
+                result_factory=result_factory,
+                key=transaction.key,
+                expiration=expiration,
+                # defer persistence to transaction commit
+                defer_persistence=True,
+            )
+        )
+        transaction.stage(
+            terminal_state.data,
+            on_rollback_hooks=self.task.on_rollback_hooks,
+            on_commit_hooks=self.task.on_commit_hooks,
+        )
+        if transaction.is_committed():
+            terminal_state.name = "Cached"
+
+        self.set_state(terminal_state)
+
+        self._return_value = result
+
+        return result
+
+    def handle_retry(self, exc: Exception) -> bool:
+        """
+        Handle any task run retries.
+
+        - If the task has retries left, set retrying state and return True.
+        - If the task has no retries left, or the retry condition is not met, return False.
+        """
+
+        if retry_state := self._retry_state(exc):
+            self.set_state(retry_state, force=True)
+            return True
 
         return False
 
@@ -437,11 +562,8 @@ class TaskRunEngine(Generic[P, R]):
 
     def handle_timeout(self, exc: TimeoutError) -> None:
         if not self.handle_retry(exc):
-            if isinstance(exc, TaskRunTimeoutError):
-                message = f"Task run exceeded timeout of {self.task.timeout_seconds} second(s)"
-            else:
-                message = f"Task run failed due to timeout: {exc!r}"
-            self.logger.error(message)
+            message = self._log_task_run_timeout(exc)
+
             state = Failed(
                 data=exc,
                 message=message,
@@ -450,64 +572,30 @@ class TaskRunEngine(Generic[P, R]):
             self.set_state(state)
             self._raised = exc
 
-    def handle_crash(self, exc: BaseException) -> None:
-        state = run_coro_as_sync(exception_to_crashed_state(exc))
-        self.logger.error(f"Crash detected! {state.message}")
-        self.logger.debug("Crash details:", exc_info=exc)
-        self.set_state(state, force=True)
-        self._raised = exc
+    def set_task_run_name(self):
+        from prefect.utilities.engine import _resolve_custom_task_run_name
 
-    @contextmanager
-    def setup_run_context(self, client: Optional[SyncPrefectClient] = None):
-        from prefect.utilities.engine import (
-            _resolve_custom_task_run_name,
-            should_log_prints,
-        )
+        task_run = self._ensure_task_run()
 
-        if client is None:
-            client = self.client
-        if not self.task_run:
-            raise ValueError("Task run is not set")
-
-        self.task_run = client.read_task_run(self.task_run.id)
-        with ExitStack() as stack:
-            if log_prints := should_log_prints(self.task):
-                stack.enter_context(patch_print())
-            stack.enter_context(
-                TaskRunContext(
-                    task=self.task,
-                    log_prints=log_prints,
-                    task_run=self.task_run,
-                    parameters=self.parameters,
-                    result_factory=run_coro_as_sync(ResultFactory.from_task(self.task)),  # type: ignore
-                    client=client,
-                )
+        # Update the task run name.
+        if not self._task_name_set and self.task.task_run_name:
+            task_run_name = _resolve_custom_task_run_name(
+                task=self.task, parameters=self.parameters
             )
-            # set the logger to the task run logger
-            self.logger = task_run_logger(task_run=self.task_run, task=self.task)  # type: ignore
-
-            # update the task run name if necessary
-            if not self._task_name_set and self.task.task_run_name:
-                task_run_name = _resolve_custom_task_run_name(
-                    task=self.task, parameters=self.parameters
-                )
-                self.client.set_task_run_name(
-                    task_run_id=self.task_run.id, name=task_run_name
-                )
-                self.logger.extra["task_run_name"] = task_run_name
-                self.logger.debug(
-                    f"Renamed task run {self.task_run.name!r} to {task_run_name!r}"
-                )
-                self.task_run.name = task_run_name
-                self._task_name_set = True
-            yield
+            self.client.set_task_run_name(task_run_id=task_run.id, name=task_run_name)
+            self.logger.extra["task_run_name"] = task_run_name
+            self.logger.debug(
+                f"Renamed task run {task_run.name!r} to {task_run_name!r}"
+            )
+            task_run.name = task_run_name
+            self._task_name_set = True
 
     @contextmanager
     def initialize_run(
         self,
         task_run_id: Optional[UUID] = None,
         dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
-    ) -> Generator["TaskRunEngine", Any, Any]:
+    ) -> Generator["SyncTaskRunEngine", Any, Any]:
         """
         Enters a client context and creates a task run if needed.
         """
@@ -527,6 +615,8 @@ class TaskRunEngine(Generic[P, R]):
                                 extra_task_inputs=dependencies,
                             )
                         )
+                        self.logger = self._task_run_logger()
+
                     # Emit an event to capture that the task run was in the `PENDING` state.
                     self._last_event = emit_task_run_state_change_event(
                         task_run=self.task_run,
@@ -534,12 +624,13 @@ class TaskRunEngine(Generic[P, R]):
                         validated_state=self.task_run.state,
                     )
 
-                    with self.setup_run_context():
-                        # setup_run_context might update the task run name, so log creation here
-                        self.logger.info(
-                            f"Created task run {self.task_run.name!r} for task {self.task.name!r}"
-                        )
-                        yield self
+                    self.set_task_run_name()
+
+                    self.logger.info(
+                        f"Created task run {self.task_run.name!r} for task {self.task.name!r}"
+                    )
+
+                    yield self
 
                 except TerminationSignal as exc:
                     # TerminationSignals are caught and handled as crashes
@@ -601,12 +692,6 @@ class TaskRunEngine(Generic[P, R]):
                     self._is_started = False
                     self._client = None
 
-    def is_running(self) -> bool:
-        """Whether or not the engine is currently running a task."""
-        if (task_run := getattr(self, "task_run", None)) is None:
-            return False
-        return task_run.state.is_running() or task_run.state.is_scheduled()
-
     async def wait_until_ready(self):
         """Waits until the scheduled time (if its the future), then enters Running."""
         if scheduled_time := self.state.state_details.scheduled_time:
@@ -616,6 +701,12 @@ class TaskRunEngine(Generic[P, R]):
                 Retrying() if self.state.name == "AwaitingRetry" else Running(),
                 force=True,
             )
+
+    def handle_crash(self, exc: BaseException) -> None:
+        state = run_coro_as_sync(exception_to_crashed_state(exc))
+        self._log_task_run_crashed(state, exc)
+        self.set_state(state, force=True)
+        self._raised = exc
 
     # --------------------------
     #
@@ -637,30 +728,18 @@ class TaskRunEngine(Generic[P, R]):
                 self.call_hooks()
 
     @contextmanager
-    def transaction_context(self) -> Generator[Transaction, None, None]:
-        result_factory = getattr(TaskRunContext.get(), "result_factory", None)
-
-        # refresh cache setting is now repurposes as overwrite transaction record
-        overwrite = (
-            self.task.refresh_cache
-            if self.task.refresh_cache is not None
-            else PREFECT_TASKS_REFRESH_CACHE.value()
-        )
-        with transaction(
-            key=self.compute_transaction_key(),
-            store=ResultFactoryStore(result_factory=result_factory),
-            overwrite=overwrite,
-            logger=self.logger,
-        ) as txn:
-            yield txn
-
-    @contextmanager
     def run_context(self):
-        timeout_context = timeout_async if self.task.isasync else timeout
-        # reenter the run context to ensure it is up to date for every run
-        with self.setup_run_context():
+        result_factory = run_coro_as_sync(ResultFactory.from_task(self.task))
+
+        self.task_run = self.client.read_task_run(self.task_run.id)
+        self.set_task_run_name()
+
+        with self.setup_run_context(
+            result_factory=result_factory,
+            client=self.client,
+        ):
             try:
-                with timeout_context(
+                with timeout(
                     seconds=self.task.timeout_seconds,
                     timeout_exc_type=TaskRunTimeoutError,
                 ):
@@ -676,7 +755,365 @@ class TaskRunEngine(Generic[P, R]):
             except Exception as exc:
                 self.handle_exception(exc)
 
-    def call_task_fn(
+    def call_task_fn(self, transaction: Transaction) -> R:
+        """
+        Convenience method to call the task function.
+        """
+        parameters = self.parameters or {}
+        if transaction.is_committed():
+            result = transaction.read()
+        else:
+            result = call_with_parameters(self.task.fn, parameters)
+        self.handle_success(result, transaction=transaction)
+        return result
+
+
+@dataclass
+class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
+    _client: Optional[PrefectClient] = None
+
+    @property
+    def client(self) -> PrefectClient:
+        if not self._is_started or self._client is None:
+            raise RuntimeError("Engine has not started.")
+        return self._client
+
+    async def call_hooks(self, state: Optional[State] = None):
+        if state is None:
+            state = self.state
+
+        self._ensure_task_run()
+
+        for hook_name, hook in self._get_hooks(task=self.task, state=state).items():
+            try:
+                self.logger.info(
+                    f"Running hook {hook_name!r} in response to entering state"
+                    f" {state.name!r}"
+                )
+                result = hook(self.task, self.task_run, state)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                self.logger.error(
+                    f"An error was encountered while running hook {hook_name!r}",
+                    exc_info=True,
+                )
+            else:
+                self.logger.info(f"Hook {hook_name!r} finished running successfully")
+
+    async def begin_run(self):
+        if not_ready_state := self._resolve_and_wait_for_dependencies():
+            await self.set_state(not_ready_state, force=self.state.is_pending())
+            return
+
+        new_state = Running()
+        state = await self.set_state(new_state)
+
+        # TODO: this is temporary until the API stops rejecting state transitions
+        # and the client / transaction store becomes the source of truth
+        # this is a bandaid caused by the API storing a Completed state with a bad
+        # result reference that no longer exists
+        if state.is_completed():
+            try:
+                await state.result(retry_result_failure=False)
+            except Exception:
+                state = await self.set_state(new_state, force=True)
+
+        backoff_count = 0
+
+        # TODO: Could this listen for state change events instead of polling?
+        while state.is_pending() or state.is_paused():
+            interval = self._calculate_backoff(backoff_count)
+            await asyncio.sleep(interval)
+            state = await self.set_state(new_state)
+
+    async def set_state(self, state: State, force: bool = False) -> State:
+        self._ensure_task_run()
+
+        try:
+            new_state = await propose_state(
+                self.client, state, task_run_id=self.task_run.id, force=force
+            )
+        except Exception as exc:
+            self._handle_propose_state_exception(exc)
+
+        self._handle_state_change(new_state)
+
+        return new_state
+
+    async def result(self, raise_on_failure: bool = True) -> "Union[R, State, None]":
+        if self._return_value is not NotSet and isinstance(
+            self._return_value, BaseResult
+        ):
+            # if the return value is a BaseResult, we need to fetch it
+            _result = self._return_value.get()
+            if inspect.isawaitable(_result):
+                _result = await _result
+            return _result
+
+        return self._result_from_non_base_result(raise_on_failure=raise_on_failure)
+
+    async def handle_success(self, result: R, transaction: Transaction) -> R:
+        result_factory = self._ensure_result_factory()
+        expiration = self._task_cache_expiration_datetime()
+
+        terminal_state = await return_value_to_state(
+            result,
+            result_factory=result_factory,
+            key=transaction.key,
+            expiration=expiration,
+            # defer persistence to transaction commit
+            defer_persistence=True,
+        )
+
+        transaction.stage(
+            terminal_state.data,
+            on_rollback_hooks=self.task.on_rollback_hooks,
+            on_commit_hooks=self.task.on_commit_hooks,
+        )
+        if transaction.is_committed():
+            terminal_state.name = "Cached"
+
+        await self.set_state(terminal_state)
+
+        self._return_value = result
+
+        return result
+
+    async def handle_retry(self, exc: Exception) -> bool:
+        """
+        Handle any task run retries.
+
+        - If the task has retries left, set retrying state and return True.
+        - If the task has no retries left, or the retry condition is not met, return False.
+        """
+
+        if retry_state := self._retry_state(exc):
+            await self.set_state(retry_state, force=True)
+            return True
+
+        return False
+
+    async def handle_exception(self, exc: Exception) -> None:
+        # If the task fails, and we have retries left, set the task to retrying.
+        if not await self.handle_retry(exc):
+            # If the task has no retries left, or the retry condition is not met, set the task to failed.
+            context = TaskRunContext.get()
+            state = await exception_to_failed_state(
+                exc,
+                message="Task run encountered an exception",
+                result_factory=getattr(context, "result_factory", None),
+            )
+            await self.set_state(state)
+            self._raised = exc
+
+    async def handle_timeout(self, exc: TimeoutError) -> None:
+        if not await self.handle_retry(exc):
+            message = self._log_task_run_timeout(exc)
+
+            state = Failed(
+                data=exc,
+                message=message,
+                name="TimedOut",
+            )
+            await self.set_state(state)
+            self._raised = exc
+
+    async def handle_crash(self, exc: BaseException) -> None:
+        state = await exception_to_crashed_state(exc)
+        self._log_task_run_crashed(state, exc)
+        await self.set_state(state, force=True)
+        self._raised = exc
+
+    async def set_task_run_name(self):
+        from prefect.utilities.engine import _resolve_custom_task_run_name
+
+        task_run = self._ensure_task_run()
+
+        # Update the task run name.
+        if not self._task_name_set and self.task.task_run_name:
+            task_run_name = _resolve_custom_task_run_name(
+                task=self.task, parameters=self.parameters
+            )
+            await self.client.set_task_run_name(
+                task_run_id=task_run.id, name=task_run_name
+            )
+            self.logger.extra["task_run_name"] = task_run_name
+            self.logger.debug(
+                f"Renamed task run {task_run.name!r} to {task_run_name!r}"
+            )
+            task_run.name = task_run_name
+            self._task_name_set = True
+
+    @asynccontextmanager
+    async def initialize_run(
+        self,
+        task_run_id: Optional[UUID] = None,
+        dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
+    ) -> AsyncGenerator["AsyncTaskRunEngine", Any]:
+        """
+        Enters a client context and creates a task run if needed.
+        """
+        with hydrated_context(self.context):
+            async with ClientContext.async_get_or_create() as client_ctx:
+                self._client = client_ctx.async_client
+                self._is_started = True
+                try:
+                    if not self.task_run:
+                        self.task_run = await self.task.create_run(
+                            client=self._client,
+                            id=task_run_id,
+                            parameters=self.parameters,
+                            flow_run_context=FlowRunContext.get(),
+                            parent_task_run_context=TaskRunContext.get(),
+                            wait_for=self.wait_for,
+                            extra_task_inputs=dependencies,
+                        )
+                        self.logger = self._task_run_logger()
+
+                    # Emit an event to capture that the task run was in the `PENDING` state.
+                    self._last_event = emit_task_run_state_change_event(
+                        task_run=self.task_run,
+                        initial_state=None,
+                        validated_state=self.task_run.state,
+                    )
+
+                    await self.set_task_run_name()
+
+                    self.logger.info(
+                        f"Created task run {self.task_run.name!r} for task {self.task.name!r}"
+                    )
+
+                    yield self
+
+                except TerminationSignal as exc:
+                    # TerminationSignals are caught and handled as crashes
+                    await self.handle_crash(exc)
+                    raise exc
+
+                except Exception:
+                    # regular exceptions are caught and re-raised to the user
+                    raise
+                except (Pause, Abort) as exc:
+                    # Do not capture internal signals as crashes
+                    if isinstance(exc, Abort):
+                        self.logger.error("Task run was aborted: %s", exc)
+                    raise
+                except GeneratorExit:
+                    # Do not capture generator exits as crashes
+                    raise
+                except BaseException as exc:
+                    # BaseExceptions are caught and handled as crashes
+                    await self.handle_crash(exc)
+                    raise
+                finally:
+                    # If debugging, use the more complete `repr` than the usual `str` description
+                    display_state = (
+                        repr(self.state) if PREFECT_DEBUG_MODE else str(self.state)
+                    )
+                    level = logging.INFO if self.state.is_completed() else logging.ERROR
+                    msg = f"Finished in state {display_state}"
+                    if self.state.is_pending():
+                        msg += (
+                            "\nPlease wait for all submitted tasks to complete"
+                            " before exiting your flow by calling `.wait()` on the "
+                            "`PrefectFuture` returned from your `.submit()` calls."
+                        )
+                        msg += dedent(
+                            """
+
+                            Example:
+
+                            from prefect import flow, task
+
+                            @task
+                            def say_hello(name):
+                                print f"Hello, {name}!"
+
+                            @flow
+                            def example_flow():
+                                future = say_hello.submit(name="Marvin)
+                                future.wait()
+
+                            example_flow()
+                                      """
+                        )
+                    self.logger.log(
+                        level=level,
+                        msg=msg,
+                    )
+
+                    self._is_started = False
+                    self._client = None
+
+    async def wait_until_ready(self):
+        """Waits until the scheduled time (if its the future), then enters Running."""
+        if scheduled_time := self.state.state_details.scheduled_time:
+            sleep_time = (scheduled_time - pendulum.now("utc")).total_seconds()
+            await anyio.sleep(sleep_time if sleep_time > 0 else 0)
+            await self.set_state(
+                Retrying() if self.state.name == "AwaitingRetry" else Running(),
+                force=True,
+            )
+
+    # --------------------------
+    #
+    # The following methods compose the main task run loop
+    #
+    # --------------------------
+
+    @asynccontextmanager
+    async def start(
+        self,
+        task_run_id: Optional[UUID] = None,
+        dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
+    ) -> AsyncGenerator[None, None]:
+        async with self.initialize_run(
+            task_run_id=task_run_id,
+            dependencies=dependencies,
+        ):
+            # Set a context variable to indicate that the task is running in
+            # the async task engine to ensure that if this task has sync tasks
+            # in it the SyncTaskRunEngine spins up a new thread for async
+            # operations.
+            token = RUNNING_IN_ASYNC_TASK_ENGINE.set(True)
+
+            await self.begin_run()
+            try:
+                yield
+            finally:
+                await self.call_hooks()
+                RUNNING_IN_ASYNC_TASK_ENGINE.reset(token)
+
+    @asynccontextmanager
+    async def run_context(self):
+        result_factory = await ResultFactory.from_task(self.task)
+
+        self.task_run = await self.client.read_task_run(self.task_run.id)
+        await self.set_task_run_name()
+
+        with self.setup_run_context(
+            result_factory=result_factory,
+            client=self.client,
+        ):
+            try:
+                with timeout_async(
+                    seconds=self.task.timeout_seconds,
+                    timeout_exc_type=TaskRunTimeoutError,
+                ):
+                    self.logger.debug(
+                        f"Executing task {self.task.name!r} for task run {self.task_run.name!r}..."
+                    )
+                    if self.is_cancelled():
+                        raise CancelledError("Task run cancelled by the task runner")
+
+                    yield self
+            except TimeoutError as exc:
+                await self.handle_timeout(exc)
+            except Exception as exc:
+                await self.handle_exception(exc)
+
+    async def call_task_fn(
         self, transaction: Transaction
     ) -> Union[R, Coroutine[Any, Any, R]]:
         """
@@ -684,24 +1121,12 @@ class TaskRunEngine(Generic[P, R]):
         task is async.
         """
         parameters = self.parameters or {}
-        if self.task.isasync:
-
-            async def _call_task_fn():
-                if transaction.is_committed():
-                    result = transaction.read()
-                else:
-                    result = await call_with_parameters(self.task.fn, parameters)
-                self.handle_success(result, transaction=transaction)
-                return result
-
-            return _call_task_fn()
+        if transaction.is_committed():
+            result = transaction.read()
         else:
-            if transaction.is_committed():
-                result = transaction.read()
-            else:
-                result = call_with_parameters(self.task.fn, parameters)
-            self.handle_success(result, transaction=transaction)
-            return result
+            result = await call_with_parameters(self.task.fn, parameters)
+        await self.handle_success(result, transaction=transaction)
+        return result
 
 
 def run_task_sync(
@@ -714,7 +1139,7 @@ def run_task_sync(
     dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
     context: Optional[Dict[str, Any]] = None,
 ) -> Union[R, State, None]:
-    engine = TaskRunEngine[P, R](
+    engine = SyncTaskRunEngine[P, R](
         task=task,
         parameters=parameters,
         task_run=task_run,
@@ -741,7 +1166,7 @@ async def run_task_async(
     dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
     context: Optional[Dict[str, Any]] = None,
 ) -> Union[R, State, None]:
-    engine = TaskRunEngine[P, R](
+    engine = AsyncTaskRunEngine[P, R](
         task=task,
         parameters=parameters,
         task_run=task_run,
@@ -749,13 +1174,14 @@ async def run_task_async(
         context=context,
     )
 
-    with engine.start(task_run_id=task_run_id, dependencies=dependencies):
+    async with engine.start(task_run_id=task_run_id, dependencies=dependencies):
         while engine.is_running():
             await engine.wait_until_ready()
-            with engine.run_context(), engine.transaction_context() as txn:
-                await engine.call_task_fn(txn)
+            async with engine.run_context():
+                with engine.transaction_context() as txn:
+                    await engine.call_task_fn(txn)
 
-    return engine.state if return_type == "state" else engine.result()
+    return engine.state if return_type == "state" else await engine.result()
 
 
 def run_generator_task_sync(
@@ -771,7 +1197,7 @@ def run_generator_task_sync(
     if return_type != "result":
         raise ValueError("The return_type for a generator task must be 'result'")
 
-    engine = TaskRunEngine[P, R](
+    engine = SyncTaskRunEngine[P, R](
         task=task,
         parameters=parameters,
         task_run=task_run,
@@ -825,7 +1251,7 @@ async def run_generator_task_async(
 ) -> AsyncGenerator[R, None]:
     if return_type != "result":
         raise ValueError("The return_type for a generator task must be 'result'")
-    engine = TaskRunEngine[P, R](
+    engine = AsyncTaskRunEngine[P, R](
         task=task,
         parameters=parameters,
         task_run=task_run,
@@ -833,40 +1259,41 @@ async def run_generator_task_async(
         context=context,
     )
 
-    with engine.start(task_run_id=task_run_id, dependencies=dependencies):
+    async with engine.start(task_run_id=task_run_id, dependencies=dependencies):
         while engine.is_running():
             await engine.wait_until_ready()
-            with engine.run_context(), engine.transaction_context() as txn:
-                # TODO: generators should default to commit_mode=OFF
-                # because they are dynamic by definition
-                # for now we just prevent this branch explicitly
-                if False and txn.is_committed():
-                    txn.read()
-                else:
-                    call_args, call_kwargs = parameters_to_args_kwargs(
-                        task.fn, engine.parameters or {}
-                    )
-                    gen = task.fn(*call_args, **call_kwargs)
-                    try:
-                        while True:
-                            # can't use anext in Python < 3.10
-                            gen_result = await gen.__anext__()
-                            # link the current state to the result for dependency tracking
-                            #
-                            # TODO: this could grow the task_run_result
-                            # dictionary in an unbounded way, so finding a
-                            # way to periodically clean it up (using
-                            # weakrefs or similar) would be good
-                            link_state_to_result(engine.state, gen_result)
-                            yield gen_result
-                    except (StopAsyncIteration, GeneratorExit) as exc:
-                        engine.handle_success(None, transaction=txn)
-                        if isinstance(exc, GeneratorExit):
-                            gen.throw(exc)
+            async with engine.run_context():
+                with engine.transaction_context() as txn:
+                    # TODO: generators should default to commit_mode=OFF
+                    # because they are dynamic by definition
+                    # for now we just prevent this branch explicitly
+                    if False and txn.is_committed():
+                        txn.read()
+                    else:
+                        call_args, call_kwargs = parameters_to_args_kwargs(
+                            task.fn, engine.parameters or {}
+                        )
+                        gen = task.fn(*call_args, **call_kwargs)
+                        try:
+                            while True:
+                                # can't use anext in Python < 3.10
+                                gen_result = await gen.__anext__()
+                                # link the current state to the result for dependency tracking
+                                #
+                                # TODO: this could grow the task_run_result
+                                # dictionary in an unbounded way, so finding a
+                                # way to periodically clean it up (using
+                                # weakrefs or similar) would be good
+                                link_state_to_result(engine.state, gen_result)
+                                yield gen_result
+                        except (StopAsyncIteration, GeneratorExit) as exc:
+                            await engine.handle_success(None, transaction=txn)
+                            if isinstance(exc, GeneratorExit):
+                                gen.throw(exc)
 
     # async generators can't return, but we can raise failures here
     if engine.state.is_failed():
-        engine.result()
+        await engine.result()
 
 
 def run_task(

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -1148,11 +1148,10 @@ class TestPauseFlowRun:
                 await asyncio.sleep(0.1)
                 flow_run = await prefect_client.read_flow_run(flow_run_id)
 
-            # execution isn't blocked, so this task should enter the engine, but not begin
-            # execution
-            with pytest.raises(RuntimeError):
-                # the sleeper mock will exhaust its side effects after 6 calls
+            try:
                 await doesnt_run()
+            except RuntimeError:
+                pass
 
         await pausing_flow()
 

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -1148,10 +1148,11 @@ class TestPauseFlowRun:
                 await asyncio.sleep(0.1)
                 flow_run = await prefect_client.read_flow_run(flow_run_id)
 
-            try:
+            # execution isn't blocked, so this task should enter the engine, but not begin
+            # execution
+            with pytest.raises(RuntimeError):
+                # the sleeper mock will exhaust its side effects after 6 calls
                 await doesnt_run()
-            except RuntimeError:
-                pass
 
         await pausing_flow()
 

--- a/tests/test_task_worker.py
+++ b/tests/test_task_worker.py
@@ -794,21 +794,17 @@ class TestTaskWorkerLimit:
         mock_subscription.return_value = mock_iter()
 
         server_task = asyncio.create_task(task_worker.start())
-        await event.wait()  # Wait for the first task to set the event
-
-        # Give some additional time for the first task to complete
-        await asyncio.sleep(0.5)
-
+        await event.wait()
         updated_task_run_1 = await prefect_client.read_task_run(task_run_1.id)
         updated_task_run_2 = await prefect_client.read_task_run(task_run_2.id)
 
         assert updated_task_run_1.state.is_completed()
         assert not updated_task_run_2.state.is_completed()
 
-        # Clear the event to allow the second task to complete
+        # clear the event to allow the second task to complete
         event.clear()
 
-        await event.wait()  # Wait for the second task to set the event
+        await event.wait()
         updated_task_run_2 = await prefect_client.read_task_run(task_run_2.id)
 
         assert updated_task_run_2.state.is_completed()


### PR DESCRIPTION
This PR is meant to address the issue where the TaskRunEngine is blocking async tasks. The PR fixes this issue by doing a major refactor of `TaskRunEngine` into three parts:

- BaseTaskRunEngine - The core parts that are all sync and non-blocking.
- SyncTaskRunEngine - The bits that are sync and blocking, mostly dealing with the client.
- AsyncTaskRunEngine - The bits that are async, again mostly dealing with the client.

A lot of the refactor was also to break apart longer methods, like `setup_run_context` or `begin_run` into component parts that can be used by both the sync and async implementations.

Closes #14113 
