### PR TITLE
Cleaner exit when Ctrl-C'ing `Flow.serve`

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -952,7 +952,8 @@ class Flow(Generic[P, R]):
                 loop.run_until_complete(runner.start(webserver=webserver))
             else:
                 asyncio.run(runner.start(webserver=webserver))
-        except (KeyboardInterrupt, TerminationSignal):
+        except (KeyboardInterrupt, TerminationSignal) as exc:
+            logger.info(f"Received {type(exc).__name__}, shutting down...")
             if loop is not None:
                 loop.stop()
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -66,6 +66,7 @@ from prefect.exceptions import (
     ObjectNotFound,
     ParameterTypeError,
     ScriptError,
+    TerminationSignal,
     UnspecifiedFlowError,
 )
 from prefect.filesystems import LocalFileSystem, ReadableDeploymentStorage
@@ -946,10 +947,14 @@ class Flow(Generic[P, R]):
             else:
                 raise
 
-        if loop is not None:
-            loop.run_until_complete(runner.start(webserver=webserver))
-        else:
-            asyncio.run(runner.start(webserver=webserver))
+        try:
+            if loop is not None:
+                loop.run_until_complete(runner.start(webserver=webserver))
+            else:
+                asyncio.run(runner.start(webserver=webserver))
+        except (KeyboardInterrupt, TerminationSignal):
+            if loop is not None:
+                loop.stop()
 
     @classmethod
     @sync_compatible


### PR DESCRIPTION
just an aesthetic / QoL thing, make the traceback cleaner when we simply Ctrl-C a `serve` process

<details>
<summary>Before</summary>

```python
» python repros/14779.py
Your flow 'foo' is being served and polling for scheduled runs!

To trigger a run for this flow, use the following command:

        $ prefect deployment run 'foo/foo'

You can also run your flow via the Prefect UI: https://app.prefect.cloud/account/9b649228-0419-40e1-9e0d-44954b5c0ab6/workspace/e49488be-6d30-4980-94b2-a82a5edbb19c/deployments/deployment/ec27d398-ce67-4ca7-a7c4-b6bcdd4853c4

^C11:18:50.646 | INFO    | prefect.runner - Pausing all deployments...
11:18:50.823 | INFO    | prefect.runner - All deployments have been paused!
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/runner/runner.py", line 389, in start
    async with self._loops_task_group as tg:
  File "/Users/nate/github.com/prefecthq/prefect/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 690, in __aexit__
    raise cancelled_exc_while_waiting_tasks
  File "/Users/nate/github.com/prefecthq/prefect/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 670, in __aexit__
    await asyncio.wait(self._tasks)
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/tasks.py", line 464, in wait
    return await _wait(fs, timeout, return_when, loop)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/tasks.py", line 550, in _wait
    await waiter
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/nate/github.com/prefecthq/prefect/repros/14779.py", line 16, in <module>
    foo.serve()
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/flows.py", line 952, in serve
    asyncio.run(runner.start(webserver=webserver))
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 123, in run
    raise KeyboardInterrupt()
KeyboardInterrupt
```
</details>

<details>
<summary>After</summary>

```python
» python repros/14779.py
Your flow 'foo' is being served and polling for scheduled runs!

To trigger a run for this flow, use the following command:

        $ prefect deployment run 'foo/foo'

You can also run your flow via the Prefect UI: <URL>

^C11:17:23.821 | INFO    | prefect.runner - Pausing all deployments...
11:17:23.989 | INFO    | prefect.runner - All deployments have been paused!
```
</details>

---

i plan to follow up with an accompanying `Task.serve` PR, where I will make that function a true sync function as well so we can cleanly shut down just like this