### PR TITLE
Fix task key computation

### DIFF
--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -402,7 +402,6 @@ def create_status_server(task_worker: TaskWorker) -> FastAPI:
     return status_app
 
 
-@sync_compatible
 async def serve(
     *tasks: Task, limit: Optional[int] = 10, status_server_port: Optional[int] = None
 ):

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -402,6 +402,7 @@ def create_status_server(task_worker: TaskWorker) -> FastAPI:
     return status_app
 
 
+@sync_compatible
 async def serve(
     *tasks: Task, limit: Optional[int] = 10, status_server_port: Optional[int] = None
 ):

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -200,6 +200,9 @@ def _generate_task_key(fn: Callable) -> str:
     Args:
         fn: The function to generate a task key for.
     """
+    if not hasattr(fn, "__qualname__"):
+        return to_qualified_name(type(fn))
+
     qualname = fn.__qualname__.split(".")[-1]
     source_hash = h[:8] if (h := hash_objects(inspect.getsource(fn))) else "unknown"
     return f"{qualname}-{source_hash}"
@@ -386,10 +389,7 @@ class Task(Generic[P, R]):
 
         self.tags = set(tags if tags else [])
 
-        if not hasattr(self.fn, "__qualname__"):
-            self.task_key = to_qualified_name(type(self.fn))
-        else:
-            self.task_key = _generate_task_key(self.fn)
+        self.task_key = _generate_task_key(self.fn)
 
         if cache_policy is not NotSet and cache_key_fn is not None:
             logger.warning(

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -205,7 +205,9 @@ def _generate_task_key(fn: Callable) -> str:
 
     qualname = fn.__qualname__.split(".")[-1]
 
-    code_hash = h[:8] if (h := hash_objects(fn.__code__)) else "unknown"
+    code_hash = (
+        h[:NUM_CHARS_DYNAMIC_KEY] if (h := hash_objects(fn.__code__)) else "unknown"
+    )
 
     return f"{qualname}-{code_hash}"
 

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -187,7 +187,7 @@ def _infer_parent_task_runs(
     return parents
 
 
-def _generate_task_key(fn: Callable) -> str:
+def _generate_task_key(fn: Callable[..., Any]) -> str:
     """Generate a task key based on the function name and source code.
 
     We may eventually want some sort of top-level namespace here to

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -4,7 +4,6 @@ Module containing the base workflow task class and decorator - for most use case
 # This file requires type-checking with pyright because mypy does not yet support PEP612
 # See https://github.com/python/mypy/issues/8645
 
-import asyncio
 import datetime
 import inspect
 from copy import copy
