### PR TITLE
Add `container_create_kwargs` to Docker worker

### DIFF
--- a/src/integrations/prefect-docker/prefect_docker/worker.py
+++ b/src/integrations/prefect-docker/prefect_docker/worker.py
@@ -504,7 +504,7 @@ class DockerWorker(BaseWorker):
         container_create_kwargs = {
             k: v
             for k, v in container_create_kwargs.items()
-            if k not in configuration.__dict__.keys()
+            if k not in configuration.model_fields.keys()
         }
 
         return dict(

--- a/src/integrations/prefect-docker/prefect_docker/worker.py
+++ b/src/integrations/prefect-docker/prefect_docker/worker.py
@@ -122,6 +122,7 @@ class DockerWorkerJobConfiguration(BaseJobConfiguration):
             `mem_limit` is 300m and `memswap_limit` is not set, containers can use
             600m in total of memory and swap.
         privileged: Give extended privileges to created containers.
+        container_create_kwargs: Extra args for docker py when creating container.
     """
 
     image: str = Field(
@@ -186,10 +187,16 @@ class DockerWorkerJobConfiguration(BaseJobConfiguration):
             "600m in total of memory and swap."
         ),
     )
-
     privileged: bool = Field(
         default=False,
         description="Give extended privileges to created container.",
+    )
+    container_create_kwargs: Optional[Dict[str, Any]] = Field(
+        default=None,
+        title="Container Configuration",
+        description=(
+            "Configuration for containers created by workers. See the [`docker-py` documentation](https://docker-py.readthedocs.io/en/stable/containers.html) for accepted values."
+        ),
     )
 
     def _convert_labels_to_docker_format(self, labels: Dict[str, str]):
@@ -488,6 +495,18 @@ class DockerWorker(BaseWorker):
     ) -> Dict:
         """Builds a dictionary of container settings to pass to the Docker API."""
         network_mode = configuration.get_network_mode()
+
+        container_create_kwargs = (
+            configuration.container_create_kwargs
+            if configuration.container_create_kwargs
+            else {}
+        )
+        container_create_kwargs = {
+            k: v
+            for k, v in container_create_kwargs.items()
+            if k not in configuration.__dict__.keys()
+        }
+
         return dict(
             image=configuration.image,
             network=configuration.networks[0] if configuration.networks else None,
@@ -502,6 +521,7 @@ class DockerWorker(BaseWorker):
             mem_limit=configuration.mem_limit,
             memswap_limit=configuration.memswap_limit,
             privileged=configuration.privileged,
+            **container_create_kwargs,
         )
 
     def _create_and_start_container(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.
- Review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/

Happy engineering!
-->

<!-- Include an overview here -->

Picks up from https://github.com/PrefectHQ/prefect-docker/pull/85.

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
```python
from prefect import flow
import socket


@flow(log_prints=True)
def docker_flow():
    print(socket.gethostname())

if __name__ == "__main__":
    docker_flow.deploy(
        name="docker-flow",
        image="my_registry/dockerflow:latest",
        work_pool_name="docker-dev",
        job_variables={"container_create_kwargs": {"hostname": "custom_hostname"}},
    )
```

```bash
13:29:40.161 | INFO    | prefect.flow_runs.worker - Completed submission of flow run '299d1d66-1f37-48f7-a454-90c1d0913ae4'
18:29:41.885 | INFO    | prefect.flow_runs.runner - Opening process...
18:29:43.211 | INFO    | Flow run 'positive-leopard' - Downloading flow code from storage at '.'
18:29:43.688 | INFO    | Flow run 'positive-leopard' - custom_hostname
18:29:43.834 | INFO    | Flow run 'positive-leopard' - Finished in state Completed()
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes a label categorizing the change e.g. `maintenance`, `fix`, `feature`, `enhancement`, `docs`.
- [x] This pull request references any related issue by including "closes `<link to issue>`"
  <!-- If you do not have permission to add a label, a maintainer will add one for you -->
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
