### PR TITLE
correctly call `is_interactive` function during server preflight check

### DIFF
--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -173,7 +173,7 @@ async def start(
 ):
     """Start a Prefect server instance"""
 
-    if is_interactive:
+    if is_interactive():
         try:
             prestart_check()
         except Exception:


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/14906

we were checking truthyness of the function itself, which is not what we want