### PR TITLE
Adds metrics for client-side event emission and subscription

### DIFF
--- a/benches/bench_import.py
+++ b/benches/bench_import.py
@@ -1,7 +1,9 @@
 import importlib
 import sys
 
+import prometheus_client
 import pytest
+from prometheus_client import CollectorRegistry
 
 
 @pytest.mark.benchmark(group="imports")
@@ -15,6 +17,9 @@ def bench_import_prefect(benchmark):
 
         # Clear importlib cache
         importlib.invalidate_caches()
+
+        # reset the prometheus registry to clear any previously measured metrics
+        prometheus_client.REGISTRY = CollectorRegistry(auto_describe=True)
 
         import prefect  # noqa
 
@@ -33,6 +38,9 @@ def bench_import_prefect_flow(benchmark):
 
         # Clear importlib cache
         importlib.invalidate_caches()
+
+        # reset the prometheus registry to clear any previously measured metrics
+        prometheus_client.REGISTRY = CollectorRegistry(auto_describe=True)
 
         from prefect import flow  # noqa
 

--- a/benches/bench_import.py
+++ b/benches/bench_import.py
@@ -18,7 +18,7 @@ def bench_import_prefect(benchmark):
         # Clear importlib cache
         importlib.invalidate_caches()
 
-        # reset the prometheus registry to clear any previously measured metrics
+        # reset the prometheus registry to clear any previously registered metrics
         prometheus_client.REGISTRY = CollectorRegistry(auto_describe=True)
 
         import prefect  # noqa
@@ -39,7 +39,7 @@ def bench_import_prefect_flow(benchmark):
         # Clear importlib cache
         importlib.invalidate_caches()
 
-        # reset the prometheus registry to clear any previously measured metrics
+        # reset the prometheus registry to clear any previously registered metrics
         prometheus_client.REGISTRY = CollectorRegistry(auto_describe=True)
 
         from prefect import flow  # noqa

--- a/benches/bench_import.py
+++ b/benches/bench_import.py
@@ -23,15 +23,19 @@ def reset_imports():
 @pytest.mark.benchmark(group="imports")
 def bench_import_prefect(benchmark: BenchmarkFixture):
     def import_prefect():
+        reset_imports()
+
         import prefect  # noqa
 
-    benchmark.pedantic(import_prefect, setup=reset_imports, rounds=15)
+    benchmark(import_prefect)
 
 
 @pytest.mark.timeout(180)
 @pytest.mark.benchmark(group="imports")
 def bench_import_prefect_flow(benchmark: BenchmarkFixture):
     def import_prefect_flow():
+        reset_imports()
+
         from prefect import flow  # noqa
 
-    benchmark.pedantic(import_prefect_flow, setup=reset_imports, rounds=15)
+    benchmark(import_prefect_flow)

--- a/benches/bench_import.py
+++ b/benches/bench_import.py
@@ -1,47 +1,37 @@
 import importlib
 import sys
 
-import prometheus_client
 import pytest
-from prometheus_client import CollectorRegistry
+from prometheus_client import REGISTRY
+from pytest_benchmark.fixture import BenchmarkFixture
+
+
+def reset_imports():
+    # Remove the module from sys.modules if it's there
+    prefect_modules = [key for key in sys.modules if key.startswith("prefect")]
+    for module in prefect_modules:
+        del sys.modules[module]
+
+    # Clear importlib cache
+    importlib.invalidate_caches()
+
+    # reset the prometheus registry to clear any previously measured metrics
+    for collector in list(REGISTRY._collector_to_names):
+        REGISTRY.unregister(collector)
 
 
 @pytest.mark.benchmark(group="imports")
-def bench_import_prefect(benchmark):
+def bench_import_prefect(benchmark: BenchmarkFixture):
     def import_prefect():
-        # To get an accurate result, we want to import the module from scratch each time
-        # Remove the module from sys.modules if it's there
-        prefect_modules = [key for key in sys.modules if key.startswith("prefect")]
-        for module in prefect_modules:
-            del sys.modules[module]
-
-        # Clear importlib cache
-        importlib.invalidate_caches()
-
-        # reset the prometheus registry to clear any previously registered metrics
-        prometheus_client.REGISTRY = CollectorRegistry(auto_describe=True)
-
         import prefect  # noqa
 
-    benchmark(import_prefect)
+    benchmark.pedantic(import_prefect, setup=reset_imports, rounds=50)
 
 
 @pytest.mark.timeout(180)
 @pytest.mark.benchmark(group="imports")
-def bench_import_prefect_flow(benchmark):
+def bench_import_prefect_flow(benchmark: BenchmarkFixture):
     def import_prefect_flow():
-        # To get an accurate result, we want to import the module from scratch each time
-        # Remove the module from sys.modules if it's there
-        prefect_modules = [key for key in sys.modules if key.startswith("prefect")]
-        for module in prefect_modules:
-            del sys.modules[module]
-
-        # Clear importlib cache
-        importlib.invalidate_caches()
-
-        # reset the prometheus registry to clear any previously registered metrics
-        prometheus_client.REGISTRY = CollectorRegistry(auto_describe=True)
-
         from prefect import flow  # noqa
 
-    benchmark(import_prefect_flow)
+    benchmark.pedantic(import_prefect_flow, setup=reset_imports, rounds=50)

--- a/benches/bench_import.py
+++ b/benches/bench_import.py
@@ -25,7 +25,7 @@ def bench_import_prefect(benchmark: BenchmarkFixture):
     def import_prefect():
         import prefect  # noqa
 
-    benchmark.pedantic(import_prefect, setup=reset_imports, rounds=50)
+    benchmark.pedantic(import_prefect, setup=reset_imports, rounds=15)
 
 
 @pytest.mark.timeout(180)
@@ -34,4 +34,4 @@ def bench_import_prefect_flow(benchmark: BenchmarkFixture):
     def import_prefect_flow():
         from prefect import flow  # noqa
 
-    benchmark.pedantic(import_prefect_flow, setup=reset_imports, rounds=50)
+    benchmark.pedantic(import_prefect_flow, setup=reset_imports, rounds=15)


### PR DESCRIPTION
Following the addition of the `prometheus_client` in #14783, this adds counters
for measuring the performance of Prefect event emissions and subscription.

A note about unit tests: I don't traditionally add unit tests for
"leaf-level" instrumentation like this.  Leaf-level here means it is measuring
something about the system and doesn't form part of a measurement API (like if
there were middleware for measuring HTTP latency, for example). Unless it is
particularly complex to calculate, I generally skip extra unit tests and let the
standard test suite and coverage inform me if the instrumentation might be a
problem or not executed.

<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
