### PR TITLE
Add workflow that auto populates labels based on linked issues

### DIFF
--- a/.github/workflows/copy-linked-issue-labels.yml
+++ b/.github/workflows/copy-linked-issue-labels.yml
@@ -1,0 +1,18 @@
+name: Copy labels from linked issues
+on:
+  pull_request_target:
+    types: [opened, edited, review_requested, synchronize, reopened, ready_for_review]
+
+jobs:
+  copy-issue-labels:
+    if: github.repository == 'prefecthq/prefect'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      contents: read
+      pull-requests: write
+    steps:
+      - name: copy-issue-labels
+        uses: michalvankodev/copy-issue-labels@v1.3.0
+        with:
+          repo-token: "${{ github.token }}"


### PR DESCRIPTION
This new workflow will automatically label a PR with all the labels from any issues referenced within its description.

Action definition is from [here](https://github.com/michalvankodev/copy-issue-labels).

Random reference of #14658 and #14671 just to see if this workflow will run on this PR (random references won't work I'm now seeing - it will need to be an official link based on [special GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)).