### PR TITLE
Add `prefect.version` to event's resource

### DIFF
--- a/src/prefect/events/worker.py
+++ b/src/prefect/events/worker.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from typing_extensions import Self
 
+import prefect
 from prefect._internal.concurrency.services import QueueService
 from prefect.settings import (
     PREFECT_API_KEY,
@@ -73,6 +74,7 @@ class EventsWorker(QueueService[Event]):
         context = self._context_cache.pop(event.id)
         with temporary_context(context=context):
             await self.attach_related_resources_from_context(event)
+            event.resource["prefect.version"] = prefect.__version__
 
         await self._client.emit(event)
 

--- a/src/prefect/events/worker.py
+++ b/src/prefect/events/worker.py
@@ -74,7 +74,7 @@ class EventsWorker(QueueService[Event]):
         context = self._context_cache.pop(event.id)
         with temporary_context(context=context):
             await self.attach_related_resources_from_context(event)
-            event.resource["prefect.version"] = prefect.__version__
+            event.resource["prefect.version"] = str(prefect.__version__)
 
         await self._client.emit(event)
 


### PR DESCRIPTION
closes: https://github.com/PrefectHQ/prefect/issues/14580

Attach `prefect.__version__` to all events.