### PR TITLE
Add support for Snowflake private_key in prefect_dbt

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/cli/configs/snowflake.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/cli/configs/snowflake.py
@@ -106,6 +106,7 @@ class SnowflakeTargetConfigs(BaseTargetConfigs):
             # duo mfa / sso
             "authenticator": "authenticator",
             # key pair
+            "private_key": "private_key",
             "private_key_path": "private_key_path",
             "private_key_passphrase": "private_key_passphrase",
             # optional
@@ -124,5 +125,9 @@ class SnowflakeTargetConfigs(BaseTargetConfigs):
                 continue
             # rename key to something dbt profile expects
             dbt_key = rename_keys.get(key) or key
-            configs_json[dbt_key] = all_configs_json[key]
+            value = all_configs_json[key]
+            if key == "private_key":
+                #  SnowflakeCredentials stores private_key as SecretBytes
+                value = value.decode()
+            configs_json[dbt_key] = value
         return configs_json

--- a/src/integrations/prefect-dbt/tests/cli/configs/test_snowflake.py
+++ b/src/integrations/prefect-dbt/tests/cli/configs/test_snowflake.py
@@ -115,3 +115,40 @@ def test_snowflake_target_configs_allow_field_overrides():
         "warehouse": "warehouse",
     }
     assert actual == expected
+
+
+def test_snowflake_target_configs_get_configs_private_key():
+    credentials = SnowflakeCredentials(
+        account="account",
+        user="user",
+        private_key="some-private-key",
+    )
+    snowflake_connector = SnowflakeConnector(
+        schema="schema",
+        database="database",
+        warehouse="warehouse",
+        credentials=credentials,
+    )
+    configs = SnowflakeTargetConfigs(
+        connector=snowflake_connector, extras={"retry_on_database_errors": True}
+    )
+
+    actual = configs.get_configs()
+    expected = dict(
+        account="account",
+        user="user",
+        private_key="some-private-key",
+        type="snowflake",
+        schema="schema",
+        database="database",
+        warehouse="warehouse",
+        authenticator="snowflake",
+        retry_on_database_errors=True,
+        threads=4,
+    )
+    for k, v in actual.items():
+        actual_v = (
+            v.get_secret_value() if isinstance(v, (SecretBytes, SecretStr)) else v
+        )
+        expected_v = expected[k]
+        assert actual_v == expected_v


### PR DESCRIPTION
Per [dbt documentation](https://docs.getdbt.com/docs/core/connect-data-platform/snowflake-setup#key-pair-authentication), 

> Starting from [dbt version 1.7](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v1.7), dbt introduced the ability to specify a private_key directly as a string instead of a private_key_path.

This change makes sure that a `private_key`, if specified in the `SnowflakeConnector`, is included in the dbt profile. 

One hiccup is that the `private_key` in `SnowflakeCredentials` is a `Optional[SecretBytes]`, which, if left as-is, is written as a binary to `profiles.yml`—which is not supported by `dbt`. So, we deal with the edge-case by manually `decode`-ing `private_key` if it exists. 

### Example

```python
from prefect_dbt.cli import DbtCliProfile
from prefect_dbt.cli.configs import SnowflakeTargetConfigs
from prefect_snowflake.credentials import SnowflakeCredentials
from prefect_snowflake.database import SnowflakeConnector

credentials = SnowflakeCredentials(
    user="user",
    account="account.region.aws",
    private_key="my-private-key",
    private_key_passphrase="my-secret-passphrase",
    role="role",
)
connector = SnowflakeConnector(
    schema="public",
    database="database",
    warehouse="warehouse",
    credentials=credentials,
)
target_configs = SnowflakeTargetConfigs(
    connector=connector,
    extras={"retry_on_database_errors": True},
)
dbt_profile = DbtCliProfile(
    name="my-profile",
    target="target",
    target_configs=target_configs,
)
dbt_profile.get_profile()
```

#### Before

Note the absence of "private_key"

```
{
    "config": {},
    "my-profile": {
        "target": "target",
        "outputs": {
            "target": {
                "retry_on_database_errors": True,
                "type": "snowflake",
                "threads": 4,
                "account": "account.region.aws",
                "user": "user",
                "private_key_passphrase": "my-secret-passphrase",
                "authenticator": "snowflake",
                "role": "role",
                "database": "database",
                "warehouse": "warehouse",
                "schema": "public",
            }
        },
    },
}
```

#### After

Note the presence of "private_key", as a decoded `str`.

```diff
 {
     "config": {},
     "my-profile": {
         "target": "target",
         "outputs": {
             "target": {
                 "retry_on_database_errors": True,
                 "type": "snowflake",
                 "threads": 4,
                 "account": "account.region.aws",
                 "user": "user",
+                "private_key": "my-private-key",
                 "private_key_passphrase": "my-secret-passphrase",
                 "authenticator": "snowflake",
                 "role": "role",
                 "database": "database",
                 "warehouse": "warehouse",
                 "schema": "public",
             }
         },
     },
 }
```

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- ~~[ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.~~
- ~~[ ] If this pull request adds functions or classes, it includes helpful docstrings.~~
