### PR TITLE
add `prefect profiles populate-defaults` CLI command

### DIFF
--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -259,27 +259,25 @@ def inspect(
 def populate_defaults():
     """Populate the profiles configuration with the default base profiles."""
     user_profiles_path = prefect.settings.PREFECT_PROFILES_PATH.value()
-    DEFAULT_PROFILES_TEMPLATE_CONTENT = (
-        prefect.settings.DEFAULT_PROFILES_PATH.read_text()
-    )
+    DEFAULT_PROFILES_CONTENT = prefect.settings.DEFAULT_PROFILES_PATH.read_text()
 
     if user_profiles_path.exists():
-        if user_profiles_path.read_text() == DEFAULT_PROFILES_TEMPLATE_CONTENT:
+        if user_profiles_path.read_text() == DEFAULT_PROFILES_CONTENT:
             app.console.print(
                 "Default profiles are already populated. [green]No action required[/green]."
             )
             return
-        if not typer.confirm(f"Overwrite existing profiles at {user_profiles_path}?"):
-            app.console.print("Operation cancelled.")
-            return
-
         if user_profiles_path.read_text() != _OLD_MINIMAL_DEFAULT_PROFILE_CONTENT:
             backup_path = user_profiles_path.with_suffix(".toml.bak")
             if typer.confirm(f"Back up existing profiles to {backup_path}?"):
                 shutil.copy(user_profiles_path, backup_path)
                 app.console.print(f"Profiles backed up to {backup_path}")
 
-    user_profiles_path.write_text(DEFAULT_PROFILES_TEMPLATE_CONTENT)
+        if not typer.confirm(f"Overwrite existing profiles at {user_profiles_path}?"):
+            app.console.print("Operation cancelled.")
+            return
+
+    user_profiles_path.write_text(DEFAULT_PROFILES_CONTENT)
 
     app.console.print(
         f"Default profiles populated in [green]{user_profiles_path}[/green]"

--- a/src/prefect/profiles.toml
+++ b/src/prefect/profiles.toml
@@ -1,14 +1,13 @@
-# This is the default profile configuration for Prefect.
-# Users can modify these profiles or create new ones to suit their needs.
+# This is a template for profile configuration for Prefect.
+# You can modify these profiles or create new ones to suit their needs.
 
 active = "ephemeral"
 
 [profiles.ephemeral]
-# The actual path will be resolved when the setting is used
 PREFECT_API_DATABASE_CONNECTION_URL = "sqlite+aiosqlite:///prefect.db"
 
 [profiles.local]
-# Users will need to set these values appropriately
+# You will need to set these values appropriately
 PREFECT_API_URL = "http://127.0.0.1:4200/api"
 
 [profiles.test]

--- a/src/prefect/profiles.toml
+++ b/src/prefect/profiles.toml
@@ -19,4 +19,4 @@ PREFECT_RESULTS_PERSIST_BY_DEFAULT = false
 # This is a placeholder for Prefect Cloud configuration
 # Run "prefect cloud login" to set up your Prefect Cloud profile
 # PREFECT_API_URL = "https://api.prefect.cloud/api/accounts/[ACCOUNT-ID]/workspaces/[WORKSPACE-ID]"
-# PREFECT_API_KEY = "your-api-key-here"
+# PREFECT_API_KEY = "pnu_rest-of-your-api-key-here"

--- a/src/prefect/profiles.toml
+++ b/src/prefect/profiles.toml
@@ -1,7 +1,9 @@
 # This is a template for profile configuration for Prefect.
 # You can modify these profiles or create new ones to suit their needs.
 
-active = "ephemeral"
+active = "default"
+
+[profiles.default]
 
 [profiles.ephemeral]
 PREFECT_API_DATABASE_CONNECTION_URL = "sqlite+aiosqlite:///prefect.db"

--- a/src/prefect/profiles.toml
+++ b/src/prefect/profiles.toml
@@ -1,3 +1,22 @@
-active = "default"
+# This is the default profile configuration for Prefect.
+# Users can modify these profiles or create new ones to suit their needs.
 
-[profiles.default]
+active = "ephemeral"
+
+[profiles.ephemeral]
+# The actual path will be resolved when the setting is used
+PREFECT_API_DATABASE_CONNECTION_URL = "sqlite+aiosqlite:///prefect.db"
+
+[profiles.local]
+# Users will need to set these values appropriately
+PREFECT_API_URL = "http://127.0.0.1:4200/api"
+
+[profiles.test]
+PREFECT_API_DATABASE_CONNECTION_URL = "sqlite+aiosqlite:///:memory:"
+PREFECT_RESULTS_PERSIST_BY_DEFAULT = false
+
+[profiles.cloud]
+# This is a placeholder for Prefect Cloud configuration
+# Run "prefect cloud login" to set up your Prefect Cloud profile
+# PREFECT_API_URL = "https://api.prefect.cloud/api/accounts/[ACCOUNT-ID]/workspaces/[WORKSPACE-ID]"
+# PREFECT_API_KEY = "your-api-key-here"

--- a/src/prefect/profiles.toml
+++ b/src/prefect/profiles.toml
@@ -12,9 +12,6 @@ PREFECT_API_DATABASE_CONNECTION_URL = "sqlite+aiosqlite:///prefect.db"
 # You will need to set these values appropriately
 PREFECT_API_URL = "http://127.0.0.1:4200/api"
 
-[profiles.test]
-PREFECT_API_DATABASE_CONNECTION_URL = "sqlite+aiosqlite:///:memory:"
-PREFECT_RESULTS_PERSIST_BY_DEFAULT = false
 
 [profiles.cloud]
 # This is a placeholder for Prefect Cloud configuration

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -2125,10 +2125,10 @@ def load_current_profile():
     This will _not_ include settings from the current settings context. Only settings
     that have been persisted to the profiles file will be saved.
     """
-    from prefect.context import SettingsContext
+    import prefect.context
 
     profiles = load_profiles()
-    context = SettingsContext.get()
+    context = prefect.context.get_settings_context()
 
     if context:
         profiles.set_active(context.profile.name)

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -610,9 +610,7 @@ def test_populate_defaults(tmp_path, monkeypatch):
     assert populated_profiles.names == default_profiles.names
     assert populated_profiles.active_name == default_profiles.active_name
 
-    assert {"local", "ephemeral", "test", "cloud", "default"} == set(
-        populated_profiles.names
-    )
+    assert {"local", "ephemeral", "cloud", "default"} == set(populated_profiles.names)
 
     for name in default_profiles.names:
         assert populated_profiles[name].settings == default_profiles[name].settings
@@ -642,7 +640,7 @@ def test_populate_defaults_with_existing_profiles(tmp_path, monkeypatch):
 
     new_profiles = load_profiles()
     assert "existing" not in new_profiles.names
-    assert {"local", "ephemeral", "test", "cloud", "default"} == set(new_profiles.names)
+    assert {"local", "ephemeral", "cloud", "default"} == set(new_profiles.names)
 
     backup_profiles = _read_profiles_from(temp_profiles_path.with_suffix(".toml.bak"))
     assert "existing" in backup_profiles.names

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -610,7 +610,9 @@ def test_populate_defaults(tmp_path, monkeypatch):
     assert populated_profiles.names == default_profiles.names
     assert populated_profiles.active_name == default_profiles.active_name
 
-    assert {"local", "ephemeral", "test", "cloud"} == set(populated_profiles.names)
+    assert {"local", "ephemeral", "test", "cloud", "default"} == set(
+        populated_profiles.names
+    )
 
     for name in default_profiles.names:
         assert populated_profiles[name].settings == default_profiles[name].settings
@@ -640,7 +642,7 @@ def test_populate_defaults_with_existing_profiles(tmp_path, monkeypatch):
 
     new_profiles = load_profiles()
     assert "existing" not in new_profiles.names
-    assert {"local", "ephemeral", "test", "cloud"} == set(new_profiles.names)
+    assert {"local", "ephemeral", "test", "cloud", "default"} == set(new_profiles.names)
 
     backup_profiles = _read_profiles_from(temp_profiles_path.with_suffix(".toml.bak"))
     assert "existing" in backup_profiles.names

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -598,7 +598,7 @@ def test_populate_defaults(tmp_path, monkeypatch):
         ["profile", "populate-defaults"],
         user_input="y",
         expected_output_contains=[
-            f"Default profiles populated in {temp_profiles_path}",
+            f"Profiles updated in {temp_profiles_path}",
             "Use with prefect profile use [PROFILE-NAME]",
         ],
     )
@@ -632,15 +632,16 @@ def test_populate_defaults_with_existing_profiles(tmp_path, monkeypatch):
             "y" + readchar.key.ENTER + "y" + readchar.key.ENTER
         ),  # Confirm overwrite and backup
         expected_output_contains=[
-            "Overwrite existing profiles",
+            "Update profiles at",
             f"Profiles backed up to {temp_profiles_path}.bak",
-            f"Default profiles populated in {temp_profiles_path}",
+            f"Profiles updated in {temp_profiles_path}",
         ],
     )
 
     new_profiles = load_profiles()
-    assert "existing" not in new_profiles.names
-    assert {"local", "ephemeral", "cloud", "default"} == set(new_profiles.names)
+    assert {"local", "ephemeral", "cloud", "default", "existing"} == set(
+        new_profiles.names
+    )
 
     backup_profiles = _read_profiles_from(temp_profiles_path.with_suffix(".toml.bak"))
     assert "existing" in backup_profiles.names

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -299,7 +299,7 @@ class TestSettingsContext:
             Profile(name="default", settings={}, source=DEFAULT_PROFILES_PATH),
             override_environment_variables=False,
         )
-        use_profile().__enter__.assert_called_once_with()
+        use_profile().__enter__.assert_called_once()
         assert result is not None
 
     @pytest.mark.parametrize(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -569,31 +569,22 @@ class TestLoadProfiles:
 
     def test_load_profiles_with_default(self, temporary_profiles_path):
         temporary_profiles_path.write_text(
-            textwrap.dedent(
-                """
-                [profiles.default]
-                PREFECT_API_KEY = "foo"
+            """
+            [profiles.default]
+            PREFECT_API_KEY = "foo"
 
-                [profiles.bar]
-                PREFECT_API_KEY = "bar"
-                """
-            )
+            [profiles.bar]
+            PREFECT_API_KEY = "bar"
+            """
         )
-        assert load_profiles() == ProfilesCollection(
-            profiles=[
-                Profile(
-                    name="default",
-                    settings={PREFECT_API_KEY: "foo"},
-                    source=temporary_profiles_path,
-                ),
-                Profile(
-                    name="bar",
-                    settings={PREFECT_API_KEY: "bar"},
-                    source=temporary_profiles_path,
-                ),
-            ],
-            active="default",
-        )
+        profiles = load_profiles()
+        expected = {
+            "default": {PREFECT_API_KEY: "foo"},
+            "bar": {PREFECT_API_KEY: "bar"},
+        }
+        for name, settings in expected.items():
+            assert profiles[name].settings == settings
+            assert profiles[name].source == temporary_profiles_path
 
     def test_load_profile_default(self):
         assert load_profile("default") == Profile(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

this PR adds a `populate-defaults` command to the `profiles` subgroup of the CLI to populate the `PREFECT_PROFILES_PATH` with a sane starting place that conveys best practices on how to use profiles.

- if the recommended template content already exists at `PREFECT_PROFILES_PATH`, no action is taken and we exit
- if a custom `profiles.toml` exists at `PREFECT_PROFILES_PATH` the user will be asked to confirm a backup and update to their existing file (if any profiles with the recommended names exist, they will be carried over untouched).
- if we havent exited, the content of `src/prefect/profiles.toml` will be written to `PREFECT_PROFILES_PATH`


this PR omits the `test` profile for now, see the comment below for why
```
[profiles.test]
PREFECT_API_DATABASE_CONNECTION_URL = "sqlite+aiosqlite:///:memory:"
PREFECT_RESULTS_PERSIST_BY_DEFAULT = false
```
