### PR TITLE
log message while events are still draining

### DIFF
--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -39,6 +39,7 @@ class QueueService(abc.ABC, Generic[T]):
             daemon=True,
             name=f"{type(self).__name__}Thread",
         )
+        self._logger = logging.getLogger(f"{type(self).__name__}")
 
     def start(self):
         logger.debug("Starting service %r", self)
@@ -157,8 +158,8 @@ class QueueService(abc.ABC, Generic[T]):
                 queue_size = self._queue.qsize()
 
                 if current_time - last_log_time >= log_interval and queue_size > 0:
-                    logger.warning(
-                        f"{type(self).__name__} is still processing: {queue_size} items remaining..."
+                    self._logger.warning(
+                        f"Still processing items. {queue_size} items remaining..."
                     )
                     last_log_time = current_time
 

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -828,12 +828,12 @@ The default logging level for Prefect loggers. Defaults to
 
 PREFECT_LOGGING_INTERNAL_LEVEL = Setting(
     str,
-    default="WARNING",
+    default="ERROR",
     value_callback=debug_mode_log_level,
 )
 """
 The default logging level for Prefect's internal machinery loggers. Defaults to
-"WARNING" during normal operation. Is forced to "DEBUG" during debug mode.
+"ERROR" during normal operation. Is forced to "DEBUG" during debug mode.
 """
 
 PREFECT_LOGGING_SERVER_LEVEL = Setting(

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -828,12 +828,12 @@ The default logging level for Prefect loggers. Defaults to
 
 PREFECT_LOGGING_INTERNAL_LEVEL = Setting(
     str,
-    default="ERROR",
+    default="WARNING",
     value_callback=debug_mode_log_level,
 )
 """
 The default logging level for Prefect's internal machinery loggers. Defaults to
-"ERROR" during normal operation. Is forced to "DEBUG" during debug mode.
+"WARNING" during normal operation. Is forced to "DEBUG" during debug mode.
 """
 
 PREFECT_LOGGING_SERVER_LEVEL = Setting(

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -191,7 +191,7 @@ class BaseTaskRunEngine(Generic[P, R]):
         )
 
     def record_terminal_state_timing(self, state: State) -> None:
-        if self.task_run.start_time and not self.task_run.end_time:
+        if self.task_run and self.task_run.start_time and not self.task_run.end_time:
             self.task_run.end_time = state.timestamp
 
             if self.task_run.state.is_running():


### PR DESCRIPTION
Log a message while items are still draining out of the `QueueService`. This is particularly important for UX of client side task run orchestration. Consider this example:

```python
from prefect import task, flow

@task
def add_one(n):
    return n + 1


@flow
def add_flow():
    futures = [add_one.submit(i) for i in range(1000)]
    for future in futures:
        future.result()


if __name__ == '__main__':
    add_flow()
```

1000 tasks will all finish at roughly the same time and generate 1000 events. The flow will finish and it will look like the process is hanging to the user. In reality we still need to churn through those 1000 events. This PR adds the following logging when the service begins to drain.

```
$ python add_flow.py
11:29:22.461 | INFO    | prefect.engine - Created flow run 'celadon-scorpion' for flow 'add-flow'
...
... 
...
11:30:29.164 | INFO    | Task run 'add_one-8d6' - Finished in state Completed()
11:30:29.165 | INFO    | Task run 'add_one-767' - Finished in state Completed()
11:30:29.165 | INFO    | Task run 'add_one-c4a' - Finished in state Completed()
11:30:29.166 | INFO    | Task run 'add_one-c10' - Finished in state Completed()
11:30:29.629 | INFO    | Flow run 'celadon-scorpion' - Finished in state Completed()
11:30:29.637 | WARNING | GlobalEventLoopThread | prefect._internal.concurrency - EventsWorker is still processing: 941 items remaining...
11:30:32.644 | WARNING | GlobalEventLoopThread | prefect._internal.concurrency - EventsWorker is still processing: 717 items remaining...
11:30:35.651 | WARNING | GlobalEventLoopThread | prefect._internal.concurrency - EventsWorker is still processing: 489 items remaining...
11:30:38.656 | WARNING | GlobalEventLoopThread | prefect._internal.concurrency - EventsWorker is still processing: 258 items remaining...
11:30:41.664 | WARNING | GlobalEventLoopThread | prefect._internal.concurrency - EventsWorker is still processing: 30 items remaining...
```

Looking for feedback on both the approach and the actual copy/UX!