### PR TITLE
Add an API endpoint that reports task and flow runs using a global concurrency limit

### DIFF
--- a/docs/3.0rc/api-ref/rest-api/server/concurrency-limits-v2/read-concurrency-limit-owners.mdx
+++ b/docs/3.0rc/api-ref/rest-api/server/concurrency-limits-v2/read-concurrency-limit-owners.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /api/v2/concurrency_limits/active_owners
+---

--- a/docs/3.0rc/api-ref/rest-api/server/schema.json
+++ b/docs/3.0rc/api-ref/rest-api/server/schema.json
@@ -4689,6 +4689,59 @@
                 }
             }
         },
+        "/api/v2/concurrency_limits/active_owners": {
+            "post": {
+                "tags": [
+                    "Concurrency Limits V2"
+                ],
+                "summary": "Read Concurrency Limit Owners",
+                "operationId": "read_concurrency_limit_owners_v2_concurrency_limits_active_owners_post",
+                "parameters": [
+                    {
+                        "name": "x-prefect-api-version",
+                        "in": "header",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "title": "X-Prefect-Api-Version"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_read_concurrency_limit_owners_v2_concurrency_limits_active_owners_post"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "title": "Response Read Concurrency Limit Owners V2 Concurrency Limits Active Owners Post"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/block_types/": {
             "post": {
                 "tags": [
@@ -13694,6 +13747,29 @@
                 },
                 "type": "object",
                 "title": "Body_read_block_types_block_types_filter_post"
+            },
+            "Body_read_concurrency_limit_owners_v2_concurrency_limits_active_owners_post": {
+                "properties": {
+                    "names": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Names",
+                        "min_items": 1
+                    },
+                    "time_window": {
+                        "type": "integer",
+                        "maximum": 3600.0,
+                        "title": "Time Window",
+                        "default": 3600
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "names"
+                ],
+                "title": "Body_read_concurrency_limit_owners_v2_concurrency_limits_active_owners_post"
             },
             "Body_read_concurrency_limits_concurrency_limits_filter_post": {
                 "properties": {

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -516,7 +516,8 @@
                     "3.0rc/api-ref/rest-api/server/concurrency-limits-v2/update-concurrency-limit-v2",
                     "3.0rc/api-ref/rest-api/server/concurrency-limits-v2/read-all-concurrency-limits-v2",
                     "3.0rc/api-ref/rest-api/server/concurrency-limits-v2/bulk-increment-active-slots",
-                    "3.0rc/api-ref/rest-api/server/concurrency-limits-v2/bulk-decrement-active-slots"
+                    "3.0rc/api-ref/rest-api/server/concurrency-limits-v2/bulk-decrement-active-slots",
+                    "3.0rc/api-ref/rest-api/server/concurrency-limits-v2/read-concurrency-limit-owners"
                   ]
                 },
                 {


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->
Using concurrency limit "acquired" and "released" events, we can report task runs and flow runs using a global concurrency limit.

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
