### PR TITLE
Adds Prometheus metrics for API and client

### DIFF
--- a/docs/3.0rc/api-ref/rest-api/server/schema.json
+++ b/docs/3.0rc/api-ref/rest-api/server/schema.json
@@ -22522,6 +22522,21 @@
                         "exclusiveMinimum": 0.0,
                         "title": "Prefect Events Websocket Backfill Page Size",
                         "default": 250
+                    },
+                    "PREFECT_API_ENABLE_METRICS": {
+                        "type": "boolean",
+                        "title": "Prefect Api Enable Metrics",
+                        "default": false
+                    },
+                    "PREFECT_CLIENT_ENABLE_METRICS": {
+                        "type": "boolean",
+                        "title": "Prefect Client Enable Metrics",
+                        "default": false
+                    },
+                    "PREFECT_CLIENT_METRICS_PORT": {
+                        "type": "integer",
+                        "title": "Prefect Client Metrics Port",
+                        "default": 4201
                     }
                 },
                 "type": "object",

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -19,6 +19,7 @@ orjson >= 3.7, < 4.0
 packaging >= 21.3, < 24.3
 pathspec >= 0.8.0
 pendulum >= 3.0.0, <4
+prometheus-client >= 0.20.0
 pydantic >= 2.7, < 3.0.0
 pydantic_core >= 2.12.0, < 3.0.0
 pydantic_extra_types >= 2.8.2, < 3.0.0

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -45,6 +45,7 @@ from prefect.settings import PREFECT_HOME, Profile, Settings
 from prefect.states import State
 from prefect.task_runners import TaskRunner
 from prefect.utilities.asyncutils import run_coro_as_sync
+from prefect.utilities.services import start_client_metrics_server
 
 T = TypeVar("T")
 
@@ -301,6 +302,11 @@ class RunContext(ContextModel):
         start_time: The time the run context was entered
         client: The Prefect client instance being used for API communication
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        start_client_metrics_server()
 
     start_time: DateTime = Field(default_factory=lambda: pendulum.now("UTC"))
     input_keyset: Optional[Dict[str, Dict[str, str]]] = None

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -92,7 +92,10 @@ from prefect.utilities.asyncutils import (
 )
 from prefect.utilities.engine import propose_state
 from prefect.utilities.processutils import _register_signal, run_process
-from prefect.utilities.services import critical_service_loop
+from prefect.utilities.services import (
+    critical_service_loop,
+    start_client_metrics_server,
+)
 from prefect.utilities.slugify import slugify
 
 if TYPE_CHECKING:
@@ -379,6 +382,8 @@ class Runner:
                 daemon=True,
             )
             server_thread.start()
+
+        start_client_metrics_server()
 
         async with self as runner:
             async with self._loops_task_group as tg:

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -17,7 +17,7 @@ import asyncpg
 import sqlalchemy as sa
 import sqlalchemy.exc
 import sqlalchemy.orm.exc
-from fastapi import APIRouter, Depends, FastAPI, Request, status
+from fastapi import APIRouter, Depends, FastAPI, Request, Response, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
@@ -693,6 +693,13 @@ def create_app(
 
     if prefect.settings.PREFECT_SERVER_CSRF_PROTECTION_ENABLED.value():
         app.add_middleware(api.middleware.CsrfMiddleware)
+
+    if prefect.settings.PREFECT_API_ENABLE_METRICS:
+        from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+        @api_app.get("/metrics")
+        async def metrics():
+            return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
     api_app.mount(
         "/static",

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1561,6 +1561,26 @@ The page size for the queries to backfill events for websocket subscribers
 """
 
 
+# Metrics settings
+
+PREFECT_API_ENABLE_METRICS = Setting(bool, default=False)
+"""
+Whether or not to enable Prometheus metrics in the server application.  Metrics are
+served at the path /api/metrics on the API server.
+"""
+
+PREFECT_CLIENT_ENABLE_METRICS = Setting(bool, default=False)
+"""
+Whether or not to enable Prometheus metrics in the client SDK.  Metrics are served
+at the path /metrics.
+"""
+
+PREFECT_CLIENT_METRICS_PORT = Setting(int, default=4201)
+"""
+The port to expose the client Prometheus metrics on.
+"""
+
+
 # Deprecated settings ------------------------------------------------------------------
 
 

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -38,6 +38,7 @@ from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import asyncnullcontext, sync_compatible
 from prefect.utilities.engine import emit_task_run_state_change_event, propose_state
 from prefect.utilities.processutils import _register_signal
+from prefect.utilities.services import start_client_metrics_server
 from prefect.utilities.urls import url_for
 
 logger = get_logger("task_worker")
@@ -157,6 +158,8 @@ class TaskWorker:
         Starts a task worker, which runs the tasks provided in the constructor.
         """
         _register_signal(signal.SIGTERM, self.handle_sigterm)
+
+        start_client_metrics_server()
 
         async with asyncnullcontext() if self.started else self:
             logger.info("Starting task worker...")


### PR DESCRIPTION
This adds the `prometheus_client` library as a client-side dependency.  This
is a very lightweight (<500KB compiled) library with no transitive dependencies.
I'm choosing Prometheus here as it is the current standard for metrics from the
CNCF, and because its Python client library is very light and thus suitable for
inclusion on the client-side of Prefect.

There are two "sides" that expose a Prometheus metrics endpoint:

* The Prefect server will expose it from startup if `PREFECT_API_ENABLE_METRICS`
  is on.  This endpoint is at `/api/metrics` (to avoid any potential collision
  with future UI routes).

* The Prefect client SDK will expose these from any of the following points if
  `PREFECT_CLIENT_ENABLE_METRICS` is on:

  * Serving one or more flow via `serve(...)`
  * Serving one or more tasks via `serve(...)`
  * Entering a flow run context for a flow (e.g. entering the engine for a flow
    as a Kubernetes job)

  The client metrics will be served via `localhost` at the port defined in
  `PREFECT_CLIENT_METRICS_PORT`

Note that I haven't included any Prefect-specific metrics here, so we will start
with the stock Python-oriented metrics that come out of the box with
`prometheus_client`.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
