### PR TITLE
Chore: Remove results tab from flow run page

### DIFF
--- a/ui/src/pages/FlowRun.vue
+++ b/ui/src/pages/FlowRun.vue
@@ -15,10 +15,6 @@
         <FlowRunLogs :flow-run="flowRun" />
       </template>
 
-      <template #results>
-        <FlowRunResults :flow-run="flowRun" />
-      </template>
-
       <template #artifacts>
         <FlowRunArtifacts :flow-run="flowRun" />
       </template>
@@ -53,7 +49,6 @@
     FlowRunDetails,
     FlowRunLogs,
     FlowRunTaskRuns,
-    FlowRunResults,
     FlowRunFilteredList,
     useFavicon,
     CopyableWrapper,
@@ -88,7 +83,6 @@
     { label: 'Logs' },
     { label: 'Task Runs', hidden: isPending.value },
     { label: 'Subflow Runs', hidden: isPending.value },
-    { label: 'Results', hidden: isPending.value },
     { label: 'Artifacts', hidden: isPending.value },
     { label: 'Details' },
     { label: 'Parameters' },


### PR DESCRIPTION
## Description
Results (both task run and flow run) are improving with 3.x; one of the most important changes is that we're no longer automatically storing results as artifacts with a special type. This means this tab won't be showing helpful information and users should instead persist information as true artifacts if they need access to them in the UI.

This PR removes the results tab from the flow run page. 