### PR TITLE
Update dependabot given recent OSS changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,30 +5,30 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    labels: ["maintenance"]
+    labels: ["development"]
 
   - package-ecosystem: "npm"
     directory: '/ui/'
     schedule:
       interval: "weekly"
-    labels: ["ui", "maintenance"]
+    labels: ["ui", "development"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    labels: ["maintenance"]
+    labels: ["development"]
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
-    labels: ["maintenance"]
+    labels: ["development"]
 
-  # Check for Python updates in v1
+  # Check for Python updates in v2
   - package-ecosystem: "pip"
-    target-branch: "1.x"
+    target-branch: "2.x"
     directory: "/"
     schedule:
       interval: "daily"
-    labels: ["maintenance", "v1"]
+    labels: ["development", "2.x"]


### PR DESCRIPTION
Updates dependabot settings to account for new labels and the 2.x/3.x split.