### PR TITLE
Updates de-normalized state fields during client-side orchestration

### DIFF
--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -309,8 +309,6 @@ class TaskRunEngine(Generic[P, R]):
                 new_state.state_details.flow_run_id = (
                     last_state.state_details.flow_run_id
                 )
-
-                self.task_run.state = new_state
             else:
                 new_state = propose_state_sync(
                     self.client, state, task_run_id=self.task_run.id, force=force

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -1749,3 +1749,123 @@ class TestAsyncGenerators:
         except ValueError:
             pass
         assert values == [1, 2]
+
+
+class TestRunStateIsDenormalized:
+    async def test_state_attributes_are_denormalized_async_success(self):
+        ID = None
+
+        @task
+        async def foo():
+            nonlocal ID
+            ID = TaskRunContext.get().task_run.id
+
+            task_run = TaskRunContext.get().task_run
+
+            # while we are Running, we should have the state attributes copied onto the
+            # current task run instance
+            assert task_run.state
+            assert task_run.state_id == task_run.state.id
+            assert task_run.state_type == task_run.state.type == StateType.RUNNING
+            assert task_run.state_name == task_run.state.name == "Running"
+
+        await run_task_async(foo)
+
+        task_run = await get_task_run(ID)
+
+        assert task_run
+        assert task_run.state
+
+        assert task_run.state_id == task_run.state.id
+        assert task_run.state_type == task_run.state.type == StateType.COMPLETED
+        assert task_run.state_name == task_run.state.name == "Completed"
+
+    async def test_state_attributes_are_denormalized_async_failure(self):
+        ID = None
+
+        @task
+        async def foo():
+            nonlocal ID
+            ID = TaskRunContext.get().task_run.id
+
+            task_run = TaskRunContext.get().task_run
+
+            # while we are Running, we should have the state attributes copied onto the
+            # current task run instance
+            assert task_run.state
+            assert task_run.state_id == task_run.state.id
+            assert task_run.state_type == task_run.state.type == StateType.RUNNING
+            assert task_run.state_name == task_run.state.name == "Running"
+
+            raise ValueError("woops!")
+
+        with pytest.raises(ValueError, match="woops!"):
+            await run_task_async(foo)
+
+        task_run = await get_task_run(ID)
+
+        assert task_run
+        assert task_run.state
+
+        assert task_run.state_id == task_run.state.id
+        assert task_run.state_type == task_run.state.type == StateType.FAILED
+        assert task_run.state_name == task_run.state.name == "Failed"
+
+    def test_state_attributes_are_denormalized_sync_success(self):
+        ID = None
+
+        @task
+        def foo():
+            nonlocal ID
+            ID = TaskRunContext.get().task_run.id
+
+            task_run = TaskRunContext.get().task_run
+
+            # while we are Running, we should have the state attributes copied onto the
+            # current task run instance
+            assert task_run.state
+            assert task_run.state_id == task_run.state.id
+            assert task_run.state_type == task_run.state.type == StateType.RUNNING
+            assert task_run.state_name == task_run.state.name == "Running"
+
+        run_task_sync(foo)
+
+        task_run = get_task_run_sync(ID)
+
+        assert task_run
+        assert task_run.state
+
+        assert task_run.state_id == task_run.state.id
+        assert task_run.state_type == task_run.state.type == StateType.COMPLETED
+        assert task_run.state_name == task_run.state.name == "Completed"
+
+    def test_state_attributes_are_denormalized_sync_failure(self):
+        ID = None
+
+        @task
+        def foo():
+            nonlocal ID
+            ID = TaskRunContext.get().task_run.id
+
+            task_run = TaskRunContext.get().task_run
+
+            # while we are Running, we should have the state attributes copied onto the
+            # current task run instance
+            assert task_run.state
+            assert task_run.state_id == task_run.state.id
+            assert task_run.state_type == task_run.state.type == StateType.RUNNING
+            assert task_run.state_name == task_run.state.name == "Running"
+
+            raise ValueError("woops!")
+
+        with pytest.raises(ValueError, match="woops!"):
+            run_task_sync(foo)
+
+        task_run = get_task_run_sync(ID)
+
+        assert task_run
+        assert task_run.state
+
+        assert task_run.state_id == task_run.state.id
+        assert task_run.state_type == task_run.state.type == StateType.FAILED
+        assert task_run.state_name == task_run.state.name == "Failed"


### PR DESCRIPTION
This is the client-side version of the `SetRunState*` orchestration rules.  The
task run recorder in Cloud (and soon to be in OSS) covers the equivalent
server-side denormalizations for the database models.
