### PR TITLE
First order deep merge of flow run overrides with deployment overrides

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -981,7 +981,14 @@ class BaseWorker(abc.ABC):
 
         deployment_vars = deployment.job_variables or {}
         flow_run_vars = flow_run.job_variables or {}
-        job_variables = {**deployment_vars, **flow_run_vars}
+        job_variables = {**deployment_vars}
+
+        # merge any dictionaries, otherwise full override
+        for key, val in flow_run_vars.items():
+            if isinstance(job_variables.get(key), dict):
+                job_variables[key].update(val)
+            else:
+                job_variables[key] = val
 
         configuration = await self.job_configuration.from_template_and_values(
             base_job_template=self._work_pool.base_job_template,

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -983,12 +983,10 @@ class BaseWorker(abc.ABC):
         flow_run_vars = flow_run.job_variables or {}
         job_variables = {**deployment_vars}
 
-        # merge any dictionaries, otherwise full override
-        for key, val in flow_run_vars.items():
-            if isinstance(job_variables.get(key), dict):
-                job_variables[key].update(val)
-            else:
-                job_variables[key] = val
+        # merge environment variables carefully, otherwise full override
+        if isinstance(job_variables.get("env"), dict):
+            job_variables["env"].update(flow_run_vars.pop("env", {}))
+        job_variables.update(flow_run_vars)
 
         configuration = await self.job_configuration.from_template_and_values(
             base_job_template=self._work_pool.base_job_template,

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -2090,6 +2090,7 @@ async def test_env_merge_logic_is_deep(prefect_client, session, flow):
         ),
     )
     await session.commit()
+
     flow_run = await prefect_client.create_flow_run_from_deployment(
         deployment.id,
         state=Pending(),


### PR DESCRIPTION
Closes #11041 

This PR more gracefully merges flow run overrides with deployment overrides, specifically allowing for first-order deep merging of dictionaries.  The most prominent use case for this would be things like overriding one and only one environment variable on a per-run basis (e.g., a git branch) - it would be unreasonable to expect flow-run creators to maintain a duplicate copy of all the environment variables set on the deployment.

Note that this change will also affect any other dictionary field present on a deployment job variable.  If for some reason that is an issue, we can scope this change to environment variables only.