### PR TITLE
Fix error code when work pool name not found

### DIFF
--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -411,7 +411,7 @@ async def update(
                 work_pool=wp,
             )
         except ObjectNotFound:
-            exit_with_error("Work pool named {name!r} does not exist.")
+            exit_with_error(f"Work pool named {name!r} does not exist.")
 
         exit_with_success(f"Updated work pool {name!r}")
 


### PR DESCRIPTION
Produce correct error message when work pool name doesn't exist

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

Currently when you run `prefect work-pool update ... my-work-pool` and the work pool doesn't exist you do not receive the correct message code.

The following is currently returned:
```bash
Work pool named {name!r} does not exist.
```

The expected result is:
```bash
Work pool named my-work-pool does not exist.
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
