### PR TITLE
Follow up on `prefect profile populate-defaults`

### DIFF
--- a/docs/3.0rc/manage/settings-and-profiles.mdx
+++ b/docs/3.0rc/manage/settings-and-profiles.mdx
@@ -38,6 +38,7 @@ The `prefect profile` CLI commands enable you to create, review, and manage prof
 | `ls` | List all profile names. |
 | `rename` | Change the name of a profile. |
 | `use` | Switch the active profile. |
+| `populate-defaults` | Populate your `profiles.toml` file with opinionated stock profiles. |
 
 ### Configure settings
 

--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -277,10 +277,8 @@ def _show_profile_changes(
         elif user_profiles[name].settings != profile.settings:
             profiles_to_modify.append(name)
 
-    if profiles_to_add or profiles_to_modify:
-        app.console.print("\n[bold]Changes to be made:[/bold]")
     if profiles_to_add:
-        app.console.print("\n[blue]Profiles to be added:[/blue]")
+        app.console.print("\n[bold][blue]Profiles to be added:[/blue][bold]")
         for name in profiles_to_add:
             app.console.print(f"  - {name}")
     if profiles_to_modify:
@@ -293,13 +291,17 @@ def _show_profile_changes(
         )
         return [], []
 
-    app.console.print("\n[bold]Default Profile Summaries:[/bold]")
+    app.console.print("\n[bold]Default Profile Configurations:[/bold]")
     for name in profiles_to_add + profiles_to_modify:
         profile = default_profiles[name]
-        if profile_items := list(profile.settings.items()):
-            app.console.print(f"\n[underline]{name}[/underline]:")
+        app.console.print(f"\n[underline]{name}[/underline]:")
+
+        if not (profile_items := list(profile.settings.items())):
+            app.console.print("  (empty)")
+            continue
+
         for setting, value in profile_items:
-            app.console.print(f"  {setting.name}: {value}")
+            app.console.print(f"  {setting.name}: {value or '(empty)'}")
 
     return profiles_to_add, profiles_to_modify
 
@@ -330,7 +332,7 @@ def populate_defaults():
 
         if user_content != _OLD_MINIMAL_DEFAULT_PROFILE_CONTENT:
             backup_path = user_path.with_suffix(".toml.bak")
-            if typer.confirm(f"Back up existing profiles to {backup_path}?"):
+            if typer.confirm(f"\nBack up existing profiles to {backup_path}?"):
                 shutil.copy(user_path, backup_path)
                 app.console.print(f"Profiles backed up to {backup_path}")
     else:

--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -301,7 +301,7 @@ def _show_profile_changes(
             continue
 
         for setting, value in profile_items:
-            app.console.print(f"  {setting.name}: {value or '(empty)'}")
+            app.console.print(f"  {setting.name}: {value}")
 
     return profiles_to_add, profiles_to_modify
 

--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -21,6 +21,7 @@ from prefect.cli.root import app, is_interactive
 from prefect.client.orchestration import ServerType, get_client
 from prefect.context import use_profile
 from prefect.exceptions import ObjectNotFound
+from prefect.settings import ProfilesCollection
 from prefect.utilities.collections import AutoEnum
 
 profile_app = PrefectTyper(name="profile", help="Select and manage Prefect profiles.")
@@ -122,11 +123,11 @@ async def use(name: str):
             exit_with_error,
             f"Error authenticating with Prefect Cloud using profile {name!r}",
         ),
-        ConnectionStatus.ORION_CONNECTED: (
+        ConnectionStatus.SERVER_CONNECTED: (
             exit_with_success,
             f"Connected to Prefect server using profile {name!r}",
         ),
-        ConnectionStatus.ORION_ERROR: (
+        ConnectionStatus.SERVER_ERROR: (
             exit_with_error,
             f"Error connecting to Prefect server using profile {name!r}",
         ),
@@ -161,7 +162,7 @@ async def use(name: str):
         )
 
         with use_profile(name, include_current_context=False):
-            connection_status = await check_orion_connection()
+            connection_status = await check_server_connection()
 
         exit_method, msg = status_messages[connection_status]
 
@@ -191,7 +192,7 @@ def delete(name: str):
     profiles.remove_profile(name)
 
     verb = "Removed"
-    if name == "default":
+    if name == "ephemeral":
         verb = "Reset"
 
     prefect.settings.save_profiles(profiles)
@@ -255,6 +256,54 @@ def inspect(
         app.console.print(f"{setting.name}='{value}'")
 
 
+def _show_profile_changes(
+    default_profiles: ProfilesCollection, user_profiles: ProfilesCollection
+) -> tuple[list[str], list[str]]:
+    """
+    Display detailed information about profile changes.
+
+    Args:
+        default_profiles: The default profiles.
+        user_profiles: The user's existing profiles.
+
+    Returns:
+        tuple: A tuple containing lists of profiles to add and modify.
+    """
+    profiles_to_add: list[str] = []
+    profiles_to_modify: list[str] = []
+    for name, profile in default_profiles.items():
+        if name not in user_profiles:
+            profiles_to_add.append(name)
+        elif user_profiles[name].settings != profile.settings:
+            profiles_to_modify.append(name)
+
+    if profiles_to_add or profiles_to_modify:
+        app.console.print("\n[bold]Changes to be made:[/bold]")
+    if profiles_to_add:
+        app.console.print("\n[blue]Profiles to be added:[/blue]")
+        for name in profiles_to_add:
+            app.console.print(f"  - {name}")
+    if profiles_to_modify:
+        app.console.print("\n[yellow]Profiles to be modified:[/yellow]")
+        for name in profiles_to_modify:
+            app.console.print(f"  - {name}")
+    if not profiles_to_add and not profiles_to_modify:
+        app.console.print(
+            "[green]No changes needed. All default profiles are up to date.[/green]"
+        )
+        return [], []
+
+    app.console.print("\n[bold]Default Profile Summaries:[/bold]")
+    for name in profiles_to_add + profiles_to_modify:
+        profile = default_profiles[name]
+        if profile_items := list(profile.settings.items()):
+            app.console.print(f"\n[underline]{name}[/underline]:")
+        for setting, value in profile_items:
+            app.console.print(f"  {setting.name}: {value}")
+
+    return profiles_to_add, profiles_to_modify
+
+
 @profile_app.command()
 def populate_defaults():
     """Populate the profiles configuration with default base profiles, preserving existing user profiles."""
@@ -271,44 +320,56 @@ def populate_defaults():
             )
             return
 
+        user_profiles = prefect.settings._read_profiles_from(user_path)
+        profiles_to_add, profiles_to_modify = _show_profile_changes(
+            default_profiles, user_profiles
+        )
+
+        if not profiles_to_add and not profiles_to_modify:
+            return
+
         if user_content != _OLD_MINIMAL_DEFAULT_PROFILE_CONTENT:
             backup_path = user_path.with_suffix(".toml.bak")
             if typer.confirm(f"Back up existing profiles to {backup_path}?"):
                 shutil.copy(user_path, backup_path)
                 app.console.print(f"Profiles backed up to {backup_path}")
-
-        user_profiles = prefect.settings._read_profiles_from(user_path)
-
-        # Merge profiles, keeping existing user profiles unchanged
-        for name, profile in default_profiles.items():
-            if name not in user_profiles:
-                user_profiles.add_profile(profile)
-                app.console.print(f"Added default profile: [blue]{name}[/blue]")
     else:
         user_profiles = default_profiles
+        app.console.print(
+            "\n[bold]Creating new profiles file with default profiles.[/bold]"
+        )
+        _show_profile_changes(default_profiles, ProfilesCollection([]))
 
-    if not typer.confirm(f"Update profiles at {user_path}?"):
+    if not typer.confirm(f"\nUpdate profiles at {user_path}?"):
         app.console.print("Operation cancelled.")
         return
 
+    # Merge profiles, keeping existing user profiles unchanged
+    for name, profile in default_profiles.items():
+        if name not in user_profiles:
+            user_profiles.add_profile(profile)
+
     prefect.settings._write_profiles_to(user_path, user_profiles)
-    app.console.print(f"Profiles updated in [green]{user_path}[/green]")
+    app.console.print(f"\nProfiles updated in [green]{user_path}[/green]")
     app.console.print(
-        "Use with [green]prefect profile use[/green] [red][PROFILE-NAME][/red]"
+        "\nUse with [green]prefect profile use[/green] [blue][PROFILE-NAME][/blue]"
     )
+    app.console.print("\nAvailable profiles:")
+    for name in user_profiles.names:
+        app.console.print(f"  - {name}")
 
 
 class ConnectionStatus(AutoEnum):
     CLOUD_CONNECTED = AutoEnum.auto()
     CLOUD_ERROR = AutoEnum.auto()
     CLOUD_UNAUTHORIZED = AutoEnum.auto()
-    ORION_CONNECTED = AutoEnum.auto()
-    ORION_ERROR = AutoEnum.auto()
+    SERVER_CONNECTED = AutoEnum.auto()
+    SERVER_ERROR = AutoEnum.auto()
     EPHEMERAL = AutoEnum.auto()
     INVALID_API = AutoEnum.auto()
 
 
-async def check_orion_connection():
+async def check_server_connection():
     httpx_settings = dict(timeout=3)
     try:
         # attempt to infer Cloud 2.0 API from the connection URL
@@ -331,31 +392,29 @@ async def check_orion_connection():
             async with client:
                 connect_error = await client.api_healthcheck()
             if connect_error is not None:
-                return ConnectionStatus.ORION_ERROR
+                return ConnectionStatus.SERVER_ERROR
             elif client.server_type == ServerType.EPHEMERAL:
                 # if the client is using an ephemeral Prefect app, inform the user
                 return ConnectionStatus.EPHEMERAL
             else:
-                return ConnectionStatus.ORION_CONNECTED
+                return ConnectionStatus.SERVER_CONNECTED
         except Exception:
-            return ConnectionStatus.ORION_ERROR
+            return ConnectionStatus.SERVER_ERROR
     except httpx.HTTPStatusError:
         return ConnectionStatus.CLOUD_ERROR
     except TypeError:
         # if no Prefect API URL has been set, httpx will throw a TypeError
         try:
-            # try to connect with the client anyway, it will likely use an
-            # ephemeral Prefect instance
             client = get_client(httpx_settings=httpx_settings)
+            if client.server_type == ServerType.EPHEMERAL:
+                return ConnectionStatus.EPHEMERAL
             async with client:
                 connect_error = await client.api_healthcheck()
             if connect_error is not None:
-                return ConnectionStatus.ORION_ERROR
-            elif client.server_type == ServerType.EPHEMERAL:
-                return ConnectionStatus.EPHEMERAL
+                return ConnectionStatus.SERVER_ERROR
             else:
-                return ConnectionStatus.ORION_CONNECTED
+                return ConnectionStatus.SERVER_CONNECTED
         except Exception:
-            return ConnectionStatus.ORION_ERROR
+            return ConnectionStatus.SERVER_ERROR
     except (httpx.ConnectError, httpx.UnsupportedProtocol):
         return ConnectionStatus.INVALID_API

--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -191,12 +191,8 @@ def delete(name: str):
         exit_with_error("Deletion aborted.")
     profiles.remove_profile(name)
 
-    verb = "Removed"
-    if name == "ephemeral":
-        verb = "Reset"
-
     prefect.settings.save_profiles(profiles)
-    exit_with_success(f"{verb} profile {name!r}.")
+    exit_with_success(f"Removed profile {name!r}.")
 
 
 @profile_app.command()

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -661,7 +661,7 @@ def root_settings_context():
             ),
             file=sys.stderr,
         )
