### PR TITLE
Fix syntax for client test suite `pytest` command

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -56,7 +56,7 @@ jobs:
           - name: Server Tests
             modules: tests/server/ tests/events/server
           - name: Client Tests
-            modules: tests/ --ignore tests/server/ tests/events/server
+            modules: tests/ --ignore=tests/server/ --ignore=tests/events/server
         database:
           - "postgres:14"
           - "sqlite"

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -69,7 +69,7 @@ jobs:
           - database: "sqlite"
             test-type: 
               name: Client Tests
-              modules: tests/ --ignore tests/server/ tests/events/server
+              modules: tests/ --ignore=tests/server/ --ignore=tests/events/server
 
       fail-fast: true
 

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -1,6 +1,5 @@
 import json
 import os
-import subprocess
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import Generator, List
@@ -104,18 +103,15 @@ class TestGetClient:
     def test_get_client_starts_subprocess_server_when_enabled(
         self, enable_ephemeral_server, monkeypatch
     ):
-        popen_spy = MagicMock()
-        orig_popen = subprocess.Popen
+        subprocess_server_mock = MagicMock()
 
-        def popen_stub(*args, **kwargs):
-            popen_spy(*args, **kwargs)
-            return orig_popen(*args, **kwargs)
-
-        monkeypatch.setattr("prefect.server.api.server.subprocess.Popen", popen_stub)
+        monkeypatch.setattr(
+            prefect.server.api.server, "SubprocessASGIServer", subprocess_server_mock
+        )
 
         get_client()
-        assert popen_spy.call_count == 1
-        assert "prefect.server.api.server:create_app" in popen_spy.call_args[1]["args"]
+        assert subprocess_server_mock.call_count == 1
+        assert subprocess_server_mock.return_value.start.call_count == 1
 
     def test_get_client_rasises_error_when_no_api_url_and_no_ephemeral_mode(
         self, disable_hosted_api_server

--- a/tests/test_import_interceptor.py
+++ b/tests/test_import_interceptor.py
@@ -1,7 +1,0 @@
-import pytest
-
-
-def test_prefect_1_import_warning():
-    with pytest.raises(ImportError):
-        with pytest.warns(UserWarning, match="Attempted import of 'prefect.Client"):
-            from prefect import Client  # noqa


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR fixes the client side pytest workflow to use the `--ignore` flag correctly. Since upgrading to `pytest>8`, only the `test/events/server` module has been running. An example of the current behavior can be seen [here](https://github.com/PrefectHQ/prefect/actions/runs/10253505240/job/28366270121).

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