@@ -64,6 +63,7 @@ from prefect.states import Pending, Scheduled, State
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import (
     run_coro_as_sync,
+    sync_compatible,
 )
 from prefect.utilities.callables import (
     expand_mapping_parameters,
@@ -1498,7 +1498,8 @@ class Task(Generic[P, R]):
         """
         return self.apply_async(args=args, kwargs=kwargs)
 
-    def serve(self):
+    @sync_compatible
+    async def serve(self) -> NoReturn:
         """Serve the task using the provided task runner. This method is used to
         establish a websocket connection with the Prefect server and listen for
         submitted task runs to execute.
@@ -1517,7 +1518,7 @@ class Task(Generic[P, R]):
         """
         from prefect.task_worker import serve
 
-        asyncio.run(serve(self))
+        await serve(self)
 
 
 @overload

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -204,8 +204,10 @@ def _generate_task_key(fn: Callable) -> str:
         return to_qualified_name(type(fn))
 
     qualname = fn.__qualname__.split(".")[-1]
-    source_hash = h[:8] if (h := hash_objects(inspect.getsource(fn))) else "unknown"
-    return f"{qualname}-{source_hash}"
+
+    code_hash = h[:8] if (h := hash_objects(fn.__code__)) else "unknown"
+
+    return f"{qualname}-{code_hash}"
 
 
 class Task(Generic[P, R]):

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -60,11 +60,7 @@ async def test_task_state_change_happy_path(
         == task_run.expected_start_time
     )
     assert pending.payload["task_run"].pop("estimated_start_time_delta") > 0.0
-    assert (
-        pending.payload["task_run"]
-        .pop("task_key")
-        .startswith("test_task_state_change_happy_path.<locals>.happy_little_tree")
-    )
+    assert pending.payload["task_run"].pop("task_key").startswith("happy_little_tree")
     assert pending.payload == {
         "initial_state": None,
         "intended": {"from": None, "to": "PENDING"},
@@ -112,11 +108,7 @@ async def test_task_state_change_happy_path(
         == task_run.expected_start_time
     )
     assert running.payload["task_run"].pop("estimated_start_time_delta") > 0.0
-    assert (
-        running.payload["task_run"]
-        .pop("task_key")
-        .startswith("test_task_state_change_happy_path.<locals>.happy_little_tree")
-    )
+    assert running.payload["task_run"].pop("task_key").startswith("happy_little_tree")
     assert running.payload == {
         "intended": {"from": "PENDING", "to": "RUNNING"},
         "initial_state": {
@@ -169,11 +161,7 @@ async def test_task_state_change_happy_path(
         == task_run.expected_start_time
     )
     assert completed.payload["task_run"].pop("estimated_start_time_delta") > 0.0
-    assert (
-        completed.payload["task_run"]
-        .pop("task_key")
-        .startswith("test_task_state_change_happy_path.<locals>.happy_little_tree")
-    )
+    assert completed.payload["task_run"].pop("task_key").startswith("happy_little_tree")
     assert completed.payload["task_run"].pop("estimated_run_time") > 0.0
     assert (
         pendulum.parse(completed.payload["task_run"].pop("start_time"))
@@ -262,11 +250,7 @@ async def test_task_state_change_task_failure(
         == task_run.expected_start_time
     )
     assert pending.payload["task_run"].pop("estimated_start_time_delta") > 0.0
-    assert (
-        pending.payload["task_run"]
-        .pop("task_key")
-        .startswith("test_task_state_change_task_failure.<locals>.happy_little_tree")
-    )
+    assert pending.payload["task_run"].pop("task_key").startswith("happy_little_tree")
     assert pending.payload == {
         "initial_state": None,
         "intended": {"from": None, "to": "PENDING"},
@@ -314,11 +298,7 @@ async def test_task_state_change_task_failure(
         == task_run.expected_start_time
     )
     assert running.payload["task_run"].pop("estimated_start_time_delta") > 0.0
-    assert (
-        running.payload["task_run"]
-        .pop("task_key")
-        .startswith("test_task_state_change_task_failure.<locals>.happy_little_tree")
-    )
+    assert running.payload["task_run"].pop("task_key").startswith("happy_little_tree")
     assert running.payload == {
         "intended": {"from": "PENDING", "to": "RUNNING"},
         "initial_state": {
@@ -374,11 +354,7 @@ async def test_task_state_change_task_failure(
         == task_run.expected_start_time
     )
     assert failed.payload["task_run"].pop("estimated_start_time_delta") > 0.0
-    assert (
-        failed.payload["task_run"]
-        .pop("task_key")
-        .startswith("test_task_state_change_task_failure.<locals>.happy_little_tree")
-    )
+    assert failed.payload["task_run"].pop("task_key").startswith("happy_little_tree")
     assert failed.payload["task_run"].pop("estimated_run_time") > 0.0
     assert (
         pendulum.parse(failed.payload["task_run"].pop("start_time"))

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -1,6 +1,4 @@
 import asyncio
-import inspect
-import os
 from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, AsyncGenerator, Iterable, Tuple
@@ -26,7 +24,6 @@ from prefect.settings import (
     temporary_settings,
 )
 from prefect.task_worker import TaskWorker
-from prefect.utilities.hashing import hash_objects
 
 if TYPE_CHECKING:
     from prefect.client.orchestration import PrefectClient
@@ -447,22 +444,3 @@ class TestMap:
                 "parameters": {"x": i + 1, "mappable": ["some", "iterable"]},
                 "context": mock.ANY,
             }
-
-
-class TestTaskKey:
-    def test_task_key_includes_qualname_and_source_file_hash(self):
-        def some_fn():
-            pass
-
-        t = Task(fn=some_fn)
-        source_file = os.path.abspath(inspect.getsourcefile(some_fn))
-        task_origin_hash = hash_objects(t.name, source_file)
-        assert t.task_key == f"{some_fn.__qualname__}-{task_origin_hash}"
-
-    def test_task_key_handles_unknown_source_file(self, monkeypatch):
-        def some_fn():
-            pass
-
-        monkeypatch.setattr(inspect, "getsourcefile", lambda x: None)
-        t = Task(fn=some_fn)
-        assert t.task_key == f"{some_fn.__qualname__}-unknown-source-file"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -102,6 +102,20 @@ class TestTaskName:
         assert my_task.name == "another_name"
 
 
+class TestTaskKey:
+    def test_task_key_typical_case(self):
+        @task
+        def my_task():
+            pass
+
+        assert my_task.task_key.startswith("my_task-")
+
+    def test_task_key_after_import(self):
+        from tests.generic_tasks import noop
+
+        assert noop.task_key.startswith("noop-")
+
+
 class TestTaskRunName:
     def test_run_name_default(self):
         @task


### PR DESCRIPTION
closes #13735 

this PR removes our reliance on the absolute path of the source file, which caused persistent cache misses due to source code being cloned to tmp dirs

the original issue was reported on a 2.x version - if this looks good I can backport this to `2.x`