### PR TITLE
enable cstro in `test_tasks.py`

### DIFF
--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -624,21 +624,23 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             self.logger = task_run_logger(task_run=self.task_run, task=self.task)  # type: ignore
 
             # update the task run name if necessary
-            if not PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
-                # update the task run name if necessary
-                if not self._task_name_set and self.task.task_run_name:
-                    task_run_name = _resolve_custom_task_run_name(
-                        task=self.task, parameters=self.parameters
-                    )
+            if not self._task_name_set and self.task.task_run_name:
+                task_run_name = _resolve_custom_task_run_name(
+                    task=self.task, parameters=self.parameters
+                )
+
+                if not PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
+                    # update the task run name if necessary
                     self.client.set_task_run_name(
                         task_run_id=self.task_run.id, name=task_run_name
                     )
-                    self.logger.extra["task_run_name"] = task_run_name
-                    self.logger.debug(
-                        f"Renamed task run {self.task_run.name!r} to {task_run_name!r}"
-                    )
-                    self.task_run.name = task_run_name
-                    self._task_name_set = True
+
+                self.logger.extra["task_run_name"] = task_run_name
+                self.logger.debug(
+                    f"Renamed task run {self.task_run.name!r} to {task_run_name!r}"
+                )
+                self.task_run.name = task_run_name
+                self._task_name_set = True
             yield
 
     @contextmanager
@@ -1187,21 +1189,21 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
             self.logger = task_run_logger(task_run=self.task_run, task=self.task)  # type: ignore
 
-            if not PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
-                # update the task run name if necessary
-                if not self._task_name_set and self.task.task_run_name:
-                    task_run_name = _resolve_custom_task_run_name(
-                        task=self.task, parameters=self.parameters
-                    )
+            if not self._task_name_set and self.task.task_run_name:
+                task_run_name = _resolve_custom_task_run_name(
+                    task=self.task, parameters=self.parameters
+                )
+                if not PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
+                    # update the task run name if necessary
                     await self.client.set_task_run_name(
                         task_run_id=self.task_run.id, name=task_run_name
                     )
-                    self.logger.extra["task_run_name"] = task_run_name
-                    self.logger.debug(
-                        f"Renamed task run {self.task_run.name!r} to {task_run_name!r}"
-                    )
-                    self.task_run.name = task_run_name
-                    self._task_name_set = True
+                self.logger.extra["task_run_name"] = task_run_name
+                self.logger.debug(
+                    f"Renamed task run {self.task_run.name!r} to {task_run_name!r}"
+                )
+                self.task_run.name = task_run_name
+                self._task_name_set = True
             yield
 
     @asynccontextmanager

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -624,18 +624,11 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             self.logger = task_run_logger(task_run=self.task_run, task=self.task)  # type: ignore
 
             # update the task run name if necessary
