### PR TITLE
Return early from concurrency() and rate_limit() without limit names

### DIFF
--- a/src/prefect/concurrency/asyncio.py
+++ b/src/prefect/concurrency/asyncio.py
@@ -62,7 +62,12 @@ async def concurrency(
         await resource_heavy()
     ```
     """
+    if not names:
+        yield
+        return
+
     names = names if isinstance(names, list) else [names]
+
     limits = await _acquire_concurrency_slots(
         names,
         occupy,
@@ -99,7 +104,11 @@ async def rate_limit(
             raising a `TimeoutError`. A timeout of `None` will wait indefinitely.
         create_if_missing: Whether to create the concurrency limits if they do not exist.
     """
+    if not names:
+        return
+
     names = names if isinstance(names, list) else [names]
+
     limits = await _acquire_concurrency_slots(
         names,
         occupy,

--- a/src/prefect/concurrency/sync.py
+++ b/src/prefect/concurrency/sync.py
@@ -68,6 +68,10 @@ def concurrency(
         resource_heavy()
     ```
     """
+    if not names:
+        yield
+        return
+
     names = names if isinstance(names, list) else [names]
 
     limits: List[MinimalConcurrencyLimitResponse] = _call_async_function_from_sync(
@@ -110,7 +114,11 @@ def rate_limit(
             raising a `TimeoutError`. A timeout of `None` will wait indefinitely.
         create_if_missing: Whether to create the concurrency limits if they do not exist.
     """
+    if not names:
+        return
+
     names = names if isinstance(names, list) else [names]
+
     limits = _call_async_function_from_sync(
         _acquire_concurrency_slots,
         names,

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -149,6 +149,33 @@ def test_concurrency_can_be_used_within_a_flow(
     assert executed
 
 
+@pytest.mark.parametrize("names", [[], None])
+def test_rate_limit_without_limit_names_sync(names):
+    executed = False
+
+    def resource_heavy():
+        nonlocal executed
+        rate_limit(names=names, occupy=1)
+        executed = True
+
+    assert not executed
+
+    with mock.patch(
+        "prefect.concurrency.sync._acquire_concurrency_slots",
+        wraps=lambda *args, **kwargs: None,  # Mocking to do nothing
+    ) as acquire_spy:
+        with mock.patch(
+            "prefect.concurrency.sync._release_concurrency_slots",
+            wraps=lambda *args, **kwargs: None,  # Mocking to do nothing
+        ) as release_spy:
+            resource_heavy()
+
+            acquire_spy.assert_not_called()
+            release_spy.assert_not_called()
+
+    assert executed
+
+
 async def test_concurrency_can_be_used_while_event_loop_is_running(
     concurrency_limit: ConcurrencyLimitV2,
 ):
@@ -350,3 +377,30 @@ def test_rate_limit_emits_events(
         ),
         "prefect.resource.role": "concurrency-limit",
     }
+
+
+@pytest.mark.parametrize("names", [[], None])
+def test_concurrency_without_limit_names_sync(names):
+    executed = False
+
+    def resource_heavy():
+        nonlocal executed
+        with concurrency(names=names, occupy=1):
+            executed = True
+
+    assert not executed
+
+    with mock.patch(
+        "prefect.concurrency.sync._acquire_concurrency_slots",
+        wraps=lambda *args, **kwargs: None,  # Mocking to do nothing
+    ) as acquire_spy:
+        with mock.patch(
+            "prefect.concurrency.sync._release_concurrency_slots",
+            wraps=lambda *args, **kwargs: None,  # Mocking to do nothing
+        ) as release_spy:
+            resource_heavy()
+
+            acquire_spy.assert_not_called()
+            release_spy.assert_not_called()
+
+    assert executed

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -162,11 +162,11 @@ def test_rate_limit_without_limit_names_sync(names):
 
     with mock.patch(
         "prefect.concurrency.sync._acquire_concurrency_slots",
-        wraps=lambda *args, **kwargs: None,  # Mocking to do nothing
+        wraps=lambda *args, **kwargs: None,
     ) as acquire_spy:
         with mock.patch(
             "prefect.concurrency.sync._release_concurrency_slots",
-            wraps=lambda *args, **kwargs: None,  # Mocking to do nothing
+            wraps=lambda *args, **kwargs: None,
         ) as release_spy:
             resource_heavy()
 
@@ -392,11 +392,11 @@ def test_concurrency_without_limit_names_sync(names):
 
     with mock.patch(
         "prefect.concurrency.sync._acquire_concurrency_slots",
-        wraps=lambda *args, **kwargs: None,  # Mocking to do nothing
+        wraps=lambda *args, **kwargs: None,
     ) as acquire_spy:
         with mock.patch(
             "prefect.concurrency.sync._release_concurrency_slots",
-            wraps=lambda *args, **kwargs: None,  # Mocking to do nothing
+            wraps=lambda *args, **kwargs: None,
         ) as release_spy:
             resource_heavy()
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

If a user calls `concurrency()` or `rate_limit()` and passes a None value or an empty collection, return early to avoid making unnecessary API requests.

Fixes #14786 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
