### PR TITLE
Make flow/task engine release slots after a timeout

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -3025,6 +3025,19 @@ class PrefectClient:
     async def release_concurrency_slots(
         self, names: List[str], slots: int, occupancy_seconds: float
     ) -> httpx.Response:
+        """
+        Release concurrency slots for the specified limits.
+
+        Args:
+            names (List[str]): A list of limit names for which to release slots.
+            slots (int): The number of concurrency slots to release.
+            occupancy_seconds (float): The duration in seconds that the slots
+                were occupied.
+
+        Returns:
+            httpx.Response: The HTTP response from the server.
+        """
+
         return await self._client.post(
             "/v2/concurrency_limits/decrement",
             json={
@@ -4068,3 +4081,27 @@ class SyncPrefectClient:
         )
 
         return Artifact.model_validate(response.json())
+
+    def release_concurrency_slots(
+        self, names: List[str], slots: int, occupancy_seconds: float
+    ) -> httpx.Response:
+        """
+        Release concurrency slots for the specified limits.
+
+        Args:
+            names (List[str]): A list of limit names for which to release slots.
+            slots (int): The number of concurrency slots to release.
+            occupancy_seconds (float): The duration in seconds that the slots
+                were occupied.
+
+        Returns:
+            httpx.Response: The HTTP response from the server.
+        """
+        return self._client.post(
+            "/v2/concurrency_limits/decrement",
+            json={
+                "names": names,
+                "slots": slots,
+                "occupancy_seconds": occupancy_seconds,
+            },
+        )

--- a/src/prefect/concurrency/context.py
+++ b/src/prefect/concurrency/context.py
@@ -1,0 +1,24 @@
+from contextvars import ContextVar
+from typing import List, Tuple
+
+from prefect.client.orchestration import get_client
+from prefect.context import ContextModel, Field
+
+
+class ConcurrencyContext(ContextModel):
+    __var__: ContextVar = ContextVar("concurrency")
+
+    # Track the slots that have been acquired but were not able to be released
+    # due to cancellation or some other error. These slots are released when
+    # the context manager exits.
+    cleanup_slots: List[Tuple[List[str], int, float]] = Field(default_factory=list)
+
+    def __exit__(self, *exc_info):
+        if self.cleanup_slots:
+            with get_client(sync_client=True) as client:
+                for names, occupy, occupancy_seconds in self.cleanup_slots:
+                    client.release_concurrency_slots(
+                        names=names, slots=occupy, occupancy_seconds=occupancy_seconds
+                    )
+
+        return super().__exit__(*exc_info)

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -354,7 +354,7 @@ class EngineContext(RunContext):
         default_factory=weakref.WeakValueDictionary
     )
 
-    # Events worker to emit events to Prefect Cloud
+    # Events worker to emit events
     events: Optional[EventsWorker] = None
 
     __var__: ContextVar = ContextVar("flow_run")

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -29,6 +29,7 @@ from prefect.client.orchestration import SyncPrefectClient, get_client
 from prefect.client.schemas import FlowRun, TaskRun
 from prefect.client.schemas.filters import FlowRunFilter
 from prefect.client.schemas.sorting import FlowRunSort
+from prefect.concurrency.context import ConcurrencyContext
 from prefect.context import FlowRunContext, SyncClientContext, TagsContext
 from prefect.exceptions import (
     Abort,
@@ -505,6 +506,8 @@ class FlowRunEngine(Generic[P, R]):
                     task_runner=task_runner,
                 )
             )
+            stack.enter_context(ConcurrencyContext())
+
             # set the logger to the flow run logger
             self.logger = flow_run_logger(flow_run=self.flow_run, flow=self.flow)
 

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -35,6 +35,7 @@ from prefect.client.orchestration import PrefectClient, SyncPrefectClient
 from prefect.client.schemas import TaskRun
 from prefect.client.schemas.objects import State, TaskRunInput
 from prefect.concurrency.asyncio import concurrency as aconcurrency
+from prefect.concurrency.context import ConcurrencyContext
 from prefect.concurrency.sync import concurrency
 from prefect.context import (
     AsyncClientContext,
@@ -592,6 +593,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                     client=client,
                 )
             )
+            stack.enter_context(ConcurrencyContext())
 
             self.logger = task_run_logger(task_run=self.task_run, task=self.task)  # type: ignore
 
@@ -1137,6 +1139,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                     client=client,
                 )
             )
+            stack.enter_context(ConcurrencyContext())
 
             self.logger = task_run_logger(task_run=self.task_run, task=self.task)  # type: ignore
 

--- a/tests/concurrency/test_context.py
+++ b/tests/concurrency/test_context.py
@@ -1,0 +1,62 @@
+import asyncio
+import time
+
+import pytest
+
+from prefect.client.orchestration import PrefectClient
+from prefect.concurrency.asyncio import concurrency as aconcurrency
+from prefect.concurrency.context import ConcurrencyContext
+from prefect.concurrency.sync import concurrency
+from prefect.server.schemas.core import ConcurrencyLimitV2
+from prefect.utilities.asyncutils import run_coro_as_sync
+from prefect.utilities.timeout import timeout, timeout_async
+
+
+async def test_concurrency_context_releases_slots_async(
+    concurrency_limit: ConcurrencyLimitV2, prefect_client: PrefectClient
+):
+    async def expensive_task():
+        async with aconcurrency(concurrency_limit.name):
+            response = await prefect_client.read_global_concurrency_limit_by_name(
+                concurrency_limit.name
+            )
+            assert response.active_slots == 1
+
+            # Occupy the slot for longer than the timeout
+            await asyncio.sleep(1)
+
+    with pytest.raises(TimeoutError):
+        with timeout_async(seconds=0.5):
+            with ConcurrencyContext():
+                await expensive_task()
+
+    response = await prefect_client.read_global_concurrency_limit_by_name(
+        concurrency_limit.name
+    )
+    assert response.active_slots == 0
+
+
+async def test_concurrency_context_releases_slots_sync(
+    concurrency_limit: ConcurrencyLimitV2, prefect_client: PrefectClient
+):
+    def expensive_task():
+        with concurrency(concurrency_limit.name):
+            response = run_coro_as_sync(
+                prefect_client.read_global_concurrency_limit_by_name(
+                    concurrency_limit.name
+                )
+            )
+            assert response and response.active_slots == 1
+
+            # Occupy the slot for longer than the timeout
+            time.sleep(1)
+
+    with pytest.raises(TimeoutError):
+        with timeout(seconds=0.5):
+            with ConcurrencyContext():
+                expensive_task()
+
+    response = await prefect_client.read_global_concurrency_limit_by_name(
+        concurrency_limit.name
+    )
+    assert response.active_slots == 0


### PR DESCRIPTION
Because the Flow and Task engines cancel the running flow/task when they hit a timeout the underlying concurrency manager is not able to actually release the acquired slots. This adds a context that allows for tracking when this happens and then releasing the slots when the context exits. 

Related to https://github.com/PrefectHQ/nebula/issues/8177