### PR TITLE
Microsoft Teams Webhook Support for Power Automate (Workflows)

### DIFF
--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -151,15 +151,14 @@ class MicrosoftTeamsWebhook(AppriseNotificationBlock):
         """see https://github.com/caronc/apprise/pull/1172"""
         from apprise.plugins.workflows import NotifyWorkflows
 
-        parsed_url = NotifyWorkflows.parse_native_url(self.url.get_secret_value())
-        if not parsed_url:
+        if not (
+            parsed_url := NotifyWorkflows.parse_native_url(self.url.get_secret_value())
+        ):
             raise ValueError("Invalid Microsoft Teams Workflow URL provided.")
 
-        parsed_url["include_image"] = self.include_image
-        parsed_url["wrap"] = self.wrap
+        parsed_url |= {"include_image": self.include_image, "wrap": self.wrap}
 
-        notify_workflows = NotifyWorkflows(**parsed_url)
-        self._start_apprise_client(SecretStr(notify_workflows.url()))
+        self._start_apprise_client(SecretStr(NotifyWorkflows(**parsed_url).url()))
 
 
 class PagerDutyWebHook(AbstractAppriseNotificationBlock):

--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -129,13 +129,37 @@ class MicrosoftTeamsWebhook(AppriseNotificationBlock):
     _documentation_url = "https://docs.prefect.io/api-ref/prefect/blocks/notifications/#prefect.blocks.notifications.MicrosoftTeamsWebhook"
 
     url: SecretStr = Field(
-        ...,
+        default=...,
         title="Webhook URL",
-        description="The Teams incoming webhook URL used to send notifications.",
+        description="The Microsoft Power Automate (Workflows) URL used to send notifications to Teams.",
         examples=[
-            "https://your-org.webhook.office.com/webhookb2/XXX/IncomingWebhook/YYY/ZZZ"
+            "https://prod-NO.LOCATION.logic.azure.com:443/workflows/WFID/triggers/manual/paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=SIGNATURE"
         ],
     )
+
+    include_image: bool = Field(
+        default=True,
+        description="Include an image with the notification.",
+    )
+
+    wrap: bool = Field(
+        default=True,
+        description="Wrap the notification text.",
+    )
+
+    def block_initialization(self) -> None:
+        """see https://github.com/caronc/apprise/pull/1172"""
+        from apprise.plugins.workflows import NotifyWorkflows
+
+        parsed_url = NotifyWorkflows.parse_native_url(self.url.get_secret_value())
+        if not parsed_url:
+            raise ValueError("Invalid Microsoft Teams Workflow URL provided.")
+
+        parsed_url["include_image"] = self.include_image
+        parsed_url["wrap"] = self.wrap
+
+        notify_workflows = NotifyWorkflows(**parsed_url)
+        self._start_apprise_client(SecretStr(notify_workflows.url()))
 
 
 class PagerDutyWebHook(AbstractAppriseNotificationBlock):

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -12,6 +12,7 @@ from prefect.blocks.notifications import (
     CustomWebhookNotificationBlock,
     DiscordWebhook,
     MattermostWebhook,
+    MicrosoftTeamsWebhook,
     OpsgenieWebhook,
     PagerDutyWebHook,
     SendgridEmail,
@@ -22,7 +23,12 @@ from prefect.testing.utilities import AsyncMock
 
 # A list of the notification classes Pytest should use as parameters to each method in TestAppriseNotificationBlock
 notification_classes = sorted(
-    AppriseNotificationBlock.__subclasses__(), key=lambda cls: cls.__name__
+    [
+        cls
+        for cls in AppriseNotificationBlock.__subclasses__()
+        if cls != MicrosoftTeamsWebhook
+    ],
+    key=lambda cls: cls.__name__,
 )
 
 
@@ -44,10 +50,8 @@ class TestAppriseNotificationBlock:
             apprise_instance_mock.add.assert_called_once_with(
                 block.url.get_secret_value()
             )
-
-            notify_type = PREFECT_NOTIFY_TYPE_DEFAULT
             apprise_instance_mock.async_notify.assert_awaited_once_with(
-                body="test", title=None, notify_type=notify_type
+                body="test", title=None, notify_type=PREFECT_NOTIFY_TYPE_DEFAULT
             )
 
     def test_notify_sync(self, block_class: Type[AppriseNotificationBlock]):
@@ -72,7 +76,7 @@ class TestAppriseNotificationBlock:
             )
 
     def test_is_picklable(self, block_class: Type[AppriseNotificationBlock]):
