### PR TITLE
Remove importlib-resources as an explicit requirement

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -12,7 +12,6 @@ griffe >= 0.20.0, <0.48.0
 httpcore >=1.0.5, < 2.0.0
 httpx[http2] >= 0.23, != 0.23.2
 importlib_metadata >= 4.4; python_version < '3.10'
-importlib-resources >= 6.1.3, < 6.2.0
 jsonpatch >= 1.32, < 2.0
 jsonschema >= 4.0.0, < 5.0.0
 orjson >= 3.7, < 4.0


### PR DESCRIPTION
It [appears](https://github.com/PrefectHQ/prefect/pull/14947) this is no longer necessary as the original issue was related to Python 3.8 - closes https://github.com/PrefectHQ/prefect/issues/12265