### PR TITLE
Avoid raising errors on database passwords that contain a `$` character

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -323,7 +323,11 @@ def template_with_settings(*upstream_settings: Setting) -> Callable[["Settings",
             setting.name: setting.value_from(settings) for setting in upstream_settings
         }
         template = string.Template(str(value))
-        return original_type(template.substitute(template_values))
+        # Note the use of `safe_substitute` to avoid raising an exception if a
+        # template value is missing. In this case, template values will be left
+        # as-is in the string. Using `safe_substitute` prevents us raising when
+        # the DB password contains a `$` character.
+        return original_type(template.safe_substitute(template_values))
 
     return templater
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -569,6 +569,31 @@ class TestDatabaseSettings:
             ):
                 pass
 
+    def test_connection_string_with_dollar_sign(self):
+        """
+        Regression test for https://github.com/PrefectHQ/prefect/issues/11067.
+
+        This test ensures that passwords with dollar signs do not cause issues when
+        templating the connection string.
+        """
+        with temporary_settings(
+            {
+                PREFECT_API_DATABASE_CONNECTION_URL: (
+                    "postgresql+asyncpg://"
+                    "the-user:the-$password@"
+                    "the-database-server.example.com:5432"
+                    "/the-database"
+                ),
+                PREFECT_API_DATABASE_USER: "the-user",
+            }
+        ):
+            assert PREFECT_API_DATABASE_CONNECTION_URL.value() == (
+                "postgresql+asyncpg://"
+                "the-user:the-$password@"
+                "the-database-server.example.com:5432"
+                "/the-database"
+            )
+
 
 class TestTemporarySettings:
     def test_temporary_settings(self):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

This PR fixes errors raised when a database password contains a `$` character by using `safe_substitute` when templating. Templating will not occur when a `$` character is present in the password, which means that errors may still occur with settings like the following:
```bash
PREFECT_API_DATABASE_NAME="the-database"
PREFECT_API_DATABASE_CONNECTION_URL="postgresql+asyncpg://the-user:the-$password@localhost:5432/${PREFECT_API_DATABASE_NAME}"
```
Since this setup would fail without these changes, and the docs recommend setting `PREFECT_API_DATABASE_CONNECTION_URL` directly, I think this behavior is acceptable.

Closes https://github.com/PrefectHQ/prefect/issues/11067

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