-        active_name = "default"
+        active_name = "ephemeral"
 
     with use_profile(
         profiles[active_name],

--- a/src/prefect/profiles.toml
+++ b/src/prefect/profiles.toml
@@ -12,4 +12,3 @@ PREFECT_API_URL = "http://127.0.0.1:4200/api"
 
 
 [profiles.cloud]
-PREFECT_API_KEY = "run `prefect cloud login` to set up your Prefect Cloud profile"

--- a/src/prefect/profiles.toml
+++ b/src/prefect/profiles.toml
@@ -1,15 +1,13 @@
 # This is a template for profile configuration for Prefect.
-# You can modify these profiles or create new ones to suit their needs.
+# You can modify these profiles or create new ones to suit your needs.
 
-active = "default"
-
-[profiles.default]
+active = "ephemeral"
 
 [profiles.ephemeral]
 PREFECT_API_DATABASE_CONNECTION_URL = "sqlite+aiosqlite:///prefect.db"
 
 [profiles.local]
-# You will need to set these values appropriately
+# You will need to set these values appropriately for your local development environment
 PREFECT_API_URL = "http://127.0.0.1:4200/api"
 
 

--- a/src/prefect/profiles.toml
+++ b/src/prefect/profiles.toml
@@ -12,7 +12,4 @@ PREFECT_API_URL = "http://127.0.0.1:4200/api"
 
 
 [profiles.cloud]
-# This is a placeholder for Prefect Cloud configuration
-# Run "prefect cloud login" to set up your Prefect Cloud profile
-# PREFECT_API_URL = "https://api.prefect.cloud/api/accounts/[ACCOUNT-ID]/workspaces/[WORKSPACE-ID]"
-# PREFECT_API_KEY = "pnu_rest-of-your-api-key-here"
+PREFECT_API_KEY = "run `prefect cloud login` to set up your Prefect Cloud profile"

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -284,7 +284,7 @@ def test_login_with_key_and_workspace_overrides_current_workspace(respx_mock):
 
     # Set up a current profile with a different workspace
     profiles = load_profiles()
-    profiles.set_active("default")
+    profiles.set_active("ephemeral")
     assert profiles.active_profile is not None
     profiles.active_profile.settings[PREFECT_API_URL] = foo_workspace.api_url()
     assert profiles.active_profile.settings[PREFECT_API_URL] == foo_workspace.api_url()

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -7,6 +7,7 @@ import prefect.context
 import prefect.settings
 from prefect.context import use_profile
 from prefect.settings import (
+    PREFECT_API_DATABASE_CONNECTION_URL,
     PREFECT_API_DATABASE_TIMEOUT,
     PREFECT_API_KEY,
     PREFECT_LOGGING_TO_API_MAX_LOG_SIZE,
@@ -54,18 +55,21 @@ def temporary_profiles_path(tmp_path):
 
 
 def test_set_using_default_profile():
-    with use_profile("default"):
+    with use_profile("ephemeral"):
         invoke_and_assert(
             ["config", "set", "PREFECT_TEST_SETTING=DEBUG"],
             expected_output="""
                 Set 'PREFECT_TEST_SETTING' to 'DEBUG'.
-                Updated profile 'default'.
+                Updated profile 'ephemeral'.
                 """,
         )
 
     profiles = load_profiles()
-    assert "default" in profiles
-    assert profiles["default"].settings == {PREFECT_TEST_SETTING: "DEBUG"}
+    assert "ephemeral" in profiles
+    assert profiles["ephemeral"].settings == {
+        PREFECT_TEST_SETTING: "DEBUG",
+        PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///prefect.db",
+    }
 
 
 def test_set_using_profile_flag():

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -702,7 +702,6 @@ def test_show_profile_changes(capsys):
     assert "- ephemeral" in output
 
     # Check profile summaries
-    assert "Default Profile Summaries:" in output
     assert "cloud:" in output
     assert "PREFECT_API_URL: https://api.prefect.cloud" in output
     assert "ephemeral:" in output

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -388,32 +388,6 @@ def test_delete_profile():
     assert "bar" not in profiles
 
 
-def test_delete_profile_ephemeral_is_reset():
-    save_profiles(
-        ProfilesCollection(
-            profiles=[
-                Profile(name="ephemeral", settings={PREFECT_API_KEY: "foo"}),
-            ],
-            active=None,
-        )
-    )
-
-    invoke_and_assert(
-        ["profile", "delete", "ephemeral"],
-        user_input="y",
-        expected_output_contains="Reset profile 'ephemeral'.",
-    )
-
-    profiles = load_profiles()
-    assert profiles["ephemeral"] == Profile(
-        name="ephemeral",
-        settings={
-            PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///prefect.db"
-        },
-        source=DEFAULT_PROFILES_PATH,
-    )
-
-
 def test_delete_profile_unknown_name():
     invoke_and_assert(
         ["profile", "delete", "foo"],

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -1,3 +1,4 @@
+import shutil
 from uuid import uuid4
 
 import pytest
@@ -8,6 +9,7 @@ from httpx import Response
 from prefect.context import use_profile
 from prefect.settings import (
     DEFAULT_PROFILES_PATH,
+    PREFECT_API_DATABASE_CONNECTION_URL,
     PREFECT_API_KEY,
     PREFECT_DEBUG_MODE,
     PREFECT_PROFILES_PATH,
@@ -36,41 +38,38 @@ def test_use_profile_unknown_key():
     )
 
 
-class TestChangingProfileAndCheckingOrionConnection:
+class TestChangingProfileAndCheckingServerConnection:
     @pytest.fixture
     def profiles(self):
         prefect_cloud_api_url = "https://mock-cloud.prefect.io/api"
-        prefect_cloud_orion_api_url = (
+        prefect_cloud_server_api_url = (
             f"{prefect_cloud_api_url}/accounts/{uuid4()}/workspaces/{uuid4()}"
         )
-        hosted_orion_api_url = "https://hosted-orion.prefect.io/api"
+        hosted_server_api_url = "https://hosted-server.prefect.io/api"
 
         return ProfilesCollection(
             profiles=[
                 Profile(
                     name="prefect-cloud",
                     settings={
-                        "PREFECT_API_URL": prefect_cloud_orion_api_url,
+                        "PREFECT_API_URL": prefect_cloud_server_api_url,
                         "PREFECT_API_KEY": "a working cloud api key",
                     },
                 ),
                 Profile(
                     name="prefect-cloud-with-invalid-key",
                     settings={
-                        "PREFECT_API_URL": prefect_cloud_orion_api_url,
+                        "PREFECT_API_URL": prefect_cloud_server_api_url,
                         "PREFECT_API_KEY": "a broken cloud api key",
                     },
                 ),
                 Profile(
-                    name="hosted-orion",
+                    name="hosted-server",
                     settings={
-                        "PREFECT_API_URL": hosted_orion_api_url,
+                        "PREFECT_API_URL": hosted_server_api_url,
                     },
                 ),
-                Profile(
-                    name="ephemeral-prefect",
-                    settings={},
-                ),
+                Profile(name="ephemeral", settings={}),
             ],
             active=None,
         )
@@ -107,20 +106,20 @@ class TestChangingProfileAndCheckingOrionConnection:
             yield unhealthy_cloud
 
     @pytest.fixture
-    def hosted_orion_has_no_cloud_api(self):
+    def hosted_server_has_no_cloud_api(self):
         # if the API URL points to a hosted Prefect server instance, no Cloud API will be found
         with respx.mock:
             hosted = respx.get(
-                "https://hosted-orion.prefect.io/api/me/workspaces",
+                "https://hosted-server.prefect.io/api/me/workspaces",
             ).mock(return_value=Response(404, json={}))
 
             yield hosted
 
     @pytest.fixture
-    def healthy_hosted_orion(self):
+    def healthy_hosted_server(self):
         with respx.mock:
             hosted = respx.get(
-                "https://hosted-orion.prefect.io/api/health",
+                "https://hosted-server.prefect.io/api/health",
             ).mock(return_value=Response(200, json={}))
 
             yield hosted
@@ -129,10 +128,10 @@ class TestChangingProfileAndCheckingOrionConnection:
         raise Exception
 
     @pytest.fixture
-    def unhealthy_hosted_orion(self):
+    def unhealthy_hosted_server(self):
         with respx.mock:
             badly_hosted = respx.get(
-                "https://hosted-orion.prefect.io/api/health",
+                "https://hosted-server.prefect.io/api/health",
             ).mock(side_effect=self.connection_error)
 
             yield badly_hosted
@@ -175,57 +174,57 @@ class TestChangingProfileAndCheckingOrionConnection:
         profiles = load_profiles()
         assert profiles.active_name == "prefect-cloud"
 
-    def test_using_hosted_orion(
-        self, hosted_orion_has_no_cloud_api, healthy_hosted_orion, profiles
+    def test_using_hosted_server(
+        self, hosted_server_has_no_cloud_api, healthy_hosted_server, profiles
     ):
         save_profiles(profiles)
         invoke_and_assert(
-            ["profile", "use", "hosted-orion"],
+            ["profile", "use", "hosted-server"],
             expected_output_contains=(
-                "Connected to Prefect server using profile 'hosted-orion'"
+                "Connected to Prefect server using profile 'hosted-server'"
             ),
             expected_code=0,
         )
 
         profiles = load_profiles()
-        assert profiles.active_name == "hosted-orion"
+        assert profiles.active_name == "hosted-server"
 
-    def test_unhealthy_hosted_orion(
-        self, hosted_orion_has_no_cloud_api, unhealthy_hosted_orion, profiles
+    def test_unhealthy_hosted_server(
+        self, hosted_server_has_no_cloud_api, unhealthy_hosted_server, profiles
     ):
         save_profiles(profiles)
         invoke_and_assert(
-            ["profile", "use", "hosted-orion"],
+            ["profile", "use", "hosted-server"],
             expected_output_contains="Error connecting to Prefect server",
             expected_code=1,
         )
 
         profiles = load_profiles()
-        assert profiles.active_name == "hosted-orion"
+        assert profiles.active_name == "hosted-server"
 
-    def test_using_ephemeral_orion(self, profiles):
+    def test_using_ephemeral_server(self, profiles):
         save_profiles(profiles)
         invoke_and_assert(
-            ["profile", "use", "ephemeral-prefect"],
+            ["profile", "use", "ephemeral"],
             expected_output_contains=(
-                "No Prefect server specified using profile 'ephemeral-prefect'"
+                "No Prefect server specified using profile 'ephemeral'"
             ),
             expected_code=0,
         )
 
         profiles = load_profiles()
-        assert profiles.active_name == "ephemeral-prefect"
+        assert profiles.active_name == "ephemeral"
 
 
 def test_ls_default_profiles():
-    # 'default' is not the current profile because we have a temporary profile in-use
+    # 'ephemeral' is not the current profile because we have a temporary profile in-use
     # during tests
 
-    invoke_and_assert(["profile", "ls"], expected_output_contains="default")
+    invoke_and_assert(["profile", "ls"], expected_output_contains="ephemeral")
 
 
 def test_ls_additional_profiles():
-    # 'default' is not the current profile because we have a temporary profile in-use
+    # 'ephemeral' is not the current profile because we have a temporary profile in-use
     # during tests
 
     save_profiles(
@@ -241,7 +240,7 @@ def test_ls_additional_profiles():
     invoke_and_assert(
         ["profile", "ls"],
         expected_output_contains=(
-            "default",
+            "ephemeral",
             "foo",
             "bar",
         ),
@@ -261,7 +260,7 @@ def test_ls_respects_current_from_profile_flag():
     invoke_and_assert(
         ["--profile", "foo", "profile", "ls"],
         expected_output_contains=(
-            "default",
+            "ephemeral",
             "* foo",
         ),
     )
@@ -282,7 +281,7 @@ def test_ls_respects_current_from_context():
         invoke_and_assert(
             ["profile", "ls"],
             expected_output_contains=(
-                "default",
+                "ephemeral",
                 "foo",
                 "* bar",
             ),
@@ -355,12 +354,12 @@ def test_create_profile_from_unknown_profile():
 
 def test_create_profile_with_existing_profile():
     invoke_and_assert(
-        ["profile", "create", "default"],
+        ["profile", "create", "ephemeral"],
         expected_output="""
-            Profile 'default' already exists.
+            Profile 'ephemeral' already exists.
             To create a new profile, remove the existing profile first:
 
-                prefect profile delete 'default'
+                prefect profile delete 'ephemeral'
             """,
         expected_code=1,
     )
@@ -388,26 +387,28 @@ def test_delete_profile():
     assert "bar" not in profiles
 
 
-def test_delete_profile_default_is_reset():
+def test_delete_profile_ephemeral_is_reset():
     save_profiles(
         ProfilesCollection(
             profiles=[
-                Profile(name="default", settings={PREFECT_API_KEY: "foo"}),
+                Profile(name="ephemeral", settings={PREFECT_API_KEY: "foo"}),
             ],
             active=None,
         )
     )
 
     invoke_and_assert(
-        ["profile", "delete", "default"],
+        ["profile", "delete", "ephemeral"],
         user_input="y",
-        expected_output_contains="Reset profile 'default'.",
+        expected_output_contains="Reset profile 'ephemeral'.",
     )
 
     profiles = load_profiles()
-    assert profiles["default"] == Profile(
-        name="default",
-        settings={},
+    assert profiles["ephemeral"] == Profile(
+        name="ephemeral",
+        settings={
+            PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///prefect.db"
+        },
         source=DEFAULT_PROFILES_PATH,
     )
 
@@ -610,7 +611,7 @@ def test_populate_defaults(tmp_path, monkeypatch):
     assert populated_profiles.names == default_profiles.names
     assert populated_profiles.active_name == default_profiles.active_name
 
-    assert {"local", "ephemeral", "cloud", "default"} == set(populated_profiles.names)
+    assert {"local", "ephemeral", "cloud"} == set(populated_profiles.names)
 
     for name in default_profiles.names:
         assert populated_profiles[name].settings == default_profiles[name].settings
@@ -639,10 +640,25 @@ def test_populate_defaults_with_existing_profiles(tmp_path, monkeypatch):
     )
 
     new_profiles = load_profiles()
-    assert {"local", "ephemeral", "cloud", "default", "existing"} == set(
-        new_profiles.names
-    )
+    assert {"local", "ephemeral", "cloud", "existing"} == set(new_profiles.names)
 
     backup_profiles = _read_profiles_from(temp_profiles_path.with_suffix(".toml.bak"))
     assert "existing" in backup_profiles.names
     assert backup_profiles["existing"].settings == {PREFECT_API_KEY: "test_key"}
+
+
+def test_populate_defaults_no_changes_needed(tmp_path, monkeypatch):
+    temp_profiles_path = tmp_path / "profiles.toml"
+    monkeypatch.setattr(PREFECT_PROFILES_PATH, "value", lambda: temp_profiles_path)
+
+    shutil.copy(DEFAULT_PROFILES_PATH, temp_profiles_path)
+
+    invoke_and_assert(
+        ["profile", "populate-defaults"],
+        expected_output_contains=[
+            "Default profiles already populated. No action required.",
+        ],
+        expected_code=0,
+    )
+
+    assert temp_profiles_path.read_text() == DEFAULT_PROFILES_PATH.read_text()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -26,6 +26,7 @@ from prefect.exceptions import MissingContextError
 from prefect.results import ResultFactory
 from prefect.settings import (
     DEFAULT_PROFILES_PATH,
+    PREFECT_API_DATABASE_CONNECTION_URL,
     PREFECT_API_KEY,
     PREFECT_API_URL,
     PREFECT_HOME,
@@ -243,7 +244,7 @@ class TestSettingsContext:
         monkeypatch.setattr(
             "prefect.logging.configuration.setup_logging", setup_logging
         )
-        with use_profile("default"):
+        with use_profile("ephemeral"):
             setup_logging.assert_not_called()
 
     def test_settings_context_nesting(self, temporary_profiles_path):
@@ -296,7 +297,13 @@ class TestSettingsContext:
         monkeypatch.setattr("prefect.context.use_profile", use_profile)
         result = root_settings_context()
         use_profile.assert_called_once_with(
-            Profile(name="default", settings={}, source=DEFAULT_PROFILES_PATH),
+            Profile(
+                name="ephemeral",
+                settings={
+                    PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///prefect.db"
+                },
+                source=DEFAULT_PROFILES_PATH,
+            ),
             override_environment_variables=False,
         )
         use_profile().__enter__.assert_called_once()
@@ -319,7 +326,13 @@ class TestSettingsContext:
         monkeypatch.setattr("sys.argv", cli_command)
         result = root_settings_context()
         use_profile.assert_called_once_with(
-            Profile(name="default", settings={}, source=DEFAULT_PROFILES_PATH),
+            Profile(
+                name="ephemeral",
+                settings={
+                    PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///prefect.db"
+                },
+                source=DEFAULT_PROFILES_PATH,
+            ),
             override_environment_variables=False,
         )
         use_profile().__enter__.assert_called_once_with()


### PR DESCRIPTION
following up on some feedback that came in after https://github.com/PrefectHQ/prefect/pull/14749 was merged

this PR:
- removes `default` as the "default" profile, in favor of `ephemeral`
- shows changes to be made to the user before confirming the write to `PREFECT_PROFILES_PATH`
- updates some missed `orion` -> `server` variable names
- updates tests according to changes

<img width="600" alt="image" src="https://github.com/user-attachments/assets/0df5395b-3fff-4d56-8ec8-5de145fd18a0">

---

### on leaving breadcrumbs within the `profiles.toml` file
- its prohibitively complex to intersperse toml with comments in a way that can be preserved between parses. there's a library [here](https://github.com/python-poetry/tomlkit) for that, but not sure its worth the squeeze

- [unfortunately](https://github.com/toml-lang/toml/issues/30#issuecomment-14003959) there is no concept of a `None / nil` in toml, and I'm not a huge fan of setting dummy "english" as values of real settings (e.g. `PREFECT_API_KEY = "run prefect cloud login to get started!"`) since we load and sporadically depend on these values existing across the codebase

I will think about ways to add breadcrumbs in a subsequent PR in a way that doesnt break things