### PR TITLE
client-side task orchestration - `IncrementRunTime`

### DIFF
--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -392,6 +392,11 @@ class TaskRunEngine(Generic[P, R]):
         )
         if transaction.is_committed():
             terminal_state.name = "Cached"
+
+        if PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
+            if self.task_run.start_time and not self.task_run.end_time:
+                self.task_run.end_time = terminal_state.timestamp
+
         self.set_state(terminal_state)
         self._return_value = result
         return result
@@ -452,6 +457,9 @@ class TaskRunEngine(Generic[P, R]):
                     result_factory=getattr(context, "result_factory", None),
                 )
             )
+            if PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
+                if self.task_run.start_time and not self.task_run.end_time:
+                    self.task_run.end_time = state.timestamp
             self.set_state(state)
             self._raised = exc
 
@@ -474,6 +482,9 @@ class TaskRunEngine(Generic[P, R]):
         state = run_coro_as_sync(exception_to_crashed_state(exc))
         self.logger.error(f"Crash detected! {state.message}")
         self.logger.debug("Crash details:", exc_info=exc)
+        if PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
+            if self.task_run.start_time and not self.task_run.end_time:
+                self.task_run.end_time = state.timestamp
         self.set_state(state, force=True)
         self._raised = exc
 

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -1108,7 +1108,7 @@ class TestTaskCrashDetection:
 
 
 class TestTaskTimeTracking:
-    async def test_sync_task_start_time_set_on_running(self):
+    async def test_sync_task_sets_start_time_on_running(self):
         @task
         def foo():
             return TaskRunContext.get().task_run.id
@@ -1121,7 +1121,7 @@ class TestTaskTimeTracking:
         assert len(states) == 1 and states[0].type == StateType.RUNNING
         assert states[0].timestamp == run.start_time
 
-    async def test_async_task_start_time_set_on_running(self):
+    async def test_async_task_sets_start_time_on_running(self):
         ID = None
 
         @task
@@ -1136,6 +1136,144 @@ class TestTaskTimeTracking:
         states = await get_task_run_states(ID, StateType.RUNNING)
         assert len(states) == 1 and states[0].type == StateType.RUNNING
         assert states[0].timestamp == run.start_time
+
+    async def test_sync_task_sets_end_time_on_completed(self):
+        @task
+        def foo():
+            return TaskRunContext.get().task_run.id
+
+        task_run_id = run_task_sync(foo)
+        run = await get_task_run(task_run_id)
+
+        assert run.end_time is not None
+        states = await get_task_run_states(task_run_id, StateType.COMPLETED)
+        assert len(states) == 1 and states[0].type == StateType.COMPLETED
+        assert states[0].timestamp == run.end_time
+
+    async def test_async_task_sets_end_time_on_completed(self):
+        @task
+        async def foo():
+            return TaskRunContext.get().task_run.id
+
+        task_run_id = await run_task_async(foo)
+        run = await get_task_run(task_run_id)
+
+        assert run.end_time is not None
+        states = await get_task_run_states(task_run_id, StateType.COMPLETED)
+        assert len(states) == 1 and states[0].type == StateType.COMPLETED
+        assert states[0].timestamp == run.end_time
+
+    async def test_sync_task_sets_end_time_on_failed(self):
+        ID = None
+
+        @task
+        def foo():
+            nonlocal ID
+            ID = TaskRunContext.get().task_run.id
+            raise ValueError("failure!!!")
+
+        with pytest.raises(ValueError):
+            run_task_sync(foo)
+
+        run = await get_task_run(ID)
+
+        assert run.end_time is not None
+        states = await get_task_run_states(ID, StateType.FAILED)
+        assert len(states) == 1 and states[0].type == StateType.FAILED
+        assert states[0].timestamp == run.end_time
+
+    async def test_async_task_sets_end_time_on_failed(self):
+        ID = None
+
+        @task
+        async def foo():
+            nonlocal ID
+            ID = TaskRunContext.get().task_run.id
+            raise ValueError("failure!!!")
+
+        with pytest.raises(ValueError):
+            await run_task_async(foo)
+
+        run = await get_task_run(ID)
+
+        assert run.end_time is not None
+        states = await get_task_run_states(ID, StateType.FAILED)
+        assert len(states) == 1 and states[0].type == StateType.FAILED
+        assert states[0].timestamp == run.end_time
+
+    async def test_sync_task_sets_end_time_on_crashed(self):
+        ID = None
+
+        @task
+        def foo():
+            nonlocal ID
+            ID = TaskRunContext.get().task_run.id
+            raise SystemExit
+
+        with pytest.raises(SystemExit):
+            run_task_sync(foo)
+
+        run = await get_task_run(ID)
+
+        assert run.end_time is not None
+        states = await get_task_run_states(ID, StateType.CRASHED)
+        assert len(states) == 1 and states[0].type == StateType.CRASHED
+        assert states[0].timestamp == run.end_time
+
+    async def test_async_task_sets_end_time_on_crashed(self):
+        ID = None
+
+        @task
+        async def foo():
+            nonlocal ID
+            ID = TaskRunContext.get().task_run.id
+            raise SystemExit
+
+        with pytest.raises(SystemExit):
+            await run_task_async(foo)
+
+        run = await get_task_run(ID)
+
+        assert run.end_time is not None
+        states = await get_task_run_states(ID, StateType.CRASHED)
+        assert len(states) == 1 and states[0].type == StateType.CRASHED
+        assert states[0].timestamp == run.end_time
+
+    async def test_sync_task_does_not_set_end_time_on_crash_pre_runnning(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            TaskRunEngine, "begin_run", MagicMock(side_effect=SystemExit)
+        )
+
+        @task
+        def my_task():
+            pass
+
+        with pytest.raises(SystemExit):
+            my_task()
+
+        run = await get_task_run(task_run_id=None)
+
+        assert run.end_time is None
+
+    async def test_async_task_does_not_set_end_time_on_crash_pre_running(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            TaskRunEngine, "begin_run", MagicMock(side_effect=SystemExit)
+        )
+
+        @task
+        async def my_task():
+            pass
+
+        with pytest.raises(SystemExit):
+            await my_task()
+
+        run = await get_task_run(task_run_id=None)
+
+        assert run.end_time is None
 
 
 class TestSyncAsyncTasks:


### PR DESCRIPTION
This PR implements the client-side task orchestration version of `IncrementRunTime`. I added a method `TaskEngine.record_terminal_state_timing` to encapsulate this.