### PR TITLE
disable task run recorder in tests

### DIFF
--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -346,6 +346,47 @@ class PrefectEventsClient(EventsClient):
                     await asyncio.sleep(1)
 
 
+class AssertingPrefectEventsClient(PrefectEventsClient):
+    """A Prefect Events client that BOTH records all events sent to it for inspection
+    during tests AND sends them to a Prefect server."""
+
+    last: ClassVar["Optional[AssertingPrefectEventsClient]"] = None
+    all: ClassVar[List["AssertingPrefectEventsClient"]] = []
+
+    args: Tuple
+    kwargs: Dict[str, Any]
+    events: List[Event]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        AssertingPrefectEventsClient.last = self
+        AssertingPrefectEventsClient.all.append(self)
+        self.args = args
+        self.kwargs = kwargs
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.last = None
+        cls.all = []
+
+    def pop_events(self) -> List[Event]:
+        events = self.events
+        self.events = []
+        return events
+
+    async def _emit(self, event: Event) -> None:
+        # actually send the event to the server
+        await super()._emit(event)
+
+        # record the event for inspection
+        self.events.append(event)
+
+    async def __aenter__(self) -> Self:
+        await super().__aenter__()
+        self.events = []
+        return self
+
+
 class PrefectCloudEventsClient(PrefectEventsClient):
     """A Prefect Events client that streams events to a Prefect Cloud Workspace"""
 

--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -346,12 +346,12 @@ class PrefectEventsClient(EventsClient):
                     await asyncio.sleep(1)
 
 
-class AssertingPrefectEventsClient(PrefectEventsClient):
+class AssertingPassthroughEventsClient(PrefectEventsClient):
     """A Prefect Events client that BOTH records all events sent to it for inspection
     during tests AND sends them to a Prefect server."""
 
-    last: ClassVar["Optional[AssertingPrefectEventsClient]"] = None
-    all: ClassVar[List["AssertingPrefectEventsClient"]] = []
+    last: ClassVar["Optional[AssertingPassthroughEventsClient]"] = None
+    all: ClassVar[List["AssertingPassthroughEventsClient"]] = []
 
     args: Tuple
     kwargs: Dict[str, Any]
@@ -359,8 +359,8 @@ class AssertingPrefectEventsClient(PrefectEventsClient):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        AssertingPrefectEventsClient.last = self
-        AssertingPrefectEventsClient.all.append(self)
+        AssertingPassthroughEventsClient.last = self
+        AssertingPassthroughEventsClient.all.append(self)
         self.args = args
         self.kwargs = kwargs
 

--- a/src/prefect/events/utilities.py
+++ b/src/prefect/events/utilities.py
@@ -7,7 +7,7 @@ from pydantic_extra_types.pendulum_dt import DateTime
 
 from .clients import (
     AssertingEventsClient,
-    AssertingPrefectEventsClient,
+    AssertingPassthroughEventsClient,
     PrefectCloudEventsClient,
     PrefectEventsClient,
 )
