### PR TITLE
Fix runtime load from entrypoint

### DIFF
--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -91,9 +91,12 @@ def load_flow_and_flow_run(flow_run_id: UUID) -> Tuple[FlowRun, Flow]:
 
     flow_run = client.read_flow_run(flow_run_id)
     if entrypoint:
-        flow = load_flow_from_entrypoint(entrypoint)
+        # we should not accept a placeholder flow at runtime
+        flow = load_flow_from_entrypoint(entrypoint, use_placeholder_flow=False)
     else:
-        flow = run_coro_as_sync(load_flow_from_flow_run(flow_run))
+        flow = run_coro_as_sync(
+            load_flow_from_flow_run(flow_run, use_placeholder_flow=False)
+        )
 
     return flow_run, flow
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1712,6 +1712,8 @@ def load_flow_from_entrypoint(
     Args:
         entrypoint: a string in the format `<path_to_script>:<flow_func_name>` or a module path
             to a flow function
+        use_placeholder_flow: if True, use a placeholder Flow object if the actual flow object
+            cannot be loaded from the entrypoint (e.g. dependencies are missing)
 
     Returns:
         The flow object from the script

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1704,6 +1704,7 @@ def select_flow(
 
 def load_flow_from_entrypoint(
     entrypoint: str,
+    use_placeholder_flow: bool = True,
 ) -> Flow:
     """
     Extract a flow object from a script at an entrypoint by running all of the code in the file.
@@ -1737,8 +1738,10 @@ def load_flow_from_entrypoint(
         # drawback of this approach is that we're unable to actually load the
         # function, so we create a placeholder flow that will re-raise this
         # exception when called.
-
-        flow = load_placeholder_flow(entrypoint=entrypoint, raises=exc)
+        if use_placeholder_flow:
+            flow = load_placeholder_flow(entrypoint=entrypoint, raises=exc)
+        else:
+            raise
 
     if not isinstance(flow, Flow):
         raise MissingFlowError(
@@ -1856,6 +1859,7 @@ async def load_flow_from_flow_run(
     flow_run: "FlowRun",
     ignore_storage: bool = False,
     storage_base_path: Optional[str] = None,
+    use_placeholder_flow: bool = True,
 ) -> Flow:
     """
     Load a flow from the location/script provided in a deployment's storage document.
@@ -1882,7 +1886,9 @@ async def load_flow_from_flow_run(
             f"Importing flow code from module path {deployment.entrypoint}"
         )
         flow = await run_sync_in_worker_thread(
-            load_flow_from_entrypoint, deployment.entrypoint
+            load_flow_from_entrypoint,
+            deployment.entrypoint,
+            use_placeholder_flow=use_placeholder_flow,
         )
         return flow
 
@@ -1924,7 +1930,11 @@ async def load_flow_from_flow_run(
     import_path = relative_path_to_current_platform(deployment.entrypoint)
     run_logger.debug(f"Importing flow code from '{import_path}'")
 
-    flow = await run_sync_in_worker_thread(load_flow_from_entrypoint, str(import_path))
+    flow = await run_sync_in_worker_thread(
+        load_flow_from_entrypoint,
+        str(import_path),
+        use_placeholder_flow=use_placeholder_flow,
+    )
 
     return flow
 

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -167,9 +167,7 @@ class Runner:
         self.query_seconds = query_seconds or PREFECT_RUNNER_POLL_FREQUENCY.value()
         self._prefetch_seconds = prefetch_seconds
 
-        self._limiter: Optional[anyio.CapacityLimiter] = anyio.CapacityLimiter(
-            self.limit
-        )
+        self._limiter: Optional[anyio.CapacityLimiter] = None
         self._client = get_client()
         self._submitting_flow_run_ids = set()
         self._cancelling_flow_run_ids = set()
@@ -1226,6 +1224,8 @@ class Runner:
         self._logger.debug("Starting runner...")
         self._client = get_client()
         self._tmp_dir.mkdir(parents=True)
+
+        self._limiter = anyio.CapacityLimiter(self.limit)
 
         if not hasattr(self, "_loop") or not self._loop:
             self._loop = asyncio.get_event_loop()

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -4383,7 +4383,9 @@ class TestLoadFlowFromFlowRun:
         result = await load_flow_from_flow_run(flow_run)
 
         assert result == pretend_flow
-        load_flow_from_entrypoint.assert_called_once_with("my.module.pretend_flow")
+        load_flow_from_entrypoint.assert_called_once_with(
+            "my.module.pretend_flow", use_placeholder_flow=True
+        )
 
 
 class TestTransactions:

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -2540,118 +2540,135 @@ class TestFlowRetries:
             assert run_count == 2
 
 
-def test_load_flow_from_entrypoint(tmp_path):
-    flow_code = """
-    from prefect import flow
+class TestLoadFlowFromEntrypoint:
+    def test_load_flow_from_entrypoint(self, tmp_path):
+        flow_code = """
+        from prefect import flow
 
-    @flow
-    def dog():
-        return "woof!"
-    """
-    fpath = tmp_path / "f.py"
-    fpath.write_text(dedent(flow_code))
+        @flow
+        def dog():
+            return "woof!"
+        """
+        fpath = tmp_path / "f.py"
+        fpath.write_text(dedent(flow_code))
 
-    flow = load_flow_from_entrypoint(f"{fpath}:dog")
-    assert flow.fn() == "woof!"
+        flow = load_flow_from_entrypoint(f"{fpath}:dog")
+        assert flow.fn() == "woof!"
 
+    def test_load_flow_from_entrypoint_with_absolute_path(self, tmp_path):
+        # test absolute paths to ensure compatibility for all operating systems
 
-def test_load_flow_from_entrypoint_with_absolute_path(tmp_path):
-    # test absolute paths to ensure compatibility for all operating systems
+        flow_code = """
+        from prefect import flow
 
-    flow_code = """
-    from prefect import flow
+        @flow
+        def dog():
+            return "woof!"
+        """
+        fpath = tmp_path / "f.py"
+        fpath.write_text(dedent(flow_code))
 
-    @flow
-    def dog():
-        return "woof!"
-    """
-    fpath = tmp_path / "f.py"
-    fpath.write_text(dedent(flow_code))
+        # convert the fpath into an absolute path
+        absolute_fpath = str(fpath.resolve())
 
-    # convert the fpath into an absolute path
-    absolute_fpath = str(fpath.resolve())
+        flow = load_flow_from_entrypoint(f"{absolute_fpath}:dog")
+        assert flow.fn() == "woof!"
 
-    flow = load_flow_from_entrypoint(f"{absolute_fpath}:dog")
-    assert flow.fn() == "woof!"
+    def test_load_flow_from_entrypoint_with_module_path(self, monkeypatch):
+        @flow
+        def pretend_flow():
+            pass
 
+        import_object_mock = MagicMock(return_value=pretend_flow)
+        monkeypatch.setattr(
+            "prefect.flows.import_object",
+            import_object_mock,
+        )
+        result = load_flow_from_entrypoint("my.module.pretend_flow")
 
-def test_load_flow_from_entrypoint_with_module_path(monkeypatch):
-    @flow
-    def pretend_flow():
-        pass
+        assert result == pretend_flow
+        import_object_mock.assert_called_with("my.module.pretend_flow")
 
-    import_object_mock = MagicMock(return_value=pretend_flow)
-    monkeypatch.setattr(
-        "prefect.flows.import_object",
-        import_object_mock,
-    )
-    result = load_flow_from_entrypoint("my.module.pretend_flow")
+    def test_load_flow_from_entrypoint_script_error_loads_placeholder(self, tmp_path):
+        flow_code = """
+        from not_a_module import not_a_function
+        from prefect import flow
 
-    assert result == pretend_flow
-    import_object_mock.assert_called_with("my.module.pretend_flow")
+        @flow(description="Says woof!")
+        def dog():
+            return "woof!"
+        """
+        fpath = tmp_path / "f.py"
+        fpath.write_text(dedent(flow_code))
 
-
-def test_load_flow_from_entrypoint_script_error_loads_placeholder(tmp_path):
-    flow_code = """
-    from not_a_module import not_a_function
-    from prefect import flow
-
-    @flow(description="Says woof!")
-    def dog():
-        return "woof!"
-    """
-    fpath = tmp_path / "f.py"
-    fpath.write_text(dedent(flow_code))
-
-    flow = load_flow_from_entrypoint(f"{fpath}:dog")
-
-    # Since `not_a_module` isn't a real module, loading the flow as python
-    # should fail, and `load_flow_from_entrypoint` should fallback to
-    # returning a placeholder flow with the correct name, description, etc.
-    assert flow.name == "dog"
-    assert flow.description == "Says woof!"
-
-    # But if the flow is called, it should raise the ScriptError
-    with pytest.raises(ScriptError):
-        flow.fn()
-
-
-@pytest.mark.skip(reason="Fails with new engine, passed on old engine")
-async def test_handling_script_with_unprotected_call_in_flow_script(
-    tmp_path,
-    caplog,
-    prefect_client,
-):
-    flow_code_with_call = """
-    from prefect import flow
-from prefect.logging import get_run_logger
-
-    @flow
-    def dog():
-        get_run_logger().warning("meow!")
-        return "woof!"
-
-    dog()
-    """
-    fpath = tmp_path / "f.py"
-    fpath.write_text(dedent(flow_code_with_call))
-    with caplog.at_level("WARNING"):
         flow = load_flow_from_entrypoint(f"{fpath}:dog")
 
-        # Make sure that warning is raised
-        assert (
-            "Script loading is in progress, flow 'dog' will not be executed. "
-            "Consider updating the script to only call the flow" in caplog.text
-        )
+        # Since `not_a_module` isn't a real module, loading the flow as python
+        # should fail, and `load_flow_from_entrypoint` should fallback to
+        # returning a placeholder flow with the correct name, description, etc.
+        assert flow.name == "dog"
+        assert flow.description == "Says woof!"
 
-    flow_runs = await prefect_client.read_flows()
-    assert len(flow_runs) == 0
+        # But if the flow is called, it should raise the ScriptError
+        with pytest.raises(ScriptError):
+            flow.fn()
 
-    # Make sure that flow runs when called
-    res = flow()
-    assert res == "woof!"
-    flow_runs = await prefect_client.read_flows()
-    assert len(flow_runs) == 1
+    @pytest.mark.skip(reason="Fails with new engine, passed on old engine")
+    async def test_handling_script_with_unprotected_call_in_flow_script(
+        self, tmp_path, caplog, prefect_client
+    ):
+        flow_code_with_call = """
+        from prefect import flow
+        from prefect.logging import get_run_logger
+
+        @flow
+        def dog():
+            get_run_logger().warning("meow!")
+            return "woof!"
+
+        dog()
+        """
+        fpath = tmp_path / "f.py"
+        fpath.write_text(dedent(flow_code_with_call))
+        with caplog.at_level("WARNING"):
+            flow = load_flow_from_entrypoint(f"{fpath}:dog")
+
+            # Make sure that warning is raised
+            assert (
+                "Script loading is in progress, flow 'dog' will not be executed. "
+                "Consider updating the script to only call the flow" in caplog.text
+            )
+
+        flow_runs = await prefect_client.read_flows()
+        assert len(flow_runs) == 0
+
+        # Make sure that flow runs when called
+        res = flow()
+        assert res == "woof!"
+        flow_runs = await prefect_client.read_flows()
+        assert len(flow_runs) == 1
+
+    def test_load_flow_from_entrypoint_with_use_placeholder_flow(self, tmp_path):
+        flow_code = """
+        from not_a_module import not_a_function
+        from prefect import flow
+
+        @flow(description="Says woof!")
+        def dog():
+            return "woof!"
+        """
+        fpath = tmp_path / "f.py"
+        fpath.write_text(dedent(flow_code))
+
+        # Test with use_placeholder_flow=True (default behavior)
+        flow = load_flow_from_entrypoint(f"{fpath}:dog")
+        assert isinstance(flow, Flow)
+        with pytest.raises(ScriptError):
+            flow.fn()
+
+        # Test with use_placeholder_flow=False
+        with pytest.raises(ScriptError):
+            load_flow_from_entrypoint(f"{fpath}:dog", use_placeholder_flow=False)
 
 
 class TestFlowRunName:


### PR DESCRIPTION
closes #14663 

This PR:
- Adds `use_placeholder_flow: bool` flag to `load_flow_from_entrypoint`
- Updates uses to `use_placeholder_flow=True` at deployment time and `False` at runtime
- Adds test for `use_placeholder_flow`
- moves the `Runner`'s capacity limiter to `__aenter__` for consistency with the other attrs that need to be created in an async context

Addresses misleading `SignatureMismatchError`s when flows run with missing dependencies. Allows immediate failure with `ScriptError` during runtime, while maintaining placeholder flows for deployment creation.

we now get an error like this on the worker if we cant load the flow
```python
prefect.exceptions.ScriptError: Script at 'src/demo_project/param_sig.py' encountered an exception: ModuleNotFoundError("No module named 'pandas'")
```


---
the diff is a bit ugly in `test_flows.py` because I made a class for `TestLoadFlowFromEntrypoint`