-            if not self._task_name_set and self.task.task_run_name:
-                if PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
+            if not PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
+                # update the task run name if necessary
+                if not self._task_name_set and self.task.task_run_name:
                     task_run_name = _resolve_custom_task_run_name(
                         task=self.task, parameters=self.parameters
-                    )
-                    self.task_run.name = task_run_name
-                else:
-                    task_run_name = _resolve_custom_task_run_name(
-                        task=self.task, parameters=self.parameters
-                    )
-                    self.client.set_task_run_name(
-                        task_run_id=self.task_run.id, name=task_run_name
                     )
                     self.logger.extra["task_run_name"] = task_run_name
                     self.logger.debug(
@@ -1191,18 +1184,13 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
             self.logger = task_run_logger(task_run=self.task_run, task=self.task)  # type: ignore
 
-            # update the task run name if necessary
-            if not self._task_name_set and self.task.task_run_name:
-                if PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
+            if not PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
+                # update the task run name if necessary
+                if not self._task_name_set and self.task.task_run_name:
                     task_run_name = _resolve_custom_task_run_name(
                         task=self.task, parameters=self.parameters
                     )
-                    self.task_run.name = task_run_name
-                else:
-                    task_run_name = _resolve_custom_task_run_name(
-                        task=self.task, parameters=self.parameters
-                    )
-                    self.client.set_task_run_name(
+                    await self.client.set_task_run_name(
                         task_run_id=self.task_run.id, name=task_run_name
                     )
                     self.logger.extra["task_run_name"] = task_run_name

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -630,6 +630,9 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                     task_run_name = _resolve_custom_task_run_name(
                         task=self.task, parameters=self.parameters
                     )
+                    self.client.set_task_run_name(
+                        task_run_id=self.task_run.id, name=task_run_name
+                    )
                     self.logger.extra["task_run_name"] = task_run_name
                     self.logger.debug(
                         f"Renamed task run {self.task_run.name!r} to {task_run_name!r}"

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -659,21 +659,6 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 self._is_started = True
                 try:
                     if PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
-                        from prefect.utilities.engine import (
-                            _resolve_custom_task_run_name,
-                        )
-
-                        task_run_name = (
-                            _resolve_custom_task_run_name(
-                                task=self.task, parameters=self.parameters
-                            )
-                            if self.task.task_run_name
-                            else None
-                        )
-
-                        if self.task_run and task_run_name:
-                            self.task_run.name = task_run_name
-
                         if not self.task_run:
                             self.task_run = run_coro_as_sync(
                                 self.task.create_local_run(
@@ -683,7 +668,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                                     parent_task_run_context=TaskRunContext.get(),
                                     wait_for=self.wait_for,
                                     extra_task_inputs=dependencies,
-                                    task_run_name=task_run_name,
+                                    task_run_name=None,
                                 )
                             )
                             # Emit an event to capture that the task run was in the `PENDING` state.

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -668,7 +668,6 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                                     parent_task_run_context=TaskRunContext.get(),
                                     wait_for=self.wait_for,
                                     extra_task_inputs=dependencies,
-                                    task_run_name=None,
                                 )
                             )
                             # Emit an event to capture that the task run was in the `PENDING` state.
@@ -1207,21 +1206,6 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 self._is_started = True
                 try:
                     if PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
-                        from prefect.utilities.engine import (
-                            _resolve_custom_task_run_name,
-                        )
-
-                        task_run_name = (
-                            _resolve_custom_task_run_name(
-                                task=self.task, parameters=self.parameters
-                            )
-                            if self.task.task_run_name
-                            else None
-                        )
-
-                        if self.task_run and task_run_name:
-                            self.task_run.name = task_run_name
-
                         if not self.task_run:
                             self.task_run = await self.task.create_local_run(
                                 id=task_run_id,
@@ -1230,7 +1214,6 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                                 parent_task_run_context=TaskRunContext.get(),
                                 wait_for=self.wait_for,
                                 extra_task_inputs=dependencies,
-                                task_run_name=task_run_name,
                             )
                             # Emit an event to capture that the task run was in the `PENDING` state.
                             self._last_event = emit_task_run_state_change_event(

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -211,40 +211,42 @@ class BaseTaskRunEngine(Generic[P, R]):
         return task_run.state.is_running() or task_run.state.is_scheduled()
 
     def log_finished_message(self):
-        if self.task_run:
-            # If debugging, use the more complete `repr` than the usual `str` description
-            display_state = repr(self.state) if PREFECT_DEBUG_MODE else str(self.state)
-            level = logging.INFO if self.state.is_completed() else logging.ERROR
-            msg = f"Finished in state {display_state}"
-            if self.state.is_pending():
-                msg += (
-                    "\nPlease wait for all submitted tasks to complete"
-                    " before exiting your flow by calling `.wait()` on the "
-                    "`PrefectFuture` returned from your `.submit()` calls."
-                )
-                msg += dedent(
-                    """
-    
-                            Example:
-    
-                            from prefect import flow, task
-    
-                            @task
-                            def say_hello(name):
-                                print(f"Hello, {name}!")
-    
-                            @flow
-                            def example_flow():
-                                future = say_hello.submit(name="Marvin")
-                                future.wait()
-    
-                            example_flow()
-                                        """
-                )
-            self.logger.log(
-                level=level,
-                msg=msg,
+        if not self.task_run:
+            return
+
+        # If debugging, use the more complete `repr` than the usual `str` description
+        display_state = repr(self.state) if PREFECT_DEBUG_MODE else str(self.state)
+        level = logging.INFO if self.state.is_completed() else logging.ERROR
+        msg = f"Finished in state {display_state}"
+        if self.state.is_pending():
+            msg += (
+                "\nPlease wait for all submitted tasks to complete"
+                " before exiting your flow by calling `.wait()` on the "
+                "`PrefectFuture` returned from your `.submit()` calls."
             )
+            msg += dedent(
+                """
+
+                        Example:
+
+                        from prefect import flow, task
+
+                        @task
+                        def say_hello(name):
+                            print(f"Hello, {name}!")
+
+                        @flow
+                        def example_flow():
+                            future = say_hello.submit(name="Marvin")
+                            future.wait()
+
+                        example_flow()
+                                    """
+            )
+        self.logger.log(
+            level=level,
+            msg=msg,
+        )
 
     def handle_rollback(self, txn: Transaction) -> None:
         assert self.task_run is not None

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -814,7 +814,6 @@ class Task(Generic[P, R]):
         wait_for: Optional[Iterable[PrefectFuture]] = None,
         extra_task_inputs: Optional[Dict[str, Set[TaskRunInput]]] = None,
         deferred: bool = False,
-        task_run_name: Optional[str] = None,
     ) -> TaskRun:
         if not PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
             raise RuntimeError(
@@ -839,12 +838,12 @@ class Task(Generic[P, R]):
         async with client:
             if not flow_run_context:
                 dynamic_key = f"{self.task_key}-{str(uuid4().hex)}"
-                task_run_name = task_run_name or self.name
+                task_run_name = self.name
             else:
                 dynamic_key = _dynamic_key_for_task_run(
                     context=flow_run_context, task=self
                 )
-                task_run_name = task_run_name or f"{self.name}-{dynamic_key}"
+                task_run_name = f"{self.name}-{dynamic_key}"
 
             if deferred:
                 state = Scheduled()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1787,17 +1787,18 @@ class TestTaskCaching:
     async def test_changing_result_storage_key_busts_cache(
         self, enable_client_side_task_run_orchestration
     ):
+        cstro_enabled = str(enable_client_side_task_run_orchestration)
+
         @task(
-            cache_key_fn=lambda *_: "cache-hit-10"
-            + str(enable_client_side_task_run_orchestration),
-            result_storage_key="before",
+            cache_key_fn=lambda *_: "cache-hit-10" + cstro_enabled,
+            result_storage_key="before" + cstro_enabled,
             persist_result=True,
         )
         def foo(x):
             return x
 
         first_state = foo(1, return_state=True)
-        second_state = foo.with_options(result_storage_key="after")(
+        second_state = foo.with_options(result_storage_key="after" + cstro_enabled)(
             2, return_state=True
         )
         assert first_state.name == "Completed"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -21,7 +21,8 @@ from prefect.cache_policies import DEFAULT, INPUTS, NONE, TASK_SOURCE, CachePoli
 from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.filters import LogFilter, LogFilterFlowRunId
 from prefect.client.schemas.objects import StateType, TaskRunResult
-from prefect.context import FlowRunContext, TaskRunContext, get_run_context
+from prefect.context import FlowRunContext, TaskRunContext
+from prefect.events.worker import EventsWorker
 from prefect.exceptions import (
     MappingLengthMismatch,
     MappingMissingIterable,
@@ -37,6 +38,7 @@ from prefect.runtime import task_run as task_run_ctx
 from prefect.server import models
 from prefect.settings import (
     PREFECT_DEBUG_MODE,
+    PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION,
     PREFECT_TASK_DEFAULT_RETRIES,
     PREFECT_TASKS_REFRESH_CACHE,
     PREFECT_UI_URL,
@@ -50,6 +52,17 @@ from prefect.utilities.annotations import allow_failure, unmapped
 from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.collections import quote
 from prefect.utilities.engine import get_state_for_result
+
+
+@pytest.fixture(autouse=True, params=[False])
+def enable_client_side_task_run_orchestration(
+    request, asserting_events_worker: EventsWorker
+):
+    enabled = request.param
+    with temporary_settings(
+        {PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION: enabled}
+    ):
+        yield enabled
 
 
 def comparable_inputs(d):
@@ -941,7 +954,9 @@ class TestTaskVersion:
 
         assert my_task.version == "test-dev-experimental"
 
-    async def test_task_version_is_set_in_backend(self, prefect_client):
+    async def test_task_version_is_set_in_backend(
+        self, prefect_client, events_pipeline
+    ):
         @task(version="test-dev-experimental")
         def my_task():
             pass
@@ -951,6 +966,9 @@ class TestTaskVersion:
             return my_task(return_state=True)
 
         task_state = test()
+
+        await events_pipeline.process_events()
+
         task_run = await prefect_client.read_task_run(
             task_state.state_details.task_run_id
         )
@@ -1101,7 +1119,9 @@ class TestTaskRetries:
     """
 
     @pytest.mark.parametrize("always_fail", [True, False])
-    async def test_task_respects_retry_count(self, always_fail, prefect_client):
+    async def test_task_respects_retry_count(
+        self, always_fail, prefect_client, events_pipeline
+    ):
         mock = MagicMock()
         exc = ValueError()
 
@@ -1136,6 +1156,8 @@ class TestTaskRetries:
             assert await task_run_state.result() is True
             assert mock.call_count == 4
 
+        await events_pipeline.process_events()
+
         states = await prefect_client.read_task_run_states(task_run_id)
 
         state_names = [state.name for state in states]
@@ -1149,7 +1171,9 @@ class TestTaskRetries:
             "Failed" if always_fail else "Completed",
         ]
 
-    async def test_task_only_uses_necessary_retries(self, prefect_client):
+    async def test_task_only_uses_necessary_retries(
+        self, prefect_client, events_pipeline
+    ):
         mock = MagicMock()
         exc = ValueError()
 
@@ -1173,6 +1197,8 @@ class TestTaskRetries:
         assert await task_run_state.result() is True
         assert mock.call_count == 2
 
+        await events_pipeline.process_events()
+
         states = await prefect_client.read_task_run_states(task_run_id)
         state_names = [state.name for state in states]
         # task retries are client side in the new engine
@@ -1183,12 +1209,19 @@ class TestTaskRetries:
             "Completed",
         ]
 
-    async def test_task_retries_receive_latest_task_run_in_context(self):
-        contexts: List[TaskRunContext] = []
+    async def test_task_retries_receive_latest_task_run_in_context(
+        self, events_pipeline
+    ):
+        state_names: List[str] = []
+        run_counts = []
+        start_times = []
 
         @task(retries=3)
         def flaky_function():
-            contexts.append(get_run_context())
+            ctx = TaskRunContext.get()
+            state_names.append(ctx.task_run.state_name)
+            run_counts.append(ctx.task_run.run_count)
+            start_times.append(ctx.start_time)
             raise ValueError()
 
         @flow
@@ -1204,15 +1237,15 @@ class TestTaskRetries:
             "Retrying",
             "Retrying",
         ]
-        assert len(contexts) == len(expected_state_names)
-        for i, context in enumerate(contexts):
-            assert context.task_run.run_count == i + 1
-            assert context.task_run.state_name == expected_state_names[i]
+        assert len(state_names) == len(expected_state_names) == len(run_counts)
+        for i in range(len(state_names)):
+            assert run_counts[i] == i + 1
+            assert state_names[i] == expected_state_names[i]
 
             if i > 0:
-                last_context = contexts[i - 1]
+                last_start_time = start_times[i - 1]
                 assert (
-                    last_context.start_time < context.start_time
+                    last_start_time < start_times[i]
                 ), "Timestamps should be increasing"
 
     async def test_global_task_retry_config(self):
@@ -1345,8 +1378,14 @@ class TestTaskCaching:
         assert second_state.name == "Cached"
         assert await second_state.result() == await first_state.result()
 
-    async def test_cache_hits_within_flows_are_cached(self):
-        @task(cache_key_fn=lambda *_: "cache_hit-1", persist_result=True)
+    async def test_cache_hits_within_flows_are_cached(
+        self, enable_client_side_task_run_orchestration
+    ):
+        @task(
+            cache_key_fn=lambda *_: "cache_hit-1"
+            + str(enable_client_side_task_run_orchestration),
+            persist_result=True,
+        )
         def foo(x):
             return x
 
@@ -1359,8 +1398,14 @@ class TestTaskCaching:
         assert second_state.name == "Cached"
         assert await second_state.result() == await first_state.result()
 
-    def test_many_repeated_cache_hits_within_flows_cached(self):
-        @task(cache_key_fn=lambda *_: "cache_hit-2", persist_result=True)
+    def test_many_repeated_cache_hits_within_flows_cached(
+        self, enable_client_side_task_run_orchestration
+    ):
+        @task(
+            cache_key_fn=lambda *_: "cache_hit-2"
+            + str(enable_client_side_task_run_orchestration),
+            persist_result=True,
+        )
         def foo(x):
             return x
 
@@ -1372,8 +1417,14 @@ class TestTaskCaching:
         states = bar()
         assert all(state.name == "Cached" for state in states), states
 
-    async def test_cache_hits_between_flows_are_cached(self):
-        @task(cache_key_fn=lambda *_: "cache_hit-3", persist_result=True)
+    async def test_cache_hits_between_flows_are_cached(
+        self, enable_client_side_task_run_orchestration
+    ):
+        @task(
+            cache_key_fn=lambda *_: "cache_hit-3"
+            + str(enable_client_side_task_run_orchestration),
+            persist_result=True,
+        )
         def foo(x):
             return x
 
@@ -1387,11 +1438,15 @@ class TestTaskCaching:
         assert second_state.name == "Cached"
         assert await second_state.result() == await first_state.result() == 1
 
-    def test_cache_misses_arent_cached(self):
+    def test_cache_misses_arent_cached(self, enable_client_side_task_run_orchestration):
         # this hash fn won't return the same value twice
         def mutating_key(*_, tally=[]):
             tally.append("x")
-            return "call tally:" + "".join(tally)
+            return (
+                "call tally:"
+                + "".join(tally)
+                + str(enable_client_side_task_run_orchestration)
+            )
 
         @task(cache_key_fn=mutating_key, persist_result=True)
         def foo(x):
@@ -1432,11 +1487,13 @@ class TestTaskCaching:
         assert await third_state.result() == "something"
         assert await fourth_state.result() == "something"
 
-    async def test_cache_key_fn_receives_resolved_futures(self):
+    async def test_cache_key_fn_receives_resolved_futures(
+        self, enable_client_side_task_run_orchestration
+    ):
         def check_args(context, params):
             assert params["x"] == "something"
             assert len(params) == 1
-            return params["x"]
+            return params["x"] + str(enable_client_side_task_run_orchestration)
 
         @task
         def foo(x):
@@ -1459,9 +1516,11 @@ class TestTaskCaching:
         assert second_state.name == "Cached"
         assert await second_state.result() == "something"
 
-    async def test_cache_key_fn_arg_inputs_are_stable(self):
+    async def test_cache_key_fn_arg_inputs_are_stable(
+        self, enable_client_side_task_run_orchestration
+    ):
         def stringed_inputs(context, args):
-            return str(args)
+            return str(args) + str(enable_client_side_task_run_orchestration)
 
         @task(cache_key_fn=stringed_inputs, persist_result=True)
         def foo(a, b, c=3):
@@ -1485,9 +1544,12 @@ class TestTaskCaching:
         assert await second_state.result() == 6
         assert await third_state.result() == 6
 
-    async def test_cache_key_hits_with_future_expiration_are_cached(self):
+    async def test_cache_key_hits_with_future_expiration_are_cached(
+        self, enable_client_side_task_run_orchestration
+    ):
         @task(
-            cache_key_fn=lambda *_: "cache-hit-4",
+            cache_key_fn=lambda *_: "cache-hit-4"
+            + str(enable_client_side_task_run_orchestration),
             cache_expiration=datetime.timedelta(seconds=5),
             persist_result=True,
         )
@@ -1539,9 +1601,12 @@ class TestTaskCaching:
         assert second_state.name == "Completed"
         assert await second_state.result() != await first_state.result()
 
-    async def test_cache_hits_wo_refresh_cache(self):
+    async def test_cache_hits_wo_refresh_cache(
+        self, enable_client_side_task_run_orchestration
+    ):
         @task(
-            cache_key_fn=lambda *_: "cache-hit-7",
+            cache_key_fn=lambda *_: "cache-hit-7"
+            + str(enable_client_side_task_run_orchestration),
             refresh_cache=False,
             persist_result=True,
         )
@@ -1649,7 +1714,9 @@ class TestTaskCaching:
         assert await s3.result() == 105
         assert await s4.result() == 105
 
-    async def test_instance_methods_can_share_a_cache(self):
+    async def test_instance_methods_can_share_a_cache(
+        self, enable_client_side_task_run_orchestration
+    ):
         """
         Test that instance methods can share a cache by using a cache key function that
         ignores the bound instance argument
@@ -1659,7 +1726,7 @@ class TestTaskCaching:
             # remove the self arg from the cache key
             cache_args = args.copy()
             cache_args.pop("self")
-            return str(cache_args)
+            return str(cache_args) + str(enable_client_side_task_run_orchestration)
 
         class Foo:
             def __init__(self, x):
@@ -1717,9 +1784,12 @@ class TestTaskCaching:
         assert await second_state.result() == await first_state.result()
         assert "`cache_key_fn` will be used" in caplog.text
 
-    async def test_changing_result_storage_key_busts_cache(self):
+    async def test_changing_result_storage_key_busts_cache(
+        self, enable_client_side_task_run_orchestration
+    ):
         @task(
-            cache_key_fn=lambda *_: "cache-hit-10",
+            cache_key_fn=lambda *_: "cache-hit-10"
+            + str(enable_client_side_task_run_orchestration),
             result_storage_key="before",
             persist_result=True,
         )
@@ -1774,8 +1844,14 @@ class TestTaskCaching:
 
 
 class TestCacheFunctionBuiltins:
-    async def test_task_input_hash_within_flows(self):
-        @task(cache_key_fn=task_input_hash, persist_result=True)
+    async def test_task_input_hash_within_flows(
+        self, enable_client_side_task_run_orchestration
+    ):
+        @task(
+            cache_key_fn=lambda ctx,
+            *args: f"{task_input_hash(ctx, *args)}:{enable_client_side_task_run_orchestration}",
+            persist_result=True,
+        )
         def foo(x):
             return x
 
@@ -1796,8 +1872,14 @@ class TestCacheFunctionBuiltins:
         assert await first_state.result() == await third_state.result()
         assert await first_state.result() == 1
 
-    async def test_task_input_hash_between_flows(self):
-        @task(cache_key_fn=task_input_hash, persist_result=True)
+    async def test_task_input_hash_between_flows(
+        self, enable_client_side_task_run_orchestration
+    ):
+        @task(
+            cache_key_fn=lambda ctx,
+            *args: f"{task_input_hash(ctx, *args)}:{enable_client_side_task_run_orchestration}",
+            persist_result=True,
+        )
         def foo(x):
             return x
 
@@ -1814,7 +1896,9 @@ class TestCacheFunctionBuiltins:
         assert await first_state.result() != await second_state.result()
         assert await first_state.result() == await third_state.result() == 1
 
-    async def test_task_input_hash_works_with_object_return_types(self):
+    async def test_task_input_hash_works_with_object_return_types(
+        self, enable_client_side_task_run_orchestration
+    ):
         """
         This is a regression test for a weird bug where `task_input_hash` would always
         use cloudpickle to generate the hash since we were passing in the raw function
@@ -1831,7 +1915,11 @@ class TestCacheFunctionBuiltins:
             def __eq__(self, other) -> bool:
                 return type(self) == type(other) and self.x == other.x
 
-        @task(cache_key_fn=task_input_hash, persist_result=True)
+        @task(
+            cache_key_fn=lambda ctx,
+            *args: f"{task_input_hash(ctx, *args)}:{enable_client_side_task_run_orchestration}",
+            persist_result=True,
+        )
         def foo(x):
             return TestClass(x)
 
@@ -1851,7 +1939,9 @@ class TestCacheFunctionBuiltins:
         assert await first_state.result() != await second_state.result()
         assert await first_state.result() == await third_state.result()
 
-    async def test_task_input_hash_works_with_object_input_types(self):
+    async def test_task_input_hash_works_with_object_input_types(
+        self, enable_client_side_task_run_orchestration
+    ):
         class TestClass:
             def __init__(self, x):
                 self.x = x
@@ -1859,7 +1949,11 @@ class TestCacheFunctionBuiltins:
             def __eq__(self, other) -> bool:
                 return type(self) == type(other) and self.x == other.x
 
-        @task(cache_key_fn=task_input_hash, persist_result=True)
+        @task(
+            cache_key_fn=lambda ctx,
+            *args: f"{task_input_hash(ctx, *args)}:{enable_client_side_task_run_orchestration}",
+            persist_result=True,
+        )
         def foo(instance):
             return instance.x
 
@@ -1879,13 +1973,19 @@ class TestCacheFunctionBuiltins:
         assert await first_state.result() != await second_state.result()
         assert await first_state.result() == await third_state.result() == 1
 
-    async def test_task_input_hash_works_with_block_input_types(self):
+    async def test_task_input_hash_works_with_block_input_types(
+        self, enable_client_side_task_run_orchestration
+    ):
         class TestBlock(Block):
             x: int
             y: int
             z: int
 
-        @task(cache_key_fn=task_input_hash, persist_result=True)
+        @task(
+            cache_key_fn=lambda ctx,
+            *args: f"{task_input_hash(ctx, *args)}:{enable_client_side_task_run_orchestration}",
+            persist_result=True,
+        )
         def foo(instance):
             return instance.x
 
@@ -1905,8 +2005,14 @@ class TestCacheFunctionBuiltins:
         assert await first_state.result() != await second_state.result()
         assert await first_state.result() == await third_state.result() == 1
 
-    async def test_task_input_hash_depends_on_task_key_and_code(self):
-        @task(cache_key_fn=task_input_hash, persist_result=True)
+    async def test_task_input_hash_depends_on_task_key_and_code(
+        self, enable_client_side_task_run_orchestration
+    ):
+        @task(
+            cache_key_fn=lambda ctx,
+            *args: f"{task_input_hash(ctx, *args)}:{enable_client_side_task_run_orchestration}",
+            persist_result=True,
+        )
         def foo(x):
             return x
 
@@ -1916,7 +2022,11 @@ class TestCacheFunctionBuiltins:
         def foo_same_code(x):
             return x
 
-        @task(cache_key_fn=task_input_hash, persist_result=True)
+        @task(
+            cache_key_fn=lambda ctx,
+            *args: f"{task_input_hash(ctx, *args)}:{enable_client_side_task_run_orchestration}",
+            persist_result=True,
+        )
         def bar(x):
             return x
 
@@ -1948,13 +2058,19 @@ class TestCacheFunctionBuiltins:
         assert await first_state.result() != await third_state.result()
         assert await fourth_state.result() == await fifth_state.result() == 1
 
-    async def test_task_input_hash_works_with_block_input_types_and_bytes(self):
+    async def test_task_input_hash_works_with_block_input_types_and_bytes(
+        self, enable_client_side_task_run_orchestration
+    ):
         class TestBlock(Block):
             x: int
             y: int
             z: bytes
 
-        @task(cache_key_fn=task_input_hash, persist_result=True)
+        @task(
+            cache_key_fn=lambda ctx,
+            *args: f"{task_input_hash(ctx, *args)}:{enable_client_side_task_run_orchestration}",
+            persist_result=True,
+        )
         def foo(instance):
             return instance.x
 
@@ -2034,7 +2150,9 @@ class TestTaskTimeouts:
 
 
 class TestTaskRunTags:
-    async def test_task_run_tags_added_at_submission(self, prefect_client):
+    async def test_task_run_tags_added_at_submission(
+        self, prefect_client, events_pipeline
+    ):
         @flow
         def my_flow():
             with tags("a", "b"):
@@ -2047,12 +2165,14 @@ class TestTaskRunTags:
             pass
 
         task_state = my_flow()
+        await events_pipeline.process_events()
+
         task_run = await prefect_client.read_task_run(
             task_state.state_details.task_run_id
         )
         assert set(task_run.tags) == {"a", "b"}
 
-    async def test_task_run_tags_added_at_run(self, prefect_client):
+    async def test_task_run_tags_added_at_run(self, prefect_client, events_pipeline):
         @flow
         def my_flow():
             with tags("a", "b"):
@@ -2065,12 +2185,13 @@ class TestTaskRunTags:
             pass
 
         task_state = my_flow()
+        await events_pipeline.process_events()
         task_run = await prefect_client.read_task_run(
             task_state.state_details.task_run_id
         )
         assert set(task_run.tags) == {"a", "b"}
 
-    async def test_task_run_tags_added_at_call(self, prefect_client):
+    async def test_task_run_tags_added_at_call(self, prefect_client, events_pipeline):
         @flow
         def my_flow():
             with tags("a", "b"):
@@ -2083,12 +2204,15 @@ class TestTaskRunTags:
             return "foo"
 
         task_state = my_flow()
+        await events_pipeline.process_events()
         task_run = await prefect_client.read_task_run(
             task_state.state_details.task_run_id
         )
         assert set(task_run.tags) == {"a", "b"}
 
-    async def test_task_run_tags_include_tags_on_task_object(self, prefect_client):
+    async def test_task_run_tags_include_tags_on_task_object(
+        self, prefect_client, events_pipeline
+    ):
         @flow
         def my_flow():
             with tags("c", "d"):
@@ -2101,12 +2225,15 @@ class TestTaskRunTags:
             pass
 
         task_state = my_flow()
+        await events_pipeline.process_events()
         task_run = await prefect_client.read_task_run(
             task_state.state_details.task_run_id
         )
         assert set(task_run.tags) == {"a", "b", "c", "d"}
 
-    async def test_task_run_tags_include_flow_run_tags(self, prefect_client):
+    async def test_task_run_tags_include_flow_run_tags(
+        self, prefect_client, events_pipeline
+    ):
         @flow
         def my_flow():
             with tags("c", "d"):
@@ -2121,12 +2248,15 @@ class TestTaskRunTags:
         with tags("a", "b"):
             task_state = my_flow()
 
+        await events_pipeline.process_events()
         task_run = await prefect_client.read_task_run(
             task_state.state_details.task_run_id
         )
         assert set(task_run.tags) == {"a", "b", "c", "d"}
 
-    async def test_task_run_tags_not_added_outside_context(self, prefect_client):
+    async def test_task_run_tags_not_added_outside_context(
+        self, prefect_client, events_pipeline
+    ):
         @flow
         def my_flow():
             with tags("a", "b"):
@@ -2140,12 +2270,15 @@ class TestTaskRunTags:
             pass
 
         task_state = my_flow()
+        await events_pipeline.process_events()
         task_run = await prefect_client.read_task_run(
             task_state.state_details.task_run_id
         )
         assert not task_run.tags
 
-    async def test_task_run_tags_respects_nesting(self, prefect_client):
+    async def test_task_run_tags_respects_nesting(
+        self, prefect_client, events_pipeline
+    ):
         @flow
         def my_flow():
             with tags("a", "b"):
@@ -2159,6 +2292,7 @@ class TestTaskRunTags:
             pass
 
         task_state = my_flow()
+        await events_pipeline.process_events()
         task_run = await prefect_client.read_task_run(
             task_state.state_details.task_run_id
         )
@@ -2192,7 +2326,9 @@ class TestTaskInputs:
 
         return upstream_downstream_flow
 
-    async def test_task_inputs_populated_with_no_upstreams(self, prefect_client):
+    async def test_task_inputs_populated_with_no_upstreams(
+        self, prefect_client, events_pipeline
+    ):
         @task
         def foo(x):
             return x
@@ -2203,13 +2339,14 @@ class TestTaskInputs:
 
         flow_state = test_flow(return_state=True)
         x = await flow_state.result()
+        await events_pipeline.process_events()
 
         task_run = await prefect_client.read_task_run(x.state_details.task_run_id)
 
         assert task_run.task_inputs == dict(x=[])
 
     async def test_task_inputs_populated_with_no_upstreams_and_multiple_parameters(
-        self, prefect_client
+        self, prefect_client, events_pipeline
     ):
         @task
         def foo(x, *a, **k):
@@ -2221,13 +2358,14 @@ class TestTaskInputs:
 
         flow_state = test_flow(return_state=True)
         x = await flow_state.result()
+        await events_pipeline.process_events()
 
         task_run = await prefect_client.read_task_run(x.state_details.task_run_id)
 
         assert task_run.task_inputs == dict(x=[], a=[], k=[])
 
     async def test_task_inputs_populated_with_one_upstream_positional_future(
-        self, prefect_client
+        self, prefect_client, events_pipeline
     ):
         @task
         def foo(x):
@@ -2247,6 +2385,7 @@ class TestTaskInputs:
         flow_state = test_flow(return_state=True)
         a, b, c = await flow_state.result()
 
+        await events_pipeline.process_events()
         task_run = await prefect_client.read_task_run(c.state_details.task_run_id)
 
         assert task_run.task_inputs == dict(
@@ -2255,7 +2394,7 @@ class TestTaskInputs:
         )
 
     async def test_task_inputs_populated_with_one_upstream_keyword_future(
-        self, prefect_client
+        self, prefect_client, events_pipeline
     ):
         @task
         def foo(x):
@@ -2275,6 +2414,7 @@ class TestTaskInputs:
         flow_state = test_flow(return_state=True)
         a, b, c = await flow_state.result()
 
+        await events_pipeline.process_events()
         task_run = await prefect_client.read_task_run(c.state_details.task_run_id)
 
         assert task_run.task_inputs == dict(
@@ -2283,7 +2423,7 @@ class TestTaskInputs:
         )
 
     async def test_task_inputs_populated_with_two_upstream_futures(
-        self, prefect_client
+        self, prefect_client, events_pipeline
     ):
         @task
         def foo(x):
@@ -2302,7 +2442,7 @@ class TestTaskInputs:
 
         flow_state = test_flow(return_state=True)
         a, b, c = await flow_state.result()
-
+        await events_pipeline.process_events()
         task_run = await prefect_client.read_task_run(c.state_details.task_run_id)
 
         assert task_run.task_inputs == dict(
@@ -2311,7 +2451,7 @@ class TestTaskInputs:
         )
 
     async def test_task_inputs_populated_with_two_upstream_futures_from_same_task(
-        self, prefect_client
+        self, prefect_client, events_pipeline
     ):
         @task
         def foo(x):
@@ -2330,6 +2470,7 @@ class TestTaskInputs:
         flow_state = test_flow(return_state=True)
         a, c = await flow_state.result()
 
+        await events_pipeline.process_events()
         task_run = await prefect_client.read_task_run(c.state_details.task_run_id)
 
         assert task_run.task_inputs == dict(
@@ -2338,7 +2479,7 @@ class TestTaskInputs:
         )
 
     async def test_task_inputs_populated_with_nested_upstream_futures(
-        self, prefect_client
+        self, prefect_client, events_pipeline
     ):
         @task
         def foo(x):
@@ -2360,6 +2501,8 @@ class TestTaskInputs:
 
         a, b, c, d = await flow_state.result()
 
+        await events_pipeline.process_events()
+
         task_run = await prefect_client.read_task_run(d.state_details.task_run_id)
 
         assert comparable_inputs(task_run.task_inputs) == dict(
@@ -2373,7 +2516,9 @@ class TestTaskInputs:
             },
         )
 
-    async def test_task_inputs_populated_with_subflow_upstream(self, prefect_client):
+    async def test_task_inputs_populated_with_subflow_upstream(
+        self, prefect_client, events_pipeline
+    ):
         @task
         def foo(x):
             return x
@@ -2390,6 +2535,8 @@ class TestTaskInputs:
         parent_state = parent(return_state=True)
         child_state, task_state = await parent_state.result()
 
+        await events_pipeline.process_events()
+
         task_run = await prefect_client.read_task_run(
             task_state.state_details.task_run_id
         )
@@ -2399,7 +2546,7 @@ class TestTaskInputs:
         )
 
     async def test_task_inputs_populated_with_result_upstream(
-        self, sync_prefect_client
+        self, sync_prefect_client, events_pipeline
     ):
         @task
         def name():
@@ -2418,6 +2565,8 @@ class TestTaskInputs:
         flow_state = test_flow(return_state=True)
         name_state, hi_state = await flow_state.result()
 
+        await events_pipeline.process_events()
+
         task_run = sync_prefect_client.read_task_run(hi_state.state_details.task_run_id)
 
         assert task_run.task_inputs == dict(
@@ -2425,7 +2574,7 @@ class TestTaskInputs:
         )
 
     async def test_task_inputs_populated_with_result_upstream_from_future(
-        self, prefect_client
+        self, prefect_client, events_pipeline
     ):
         @task
         def upstream(x):
@@ -2445,6 +2594,8 @@ class TestTaskInputs:
 
         upstream_state, downstream_state = test_flow()
 
+        await events_pipeline.process_events()
+
         task_run = await prefect_client.read_task_run(
             downstream_state.state_details.task_run_id
         )
@@ -2454,7 +2605,7 @@ class TestTaskInputs:
         )
 
     async def test_task_inputs_populated_with_result_upstream_from_state(
-        self, prefect_client
+        self, prefect_client, events_pipeline
     ):
         @task
         def upstream(x):
@@ -2473,9 +2624,13 @@ class TestTaskInputs:
 
         upstream_state, downstream_state = test_flow()
 
+        await events_pipeline.process_events()
+
         await prefect_client.read_task_run(downstream_state.state_details.task_run_id)
 
-    async def test_task_inputs_populated_with_state_upstream(self, prefect_client):
+    async def test_task_inputs_populated_with_state_upstream(
+        self, prefect_client, events_pipeline
+    ):
         @task
         def upstream(x):
             return x
@@ -2492,6 +2647,8 @@ class TestTaskInputs:
 
         upstream_state, downstream_state = test_flow()
 
+        await events_pipeline.process_events()
+
         task_run = await prefect_client.read_task_run(
             downstream_state.state_details.task_run_id
         )
@@ -2501,7 +2658,7 @@ class TestTaskInputs:
         )
 
     async def test_task_inputs_populated_with_state_upstream_wrapped_with_allow_failure(
-        self, prefect_client
+        self, prefect_client, events_pipeline
     ):
         @task
         def upstream(x):
@@ -2521,6 +2678,8 @@ class TestTaskInputs:
 
         upstream_state, downstream_state = test_flow()
 
+        await events_pipeline.process_events()
+
         task_run = await prefect_client.read_task_run(
             downstream_state.state_details.task_run_id
         )
@@ -2531,10 +2690,12 @@ class TestTaskInputs:
 
     @pytest.mark.parametrize("result", [["Fred"], {"one": 1}, {1, 2, 2}, (1, 2)])
     async def test_task_inputs_populated_with_collection_result_upstream(
-        self, result, prefect_client, flow_with_upstream_downstream
+        self, result, prefect_client, flow_with_upstream_downstream, events_pipeline
     ):
         flow_state = flow_with_upstream_downstream(result, return_state=True)
         upstream_state, downstream_state = await flow_state.result()
+
+        await events_pipeline.process_events()
 
         task_run = await prefect_client.read_task_run(
             downstream_state.state_details.task_run_id
@@ -2546,10 +2707,12 @@ class TestTaskInputs:
 
     @pytest.mark.parametrize("result", ["Fred", 5.1])
     async def test_task_inputs_populated_with_basic_result_types_upstream(
-        self, result, prefect_client, flow_with_upstream_downstream
+        self, result, prefect_client, flow_with_upstream_downstream, events_pipeline
     ):
         flow_state = flow_with_upstream_downstream(result, return_state=True)
         upstream_state, downstream_state = await flow_state.result()
+
+        await events_pipeline.process_events()
 
         task_run = await prefect_client.read_task_run(
             downstream_state.state_details.task_run_id
@@ -2560,10 +2723,12 @@ class TestTaskInputs:
 
     @pytest.mark.parametrize("result", [True, False, None, ..., NotImplemented])
     async def test_task_inputs_not_populated_with_singleton_results_upstream(
-        self, result, prefect_client, flow_with_upstream_downstream
+        self, result, prefect_client, flow_with_upstream_downstream, events_pipeline
     ):
         flow_state = flow_with_upstream_downstream(result, return_state=True)
         _, downstream_state = await flow_state.result()
+
+        await events_pipeline.process_events()
 
         task_run = await prefect_client.read_task_run(
             downstream_state.state_details.task_run_id
@@ -2572,7 +2737,7 @@ class TestTaskInputs:
         assert task_run.task_inputs == dict(value=[])
 
     async def test_task_inputs_populated_with_result_upstream_from_state_with_unpacking_trackables(
-        self, prefect_client
+        self, prefect_client, events_pipeline
     ):
         @task
         def task_1():
@@ -2599,6 +2764,8 @@ class TestTaskInputs:
 
         t1_state, t2_state, t3_state = unpacking_flow()
 
+        await events_pipeline.process_events()
+
         task_3_run = await prefect_client.read_task_run(
             t3_state.state_details.task_run_id
         )
@@ -2616,7 +2783,7 @@ class TestTaskInputs:
         )
 
     async def test_task_inputs_populated_with_result_upstream_from_state_with_unpacking_mixed_untrackable_types(
-        self, prefect_client
+        self, prefect_client, events_pipeline
     ):
         @task
         def task_1():
@@ -2643,6 +2810,8 @@ class TestTaskInputs:
 
         t1_state, t2_state, t3_state = unpacking_flow()
 
+        await events_pipeline.process_events()
+
         task_3_run = await prefect_client.read_task_run(
             t3_state.state_details.task_run_id
         )
@@ -2660,7 +2829,7 @@ class TestTaskInputs:
         )
 
     async def test_task_inputs_populated_with_result_upstream_from_state_with_unpacking_no_trackable_types(
-        self, prefect_client
+        self, prefect_client, events_pipeline
     ):
         @task
         def task_1():
@@ -2685,6 +2854,8 @@ class TestTaskInputs:
             return t1_state, t2_state, t3_state
 
         t1_state, t2_state, t3_state = unpacking_flow()
+
+        await events_pipeline.process_events()
 
         task_3_run = await prefect_client.read_task_run(
             t3_state.state_details.task_run_id
@@ -2894,7 +3065,9 @@ class TestTaskWaitFor:
 
         assert test_flow() == 2
 
-    async def test_backend_task_inputs_includes_wait_for_tasks(self, prefect_client):
+    async def test_backend_task_inputs_includes_wait_for_tasks(
+        self, prefect_client, events_pipeline
+    ):
         @task
         def foo(x):
             return x
@@ -2907,6 +3080,7 @@ class TestTaskWaitFor:
             return (a, b, c, d)
 
         a, b, c, d = test_flow()
+        await events_pipeline.process_events()
         d_task_run = await prefect_client.read_task_run(d.state_details.task_run_id)
 
         assert d_task_run.task_inputs["x"] == [
@@ -3220,8 +3394,14 @@ class TestTaskWithOptions:
         assert task_with_options.retries == 0
         assert task_with_options.retry_delay_seconds == 0
 
-    async def test_with_options_refresh_cache(self):
-        @task(cache_key_fn=lambda *_: "cache hit", persist_result=True)
+    async def test_with_options_refresh_cache(
+        self, enable_client_side_task_run_orchestration
+    ):
+        @task(
+            cache_key_fn=lambda *_: "cache hit"
+            + str(enable_client_side_task_run_orchestration),
+            persist_result=True,
+        )
         def foo(x):
             return x
 
@@ -3367,7 +3547,7 @@ class TestTaskMap:
         return {x["id"]: [d.id for d in x["upstream_dependencies"]] for x in graph}
 
     async def test_map_preserves_dependencies_between_futures_all_mapped_children(
-        self, session
+        self, session, events_pipeline
     ):
         @flow
         def my_flow():
@@ -3381,6 +3561,8 @@ class TestTaskMap:
             return numbers, TestTaskMap.add_together.map(numbers, y=0)
 
         numbers_state, add_task_states = my_flow()
+        await events_pipeline.process_events()
+
         dependency_ids = await self.get_dependency_ids(
             session, numbers_state.state_details.flow_run_id
         )
@@ -3395,7 +3577,7 @@ class TestTaskMap:
         )
 
     async def test_map_preserves_dependencies_between_futures_all_mapped_children_multiple(
-        self, session
+        self, session, events_pipeline
     ):
         @flow
         def my_flow():
@@ -3412,6 +3594,7 @@ class TestTaskMap:
             )
 
         numbers_states, add_task_states = my_flow()
+        await events_pipeline.process_events()
         dependency_ids = await self.get_dependency_ids(
             session, numbers_states[0].state_details.flow_run_id
         )
@@ -3429,7 +3612,7 @@ class TestTaskMap:
         )
 
     async def test_map_preserves_dependencies_between_futures_differing_parents(
-        self, session
+        self, session, events_pipeline
     ):
         @flow
         def my_flow():
@@ -3443,6 +3626,7 @@ class TestTaskMap:
             return (x1, x2), TestTaskMap.add_together.map([x1, x2], y=0)
 
         echo_futures, add_task_states = my_flow()
+        await events_pipeline.process_events()
         dependency_ids = await self.get_dependency_ids(
             session, echo_futures[0].state_details.flow_run_id
         )
@@ -3457,7 +3641,9 @@ class TestTaskMap:
             for a, e in zip(add_task_states, echo_futures)
         )
 
-    async def test_map_preserves_dependencies_between_futures_static_arg(self, session):
+    async def test_map_preserves_dependencies_between_futures_static_arg(
+        self, session, events_pipeline
+    ):
         @flow
         def my_flow():
             """
@@ -3470,6 +3656,8 @@ class TestTaskMap:
             return x, TestTaskMap.add_together.map([1, 2, 3], y=x)
 
         echo_future, add_task_states = my_flow()
+        await events_pipeline.process_events()
+
         dependency_ids = await self.get_dependency_ids(
             session, echo_future.state_details.flow_run_id
         )
@@ -3483,7 +3671,9 @@ class TestTaskMap:
             for a in add_task_states
         )
 
-    async def test_map_preserves_dependencies_between_futures_mixed_map(self, session):
+    async def test_map_preserves_dependencies_between_futures_mixed_map(
+        self, session, events_pipeline
+    ):
         @flow
         def my_flow():
             """
@@ -3495,6 +3685,7 @@ class TestTaskMap:
             return x, TestTaskMap.add_together.map([x, 2], y=1)
 
         echo_future, add_task_states = my_flow()
+        await events_pipeline.process_events()
         dependency_ids = await self.get_dependency_ids(
             session, echo_future.state_details.flow_run_id
         )
@@ -3508,7 +3699,7 @@ class TestTaskMap:
         assert dependency_ids[add_task_states[1].state_details.task_run_id] == []
 
     async def test_map_preserves_dependencies_between_futures_deep_nesting(
-        self, session
+        self, session, events_pipeline
     ):
         @flow
         def my_flow():
@@ -3524,6 +3715,7 @@ class TestTaskMap:
             )
 
         echo_futures, add_task_futures = my_flow()
+        await events_pipeline.process_events()
         dependency_ids = await self.get_dependency_ids(
             session, echo_futures[0].state_details.flow_run_id
         )
@@ -3802,7 +3994,7 @@ class TestTaskConstructorValidation:
                 raise RuntimeError("try again!")
 
 
-async def test_task_run_name_is_set(prefect_client):
+async def test_task_run_name_is_set(prefect_client, events_pipeline):
     @task(task_run_name="fixed-name")
     def my_task(name):
         return name
@@ -3812,6 +4004,7 @@ async def test_task_run_name_is_set(prefect_client):
         return my_task(name, return_state=True)
 
     tr_state = my_flow(name="chris")
+    await events_pipeline.process_events()
 
     # Check that the state completed happily
     assert tr_state.is_completed()
@@ -3819,7 +4012,9 @@ async def test_task_run_name_is_set(prefect_client):
     assert task_run.name == "fixed-name"
 
 
-async def test_task_run_name_is_set_with_kwargs_including_defaults(prefect_client):
+async def test_task_run_name_is_set_with_kwargs_including_defaults(
+    prefect_client, events_pipeline
+):
     @task(task_run_name="{name}-wuz-{where}")
     def my_task(name, where="here"):
         return name
@@ -3829,6 +4024,7 @@ async def test_task_run_name_is_set_with_kwargs_including_defaults(prefect_clien
         return my_task(name, return_state=True)
 
     tr_state = my_flow(name="chris")
+    await events_pipeline.process_events()
 
     # Check that the state completed happily
     assert tr_state.is_completed()
@@ -3836,7 +4032,7 @@ async def test_task_run_name_is_set_with_kwargs_including_defaults(prefect_clien
     assert task_run.name == "chris-wuz-here"
 
 
-async def test_task_run_name_is_set_with_function(prefect_client):
+async def test_task_run_name_is_set_with_function(prefect_client, events_pipeline):
     def generate_task_run_name():
         return "is-this-a-bird"
 
@@ -3849,6 +4045,7 @@ async def test_task_run_name_is_set_with_function(prefect_client):
         return my_task(name, return_state=True)
 
     tr_state = my_flow(name="butterfly")
+    await events_pipeline.process_events()
 
     # Check that the state completed happily
     assert tr_state.is_completed()
@@ -3856,7 +4053,9 @@ async def test_task_run_name_is_set_with_function(prefect_client):
     assert task_run.name == "is-this-a-bird"
 
 
-async def test_task_run_name_is_set_with_function_using_runtime_context(prefect_client):
+async def test_task_run_name_is_set_with_function_using_runtime_context(
+    prefect_client, events_pipeline
+):
     def generate_task_run_name():
         params = task_run_ctx.parameters
         tokens = []
@@ -3875,6 +4074,7 @@ async def test_task_run_name_is_set_with_function_using_runtime_context(prefect_
         return my_task(name, return_state=True)
 
     tr_state = my_flow(name="chris")
+    await events_pipeline.process_events()
 
     # Check that the state completed happily
     assert tr_state.is_completed()
@@ -4566,12 +4766,16 @@ class TestNestedTasks:
 
         assert await my_flow() == 10
 
-    async def test_nested_cache_key_fn(self):
+    async def test_nested_cache_key_fn(self, enable_client_side_task_run_orchestration):
         @task
         def inner_task(x):
             return x * 2
 
-        @task(cache_key_fn=task_input_hash, persist_result=True)
+        @task(
+            cache_key_fn=lambda ctx,
+            *args: f"{task_input_hash(ctx, *args)}:{enable_client_side_task_run_orchestration}",
+            persist_result=True,
+        )
         def outer_task(x):
             return inner_task(x)
 
@@ -4590,12 +4794,18 @@ class TestNestedTasks:
         assert await state1.result() == 4
         assert await state2.result() == 4
 
-    async def test_nested_async_cache_key_fn(self):
+    async def test_nested_async_cache_key_fn(
+        self, enable_client_side_task_run_orchestration
+    ):
         @task
         async def inner_task(x):
             return x * 2
 
-        @task(cache_key_fn=task_input_hash, persist_result=True)
+        @task(
+            cache_key_fn=lambda ctx,
+            *args: f"{task_input_hash(ctx, *args)}:{enable_client_side_task_run_orchestration}",
+            persist_result=True,
+        )
         async def outer_task(x):
             return await inner_task(x)
 
@@ -4614,14 +4824,19 @@ class TestNestedTasks:
         assert await state1.result() == 4
         assert await state2.result() == 4
 
-    async def test_nested_cache_key_fn_inner_task_cached_default(self):
+    async def test_nested_cache_key_fn_inner_task_cached_default(
+        self, enable_client_side_task_run_orchestration
+    ):
         """
         By default, task transactions are LAZY committed and therefore
         inner tasks do not persist data (i.e., create a cache) until
         the outer task is complete.
         """
 
-        @task(cache_key_fn=task_input_hash)
+        @task(
+            cache_key_fn=lambda ctx,
+            *args: f"{task_input_hash(ctx, *args)}:{enable_client_side_task_run_orchestration}"
+        )
         def inner_task(x):
             return x * 2
 
@@ -4645,7 +4860,9 @@ class TestNestedTasks:
         assert await inner_state1.result() == 4
         assert await inner_state2.result() == 4
 
-    async def test_nested_cache_key_fn_inner_task_cached_eager(self):
+    async def test_nested_cache_key_fn_inner_task_cached_eager(
+        self, enable_client_side_task_run_orchestration
+    ):
         """
         By default, task transactions are LAZY committed and therefore
         inner tasks do not persist data (i.e., create a cache) until
@@ -4654,7 +4871,11 @@ class TestNestedTasks:
         This behavior can be modified by using a transaction context manager.
         """
 
-        @task(cache_key_fn=task_input_hash, persist_result=True)
+        @task(
+            cache_key_fn=lambda ctx,
+            *args: f"{task_input_hash(ctx, *args)}:{enable_client_side_task_run_orchestration}",
+            persist_result=True,
+        )
         def inner_task(x):
             return x * 2
 
@@ -4679,7 +4900,9 @@ class TestNestedTasks:
         assert await inner_state1.result() == 8
         assert await inner_state2.result() == 8
 
-    async def test_nested_async_cache_key_fn_inner_task_cached_default(self):
+    async def test_nested_async_cache_key_fn_inner_task_cached_default(
+        self, enable_client_side_task_run_orchestration
+    ):
         """
         By default, task transactions are LAZY committed and therefore
         inner tasks do not persist data (i.e., create a cache) until
@@ -4688,7 +4911,10 @@ class TestNestedTasks:
         This behavior can be modified by using a transaction context manager.
         """
 
-        @task(cache_key_fn=task_input_hash)
+        @task(
+            cache_key_fn=lambda ctx,
+            *args: f"{task_input_hash(ctx, *args)}:{enable_client_side_task_run_orchestration}"
+        )
         async def inner_task(x):
             return x * 2
 
@@ -4712,7 +4938,9 @@ class TestNestedTasks:
         assert await inner_state1.result() == 4
         assert await inner_state2.result() == 4
 
-    async def test_nested_async_cache_key_fn_inner_task_cached_eager(self):
+    async def test_nested_async_cache_key_fn_inner_task_cached_eager(
+        self, enable_client_side_task_run_orchestration
+    ):
         """
         By default, task transactions are LAZY committed and therefore
         inner tasks do not persist data (i.e., create a cache) until
@@ -4721,7 +4949,11 @@ class TestNestedTasks:
         This behavior can be modified by using a transaction context manager.
         """
 
-        @task(cache_key_fn=task_input_hash, persist_result=True)
+        @task(
+            cache_key_fn=lambda ctx,
+            *args: f"{task_input_hash(ctx, *args)}:{enable_client_side_task_run_orchestration}",
+            persist_result=True,
+        )
         async def inner_task(x):
             return x * 2
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -873,12 +873,19 @@ class TestTaskSubmit:
         with pytest.raises(ValueError, match="deadlock"):
             my_flow()
 
-    def test_logs_message_when_submitted_tasks_end_in_pending(self, caplog):
+    def test_logs_message_when_submitted_tasks_end_in_pending(
+        self, caplog, enable_client_side_task_run_orchestration
+    ):
         """
         If submitted tasks aren't waited on before a flow exits, they may fail to run
         because they're transition from PENDING to RUNNING is denied. This test ensures
         that a message is logged when this happens.
         """
+
+        if enable_client_side_task_run_orchestration:
+            pytest.xfail(
+                "This test is not compatible with the current state of client side task orchestration"
+            )
 
         @task
         def find_palindromes():

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -54,7 +54,7 @@ from prefect.utilities.collections import quote
 from prefect.utilities.engine import get_state_for_result
 
 
-@pytest.fixture(autouse=True, params=[False])
+@pytest.fixture(autouse=True, params=[False, True])
 def enable_client_side_task_run_orchestration(
     request, asserting_events_worker: EventsWorker
 ):


### PR DESCRIPTION
Updates the `test_task.py` test suite to be compatible with client side task run orchestration. This is the final test suite that needed updates in order to make the flag the default. 