### PR TITLE
Run flow hooks in flow run context

### DIFF
--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -31,6 +31,7 @@ from prefect.client.schemas.schedules import (
     IntervalSchedule,
     RRuleSchedule,
 )
+from prefect.context import FlowRunContext, get_run_context
 from prefect.deployments.runner import RunnerDeployment
 from prefect.docker.docker_image import DockerImage
 from prefect.events import DeploymentEventTrigger, Posture
@@ -40,6 +41,7 @@ from prefect.exceptions import (
     ParameterTypeError,
     ReservedArgumentError,
     ScriptError,
+    UnfinishedRun,
 )
 from prefect.filesystems import LocalFileSystem
 from prefect.flows import (
@@ -60,6 +62,7 @@ from prefect.settings import (
 )
 from prefect.states import (
     Cancelled,
+    Cancelling,
     Paused,
     PausedRun,
     State,
@@ -2807,6 +2810,44 @@ def create_async_hook(mock_obj):
         mock_obj()
 
     return my_hook
+
+
+class TestFlowHooksContext:
+    @pytest.mark.parametrize(
+        "hook_type, fn_body, expected_exc",
+        [
+            ("on_completion", lambda: None, None),
+            ("on_failure", lambda: 100 / 0, ZeroDivisionError),
+            ("on_cancellation", lambda: Cancelling(), UnfinishedRun),
+        ],
+    )
+    def test_hooks_are_called_within_flow_run_context(
+        self, caplog, hook_type, fn_body, expected_exc
+    ):
+        was_in_context = False
+
+        def hook(flow, flow_run, state):
+            nonlocal was_in_context
+            ctx: FlowRunContext = get_run_context()  # type: ignore
+            assert ctx is not None
+            was_in_context = True
+            assert ctx.flow_run and ctx.flow_run == flow_run
+            assert ctx.flow_run.state == state
+            assert ctx.flow == flow
+
+        @flow(**{hook_type: [hook]})  # type: ignore
+        def foo_flow():
+            return fn_body()
+
+        with caplog.at_level("INFO"):
+            if expected_exc:
+                with pytest.raises(expected_exc):
+                    foo_flow()
+            else:
+                foo_flow()
+
+        assert was_in_context
+        assert "Hook 'hook' finished running successfully" in caplog.text
 
 
 class TestFlowHooksWithKwargs:

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -2824,13 +2824,9 @@ class TestFlowHooksContext:
     def test_hooks_are_called_within_flow_run_context(
         self, caplog, hook_type, fn_body, expected_exc
     ):
-        was_in_context = False
-
         def hook(flow, flow_run, state):
-            nonlocal was_in_context
             ctx: FlowRunContext = get_run_context()  # type: ignore
             assert ctx is not None
-            was_in_context = True
             assert ctx.flow_run and ctx.flow_run == flow_run
             assert ctx.flow_run.state == state
             assert ctx.flow == flow
@@ -2846,7 +2842,6 @@ class TestFlowHooksContext:
             else:
                 foo_flow()
 
-        assert was_in_context
         assert "Hook 'hook' finished running successfully" in caplog.text
 
 


### PR DESCRIPTION
This PR moves the `call_hooks` in the flow engine so that the hooks run within the flow run context, the fact this has not been the case has been a common sticking point in the past. With planned restrictions like https://github.com/PrefectHQ/prefect/pull/13688 (creating artifacts only in a flow run context), it would be nice to be able to create artifacts in an `on_completion` hook for example.

There is a consideration here about the injected kwargs (flow, flow_run, state), since this PR would make it trivially easy to get these things from `get_run_context` (many ways to do the same thing), open to feedback on this.

Intentionally did not do the task run engine in this PR as I figured I should wait for https://github.com/PrefectHQ/prefect/pull/14643 to land