### PR TITLE
Allow starting an ephemeral server when emitting or subscribing to events

### DIFF
--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -30,7 +30,12 @@ from websockets.exceptions import (
 
 from prefect.events import Event
 from prefect.logging import get_logger
-from prefect.settings import PREFECT_API_KEY, PREFECT_API_URL, PREFECT_CLOUD_API_URL
+from prefect.settings import (
+    PREFECT_API_KEY,
+    PREFECT_API_URL,
+    PREFECT_CLOUD_API_URL,
+    PREFECT_SERVER_ALLOW_EPHEMERAL_MODE,
+)
 
 if TYPE_CHECKING:
     from prefect.events.filters import EventFilter
@@ -77,7 +82,7 @@ def get_events_client(
             reconnection_attempts=reconnection_attempts,
             checkpoint_every=checkpoint_every,
         )
-    else:
+    elif PREFECT_SERVER_ALLOW_EPHEMERAL_MODE:
         from prefect.server.api.server import SubprocessASGIServer
 
         server = SubprocessASGIServer()
@@ -86,6 +91,10 @@ def get_events_client(
             api_url=server.api_url,
             reconnection_attempts=reconnection_attempts,
             checkpoint_every=checkpoint_every,
+        )
+    else:
+        raise ValueError(
+            "No Prefect API URL provided. Please set PREFECT_API_URL to the address of a running Prefect server."
         )
 
 
@@ -103,7 +112,7 @@ def get_events_subscriber(
         return PrefectEventSubscriber(
             filter=filter, reconnection_attempts=reconnection_attempts
         )
-    else:
+    elif PREFECT_SERVER_ALLOW_EPHEMERAL_MODE:
         from prefect.server.api.server import SubprocessASGIServer
 
         server = SubprocessASGIServer()
@@ -112,6 +121,10 @@ def get_events_subscriber(
             api_url=server.api_url,
             filter=filter,
             reconnection_attempts=reconnection_attempts,
+        )
+    else:
+        raise ValueError(
+            "No Prefect API URL provided. Please set PREFECT_API_URL to the address of a running Prefect server."
         )
 
 

--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -15,7 +15,6 @@ from typing import (
 )
 from uuid import UUID
 
-import httpx
 import orjson
 import pendulum
 from cachetools import TTLCache
@@ -29,7 +28,6 @@ from websockets.exceptions import (
     ConnectionClosedOK,
 )
 
-from prefect.client.base import PrefectHttpxAsyncClient
 from prefect.events import Event
 from prefect.logging import get_logger
 from prefect.settings import PREFECT_API_KEY, PREFECT_API_URL, PREFECT_CLOUD_API_URL
@@ -74,13 +72,21 @@ def get_events_client(
             reconnection_attempts=reconnection_attempts,
             checkpoint_every=checkpoint_every,
         )
-    elif PREFECT_API_URL:
+    elif api_url:
         return PrefectEventsClient(
             reconnection_attempts=reconnection_attempts,
             checkpoint_every=checkpoint_every,
         )
     else:
-        return PrefectEphemeralEventsClient()
+        from prefect.server.api.server import SubprocessASGIServer
+
+        server = SubprocessASGIServer()
+        server.start()
+        return PrefectEventsClient(
+            api_url=server.api_url,
+            reconnection_attempts=reconnection_attempts,
+            checkpoint_every=checkpoint_every,
+        )
 
 
 def get_events_subscriber(
@@ -88,19 +94,24 @@ def get_events_subscriber(
     reconnection_attempts: int = 10,
 ) -> "PrefectEventSubscriber":
     api_url = PREFECT_API_URL.value()
-    if not api_url:
-        raise ValueError(
-            "A Prefect server or Prefect Cloud is required to start an event "
-            "subscriber.  Please check the PREFECT_API_URL setting in your profile."
-        )
 
     if isinstance(api_url, str) and api_url.startswith(PREFECT_CLOUD_API_URL.value()):
         return PrefectCloudEventSubscriber(
             filter=filter, reconnection_attempts=reconnection_attempts
         )
-    else:
+    elif api_url:
         return PrefectEventSubscriber(
             filter=filter, reconnection_attempts=reconnection_attempts
+        )
+    else:
+        from prefect.server.api.server import SubprocessASGIServer
+
+        server = SubprocessASGIServer()
+        server.start()
+        return PrefectEventSubscriber(
+            api_url=server.api_url,
+            filter=filter,
+            reconnection_attempts=reconnection_attempts,
         )
 
 
@@ -199,47 +210,6 @@ def _get_api_url_and_key(
         )
 
     return api_url, api_key
-
-
-class PrefectEphemeralEventsClient(EventsClient):
-    """A Prefect Events client that sends events to an ephemeral Prefect server"""
-
-    def __init__(self):
-        if PREFECT_API_KEY.value():
-            raise ValueError(
-                "PrefectEphemeralEventsClient cannot be used when PREFECT_API_KEY is set."
-                " Please use PrefectEventsClient or PrefectCloudEventsClient instead."
-            )
-        from prefect.server.api.server import create_app
-
-        app = create_app(ephemeral=True)
-
-        self._http_client = PrefectHttpxAsyncClient(
-            transport=httpx.ASGITransport(app=app, raise_app_exceptions=False),
-            base_url="http://ephemeral-prefect/api",
-            enable_csrf_support=False,
-        )
-
-    async def __aenter__(self) -> Self:
-        await super().__aenter__()
-        await self._http_client.__aenter__()
-        return self
-
-    async def __aexit__(
-        self,
-        exc_type: Optional[Type[Exception]],
-        exc_val: Optional[Exception],
-        exc_tb: Optional[TracebackType],
-    ) -> None:
-        self._websocket = None
-        await self._http_client.__aexit__(exc_type, exc_val, exc_tb)
-        return await super().__aexit__(exc_type, exc_val, exc_tb)
-
-    async def _emit(self, event: Event) -> None:
-        await self._http_client.post(
-            "/events",
-            json=[event.model_dump(mode="json")],
-        )
 
 
 class PrefectEventsClient(EventsClient):
@@ -435,9 +405,9 @@ class PrefectEventSubscriber:
             reconnection_attempts: When the client is disconnected, how many times
                 the client should attempt to reconnect
         """
+        self._api_key = None
         if not api_url:
             api_url = cast(str, PREFECT_API_URL.value())
-            self._api_key = None
 
         from prefect.events.filters import EventFilter
 

--- a/src/prefect/events/utilities.py
+++ b/src/prefect/events/utilities.py
@@ -8,7 +8,6 @@ from pydantic_extra_types.pendulum_dt import DateTime
 from .clients import (
     AssertingEventsClient,
     PrefectCloudEventsClient,
-    PrefectEphemeralEventsClient,
     PrefectEventsClient,
 )
 from .schemas.events import Event, RelatedResource
@@ -53,7 +52,6 @@ def emit_event(
         AssertingEventsClient,
         PrefectCloudEventsClient,
         PrefectEventsClient,
-        PrefectEphemeralEventsClient,
     ]
     worker_instance = EventsWorker.instance()
 

--- a/tests/events/client/test_events_client.py
+++ b/tests/events/client/test_events_client.py
@@ -4,17 +4,17 @@ from unittest import mock
 import pytest
 from websockets.exceptions import ConnectionClosed
 
-from prefect.client.base import PrefectHttpxAsyncClient
 from prefect.events import Event, get_events_client
 from prefect.events.clients import (
     PrefectCloudEventsClient,
-    PrefectEphemeralEventsClient,
     PrefectEventsClient,
+    get_events_subscriber,
 )
 from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
+    PREFECT_SERVER_ALLOW_EPHEMERAL_MODE,
     temporary_settings,
 )
 from prefect.testing.fixtures import Puppeteer, Recorder
@@ -27,13 +27,14 @@ def ephemeral_settings():
             PREFECT_API_URL: None,
             PREFECT_API_KEY: None,
             PREFECT_CLOUD_API_URL: "https://cloudy/api",
+            PREFECT_SERVER_ALLOW_EPHEMERAL_MODE: True,
         }
     ):
         yield
 
 
-async def test_constructs_ephemeral_client(ephemeral_settings):
-    assert isinstance(get_events_client(), PrefectEphemeralEventsClient)
+async def test_constructs_client_when_ephemeral_enabled(ephemeral_settings):
+    assert isinstance(get_events_client(), PrefectEventsClient)
 
 
 @pytest.fixture
@@ -68,30 +69,19 @@ async def test_constructs_cloud_client(cloud_settings):
     assert isinstance(get_events_client(), PrefectCloudEventsClient)
 
 
-async def test_ephemeral_events_client_can_emit(
+async def test_events_client_can_emit_when_ephemeral_enabled(
     example_event_1: Event, monkeypatch: pytest.MonkeyPatch, ephemeral_settings
 ):
-    mock_http_client = mock.MagicMock(
-        spec=PrefectHttpxAsyncClient, name="PrefectHttpxAsyncClient"
-    )
-    mock_http_client.return_value.__aenter__ = mock.AsyncMock(
-        return_value=mock_http_client
-    )
-    mock_http_client.return_value.post = mock.AsyncMock()
-    monkeypatch.setattr(
-        "prefect.events.clients.PrefectHttpxAsyncClient", mock_http_client
-    )
-
     assert not PREFECT_API_URL.value()
     assert not PREFECT_API_KEY.value()
 
-    async with PrefectEphemeralEventsClient() as client:
-        await client.emit(example_event_1)
+    async with get_events_subscriber() as events_subscriber:
+        async with get_events_client() as events_client:
+            await events_client.emit(example_event_1)
 
-    mock_http_client().post.assert_called_once_with(
-        "/events",
-        json=[example_event_1.model_dump(mode="json")],
-    )
+            async for event in events_subscriber:
+                assert event == example_event_1
+                break
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc):

--- a/tests/events/client/test_events_client.py
+++ b/tests/events/client/test_events_client.py
@@ -37,6 +37,19 @@ async def test_constructs_client_when_ephemeral_enabled(ephemeral_settings):
     assert isinstance(get_events_client(), PrefectEventsClient)
 
 
+def test_errors_when_missing_api_url_and_ephemeral_disabled():
+    with temporary_settings(
+        {
+            PREFECT_API_URL: None,
+            PREFECT_API_KEY: None,
+            PREFECT_CLOUD_API_URL: "https://cloudy/api",
+            PREFECT_SERVER_ALLOW_EPHEMERAL_MODE: False,
+        }
+    ):
+        with pytest.raises(ValueError, match="PREFECT_API_URL"):
+            get_events_client()
+
+
 @pytest.fixture
 def server_settings():
     with temporary_settings(

--- a/tests/events/client/test_events_subscriber.py
+++ b/tests/events/client/test_events_subscriber.py
@@ -14,9 +14,23 @@ from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
+    PREFECT_SERVER_ALLOW_EPHEMERAL_MODE,
     temporary_settings,
 )
 from prefect.testing.fixtures import Puppeteer, Recorder
+
+
+@pytest.fixture
+def ephemeral_settings():
+    with temporary_settings(
+        {
+            PREFECT_API_URL: None,
+            PREFECT_API_KEY: None,
+            PREFECT_CLOUD_API_URL: "https://cloudy/api",
+            PREFECT_SERVER_ALLOW_EPHEMERAL_MODE: True,
+        }
+    ):
+        yield
 
 
 @pytest.fixture
@@ -31,6 +45,10 @@ def server_settings():
 
 
 async def test_constructs_server_client(server_settings):
+    assert isinstance(get_events_subscriber(), PrefectEventSubscriber)
+
+
+async def test_constructs_client_when_ephemeral_enabled(ephemeral_settings):
     assert isinstance(get_events_subscriber(), PrefectEventSubscriber)
 
 

--- a/tests/events/client/test_events_subscriber.py
+++ b/tests/events/client/test_events_subscriber.py
@@ -52,6 +52,19 @@ async def test_constructs_client_when_ephemeral_enabled(ephemeral_settings):
     assert isinstance(get_events_subscriber(), PrefectEventSubscriber)
 
 
+def test_errors_when_missing_api_url_and_ephemeral_disabled():
+    with temporary_settings(
+        {
+            PREFECT_API_URL: None,
+            PREFECT_API_KEY: None,
+            PREFECT_CLOUD_API_URL: "https://cloudy/api",
+            PREFECT_SERVER_ALLOW_EPHEMERAL_MODE: False,
+        }
+    ):
+        with pytest.raises(ValueError, match="PREFECT_API_URL"):
+            get_events_subscriber()
+
+
 @pytest.fixture
 def cloud_settings():
     with temporary_settings(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR updates `get_events_client` and `get_events_subscriber` to start a subprocess server when necessary and allowed. This enables users to use the events subscriber with an ephemeral server, which wasn't previously allowed.

Note that running a persistent server when emitting and consuming events is still recommended. Running the event producer and the event subscriber in different processes will result in two subprocess servers running with different in-memory event queues. In this case, the event subscriber will not receive events from the event producer.

Related to https://github.com/PrefectHQ/prefect/issues/14716

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
