### PR TITLE
fix teams webhook block syntax for 3.8

### DIFF
--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -164,10 +164,12 @@ class MicrosoftTeamsWebhook(AppriseNotificationBlock):
         ):
             raise ValueError("Invalid Microsoft Teams Workflow URL provided.")
 
-        parsed_url |= {  # novermin
-            "include_image": self.include_image,
-            "wrap": self.wrap,
-        }
+        parsed_url.update(
+            {
+                "include_image": self.include_image,
+                "wrap": self.wrap,
+            }
+        )
 
         self._start_apprise_client(SecretStr(NotifyWorkflows(**parsed_url).url()))
 


### PR DESCRIPTION
3.8 doesn't support the nice `|=` dict merge