### PR TITLE
Allow `schedules: null` in `prefect.yaml`

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -830,7 +830,7 @@ def _construct_schedules(
     Returns:
         A list of schedule objects
     """
-    schedule_configs = deploy_config.get("schedules", NotSet)
+    schedule_configs = deploy_config.get("schedules", NotSet) or []
 
     if schedule_configs is not NotSet:
         schedules = [
@@ -1524,7 +1524,7 @@ def _apply_cli_options_to_deploy_config(deploy_config, cli_options):
     timezone = cli_options.get("timezone")
 
     # Apply anchor_date and timezone to new and existing schedules
-    for schedule_config in deploy_config.get("schedules", []):
+    for schedule_config in deploy_config.get("schedules") or []:
         if anchor_date and schedule_config.get("interval"):
             schedule_config["anchor_date"] = anchor_date
         if timezone:

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -2413,6 +2413,32 @@ class TestSchedules:
         }
 
     @pytest.mark.usefixtures("project_dir")
+    async def test_yaml_with_null_value_for_schedules(self, prefect_client, work_pool):
+        prefect_yaml = Path("prefect.yaml")
+        with prefect_yaml.open(mode="r") as f:
+            deploy_config = yaml.safe_load(f)
+
+        deploy_config["deployments"][0]["name"] = "test-name"
+        deploy_config["deployments"][0]["schedules"] = None
+
+        with prefect_yaml.open(mode="w") as f:
+            yaml.safe_dump(deploy_config, f)
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            command=f"deploy ./flows/hello.py:my_flow -n test-name --pool {work_pool.name}",
+            expected_code=0,
+            expected_output_contains=[
+                "Deployment 'An important name/test-name' successfully created"
+            ],
+        )
+
+        deployment = await prefect_client.read_deployment_by_name(
+            "An important name/test-name"
+        )
+        assert deployment.schedule is None
+
+    @pytest.mark.usefixtures("project_dir")
     async def test_yaml_with_schedule_and_schedules_raises_error(self, work_pool):
         prefect_yaml = Path("prefect.yaml")
         with prefect_yaml.open(mode="r") as f:


### PR DESCRIPTION
currently on `main`, providing a `null` for `schedules` (which you should be able to use to avoid the prompt specifically about schedules) in `prefect.yaml` raises the following unfriendly error

```python
  File "/Users/nate/github.com/prefecthq/flows/.venv/lib/python3.12/site-packages/prefect/cli/deploy.py", line 424, in deploy
    await _run_single_deploy(
...
  File "/Users/nate/github.com/prefecthq/flows/.venv/lib/python3.12/site-packages/prefect/cli/deploy.py", line 1527, in _apply_cli_options_to_deploy_config
    for schedule_config in deploy_config.get("schedules", []):
TypeError: 'NoneType' object is not iterable
```
