### PR TITLE
Add `test` profile to default profiles

### DIFF
--- a/src/prefect/profiles.toml
+++ b/src/prefect/profiles.toml
@@ -12,6 +12,6 @@ PREFECT_API_URL = "http://127.0.0.1:4200/api"
 
 [profiles.test]
 PREFECT_SERVER_ALLOW_EPHEMERAL_MODE = "true"
-PREFECT_API_DATABASE_CONNECTION_URL = "sqlite+aiosqlite:///"
+PREFECT_API_DATABASE_CONNECTION_URL = "sqlite+aiosqlite:///:memory:"
 
 [profiles.cloud]

--- a/src/prefect/profiles.toml
+++ b/src/prefect/profiles.toml
@@ -10,5 +10,8 @@ PREFECT_SERVER_ALLOW_EPHEMERAL_MODE = "true"
 # You will need to set these values appropriately for your local development environment
 PREFECT_API_URL = "http://127.0.0.1:4200/api"
 
+[profiles.test]
+PREFECT_SERVER_ALLOW_EPHEMERAL_MODE = "true"
+PREFECT_API_DATABASE_CONNECTION_URL = "sqlite+aiosqlite:///"
 
 [profiles.cloud]

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -528,7 +528,7 @@ def create_app(
     async def start_services():
         """Start additional services when the Prefect REST API starts up."""
 
-        if ephemeral or os.environ.get("PREFECT__EPHEMERAL_SERVER", "0") == "1":
+        if ephemeral:
             app.state.services = None
             return
 
@@ -822,7 +822,7 @@ class SubprocessASGIServer:
     def _run_uvicorn_command(self) -> subprocess.Popen:
         # used to turn off background services
         server_env = {
-            "PREFECT__EPHEMERAL_SERVER": "1",
+            "PREFECT_UI_ENABLED": "0",
         }
         return subprocess.Popen(
             args=[

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -528,7 +528,7 @@ def create_app(
     async def start_services():
         """Start additional services when the Prefect REST API starts up."""
 
-        if ephemeral:
+        if ephemeral or os.environ.get("PREFECT__EPHEMERAL_SERVER", "0") == "1":
             app.state.services = None
             return
 
@@ -820,7 +820,10 @@ class SubprocessASGIServer:
                 raise
 
     def _run_uvicorn_command(self) -> subprocess.Popen:
-        server_env = {"PREFECT_UI_ENABLED": "0"}
+        # used to turn off background services
+        server_env = {
+            "PREFECT__EPHEMERAL_SERVER": "1",
+        }
         return subprocess.Popen(
             args=[
                 get_sys_executable(),

--- a/src/prefect/server/database/configurations.py
+++ b/src/prefect/server/database/configurations.py
@@ -341,7 +341,12 @@ class AioSqliteConfiguration(BaseDatabaseConfiguration):
             # ensure a long-lasting pool is used with in-memory databases
             # because they disappear when the last connection closes
             if ":memory:" in self.connection_url:
-                kwargs.update(poolclass=sa.pool.SingletonThreadPool)
+                kwargs.update(
+                    poolclass=sa.pool.AsyncAdaptedQueuePool,
+                    pool_size=1,
+                    max_overflow=0,
+                    pool_recycle=-1,
+                )
 
             engine = create_async_engine(self.connection_url, echo=self.echo, **kwargs)
             sa.event.listen(engine.sync_engine, "connect", self.setup_sqlite)

--- a/src/prefect/server/database/interface.py
+++ b/src/prefect/server/database/interface.py
@@ -85,10 +85,6 @@ class PrefectDBInterface(metaclass=DBSingleton):
         """
         engine = await self.database_config.engine()
 
-        if self.database_config.is_inmemory():
-            async with engine.begin() as conn:
-                await self.database_config.create_db(conn, self.Base.metadata)
-
         return engine
 
     async def session(self):

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -578,6 +578,7 @@ class TestProfilesPopulateDefaults:
                 "Add 'ephemeral'",
                 "Add 'local'",
                 "Add 'cloud'",
+                "Add 'test'",
                 f"Profiles updated in {temporary_profiles_path}",
                 "Use with prefect profile use [PROFILE-NAME]",
             ],
@@ -590,7 +591,7 @@ class TestProfilesPopulateDefaults:
         assert populated_profiles.names == default_profiles.names
         assert populated_profiles.active_name == default_profiles.active_name
 
-        assert {"local", "ephemeral", "cloud"} == set(populated_profiles.names)
+        assert {"local", "ephemeral", "cloud", "test"} == set(populated_profiles.names)
 
         for name in default_profiles.names:
             assert populated_profiles[name].settings == default_profiles[name].settings
@@ -617,7 +618,9 @@ class TestProfilesPopulateDefaults:
         )
 
         new_profiles = load_profiles()
-        assert {"local", "ephemeral", "cloud", "existing"} == set(new_profiles.names)
+        assert {"local", "ephemeral", "cloud", "test", "existing"} == set(
+            new_profiles.names
+        )
 
         backup_profiles = _read_profiles_from(
             temporary_profiles_path.with_suffix(".toml.bak")
@@ -663,7 +666,9 @@ class TestProfilesPopulateDefaults:
         )
 
         new_profiles = load_profiles()
-        assert {"ephemeral", "local", "cloud", "custom"} == set(new_profiles.names)
+        assert {"ephemeral", "local", "cloud", "test", "custom"} == set(
+            new_profiles.names
+        )
         assert "default" not in new_profiles.names
         assert new_profiles.active_name == "ephemeral"
         assert new_profiles["ephemeral"].settings == {

--- a/tests/server/api/test_server.py
+++ b/tests/server/api/test_server.py
@@ -411,7 +411,8 @@ class TestSubprocessASGIServer:
         with temporary_settings(
             {PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///:memory:"}
         ):
-            server = SubprocessASGIServer(port=8000)
+            SubprocessASGIServer._instances = {}
+            server = SubprocessASGIServer()
             server.start()
 
             with temporary_settings({PREFECT_API_URL: server.api_url}):
@@ -424,7 +425,7 @@ class TestSubprocessASGIServer:
 
             # do it again to ensure the db is recreated
 
-            server = SubprocessASGIServer(port=8000)
+            server = SubprocessASGIServer()
             server.start()
 
             with temporary_settings({PREFECT_API_URL: server.api_url}):

--- a/tests/server/api/test_server.py
+++ b/tests/server/api/test_server.py
@@ -397,3 +397,40 @@ class TestSubprocessASGIServer:
             assert len(client.read_flow_runs()) == 1
 
         server.stop()
+
+    def test_run_with_temp_db(self):
+        """
+        This test ensures that the format of the database connection URL used for the default
+        test profile does not retain state between subprocess server runs.
+        """
+
+        @flow
+        def f():
+            return 42
+
+        with temporary_settings(
+            {PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///"}
+        ):
+            server = SubprocessASGIServer(port=8000)
+            server.start()
+
+            with temporary_settings({PREFECT_API_URL: server.api_url}):
+                assert f() == 42
+
+                client = get_client(sync_client=True)
+                assert len(client.read_flow_runs()) == 1
+
+            server.stop()
+
+            # do it again to ensure the db is recreated
+
+            server = SubprocessASGIServer(port=8000)
+            server.start()
+
+            with temporary_settings({PREFECT_API_URL: server.api_url}):
+                assert f() == 42
+
+                client = get_client(sync_client=True)
+                assert len(client.read_flow_runs()) == 1
+
+            server.stop()

--- a/tests/server/api/test_server.py
+++ b/tests/server/api/test_server.py
@@ -409,7 +409,7 @@ class TestSubprocessASGIServer:
             return 42
 
         with temporary_settings(
-            {PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///"}
+            {PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///:memory:"}
         ):
             server = SubprocessASGIServer(port=8000)
             server.start()

--- a/tests/server/api/test_server.py
+++ b/tests/server/api/test_server.py
@@ -413,7 +413,7 @@ class TestSubprocessASGIServer:
         ):
             SubprocessASGIServer._instances = {}
             server = SubprocessASGIServer()
-            server.start()
+            server.start(timeout=30)
 
             with temporary_settings({PREFECT_API_URL: server.api_url}):
                 assert f() == 42
@@ -426,7 +426,7 @@ class TestSubprocessASGIServer:
             # do it again to ensure the db is recreated
 
             server = SubprocessASGIServer()
-            server.start()
+            server.start(timeout=30)
 
             with temporary_settings({PREFECT_API_URL: server.api_url}):
                 assert f() == 42


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

This PR adds a `test` profile to the default set of profiles that uses an ephemeral server and an ephemeral DB by default. Using this profile in its default form will prevent data persistence and can be used to test functionality without persisting data in other environments. Users can update this profile to match their test environment (e.g. a local server or a dev Prefect Cloud workspace).

Related to https://github.com/PrefectHQ/prefect/issues/14716

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
