### PR TITLE
Make dynamic key depend on flow run run count

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -733,7 +733,9 @@ class Task(Generic[P, R]):
                 task_run_name = self.name
             else:
                 dynamic_key = _dynamic_key_for_task_run(
-                    context=flow_run_context, task=self
+                    context=flow_run_context,
+                    task=self,
+                    starts_at=0,
                 )
                 task_run_name = f"{self.name}-{dynamic_key}"
 

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -838,7 +838,7 @@ class Task(Generic[P, R]):
                 dynamic_key = _dynamic_key_for_task_run(
                     context=flow_run_context, task=self
                 )
-                task_run_name = f"{self.name}-{dynamic_key}"
+                task_run_name = f"{self.name}-{dynamic_key[:3]}"
 
             if deferred:
                 state = Scheduled()

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -735,7 +735,7 @@ class Task(Generic[P, R]):
                 dynamic_key = _dynamic_key_for_task_run(
                     context=flow_run_context,
                     task=self,
-                    starts_at=0,
+                    stable=True,
                 )
                 task_run_name = f"{self.name}-{dynamic_key}"
 

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -567,7 +567,7 @@ def _dynamic_key_for_task_run(context: FlowRunContext, task: Task) -> Union[int,
         )
 
     elif task.task_key not in context.task_run_dynamic_keys:
