### PR TITLE
Sharing state with transaction hooks

### DIFF
--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -65,17 +65,17 @@ class Transaction(ContextModel):
     )
     overwrite: bool = False
     logger: Union[logging.Logger, logging.LoggerAdapter, None] = None
-    _hook_data: Dict[str, Any] = PrivateAttr(default_factory=dict)
+    _stored_values: Dict[str, Any] = PrivateAttr(default_factory=dict)
     _staged_value: Any = None
     __var__: ContextVar = ContextVar("transaction")
 
     def set(self, name: str, value: Any) -> None:
-        self._hook_data[name] = value
+        self._stored_values[name] = value
 
     def get(self, name: str) -> Any:
-        if name not in self._hook_data:
+        if name not in self._stored_values:
             raise ValueError(f"Could not retrieve unknown key: {name}")
-        return self._hook_data.get(name)
+        return self._stored_values.get(name)
 
     def is_committed(self) -> bool:
         return self.state == TransactionState.COMMITTED

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -1,9 +1,11 @@
+import inspect
 import logging
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from typing import (
     Any,
     Callable,
+    Dict,
     Generator,
     List,
     Optional,
@@ -25,6 +27,7 @@ from prefect.results import (
     get_default_result_storage,
 )
 from prefect.utilities.asyncutils import run_coro_as_sync
+from prefect.utilities.callables import parameters_to_args_kwargs
 from prefect.utilities.collections import AutoEnum
 from prefect.utilities.engine import _get_hook_name
 
@@ -64,8 +67,15 @@ class Transaction(ContextModel):
     )
     overwrite: bool = False
     logger: Union[logging.Logger, logging.LoggerAdapter, None] = None
+    hook_data: Dict[str, Any] = Field(default_factory=dict)
     _staged_value: Any = None
     __var__: ContextVar = ContextVar("transaction")
+
+    def set(self, name: str, value: Any) -> None:
+        self.hook_data[name] = value
+
+    def get(self, name: str) -> Any:
+        return self.hook_data.get(name)
 
     def is_committed(self) -> bool:
         return self.state == TransactionState.COMMITTED
@@ -232,6 +242,23 @@ class Transaction(ContextModel):
             self.on_rollback_hooks += on_rollback_hooks
             self.on_commit_hooks += on_commit_hooks
             self.state = TransactionState.STAGED
+
+    def _prepare_args_kwargs_for_hook(self, hook) -> dict:
+        signature = inspect.signature(hook)
+        try:
+            params = signature.bind(self, **self.hook_data)
+        except TypeError:
+            # in this case, we are more surgical
+            hook_params = dict(signature.parameters).keys()
+            partial_data = {
+                key: value
+                for key, value in self.hook_data.items()
+                if key in hook_params
+            }
+            params = signature.bind(self, **partial_data)
+
+        params.apply_defaults()
+        return parameters_to_args_kwargs(hook, dict(params.arguments))
 
     def rollback(self) -> bool:
         if self.state in [TransactionState.ROLLED_BACK, TransactionState.COMMITTED]:

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -348,33 +348,7 @@ class TestHooks:
             txn.set("x", 42)
             assert txn.get("x") == 42
 
-    def test_get_is_safe(self):
+    def test_get_raises_on_unknown(self):
         with transaction(key="test") as txn:
-            assert txn.get("y") is None
-
-    def test_hook_prep_with_defaults(self):
-        def hook(txn, x=42):
-            pass
-
-        txn = Transaction()
-        assert txn._prepare_args_kwargs_for_hook(hook) == ((txn, 42), {})
-
-    def test_hook_prep_with_set_data(self):
-        def hook(txn, y, x=42):
-            pass
-
-        txn = Transaction()
-        txn.set("y", True)
-        assert txn._prepare_args_kwargs_for_hook(hook) == ((txn, True, 42), {})
-        txn.set("x", 5)
-        assert txn._prepare_args_kwargs_for_hook(hook) == ((txn, True, 5), {})
-
-    def test_hook_prep_with_extraneous_data(self):
-        def hook(txn, y, x=42):
-            pass
-
-        txn = Transaction()
-        txn.set("y", True)
-        txn.set("x", 5)
-        txn.set("z", False)  # should be ignored
-        assert txn._prepare_args_kwargs_for_hook(hook) == ((txn, True, 5), {})
+            with pytest.raises(ValueError, match="foobar"):
+                txn.get("foobar")

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -348,6 +348,15 @@ class TestHooks:
             txn.set("x", 42)
             assert txn.get("x") == 42
 
+    def test_get_and_set_data_in_nested_context(self):
+        with transaction(key="test") as top:
+            top.set("key", 42)
+            with transaction(key="nested") as inner:
+                inner.set("key", "string")
+                assert inner.get("key") == "string"
+                assert top.get("key") == 42
+            assert top.get("key") == 42
+
     def test_get_raises_on_unknown(self):
         with transaction(key="test") as txn:
             with pytest.raises(ValueError, match="foobar"):


### PR DESCRIPTION
Right now, users must hard code any state that needs to be shared between a task and its transaction lifecycle hooks (`on_commit` and `on_rollback`).  This PR exposes a simple `get` / `set` mechanic for persisting arbitrary data to a task's transaction:

```python
from prefect import task
from prefect.transactions import get_transaction

@task
def main_task(fpath: str):
    with open(fpath, "w') as f:
        f.write("hello")
    
    get_transaction().set("fpath", fpath)


@main_task.on_rollback
def hook(txn):
    fpath = txn.get("fpath")
    os.unlink(fpath)
```

I explored more magical ways of exposing this interface as well, such as by auto-injecting data into hook keyword arguments, but I thought starting simple and seeing what patterns emerge was a safer plan of action.