### PR TITLE
update task run event tests for client side orchestration

### DIFF
--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -293,6 +293,8 @@ class TaskWorker:
                     await self._client._client.delete(f"/task_runs/{task_run.id}")
                 return
 
+        initial_state = task_run.state
+
         if PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
             new_state = Pending()
             new_state.state_details.deferred = True
@@ -331,7 +333,7 @@ class TaskWorker:
 
         emit_task_run_state_change_event(
             task_run=task_run,
-            initial_state=task_run.state,
+            initial_state=initial_state,
             validated_state=state,
         )
 

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -299,6 +299,7 @@ class TaskWorker:
             new_state.state_details.task_run_id = task_run.id
             new_state.state_details.flow_run_id = task_run.flow_run_id
             state = new_state
+            task_run.state = state
         else:
             try:
                 new_state = Pending()

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -383,9 +383,12 @@ def asserting_events_worker(monkeypatch) -> Generator[EventsWorker, None, None]:
 async def events_pipeline(asserting_events_worker: EventsWorker):
     class AssertingEventsPipeline(EventsPipeline):
         @sync_compatible
-        async def process_events(self):
+        async def process_events(self, dequeue_events: bool = True):
             asserting_events_worker.wait_until_empty()
-            events = asserting_events_worker._client.pop_events()
+            if dequeue_events:
+                events = asserting_events_worker._client.pop_events()
+            else:
+                events = asserting_events_worker._client.events
             messages = self.events_to_messages(events)
             await self.process_messages(messages)
 

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -1,4 +1,5 @@
 import pendulum
+import pytest
 
 from prefect import flow, task
 from prefect.client.orchestration import PrefectClient
@@ -7,13 +8,30 @@ from prefect.events.clients import AssertingEventsClient
 from prefect.events.schemas.events import Resource
 from prefect.events.worker import EventsWorker
 from prefect.filesystems import LocalFileSystem
+from prefect.settings import (
+    PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION,
+    temporary_settings,
+)
 from prefect.task_worker import TaskWorker
+
+
+@pytest.fixture(autouse=True, params=[False, True])
+def enable_client_side_task_run_orchestration(
+    request, asserting_events_worker: EventsWorker
+):
+    enabled = request.param
+    with temporary_settings(
+        {PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION: enabled}
+    ):
+        yield enabled
 
 
 async def test_task_state_change_happy_path(
     asserting_events_worker: EventsWorker,
     reset_worker_events: None,
     prefect_client: PrefectClient,
+    events_pipeline,
+    enable_client_side_task_run_orchestration,
 ):
     @task
     def happy_little_tree():
