### PR TITLE
Backport _sync kwarg to 2.x

### DIFF
--- a/tests/utilities/test_asyncutils.py
+++ b/tests/utilities/test_asyncutils.py
@@ -45,6 +45,22 @@ def test_is_async_fn_lambda():
     assert not is_async_fn(lambda: True)
 
 
+def test_sync_compatible_allows_forced_behavior_sync():
+    async def foo():
+        return 42
+
+    assert sync_compatible(foo)(_sync=True) == 42
+
+
+async def test_sync_compatible_allows_forced_behavior_sync_and_async():
+    async def foo():
+        return 42
+
+    assert sync_compatible(foo)(_sync=True) == 42
+    assert await sync_compatible(foo)(_sync=False) == 42
+    assert await sync_compatible(foo)() == 42
+
+
 def test_is_async_fn_sync_context_manager():
     @contextmanager
     def foo():


### PR DESCRIPTION
This PR backports the `_sync` kwarg on `sync_compatible` decorated methods and functions.

There's a lot of conditional logic here so it may take some inspection to convince yourself that this won't affect current behavior.

Related to #14712 