### PR TITLE
refactors how cluster_config is implemented

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -740,7 +740,8 @@ class KubernetesWorker(BaseWorker):
         else:
             # Try to load in-cluster configuration
             try:
-                await config.load_incluster_config()
+                
+                config.load_incluster_config()
                 client = ApiClient()
             except config.ConfigException:
                 # If in-cluster config fails, load the local kubeconfig

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -740,7 +740,6 @@ class KubernetesWorker(BaseWorker):
         else:
             # Try to load in-cluster configuration
             try:
-                
                 config.load_incluster_config()
                 client = ApiClient()
             except config.ConfigException:

--- a/src/integrations/prefect-kubernetes/tests/test_worker.py
+++ b/src/integrations/prefect-kubernetes/tests/test_worker.py
@@ -68,13 +68,14 @@ async def mock_stream(*args, **kwargs):
 
 @pytest.fixture
 def mock_cluster_config(monkeypatch):
-    mock = AsyncMock()
+    mock = MagicMock()
     # We cannot mock this or the `except` clause will complain
-    mock.return_value.ConfigException.return_value = ConfigException
-    mock.return_value.list_kube_config_contexts.return_value = (
+    mock.ConfigException.return_value = ConfigException
+    mock.list_kube_config_contexts.return_value = (
         [],
         {"context": {"cluster": FAKE_CLUSTER}},
     )
+    mock.new_client_from_config = AsyncMock()
     monkeypatch.setattr("prefect_kubernetes.worker.config", mock)
     monkeypatch.setattr(
         "prefect_kubernetes.worker.config.ConfigException", ConfigException


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->
Removes await from `load_incluster_config` and refactors the way the config is mocked as not all config functions are not async.

closes #14799 
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ x ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ x  ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ x ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ x ] If this pull request adds functions or classes, it includes helpful docstrings.