### PR TITLE
Allow for defaults on txn.get

### DIFF
--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -25,6 +25,7 @@ from prefect.results import (
     ResultFactory,
     get_default_result_storage,
 )
+from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.collections import AutoEnum
 from prefect.utilities.engine import _get_hook_name
@@ -72,8 +73,10 @@ class Transaction(ContextModel):
     def set(self, name: str, value: Any) -> None:
         self._stored_values[name] = value
 
-    def get(self, name: str) -> Any:
+    def get(self, name: str, default: Any = NotSet) -> Any:
         if name not in self._stored_values:
+            if default is not NotSet:
+                return default
             raise ValueError(f"Could not retrieve value for unknown key: {name}")
         return self._stored_values.get(name)
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -357,7 +357,9 @@ class TestHooks:
                 assert top.get("key") == 42
             assert top.get("key") == 42
 
-    def test_get_raises_on_unknown(self):
+    def test_get_raises_on_unknown_but_allows_default(self):
         with transaction(key="test") as txn:
             with pytest.raises(ValueError, match="foobar"):
                 txn.get("foobar")
+            assert txn.get("foobar", None) is None
+            assert txn.get("foobar", "string") == "string"


### PR DESCRIPTION
This PR allows users to provide default values for `transaction.get` in the case that a value wasn't set; this allows for code that is more graceful / easier to test in isolation without having to resort to `try/except` patterns.

Basic usage:
```python
with transaction() as txn:
    assert txn.get("unknown", 42) == 42
```