### PR TITLE
Avoid `__getitem__` calls on a `PrefectFuture` or `State` in checking `Flow` parameter serialization

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -624,7 +624,7 @@ class Flow(Generic[P, R]):
                     f"Type {type(value).__name__!r} and will not be stored "
                     "in the backend."
                 )
-            serialized_parameters[key] = f"<{type(value).__name__}>"
+                serialized_parameters[key] = f"<{type(value).__name__}>"
         return serialized_parameters
 
     @sync_compatible

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -619,7 +619,7 @@ class Flow(Generic[P, R]):
                 serialized_parameters[key] = jsonable_encoder(value)
             except (TypeError, ValueError):
                 logger.debug(
-                    f"Parameter {key!r} for flow {self.name!r} is of unserializable. "
+                    f"Parameter {key!r} for flow {self.name!r} is unserializable. "
                     f"Type {type(value).__name__!r} and will not be stored "
                     "in the backend."
                 )

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -612,11 +612,15 @@ class Flow(Generic[P, R]):
             if self.ismethod and value is self.fn.__prefect_self__:
                 continue
             try:
+                if isinstance(value, (PrefectFuture, State)):
+                    # Don't call jsonable_encoder() on a PrefectFuture or State to
+                    # avoid triggering a __getitem__ call
+                    raise TypeError
                 serialized_parameters[key] = jsonable_encoder(value)
             except (TypeError, ValueError):
                 logger.debug(
-                    f"Parameter {key!r} for flow {self.name!r} is of unserializable "
-                    f"type {type(value).__name__!r} and will not be stored "
+                    f"Parameter {key!r} for flow {self.name!r} is of unserializable. "
+                    f"Type {type(value).__name__!r} and will not be stored "
                     "in the backend."
                 )
                 serialized_parameters[key] = f"<{type(value).__name__}>"

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -611,7 +611,7 @@ class Flow(Generic[P, R]):
             # do not serialize the bound self object
             if self.ismethod and value is self.fn.__prefect_self__:
                 continue
-            elif isinstance(value, (PrefectFuture, State)):
+            if isinstance(value, (PrefectFuture, State)):
                 # Don't call jsonable_encoder() on a PrefectFuture or State to
                 # avoid triggering a __getitem__ call
                 serialized_parameters[key] = f"<{type(value).__name__}>"


### PR DESCRIPTION
## Overview

This PR introduces a very small change to the logic in `prefect.flows.Flow.serialize_parameters` that will check to see if the parameter is a `PrefectFuture` or `State`, and if it is, it will automatically assume that it is not serializable.

I also fixed the grammar of a debug statement.

## Background

Previously, this was done by calling the following block of code:

https://github.com/PrefectHQ/prefect/blob/aad6693608aeb2dbe71dfcf8dde2e48a45e30942/src/prefect/flows.py#L614-L622

In the code above, `jsonable_encoder(value)` in turn calls `dict(PrefectFuture)` or `dict(State)`. That will correctly raise an exception and mark the `value` as unserializable. Nonetheless, I am proposing this PR as a way to address https://github.com/PrefectHQ/prefect/discussions/14881. It would be really convenient to allow software developers building around Prefect to implement custom `.__getitem__` behavior on `PrefectFuture`s (since this is intentionally avoided by the Prefect development team, as outlined in https://github.com/PrefectHQ/prefect/issues/10928), which is possible with Prefect 2 but not Prefect 3. This PR ensures that this remains possible without changing any features or functionality of Prefect 3 as it currently stands. I fully recognize that this is more of a favor request than a bug fix, but I hope that this small change is something that you all would be willing to entertain. In exchange, you will have my deepest admiration as well as future, more useful PRs from me since I can finally transition to Prefect 3. 🙏 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] If this pull request adds new functionality, it includes unit tests that cover the changes
- [X] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [X] If this pull request adds functions or classes, it includes helpful docstrings.
