### PR TITLE
Update github auto-release notes template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -17,10 +17,13 @@ changelog:
     - title: Experimental 🔬
       labels:
         - experimental
-    - title: Integrations & Dependencies
+    - title: Integrations & Dependencies 🤝
       labels:
         - integrations
         - upstream dependency
+    - title: Development & Tidiness 🧹
+      labels:
+        - development
     - title: Uncategorized
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,34 +1,26 @@
 # .github/release.yml
 
 changelog:
-  exclude:
-    labels:
-      - maintenance
   categories:
-    - title: Breaking Changes
+    - title: Breaking Changes ⚠️
       labels:
         - breaking
-    - title: Exciting New Features 🎉
+        - deprecation
+    - title: New Features 🎉
       labels:
         - feature
-    - title: Enhancements
-      labels:
         - enhancement
-    - title: Fixes
+    - title: Bug Fixes 🐞
       labels:
         - fix
-    - title: Experimental
+        - bug
+    - title: Experimental 🔬
       labels:
         - experimental
-    - title: Deprecations
+    - title: Integrations & Dependencies
       labels:
-        - deprecation
-    - title: Documentation
-      labels:
-        - docs
-    - title: Collections
-      labels:
-        - collections
+        - integrations
+        - upstream dependency
     - title: Uncategorized
       labels:
         - "*"


### PR DESCRIPTION
This PR updates the template for our auto-generated release notes within GitHub, and will replace our `generate-release-notes.py` script once tested.