### PR TITLE
use `obfuscate` instead of `obfuscate_string`

### DIFF
--- a/src/prefect/server/models/block_documents.py
+++ b/src/prefect/server/models/block_documents.py
@@ -19,7 +19,6 @@ from prefect.server.schemas.actions import BlockDocumentReferenceCreate
 from prefect.server.schemas.core import BlockDocument, BlockDocumentReference
 from prefect.server.schemas.filters import BlockSchemaFilter
 from prefect.server.utilities.database import UUID as UUIDTypeDecorator
-from prefect.server.utilities.names import obfuscate_string
 from prefect.utilities.collections import dict_to_flatdict, flatdict_to_dict
 from prefect.utilities.names import obfuscate
 
@@ -486,7 +485,7 @@ async def update_block_document(
             secret_key = tuple(secret_field.split("."))
             current_secret = flat_current_data.get(secret_key)
             if current_secret is not None:
-                if flat_update_data.get(secret_key) == obfuscate_string(current_secret):
+                if flat_update_data.get(secret_key) == obfuscate(current_secret):
                     flat_update_data[secret_key] = current_secret
             # Looks for obfuscated values nested under a secret field with a wildcard.
             # If any obfuscated values are found, we assume that it shouldn't be update,

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -49,7 +49,7 @@ from prefect.types import (
     StrictVariableValue,
 )
 from prefect.utilities.collections import dict_to_flatdict, flatdict_to_dict, listrepr
-from prefect.utilities.names import generate_slug, obfuscate, obfuscate_string
+from prefect.utilities.names import generate_slug, obfuscate
 
 if TYPE_CHECKING:
     from prefect.server.database import orm_models
@@ -781,7 +781,7 @@ class BlockDocument(ORMBaseModel):
             ):
                 secret_key = tuple(secret_field.split("."))
                 if flat_data.get(secret_key) is not None:
-                    flat_data[secret_key] = obfuscate_string(flat_data[secret_key])
+                    flat_data[secret_key] = obfuscate(flat_data[secret_key])
                 # If a wildcard (*) is in the current secret key path, we take the portion
                 # of the path before the wildcard and compare it to the same level of each
                 # key. A match means that the field is nested under the secret key and should


### PR DESCRIPTION
`obfuscate` is just a more general form of `obfuscate_string` that will behave in the same way and paves the way for other secret block types being masked by the API