### PR TITLE
Move `exceptiongroup` to `requirements-client.txt`

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -5,6 +5,7 @@ cloudpickle >= 2.0, < 4.0
 coolname >= 1.0.4, < 3.0.0
 croniter >= 1.0.12, < 3.0.0
 fsspec >= 2022.5.0
+exceptiongroup >= 1.2.1
 graphviz >= 0.20.1
 griffe >= 0.20.0, <0.48.0
 httpcore >=1.0.5, < 2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,3 @@ pytz >= 2021.1, < 2025
 readchar >= 4.0.0, < 5.0.0
 sqlalchemy[asyncio] >= 1.4.22, != 1.4.33, < 3.0.0
 typer >= 0.12.0, != 0.12.2, < 0.13.0
-exceptiongroup >= 1.2.1


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

This PR moves the `exceptiongroup` dependency from `requirements.txt` to `requirements-client.txt` to ensure the `exceptiongroup` module is available when installing `prefect-client`. `exceptiongroup` is listed in `requirements-client.txt` on `main`, so I think this only affects `2.x` versions of `prefect-client`.

Closes #14870 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
