### PR TITLE
Add is_null_ filter to logs filter endpoint

### DIFF
--- a/docs/3.0rc/api-ref/rest-api/server/schema.json
+++ b/docs/3.0rc/api-ref/rest-api/server/schema.json
@@ -20424,6 +20424,21 @@
                         ],
                         "title": "Any ",
                         "description": "A list of task run IDs to include"
+                    },
+                    "is_null_": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+
+                            },
+                            {
+                                "type": "null"
+
+                            }
+
+                        ],
+                        "title": "Is Null ",
+                        "description": "If true, only include logs without a task run id"
                     }
                 },
                 "additionalProperties": false,

--- a/docs/3.0rc/api-ref/rest-api/server/schema.json
+++ b/docs/3.0rc/api-ref/rest-api/server/schema.json
@@ -20429,13 +20429,10 @@
                         "anyOf": [
                             {
                                 "type": "boolean"
-
                             },
                             {
                                 "type": "null"
-
                             }
-
                         ],
                         "title": "Is Null ",
                         "description": "If true, only include logs without a task run id"

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -1191,9 +1191,9 @@ class LogFilterTaskRunId(PrefectFilterBaseModel):
             filters.append(orm_models.Log.task_run_id.in_(self.any_))
         if self.is_null_ is not None:
             filters.append(
-                orm_models.Log.task_run_id is None
+                orm_models.Log.task_run_id.is_(None)
                 if self.is_null_
-                else orm_models.Log.task_run_id is not None
+                else orm_models.Log.task_run_id.is_not(None)
             )
         return filters
 

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -1180,10 +1180,21 @@ class LogFilterTaskRunId(PrefectFilterBaseModel):
         default=None, description="A list of task run IDs to include"
     )
 
+    is_null_: Optional[bool] = Field(
+        default=None,
+        description="If true, only include logs without a task run id",
+    )
+
     def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
             filters.append(orm_models.Log.task_run_id.in_(self.any_))
+        if self.is_null_ is not None:
+            filters.append(
+                orm_models.Log.task_run_id == None
+                if self.is_null_
+                else orm_models.Log.task_run_id != None
+            )
         return filters
 
 

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -1191,9 +1191,9 @@ class LogFilterTaskRunId(PrefectFilterBaseModel):
             filters.append(orm_models.Log.task_run_id.in_(self.any_))
         if self.is_null_ is not None:
             filters.append(
-                orm_models.Log.task_run_id == None
+                orm_models.Log.task_run_id is None
                 if self.is_null_
-                else orm_models.Log.task_run_id != None
+                else orm_models.Log.task_run_id is not None
             )
         return filters
 

--- a/tests/server/models/test_logs.py
+++ b/tests/server/models/test_logs.py
@@ -117,3 +117,17 @@ class TestReadLogs:
 
         assert len(logs) == 1
         assert all([log.task_run_id == task_run_id for log in logs])
+
+    async def test_read_logs_task_run_id_is_null(self, session, logs):
+        log_filter = LogFilter(task_run_id={"is_null_": True})
+        logs = await models.logs.read_logs(session=session, log_filter=log_filter)
+
+        assert len(logs) == 2
+        assert all([log.task_run_id is None for log in logs])
+
+    async def test_read_logs_task_run_id_is_not_null(self, session, logs):
+        log_filter = LogFilter(task_run_id={"is_null_": False})
+        logs = await models.logs.read_logs(session=session, log_filter=log_filter)
+
+        assert len(logs) == 1
+        assert all([log.task_run_id is not None for log in logs])

--- a/tests/server/models/test_logs.py
+++ b/tests/server/models/test_logs.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 from prefect.server import models
 from prefect.server.schemas.actions import LogCreate
 from prefect.server.schemas.core import Log
-from prefect.server.schemas.filters import LogFilter
+from prefect.server.schemas.filters import LogFilter, LogFilterTaskRunId
 from prefect.server.schemas.sorting import LogSort
 
 NOW = pendulum.now("UTC")
@@ -118,15 +118,15 @@ class TestReadLogs:
         assert len(logs) == 1
         assert all([log.task_run_id == task_run_id for log in logs])
 
-    async def test_read_logs_task_run_id_is_null(self, session, logs):
-        log_filter = LogFilter(task_run_id={"is_null_": True})
-        logs = await models.logs.read_logs(session=session, log_filter=log_filter)
+    async def test_read_logs_task_run_id_is_null(self, session, logs, flow_run_id):
+        log_filter = LogFilter(flow_run_id={"any_": [flow_run_id]}, task_run_id=LogFilterTaskRunId(is_null_=True))
+        logs_filtered = await models.logs.read_logs(session=session, log_filter=log_filter)
 
-        assert len(logs) == 2
-        assert all([log.task_run_id is None for log in logs])
+        assert len(logs_filtered) == 2
+        assert all([log.task_run_id is None for log in logs_filtered])
 
-    async def test_read_logs_task_run_id_is_not_null(self, session, logs):
-        log_filter = LogFilter(task_run_id={"is_null_": False})
+    async def test_read_logs_task_run_id_is_not_null(self, session, logs, flow_run_id):
+        log_filter = LogFilter(flow_run_id={"any_": [flow_run_id]}, task_run_id={"is_null_": False})
         logs = await models.logs.read_logs(session=session, log_filter=log_filter)
 
         assert len(logs) == 1

--- a/tests/server/models/test_logs.py
+++ b/tests/server/models/test_logs.py
@@ -119,14 +119,21 @@ class TestReadLogs:
         assert all([log.task_run_id == task_run_id for log in logs])
 
     async def test_read_logs_task_run_id_is_null(self, session, logs, flow_run_id):
-        log_filter = LogFilter(flow_run_id={"any_": [flow_run_id]}, task_run_id=LogFilterTaskRunId(is_null_=True))
-        logs_filtered = await models.logs.read_logs(session=session, log_filter=log_filter)
+        log_filter = LogFilter(
+            flow_run_id={"any_": [flow_run_id]},
+            task_run_id=LogFilterTaskRunId(is_null_=True),
+        )
+        logs_filtered = await models.logs.read_logs(
+            session=session, log_filter=log_filter
+        )
 
         assert len(logs_filtered) == 2
         assert all([log.task_run_id is None for log in logs_filtered])
 
     async def test_read_logs_task_run_id_is_not_null(self, session, logs, flow_run_id):
-        log_filter = LogFilter(flow_run_id={"any_": [flow_run_id]}, task_run_id={"is_null_": False})
+        log_filter = LogFilter(
+            flow_run_id={"any_": [flow_run_id]}, task_run_id={"is_null_": False}
+        )
         logs = await models.logs.read_logs(session=session, log_filter=log_filter)
 
         assert len(logs) == 1


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Allows clients to retrieve only flow run-level logs that pertain to a given flow run and not those of nested task runs.