### PR TITLE
fix `task-run.Scheduled` event emission

### DIFF
--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -690,6 +690,12 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                                     task_run_name=task_run_name,
                                 )
                             )
+                            # Emit an event to capture that the task run was in the `PENDING` state.
+                            self._last_event = emit_task_run_state_change_event(
+                                task_run=self.task_run,
+                                initial_state=None,
+                                validated_state=self.task_run.state,
+                            )
                     else:
                         if not self.task_run:
                             self.task_run = run_coro_as_sync(
@@ -702,12 +708,12 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                                     extra_task_inputs=dependencies,
                                 )
                             )
-                    # Emit an event to capture that the task run was in the `PENDING` state.
-                    self._last_event = emit_task_run_state_change_event(
-                        task_run=self.task_run,
-                        initial_state=None,
-                        validated_state=self.task_run.state,
-                    )
+                            # Emit an event to capture that the task run was in the `PENDING` state.
+                            self._last_event = emit_task_run_state_change_event(
+                                task_run=self.task_run,
+                                initial_state=None,
+                                validated_state=self.task_run.state,
+                            )
 
                     with self.setup_run_context():
                         # setup_run_context might update the task run name, so log creation here

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -1258,6 +1258,12 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                                 extra_task_inputs=dependencies,
                                 task_run_name=task_run_name,
                             )
+                            # Emit an event to capture that the task run was in the `PENDING` state.
+                            self._last_event = emit_task_run_state_change_event(
+                                task_run=self.task_run,
+                                initial_state=None,
+                                validated_state=self.task_run.state,
+                            )
                     else:
                         if not self.task_run:
                             self.task_run = await self.task.create_run(
@@ -1268,12 +1274,12 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                                 wait_for=self.wait_for,
                                 extra_task_inputs=dependencies,
                             )
-                    # Emit an event to capture that the task run was in the `PENDING` state.
-                    self._last_event = emit_task_run_state_change_event(
-                        task_run=self.task_run,
-                        initial_state=None,
-                        validated_state=self.task_run.state,
-                    )
+                            # Emit an event to capture that the task run was in the `PENDING` state.
+                            self._last_event = emit_task_run_state_change_event(
+                                task_run=self.task_run,
+                                initial_state=None,
+                                validated_state=self.task_run.state,
+                            )
 
                     async with self.setup_run_context():
                         # setup_run_context might update the task run name, so log creation here

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -67,6 +67,7 @@ from prefect.utilities.callables import (
     get_call_parameters,
     raise_for_reserved_arguments,
 )
+from prefect.utilities.engine import emit_task_run_state_change_event
 from prefect.utilities.hashing import hash_objects
 from prefect.utilities.importtools import to_qualified_name
 from prefect.utilities.urls import url_for
@@ -1449,6 +1450,13 @@ class Task(Generic[P, R]):
                 extra_task_inputs=dependencies,
             )
         )  # type: ignore
+
+        # emit a `SCHEDULED` event for the task run
+        emit_task_run_state_change_event(
+            task_run=task_run,
+            initial_state=None,
+            validated_state=task_run.state,
+        )
 
         if task_run_url := url_for(task_run):
             logger.info(

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -67,7 +67,6 @@ from prefect.utilities.callables import (
     get_call_parameters,
     raise_for_reserved_arguments,
 )
-from prefect.utilities.engine import emit_task_run_state_change_event
 from prefect.utilities.hashing import hash_objects
 from prefect.utilities.importtools import to_qualified_name
 from prefect.utilities.urls import url_for
@@ -1450,6 +1449,8 @@ class Task(Generic[P, R]):
                 extra_task_inputs=dependencies,
             )
         )  # type: ignore
+
+        from prefect.utilities.engine import emit_task_run_state_change_event
 
         # emit a `SCHEDULED` event for the task run
         emit_task_run_state_change_event(

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -783,6 +783,9 @@ def emit_task_run_state_change_event(
                     "state_type",
                     "state_name",
                     "state",
+                    # server materialized fields
+                    "estimated_start_time_delta",
+                    "estimated_run_time",
                 },
             ),
         },


### PR DESCRIPTION
Previously the only way a `task-run.Scheduled` event appears to be something like this:

- task run gets created via apply async
- worker gets the run, sets state to pending and emits `SCHEDULED` -> `PENDING` event
- worker would open the engine context and inside of the engine a `None` -> `SCHEDULED` event would be [emitted](https://github.com/PrefectHQ/prefect/blob/4a7424d9ced3477ec21839c2f41413bed9d3ef74/src/prefect/task_engine.py#L705-L710) 

This does not seem intentional and is certainly unintuitive. However I think we do want to keep `task-run.Scheduled` events as they are useful. This PR makes the following updates:
- Only emit an initial task run event in the engine if we're creating a new run (this is the classic `PENDING` event)
- Actually emit a `SCHEDULED` event inside of `apply_async`
