### PR TITLE
silence `PrefectDeprecationWarning` in tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,7 @@ filterwarnings =
     ignore::ResourceWarning
     ignore::pytest.PytestUnraisableExceptionWarning
     ignore::pluggy.PluggyTeardownRaisedWarning
+    ignore::prefect._internal.compatibility.deprecated.PrefectDeprecationWarning
 
 [mypy]
 plugins=


### PR DESCRIPTION
update setup.cfg to allow us to show users deprecation warnings without failing tests