### PR TITLE
log message while events are still draining

### DIFF
--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -159,7 +159,7 @@ class QueueService(abc.ABC, Generic[T]):
 
                 if current_time - last_log_time >= log_interval and queue_size > 0:
                     self._logger.warning(
-                        f"Still processing items. {queue_size} items remaining..."
+                        f"Still processing items: {queue_size} items remaining..."
                     )
                     last_log_time = current_time
 

--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -39,6 +39,7 @@ class QueueService(abc.ABC, Generic[T]):
             daemon=True,
             name=f"{type(self).__name__}Thread",
         )
+        self._logger = logging.getLogger(f"{type(self).__name__}")
 
     def start(self):
         logger.debug("Starting service %r", self)
@@ -144,10 +145,23 @@ class QueueService(abc.ABC, Generic[T]):
             self._done_event.set()
 
     async def _main_loop(self):
+        last_log_time = 0
+        log_interval = 4  # log every 4 seconds
+
         while True:
             item: T = await self._queue_get_thread.submit(
                 create_call(self._queue.get)
             ).aresult()
+
+            if self._stopped:
+                current_time = asyncio.get_event_loop().time()
+                queue_size = self._queue.qsize()
+
+                if current_time - last_log_time >= log_interval and queue_size > 0:
+                    self._logger.warning(
+                        f"Still processing items. {queue_size} items remaining..."
+                    )
+                    last_log_time = current_time
 
             if item is None:
                 logger.debug("Exiting service %r", self)

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -196,7 +196,11 @@ class BaseTaskRunEngine(Generic[P, R]):
 
     def record_terminal_state_timing(self, state: State) -> None:
         if PREFECT_EXPERIMENTAL_ENABLE_CLIENT_SIDE_TASK_ORCHESTRATION:
-            if self.task_run.start_time and not self.task_run.end_time:
+            if (
+                self.task_run
+                and self.task_run.start_time
+                and not self.task_run.end_time
+            ):
                 self.task_run.end_time = state.timestamp
 
                 if self.task_run.state.is_running():


### PR DESCRIPTION
Log a message while items are still draining out of the `QueueService`. This is particularly important for UX of client side task run orchestration. Consider this example:

```python
from prefect import task, flow

@task
def add_one(n):
    return n + 1


@flow
def add_flow():
    futures = [add_one.submit(i) for i in range(1000)]
    for future in futures:
        future.result()


if __name__ == '__main__':
    add_flow()
```

1000 tasks will all finish at roughly the same time and generate 1000 events. The flow will finish and it will look like the process is hanging to the user. In reality we still need to churn through those 1000 events. This PR adds the following logging when the service begins to drain.

```
$ python add_flow.py
13:59:37.814 | INFO    | prefect.engine - Created flow run 'witty-aardwolf' for flow 'add-flow'
...
... 
...
14:00:44.822 | INFO    | Task run 'add_one-673' - Finished in state Completed()
14:00:44.822 | INFO    | Task run 'add_one-fc4' - Finished in state Completed()
14:00:44.822 | INFO    | Task run 'add_one-853' - Finished in state Completed()
14:00:44.823 | INFO    | Task run 'add_one-815' - Finished in state Completed()
14:00:45.256 | INFO    | Flow run 'witty-aardwolf' - Finished in state Completed()
14:00:45.258 | WARNING | EventsWorker - Still processing items: 939 items remaining...
14:00:49.259 | WARNING | EventsWorker - Still processing items: 639 items remaining...
14:00:53.265 | WARNING | EventsWorker - Still processing items: 344 items remaining...
14:00:57.266 | WARNING | EventsWorker - Still processing items: 42 items remaining...
```

Looking for feedback on both the approach and the actual copy/UX!