### PR TITLE
Transactions should inherit data from their parents

### DIFF
--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -104,6 +104,7 @@ class Transaction(ContextModel):
             # either inherit from parent or set a default of eager
             if parent:
                 self.commit_mode = parent.commit_mode
+                self._stored_values = parent._stored_values.copy()
             else:
                 self.commit_mode = CommitMode.LAZY
 

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
@@ -107,7 +108,7 @@ class Transaction(ContextModel):
             # either inherit from parent or set a default of eager
             if parent:
                 self.commit_mode = parent.commit_mode
-                self._stored_values = parent._stored_values.copy()
+                self._stored_values = copy.deepcopy(parent._stored_values)
             else:
                 self.commit_mode = CommitMode.LAZY
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -360,6 +360,15 @@ class TestHooks:
                 assert top.get("key") == 42
             assert top.get("key") == 42
 
+    def test_get_and_set_data_doesnt_mutate_parent(self):
+        with transaction(key="test") as top:
+            top.set("key", {"x": [42]})
+            with transaction(key="nested") as inner:
+                inner.get("key")["x"].append(43)
+                assert inner.get("key") == {"x": [42, 43]}
+                assert top.get("key") == {"x": [42]}
+            assert top.get("key") == {"x": [42]}
+
     def test_get_raises_on_unknown_but_allows_default(self):
         with transaction(key="test") as txn:
             with pytest.raises(ValueError, match="foobar"):

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -352,7 +352,10 @@ class TestHooks:
         with transaction(key="test") as top:
             top.set("key", 42)
             with transaction(key="nested") as inner:
-                inner.set("key", "string")
+                assert (
+                    inner.get("key") == 42
+                )  # children inherit from their parents first
+                inner.set("key", "string")  # and can override
                 assert inner.get("key") == "string"
                 assert top.get("key") == 42
             assert top.get("key") == 42


### PR DESCRIPTION
This PR adds one line that ensures child/nested transactions inherit data from their parents, which they can then safely override.  The primary use case for such a thing is to allow for patterns such as:

```python
@flow 
def my_flow():
    with transaction() as txn:
        txn.set("global_state", value)
        task_one()
        task_two()
```

And now `task_one` and `task_two` can define commit/rollback hooks that look for `"global_state"` without having to individually set the value within their respective definitions.