@@ -50,7 +50,7 @@ def emit_event(
         return None
 
     operational_clients = [
-        AssertingPrefectEventsClient,
+        AssertingPassthroughEventsClient,
         AssertingEventsClient,
         PrefectCloudEventsClient,
         PrefectEventsClient,

--- a/src/prefect/events/utilities.py
+++ b/src/prefect/events/utilities.py
@@ -7,6 +7,7 @@ from pydantic_extra_types.pendulum_dt import DateTime
 
 from .clients import (
     AssertingEventsClient,
+    AssertingPrefectEventsClient,
     PrefectCloudEventsClient,
     PrefectEventsClient,
 )
@@ -49,6 +50,7 @@ def emit_event(
         return None
 
     operational_clients = [
+        AssertingPrefectEventsClient,
         AssertingEventsClient,
         PrefectCloudEventsClient,
         PrefectEventsClient,

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -564,14 +564,14 @@ def create_app(
             service_instances.append(ProactiveTriggers())
             service_instances.append(Actions())
 
+        if prefect.settings.PREFECT_API_SERVICES_TASK_RUN_RECORDER_ENABLED:
+            service_instances.append(TaskRunRecorder())
+
         if prefect.settings.PREFECT_API_SERVICES_EVENT_PERSISTER_ENABLED:
             service_instances.append(EventPersister())
 
         if prefect.settings.PREFECT_API_EVENTS_STREAM_OUT_ENABLED:
             service_instances.append(stream.Distributor())
-
-        if prefect.settings.PREFECT_API_SERVICES_TASK_RUN_RECORDER_ENABLED:
-            service_instances.append(TaskRunRecorder())
 
         loop = asyncio.get_running_loop()
 

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -47,6 +47,7 @@ from prefect.server.events.services.actions import Actions
 from prefect.server.events.services.event_persister import EventPersister
 from prefect.server.events.services.triggers import ProactiveTriggers, ReactiveTriggers
 from prefect.server.exceptions import ObjectNotFoundError
+from prefect.server.services.task_run_recorder import TaskRunRecorder
 from prefect.server.utilities.database import get_dialect
 from prefect.settings import (
     PREFECT_API_DATABASE_CONNECTION_URL,
@@ -569,8 +570,8 @@ def create_app(
         if prefect.settings.PREFECT_API_EVENTS_STREAM_OUT_ENABLED:
             service_instances.append(stream.Distributor())
 
-        # if prefect.settings.PREFECT_API_SERVICES_TASK_RUN_RECORDER_ENABLED:
-        #     service_instances.append(TaskRunRecorder())
+        if prefect.settings.PREFECT_API_SERVICES_TASK_RUN_RECORDER_ENABLED:
+            service_instances.append(TaskRunRecorder())
 
         loop = asyncio.get_running_loop()
 

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -47,7 +47,6 @@ from prefect.server.events.services.actions import Actions
 from prefect.server.events.services.event_persister import EventPersister
 from prefect.server.events.services.triggers import ProactiveTriggers, ReactiveTriggers
 from prefect.server.exceptions import ObjectNotFoundError
-from prefect.server.services.task_run_recorder import TaskRunRecorder
 from prefect.server.utilities.database import get_dialect
 from prefect.settings import (
     PREFECT_API_DATABASE_CONNECTION_URL,
@@ -570,8 +569,8 @@ def create_app(
         if prefect.settings.PREFECT_API_EVENTS_STREAM_OUT_ENABLED:
             service_instances.append(stream.Distributor())
 
-        if prefect.settings.PREFECT_API_SERVICES_TASK_RUN_RECORDER_ENABLED:
-            service_instances.append(TaskRunRecorder())
+        # if prefect.settings.PREFECT_API_SERVICES_TASK_RUN_RECORDER_ENABLED:
+        #     service_instances.append(TaskRunRecorder())
 
         loop = asyncio.get_running_loop()
 

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -369,7 +369,6 @@ def mock_should_emit_events(monkeypatch) -> mock.Mock:
     return m
 
 
-@pytest.fixture(autouse=True)
 def asserting_events_worker(monkeypatch) -> Generator[EventsWorker, None, None]:
     worker = EventsWorker.instance(AssertingEventsClient)
     # Always yield the asserting worker when new instances are retrieved

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -369,6 +369,7 @@ def mock_should_emit_events(monkeypatch) -> mock.Mock:
     return m
 
 
+@pytest.fixture
 def asserting_events_worker(monkeypatch) -> Generator[EventsWorker, None, None]:
     worker = EventsWorker.instance(AssertingEventsClient)
     # Always yield the asserting worker when new instances are retrieved

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -17,7 +17,10 @@ from websockets.exceptions import ConnectionClosed
 from websockets.legacy.server import WebSocketServer, WebSocketServerProtocol, serve
 
 from prefect.events import Event
-from prefect.events.clients import AssertingEventsClient, AssertingPrefectEventsClient
+from prefect.events.clients import (
+    AssertingEventsClient,
+    AssertingPassthroughEventsClient,
+)
 from prefect.events.filters import EventFilter
 from prefect.events.worker import EventsWorker
 from prefect.server.api.server import SubprocessASGIServer
@@ -384,7 +387,7 @@ def asserting_events_worker(monkeypatch) -> Generator[EventsWorker, None, None]:
 def asserting_and_emitting_events_worker(
     monkeypatch,
 ) -> Generator[EventsWorker, None, None]:
-    worker = EventsWorker.instance(AssertingPrefectEventsClient)
+    worker = EventsWorker.instance(AssertingPassthroughEventsClient)
     # Always yield the asserting worker when new instances are retrieved
     monkeypatch.setattr(EventsWorker, "instance", lambda *_: worker)
     try:

--- a/src/prefect/testing/fixtures.py
+++ b/src/prefect/testing/fixtures.py
@@ -369,7 +369,7 @@ def mock_should_emit_events(monkeypatch) -> mock.Mock:
     return m
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def asserting_events_worker(monkeypatch) -> Generator[EventsWorker, None, None]:
     worker = EventsWorker.instance(AssertingEventsClient)
     # Always yield the asserting worker when new instances are retrieved

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ from prefect.settings import (
     PREFECT_API_SERVICES_LATE_RUNS_ENABLED,
     PREFECT_API_SERVICES_PAUSE_EXPIRATIONS_ENABLED,
     PREFECT_API_SERVICES_SCHEDULER_ENABLED,
+    PREFECT_API_SERVICES_TASK_RUN_RECORDER_ENABLED,
     PREFECT_API_SERVICES_TRIGGERS_ENABLED,
     PREFECT_API_URL,
     PREFECT_ASYNC_FETCH_STATE_RESULT,
@@ -335,6 +336,8 @@ def pytest_sessionstart(session):
             # lock the DB during tests while writing events
             PREFECT_API_SERVICES_EVENT_PERSISTER_ENABLED: False,
             PREFECT_API_SERVICES_TRIGGERS_ENABLED: False,
+            # Disable the task run recorder service
+            PREFECT_API_SERVICES_TASK_RUN_RECORDER_ENABLED: False,
         },
         source=__file__,
     )

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1001,7 +1001,7 @@ async def test_run_logger_in_nested_flow(prefect_client):
     }
 
 
-async def test_run_logger_in_task(prefect_client):
+async def test_run_logger_in_task(prefect_client, events_pipeline):
     @task
     def test_task():
         return get_run_logger()
@@ -1013,6 +1013,9 @@ async def test_run_logger_in_task(prefect_client):
     flow_state = test_flow(return_state=True)
     flow_run = await prefect_client.read_flow_run(flow_state.state_details.flow_run_id)
     task_state = await flow_state.result()
+
+    await events_pipeline.process_events()
+
     task_run = await prefect_client.read_task_run(task_state.state_details.task_run_id)
     logger = await task_state.result()
     assert logger.name == "prefect.task_runs"

--- a/tests/test_task_runs.py
+++ b/tests/test_task_runs.py
@@ -25,7 +25,7 @@ class TestTaskRunWaiter:
 
     @pytest.mark.timeout(20)
     @pytest.mark.usefixtures("use_hosted_api_server")
-    async def test_wait_for_task_run(self, prefect_client):
+    async def test_wait_for_task_run(self, prefect_client, events_pipeline):
         """This test will fail with a timeout error if waiting is not working correctly."""
 
         @task
@@ -34,6 +34,8 @@ class TestTaskRunWaiter:
 
         task_run_id = uuid.uuid4()
         asyncio.create_task(run_task_async(task=test_task, task_run_id=task_run_id))
+
+        await events_pipeline.process_events(min_events=3)
 
         await TaskRunWaiter.wait_for_task_run(task_run_id)
 

--- a/tests/test_task_runs.py
+++ b/tests/test_task_runs.py
@@ -25,7 +25,7 @@ class TestTaskRunWaiter:
 
     @pytest.mark.timeout(20)
     @pytest.mark.usefixtures("use_hosted_api_server")
-    async def test_wait_for_task_run(self, prefect_client, events_pipeline):
+    async def test_wait_for_task_run(self, prefect_client, emitting_events_pipeline):
         """This test will fail with a timeout error if waiting is not working correctly."""
 
         @task
@@ -35,9 +35,9 @@ class TestTaskRunWaiter:
         task_run_id = uuid.uuid4()
         asyncio.create_task(run_task_async(task=test_task, task_run_id=task_run_id))
 
-        await events_pipeline.process_events(min_events=3)
-
         await TaskRunWaiter.wait_for_task_run(task_run_id)
+
+        await emitting_events_pipeline.process_events()
 
         task_run = await prefect_client.read_task_run(task_run_id)
         assert task_run.state.is_completed()
@@ -61,7 +61,7 @@ class TestTaskRunWaiter:
 
     @pytest.mark.timeout(20)
     @pytest.mark.usefixtures("use_hosted_api_server")
-    async def test_non_singleton_mode(self, prefect_client):
+    async def test_non_singleton_mode(self, prefect_client, emitting_events_pipeline):
         waiter = TaskRunWaiter()
         assert waiter is not TaskRunWaiter.instance()
 
@@ -74,6 +74,8 @@ class TestTaskRunWaiter:
 
         await waiter.wait_for_task_run(task_run_id)
 
+        await emitting_events_pipeline.process_events()
+
         task_run = await prefect_client.read_task_run(task_run_id)
         assert task_run.state.is_completed()
 
@@ -81,7 +83,9 @@ class TestTaskRunWaiter:
 
     @pytest.mark.timeout(20)
     @pytest.mark.usefixtures("use_hosted_api_server")
-    async def test_handles_concurrent_task_runs(self, prefect_client):
+    async def test_handles_concurrent_task_runs(
+        self, prefect_client, emitting_events_pipeline
+    ):
         @task
         async def fast_task():
             await asyncio.sleep(1)
@@ -98,6 +102,8 @@ class TestTaskRunWaiter:
 
         await TaskRunWaiter.wait_for_task_run(task_run_id_1)
 
+        await emitting_events_pipeline.process_events()
+
         task_run_1 = await prefect_client.read_task_run(task_run_id_1)
         task_run_2 = await prefect_client.read_task_run(task_run_id_2)
 
@@ -105,6 +111,8 @@ class TestTaskRunWaiter:
         assert not task_run_2.state.is_completed()
 
         await TaskRunWaiter.wait_for_task_run(task_run_id_2)
+
+        await emitting_events_pipeline.process_events()
 
         task_run_1 = await prefect_client.read_task_run(task_run_id_1)
         task_run_2 = await prefect_client.read_task_run(task_run_id_2)


### PR DESCRIPTION
This PR disables the `TaskRunRecorder` service when running the hosted api during tests. This is consistent with our other services that are disabled during tests. While it was enabled it was leading to deadlocks during test setup, while it was trying to insert things from the last test, and the next test was trying to do it's setup.

It also introduces the `AssertingPrefectEventsClient`. This client both emits the event to the server (which is configured to do nothing with it but distribute it to connected websockets) AND stashes a copy of the event on the client. The existing `AssertingEventsClient` and `events_pipeline`, would _catch_ events from being sent to the server and then we would do things with them like run the `task_run_recorder` manually. 

This lets us satisfy tests around special cases like `TaskRunWaiter` where we both need the event to come through a websocket (actually making it's way to the server) but then we also need to have a copy of the event to manually run the `task_run_recorder` in the test, so we can do things like look at the task run.

