### PR TITLE
Flush logs when exiting `prefect_test_harness` to avoid error logs

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -851,8 +851,8 @@ class SubprocessASGIServer:
         )
 
     def stop(self):
-        subprocess_server_logger.info(f"Stopping server on {self.address}")
         if self.server_process:
+            subprocess_server_logger.info(f"Stopping server on {self.address}")
             self.server_process.terminate()
             try:
                 self.server_process.wait(timeout=5)

--- a/tests/testing/test_utilites.py
+++ b/tests/testing/test_utilites.py
@@ -6,7 +6,7 @@ import pytest
 from prefect import flow, task
 from prefect.client.orchestration import get_client
 from prefect.server import schemas
-from prefect.settings import PREFECT_API_DATABASE_CONNECTION_URL
+from prefect.settings import PREFECT_API_DATABASE_CONNECTION_URL, PREFECT_API_URL
 from prefect.testing.utilities import assert_does_not_warn, prefect_test_harness
 
 
@@ -27,11 +27,9 @@ def test_assert_does_not_warn_raises_assertion_error():
             warnings.warn("Test")
 
 
-@pytest.mark.skip(reason="Test is failing consistently")
 async def test_prefect_test_harness():
-    # TODO: This test fails intemittently in two cases:
-    #   - A timeout error entering lifespan management of the ephemeral application
-    #   - A directory error in Windows do to temporary directory differences
+    # TODO: This test fails intermittently with a directory error in Windows
+    # due to temporary directory differences
     very_specific_name = str(uuid.uuid4())
 
     @task
@@ -44,6 +42,7 @@ async def test_prefect_test_harness():
         return "foo"
 
     existing_db_url = PREFECT_API_DATABASE_CONNECTION_URL.value()
+    existing_api_url = PREFECT_API_URL.value()
 
     with prefect_test_harness():
         async with get_client() as client:
@@ -59,11 +58,16 @@ async def test_prefect_test_harness():
             assert len(flows) == 1
             assert flows[0].name == very_specific_name
 
-            # should be using an ephemeral client
-            assert client._ephemeral_app is not None
+            assert PREFECT_API_URL.value() != existing_api_url
 
             # should be connected to a different database
             assert PREFECT_API_DATABASE_CONNECTION_URL.value() != existing_db_url
+
+    # API URL should be reset
+    assert PREFECT_API_URL.value() == existing_api_url
+
+    # database connection should be reset
+    assert PREFECT_API_DATABASE_CONNECTION_URL.value() == existing_db_url
 
     # outside the context, none of the test runs should not persist
     async with get_client() as client:
@@ -71,6 +75,3 @@ async def test_prefect_test_harness():
             flow_filter=schemas.filters.FlowFilter(name={"any_": [very_specific_name]})
         )
         assert len(flows) == 0
-
-    # database connection should be reset
-    assert PREFECT_API_DATABASE_CONNECTION_URL.value() == existing_db_url


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
Adds a explicit drain of the `APILogWorker` before stopping the server started by the `prefect_test_harness` to ensure no connection errors are printed upon exit.

Closes https://github.com/PrefectHQ/prefect/issues/14845

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
