### PR TITLE
Ensure global codeowner reviews are accepted for specific files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,7 @@
 /ui                                  @znicholasbrown
 
 # documentation
-/docs                                @discdiver @daniel-prefect
-
+/docs                                @discdiver @cicdw @desertaxle @zzstoatzz
 # imports
-/src/prefect/__init__.py              @aaazzam @chrisguidry
-/src/prefect/main.py                  @aaazzam @chrisguidry
+/src/prefect/__init__.py              @aaazzam @chrisguidry @cicdw @desertaxle @zzstoatzz
+/src/prefect/main.py                  @aaazzam @chrisguidry @cicdw @desertaxle @zzstoatzz


### PR DESCRIPTION
Without this, it appears that the CODEONWER hierarchy assumes more specific owners are required over and above global owners, so this adds @desertaxle @zzstoatzz and myself to those specific subgroups as well.