### PR TITLE
make `Task.serve` sync and shutdown cleaner

### DIFF
--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -158,16 +158,8 @@ class TaskWorker:
         start_client_metrics_server()
 
         async with asyncnullcontext() if self.started else self:
-            logger.info("Starting task worker...")
             try:
                 await self._subscribe_to_task_scheduling()
-
-            except ExceptionGroup as exc:  # novermin
-                description = "Encountered an error while subscribing to task runs."
-                for e in exc.exceptions:
-                    description += f"\n\n{e}"
-                raise ValueError(description) from exc
-
             except InvalidStatusCode as exc:
                 if exc.status_code == 403:
                     logger.error(
@@ -223,6 +215,7 @@ class TaskWorker:
             task_key.split(".")[-1].split("-")[0] for task_key in sorted(self.task_keys)
         )
         logger.info(f"Subscribing to runs of task(s): {task_keys_repr}")
+
         async for task_run in Subscription(
             model=TaskRun,
             path="/task_runs/subscriptions/scheduled",

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -38,7 +38,6 @@ from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import (
     asyncnullcontext,
     run_coro_as_sync,
-    sync_compatible,
 )
 from prefect.utilities.engine import emit_task_run_state_change_event, propose_state
 from prefect.utilities.processutils import _register_signal
@@ -150,7 +149,6 @@ class TaskWorker:
 
         sys.exit(0)
 
-    @sync_compatible
     async def start(self) -> None:
         """
         Starts a task worker, which runs the tasks provided in the constructor.
@@ -174,7 +172,6 @@ class TaskWorker:
                 else:
                     raise
 
-    @sync_compatible
     async def stop(self):
         """Stops the task worker's polling cycle."""
         if not self.started:
@@ -470,7 +467,7 @@ def serve(
         status_server_task = loop.create_task(server.serve())
 
     try:
-        task_worker.start()
+        run_coro_as_sync(task_worker.start())
 
     except BaseExceptionGroup as exc:  # novermin
         exceptions = exc.exceptions

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -161,6 +161,13 @@ class TaskWorker:
             logger.info("Starting task worker...")
             try:
                 await self._subscribe_to_task_scheduling()
+
+            except ExceptionGroup as exc:  # novermin
+                description = "Encountered an error while subscribing to task runs."
+                for e in exc.exceptions:
+                    description += f"\n\n{e}"
+                raise ValueError(description) from exc
+
             except InvalidStatusCode as exc:
                 if exc.status_code == 403:
                     logger.error(

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -35,7 +35,11 @@ from prefect.settings import (
 from prefect.states import Pending
 from prefect.task_engine import run_task_async, run_task_sync
 from prefect.utilities.annotations import NotSet
-from prefect.utilities.asyncutils import asyncnullcontext, sync_compatible
+from prefect.utilities.asyncutils import (
+    asyncnullcontext,
+    run_coro_as_sync,
+    sync_compatible,
+)
 from prefect.utilities.engine import emit_task_run_state_change_event, propose_state
 from prefect.utilities.processutils import _register_signal
 from prefect.utilities.services import start_client_metrics_server
@@ -98,11 +102,6 @@ class TaskWorker:
 
         self._client = get_client()
         self._exit_stack = AsyncExitStack()
-
-        if not asyncio.get_event_loop().is_running():
-            raise RuntimeError(
-                "TaskWorker must be initialized within an async context."
-            )
 
         self._runs_task_group: anyio.abc.TaskGroup = anyio.create_task_group()
         self._executor = ThreadPoolExecutor(max_workers=limit if limit else None)
@@ -416,7 +415,12 @@ def create_status_server(task_worker: TaskWorker) -> FastAPI:
     return status_app
 
 
-async def serve(
+async def _make_task_worker(*args, **kwargs) -> TaskWorker:
+    """Utility function to create a TaskWorker instance in an async context."""
+    return TaskWorker(*args, **kwargs)
+
+
+def serve(
     *tasks: Task, limit: Optional[int] = 10, status_server_port: Optional[int] = None
 ):
     """Serve the provided tasks so that their runs may be submitted to and executed.
@@ -450,7 +454,10 @@ async def serve(
             serve(say, yell)
         ```
     """
-    task_worker = TaskWorker(*tasks, limit=limit)
+
+    task_worker = run_coro_as_sync(_make_task_worker(*tasks, limit=limit))
+
+    assert isinstance(task_worker, TaskWorker)
 
     status_server_task = None
     if status_server_port is not None:
@@ -467,7 +474,7 @@ async def serve(
         status_server_task = loop.create_task(server.serve())
 
     try:
-        await task_worker.start()
+        task_worker.start()
 
     except BaseExceptionGroup as exc:  # novermin
         exceptions = exc.exceptions
@@ -487,6 +494,6 @@ async def serve(
         if status_server_task:
             status_server_task.cancel()
             try:
-                await status_server_task
+                run_coro_as_sync(status_server_task)
             except asyncio.CancelledError:
                 pass

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -103,6 +103,11 @@ class TaskWorker:
         self._client = get_client()
         self._exit_stack = AsyncExitStack()
 
+        if not asyncio.get_event_loop().is_running():
+            raise RuntimeError(
+                "TaskWorker must be initialized within an async context."
+            )
+
         self._runs_task_group: anyio.abc.TaskGroup = anyio.create_task_group()
         self._executor = ThreadPoolExecutor(max_workers=limit if limit else None)
         self._limiter = anyio.CapacityLimiter(limit) if limit else None

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -416,7 +416,6 @@ def create_status_server(task_worker: TaskWorker) -> FastAPI:
     return status_app
 
 
-@sync_compatible
 async def serve(
     *tasks: Task, limit: Optional[int] = 10, status_server_port: Optional[int] = None
 ):
@@ -481,8 +480,8 @@ async def serve(
     except StopTaskWorker:
         logger.info("Task worker stopped.")
 
-    except (asyncio.CancelledError, KeyboardInterrupt):
-        logger.info("Task worker interrupted, stopping...")
+    except (asyncio.CancelledError, KeyboardInterrupt) as exc:
+        logger.info(f"Received {type(exc).__name__}, shutting down...")
 
     finally:
         if status_server_task:

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -4,6 +4,7 @@ Module containing the base workflow task class and decorator - for most use case
 # This file requires type-checking with pyright because mypy does not yet support PEP612
 # See https://github.com/python/mypy/issues/8645
 
+import asyncio
 import datetime
 import inspect
 from copy import copy
@@ -60,7 +61,6 @@ from prefect.states import Pending, Scheduled, State
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import (
     run_coro_as_sync,
-    sync_compatible,
 )
 from prefect.utilities.callables import (
     expand_mapping_parameters,
@@ -1506,8 +1506,7 @@ class Task(Generic[P, R]):
         """
         return self.apply_async(args=args, kwargs=kwargs)
 
-    @sync_compatible
-    async def serve(self) -> NoReturn:
+    def serve(self):
         """Serve the task using the provided task runner. This method is used to
         establish a websocket connection with the Prefect server and listen for
         submitted task runs to execute.
@@ -1526,7 +1525,7 @@ class Task(Generic[P, R]):
         """
         from prefect.task_worker import serve
 
-        await serve(self)
+        asyncio.run(serve(self))
 
 
 @overload

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -4,7 +4,6 @@ Module containing the base workflow task class and decorator - for most use case
 # This file requires type-checking with pyright because mypy does not yet support PEP612
 # See https://github.com/python/mypy/issues/8645
 
-import asyncio
 import datetime
 import inspect
 from copy import copy
@@ -1525,7 +1524,7 @@ class Task(Generic[P, R]):
         """
         from prefect.task_worker import serve
 
-        asyncio.run(serve(self))
+        serve(self)
 
 
 @overload

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1505,22 +1505,17 @@ class Task(Generic[P, R]):
         """
         return self.apply_async(args=args, kwargs=kwargs)
 
-    def serve(
-        self, limit: Optional[int] = 10, status_server_port: Optional[int] = None
-    ):
-        """Serve the task and listen for scheduled task runs to execute. This method is used to
+    def serve(self):
+        """Serve the task using the provided task runner. This method is used to
         establish a websocket connection with the Prefect server and listen for
         submitted task runs to execute.
 
         Args:
-            limit: The maximum number of tasks that can be run concurrently. Defaults to 10.
-                Pass `None` to remove the limit.
-            status_server_port: An optional port on which to start an HTTP server
-                exposing status information about the task worker. If not provided, no
-                status server will run.
+            task_runner: The task runner to use for serving the task. If not provided,
+                the default task runner will be used.
 
         Examples:
-            Serve a task
+            Serve a task using the default task runner
             >>> @task
             >>> def my_task():
             >>>     return 1
@@ -1529,7 +1524,7 @@ class Task(Generic[P, R]):
         """
         from prefect.task_worker import serve
 
-        serve(self, limit=limit, status_server_port=status_server_port)
+        serve(self)
 
 
 @overload

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1508,7 +1508,7 @@ class Task(Generic[P, R]):
     def serve(
         self, limit: Optional[int] = 10, status_server_port: Optional[int] = None
     ):
-        """Serve the task using the provided task runner. This method is used to
+        """Serve the task and listen for scheduled task runs to execute. This method is used to
         establish a websocket connection with the Prefect server and listen for
         submitted task runs to execute.
 
@@ -1520,7 +1520,7 @@ class Task(Generic[P, R]):
                 status server will run.
 
         Examples:
-            Serve a task using the default task runner
+            Serve a task
             >>> @task
             >>> def my_task():
             >>>     return 1

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1505,14 +1505,19 @@ class Task(Generic[P, R]):
         """
         return self.apply_async(args=args, kwargs=kwargs)
 
-    def serve(self):
+    def serve(
+        self, limit: Optional[int] = 10, status_server_port: Optional[int] = None
+    ):
         """Serve the task using the provided task runner. This method is used to
         establish a websocket connection with the Prefect server and listen for
         submitted task runs to execute.
 
         Args:
-            task_runner: The task runner to use for serving the task. If not provided,
-                the default task runner will be used.
+            limit: The maximum number of tasks that can be run concurrently. Defaults to 10.
+                Pass `None` to remove the limit.
+            status_server_port: An optional port on which to start an HTTP server
+                exposing status information about the task worker. If not provided, no
+                status server will run.
 
         Examples:
             Serve a task using the default task runner
@@ -1524,7 +1529,7 @@ class Task(Generic[P, R]):
         """
         from prefect.task_worker import serve
 
-        serve(self)
+        serve(self, limit=limit, status_server_port=status_server_port)
 
 
 @overload

--- a/tests/test_task_worker.py
+++ b/tests/test_task_worker.py
@@ -232,7 +232,7 @@ async def test_task_worker_emits_run_ui_url_upon_submission(
 @pytest.mark.usefixtures("mock_task_worker_start")
 class TestServe:
     async def test_serve_basic_sync_task(self, foo_task, mock_task_worker_start):
-        await serve(foo_task)
+        serve(foo_task)
         mock_task_worker_start.assert_called_once()
 
         task_run_future = foo_task.apply_async((42,))
@@ -242,7 +242,7 @@ class TestServe:
         assert task_run_future.state.is_scheduled()
 
     async def test_serve_basic_async_task(self, async_foo_task, mock_task_worker_start):
-        await serve(async_foo_task)
+        serve(async_foo_task)
         mock_task_worker_start.assert_called_once()
 
         task_run_future = async_foo_task.apply_async((42,))
@@ -955,8 +955,8 @@ class TestTaskWorkerLimit:
 
         # only one should run at a time, so we'll move on after 1 second
         # to ensure that the second task hasn't started
-        with anyio.move_on_after(1):
-            await serve(slow_task, limit=1)
+        with anyio.move_on_after(1.1):
+            serve(slow_task, limit=1)
 
         await events_pipeline.process_events()
 

--- a/tests/test_task_worker.py
+++ b/tests/test_task_worker.py
@@ -955,7 +955,7 @@ class TestTaskWorkerLimit:
 
         # only one should run at a time, so we'll move on after 1 second
         # to ensure that the second task hasn't started
-        with anyio.move_on_after(1.1):
+        with anyio.move_on_after(1):
             serve(slow_task, limit=1)
 
         await events_pipeline.process_events()

--- a/tests/test_task_worker.py
+++ b/tests/test_task_worker.py
@@ -13,7 +13,6 @@ from pydantic import BaseModel
 from prefect import flow, task
 from prefect.events.worker import EventsWorker
 from prefect.filesystems import LocalFileSystem
-from prefect.futures import PrefectDistributedFuture
 from prefect.settings import (
     PREFECT_API_URL,
     PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION,
@@ -21,7 +20,7 @@ from prefect.settings import (
     temporary_settings,
 )
 from prefect.states import Running
-from prefect.task_worker import TaskWorker, serve
+from prefect.task_worker import TaskWorker
 from prefect.tasks import task_input_hash
 
 pytestmark = pytest.mark.usefixtures("use_hosted_api_server")
@@ -228,29 +227,6 @@ async def test_task_worker_emits_run_ui_url_upon_submission(
         await task_worker.execute_task_run(task_run)
 
     assert "in the UI: http://test/api/runs/task-run/" in caplog.text
-
-
-@pytest.mark.usefixtures("mock_task_worker_start")
-class TestServe:
-    async def test_serve_basic_sync_task(self, foo_task, mock_task_worker_start):
-        serve(foo_task)
-        mock_task_worker_start.assert_called_once()
-
-        task_run_future = foo_task.apply_async((42,))
-
-        assert isinstance(task_run_future, PrefectDistributedFuture)
-
-        assert task_run_future.state.is_scheduled()
-
-    async def test_serve_basic_async_task(self, async_foo_task, mock_task_worker_start):
-        serve(async_foo_task)
-        mock_task_worker_start.assert_called_once()
-
-        task_run_future = async_foo_task.apply_async((42,))
-
-        assert isinstance(task_run_future, PrefectDistributedFuture)
-
-        assert task_run_future.state.is_scheduled()
 
 
 async def test_task_worker_can_execute_a_single_async_single_task_run(


### PR DESCRIPTION
this PR accomplishes for `Task.serve` what these PRs:
- https://github.com/PrefectHQ/prefect/pull/14563
- https://github.com/PrefectHQ/prefect/pull/14848

did for `Flow.serve`

that is:
- make `serve` sync (its always blocking anyways)
- update resulting error when we `Ctrl-C` `Task.serve` to be consistent with `Flow.serve`

<details>
<summary>Before</summary>

```python
» python flows/repros/serve_task.py
14:20:32.048 | INFO    | prefect.task_worker - Starting task worker...
14:20:32.049 | INFO    | prefect.task_worker - Subscribing to runs of task(s): foo
^CTraceback (most recent call last):
  File "/Users/nate/github.com/prefecthq/prefect/flows/repros/serve_task.py", line 10, in <module>
    foo.serve()
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/utilities/asyncutils.py", line 392, in coroutine_wrapper
14:20:32.709 | INFO    | prefect.task_worker - Task worker interrupted, stopping...
    return run_coro_as_sync(ctx_call())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/utilities/asyncutils.py", line 243, in run_coro_as_sync
    return call.result()
           ^^^^^^^^^^^^^
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/_internal/concurrency/calls.py", line 312, in result
    return self.future.result(timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/_internal/concurrency/calls.py", line 175, in result
    self._condition.wait(timeout)
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 355, in wait
    waiter.acquire()
KeyboardInterrupt
```
</details>

<details>
<summary>After</summary>

```python
» python flows/repros/serve_task.py
14:59:19.585 | INFO    | prefect.task_worker - Starting task worker...
14:59:19.586 | INFO    | prefect.task_worker - Subscribing to runs of task(s): f
^C14:59:20.559 | INFO    | prefect.task_worker - Received KeyboardInterrupt, shutting down...
```
</details>

___

this PR also moves the creation of the `anyio` task group and capacity limiter from `TaskWorker.__init__` to `TaskWorker.__aenter__` so that the task `serve` utility can be sync like the flow utility.