### PR TITLE
tweak task runner docs

### DIFF
--- a/docs/3.0rc/develop/task-runners.mdx
+++ b/docs/3.0rc/develop/task-runners.mdx
@@ -281,9 +281,10 @@ def add_together(x, y):
 @flow
 def sum_it(numbers, static_value):
     futures = add_together.map(numbers, static_value)
-    return futures
+    return futures.result()
 
-sum_it([1, 2, 3], 5)
+resulting_sum = sum_it([1, 2, 3], 5)
+assert resulting_sum == [6, 7, 8]
 ```
 
 If your static argument is an iterable, wrap it with `unmapped` to tell Prefect to treat it 
@@ -298,8 +299,9 @@ def sum_plus(x, static_iterable):
 
 @flow
 def sum_it(numbers, static_iterable):
-    futures = sum_plus.map(numbers, static_iterable)
-    return futures
+    futures = sum_plus.map(numbers, unmapped(static_iterable))
+    return futures.result()
 
-sum_it([4, 5, 6], unmapped([1, 2, 3]))
+resulting_sum = sum_it([4, 5, 6], [1, 2, 3])
+assert resulting_sum == [10, 11, 12]
 ```

--- a/docs/3.0rc/develop/task-runners.mdx
+++ b/docs/3.0rc/develop/task-runners.mdx
@@ -287,6 +287,25 @@ resulting_sum = sum_it([1, 2, 3], 5)
 assert resulting_sum == [6, 7, 8]
 ```
 
+<Tip>
+**Get the results from a list of mapped futures**
+
+When using `.map` as in the above example, the result of the task is a list of futures. 
+You can wait for or retrieve the results from these futures with `wait` or `result` methods:
+
+```python
+futures = some_task.map(some_iterable)
+results = futures.result()
+```
+which is shorthand for:
+
+```python
+futures = some_task.map(some_iterable)
+results = [future.result() for future in futures]
+```
+</Tip>
+
+
 If your static argument is an iterable, wrap it with `unmapped` to tell Prefect to treat it 
 as a static value.
 


### PR DESCRIPTION
tweak the examples
- make it more obvious how to get the actual results out
- encourage use of `unmapped` in the flow definition as opposed to wrapping the parameter value provided at runtime, since otherwise I'd argue the `static_iterable` variable name is misleading (this is generally how I think we should recommend the use of `unmapped` anyways