### PR TITLE
Fix excessive memory usage in flows with many tasks

### DIFF
--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -9,6 +9,7 @@ For more user-accessible information about the current run, see [`prefect.runtim
 import os
 import sys
 import warnings
+import weakref
 from contextlib import ExitStack, contextmanager
 from contextvars import ContextVar, Token
 from pathlib import Path
@@ -291,8 +292,12 @@ class EngineContext(RunContext):
     # Counter for flow pauses
     observed_flow_pauses: Dict[str, int] = Field(default_factory=dict)
 
-    # Tracking for result from task runs in this flow run
-    task_run_results: Dict[int, State] = Field(default_factory=dict)
+    # Tracking for result from task runs in this flow run for dependency tracking
+    # Holds the ID of the object returned by the task run and task run state
+    # This is a weakref dictionary to avoid undermining garbage collection
+    task_run_results: Dict[int, State] = Field(
+        default_factory=weakref.WeakValueDictionary
+    )
 
     # Events worker to emit events to Prefect Cloud
     events: Optional[EventsWorker] = None

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -18,6 +18,7 @@ from typing import (
     Any,
     Dict,
     Generator,
+    Mapping,
     Optional,
     Set,
     Type,
@@ -295,7 +296,7 @@ class EngineContext(RunContext):
     # Tracking for result from task runs in this flow run for dependency tracking
     # Holds the ID of the object returned by the task run and task run state
     # This is a weakref dictionary to avoid undermining garbage collection
-    task_run_results: Dict[int, State] = Field(
+    task_run_results: Mapping[int, State] = Field(
         default_factory=weakref.WeakValueDictionary
     )
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->
### Summary
When running tasks within a flow, the client will attempt to track data dependencies between tasks by associating the object ID of a task execution's return value with the state of the corresponding task run. Those values are stored in a dictionary on the `FlowRunContext` of the current flow run.

This behavior leads to excessive memory usage that scales as a function of the size of the task execution return values and the number of task executions in a flow. The state stored on the `FlowRunContext` contains a reference to the result of the task run, which holds a reference to the return value of the user's code (as long as `cache_result_in_memory` is enabled, which it is by default). These held references prevent the Python runtime from garbage-collecting task execution return values (even if the return value was never assigned) until the flow execution completes.

This PR uses a `weakref.WeakValueDictionary` on the `FlowRunContext` to allow tracking of object IDs and task run states to continue and to allow the Python runtime to garbage-collect entries when there are no other remaining references to them. This change keeps memory usage flat across flows with differing task run execution counts. See the Example section for more details.

Closes https://github.com/PrefectHQ/prefect/issues/14329

### TL;DR

We have a secret dictionary sabotaging Python's garbage collection. This PR replaces that dictionary with a weak value dictionary.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
The excessive memory usage can be seen with this script:
```python
from memory_profiler import profile

from prefect import flow, task


@task
def with_task():
    return [{"abc": "123"} for _ in range(10_000)]

@flow
@profile
def some_flow(n: int = 100):
    for _ in range(n):
        with_task()
    print("DONE")


@profile
def main():
    some_flow(n=1000)


if __name__ == "__main__":
    main()
```

#### Before
Running this script before the changes in this PR with varying task invocations gives the following results:

100 tasks:
```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    10    132.6 MiB    132.6 MiB           1   @flow
    11                                         @profile
    12                                         def some_flow(n: int = 100):
    13    307.0 MiB  -1762.6 MiB         101       for _ in range(n):
    14    307.0 MiB  -1588.2 MiB         100           with_task()
    15    249.6 MiB    -57.4 MiB           1       print("DONE")



Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    18    127.2 MiB    127.2 MiB           1   @profile
    19                                         def main():
    20    249.8 MiB    122.6 MiB           1       some_flow(n=100)
```

1000 tasks:
```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    10    134.8 MiB    134.8 MiB           1   @flow
    11                                         @profile
    12                                         def some_flow(n: int = 100):
    13   1359.5 MiB -432178.9 MiB        1001       for _ in range(n):
    14   1359.5 MiB -430954.4 MiB        1000           with_task()
    15    374.0 MiB   -985.5 MiB           1       print("DONE")

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    18    130.1 MiB    130.1 MiB           1   @profile
    19                                         def main():
    20    375.7 MiB    245.6 MiB           1       some_flow(n=1000)
```
As you can see, memory usage scales with the number of task invocations.

#### After
Running this script with the changes in this PR with varying task invocations gives the following results:

100 tasks:
```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    10    141.5 MiB    141.5 MiB           1   @flow
    11                                         @profile
    12                                         def some_flow(n: int = 100):
    13    168.9 MiB   -718.7 MiB         101       for _ in range(n):
    14    168.9 MiB   -691.3 MiB         100           with_task()
    15    158.9 MiB    -10.0 MiB           1       print("DONE")

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    18    136.3 MiB    136.3 MiB           1   @profile
    19                                         def main():
    20    158.9 MiB     22.6 MiB           1       some_flow(n=100)
```

1000 tasks:
```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    10    140.4 MiB    140.4 MiB           1   @flow
    11                                         @profile
    12                                         def some_flow(n: int = 100):
    13    164.6 MiB  -6694.6 MiB        1001       for _ in range(n):
    14    164.6 MiB  -6670.7 MiB        1000           with_task()
    15    154.7 MiB     -9.9 MiB           1       print("DONE")

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
    18    135.3 MiB    135.3 MiB           1   @profile
    19                                         def main():
    20    154.8 MiB     19.4 MiB           1       some_flow(n=1000)
```

With these changes, overall memory usage decreases **and** stays flat even when the number of task runs increases.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
- [x] This pull request references any related issue by including "closes `<link to issue>`"
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
