### PR TITLE
Add ability to configure isolation level for a transaction

### DIFF
--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -131,7 +131,7 @@ class ContextModel(BaseModel):
         extra="forbid",
     )
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         if self._token is not None:
             raise RuntimeError(
                 "Context already entered. Context enter calls cannot be nested."

--- a/src/prefect/records/base.py
+++ b/src/prefect/records/base.py
@@ -1,22 +1,81 @@
+import abc
 import os
 import socket
 import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from prefect.results import BaseResult
+if TYPE_CHECKING:
+    from prefect.results import BaseResult
+    from prefect.transactions import IsolationLevel
 
 
-class RecordStore:
-    def read(self, key: str):
-        raise NotImplementedError
+@dataclass
+class TransactionRecord:
+    """
+    A dataclass representation of a transaction record.
+    """
 
-    def write(self, key: str, value: dict):
-        raise NotImplementedError
+    key: str
+    result: "BaseResult"
 
+
+class RecordStore(abc.ABC):
+    @abc.abstractmethod
+    def read(self, key: str) -> Optional[TransactionRecord]:
+        """
+        Read the transaction record with the given key.
+
+        Args:
+            key: Unique identifier for the transaction record.
+
+        Returns:
+            TransactionRecord: The transaction record with the given key.
+        """
+        ...
+
+    @abc.abstractmethod
+    def write(self, key: str, result: "BaseResult", holder: Optional[str] = None):
+        """
+        Write the transaction record with the given key.
+
+        Args:
+            key: Unique identifier for the transaction record.
+            record: The transaction record to write.
+            holder: Unique identifier for the holder of the lock. If a lock exists on
+                the record being written, the write will be rejected if the provided
+                holder does not match the holder of the lock. If not provided,
+                a default holder based on the current host, process, and thread will
+                be used.
+        """
+        ...
+
+    @abc.abstractmethod
     def exists(self, key: str) -> bool:
-        return False
+        """
+        Check if the transaction record with the given key exists.
+
+        Args:
+            key: Unique identifier for the transaction record.
+
+        Returns:
+            bool: True if the record exists; False otherwise.
+        """
+        ...
+
+    @abc.abstractmethod
+    def supports_isolation_level(self, isolation_level: "IsolationLevel") -> bool:
+        """
+        Check if the record store supports the given isolation level.
+
+        Args:
+            isolation_level: The isolation level to check.
+
+        Returns:
+            bool: True if the record store supports the isolation level; False otherwise.
+        """
+        ...
 
     def acquire_lock(
         self,
@@ -155,13 +214,3 @@ class RecordStore:
             yield
         finally:
             self.release_lock(key=key, holder=holder)
-
-
-@dataclass
-class TransactionRecord:
-    """
-    A dataclass representation of a transaction record.
-    """
-
-    key: str
-    result: Optional[BaseResult] = None

--- a/src/prefect/records/memory.py
+++ b/src/prefect/records/memory.py
@@ -39,7 +39,13 @@ class MemoryRecordStore(RecordStore):
         self._locks: Dict[str, _LockInfo] = {}
         self._records: Dict[str, TransactionRecord] = {}
 
-    def read(self, key: str) -> Optional[TransactionRecord]:
+    def read(
+        self, key: str, holder: Optional[str] = None
+    ) -> Optional[TransactionRecord]:
+        holder = holder or self.generate_default_holder()
+
+        if self.is_locked(key) and not self.is_lock_holder(key, holder):
+            self.wait_for_lock(key)
         return self._records.get(key)
 
     def write(self, key: str, result: BaseResult, holder: Optional[str] = None) -> None:

--- a/src/prefect/records/result_store.py
+++ b/src/prefect/records/result_store.py
@@ -47,14 +47,12 @@ class ResultFactoryStore(RecordStore):
             # this is a bit of a bandaid for functionality
             raise ValueError("Result could not be read")
 
-    def write(self, key: str, result: Any):
+    def write(self, key: str, result: Any, holder: Optional[str] = None) -> None:
         if isinstance(result, PersistedResult):
             # if the value is already a persisted result, write it
             result.write(_sync=True)
-            return result
-        elif isinstance(result, BaseResult):
-            return result
-        run_coro_as_sync(self.result_factory.create_result(obj=result, key=key))
+        elif not isinstance(result, BaseResult):
+            run_coro_as_sync(self.result_factory.create_result(obj=result, key=key))
 
     def supports_isolation_level(self, isolation_level: IsolationLevel) -> bool:
         return isolation_level == IsolationLevel.READ_COMMITTED

--- a/src/prefect/records/result_store.py
+++ b/src/prefect/records/result_store.py
@@ -17,7 +17,10 @@ class ResultFactoryStore(RecordStore):
 
     def exists(self, key: str) -> bool:
         try:
-            result = self.read(key)
+            record = self.read(key)
+            if not record:
+                return False
+            result = record.result
             result.get(_sync=True)
             if result.expiration:
                 # if the result has an expiration,

--- a/src/prefect/records/result_store.py
+++ b/src/prefect/records/result_store.py
@@ -1,18 +1,19 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional
 
 import pendulum
 
 from prefect.results import BaseResult, PersistedResult, ResultFactory
+from prefect.transactions import IsolationLevel
 from prefect.utilities.asyncutils import run_coro_as_sync
 
-from .base import RecordStore
+from .base import RecordStore, TransactionRecord
 
 
 @dataclass
 class ResultFactoryStore(RecordStore):
     result_factory: ResultFactory
-    cache: PersistedResult = None
+    cache: Optional[PersistedResult] = None
 
     def exists(self, key: str) -> bool:
         try:
@@ -29,25 +30,28 @@ class ResultFactoryStore(RecordStore):
         except Exception:
             return False
 
-    def read(self, key: str) -> BaseResult:
+    def read(self, key: str) -> TransactionRecord:
         if self.cache:
-            return self.cache
+            return TransactionRecord(key=key, result=self.cache)
         try:
             result = PersistedResult(
                 serializer_type=self.result_factory.serializer.type,
                 storage_block_id=self.result_factory.storage_block_id,
                 storage_key=key,
             )
-            return result
+            return TransactionRecord(key=key, result=result)
         except Exception:
             # this is a bit of a bandaid for functionality
             raise ValueError("Result could not be read")
 
-    def write(self, key: str, value: Any) -> BaseResult:
-        if isinstance(value, PersistedResult):
+    def write(self, key: str, result: Any):
+        if isinstance(result, PersistedResult):
             # if the value is already a persisted result, write it
-            value.write(_sync=True)
-            return value
-        elif isinstance(value, BaseResult):
-            return value
-        return run_coro_as_sync(self.result_factory.create_result(obj=value, key=key))
+            result.write(_sync=True)
+            return result
+        elif isinstance(result, BaseResult):
+            return result
+        run_coro_as_sync(self.result_factory.create_result(obj=result, key=key))
+
+    def supports_isolation_level(self, isolation_level: IsolationLevel) -> bool:
+        return isolation_level == IsolationLevel.READ_COMMITTED

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -2,6 +2,7 @@ import copy
 import logging
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
+from functools import partial
 from typing import (
     Any,
     Callable,
@@ -18,9 +19,8 @@ from typing_extensions import Self
 
 from prefect.context import ContextModel, FlowRunContext, TaskRunContext
 from prefect.exceptions import MissingContextError
-from prefect.logging.loggers import PrefectLogAdapter, get_logger, get_run_logger
+from prefect.logging.loggers import get_logger, get_run_logger
 from prefect.records import RecordStore
-from prefect.records.result_store import ResultFactoryStore
 from prefect.results import (
     BaseResult,
     ResultFactory,
@@ -60,13 +60,16 @@ class Transaction(ContextModel):
     key: Optional[str] = None
     children: List["Transaction"] = Field(default_factory=list)
     commit_mode: Optional[CommitMode] = None
+    isolation_level: Optional[IsolationLevel] = IsolationLevel.READ_COMMITTED
     state: TransactionState = TransactionState.PENDING
     on_commit_hooks: List[Callable[["Transaction"], None]] = Field(default_factory=list)
     on_rollback_hooks: List[Callable[["Transaction"], None]] = Field(
         default_factory=list
     )
     overwrite: bool = False
-    logger: Union[logging.Logger, logging.LoggerAdapter, None] = None
+    logger: Union[logging.Logger, logging.LoggerAdapter] = Field(
+        default_factory=partial(get_logger, "transactions")
+    )
     _stored_values: Dict[str, Any] = PrivateAttr(default_factory=dict)
     _staged_value: Any = None
     __var__: ContextVar = ContextVar("transaction")
@@ -101,16 +104,27 @@ class Transaction(ContextModel):
             raise RuntimeError(
                 "Context already entered. Context enter calls cannot be nested."
             )
-        # set default commit behavior
+        parent = get_transaction()
+        if parent:
+            self._stored_values = copy.deepcopy(parent._stored_values)
+        # set default commit behavior; either inherit from parent or set a default of eager
         if self.commit_mode is None:
-            parent = get_transaction()
+            self.commit_mode = parent.commit_mode if parent else CommitMode.LAZY
+        # set default isolation level; either inherit from parent or set a default of read committed
+        if self.isolation_level is None:
+            self.isolation_level = (
+                parent.isolation_level if parent else IsolationLevel.READ_COMMITTED
+            )
 
-            # either inherit from parent or set a default of eager
-            if parent:
-                self.commit_mode = parent.commit_mode
-                self._stored_values = copy.deepcopy(parent._stored_values)
-            else:
-                self.commit_mode = CommitMode.LAZY
+        assert self.isolation_level is not None, "Isolation level was not set correctly"
+        if (
+            self.store
+            and self.key
+            and not self.store.supports_isolation_level(self.isolation_level)
+        ):
+            raise ValueError(
+                f"Isolation level {self.isolation_level.name} is not supported by record store type {self.store.__class__.__name__}"
+            )
 
         # this needs to go before begin, which could set the state to committed
         self.state = TransactionState.ACTIVE
@@ -158,11 +172,12 @@ class Transaction(ContextModel):
         ):
             self.state = TransactionState.COMMITTED
 
-    def read(self) -> BaseResult:
+    def read(self) -> Optional[BaseResult]:
         if self.store and self.key:
-            return self.store.read(key=self.key)
-        else:
-            return {}  # TODO: Determine what this should be
+            record = self.store.read(key=self.key)
+            if record is not None:
+                return record.result
+        return None
 
     def reset(self) -> None:
         parent = self.get_parent()
@@ -202,7 +217,7 @@ class Transaction(ContextModel):
                 self.run_hook(hook, "commit")
 
             if self.store and self.key:
-                self.store.write(key=self.key, value=self._staged_value)
+                self.store.write(key=self.key, result=self._staged_value)
             self.state = TransactionState.COMMITTED
             return True
         except Exception:
@@ -284,8 +299,9 @@ def transaction(
     key: Optional[str] = None,
     store: Optional[RecordStore] = None,
     commit_mode: Optional[CommitMode] = None,
+    isolation_level: Optional[IsolationLevel] = None,
     overwrite: bool = False,
-    logger: Optional[PrefectLogAdapter] = None,
+    logger: Union[logging.Logger, logging.LoggerAdapter, None] = None,
 ) -> Generator[Transaction, None, None]:
     """
     A context manager for opening and managing a transaction.
@@ -309,6 +325,7 @@ def transaction(
             flow_run_context, "result_factory", None
         )
 
+        new_factory: ResultFactory
         if existing_factory and existing_factory.storage_block_id:
             new_factory = existing_factory.model_copy(
                 update={
@@ -332,6 +349,8 @@ def transaction(
                         result_storage=default_storage,
                     )
                 )
+        from prefect.records.result_store import ResultFactoryStore
+
         store = ResultFactoryStore(
             result_factory=new_factory,
         )
@@ -345,6 +364,7 @@ def transaction(
         key=key,
         store=store,
         commit_mode=commit_mode,
+        isolation_level=isolation_level,
         overwrite=overwrite,
         logger=logger,
     ) as txn:

--- a/tests/records/test_memory.py
+++ b/tests/records/test_memory.py
@@ -6,6 +6,7 @@ import pytest
 
 from prefect.records.memory import MemoryRecordStore
 from prefect.results import ResultFactory
+from prefect.transactions import IsolationLevel
 
 
 class TestInMemoryRecordStore:
@@ -177,3 +178,8 @@ class TestInMemoryRecordStore:
 
         # the lock should have been acquired by the thread
         assert store.is_locked
+
+    def test_supports_serialization_level(self):
+        store = MemoryRecordStore()
+        assert store.supports_isolation_level(IsolationLevel.READ_COMMITTED)
+        assert store.supports_isolation_level(IsolationLevel.SERIALIZABLE)

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -5,8 +5,10 @@ import pytest
 from prefect.filesystems import LocalFileSystem
 from prefect.flows import flow
 from prefect.records import RecordStore
+from prefect.records.memory import MemoryRecordStore
 from prefect.records.result_store import ResultFactoryStore
 from prefect.results import (
+    ResultFactory,
     get_default_result_storage,
     get_or_create_default_task_scheduling_storage,
 )
@@ -18,11 +20,13 @@ from prefect.settings import (
 from prefect.tasks import task
 from prefect.transactions import (
     CommitMode,
+    IsolationLevel,
     Transaction,
     TransactionState,
     get_transaction,
     transaction,
 )
+from prefect.utilities.asyncutils import run_coro_as_sync
 
 
 def test_basic_init():
@@ -240,6 +244,9 @@ def test_overwrite_ignores_existing_record():
         def write(self, **kwargs):
             pass
 
+        def supports_isolation_level(self, *args, **kwargs):
+            return True
+
     with Transaction(
         key="test_overwrite_ignores_existing_record", store=Store()
     ) as txn:
@@ -267,9 +274,13 @@ class TestDefaultTransactionStorage:
     async def test_transaction_outside_of_run(self):
         with transaction(key="test_transaction_outside_of_run") as txn:
             assert isinstance(txn.store, ResultFactoryStore)
-            txn.stage({"foo": "bar"})
+            result = await txn.store.result_factory.create_result(
+                obj={"foo": "bar"}, key=txn.key
+            )
+            txn.stage(result)
 
         result = txn.read()
+        assert result
         assert await result.get() == {"foo": "bar"}
 
     async def test_transaction_inside_flow_default_storage(self):
@@ -277,15 +288,19 @@ class TestDefaultTransactionStorage:
         def test_flow():
             with transaction(key="test_transaction_inside_flow_default_storage") as txn:
                 assert isinstance(txn.store, ResultFactoryStore)
-                txn.stage({"foo": "bar"})
+                result = txn.store.result_factory.create_result(
+                    obj={"foo": "bar"}, key=txn.key, _sync=True
+                )
+                txn.stage(result)
 
             result = txn.read()
+            assert result
             # make sure we aren't using an anonymous block
             assert (
                 result.storage_block_id
                 == get_default_result_storage()._block_document_id
             )
-            return result
+            return result.get()
 
         assert test_flow() == {"foo": "bar"}
 
@@ -299,13 +314,17 @@ class TestDefaultTransactionStorage:
                 key="test_transaction_inside_flow_configured_storage"
             ) as txn:
                 assert isinstance(txn.store, ResultFactoryStore)
-                txn.stage({"foo": "bar"})
+                result = await txn.store.result_factory.create_result(
+                    obj={"foo": "bar"}, key=txn.key
+                )
+                txn.stage(result)
 
             result = txn.read()
-            result.storage_block_id = block._block_document_id
-            return result
+            assert result
+            assert result.storage_block_id == block._block_document_id
+            return await result.get()
 
-        await test_flow() == {"foo": "bar"}
+        assert await test_flow() == {"foo": "bar"}
 
     async def test_transaction_inside_task_default_storage(self):
         default_task_storage = await get_or_create_default_task_scheduling_storage()
@@ -314,12 +333,16 @@ class TestDefaultTransactionStorage:
         async def test_task():
             with transaction(key="test_transaction_inside_task_default_storage") as txn:
                 assert isinstance(txn.store, ResultFactoryStore)
-                txn.stage({"foo": "bar"})
+                result = await txn.store.result_factory.create_result(
+                    obj={"foo": "bar"}, key=txn.key
+                )
+                txn.stage(result)
 
             result = txn.read()
+            assert result
             # make sure we aren't using an anonymous block
             assert result.storage_block_id == default_task_storage._block_document_id
-            return result
+            return await result.get()
 
         assert await test_task() == {"foo": "bar"}
 
@@ -333,13 +356,17 @@ class TestDefaultTransactionStorage:
                 key="test_transaction_inside_task_configured_storage"
             ) as txn:
                 assert isinstance(txn.store, ResultFactoryStore)
-                txn.stage({"foo": "bar"})
+                result = await txn.store.result_factory.create_result(
+                    obj={"foo": "bar"}, key=txn.key
+                )
+                txn.stage(result)
 
             result = txn.read()
-            result.storage_block_id = block._block_document_id
-            return result
+            assert result
+            assert result.storage_block_id == block._block_document_id
+            return await result.get()
 
-        await test_task() == {"foo": "bar"}
+        assert await test_task() == {"foo": "bar"}
 
 
 class TestHooks:
@@ -375,3 +402,36 @@ class TestHooks:
                 txn.get("foobar")
             assert txn.get("foobar", None) is None
             assert txn.get("foobar", "string") == "string"
+
+
+class TestIsolationLevel:
+    def test_default_isolation_level(self):
+        with transaction(key="test") as txn:
+            assert txn.isolation_level == IsolationLevel.READ_COMMITTED
+
+    def test_inherited_isolation_level(self):
+        with transaction(
+            key="test",
+            store=MemoryRecordStore(),
+            isolation_level=IsolationLevel.SERIALIZABLE,
+        ) as top:
+            with transaction(key="nested", store=MemoryRecordStore()) as inner:
+                assert (
+                    inner.isolation_level
+                    == top.isolation_level
+                    == IsolationLevel.SERIALIZABLE
+                )
+
+    def test_raises_on_unsupported_isolation_level(self):
+        with pytest.raises(
+            ValueError,
+            match="Isolation level SERIALIZABLE is not supported by record store type ResultFactoryStore",
+        ):
+            with transaction(
+                key="test",
+                store=ResultFactoryStore(
+                    result_factory=run_coro_as_sync(ResultFactory.default_factory())
+                ),
+                isolation_level=IsolationLevel.SERIALIZABLE,
+            ):
+                pass

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,6 +1,5 @@
 import threading
 import uuid
-from time import sleep
 
 import pytest
 
@@ -412,31 +411,20 @@ class TestWithMemoryRecordStore:
     async def test_competing_read_transaction(self, result_1):
         transaction_1_open = threading.Event()
         transaction_2_open = threading.Event()
+        store = MemoryRecordStore()
 
-        def competing_transaction(
-            store, key, result, transaction_1_open, transaction_2_open
-        ):
+        def writing_transaction():
             # isolation level is SERIALIZABLE, so a lock will be taken
             with transaction(
-                key=key, store=store, isolation_level=IsolationLevel.SERIALIZABLE
+                key="test_competing_read_transaction",
+                store=store,
+                isolation_level=IsolationLevel.SERIALIZABLE,
             ) as txn:
                 transaction_1_open.set()
                 transaction_2_open.wait()
-                # artificial delay to ensure the other transaction waits on read
-                sleep(1)
-                txn.stage(result)
+                txn.stage(result_1)
 
-        store = MemoryRecordStore()
-        thread = threading.Thread(
-            target=competing_transaction,
-            args=(
-                store,
-                "test_competing_read_transaction",
-                result_1,
-                transaction_1_open,
-                transaction_2_open,
-            ),
-        )
+        thread = threading.Thread(target=writing_transaction)
         thread.start()
         transaction_1_open.wait()
         with transaction(key="test_competing_read_transaction", store=store) as txn:
@@ -448,26 +436,18 @@ class TestWithMemoryRecordStore:
 
     async def test_competing_write_transaction(self, result_1, result_2):
         transaction_1_open = threading.Event()
+        store = MemoryRecordStore()
 
-        def competing_transaction(store, key, result, transaction_1_open):
+        def winning_transaction():
             with transaction(
-                key=key, store=store, isolation_level=IsolationLevel.SERIALIZABLE
+                key="test_competing_write_transaction",
+                store=store,
+                isolation_level=IsolationLevel.SERIALIZABLE,
             ) as txn:
                 transaction_1_open.set()
-                # artificial delay to ensure the other transaction waits on open
-                sleep(1)
-                txn.stage(result)
+                txn.stage(result_1)
 
-        store = MemoryRecordStore()
-        thread = threading.Thread(
-            target=competing_transaction,
-            args=(
-                store,
-                "test_competing_write_transaction",
-                result_1,
-                transaction_1_open,
-            ),
-        )
+        thread = threading.Thread(target=winning_transaction)
         thread.start()
         transaction_1_open.wait()
         with transaction(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR adds the ability to configure the isolation level for a transaction. The isolation level will default to `READ_COMMITTED`, and the available isolation level will be determined by the `RecordStore` implementation used with the transaction. The new `MemoryRecordStore` supports the `SERIALIZABLE` isolation level and is used to test the addition of locking logic to the `Transaction` class.

I also updated the `RecordStore` to have abstract methods to clarify which methods must be included in a `RecordStore` implementation and which are optional. I also updated the `ResultFactoryStore` to adhere to the updated interface.

Related to https://github.com/PrefectHQ/prefect/issues/14914

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
