### PR TITLE
let dynamic key be more dynamic for client side task run orchestration

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -841,9 +841,9 @@ class Task(Generic[P, R]):
                 task_run_name = self.name
             else:
                 dynamic_key = _dynamic_key_for_task_run(
-                    context=flow_run_context, task=self
+                    context=flow_run_context, task=self, stable=False
                 )
-                task_run_name = f"{self.name}-{dynamic_key}"
+                task_run_name = f"{self.name}-{dynamic_key[:3]}"
 
             if deferred:
                 state = Scheduled()

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -560,7 +560,7 @@ def propose_state_sync(
 
 
 def _dynamic_key_for_task_run(
-    context: FlowRunContext, task: Task, stable: bool = False
+    context: FlowRunContext, task: Task, stable: bool = True
 ) -> Union[int, str]:
     if (
         stable is False or context.detached

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -559,8 +559,12 @@ def propose_state_sync(
         )
 
 
-def _dynamic_key_for_task_run(context: FlowRunContext, task: Task) -> Union[int, str]:
-    if context.detached:  # this task is running on remote infrastructure
+def _dynamic_key_for_task_run(
+    context: FlowRunContext, task: Task, stable: bool = False
+) -> Union[int, str]:
+    if (
+        stable is False or context.detached
+    ):  # this task is running on remote infrastructure
         return str(uuid4())
     elif context.flow_run is None:  # this is an autonomous task run
         context.task_run_dynamic_keys[task.task_key] = getattr(

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -95,7 +95,7 @@ async def test_task_state_change_happy_path(
                 "data": None,
             },
             "task_run": {
-                "dynamic_key": "0",
+                "dynamic_key": task_run.dynamic_key,
                 "empirical_policy": {
                     "max_retries": 0,
                     "retries": 0,
@@ -103,7 +103,7 @@ async def test_task_state_change_happy_path(
                     "retry_delay_seconds": 0.0,
                 },
                 "flow_run_run_count": 0,
-                "name": "happy_little_tree-0",
+                "name": task_run.name,
                 "run_count": 0,
                 "tags": [],
                 "task_inputs": {},
@@ -152,7 +152,7 @@ async def test_task_state_change_happy_path(
                 "data": None,
             },
             "task_run": {
-                "dynamic_key": "0",
+                "dynamic_key": task_run.dynamic_key,
                 "empirical_policy": {
                     "max_retries": 0,
                     "retries": 0,
@@ -160,7 +160,7 @@ async def test_task_state_change_happy_path(
                     "retry_delay_seconds": 0.0,
                 },
                 "flow_run_run_count": 1,
-                "name": "happy_little_tree-0",
+                "name": task_run.name,
                 "run_count": 1,
                 "tags": [],
                 "task_inputs": {},
@@ -216,7 +216,7 @@ async def test_task_state_change_happy_path(
                 "data": {"type": "unpersisted"},
             },
             "task_run": {
-                "dynamic_key": "0",
+                "dynamic_key": task_run.dynamic_key,
                 "empirical_policy": {
                     "max_retries": 0,
                     "retries": 0,
@@ -224,7 +224,7 @@ async def test_task_state_change_happy_path(
                     "retry_delay_seconds": 0.0,
                 },
                 "flow_run_run_count": 1,
-                "name": "happy_little_tree-0",
+                "name": task_run.name,
                 "run_count": 1,
                 "tags": [],
                 "task_inputs": {},
@@ -475,7 +475,7 @@ async def test_task_state_change_task_failure(
                 "data": None,
             },
             "task_run": {
-                "dynamic_key": "0",
+                "dynamic_key": task_run.dynamic_key,
                 "empirical_policy": {
                     "max_retries": 0,
                     "retries": 0,
@@ -483,7 +483,7 @@ async def test_task_state_change_task_failure(
                     "retry_delay_seconds": 0.0,
                 },
                 "flow_run_run_count": 0,
-                "name": "happy_little_tree-0",
+                "name": task_run.name,
                 "run_count": 0,
                 "tags": [],
                 "task_inputs": {},
@@ -532,7 +532,7 @@ async def test_task_state_change_task_failure(
                 "data": None,
             },
             "task_run": {
-                "dynamic_key": "0",
+                "dynamic_key": task_run.dynamic_key,
                 "empirical_policy": {
                     "max_retries": 0,
                     "retries": 0,
@@ -540,7 +540,7 @@ async def test_task_state_change_task_failure(
                     "retry_delay_seconds": 0.0,
                 },
                 "flow_run_run_count": 1,
-                "name": "happy_little_tree-0",
+                "name": task_run.name,
                 "run_count": 1,
                 "tags": [],
                 "task_inputs": {},
@@ -600,7 +600,7 @@ async def test_task_state_change_task_failure(
                 "data": {"type": "unpersisted"},
             },
             "task_run": {
-                "dynamic_key": "0",
+                "dynamic_key": task_run.dynamic_key,
                 "empirical_policy": {
                     "max_retries": 0,
                     "retries": 0,
@@ -608,7 +608,7 @@ async def test_task_state_change_task_failure(
                     "retry_delay_seconds": 0.0,
                 },
                 "flow_run_run_count": 1,
-                "name": "happy_little_tree-0",
+                "name": task_run.name,
                 "run_count": 1,
                 "tags": [],
                 "task_inputs": {},


### PR DESCRIPTION
Creating this PR to merge this change to main ahead of https://github.com/PrefectHQ/prefect/pull/14944, which was dependent on enabling client side orchestration by default