### PR TITLE
record events with ephemeral api

### DIFF
--- a/src/prefect/server/events/pipeline.py
+++ b/src/prefect/server/events/pipeline.py
@@ -2,7 +2,7 @@ from typing import List
 
 import pendulum
 
-from prefect.server.events.schemas.events import ReceivedEvent
+from prefect.server.events.schemas.events import Event, ReceivedEvent
 from prefect.server.events.services import event_persister
 from prefect.server.services import task_run_recorder
 from prefect.server.utilities.messaging.memory import MemoryMessage
@@ -22,6 +22,10 @@ class EventsPipeline:
             )
             messages.append(message)
         return messages
+
+    async def process_events(self, events: List[Event]):
+        messages = self.events_to_messages(events)
+        await self.process_messages(messages)
 
     async def process_messages(self, messages: List[MemoryMessage]):
         for message in messages:

--- a/src/prefect/server/events/pipeline.py
+++ b/src/prefect/server/events/pipeline.py
@@ -1,7 +1,5 @@
 from typing import List
 
-import pendulum
-
 from prefect.server.events.schemas.events import Event, ReceivedEvent
 from prefect.server.events.services import event_persister
 from prefect.server.services import task_run_recorder
@@ -13,9 +11,7 @@ class EventsPipeline:
     def events_to_messages(events) -> List[MemoryMessage]:
         messages = []
         for event in events:
-            received_event = ReceivedEvent(
-                received=pendulum.now("UTC"), **event.model_dump()
-            )
+            received_event = ReceivedEvent(**event.model_dump())
             message = MemoryMessage(
                 data=received_event.model_dump_json().encode(),
                 attributes={"id": str(event.id), "event": event.event},


### PR DESCRIPTION
When receiving events via `ephemeral_request`, we previously wrote the events directly to the DB. This PR updates that to use the newly added `EventsPipeline` to make sure we're doing all the bookkeeping we want when an event reaches the api.