### PR TITLE
update task run counts on retry with client-side task orchestration

### DIFF
--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -426,6 +426,8 @@ class TaskRunEngine(Generic[P, R]):
             else:
                 delay = None
                 new_state = Retrying()
+                if PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
+                    self.task_run.run_count += 1
 
             self.logger.info(
                 "Task run failed with exception: %r - " "Retry %s/%s will start %s",


### PR DESCRIPTION
When moving to a `Retrying()` state and using client side orchestration, make sure to update the run count. This lets us remove an `xfail` around an existing test