### PR TITLE
Don't persist exceptions

### DIFF
--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -232,13 +232,6 @@ async def exception_to_failed_state(
     else:
         pass
 
-    if result_factory:
-        data = await result_factory.create_result(exc)
-    else:
-        # Attach the exception for local usage, will not be available when retrieved
-        # from the API
-        data = exc
-
     existing_message = kwargs.pop("message", "")
     if existing_message and not existing_message.endswith(" "):
         existing_message += " "
@@ -247,7 +240,7 @@ async def exception_to_failed_state(
     #       excluded from messages for now
     message = existing_message + format_exception(exc)
 
-    state = Failed(data=data, message=message, **kwargs)
+    state = Failed(data=exc, message=message, **kwargs)
     state.state_details.retriable = False
 
     return state

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -597,7 +597,7 @@ async def test_task_state_change_task_failure(
                     "Here's a happy little accident."
                 ),
                 "state_details": {"retriable": False},
-                "data": {"type": "unpersisted"},
+                "data": None,
             },
             "task_run": {
                 "dynamic_key": task_run.dynamic_key,
@@ -776,7 +776,7 @@ async def test_task_state_change_task_failure(
                     "retriable": False,
                     "untrackable_result": False,
                 },
-                "data": {"type": "unpersisted"},
+                "data": None,
             },
             "task_run": {
                 "dynamic_key": "0",

--- a/tests/events/client/instrumentation/test_task_run_state_change_events.py
+++ b/tests/events/client/instrumentation/test_task_run_state_change_events.py
@@ -1,5 +1,4 @@
 import pendulum
-import pytest
 
 from prefect import flow, task
 from prefect.client.orchestration import PrefectClient
@@ -8,22 +7,7 @@ from prefect.events.clients import AssertingEventsClient
 from prefect.events.schemas.events import Resource
 from prefect.events.worker import EventsWorker
 from prefect.filesystems import LocalFileSystem
-from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION,
-    temporary_settings,
-)
 from prefect.task_worker import TaskWorker
-
-
-@pytest.fixture(autouse=True, params=[False, True])
-def enable_client_side_task_run_orchestration(
-    request, asserting_events_worker: EventsWorker
-):
-    enabled = request.param
-    with temporary_settings(
-        {PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION: enabled}
-    ):
-        yield enabled
 
 
 async def test_task_state_change_happy_path(
@@ -31,7 +15,6 @@ async def test_task_state_change_happy_path(
     reset_worker_events: None,
     prefect_client: PrefectClient,
     events_pipeline,
-    enable_client_side_task_run_orchestration,
 ):
     @task
     def happy_little_tree():
@@ -62,349 +45,165 @@ async def test_task_state_change_happy_path(
 
     pending, running, completed = events
 
-    if enable_client_side_task_run_orchestration:
-        assert pending.event == "prefect.task-run.Pending"
-        assert pending.id == task_run_states[0].id
-        assert pending.occurred == task_run_states[0].timestamp
-        assert pending.resource == Resource(
-            {
-                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-                "prefect.resource.name": task_run.name,
-                "prefect.state-message": "",
-                "prefect.state-type": "PENDING",
-                "prefect.state-name": "Pending",
-                "prefect.state-timestamp": task_run_states[0].timestamp.isoformat(),
-                "prefect.orchestration": "client",
-            }
-        )
-        assert (
-            pendulum.parse(pending.payload["task_run"].pop("expected_start_time"))
-            == task_run.expected_start_time
-        )
-        assert (
-            pending.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-        )
-        assert pending.payload == {
-            "initial_state": None,
-            "intended": {"from": None, "to": "PENDING"},
-            "validated_state": {
-                "type": "PENDING",
-                "name": "Pending",
-                "message": "",
-                "state_details": {},
-                "data": None,
-            },
-            "task_run": {
-                "dynamic_key": task_run.dynamic_key,
-                "empirical_policy": {
-                    "max_retries": 0,
-                    "retries": 0,
-                    "retry_delay": 0,
-                    "retry_delay_seconds": 0.0,
-                },
-                "flow_run_run_count": 0,
-                "name": task_run.name,
-                "run_count": 0,
-                "tags": [],
-                "task_inputs": {},
-                "total_run_time": 0.0,
-            },
+    assert pending.event == "prefect.task-run.Pending"
+    assert pending.id == task_run_states[0].id
+    assert pending.occurred == task_run_states[0].timestamp
+    assert pending.resource == Resource(
+        {
+            "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+            "prefect.resource.name": task_run.name,
+            "prefect.state-message": "",
+            "prefect.state-type": "PENDING",
+            "prefect.state-name": "Pending",
+            "prefect.state-timestamp": task_run_states[0].timestamp.isoformat(),
+            "prefect.orchestration": "client",
         }
+    )
+    assert (
+        pendulum.parse(pending.payload["task_run"].pop("expected_start_time"))
+        == task_run.expected_start_time
+    )
+    assert pending.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+    assert pending.payload == {
+        "initial_state": None,
+        "intended": {"from": None, "to": "PENDING"},
+        "validated_state": {
+            "type": "PENDING",
+            "name": "Pending",
+            "message": "",
+            "state_details": {},
+            "data": None,
+        },
+        "task_run": {
+            "dynamic_key": task_run.dynamic_key,
+            "empirical_policy": {
+                "max_retries": 0,
+                "retries": 0,
+                "retry_delay": 0,
+                "retry_delay_seconds": 0.0,
+            },
+            "flow_run_run_count": 0,
+            "name": task_run.name,
+            "run_count": 0,
+            "tags": [],
+            "task_inputs": {},
+            "total_run_time": 0.0,
+        },
+    }
 
-        assert running.event == "prefect.task-run.Running"
-        assert running.id == task_run_states[1].id
-        assert running.occurred == task_run_states[1].timestamp
-        assert running.resource == Resource(
-            {
-                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-                "prefect.resource.name": task_run.name,
-                "prefect.state-message": "",
-                "prefect.state-type": "RUNNING",
-                "prefect.state-name": "Running",
-                "prefect.state-timestamp": task_run_states[1].timestamp.isoformat(),
-                "prefect.orchestration": "client",
-            }
-        )
-        assert (
-            pendulum.parse(running.payload["task_run"].pop("expected_start_time"))
-            == task_run.expected_start_time
-        )
-        assert (
-            running.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-        )
-        assert (
-            pendulum.parse(running.payload["task_run"].pop("start_time"))
-            == task_run.start_time
-        )
-        assert running.payload == {
-            "intended": {"from": "PENDING", "to": "RUNNING"},
-            "initial_state": {
-                "type": "PENDING",
-                "name": "Pending",
-                "message": "",
-                "state_details": {},
-            },
-            "validated_state": {
-                "type": "RUNNING",
-                "name": "Running",
-                "message": "",
-                "state_details": {},
-                "data": None,
-            },
-            "task_run": {
-                "dynamic_key": task_run.dynamic_key,
-                "empirical_policy": {
-                    "max_retries": 0,
-                    "retries": 0,
-                    "retry_delay": 0,
-                    "retry_delay_seconds": 0.0,
-                },
-                "flow_run_run_count": 1,
-                "name": task_run.name,
-                "run_count": 1,
-                "tags": [],
-                "task_inputs": {},
-                "total_run_time": 0.0,
-            },
+    assert running.event == "prefect.task-run.Running"
+    assert running.id == task_run_states[1].id
+    assert running.occurred == task_run_states[1].timestamp
+    assert running.resource == Resource(
+        {
+            "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+            "prefect.resource.name": task_run.name,
+            "prefect.state-message": "",
+            "prefect.state-type": "RUNNING",
+            "prefect.state-name": "Running",
+            "prefect.state-timestamp": task_run_states[1].timestamp.isoformat(),
+            "prefect.orchestration": "client",
         }
+    )
+    assert (
+        pendulum.parse(running.payload["task_run"].pop("expected_start_time"))
+        == task_run.expected_start_time
+    )
+    assert running.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+    assert (
+        pendulum.parse(running.payload["task_run"].pop("start_time"))
+        == task_run.start_time
+    )
+    assert running.payload == {
+        "intended": {"from": "PENDING", "to": "RUNNING"},
+        "initial_state": {
+            "type": "PENDING",
+            "name": "Pending",
+            "message": "",
+            "state_details": {},
+        },
+        "validated_state": {
+            "type": "RUNNING",
+            "name": "Running",
+            "message": "",
+            "state_details": {},
+            "data": None,
+        },
+        "task_run": {
+            "dynamic_key": task_run.dynamic_key,
+            "empirical_policy": {
+                "max_retries": 0,
+                "retries": 0,
+                "retry_delay": 0,
+                "retry_delay_seconds": 0.0,
+            },
+            "flow_run_run_count": 1,
+            "name": task_run.name,
+            "run_count": 1,
+            "tags": [],
+            "task_inputs": {},
+            "total_run_time": 0.0,
+        },
+    }
 
-        assert completed.event == "prefect.task-run.Completed"
-        assert completed.id == task_run_states[2].id
-        assert completed.occurred == task_run_states[2].timestamp
-        assert completed.resource == Resource(
-            {
-                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-                "prefect.resource.name": task_run.name,
-                "prefect.state-message": "",
-                "prefect.state-type": "COMPLETED",
-                "prefect.state-name": "Completed",
-                "prefect.state-timestamp": task_run_states[2].timestamp.isoformat(),
-                "prefect.orchestration": "client",
-            }
-        )
-        assert (
-            pendulum.parse(completed.payload["task_run"].pop("expected_start_time"))
-            == task_run.expected_start_time
-        )
-        assert (
-            completed.payload["task_run"]
-            .pop("task_key")
-            .startswith("happy_little_tree")
-        )
-        assert (
-            pendulum.parse(completed.payload["task_run"].pop("start_time"))
-            == task_run.start_time
-        )
-        assert (
-            pendulum.parse(completed.payload["task_run"].pop("end_time"))
-            == task_run.end_time
-        )
-        assert completed.payload["task_run"].pop("total_run_time") > 0.0
-        assert completed.payload == {
-            "intended": {"from": "RUNNING", "to": "COMPLETED"},
-            "initial_state": {
-                "type": "RUNNING",
-                "name": "Running",
-                "message": "",
-                "state_details": {},
-            },
-            "validated_state": {
-                "type": "COMPLETED",
-                "name": "Completed",
-                "message": "",
-                "state_details": {},
-                "data": {"type": "unpersisted"},
-            },
-            "task_run": {
-                "dynamic_key": task_run.dynamic_key,
-                "empirical_policy": {
-                    "max_retries": 0,
-                    "retries": 0,
-                    "retry_delay": 0,
-                    "retry_delay_seconds": 0.0,
-                },
-                "flow_run_run_count": 1,
-                "name": task_run.name,
-                "run_count": 1,
-                "tags": [],
-                "task_inputs": {},
-            },
+    assert completed.event == "prefect.task-run.Completed"
+    assert completed.id == task_run_states[2].id
+    assert completed.occurred == task_run_states[2].timestamp
+    assert completed.resource == Resource(
+        {
+            "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+            "prefect.resource.name": task_run.name,
+            "prefect.state-message": "",
+            "prefect.state-type": "COMPLETED",
+            "prefect.state-name": "Completed",
+            "prefect.state-timestamp": task_run_states[2].timestamp.isoformat(),
+            "prefect.orchestration": "client",
         }
-    else:
-        assert pending.event == "prefect.task-run.Pending"
-        assert pending.id == task_run_states[0].id
-        assert pending.occurred == task_run_states[0].timestamp
-        assert pending.resource == Resource(
-            {
-                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-                "prefect.resource.name": task_run.name,
-                "prefect.state-message": "",
-                "prefect.state-type": "PENDING",
-                "prefect.state-name": "Pending",
-                "prefect.state-timestamp": task_run_states[0].timestamp.isoformat(),
-                "prefect.orchestration": "server",
-            }
-        )
-        assert (
-            pendulum.parse(pending.payload["task_run"].pop("expected_start_time"))
-            == task_run.expected_start_time
-        )
-        assert (
-            pending.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-        )
-        assert pending.payload == {
-            "initial_state": None,
-            "intended": {"from": None, "to": "PENDING"},
-            "validated_state": {
-                "type": "PENDING",
-                "name": "Pending",
-                "message": "",
-                "state_details": {
-                    "pause_reschedule": False,
-                    "untrackable_result": False,
-                },
-                "data": None,
+    )
+    assert (
+        pendulum.parse(completed.payload["task_run"].pop("expected_start_time"))
+        == task_run.expected_start_time
+    )
+    assert completed.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+    assert (
+        pendulum.parse(completed.payload["task_run"].pop("start_time"))
+        == task_run.start_time
+    )
+    assert (
+        pendulum.parse(completed.payload["task_run"].pop("end_time"))
+        == task_run.end_time
+    )
+    assert completed.payload["task_run"].pop("total_run_time") > 0.0
+    assert completed.payload == {
+        "intended": {"from": "RUNNING", "to": "COMPLETED"},
+        "initial_state": {
+            "type": "RUNNING",
+            "name": "Running",
+            "message": "",
+            "state_details": {},
+        },
+        "validated_state": {
+            "type": "COMPLETED",
+            "name": "Completed",
+            "message": "",
+            "state_details": {},
+            "data": {"type": "unpersisted"},
+        },
+        "task_run": {
+            "dynamic_key": task_run.dynamic_key,
+            "empirical_policy": {
+                "max_retries": 0,
+                "retries": 0,
+                "retry_delay": 0,
+                "retry_delay_seconds": 0.0,
             },
-            "task_run": {
-                "dynamic_key": "0",
-                "empirical_policy": {
-                    "max_retries": 0,
-                    "retries": 0,
-                    "retry_delay": 0,
-                    "retry_delay_seconds": 0.0,
-                },
-                "flow_run_run_count": 0,
-                "name": "happy_little_tree-0",
-                "run_count": 0,
-                "tags": [],
-                "task_inputs": {},
-                "total_run_time": 0.0,
-            },
-        }
-
-        assert running.event == "prefect.task-run.Running"
-        assert running.id == task_run_states[1].id
-        assert running.occurred == task_run_states[1].timestamp
-        assert running.resource == Resource(
-            {
-                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-                "prefect.resource.name": task_run.name,
-                "prefect.state-message": "",
-                "prefect.state-type": "RUNNING",
-                "prefect.state-name": "Running",
-                "prefect.state-timestamp": task_run_states[1].timestamp.isoformat(),
-                "prefect.orchestration": "server",
-            }
-        )
-        assert (
-            pendulum.parse(running.payload["task_run"].pop("expected_start_time"))
-            == task_run.expected_start_time
-        )
-        assert (
-            running.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-        )
-        assert running.payload == {
-            "intended": {"from": "PENDING", "to": "RUNNING"},
-            "initial_state": {
-                "type": "PENDING",
-                "name": "Pending",
-                "message": "",
-                "state_details": {
-                    "pause_reschedule": False,
-                    "untrackable_result": False,
-                },
-            },
-            "validated_state": {
-                "type": "RUNNING",
-                "name": "Running",
-                "message": "",
-                "state_details": {
-                    "pause_reschedule": False,
-                    "untrackable_result": False,
-                },
-                "data": None,
-            },
-            "task_run": {
-                "dynamic_key": "0",
-                "empirical_policy": {
-                    "max_retries": 0,
-                    "retries": 0,
-                    "retry_delay": 0,
-                    "retry_delay_seconds": 0.0,
-                },
-                "flow_run_run_count": 0,
-                "name": "happy_little_tree-0",
-                "run_count": 0,
-                "tags": [],
-                "task_inputs": {},
-                "total_run_time": 0.0,
-            },
-        }
-
-        assert completed.event == "prefect.task-run.Completed"
-        assert completed.id == task_run_states[2].id
-        assert completed.occurred == task_run_states[2].timestamp
-        assert completed.resource == Resource(
-            {
-                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-                "prefect.resource.name": task_run.name,
-                "prefect.state-message": "",
-                "prefect.state-type": "COMPLETED",
-                "prefect.state-name": "Completed",
-                "prefect.state-timestamp": task_run_states[2].timestamp.isoformat(),
-                "prefect.orchestration": "server",
-            }
-        )
-        assert (
-            pendulum.parse(completed.payload["task_run"].pop("expected_start_time"))
-            == task_run.expected_start_time
-        )
-        assert (
-            completed.payload["task_run"]
-            .pop("task_key")
-            .startswith("happy_little_tree")
-        )
-        assert (
-            pendulum.parse(completed.payload["task_run"].pop("start_time"))
-            == task_run.start_time
-        )
-        assert completed.payload == {
-            "intended": {"from": "RUNNING", "to": "COMPLETED"},
-            "initial_state": {
-                "type": "RUNNING",
-                "name": "Running",
-                "message": "",
-                "state_details": {
-                    "pause_reschedule": False,
-                    "untrackable_result": False,
-                },
-            },
-            "validated_state": {
-                "type": "COMPLETED",
-                "name": "Completed",
-                "message": "",
-                "state_details": {
-                    "pause_reschedule": False,
-                    "untrackable_result": False,
-                },
-                "data": {"type": "unpersisted"},
-            },
-            "task_run": {
-                "dynamic_key": "0",
-                "empirical_policy": {
-                    "max_retries": 0,
-                    "retries": 0,
-                    "retry_delay": 0,
-                    "retry_delay_seconds": 0.0,
-                },
-                "flow_run_run_count": 1,
-                "name": "happy_little_tree-0",
-                "run_count": 1,
-                "tags": [],
-                "task_inputs": {},
-                "total_run_time": 0.0,
-            },
-        }
+            "flow_run_run_count": 1,
+            "name": task_run.name,
+            "run_count": 1,
+            "tags": [],
+            "task_inputs": {},
+        },
+    }
 
 
 async def test_task_state_change_task_failure(
@@ -412,7 +211,6 @@ async def test_task_state_change_task_failure(
     reset_worker_events,
     prefect_client,
     events_pipeline,
-    enable_client_side_task_run_orchestration,
 ):
     @task
     def happy_little_tree():
@@ -442,358 +240,170 @@ async def test_task_state_change_task_failure(
 
     pending, running, failed = events
 
-    if enable_client_side_task_run_orchestration:
-        assert pending.event == "prefect.task-run.Pending"
-        assert pending.id == task_run_states[0].id
-        assert pending.occurred == task_run_states[0].timestamp
-        assert pending.resource == Resource(
-            {
-                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-                "prefect.resource.name": task_run.name,
-                "prefect.state-message": "",
-                "prefect.state-type": "PENDING",
-                "prefect.state-name": "Pending",
-                "prefect.state-timestamp": task_run_states[0].timestamp.isoformat(),
-                "prefect.orchestration": "client",
-            }
-        )
-        assert (
-            pendulum.parse(pending.payload["task_run"].pop("expected_start_time"))
-            == task_run.expected_start_time
-        )
-        assert (
-            pending.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-        )
-        assert pending.payload == {
-            "initial_state": None,
-            "intended": {"from": None, "to": "PENDING"},
-            "validated_state": {
-                "type": "PENDING",
-                "name": "Pending",
-                "message": "",
-                "state_details": {},
-                "data": None,
-            },
-            "task_run": {
-                "dynamic_key": task_run.dynamic_key,
-                "empirical_policy": {
-                    "max_retries": 0,
-                    "retries": 0,
-                    "retry_delay": 0,
-                    "retry_delay_seconds": 0.0,
-                },
-                "flow_run_run_count": 0,
-                "name": task_run.name,
-                "run_count": 0,
-                "tags": [],
-                "task_inputs": {},
-                "total_run_time": 0.0,
-            },
+    assert pending.event == "prefect.task-run.Pending"
+    assert pending.id == task_run_states[0].id
+    assert pending.occurred == task_run_states[0].timestamp
+    assert pending.resource == Resource(
+        {
+            "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+            "prefect.resource.name": task_run.name,
+            "prefect.state-message": "",
+            "prefect.state-type": "PENDING",
+            "prefect.state-name": "Pending",
+            "prefect.state-timestamp": task_run_states[0].timestamp.isoformat(),
+            "prefect.orchestration": "client",
         }
+    )
+    assert (
+        pendulum.parse(pending.payload["task_run"].pop("expected_start_time"))
+        == task_run.expected_start_time
+    )
+    assert pending.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+    assert pending.payload == {
+        "initial_state": None,
+        "intended": {"from": None, "to": "PENDING"},
+        "validated_state": {
+            "type": "PENDING",
+            "name": "Pending",
+            "message": "",
+            "state_details": {},
+            "data": None,
+        },
+        "task_run": {
+            "dynamic_key": task_run.dynamic_key,
+            "empirical_policy": {
+                "max_retries": 0,
+                "retries": 0,
+                "retry_delay": 0,
+                "retry_delay_seconds": 0.0,
+            },
+            "flow_run_run_count": 0,
+            "name": task_run.name,
+            "run_count": 0,
+            "tags": [],
+            "task_inputs": {},
+            "total_run_time": 0.0,
+        },
+    }
 
-        assert running.event == "prefect.task-run.Running"
-        assert running.id == task_run_states[1].id
-        assert running.occurred == task_run_states[1].timestamp
-        assert running.resource == Resource(
-            {
-                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-                "prefect.resource.name": task_run.name,
-                "prefect.state-message": "",
-                "prefect.state-type": "RUNNING",
-                "prefect.state-name": "Running",
-                "prefect.state-timestamp": task_run_states[1].timestamp.isoformat(),
-                "prefect.orchestration": "client",
-            }
-        )
-        assert (
-            pendulum.parse(running.payload["task_run"].pop("expected_start_time"))
-            == task_run.expected_start_time
-        )
-        assert (
-            pendulum.parse(running.payload["task_run"].pop("start_time"))
-            == task_run.start_time
-        )
-        assert (
-            running.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-        )
-        assert running.payload == {
-            "intended": {"from": "PENDING", "to": "RUNNING"},
-            "initial_state": {
-                "type": "PENDING",
-                "name": "Pending",
-                "message": "",
-                "state_details": {},
-            },
-            "validated_state": {
-                "type": "RUNNING",
-                "name": "Running",
-                "message": "",
-                "state_details": {},
-                "data": None,
-            },
-            "task_run": {
-                "dynamic_key": task_run.dynamic_key,
-                "empirical_policy": {
-                    "max_retries": 0,
-                    "retries": 0,
-                    "retry_delay": 0,
-                    "retry_delay_seconds": 0.0,
-                },
-                "flow_run_run_count": 1,
-                "name": task_run.name,
-                "run_count": 1,
-                "tags": [],
-                "task_inputs": {},
-                "total_run_time": 0.0,
-            },
+    assert running.event == "prefect.task-run.Running"
+    assert running.id == task_run_states[1].id
+    assert running.occurred == task_run_states[1].timestamp
+    assert running.resource == Resource(
+        {
+            "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+            "prefect.resource.name": task_run.name,
+            "prefect.state-message": "",
+            "prefect.state-type": "RUNNING",
+            "prefect.state-name": "Running",
+            "prefect.state-timestamp": task_run_states[1].timestamp.isoformat(),
+            "prefect.orchestration": "client",
         }
+    )
+    assert (
+        pendulum.parse(running.payload["task_run"].pop("expected_start_time"))
+        == task_run.expected_start_time
+    )
+    assert (
+        pendulum.parse(running.payload["task_run"].pop("start_time"))
+        == task_run.start_time
+    )
+    assert running.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+    assert running.payload == {
+        "intended": {"from": "PENDING", "to": "RUNNING"},
+        "initial_state": {
+            "type": "PENDING",
+            "name": "Pending",
+            "message": "",
+            "state_details": {},
+        },
+        "validated_state": {
+            "type": "RUNNING",
+            "name": "Running",
+            "message": "",
+            "state_details": {},
+            "data": None,
+        },
+        "task_run": {
+            "dynamic_key": task_run.dynamic_key,
+            "empirical_policy": {
+                "max_retries": 0,
+                "retries": 0,
+                "retry_delay": 0,
+                "retry_delay_seconds": 0.0,
+            },
+            "flow_run_run_count": 1,
+            "name": task_run.name,
+            "run_count": 1,
+            "tags": [],
+            "task_inputs": {},
+            "total_run_time": 0.0,
+        },
+    }
 
-        assert failed.event == "prefect.task-run.Failed"
-        assert failed.id == task_run_states[2].id
-        assert failed.occurred == task_run_states[2].timestamp
-        assert failed.resource == Resource(
-            {
-                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-                "prefect.resource.name": task_run.name,
-                "prefect.state-message": (
-                    "Task run encountered an exception ValueError: "
-                    "Here's a happy little accident."
-                ),
-                "prefect.state-type": "FAILED",
-                "prefect.state-name": "Failed",
-                "prefect.state-timestamp": task_run_states[2].timestamp.isoformat(),
-                "prefect.orchestration": "client",
-            }
-        )
-        assert (
-            pendulum.parse(failed.payload["task_run"].pop("expected_start_time"))
-            == task_run.expected_start_time
-        )
-        assert (
-            failed.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-        )
-        assert (
-            pendulum.parse(failed.payload["task_run"].pop("start_time"))
-            == task_run.start_time
-        )
-        assert (
-            pendulum.parse(failed.payload["task_run"].pop("end_time"))
-            == task_run.end_time
-        )
-        assert failed.payload["task_run"].pop("total_run_time") > 0
-        assert failed.payload == {
-            "intended": {"from": "RUNNING", "to": "FAILED"},
-            "initial_state": {
-                "type": "RUNNING",
-                "name": "Running",
-                "message": "",
-                "state_details": {},
-            },
-            "validated_state": {
-                "type": "FAILED",
-                "name": "Failed",
-                "message": (
-                    "Task run encountered an exception ValueError: "
-                    "Here's a happy little accident."
-                ),
-                "state_details": {"retriable": False},
-                "data": None,
-            },
-            "task_run": {
-                "dynamic_key": task_run.dynamic_key,
-                "empirical_policy": {
-                    "max_retries": 0,
-                    "retries": 0,
-                    "retry_delay": 0,
-                    "retry_delay_seconds": 0.0,
-                },
-                "flow_run_run_count": 1,
-                "name": task_run.name,
-                "run_count": 1,
-                "tags": [],
-                "task_inputs": {},
-            },
+    assert failed.event == "prefect.task-run.Failed"
+    assert failed.id == task_run_states[2].id
+    assert failed.occurred == task_run_states[2].timestamp
+    assert failed.resource == Resource(
+        {
+            "prefect.resource.id": f"prefect.task-run.{task_run.id}",
+            "prefect.resource.name": task_run.name,
+            "prefect.state-message": (
+                "Task run encountered an exception ValueError: "
+                "Here's a happy little accident."
+            ),
+            "prefect.state-type": "FAILED",
+            "prefect.state-name": "Failed",
+            "prefect.state-timestamp": task_run_states[2].timestamp.isoformat(),
+            "prefect.orchestration": "client",
         }
-    else:
-        assert pending.event == "prefect.task-run.Pending"
-        assert pending.id == task_run_states[0].id
-        assert pending.occurred == task_run_states[0].timestamp
-        assert pending.resource == Resource(
-            {
-                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-                "prefect.resource.name": task_run.name,
-                "prefect.state-message": "",
-                "prefect.state-type": "PENDING",
-                "prefect.state-name": "Pending",
-                "prefect.state-timestamp": task_run_states[0].timestamp.isoformat(),
-                "prefect.orchestration": "server",
-            }
-        )
-        assert (
-            pendulum.parse(pending.payload["task_run"].pop("expected_start_time"))
-            == task_run.expected_start_time
-        )
-        assert (
-            pending.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-        )
-        assert pending.payload == {
-            "initial_state": None,
-            "intended": {"from": None, "to": "PENDING"},
-            "validated_state": {
-                "type": "PENDING",
-                "name": "Pending",
-                "message": "",
-                "state_details": {
-                    "pause_reschedule": False,
-                    "untrackable_result": False,
-                },
-                "data": None,
+    )
+    assert (
+        pendulum.parse(failed.payload["task_run"].pop("expected_start_time"))
+        == task_run.expected_start_time
+    )
+    assert failed.payload["task_run"].pop("task_key").startswith("happy_little_tree")
+    assert (
+        pendulum.parse(failed.payload["task_run"].pop("start_time"))
+        == task_run.start_time
+    )
+    assert (
+        pendulum.parse(failed.payload["task_run"].pop("end_time")) == task_run.end_time
+    )
+    assert failed.payload["task_run"].pop("total_run_time") > 0
+    assert failed.payload == {
+        "intended": {"from": "RUNNING", "to": "FAILED"},
+        "initial_state": {
+            "type": "RUNNING",
+            "name": "Running",
+            "message": "",
+            "state_details": {},
+        },
+        "validated_state": {
+            "type": "FAILED",
+            "name": "Failed",
+            "message": (
+                "Task run encountered an exception ValueError: "
+                "Here's a happy little accident."
+            ),
+            "state_details": {"retriable": False},
+            "data": None,
+        },
+        "task_run": {
+            "dynamic_key": task_run.dynamic_key,
+            "empirical_policy": {
+                "max_retries": 0,
+                "retries": 0,
+                "retry_delay": 0,
+                "retry_delay_seconds": 0.0,
             },
-            "task_run": {
-                "dynamic_key": "0",
-                "empirical_policy": {
-                    "max_retries": 0,
-                    "retries": 0,
-                    "retry_delay": 0,
-                    "retry_delay_seconds": 0.0,
-                },
-                "flow_run_run_count": 0,
-                "name": "happy_little_tree-0",
-                "run_count": 0,
-                "tags": [],
-                "task_inputs": {},
-                "total_run_time": 0.0,
-            },
-        }
-
-        assert running.event == "prefect.task-run.Running"
-        assert running.id == task_run_states[1].id
-        assert running.occurred == task_run_states[1].timestamp
-        assert running.resource == Resource(
-            {
-                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-                "prefect.resource.name": task_run.name,
-                "prefect.state-message": "",
-                "prefect.state-type": "RUNNING",
-                "prefect.state-name": "Running",
-                "prefect.state-timestamp": task_run_states[1].timestamp.isoformat(),
-                "prefect.orchestration": "server",
-            }
-        )
-        assert (
-            pendulum.parse(running.payload["task_run"].pop("expected_start_time"))
-            == task_run.expected_start_time
-        )
-        assert (
-            running.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-        )
-        assert running.payload == {
-            "intended": {"from": "PENDING", "to": "RUNNING"},
-            "initial_state": {
-                "type": "PENDING",
-                "name": "Pending",
-                "message": "",
-                "state_details": {
-                    "pause_reschedule": False,
-                    "untrackable_result": False,
-                },
-            },
-            "validated_state": {
-                "type": "RUNNING",
-                "name": "Running",
-                "message": "",
-                "state_details": {
-                    "pause_reschedule": False,
-                    "untrackable_result": False,
-                },
-                "data": None,
-            },
-            "task_run": {
-                "dynamic_key": "0",
-                "empirical_policy": {
-                    "max_retries": 0,
-                    "retries": 0,
-                    "retry_delay": 0,
-                    "retry_delay_seconds": 0.0,
-                },
-                "flow_run_run_count": 0,
-                "name": "happy_little_tree-0",
-                "run_count": 0,
-                "tags": [],
-                "task_inputs": {},
-                "total_run_time": 0.0,
-            },
-        }
-
-        assert failed.event == "prefect.task-run.Failed"
-        assert failed.id == task_run_states[2].id
-        assert failed.occurred == task_run_states[2].timestamp
-        assert failed.resource == Resource(
-            {
-                "prefect.resource.id": f"prefect.task-run.{task_run.id}",
-                "prefect.resource.name": task_run.name,
-                "prefect.state-message": (
-                    "Task run encountered an exception ValueError: "
-                    "Here's a happy little accident."
-                ),
-                "prefect.state-type": "FAILED",
-                "prefect.state-name": "Failed",
-                "prefect.state-timestamp": task_run_states[2].timestamp.isoformat(),
-                "prefect.orchestration": "server",
-            }
-        )
-        assert (
-            pendulum.parse(failed.payload["task_run"].pop("expected_start_time"))
-            == task_run.expected_start_time
-        )
-        assert (
-            failed.payload["task_run"].pop("task_key").startswith("happy_little_tree")
-        )
-        assert (
-            pendulum.parse(failed.payload["task_run"].pop("start_time"))
-            == task_run.start_time
-        )
-        assert failed.payload == {
-            "intended": {"from": "RUNNING", "to": "FAILED"},
-            "initial_state": {
-                "type": "RUNNING",
-                "name": "Running",
-                "message": "",
-                "state_details": {
-                    "pause_reschedule": False,
-                    "untrackable_result": False,
-                },
-            },
-            "validated_state": {
-                "type": "FAILED",
-                "name": "Failed",
-                "message": (
-                    "Task run encountered an exception ValueError: "
-                    "Here's a happy little accident."
-                ),
-                "state_details": {
-                    "pause_reschedule": False,
-                    "retriable": False,
-                    "untrackable_result": False,
-                },
-                "data": None,
-            },
-            "task_run": {
-                "dynamic_key": "0",
-                "empirical_policy": {
-                    "max_retries": 0,
-                    "retries": 0,
-                    "retry_delay": 0,
-                    "retry_delay_seconds": 0.0,
-                },
-                "flow_run_run_count": 1,
-                "name": "happy_little_tree-0",
-                "run_count": 1,
-                "tags": [],
-                "task_inputs": {},
-                "total_run_time": 0.0,
-            },
-        }
+            "flow_run_run_count": 1,
+            "name": task_run.name,
+            "run_count": 1,
+            "tags": [],
+            "task_inputs": {},
+        },
+    }
 
 
 async def test_background_task_state_changes(
@@ -849,7 +459,8 @@ async def test_background_task_state_changes(
 
 
 async def test_apply_async_emits_scheduled_event(
-    asserting_events_worker, prefect_client, enable_client_side_task_run_orchestration
+    asserting_events_worker,
+    prefect_client,
 ):
     @task
     def happy_little_tree():
@@ -881,9 +492,7 @@ async def test_apply_async_emits_scheduled_event(
             "prefect.state-type": "SCHEDULED",
             "prefect.state-name": "Scheduled",
             "prefect.state-timestamp": task_run_states[0].timestamp.isoformat(),
-            "prefect.orchestration": "client"
-            if enable_client_side_task_run_orchestration
-            else "server",
+            "prefect.orchestration": "client",
         }
     )
 

--- a/tests/results/test_flow_results.py
+++ b/tests/results/test_flow_results.py
@@ -7,7 +7,7 @@ import pytest
 from prefect import flow, task
 from prefect.blocks.core import Block
 from prefect.context import get_run_context
-from prefect.exceptions import MissingResult
+from prefect.exceptions import FailedRun, MissingResult
 from prefect.filesystems import LocalFileSystem
 from prefect.results import (
     PersistedResultBlob,
@@ -142,7 +142,7 @@ async def test_flow_literal_result_is_available_but_not_serialized_or_persisted(
     assert await api_state.result() is value
 
 
-async def test_flow_exception_is_persisted(prefect_client):
+async def test_flow_exception_is_not_persisted(prefect_client):
     @flow(persist_result=True)
     def foo():
         raise ValueError("Hello world")
@@ -154,7 +154,7 @@ async def test_flow_exception_is_persisted(prefect_client):
     api_state = (
         await prefect_client.read_flow_run(state.state_details.flow_run_id)
     ).state
-    with pytest.raises(ValueError, match="Hello world"):
+    with pytest.raises(FailedRun, match="Hello world"):
         await api_state.result()
 
 

--- a/tests/results/test_task_results.py
+++ b/tests/results/test_task_results.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from prefect.events.worker import EventsWorker
-from prefect.exceptions import MissingResult
+from prefect.exceptions import FailedRun, MissingResult
 from prefect.filesystems import LocalFileSystem
 from prefect.flows import flow
 from prefect.serializers import JSONSerializer, PickleSerializer
@@ -420,7 +420,7 @@ async def test_task_literal_result_is_handled_the_same(
     assert await api_state.result() is value
 
 
-async def test_task_exception_is_persisted(prefect_client, events_pipeline):
+async def test_task_exception_is_not_persisted(prefect_client, events_pipeline):
     @flow
     def foo():
         return quote(bar(return_state=True))
@@ -439,7 +439,7 @@ async def test_task_exception_is_persisted(prefect_client, events_pipeline):
     api_state = (
         await prefect_client.read_task_run(task_state.state_details.task_run_id)
     ).state
-    with pytest.raises(ValueError, match="Hello world"):
+    with pytest.raises(FailedRun, match="Hello world"):
         await api_state.result()
 
 

--- a/tests/results/test_task_results.py
+++ b/tests/results/test_task_results.py
@@ -2,15 +2,12 @@ from pathlib import Path
 
 import pytest
 
-from prefect.events.worker import EventsWorker
 from prefect.exceptions import FailedRun, MissingResult
 from prefect.filesystems import LocalFileSystem
 from prefect.flows import flow
 from prefect.serializers import JSONSerializer, PickleSerializer
 from prefect.settings import (
-    PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION,
     PREFECT_HOME,
-    temporary_settings,
 )
 from prefect.tasks import task
 from prefect.testing.utilities import (
@@ -18,17 +15,6 @@ from prefect.testing.utilities import (
     assert_uses_result_storage,
 )
 from prefect.utilities.annotations import quote
-
-
-@pytest.fixture(autouse=True, params=[False, True])
-def enable_client_side_task_run_orchestration(
-    request, asserting_events_worker: EventsWorker
-):
-    enabled = request.param
-    with temporary_settings(
-        {PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION: enabled}
-    ):
-        yield enabled
 
 
 @pytest.mark.parametrize("options", [{"retries": 3}])


### PR DESCRIPTION
There's really no need to persist exceptions attached to Failed states - they should be logged, and get re-raised in-process, but otherwise they don't need to be stored and retrieved. This PR removes exception persistence entirely.  Also closes #14417 