### PR TITLE
Rename the `/download-logs/csv` endpoint to `/logs/download`

### DIFF
--- a/docs/3.0rc/api-ref/rest-api/server/schema.json
+++ b/docs/3.0rc/api-ref/rest-api/server/schema.json
@@ -1508,14 +1508,14 @@
                 }
             }
         },
-        "/api/flow_runs/{id}/download-logs-csv": {
+        "/api/flow_runs/{id}/logs/download": {
             "get": {
                 "tags": [
                     "Flow Runs"
                 ],
                 "summary": "Download Logs",
                 "description": "Download all flow run logs as a CSV file, collecting all logs until there are no more logs to retrieve.",
-                "operationId": "download_logs_flow_runs__id__download_logs_csv_get",
+                "operationId": "download_logs_flow_runs__id__logs_download_get",
                 "parameters": [
                     {
                         "name": "id",

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -771,10 +771,10 @@ async def paginate_flow_runs(
         return ORJSONResponse(content=response)
 
 
-FLOW_RUN_LOGS_CSV_PAGE_LIMIT = 1000
+FLOW_RUN_LOGS_DOWNLOAD_PAGE_LIMIT = 1000
 
 
-@router.get("/{id}/download-logs-csv")
+@router.get("/{id}/logs/download")
 async def download_logs(
     flow_run_id: UUID = Path(..., description="The flow run id", alias="id"),
     db: PrefectDBInterface = Depends(provide_database_interface),
@@ -798,7 +798,7 @@ async def download_logs(
             )
 
             offset = 0
-            limit = FLOW_RUN_LOGS_CSV_PAGE_LIMIT
+            limit = FLOW_RUN_LOGS_DOWNLOAD_PAGE_LIMIT
 
             while True:
                 results = await models.logs.read_logs(

--- a/tests/server/api/test_server.py
+++ b/tests/server/api/test_server.py
@@ -22,8 +22,8 @@ from prefect.server.api.server import (
     _memoize_block_auto_registration,
     create_api_app,
     create_app,
-    method_paths_from_routes,
 )
+from prefect.server.utilities.server import method_paths_from_routes
 from prefect.settings import (
     PREFECT_API_DATABASE_CONNECTION_URL,
     PREFECT_API_URL,

--- a/tests/server/api/test_server.py
+++ b/tests/server/api/test_server.py
@@ -9,7 +9,7 @@ import httpx
 import pytest
 import sqlalchemy as sa
 import toml
-from fastapi import APIRouter, status, testclient
+from fastapi import status
 from httpx import ASGITransport, AsyncClient
 
 from prefect.client.constants import SERVER_API_VERSION
@@ -169,103 +169,6 @@ class TestCreateOrionAPI:
             expected.update(method_paths_from_routes(router.routes))
 
         assert method_paths_from_routes(app.router.routes) == expected
-
-    def test_allows_router_omission_with_null_override(self):
-        app = create_api_app(router_overrides={"/logs": None})
-
-        routes = method_paths_from_routes(app.router.routes)
-        assert all("/logs" not in route for route in routes)
-        client = testclient.TestClient(app)
-        with client:
-            assert client.post("/logs").status_code == status.HTTP_404_NOT_FOUND
-
-    def test_checks_for_router_paths_during_override(self):
-        router = APIRouter(prefix="/logs")
-
-        with pytest.raises(
-            ValueError,
-            match="override for '/logs' is missing paths",
-        ) as exc:
-            create_api_app(router_overrides={"/logs": router})
-
-        # These are displayed in a non-deterministic order
-        assert exc.match("POST /logs/filter")
-        assert exc.match("POST /logs/")
-
-    def test_checks_for_changed_prefix_during_override(self):
-        router = APIRouter(prefix="/foo")
-
-        with pytest.raises(
-            ValueError,
-            match="Router override for '/logs' defines a different prefix '/foo'",
-        ):
-            create_api_app(router_overrides={"/logs": router})
-
-    def test_checks_for_new_prefix_during_override(self):
-        router = APIRouter(prefix="/foo")
-
-        with pytest.raises(
-            KeyError,
-            match="Router override provided for prefix that does not exist: '/foo'",
-        ):
-            create_api_app(router_overrides={"/foo": router})
-
-    def test_only_includes_missing_paths_in_override_error(self):
-        router = APIRouter(prefix="/logs")
-
-        @router.post("/")
-        def foo():
-            pass
-
-        with pytest.raises(
-            ValueError,
-            match="override for '/logs' is missing paths.* {'POST /logs/filter'}",
-        ):
-            create_api_app(router_overrides={"/logs": router})
-
-    def test_override_uses_new_router(self):
-        router = APIRouter(prefix="/logs")
-
-        logs = MagicMock()
-
-        @router.post("/")
-        def foo():
-            logs()
-
-        logs_filter = MagicMock()
-        router.post("/filter")(logs_filter)
-
-        app = create_api_app(router_overrides={"/logs": router})
-        client = testclient.TestClient(app)
-        client.post("/logs")
-        logs.assert_called_once()
-        client.post("/logs/filter")
-        logs.assert_called_once()
-
-    def test_override_may_include_new_routes(self):
-        router = APIRouter(prefix="/logs")
-
-        logs = MagicMock(return_value=1)
-        logs_get = MagicMock(return_value=1)
-        logs_filter = MagicMock(return_value=1)
-
-        @router.post("/")
-        def foo():
-            return logs()
-
-        @router.post("/filter")
-        def bar():
-            return logs_filter()
-
-        @router.get("/")
-        def foobar():
-            return logs_get()
-
-        app = create_api_app(router_overrides={"/logs": router})
-
-        client = testclient.TestClient(app)
-        client.get("/logs/").raise_for_status()
-        logs_get.assert_called_once()
 
 
 class TestMemoizeBlockAutoRegistration:

--- a/tests/server/orchestration/api/test_flow_runs.py
+++ b/tests/server/orchestration/api/test_flow_runs.py
@@ -2771,11 +2771,11 @@ class TestDownloadFlowRunLogs:
         monkeypatch: pytest.MonkeyPatch,
     ):
         monkeypatch.setattr(
-            "prefect.server.api.flow_runs.FLOW_RUN_LOGS_CSV_PAGE_LIMIT", 3
+            "prefect.server.api.flow_runs.FLOW_RUN_LOGS_DOWNLOAD_PAGE_LIMIT", 3
         )
 
         async with client.stream(
-            "GET", f"/flow_runs/{flow_run_1.id}/download-logs-csv"
+            "GET", f"/flow_runs/{flow_run_1.id}/logs/download"
         ) as response:
             response_body = [
                 str(chunk, "UTF-8") async for chunk in response.aiter_bytes()


### PR DESCRIPTION
# Description
Renaming this endpoint to make it more generic the keep open the possibility of downloading flow run logs in other formats. 