### PR TITLE
Remove `PrefectHttpxSyncEphemeralClient`

### DIFF
--- a/src/prefect/client/base.py
+++ b/src/prefect/client/base.py
@@ -26,7 +26,6 @@ import httpx
 from asgi_lifespan import LifespanManager
 from httpx import HTTPStatusError, Request, Response
 from starlette import status
-from starlette.testclient import TestClient
 from typing_extensions import Self
 
 import prefect
@@ -614,33 +613,6 @@ class PrefectHttpxSyncClient(httpx.Client):
 
         request.headers["Prefect-Csrf-Token"] = self.csrf_token
         request.headers["Prefect-Csrf-Client"] = str(self.csrf_client_id)
-
-
-class PrefectHttpxSyncEphemeralClient(TestClient, PrefectHttpxSyncClient):
-    """
-    This client is a synchronous httpx client that can be used to talk directly
-    to an ASGI app, such as an ephemeral Prefect API.
-
-    It is a subclass of both Starlette's `TestClient` and Prefect's
-    `PrefectHttpxSyncClient`, so it combines the synchronous testing
-    capabilities of `TestClient` with the Prefect-specific behaviors of
-    `PrefectHttpxSyncClient`.
-    """
-
-    def __init__(
-        self,
-        *args,
-        # override TestClient default
-        raise_server_exceptions=False,
-        **kwargs,
-    ):
-        super().__init__(
-            *args,
-            raise_server_exceptions=raise_server_exceptions,
-            **kwargs,
-        )
-
-    pass
 
 
 class ServerType(AutoEnum):

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -144,7 +144,6 @@ from prefect.client.base import (
     ASGIApp,
     PrefectHttpxAsyncClient,
     PrefectHttpxSyncClient,
-    PrefectHttpxSyncEphemeralClient,
     ServerType,
     app_lifespan_context,
 )
@@ -3493,14 +3492,9 @@ class SyncPrefectClient:
             and PREFECT_CLIENT_CSRF_SUPPORT_ENABLED.value()
         )
 
-        if self.server_type == ServerType.EPHEMERAL:
-            self._client = PrefectHttpxSyncEphemeralClient(
-                api, base_url="http://ephemeral-prefect/api"
-            )
-        else:
-            self._client = PrefectHttpxSyncClient(
-                **httpx_settings, enable_csrf_support=enable_csrf_support
-            )
+        self._client = PrefectHttpxSyncClient(
+            **httpx_settings, enable_csrf_support=enable_csrf_support
+        )
 
         # See https://www.python-httpx.org/advanced/#custom-transports
         #


### PR DESCRIPTION
after #14722, `PrefectHttpxSyncEphemeralClient` is no longer needed and was causing issues since it was indiscriminately being passed a `str` that was expected to be an app instance. This will fix errors when running sync tasks or flows against an ephemeral subprocess server.