### PR TITLE
Avoid raising errors on database passwords that contain a `$` character

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -345,7 +345,11 @@ def template_with_settings(*upstream_settings: Setting) -> Callable[["Settings",
             setting.name: setting.value_from(settings) for setting in upstream_settings
         }
         template = string.Template(str(value))
-        return original_type(template.substitute(template_values))
+        # Note the use of `safe_substitute` to avoid raising an exception if a
+        # template value is missing. In this case, template values will be left
+        # as-is in the string. Using `safe_substitute` prevents us raising when
+        # the DB password contains a `$` character.
+        return original_type(template.safe_substitute(template_values))
 
     return templater
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR fixes errors raised when a database password contains a $ character by using safe_substitute when templating.

Port of https://github.com/PrefectHQ/prefect/pull/14876 to the `2.x` line.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
