### PR TITLE
fallback `TaskSource` key computation if no source code

### DIFF
--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -1046,7 +1046,7 @@ class Block(BaseModel, ABC):
     @classmethod
     @sync_compatible
     @inject_client
-    async def register_type_and_schema(cls, client: "PrefectClient" = None):
+    async def register_type_and_schema(cls, client: Optional["PrefectClient"] = None):
         """
         Makes block available for configuration with current Prefect API.
         Recursively registers all nested blocks. Registration is idempotent.

--- a/src/prefect/cache_policies.py
+++ b/src/prefect/cache_policies.py
@@ -153,6 +153,11 @@ class TaskSource(CachePolicy):
             lines = inspect.getsource(task_ctx.task)
         except TypeError:
             lines = inspect.getsource(task_ctx.task.fn.__class__)
+        except OSError as exc:
+            if "could not get source code" in str(exc):
+                lines = task_ctx.task.fn.__code__.co_code
+            else:
+                raise
 
         return hash_objects(lines)
 

--- a/src/prefect/cache_policies.py
+++ b/src/prefect/cache_policies.py
@@ -143,8 +143,8 @@ class TaskSource(CachePolicy):
     def compute_key(
         self,
         task_ctx: TaskRunContext,
-        inputs: Dict[str, Any],
-        flow_parameters: Dict[str, Any],
+        inputs: Optional[Dict[str, Any]],
+        flow_parameters: Optional[Dict[str, Any]],
         **kwargs,
     ) -> Optional[str]:
         if not task_ctx:


### PR DESCRIPTION
this PR handles an error (`OSError: could not get source code`) that occurs in `TaskSource(CachePolicy)` if you try to run a task in the native python repl

in that case or any other time we cannot `inspect.getsource`, we fall back to hashing the `__code__` object on `Task.fn`


<details>
<summary>repro on main</summary>

```python
>>> import prefect
>>> @prefect.task
... def f(): pass
...
>>> f()
22:40:56.454 | INFO    | Task run 'f' - Created task run 'f' for task 'f'
22:40:56.741 | ERROR   | Task run 'f' - Task run failed with exception: OSError('could not get source code') - Retries are exhausted
Traceback (most recent call last):
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/task_engine.py", line 804, in run_context
    yield self
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/task_engine.py", line 1419, in run_task_sync
    with engine.run_context(), engine.transaction_context() as txn:
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/task_engine.py", line 782, in transaction_context
    key=self.compute_transaction_key(),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/task_engine.py", line 149, in compute_transaction_key
    key = self.task.cache_policy.compute_key(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/cache_policies.py", line 107, in compute_key
    policy_key = policy.compute_key(
                 ^^^^^^^^^^^^^^^^^^^
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/cache_policies.py", line 153, in compute_key
    lines = inspect.getsource(task_ctx.task)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/inspect.py", line 1278, in getsource
    lines, lnum = getsourcelines(object)
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/inspect.py", line 1260, in getsourcelines
    lines, lnum = findsource(object)
                  ^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/inspect.py", line 1089, in findsource
    raise OSError('could not get source code')
OSError: could not get source code
22:40:56.856 | ERROR   | Task run 'f' - Finished in state Failed('Task run encountered an exception OSError: could not get source code')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/tasks.py", line 987, in __call__
    return run_task(
           ^^^^^^^^^
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/task_engine.py", line 1609, in run_task
    return run_task_sync(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/task_engine.py", line 1422, in run_task_sync
    return engine.state if return_type == "state" else engine.result()
                                                       ^^^^^^^^^^^^^^^
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/task_engine.py", line 471, in result
    raise self._raised
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/task_engine.py", line 804, in run_context
    yield self
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/task_engine.py", line 1419, in run_task_sync
    with engine.run_context(), engine.transaction_context() as txn:
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/task_engine.py", line 782, in transaction_context
    key=self.compute_transaction_key(),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/task_engine.py", line 149, in compute_transaction_key
    key = self.task.cache_policy.compute_key(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/cache_policies.py", line 107, in compute_key
    policy_key = policy.compute_key(
                 ^^^^^^^^^^^^^^^^^^^
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/cache_policies.py", line 153, in compute_key
    lines = inspect.getsource(task_ctx.task)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/inspect.py", line 1278, in getsource
    lines, lnum = getsourcelines(object)
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/inspect.py", line 1260, in getsourcelines
    lines, lnum = findsource(object)
                  ^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/inspect.py", line 1089, in findsource
    raise OSError('could not get source code')
OSError: could not get source code
```
</details>