### PR TITLE
Predictively updates the run IDs on `State.state_details` client-side

### DIFF
--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -1913,3 +1913,83 @@ class TestRunStateIsDenormalized:
         assert task_run.state_id == task_run.state.id
         assert task_run.state_type == task_run.state.type == StateType.FAILED
         assert task_run.state_name == task_run.state.name == "Failed"
+
+    async def test_state_details_have_denormalized_task_run_id_async(self):
+        proof_that_i_ran = uuid4()
+
+        @task
+        async def foo():
+            task_run = TaskRunContext.get().task_run
+
+            assert task_run
+            assert task_run.state
+            assert task_run.state.state_details
+
+            assert task_run.state.state_details.flow_run_id is None
+            assert task_run.state.state_details.task_run_id == task_run.id
+
+            return proof_that_i_ran
+
+        assert await run_task_async(foo) == proof_that_i_ran
+
+    async def test_state_details_have_denormalized_flow_run_id_async(self):
+        proof_that_i_ran = uuid4()
+
+        @flow
+        async def the_flow():
+            return foo()
+
+        @task
+        async def foo():
+            task_run = TaskRunContext.get().task_run
+
+            assert task_run
+            assert task_run.state
+            assert task_run.state.state_details
+
+            assert task_run.state.state_details.flow_run_id == task_run.flow_run_id
+            assert task_run.state.state_details.task_run_id == task_run.id
+
+            return proof_that_i_ran
+
+        assert await the_flow() == proof_that_i_ran
+
+    def test_state_details_have_denormalized_task_run_id_sync(self):
+        proof_that_i_ran = uuid4()
+
+        @task
+        def foo():
+            task_run = TaskRunContext.get().task_run
+
+            assert task_run
+            assert task_run.state
+            assert task_run.state.state_details
+
+            assert task_run.state.state_details.flow_run_id is None
+            assert task_run.state.state_details.task_run_id == task_run.id
+
+            return proof_that_i_ran
+
+        assert run_task_sync(foo) == proof_that_i_ran
+
+    def test_state_details_have_denormalized_flow_run_id_sync(self):
+        proof_that_i_ran = uuid4()
+
+        @flow
+        def the_flow():
+            return foo()
+
+        @task
+        def foo():
+            task_run = TaskRunContext.get().task_run
+
+            assert task_run
+            assert task_run.state
+            assert task_run.state.state_details
+
+            assert task_run.state.state_details.flow_run_id == task_run.flow_run_id
+            assert task_run.state.state_details.task_run_id == task_run.id
+
+            return proof_that_i_ran
+
+        assert the_flow() == proof_that_i_ran


### PR DESCRIPTION
This also includes a small refactoring to more cleanly split client-side from
server-side orchestration in `TaskRunEngine.set_state`.
