### PR TITLE
clearer message upon no-op `prefect block register`

### DIFF
--- a/src/prefect/cli/block.py
+++ b/src/prefect/cli/block.py
@@ -207,6 +207,14 @@ async def register(
 
     registered_blocks = await _register_blocks_in_module(imported_module)
     number_of_registered_blocks = len(registered_blocks)
+
+    if number_of_registered_blocks == 0:
+        source = f"module {module_name!r}" if module_name else f"file {file_path!r}"
+        exit_with_error(
+            f"No blocks were registered from {source}. Please make sure the {source} "
+            "contains valid blocks."
+        )
+
     block_text = "block" if 0 < number_of_registered_blocks < 2 else "blocks"
     app.console.print(
         f"[green]Successfully registered {number_of_registered_blocks} {block_text}\n"

--- a/src/prefect/cli/block.py
+++ b/src/prefect/cli/block.py
@@ -211,8 +211,8 @@ async def register(
     if number_of_registered_blocks == 0:
         source = f"module {module_name!r}" if module_name else f"file {file_path!r}"
         exit_with_error(
-            f"No blocks were registered from {source}. Please make sure the {source} "
-            "contains valid blocks."
+            f"No blocks were registered from {source}.\n\nPlease make sure the {source} "
+            "contains valid blocks.\n"
         )
 
     block_text = "block" if 0 < number_of_registered_blocks < 2 else "blocks"

--- a/tests/cli/test_block.py
+++ b/tests/cli/test_block.py
@@ -35,7 +35,7 @@ async def install_system_block_types(session):
 def test_register_blocks_from_module_with_ui_url():
     with temporary_settings(set_defaults={PREFECT_UI_URL: "https://app.prefect.cloud"}):
         invoke_and_assert(
-            ["block", "register", "-m", "prefect.blocks.core"],
+            ["block", "register", "-m", "prefect.blocks.system"],
             expected_code=0,
             expected_output_contains=[
                 "Successfully registered",
@@ -50,7 +50,7 @@ def test_register_blocks_from_module_without_ui_url(
 ):
     with temporary_settings(set_defaults={PREFECT_UI_URL: None}):
         invoke_and_assert(
-            ["block", "register", "-m", "prefect.blocks.core"],
+            ["block", "register", "-m", "prefect.blocks.system"],
             expected_code=0,
             expected_output_contains=[
                 "Successfully registered",
@@ -59,6 +59,17 @@ def test_register_blocks_from_module_without_ui_url(
             ],
             expected_output_does_not_contain=["Prefect UI: https://"],
         )
+
+
+def test_register_blocks_no_blocks_found_to_register():
+    invoke_and_assert(
+        ["block", "register", "-m", "prefect.blocks.core"],
+        expected_code=1,
+        expected_output_contains=[
+            "No blocks were registered from module 'prefect.blocks.core'",
+            "Please make sure the module 'prefect.blocks.core' contains valid blocks",
+        ],
+    )
 
 
 def test_register_blocks_from_nonexistent_module():


### PR DESCRIPTION
updates the `prefect block register` command to more clearly show when we're not finding any blocks to register

updates some tests that were passing because they checked for this boilerplate but weren't actually registering blocks

previously
```
» prefect block register -m prefect
Successfully registered 0 blocks

┏━━━━━━━━━━━━━━━━━━━┓
┃ Registered Blocks ┃
┡━━━━━━━━━━━━━━━━━━━┩
└───────────────────┘

 To configure the newly registered blocks, go to the Blocks page in the Prefect UI: http://127.0.0.1:4200/blocks/catalog
 ```
 
now
```
» prefect block register -m prefect
No blocks were registered from module 'prefect'.

Please make sure the module 'prefect' contains valid blocks.
```