-        context.task_run_dynamic_keys[task.task_key] = 0
+        context.task_run_dynamic_keys[task.task_key] = context.flow_run.run_count
     else:
         context.task_run_dynamic_keys[task.task_key] += 1
 

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -559,9 +559,10 @@ def propose_state_sync(
 
 
 def _dynamic_key_for_task_run(
-    context: FlowRunContext, task: Task, starts_at: Optional[int] = None
+    context: FlowRunContext, task: Task, stable: bool = False
 ) -> Union[int, str]:
-    if context.detached:  # this task is running on remote infrastructure
+    # this task is running on remote infrastructure or doesn't need ID stability
+    if stable is False or context.detached:
         return str(uuid4())
     elif context.flow_run is None:  # this is an autonomous task run
         context.task_run_dynamic_keys[task.task_key] = getattr(
@@ -569,8 +570,7 @@ def _dynamic_key_for_task_run(
         )
 
     elif task.task_key not in context.task_run_dynamic_keys:
-        base = starts_at if starts_at is not None else context.flow_run.run_count - 1
-        context.task_run_dynamic_keys[task.task_key] = base
+        context.task_run_dynamic_keys[task.task_key] = 0
     else:
         context.task_run_dynamic_keys[task.task_key] += 1
 

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -567,7 +567,7 @@ def _dynamic_key_for_task_run(context: FlowRunContext, task: Task) -> Union[int,
         )
 
     elif task.task_key not in context.task_run_dynamic_keys:
-        context.task_run_dynamic_keys[task.task_key] = context.flow_run.run_count
+        context.task_run_dynamic_keys[task.task_key] = context.flow_run.run_count - 1
     else:
         context.task_run_dynamic_keys[task.task_key] += 1
 

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -558,7 +558,9 @@ def propose_state_sync(
         )
 
 
-def _dynamic_key_for_task_run(context: FlowRunContext, task: Task) -> Union[int, str]:
+def _dynamic_key_for_task_run(
+    context: FlowRunContext, task: Task, starts_at: Optional[int] = None
+) -> Union[int, str]:
     if context.detached:  # this task is running on remote infrastructure
         return str(uuid4())
     elif context.flow_run is None:  # this is an autonomous task run
@@ -567,7 +569,8 @@ def _dynamic_key_for_task_run(context: FlowRunContext, task: Task) -> Union[int,
         )
 
     elif task.task_key not in context.task_run_dynamic_keys:
-        context.task_run_dynamic_keys[task.task_key] = context.flow_run.run_count - 1
+        base = starts_at if starts_at is not None else context.flow_run.run_count - 1
+        context.task_run_dynamic_keys[task.task_key] = base
     else:
         context.task_run_dynamic_keys[task.task_key] += 1
 

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -75,7 +75,7 @@ async def test_task_state_change_happy_path(
             "data": None,
         },
         "task_run": {
-            "dynamic_key": "0",
+            "dynamic_key": task_run.dynamic_key,
             "empirical_policy": {
                 "max_retries": 0,
                 "retries": 0,
@@ -83,7 +83,7 @@ async def test_task_state_change_happy_path(
                 "retry_delay_seconds": 0.0,
             },
             "flow_run_run_count": 0,
-            "name": "happy_little_tree-0",
+            "name": task_run.name,
             "run_count": 0,
             "tags": [],
             "task_inputs": {},
@@ -130,7 +130,7 @@ async def test_task_state_change_happy_path(
             "data": None,
         },
         "task_run": {
-            "dynamic_key": "0",
+            "dynamic_key": task_run.dynamic_key,
             "empirical_policy": {
                 "max_retries": 0,
                 "retries": 0,
@@ -138,7 +138,7 @@ async def test_task_state_change_happy_path(
                 "retry_delay_seconds": 0.0,
             },
             "flow_run_run_count": 1,
-            "name": "happy_little_tree-0",
+            "name": task_run.name,
             "run_count": 1,
             "tags": [],
             "task_inputs": {},
@@ -190,7 +190,7 @@ async def test_task_state_change_happy_path(
             "data": {"type": "unpersisted"},
         },
         "task_run": {
-            "dynamic_key": "0",
+            "dynamic_key": task_run.dynamic_key,
             "empirical_policy": {
                 "max_retries": 0,
                 "retries": 0,
@@ -198,7 +198,7 @@ async def test_task_state_change_happy_path(
                 "retry_delay_seconds": 0.0,
             },
             "flow_run_run_count": 1,
-            "name": "happy_little_tree-0",
+            "name": task_run.name,
             "run_count": 1,
             "tags": [],
             "task_inputs": {},
@@ -270,7 +270,7 @@ async def test_task_state_change_task_failure(
             "data": None,
         },
         "task_run": {
-            "dynamic_key": "0",
+            "dynamic_key": task_run.dynamic_key,
             "empirical_policy": {
                 "max_retries": 0,
                 "retries": 0,
@@ -278,7 +278,7 @@ async def test_task_state_change_task_failure(
                 "retry_delay_seconds": 0.0,
             },
             "flow_run_run_count": 0,
-            "name": "happy_little_tree-0",
+            "name": task_run.name,
             "run_count": 0,
             "tags": [],
             "task_inputs": {},
@@ -325,7 +325,7 @@ async def test_task_state_change_task_failure(
             "data": None,
         },
         "task_run": {
-            "dynamic_key": "0",
+            "dynamic_key": task_run.dynamic_key,
             "empirical_policy": {
                 "max_retries": 0,
                 "retries": 0,
@@ -333,7 +333,7 @@ async def test_task_state_change_task_failure(
                 "retry_delay_seconds": 0.0,
             },
             "flow_run_run_count": 1,
-            "name": "happy_little_tree-0",
+            "name": task_run.name,
             "run_count": 1,
             "tags": [],
             "task_inputs": {},
@@ -390,7 +390,7 @@ async def test_task_state_change_task_failure(
             "data": {"type": "unpersisted"},
         },
         "task_run": {
-            "dynamic_key": "0",
+            "dynamic_key": task_run.dynamic_key,
             "empirical_policy": {
                 "max_retries": 0,
                 "retries": 0,
@@ -398,7 +398,7 @@ async def test_task_state_change_task_failure(
                 "retry_delay_seconds": 0.0,
             },
             "flow_run_run_count": 1,
-            "name": "happy_little_tree-0",
+            "name": task_run.name,
             "run_count": 1,
             "tags": [],
             "task_inputs": {},


### PR DESCRIPTION
Currently the backend has a uniqueness constraint of run ID vs. dynamic key. With CSTRO, task runs reset their dynamic keys back to 0 with each retry/rerun of the same flow run ID; this causes issues with generating new task runs on each retry.  This PR uses a fully dynamic dynamic key for each task invocation, unless the task is a stand-in for a subflow run.