### PR TITLE
allow overwrite in `create_work_pool`

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2631,7 +2631,10 @@ class PrefectClient:
         except httpx.HTTPStatusError as e:
             if e.response.status_code == status.HTTP_409_CONFLICT:
                 if overwrite:
-                    if "type" in work_pool.model_fields_set:
+                    existing_work_pool = await self.read_work_pool(
+                        work_pool_name=work_pool.name
+                    )
+                    if existing_work_pool.type != work_pool.type:
                         warnings.warn(
                             "Overwriting work pool type is not supported. Ignoring provided type.",
                             category=UserWarning,

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2612,6 +2612,7 @@ class PrefectClient:
     async def create_work_pool(
         self,
         work_pool: WorkPoolCreate,
+        overwrite: bool = False,
     ) -> WorkPool:
         """
         Creates a work pool with the provided configuration.
@@ -2629,7 +2630,21 @@ class PrefectClient:
             )
         except httpx.HTTPStatusError as e:
             if e.response.status_code == status.HTTP_409_CONFLICT:
-                raise prefect.exceptions.ObjectAlreadyExists(http_exc=e) from e
+                if overwrite:
+                    if "type" in work_pool.model_fields_set:
+                        warnings.warn(
+                            "Overwriting work pool type is not supported. Ignoring provided type.",
+                            category=UserWarning,
+                        )
+                    await self.update_work_pool(
+                        work_pool_name=work_pool.name,
+                        work_pool=WorkPoolUpdate.model_validate(
+                            work_pool.model_dump(exclude={"name", "type"})
+                        ),
+                    )
+                    response = await self._client.get(f"/work_pools/{work_pool.name}")
+                else:
+                    raise prefect.exceptions.ObjectAlreadyExists(http_exc=e) from e
             else:
                 raise
 

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -149,8 +149,7 @@ class TestCreate:
             f"work-pool create {pool_name} -t process",
             expected_code=1,
             expected_output_contains=[
-                f"Work pool named {pool_name!r} already exists. Please try creating"
-                " your work pool again with a different name."
+                f"Work pool named {pool_name!r} already exists. Use --overwrite to update it."
             ],
         )
 

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -389,6 +389,44 @@ class TestCreate:
             ],
         )
 
+    @pytest.mark.usefixtures("mock_collection_registry")
+    async def test_create_work_pool_with_overwrite(self, prefect_client):
+        pool_name = "overwrite-pool"
+
+        # Create initial work pool
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            f"work-pool create {pool_name} --type process",
+            expected_code=0,
+            expected_output_contains=[f"Created work pool {pool_name!r}"],
+        )
+
+        initial_pool = await prefect_client.read_work_pool(pool_name)
+        assert initial_pool.name == pool_name
+        assert not initial_pool.is_paused
+
+        # Attempt to overwrite the work pool (updating is_paused)
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            f"work-pool create {pool_name} --paused --overwrite",
+            expected_code=0,
+            expected_output_contains=[f"Updated work pool {pool_name!r}"],
+        )
+
+        updated_pool = await prefect_client.read_work_pool(pool_name)
+        assert updated_pool.name == pool_name
+        assert updated_pool.id == initial_pool.id
+        assert updated_pool.is_paused
+
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            f"work-pool create {pool_name} --paused",
+            expected_code=1,
+            expected_output_contains=[
+                f"Work pool named {pool_name!r} already exists. Use --overwrite to update it."
+            ],
+        )
+
 
 class TestInspect:
     async def test_inspect(self, prefect_client, work_pool):

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -1862,6 +1862,7 @@ class TestWorkPools:
         await prefect_client.create_work_pool(
             work_pool=WorkPoolCreate(
                 name=work_pool.name,
+                type=work_pool.type,
                 description="new description",
             ),
             overwrite=True,
@@ -1879,7 +1880,7 @@ class TestWorkPools:
             await prefect_client.create_work_pool(
                 work_pool=WorkPoolCreate(
                     name=work_pool.name,
-                    type="test-type",
+                    type="kubernetes",
                     description=work_pool.description,
                 ),
                 overwrite=True,

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -1856,6 +1856,38 @@ class TestWorkPools:
             work_pool_2.id,
         }
 
+    async def test_create_work_pool_overwriting_existing_work_pool(
+        self, prefect_client, work_pool
+    ):
+        await prefect_client.create_work_pool(
+            work_pool=WorkPoolCreate(
+                name=work_pool.name,
+                description="new description",
+            ),
+            overwrite=True,
+        )
+
+        updated_work_pool = await prefect_client.read_work_pool(work_pool.name)
+        assert updated_work_pool.description == "new description"
+
+    async def test_create_work_pool_with_attempt_to_overwrite_type(
+        self, prefect_client, work_pool
+    ):
+        with pytest.warns(
+            UserWarning, match="Overwriting work pool type is not supported"
+        ):
+            await prefect_client.create_work_pool(
+                work_pool=WorkPoolCreate(
+                    name=work_pool.name,
+                    type="test-type",
+                    description=work_pool.description,
+                ),
+                overwrite=True,
+            )
+
+        updated_work_pool = await prefect_client.read_work_pool(work_pool.name)
+        assert updated_work_pool.type == work_pool.type
+
     async def test_update_work_pool(self, prefect_client):
         work_pool = await prefect_client.create_work_pool(
             work_pool=WorkPoolCreate(name="test-pool-1")


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/14961

allows "create or update" of work pool via a new `overwrite: bool` flag you may pass to `client.create_work_pool`

we `exclude` the fields `name` and `type` from the create action schema when calling `update_work_pool`, warning that we may not `overwrite` the `type` of a work pool once it's been created

---

makes a corresponding change to `prefect work-pool create`

### usage example
```python
» prefect work-pool ls
                                   Work Pools
┏━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
┃ Name  ┃ Type       ┃                                   ID ┃ Concurrency Limit ┃
┡━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
│ asdf  │ kubernetes │ 1ff6da22-f38b-4d29-b1a9-1e41bb6f5a1e │ None              │
│ local │ process    │ 2d760c8d-7025-4ac5-ba46-5d2db9b2807a │ None              │
└───────┴────────────┴──────────────────────────────────────┴───────────────────┘
                           (**) denotes a paused pool
(prefect) nate :: ~/github.com/prefecthq/prefect ‹overwrite-create-work-pool›
» ipython

In [1]: from prefect import get_client

In [2]: from prefect.client.schemas.actions import WorkPoolCreate

In [3]: async with get_client() as client:
   ...:     await client.create_work_pool(WorkPoolCreate(name="local", concurrency_limit=1), overwrite=True
   ...: )

In [4]: !prefect work-pool ls
                                   Work Pools
┏━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
┃ Name  ┃ Type       ┃                                   ID ┃ Concurrency Limit ┃
┡━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
│ asdf  │ kubernetes │ 1ff6da22-f38b-4d29-b1a9-1e41bb6f5a1e │ None              │
│ local │ process    │ 2d760c8d-7025-4ac5-ba46-5d2db9b2807a │ 1                 │
└───────┴────────────┴──────────────────────────────────────┴───────────────────┘
                           (**) denotes a paused pool
```