### PR TITLE
allow JSON values in `Secret` block

### DIFF
--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -150,7 +150,9 @@ def _collect_secret_fields(
             _collect_secret_fields(f"{name}.{field_name}", field.annotation, secrets)
         return
 
-    if type_ in (SecretStr, SecretBytes):
+    if type_ in (SecretStr, SecretBytes) or (
+        type_.__module__ == "pydantic.types" and type_.__name__ == "Secret"
+    ):
         secrets.append(name)
     elif type_ == SecretDict:
         # Append .* to field name to signify that all values under this

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -151,7 +151,8 @@ def _collect_secret_fields(
         return
 
     if type_ in (SecretStr, SecretBytes) or (
-        type_.__module__ == "pydantic.types" and type_.__name__ == "Secret"
+        type_.__module__ == "pydantic.types"
+        and getattr(type_, "__name__", None) == "Secret"
     ):
         secrets.append(name)
     elif type_ == SecretDict:

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -151,7 +151,8 @@ def _collect_secret_fields(
         return
 
     if type_ in (SecretStr, SecretBytes) or (
-        type_.__module__ == "pydantic.types"
+        isinstance(type_, type)
+        and getattr(type_, "__module__", None) == "pydantic.types"
         and getattr(type_, "__name__", None) == "Secret"
     ):
         secrets.append(name)

--- a/src/prefect/blocks/system.py
+++ b/src/prefect/blocks/system.py
@@ -119,9 +119,9 @@ class Secret(Block, Generic[T]):
         ```python
         from prefect.blocks.system import Secret
 
-        Secret(value="sk-1234567890").save("test-secret", overwrite=True)
+        Secret(value="sk-1234567890").save("BLOCK_NAME", overwrite=True)
 
-        secret_block = Secret.load("test-secret")
+        secret_block = Secret.load("BLOCK_NAME")
 
         # Access the stored secret
         secret_block.get()

--- a/src/prefect/blocks/system.py
+++ b/src/prefect/blocks/system.py
@@ -1,7 +1,8 @@
-from typing import Any, Dict, Generic, TypeVar, Union
+from typing import Any, Dict, Generic, List, TypeVar, Union
 
 from pydantic import (
     Field,
+    SecretStr,
     StrictFloat,
     StrictInt,
     StrictStr,
@@ -12,7 +13,7 @@ from pydantic_extra_types.pendulum_dt import DateTime as PydanticDateTime
 from prefect._internal.compatibility.deprecated import deprecated_class
 from prefect.blocks.core import Block
 
-SecretValueType = Union[StrictStr, StrictInt, StrictFloat, Dict[str, Any]]
+SecretValueType = Union[StrictStr, SecretStr, StrictInt, StrictFloat, Dict, List]
 
 T = TypeVar("T", bound=SecretValueType)
 
@@ -127,8 +128,7 @@ class Secret(Block, Generic[T]):
     value: PydanticSecret[T] = Field(
         default=...,
         description="A value that should be kept secret.",
-        examples=["sk-1234567890", '{"username": "johndoe", "password": "s3cr3t"}'],
-        # json_schema_extra=dict(format="password"),
+        examples=["sk-1234567890", {"username": "johndoe", "password": "s3cr3t"}],
     )
 
     def get(self):

--- a/src/prefect/blocks/system.py
+++ b/src/prefect/blocks/system.py
@@ -1,10 +1,20 @@
-from typing import Any
+from typing import Any, Dict, Generic, TypeVar, Union
 
-from pydantic import Field, SecretStr
-from pydantic_extra_types.pendulum_dt import DateTime
+from pydantic import (
+    Field,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+)
+from pydantic import Secret as PydanticSecret
+from pydantic_extra_types.pendulum_dt import DateTime as PydanticDateTime
 
 from prefect._internal.compatibility.deprecated import deprecated_class
 from prefect.blocks.core import Block
+
+SecretValueType = Union[StrictStr, StrictInt, StrictFloat, Dict[str, Any]]
+
+T = TypeVar("T", bound=SecretValueType)
 
 
 @deprecated_class(
@@ -86,19 +96,19 @@ class DateTime(Block):
     _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/8b3da9a6621e92108b8e6a75b82e15374e170ff7-48x48.png"
     _documentation_url = "https://docs.prefect.io/api-ref/prefect/blocks/system/#prefect.blocks.system.DateTime"
 
-    value: DateTime = Field(
+    value: PydanticDateTime = Field(
         default=...,
         description="An ISO 8601-compatible datetime value.",
     )
 
 
-class Secret(Block):
+class Secret(Block, Generic[T]):
     """
     A block that represents a secret value. The value stored in this block will be obfuscated when
     this block is logged or shown in the UI.
 
     Attributes:
-        value: A string value that should be kept secret.
+        value: A value that should be kept secret.
 
     Example:
         ```python
@@ -114,8 +124,11 @@ class Secret(Block):
     _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/c6f20e556dd16effda9df16551feecfb5822092b-48x48.png"
     _documentation_url = "https://docs.prefect.io/api-ref/prefect/blocks/system/#prefect.blocks.system.Secret"
 
-    value: SecretStr = Field(
-        default=..., description="A string value that should be kept secret."
+    value: PydanticSecret[T] = Field(
+        default=...,
+        description="A value that should be kept secret.",
+        examples=["sk-1234567890", '{"username": "johndoe", "password": "s3cr3t"}'],
+        # json_schema_extra=dict(format="password"),
     )
 
     def get(self):

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -1329,6 +1329,7 @@ class PrefectClient:
             exclude_unset=True,
             exclude={"id", "block_schema", "block_type"},
             context={"include_secrets": include_secrets},
+            serialize_as_any=True,
         )
         try:
             response = await self._client.post(

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -1324,15 +1324,16 @@ class PrefectClient:
                 `SecretBytes` fields. Note Blocks may not work as expected if
                 this is set to `False`.
         """
+        block_document_data = block_document.model_dump(
+            mode="json",
+            exclude_unset=True,
+            exclude={"id", "block_schema", "block_type"},
+            context={"include_secrets": include_secrets},
+        )
         try:
             response = await self._client.post(
                 "/block_documents/",
-                json=block_document.model_dump(
-                    mode="json",
-                    exclude_unset=True,
-                    exclude={"id", "block_schema", "block_type"},
-                    context={"include_secrets": include_secrets},
-                ),
+                json=block_document_data,
             )
         except httpx.HTTPStatusError as e:
             if e.response.status_code == status.HTTP_409_CONFLICT:

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -24,6 +24,7 @@ from pydantic import (
     model_serializer,
     model_validator,
 )
+from pydantic.functional_validators import ModelWrapValidatorHandler
 from pydantic_extra_types.pendulum_dt import DateTime
 from typing_extensions import Literal, Self, TypeVar
 
@@ -938,7 +939,9 @@ class BlockDocument(ObjectBaseModel):
         return validate_name_present_on_nonanonymous_blocks(values)
 
     @model_serializer(mode="wrap")
-    def serialize_data(self, handler, info: SerializationInfo):
+    def serialize_data(
+        self, handler: ModelWrapValidatorHandler, info: SerializationInfo
+    ):
         self.data = visit_collection(
             self.data,
             visit_fn=partial(handle_secret_render, context=info.context or {}),

--- a/tests/blocks/test_system.py
+++ b/tests/blocks/test_system.py
@@ -1,18 +1,86 @@
+from datetime import date
+from uuid import UUID
+
 import pendulum
+import pytest
+from pydantic import Secret as PydanticSecret
 from pydantic import SecretStr
+from pydantic_extra_types.pendulum_dt import DateTime as PydanticDateTime
 
-from prefect.blocks import system
+from prefect.blocks.system import DateTime, Secret, SecretMap
 
 
-async def test_datetime():
-    await system.DateTime(value=pendulum.datetime(2022, 1, 1)).save(name="test")
-    api_block = await system.DateTime.load("test")
+def test_datetime():
+    DateTime(value=PydanticDateTime(2022, 1, 1)).save(name="test")
+    api_block = DateTime.load("test")
     assert api_block.value == pendulum.datetime(2022, 1, 1)
 
 
-async def test_secret_block():
-    await system.Secret(value="test").save(name="test")
-    api_block = await system.Secret.load("test")
+@pytest.mark.parametrize(
+    "value",
+    ["test", SecretStr("test")],
+    ids=["string", "secret_str"],
+)
+def test_secret_block(value):
+    Secret(value=value).save(name="test")
+    api_block = Secret.load("test")
     assert isinstance(api_block.value, SecretStr)
 
     assert api_block.get() == "test"
+
+
+class TestSecretMap:
+    @pytest.mark.parametrize(
+        "key, value",
+        [
+            # (1, "int_secret"),
+            (3.14, "float_secret"),
+            ("string_key", "string_secret"),
+            ((1, "tuple"), "tuple_secret"),
+        ],
+    )
+    def test_secret_map_with_various_hashable_types(self, key, value):
+        secret_map = SecretMap(value={key: value})
+
+        secret_map.save(name="test")
+
+        assert secret_map.get()[key] == value
+
+        assert isinstance(secret_map.value[key], PydanticSecret)
+
+        assert secret_map.value[key].get_secret_value() == value
+
+        breakpoint()
+
+        assert SecretMap.load("test") == secret_map, secret_map.value
+
+    def test_secret_map_with_multiple_pairs(self):
+        secret_map = SecretMap(
+            value={
+                "string_key": "string_secret",
+                42: "int_secret",
+                (1, "tuple"): "tuple_secret",
+                date(2023, 8, 14): "date_secret",
+                UUID("12345678-1234-5678-1234-567812345678"): "uuid_secret",
+            }
+        )
+
+        assert secret_map.get() == {
+            "string_key": "string_secret",
+            42: "int_secret",
+            (1, "tuple"): "tuple_secret",
+            date(2023, 8, 14): "date_secret",
+            UUID("12345678-1234-5678-1234-567812345678"): "uuid_secret",
+        }
+
+        for key, value in secret_map.value.items():
+            assert isinstance(value, PydanticSecret)
+            assert value.get_secret_value() == secret_map.get()[key]
+
+    def test_secret_map_with_invalid_input(self):
+        with pytest.raises(ValueError, match="`value`|must be a mapping"):
+            SecretMap(value="not a mapping")
+
+    def test_secret_map_with_non_hashable_key(self):
+        with pytest.raises(TypeError, match="unhashable"):
+            SecretMap(value={[1, 2, 3]: "value"})

--- a/tests/blocks/test_system.py
+++ b/tests/blocks/test_system.py
@@ -1,13 +1,10 @@
-from datetime import date
-from uuid import UUID
-
 import pendulum
 import pytest
 from pydantic import Secret as PydanticSecret
 from pydantic import SecretStr
 from pydantic_extra_types.pendulum_dt import DateTime as PydanticDateTime
 
-from prefect.blocks.system import DateTime, Secret, SecretMap
+from prefect.blocks.system import DateTime, Secret
 
 
 def test_datetime():
@@ -18,69 +15,29 @@ def test_datetime():
 
 @pytest.mark.parametrize(
     "value",
-    ["test", SecretStr("test")],
-    ids=["string", "secret_str"],
+    ["test", {"key": "value"}, ["test"]],
+    ids=["string", "dict", "list"],
 )
 def test_secret_block(value):
     Secret(value=value).save(name="test")
     api_block = Secret.load("test")
-    assert isinstance(api_block.value, SecretStr)
+    assert isinstance(api_block.value, PydanticSecret)
 
-    assert api_block.get() == "test"
+    assert api_block.get() == value
 
 
-class TestSecretMap:
-    @pytest.mark.parametrize(
-        "key, value",
-        [
-            # (1, "int_secret"),
-            (3.14, "float_secret"),
-            ("string_key", "string_secret"),
-            ((1, "tuple"), "tuple_secret"),
-        ],
-    )
-    def test_secret_map_with_various_hashable_types(self, key, value):
-        secret_map = SecretMap(value={key: value})
+@pytest.mark.parametrize(
+    "value",
+    [
+        SecretStr("test"),
+        PydanticSecret[dict]({"key": "value"}),
+        PydanticSecret[list](["test"]),
+    ],
+    ids=["secret_string", "secret_dict", "secret_list"],
+)
+def test_secret_block_with_pydantic_secret(value):
+    Secret(value=value).save(name="test")
+    api_block = Secret.load("test")
+    assert isinstance(api_block.value, PydanticSecret)
 
-        secret_map.save(name="test")
-
-        assert secret_map.get()[key] == value
-
-        assert isinstance(secret_map.value[key], PydanticSecret)
-
-        assert secret_map.value[key].get_secret_value() == value
-
-        breakpoint()
-
-        assert SecretMap.load("test") == secret_map, secret_map.value
-
-    def test_secret_map_with_multiple_pairs(self):
-        secret_map = SecretMap(
-            value={
-                "string_key": "string_secret",
-                42: "int_secret",
-                (1, "tuple"): "tuple_secret",
-                date(2023, 8, 14): "date_secret",
-                UUID("12345678-1234-5678-1234-567812345678"): "uuid_secret",
-            }
-        )
-
-        assert secret_map.get() == {
-            "string_key": "string_secret",
-            42: "int_secret",
-            (1, "tuple"): "tuple_secret",
-            date(2023, 8, 14): "date_secret",
-            UUID("12345678-1234-5678-1234-567812345678"): "uuid_secret",
-        }
-
-        for key, value in secret_map.value.items():
-            assert isinstance(value, PydanticSecret)
-            assert value.get_secret_value() == secret_map.get()[key]
-
-    def test_secret_map_with_invalid_input(self):
-        with pytest.raises(ValueError, match="`value`|must be a mapping"):
-            SecretMap(value="not a mapping")
-
-    def test_secret_map_with_non_hashable_key(self):
-        with pytest.raises(TypeError, match="unhashable"):
-            SecretMap(value={[1, 2, 3]: "value"})
+    assert api_block.get() == value.get_secret_value()


### PR DESCRIPTION
this PR closes #14899 by allowing any `JSON` value (i.e. strings, lists, dictionaries) to be stored as a secret

<details>
<summary>examples</summary>

![image](https://github.com/user-attachments/assets/8749a535-2e23-4344-a3d3-3b45637ce567)
![image](https://github.com/user-attachments/assets/5fe4369b-b0c7-40a6-931b-1130526be1bc)
![image](https://github.com/user-attachments/assets/38713f55-871c-4c08-a297-f160b11a0126)
```python
In [2]: Secret.load('test').get()
Out[2]: [1, 2, 3]

In [3]: type(_)
Out[3]: list
```

```python
from pydantic import Secret as PydanticSecret

from prefect.blocks.system import Secret

Secret(value={"key": "value"}).save("secret-block", overwrite=True)

secret_block = Secret.load("secret-block")

assert secret_block.get() == {"key": "value"}
assert secret_block.value == PydanticSecret[dict]({"key": "value"})
```

</details>

---

this PR should _not_ change any behavior for current users of `Secret`, including [this outstanding issue](https://github.com/PrefectHQ/prefect/issues/6949) about stripping newlines