### PR TITLE
Client side task run orchestration - link states to results

### DIFF
--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -412,16 +412,18 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
             if new_state.is_final():
                 if (
-                    isinstance(new_state.data, BaseResult)
-                    and new_state.data.has_cached_object()
+                    isinstance(state.data, BaseResult)
+                    and state.data.has_cached_object()
                 ):
                     # Avoid fetching the result unless it is cached, otherwise we defeat
                     # the purpose of disabling `cache_result_in_memory`
-                    result = new_state.result(raise_on_failure=False, fetch=True)
+                    result = state.result(raise_on_failure=False, fetch=True)
+                    if inspect.isawaitable(result):
+                        result = run_coro_as_sync(result)
                 else:
-                    result = new_state.data
+                    result = state.data
 
-                link_state_to_result(new_state, result)
+                link_state_to_result(state, result)
 
         else:
             try:

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -409,6 +409,20 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             self.task_run.state_id = new_state.id
             self.task_run.state_type = new_state.type
             self.task_run.state_name = new_state.name
+
+            if new_state.is_final():
+                if (
+                    isinstance(new_state.data, BaseResult)
+                    and new_state.data.has_cached_object()
+                ):
+                    # Avoid fetching the result unless it is cached, otherwise we defeat
+                    # the purpose of disabling `cache_result_in_memory`
+                    result = new_state.result(raise_on_failure=False, fetch=True)
+                else:
+                    result = new_state.data
+
+                link_state_to_result(new_state, result)
+
         else:
             try:
                 new_state = propose_state_sync(
@@ -966,6 +980,20 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             self.task_run.state_id = new_state.id
             self.task_run.state_type = new_state.type
             self.task_run.state_name = new_state.name
+
+            if new_state.is_final():
+                if (
+                    isinstance(new_state.data, BaseResult)
+                    and new_state.data.has_cached_object()
+                ):
+                    # Avoid fetching the result unless it is cached, otherwise we defeat
+                    # the purpose of disabling `cache_result_in_memory`
+                    result = await new_state.result(raise_on_failure=False, fetch=True)
+                else:
+                    result = new_state.data
+
+                link_state_to_result(new_state, result)
+
         else:
             try:
                 new_state = await propose_state(

--- a/tests/deployment/test_flow_runs.py
+++ b/tests/deployment/test_flow_runs.py
@@ -11,19 +11,18 @@ from httpx import Response
 from prefect import flow
 from prefect.context import FlowRunContext
 from prefect.deployments import run_deployment
+from prefect.events.worker import EventsWorker
 from prefect.server.schemas.core import TaskRunResult
-from prefect.settings import PREFECT_API_URL
+from prefect.settings import (
+    PREFECT_API_URL,
+    PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION,
+    temporary_settings,
+)
 from prefect.tasks import task
 from prefect.utilities.slugify import slugify
 
 if TYPE_CHECKING:
     from prefect.client.orchestration import PrefectClient
-
-from prefect.events.worker import EventsWorker
-from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION,
-    temporary_settings,
-)
 
 
 @pytest.fixture(autouse=True, params=[False, True])

--- a/tests/deployment/test_flow_runs.py
+++ b/tests/deployment/test_flow_runs.py
@@ -19,6 +19,23 @@ from prefect.utilities.slugify import slugify
 if TYPE_CHECKING:
     from prefect.client.orchestration import PrefectClient
 
+from prefect.events.worker import EventsWorker
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION,
+    temporary_settings,
+)
+
+
+@pytest.fixture(autouse=True, params=[False, True])
+def enable_client_side_task_run_orchestration(
+    request, asserting_events_worker: EventsWorker
+):
+    enabled = request.param
+    with temporary_settings(
+        {PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION: enabled}
+    ):
+        yield enabled
+
 
 class TestRunDeployment:
     @pytest.fixture
@@ -347,7 +364,7 @@ class TestRunDeployment:
         assert slugify(f"foo/{deployment.name}") in task_run.task_key
 
     async def test_tracks_dependencies_when_used_in_flow(
-        self, test_deployment, use_hosted_api_server, prefect_client
+        self, test_deployment, use_hosted_api_server, prefect_client, events_pipeline
     ):
         deployment = test_deployment
 
@@ -370,6 +387,7 @@ class TestRunDeployment:
         parent_state = await foo(return_state=True)
         upstream_task_state, child_flow_run = await parent_state.result()
         assert child_flow_run.parent_task_run_id is not None
+
         task_run = await prefect_client.read_task_run(child_flow_run.parent_task_run_id)
         assert task_run.task_inputs == {
             "x": [


### PR DESCRIPTION
When using client side task run orchestration, make sure to link states to result when going to a new state. Currently this functionality is buried inside of `propose_state`. This elevates it into the client side orchestration portion of the `set_state` methods of the sync and async task engines. 

