### PR TITLE
Clearer presentation of unserializable parameters in the UI

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -624,7 +624,7 @@ class Flow(Generic[P, R]):
                     f"Type {type(value).__name__!r} and will not be stored "
                     "in the backend."
                 )
-                serialized_parameters[key] = f"<{type(value).__name__}>"
+                serialized_parameters[key] = str(value)
         return serialized_parameters
 
     @sync_compatible


### PR DESCRIPTION
## Goal

When an unserializable parameter is provided to a flow run, a placeholder is stored in the UI. However, the current approach is very opaque, and this PR seeks to improve the user experience in this regard.

## Demonstration of the Problem

To demonstrate what I mean, let us consider an example. I have a dictionary provided as a parameter to a flow run that Prefect does not know how to serialize. In the "Parameters" tab of the UI, it shows the following:

```python
{
  "atoms": "<Atoms>"
}
```

In other words, the value here could not be serialized and was instead transformed to `"<Atoms>"`, which is the name of the class (i.e. `Atoms` from the library `ase`). However, if instead of storing the name of the class we instead stored `str(value)`, we would have something potentially much more descriptive (depending on if there is a `__repr__` for the unserializable class). Indeed, in this case, we may get something like

```python
{"atoms": "Atoms(symbols='Cu', pbc=True, cell=[[0.0, 1.805, 1.805], [1.805, 0.0, 1.805], [1.805, 1.805, 0.0]])"}`
```

This is much more informative for the end-user.

## This PR

In this PR, I have changed the output in the UI to display `str(value)` rather than the name of the object. At minimum, it contains the same information as before, but it potentially can provide a much more detailed description.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] If this pull request adds new functionality, it includes unit tests that cover the changes
- [X] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [X] If this pull request adds functions or classes, it includes helpful docstrings.