@@ -25,8 +43,11 @@ async def test_task_state_change_happy_path(
 
     flow_state: State[State[str]] = happy_path(return_state=True)
 
+    await events_pipeline.process_events(dequeue_events=False)
+
     task_state: State[str] = await flow_state.result()
     task_run_id = task_state.state_details.task_run_id
+
     task_run = await prefect_client.read_task_run(task_run_id)
     task_run_states = await prefect_client.read_task_run_states(task_run_id)
 
@@ -41,163 +62,357 @@ async def test_task_state_change_happy_path(
 
     pending, running, completed = events
 
-    assert pending.event == "prefect.task-run.Pending"
-    assert pending.id == task_run_states[0].id
-    assert pending.occurred == task_run_states[0].timestamp
-    assert pending.resource == Resource(
-        {
-            "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-            "prefect.resource.name": task_run.name,
-            "prefect.state-message": "",
-            "prefect.state-type": "PENDING",
-            "prefect.state-name": "Pending",
-            "prefect.state-timestamp": task_run_states[0].timestamp.isoformat(),
-            "prefect.orchestration": "server",
-        }
-    )
-    assert (
-        pendulum.parse(pending.payload["task_run"].pop("expected_start_time"))
-        == task_run.expected_start_time
-    )
-    assert pending.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-    assert pending.payload == {
-        "initial_state": None,
-        "intended": {"from": None, "to": "PENDING"},
-        "validated_state": {
-            "type": "PENDING",
-            "name": "Pending",
-            "message": "",
-            "state_details": {"pause_reschedule": False, "untrackable_result": False},
-            "data": None,
-        },
-        "task_run": {
-            "dynamic_key": "0",
-            "empirical_policy": {
-                "max_retries": 0,
-                "retries": 0,
-                "retry_delay": 0,
-                "retry_delay_seconds": 0.0,
+    if enable_client_side_task_run_orchestration:
+        assert pending.event == "prefect.task-run.Pending"
+        assert pending.id == task_run_states[0].id
+        assert pending.occurred == task_run_states[0].timestamp
+        assert pending.resource == Resource(
+            {
+                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+                "prefect.resource.name": task_run.name,
+                "prefect.state-message": "",
+                "prefect.state-type": "PENDING",
+                "prefect.state-name": "Pending",
+                "prefect.state-timestamp": task_run_states[0].timestamp.isoformat(),
+                "prefect.orchestration": "client",
+            }
+        )
+        assert (
+            pendulum.parse(pending.payload["task_run"].pop("expected_start_time"))
+            == task_run.expected_start_time
+        )
+        assert (
+            pending.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+        )
+        assert pending.payload == {
+            "initial_state": None,
+            "intended": {"from": None, "to": "PENDING"},
+            "validated_state": {
+                "type": "PENDING",
+                "name": "Pending",
+                "message": "",
+                "state_details": {},
+                "data": None,
             },
-            "flow_run_run_count": 0,
-            "name": "happy_little_tree-0",
-            "run_count": 0,
-            "tags": [],
-            "task_inputs": {},
-            "total_run_time": 0.0,
-        },
-    }
+            "task_run": {
+                "dynamic_key": "0",
+                "empirical_policy": {
+                    "max_retries": 0,
+                    "retries": 0,
+                    "retry_delay": 0,
+                    "retry_delay_seconds": 0.0,
+                },
+                "flow_run_run_count": 0,
+                "name": "happy_little_tree-0",
+                "run_count": 0,
+                "tags": [],
+                "task_inputs": {},
+                "total_run_time": 0.0,
+            },
+        }
 
-    assert running.event == "prefect.task-run.Running"
-    assert running.id == task_run_states[1].id
-    assert running.occurred == task_run_states[1].timestamp
-    assert running.resource == Resource(
-        {
-            "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-            "prefect.resource.name": task_run.name,
-            "prefect.state-message": "",
-            "prefect.state-type": "RUNNING",
-            "prefect.state-name": "Running",
-            "prefect.state-timestamp": task_run_states[1].timestamp.isoformat(),
-            "prefect.orchestration": "server",
-        }
-    )
-    assert (
-        pendulum.parse(running.payload["task_run"].pop("expected_start_time"))
-        == task_run.expected_start_time
-    )
-    assert running.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-    assert running.payload == {
-        "intended": {"from": "PENDING", "to": "RUNNING"},
-        "initial_state": {
-            "type": "PENDING",
-            "name": "Pending",
-            "message": "",
-            "state_details": {"pause_reschedule": False, "untrackable_result": False},
-        },
-        "validated_state": {
-            "type": "RUNNING",
-            "name": "Running",
-            "message": "",
-            "state_details": {"pause_reschedule": False, "untrackable_result": False},
-            "data": None,
-        },
-        "task_run": {
-            "dynamic_key": "0",
-            "empirical_policy": {
-                "max_retries": 0,
-                "retries": 0,
-                "retry_delay": 0,
-                "retry_delay_seconds": 0.0,
+        assert running.event == "prefect.task-run.Running"
+        assert running.id == task_run_states[1].id
+        assert running.occurred == task_run_states[1].timestamp
+        assert running.resource == Resource(
+            {
+                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+                "prefect.resource.name": task_run.name,
+                "prefect.state-message": "",
+                "prefect.state-type": "RUNNING",
+                "prefect.state-name": "Running",
+                "prefect.state-timestamp": task_run_states[1].timestamp.isoformat(),
+                "prefect.orchestration": "client",
+            }
+        )
+        assert (
+            pendulum.parse(running.payload["task_run"].pop("expected_start_time"))
+            == task_run.expected_start_time
+        )
+        assert (
+            running.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+        )
+        assert (
+            pendulum.parse(running.payload["task_run"].pop("start_time"))
+            == task_run.start_time
+        )
+        assert running.payload == {
+            "intended": {"from": "PENDING", "to": "RUNNING"},
+            "initial_state": {
+                "type": "PENDING",
+                "name": "Pending",
+                "message": "",
+                "state_details": {},
             },
-            "flow_run_run_count": 0,
-            "name": "happy_little_tree-0",
-            "run_count": 0,
-            "tags": [],
-            "task_inputs": {},
-            "total_run_time": 0.0,
-        },
-    }
+            "validated_state": {
+                "type": "RUNNING",
+                "name": "Running",
+                "message": "",
+                "state_details": {},
+                "data": None,
+            },
+            "task_run": {
+                "dynamic_key": "0",
+                "empirical_policy": {
+                    "max_retries": 0,
+                    "retries": 0,
+                    "retry_delay": 0,
+                    "retry_delay_seconds": 0.0,
+                },
+                "flow_run_run_count": 1,
+                "name": "happy_little_tree-0",
+                "run_count": 1,
+                "tags": [],
+                "task_inputs": {},
+                "total_run_time": 0.0,
+            },
+        }
 
-    assert completed.event == "prefect.task-run.Completed"
-    assert completed.id == task_run_states[2].id
-    assert completed.occurred == task_run_states[2].timestamp
-    assert completed.resource == Resource(
-        {
-            "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-            "prefect.resource.name": task_run.name,
-            "prefect.state-message": "",
-            "prefect.state-type": "COMPLETED",
-            "prefect.state-name": "Completed",
-            "prefect.state-timestamp": task_run_states[2].timestamp.isoformat(),
-            "prefect.orchestration": "server",
-        }
-    )
-    assert (
-        pendulum.parse(completed.payload["task_run"].pop("expected_start_time"))
-        == task_run.expected_start_time
-    )
-    assert completed.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-    assert (
-        pendulum.parse(completed.payload["task_run"].pop("start_time"))
-        == task_run.start_time
-    )
-    assert completed.payload == {
-        "intended": {"from": "RUNNING", "to": "COMPLETED"},
-        "initial_state": {
-            "type": "RUNNING",
-            "name": "Running",
-            "message": "",
-            "state_details": {"pause_reschedule": False, "untrackable_result": False},
-        },
-        "validated_state": {
-            "type": "COMPLETED",
-            "name": "Completed",
-            "message": "",
-            "state_details": {"pause_reschedule": False, "untrackable_result": False},
-            "data": {"type": "unpersisted"},
-        },
-        "task_run": {
-            "dynamic_key": "0",
-            "empirical_policy": {
-                "max_retries": 0,
-                "retries": 0,
-                "retry_delay": 0,
-                "retry_delay_seconds": 0.0,
+        assert completed.event == "prefect.task-run.Completed"
+        assert completed.id == task_run_states[2].id
+        assert completed.occurred == task_run_states[2].timestamp
+        assert completed.resource == Resource(
+            {
+                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+                "prefect.resource.name": task_run.name,
+                "prefect.state-message": "",
+                "prefect.state-type": "COMPLETED",
+                "prefect.state-name": "Completed",
+                "prefect.state-timestamp": task_run_states[2].timestamp.isoformat(),
+                "prefect.orchestration": "client",
+            }
+        )
+        assert (
+            pendulum.parse(completed.payload["task_run"].pop("expected_start_time"))
+            == task_run.expected_start_time
+        )
+        assert (
+            completed.payload["task_run"]
+            .pop("task_key")
+            .startswith("happy_little_tree")
+        )
+        assert (
+            pendulum.parse(completed.payload["task_run"].pop("start_time"))
+            == task_run.start_time
+        )
+        assert (
+            pendulum.parse(completed.payload["task_run"].pop("end_time"))
+            == task_run.end_time
+        )
+        assert completed.payload["task_run"].pop("total_run_time") > 0.0
+        assert completed.payload == {
+            "intended": {"from": "RUNNING", "to": "COMPLETED"},
+            "initial_state": {
+                "type": "RUNNING",
+                "name": "Running",
+                "message": "",
+                "state_details": {},
             },
-            "flow_run_run_count": 1,
-            "name": "happy_little_tree-0",
-            "run_count": 1,
-            "tags": [],
-            "task_inputs": {},
-            "total_run_time": 0.0,
-        },
-    }
+            "validated_state": {
+                "type": "COMPLETED",
+                "name": "Completed",
+                "message": "",
+                "state_details": {},
+                "data": {"type": "unpersisted"},
+            },
+            "task_run": {
+                "dynamic_key": "0",
+                "empirical_policy": {
+                    "max_retries": 0,
+                    "retries": 0,
+                    "retry_delay": 0,
+                    "retry_delay_seconds": 0.0,
+                },
+                "flow_run_run_count": 1,
+                "name": "happy_little_tree-0",
+                "run_count": 1,
+                "tags": [],
+                "task_inputs": {},
+            },
+        }
+    else:
+        assert pending.event == "prefect.task-run.Pending"
+        assert pending.id == task_run_states[0].id
+        assert pending.occurred == task_run_states[0].timestamp
+        assert pending.resource == Resource(
+            {
+                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+                "prefect.resource.name": task_run.name,
+                "prefect.state-message": "",
+                "prefect.state-type": "PENDING",
+                "prefect.state-name": "Pending",
+                "prefect.state-timestamp": task_run_states[0].timestamp.isoformat(),
+                "prefect.orchestration": "server",
+            }
+        )
+        assert (
+            pendulum.parse(pending.payload["task_run"].pop("expected_start_time"))
+            == task_run.expected_start_time
+        )
+        assert (
+            pending.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+        )
+        assert pending.payload == {
+            "initial_state": None,
+            "intended": {"from": None, "to": "PENDING"},
+            "validated_state": {
+                "type": "PENDING",
+                "name": "Pending",
+                "message": "",
+                "state_details": {
+                    "pause_reschedule": False,
+                    "untrackable_result": False,
+                },
+                "data": None,
+            },
+            "task_run": {
+                "dynamic_key": "0",
+                "empirical_policy": {
+                    "max_retries": 0,
+                    "retries": 0,
+                    "retry_delay": 0,
+                    "retry_delay_seconds": 0.0,
+                },
+                "flow_run_run_count": 0,
+                "name": "happy_little_tree-0",
+                "run_count": 0,
+                "tags": [],
+                "task_inputs": {},
+                "total_run_time": 0.0,
+            },
+        }
+
+        assert running.event == "prefect.task-run.Running"
+        assert running.id == task_run_states[1].id
+        assert running.occurred == task_run_states[1].timestamp
+        assert running.resource == Resource(
+            {
+                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+                "prefect.resource.name": task_run.name,
+                "prefect.state-message": "",
+                "prefect.state-type": "RUNNING",
+                "prefect.state-name": "Running",
+                "prefect.state-timestamp": task_run_states[1].timestamp.isoformat(),
+                "prefect.orchestration": "server",
+            }
+        )
+        assert (
+            pendulum.parse(running.payload["task_run"].pop("expected_start_time"))
+            == task_run.expected_start_time
+        )
+        assert (
+            running.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+        )
+        assert running.payload == {
+            "intended": {"from": "PENDING", "to": "RUNNING"},
+            "initial_state": {
+                "type": "PENDING",
+                "name": "Pending",
+                "message": "",
+                "state_details": {
+                    "pause_reschedule": False,
+                    "untrackable_result": False,
+                },
+            },
+            "validated_state": {
+                "type": "RUNNING",
+                "name": "Running",
+                "message": "",
+                "state_details": {
+                    "pause_reschedule": False,
+                    "untrackable_result": False,
+                },
+                "data": None,
+            },
+            "task_run": {
+                "dynamic_key": "0",
+                "empirical_policy": {
+                    "max_retries": 0,
+                    "retries": 0,
+                    "retry_delay": 0,
+                    "retry_delay_seconds": 0.0,
+                },
+                "flow_run_run_count": 0,
+                "name": "happy_little_tree-0",
+                "run_count": 0,
+                "tags": [],
+                "task_inputs": {},
+                "total_run_time": 0.0,
+            },
+        }
+
+        assert completed.event == "prefect.task-run.Completed"
+        assert completed.id == task_run_states[2].id
+        assert completed.occurred == task_run_states[2].timestamp
+        assert completed.resource == Resource(
+            {
+                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+                "prefect.resource.name": task_run.name,
+                "prefect.state-message": "",
+                "prefect.state-type": "COMPLETED",
+                "prefect.state-name": "Completed",
+                "prefect.state-timestamp": task_run_states[2].timestamp.isoformat(),
+                "prefect.orchestration": "server",
+            }
+        )
+        assert (
+            pendulum.parse(completed.payload["task_run"].pop("expected_start_time"))
+            == task_run.expected_start_time
+        )
+        assert (
+            completed.payload["task_run"]
+            .pop("task_key")
+            .startswith("happy_little_tree")
+        )
+        assert (
+            pendulum.parse(completed.payload["task_run"].pop("start_time"))
+            == task_run.start_time
+        )
+        assert completed.payload == {
+            "intended": {"from": "RUNNING", "to": "COMPLETED"},
+            "initial_state": {
+                "type": "RUNNING",
+                "name": "Running",
+                "message": "",
+                "state_details": {
+                    "pause_reschedule": False,
+                    "untrackable_result": False,
+                },
+            },
+            "validated_state": {
+                "type": "COMPLETED",
+                "name": "Completed",
+                "message": "",
+                "state_details": {
+                    "pause_reschedule": False,
+                    "untrackable_result": False,
+                },
+                "data": {"type": "unpersisted"},
+            },
+            "task_run": {
+                "dynamic_key": "0",
+                "empirical_policy": {
+                    "max_retries": 0,
+                    "retries": 0,
+                    "retry_delay": 0,
+                    "retry_delay_seconds": 0.0,
+                },
+                "flow_run_run_count": 1,
+                "name": "happy_little_tree-0",
+                "run_count": 1,
+                "tags": [],
+                "task_inputs": {},
+                "total_run_time": 0.0,
+            },
+        }
 
 
 async def test_task_state_change_task_failure(
     asserting_events_worker: EventsWorker,
     reset_worker_events,
     prefect_client,
+    events_pipeline,
+    enable_client_side_task_run_orchestration,
 ):
     @task
     def happy_little_tree():
@@ -208,9 +423,11 @@ async def test_task_state_change_task_failure(
         return happy_little_tree(return_state=True)
 
     flow_state = happy_path(return_state=True)
+    await events_pipeline.process_events(dequeue_events=False)
 
     task_state = await flow_state.result(raise_on_failure=False)
     task_run_id = task_state.state_details.task_run_id
+
     task_run = await prefect_client.read_task_run(task_run_id)
     task_run_states = await prefect_client.read_task_run_states(task_run_id)
 
@@ -225,167 +442,358 @@ async def test_task_state_change_task_failure(
 
     pending, running, failed = events
 
-    assert pending.event == "prefect.task-run.Pending"
-    assert pending.id == task_run_states[0].id
-    assert pending.occurred == task_run_states[0].timestamp
-    assert pending.resource == Resource(
-        {
-            "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-            "prefect.resource.name": task_run.name,
-            "prefect.state-message": "",
-            "prefect.state-type": "PENDING",
-            "prefect.state-name": "Pending",
-            "prefect.state-timestamp": task_run_states[0].timestamp.isoformat(),
-            "prefect.orchestration": "server",
-        }
-    )
-    assert (
-        pendulum.parse(pending.payload["task_run"].pop("expected_start_time"))
-        == task_run.expected_start_time
-    )
-    assert pending.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-    assert pending.payload == {
-        "initial_state": None,
-        "intended": {"from": None, "to": "PENDING"},
-        "validated_state": {
-            "type": "PENDING",
-            "name": "Pending",
-            "message": "",
-            "state_details": {"pause_reschedule": False, "untrackable_result": False},
-            "data": None,
-        },
-        "task_run": {
-            "dynamic_key": "0",
-            "empirical_policy": {
-                "max_retries": 0,
-                "retries": 0,
-                "retry_delay": 0,
-                "retry_delay_seconds": 0.0,
+    if enable_client_side_task_run_orchestration:
+        assert pending.event == "prefect.task-run.Pending"
+        assert pending.id == task_run_states[0].id
+        assert pending.occurred == task_run_states[0].timestamp
+        assert pending.resource == Resource(
+            {
+                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+                "prefect.resource.name": task_run.name,
+                "prefect.state-message": "",
+                "prefect.state-type": "PENDING",
+                "prefect.state-name": "Pending",
+                "prefect.state-timestamp": task_run_states[0].timestamp.isoformat(),
+                "prefect.orchestration": "client",
+            }
+        )
+        assert (
+            pendulum.parse(pending.payload["task_run"].pop("expected_start_time"))
+            == task_run.expected_start_time
+        )
+        assert (
+            pending.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+        )
+        assert pending.payload == {
+            "initial_state": None,
+            "intended": {"from": None, "to": "PENDING"},
+            "validated_state": {
+                "type": "PENDING",
+                "name": "Pending",
+                "message": "",
+                "state_details": {},
+                "data": None,
             },
-            "flow_run_run_count": 0,
-            "name": "happy_little_tree-0",
-            "run_count": 0,
-            "tags": [],
-            "task_inputs": {},
-            "total_run_time": 0.0,
-        },
-    }
+            "task_run": {
+                "dynamic_key": "0",
+                "empirical_policy": {
+                    "max_retries": 0,
+                    "retries": 0,
+                    "retry_delay": 0,
+                    "retry_delay_seconds": 0.0,
+                },
+                "flow_run_run_count": 0,
+                "name": "happy_little_tree-0",
+                "run_count": 0,
+                "tags": [],
+                "task_inputs": {},
+                "total_run_time": 0.0,
+            },
+        }
 
-    assert running.event == "prefect.task-run.Running"
-    assert running.id == task_run_states[1].id
-    assert running.occurred == task_run_states[1].timestamp
-    assert running.resource == Resource(
-        {
-            "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-            "prefect.resource.name": task_run.name,
-            "prefect.state-message": "",
-            "prefect.state-type": "RUNNING",
-            "prefect.state-name": "Running",
-            "prefect.state-timestamp": task_run_states[1].timestamp.isoformat(),
-            "prefect.orchestration": "server",
-        }
-    )
-    assert (
-        pendulum.parse(running.payload["task_run"].pop("expected_start_time"))
-        == task_run.expected_start_time
-    )
-    assert running.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-    assert running.payload == {
-        "intended": {"from": "PENDING", "to": "RUNNING"},
-        "initial_state": {
-            "type": "PENDING",
-            "name": "Pending",
-            "message": "",
-            "state_details": {"pause_reschedule": False, "untrackable_result": False},
-        },
-        "validated_state": {
-            "type": "RUNNING",
-            "name": "Running",
-            "message": "",
-            "state_details": {"pause_reschedule": False, "untrackable_result": False},
-            "data": None,
-        },
-        "task_run": {
-            "dynamic_key": "0",
-            "empirical_policy": {
-                "max_retries": 0,
-                "retries": 0,
-                "retry_delay": 0,
-                "retry_delay_seconds": 0.0,
+        assert running.event == "prefect.task-run.Running"
+        assert running.id == task_run_states[1].id
+        assert running.occurred == task_run_states[1].timestamp
+        assert running.resource == Resource(
+            {
+                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+                "prefect.resource.name": task_run.name,
+                "prefect.state-message": "",
+                "prefect.state-type": "RUNNING",
+                "prefect.state-name": "Running",
+                "prefect.state-timestamp": task_run_states[1].timestamp.isoformat(),
+                "prefect.orchestration": "client",
+            }
+        )
+        assert (
+            pendulum.parse(running.payload["task_run"].pop("expected_start_time"))
+            == task_run.expected_start_time
+        )
+        assert (
+            pendulum.parse(running.payload["task_run"].pop("start_time"))
+            == task_run.start_time
+        )
+        assert (
+            running.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+        )
+        assert running.payload == {
+            "intended": {"from": "PENDING", "to": "RUNNING"},
+            "initial_state": {
+                "type": "PENDING",
+                "name": "Pending",
+                "message": "",
+                "state_details": {},
             },
-            "flow_run_run_count": 0,
-            "name": "happy_little_tree-0",
-            "run_count": 0,
-            "tags": [],
-            "task_inputs": {},
-            "total_run_time": 0.0,
-        },
-    }
+            "validated_state": {
+                "type": "RUNNING",
+                "name": "Running",
+                "message": "",
+                "state_details": {},
+                "data": None,
+            },
+            "task_run": {
+                "dynamic_key": "0",
+                "empirical_policy": {
+                    "max_retries": 0,
+                    "retries": 0,
+                    "retry_delay": 0,
+                    "retry_delay_seconds": 0.0,
+                },
+                "flow_run_run_count": 1,
+                "name": "happy_little_tree-0",
+                "run_count": 1,
+                "tags": [],
+                "task_inputs": {},
+                "total_run_time": 0.0,
+            },
+        }
 
-    assert failed.event == "prefect.task-run.Failed"
-    assert failed.id == task_run_states[2].id
-    assert failed.occurred == task_run_states[2].timestamp
-    assert failed.resource == Resource(
-        {
-            "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-            "prefect.resource.name": task_run.name,
-            "prefect.state-message": (
-                "Task run encountered an exception ValueError: "
-                "Here's a happy little accident."
-            ),
-            "prefect.state-type": "FAILED",
-            "prefect.state-name": "Failed",
-            "prefect.state-timestamp": task_run_states[2].timestamp.isoformat(),
-            "prefect.orchestration": "server",
+        assert failed.event == "prefect.task-run.Failed"
+        assert failed.id == task_run_states[2].id
+        assert failed.occurred == task_run_states[2].timestamp
+        assert failed.resource == Resource(
+            {
+                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+                "prefect.resource.name": task_run.name,
+                "prefect.state-message": (
+                    "Task run encountered an exception ValueError: "
+                    "Here's a happy little accident."
+                ),
+                "prefect.state-type": "FAILED",
+                "prefect.state-name": "Failed",
+                "prefect.state-timestamp": task_run_states[2].timestamp.isoformat(),
+                "prefect.orchestration": "client",
+            }
+        )
+        assert (
+            pendulum.parse(failed.payload["task_run"].pop("expected_start_time"))
+            == task_run.expected_start_time
+        )
+        assert (
+            failed.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+        )
+        assert (
+            pendulum.parse(failed.payload["task_run"].pop("start_time"))
+            == task_run.start_time
+        )
+        assert (
+            pendulum.parse(failed.payload["task_run"].pop("end_time"))
+            == task_run.end_time
+        )
+        assert failed.payload["task_run"].pop("total_run_time") > 0
+        assert failed.payload == {
+            "intended": {"from": "RUNNING", "to": "FAILED"},
+            "initial_state": {
+                "type": "RUNNING",
+                "name": "Running",
+                "message": "",
+                "state_details": {},
+            },
+            "validated_state": {
+                "type": "FAILED",
+                "name": "Failed",
+                "message": (
+                    "Task run encountered an exception ValueError: "
+                    "Here's a happy little accident."
+                ),
+                "state_details": {"retriable": False},
+                "data": {"type": "unpersisted"},
+            },
+            "task_run": {
+                "dynamic_key": "0",
+                "empirical_policy": {
+                    "max_retries": 0,
+                    "retries": 0,
+                    "retry_delay": 0,
+                    "retry_delay_seconds": 0.0,
+                },
+                "flow_run_run_count": 1,
+                "name": "happy_little_tree-0",
+                "run_count": 1,
+                "tags": [],
+                "task_inputs": {},
+            },
         }
-    )
-    assert (
-        pendulum.parse(failed.payload["task_run"].pop("expected_start_time"))
-        == task_run.expected_start_time
-    )
-    assert failed.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-    assert (
-        pendulum.parse(failed.payload["task_run"].pop("start_time"))
-        == task_run.start_time
-    )
-    assert failed.payload == {
-        "intended": {"from": "RUNNING", "to": "FAILED"},
-        "initial_state": {
-            "type": "RUNNING",
-            "name": "Running",
-            "message": "",
-            "state_details": {"pause_reschedule": False, "untrackable_result": False},
-        },
-        "validated_state": {
-            "type": "FAILED",
-            "name": "Failed",
-            "message": (
-                "Task run encountered an exception ValueError: "
-                "Here's a happy little accident."
-            ),
-            "state_details": {
-                "pause_reschedule": False,
-                "retriable": False,
-                "untrackable_result": False,
+    else:
+        assert pending.event == "prefect.task-run.Pending"
+        assert pending.id == task_run_states[0].id
+        assert pending.occurred == task_run_states[0].timestamp
+        assert pending.resource == Resource(
+            {
+                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+                "prefect.resource.name": task_run.name,
+                "prefect.state-message": "",
+                "prefect.state-type": "PENDING",
+                "prefect.state-name": "Pending",
+                "prefect.state-timestamp": task_run_states[0].timestamp.isoformat(),
+                "prefect.orchestration": "server",
+            }
+        )
+        assert (
+            pendulum.parse(pending.payload["task_run"].pop("expected_start_time"))
+            == task_run.expected_start_time
+        )
+        assert (
+            pending.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+        )
+        assert pending.payload == {
+            "initial_state": None,
+            "intended": {"from": None, "to": "PENDING"},
+            "validated_state": {
+                "type": "PENDING",
+                "name": "Pending",
+                "message": "",
+                "state_details": {
+                    "pause_reschedule": False,
+                    "untrackable_result": False,
+                },
+                "data": None,
             },
-            "data": {"type": "unpersisted"},
-        },
-        "task_run": {
-            "dynamic_key": "0",
-            "empirical_policy": {
-                "max_retries": 0,
-                "retries": 0,
-                "retry_delay": 0,
-                "retry_delay_seconds": 0.0,
+            "task_run": {
+                "dynamic_key": "0",
+                "empirical_policy": {
+                    "max_retries": 0,
+                    "retries": 0,
+                    "retry_delay": 0,
+                    "retry_delay_seconds": 0.0,
+                },
+                "flow_run_run_count": 0,
+                "name": "happy_little_tree-0",
+                "run_count": 0,
+                "tags": [],
+                "task_inputs": {},
+                "total_run_time": 0.0,
             },
-            "flow_run_run_count": 1,
-            "name": "happy_little_tree-0",
-            "run_count": 1,
-            "tags": [],
-            "task_inputs": {},
-            "total_run_time": 0.0,
-        },
-    }
+        }
+
+        assert running.event == "prefect.task-run.Running"
+        assert running.id == task_run_states[1].id
+        assert running.occurred == task_run_states[1].timestamp
+        assert running.resource == Resource(
+            {
+                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+                "prefect.resource.name": task_run.name,
+                "prefect.state-message": "",
+                "prefect.state-type": "RUNNING",
+                "prefect.state-name": "Running",
+                "prefect.state-timestamp": task_run_states[1].timestamp.isoformat(),
+                "prefect.orchestration": "server",
+            }
+        )
+        assert (
+            pendulum.parse(running.payload["task_run"].pop("expected_start_time"))
+            == task_run.expected_start_time
+        )
+        assert (
+            running.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+        )
+        assert running.payload == {
+            "intended": {"from": "PENDING", "to": "RUNNING"},
+            "initial_state": {
+                "type": "PENDING",
+                "name": "Pending",
+                "message": "",
+                "state_details": {
+                    "pause_reschedule": False,
+                    "untrackable_result": False,
+                },
+            },
+            "validated_state": {
+                "type": "RUNNING",
+                "name": "Running",
+                "message": "",
+                "state_details": {
+                    "pause_reschedule": False,
+                    "untrackable_result": False,
+                },
+                "data": None,
+            },
+            "task_run": {
+                "dynamic_key": "0",
+                "empirical_policy": {
+                    "max_retries": 0,
+                    "retries": 0,
+                    "retry_delay": 0,
+                    "retry_delay_seconds": 0.0,
+                },
+                "flow_run_run_count": 0,
+                "name": "happy_little_tree-0",
+                "run_count": 0,
+                "tags": [],
+                "task_inputs": {},
+                "total_run_time": 0.0,
+            },
+        }
+
+        assert failed.event == "prefect.task-run.Failed"
+        assert failed.id == task_run_states[2].id
+        assert failed.occurred == task_run_states[2].timestamp
+        assert failed.resource == Resource(
+            {
+                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+                "prefect.resource.name": task_run.name,
+                "prefect.state-message": (
+                    "Task run encountered an exception ValueError: "
+                    "Here's a happy little accident."
+                ),
+                "prefect.state-type": "FAILED",
+                "prefect.state-name": "Failed",
+                "prefect.state-timestamp": task_run_states[2].timestamp.isoformat(),
+                "prefect.orchestration": "server",
+            }
+        )
+        assert (
+            pendulum.parse(failed.payload["task_run"].pop("expected_start_time"))
+            == task_run.expected_start_time
+        )
+        assert (
+            failed.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+        )
+        assert (
+            pendulum.parse(failed.payload["task_run"].pop("start_time"))
+            == task_run.start_time
+        )
+        assert failed.payload == {
+            "intended": {"from": "RUNNING", "to": "FAILED"},
+            "initial_state": {
+                "type": "RUNNING",
+                "name": "Running",
+                "message": "",
+                "state_details": {
+                    "pause_reschedule": False,
+                    "untrackable_result": False,
+                },
+            },
+            "validated_state": {
+                "type": "FAILED",
+                "name": "Failed",
+                "message": (
+                    "Task run encountered an exception ValueError: "
+                    "Here's a happy little accident."
+                ),
+                "state_details": {
+                    "pause_reschedule": False,
+                    "retriable": False,
+                    "untrackable_result": False,
+                },
+                "data": {"type": "unpersisted"},
+            },
+            "task_run": {
+                "dynamic_key": "0",
+                "empirical_policy": {
+                    "max_retries": 0,
+                    "retries": 0,
+                    "retry_delay": 0,
+                    "retry_delay_seconds": 0.0,
+                },
+                "flow_run_run_count": 1,
+                "name": "happy_little_tree-0",
+                "run_count": 1,
+                "tags": [],
+                "task_inputs": {},
+                "total_run_time": 0.0,
+            },
+        }
 
 
 async def test_background_task_state_changes(
@@ -393,6 +801,7 @@ async def test_background_task_state_changes(
     reset_worker_events,
     prefect_client,
     tmp_path,
+    events_pipeline,
 ):
     storage = LocalFileSystem(basepath=tmp_path)
     await storage.save("test")
@@ -405,6 +814,7 @@ async def test_background_task_state_changes(
     task_run = await prefect_client.read_task_run(task_run_future.task_run_id)
 
     await TaskWorker(foo).execute_task_run(task_run)
+    await events_pipeline.process_events(dequeue_events=False)
 
     task_run_states = await prefect_client.read_task_run_states(
         task_run_future.task_run_id

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -849,7 +849,7 @@ async def test_background_task_state_changes(
 
 
 async def test_apply_async_emits_scheduled_event(
-    asserting_events_worker, prefect_client
+    asserting_events_worker, prefect_client, enable_client_side_task_run_orchestration
 ):
     @task
     def happy_little_tree():
@@ -881,7 +881,9 @@ async def test_apply_async_emits_scheduled_event(
             "prefect.state-type": "SCHEDULED",
             "prefect.state-name": "Scheduled",
             "prefect.state-timestamp": task_run_states[0].timestamp.isoformat(),
-            "prefect.orchestration": "server",
+            "prefect.orchestration": "client"
+            if enable_client_side_task_run_orchestration
+            else "server",
         }
     )
 


### PR DESCRIPTION
This PR updates `test_task_run_state_change_events.py` to pass with client side orchestration enabled. There are a couple of differences between the task runs contained in the event payload when client side orchestration is enabled vs disabled. 

With client side orchestration enabled, the engine's copy of the task run is updated directly _before_ we emit a task run event. This means the copy of the task run inside of the event payload will include updated fields like start time, run count, etc. Things that previously were not included until the engine re-read the task run from the server as part of it's main loop.