### PR TITLE
Remove extra backtick in deployment docs

### DIFF
--- a/future-docs/2.19.x/how-to-guides/work-pools/deploying-flows.mdx
+++ b/future-docs/2.19.x/how-to-guides/work-pools/deploying-flows.mdx
@@ -93,7 +93,7 @@ Then run the script to create a deployment (in future examples this step will be
 
 You should see messages in your terminal that Docker is building your image. When the deployment build succeeds you will see helpful information in your terminal showing you how to start a worker for your deployment and how to run your deployment. Your deployment will be visible on the `Deployments` page in the UI.
 
-By default, `.deploy` will build a Docker image with your flow code baked into it and push the image to the [Docker Hub](https://hub.docker.com/) registry specified in the `image` argument\`.
+By default, `.deploy` will build a Docker image with your flow code baked into it and push the image to the [Docker Hub](https://hub.docker.com/) registry specified in the `image` argument.
 
 <Note>
 **Authentication to Docker Hub**


### PR DESCRIPTION
Removes an extra backtick in the documentation on deploying flows.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

Removes an extra backtick in the docs on deploying flows:

<img width="699" alt="image" src="https://github.com/user-attachments/assets/627e008f-9500-47d4-a955-d0bc2f43f2b4">

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- ~~This pull request references any related issue by including "closes `<link to issue>`"~~
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- ~~If this pull request adds new functionality, it includes unit tests that cover the changes~~
- ~~If this pull request removes docs files, it includes redirect settings in `mint.json`.~~
- ~~If this pull request adds functions or classes, it includes helpful docstrings.~~