-        block = block_class(url="http://example.com/notification")
+        block = block_class(url="https://example.com/notification")
         pickled = cloudpickle.dumps(block)
         unpickled = cloudpickle.loads(pickled)
         assert isinstance(unpickled, block_class)
@@ -694,3 +698,54 @@ class TestSendgridEmail:
         pickled = cloudpickle.dumps(block)
         unpickled = cloudpickle.loads(pickled)
         assert isinstance(unpickled, SendgridEmail)
+
+
+class TestMicrosoftTeamsWebhook:
+    SAMPLE_URL = "https://prod-NO.LOCATION.logic.azure.com:443/workflows/WFID/triggers/manual/paths/invoke?sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=SIGNATURE"
+
+    async def test_notify_async(self):
+        with patch("apprise.Apprise", autospec=True) as AppriseMock:
+            apprise_instance_mock = AppriseMock.return_value
+            apprise_instance_mock.async_notify = AsyncMock()
+
+            block = MicrosoftTeamsWebhook(url=self.SAMPLE_URL)
+            await block.notify("test")
+
+            AppriseMock.assert_called_once()
+            apprise_instance_mock.add.assert_called_once_with(
+                "workflow://prod-NO.LOCATION.logic.azure.com:443/WFID/SIGNATURE/"
+                "?image=yes&wrap=yes"
+                "&format=markdown&overflow=upstream&rto=4.0&cto=4.0&verify=yes"
+            )
+            apprise_instance_mock.async_notify.assert_awaited_once_with(
+                body="test", title=None, notify_type=PREFECT_NOTIFY_TYPE_DEFAULT
+            )
+
+    def test_notify_sync(self):
+        with patch("apprise.Apprise", autospec=True) as AppriseMock:
+            apprise_instance_mock = AppriseMock.return_value
+            apprise_instance_mock.async_notify = AsyncMock()
+
+            block = MicrosoftTeamsWebhook(url=self.SAMPLE_URL)
+
+            @flow
+            def test_flow():
+                block.notify("test")
+
+            test_flow()
+
+            AppriseMock.assert_called_once()
+            apprise_instance_mock.add.assert_called_once_with(
+                "workflow://prod-NO.LOCATION.logic.azure.com:443/WFID/SIGNATURE/"
+                "?image=yes&wrap=yes"
+                "&format=markdown&overflow=upstream&rto=4.0&cto=4.0&verify=yes"
+            )
+            apprise_instance_mock.async_notify.assert_called_once_with(
+                body="test", title=None, notify_type=PREFECT_NOTIFY_TYPE_DEFAULT
+            )
+
+    def test_is_picklable(self):
+        block = MicrosoftTeamsWebhook(url=self.SAMPLE_URL)
+        pickled = cloudpickle.dumps(block)
+        unpickled = cloudpickle.loads(pickled)
+        assert isinstance(unpickled, MicrosoftTeamsWebhook)


### PR DESCRIPTION
closes #14575 

This PR adds support for Microsoft Teams notifications using the new Power Automate (Workflows) system. This update is necessary due to the upcoming deprecation of the old Teams webhook system (see https://github.com/caronc/apprise/issues/1161).

This PR
- Updates `MicrosoftTeamsWebhook` notification block
- Updates tests to accommodate the new block
- Leverages Apprise's `NotifyWorkflows` for handling the new URL format

### example

```python
from prefect.blocks.notifications import MicrosoftTeamsWebhook

teams_webhook = MicrosoftTeamsWebhook(
    url="https://prod-XX.REGION.logic.azure.com:443/workflows/YOUR_WORKFLOW_ID/triggers/manual/paths/invoke?sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=YOUR_SIGNATURE"
)

teams_webhook.notify("meowdy!")
```

### notes
- i dont have Teams access at the moment, so I will need a way to actually test this