### PR TITLE
Ensures that server automations schemas are parsed with only server models

### DIFF
--- a/docs/3.0rc/api-ref/rest-api/server/schema.json
+++ b/docs/3.0rc/api-ref/rest-api/server/schema.json
@@ -10742,13 +10742,13 @@
                     "trigger": {
                         "anyOf": [
                             {
-                                "$ref": "#/components/schemas/prefect__server__events__schemas__automations__EventTrigger"
+                                "$ref": "#/components/schemas/EventTrigger"
                             },
                             {
-                                "$ref": "#/components/schemas/prefect__server__events__schemas__automations__CompoundTrigger-Output"
+                                "$ref": "#/components/schemas/CompoundTrigger-Output"
                             },
                             {
-                                "$ref": "#/components/schemas/prefect__server__events__schemas__automations__SequenceTrigger-Output"
+                                "$ref": "#/components/schemas/SequenceTrigger-Output"
                             }
                         ],
                         "title": "Trigger",
@@ -10976,13 +10976,13 @@
                     "trigger": {
                         "anyOf": [
                             {
-                                "$ref": "#/components/schemas/prefect__server__events__schemas__automations__EventTrigger"
+                                "$ref": "#/components/schemas/EventTrigger"
                             },
                             {
-                                "$ref": "#/components/schemas/prefect__server__events__schemas__automations__CompoundTrigger-Input"
+                                "$ref": "#/components/schemas/CompoundTrigger-Input"
                             },
                             {
-                                "$ref": "#/components/schemas/prefect__server__events__schemas__automations__SequenceTrigger-Input"
+                                "$ref": "#/components/schemas/SequenceTrigger-Input"
                             }
                         ],
                         "title": "Trigger",
@@ -11300,13 +11300,13 @@
                     "trigger": {
                         "anyOf": [
                             {
-                                "$ref": "#/components/schemas/prefect__server__events__schemas__automations__EventTrigger"
+                                "$ref": "#/components/schemas/EventTrigger"
                             },
                             {
-                                "$ref": "#/components/schemas/prefect__server__events__schemas__automations__CompoundTrigger-Input"
+                                "$ref": "#/components/schemas/CompoundTrigger-Input"
                             },
                             {
-                                "$ref": "#/components/schemas/prefect__server__events__schemas__automations__SequenceTrigger-Input"
+                                "$ref": "#/components/schemas/SequenceTrigger-Input"
                             }
                         ],
                         "title": "Trigger",
@@ -14815,6 +14815,146 @@
                 "title": "ChangeFlowRunState",
                 "description": "Changes the state of a flow run associated with the trigger"
             },
+            "CompoundTrigger-Input": {
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "compound"
+                        ],
+                        "const": "compound",
+                        "title": "Type",
+                        "default": "compound"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id",
+                        "description": "The unique ID of this trigger"
+                    },
+                    "triggers": {
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/EventTrigger"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/CompoundTrigger-Input"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/SequenceTrigger-Input"
+                                }
+                            ]
+                        },
+                        "type": "array",
+                        "title": "Triggers"
+                    },
+                    "within": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Within"
+                    },
+                    "require": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "any",
+                                    "all"
+                                ]
+                            }
+                        ],
+                        "title": "Require"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "triggers",
+                    "within",
+                    "require"
+                ],
+                "title": "CompoundTrigger",
+                "description": "A composite trigger that requires some number of triggers to have\nfired within the given time period"
+            },
+            "CompoundTrigger-Output": {
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "compound"
+                        ],
+                        "const": "compound",
+                        "title": "Type",
+                        "default": "compound"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id",
+                        "description": "The unique ID of this trigger"
+                    },
+                    "triggers": {
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/EventTrigger"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/CompoundTrigger-Output"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/SequenceTrigger-Output"
+                                }
+                            ]
+                        },
+                        "type": "array",
+                        "title": "Triggers"
+                    },
+                    "within": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Within"
+                    },
+                    "require": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "any",
+                                    "all"
+                                ]
+                            }
+                        ],
+                        "title": "Require"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "triggers",
+                    "within",
+                    "require"
+                ],
+                "title": "CompoundTrigger",
+                "description": "A composite trigger that requires some number of triggers to have\nfired within the given time period"
+            },
             "ConcurrencyLimit": {
                 "properties": {
                     "id": {
@@ -17378,6 +17518,95 @@
                 "additionalProperties": false,
                 "type": "object",
                 "title": "EventResourceFilter"
+            },
+            "EventTrigger": {
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "event"
+                        ],
+                        "const": "event",
+                        "title": "Type",
+                        "default": "event"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id",
+                        "description": "The unique ID of this trigger"
+                    },
+                    "match": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ResourceSpecification"
+                            }
+                        ],
+                        "description": "Labels for resources which this trigger will match."
+                    },
+                    "match_related": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ResourceSpecification"
+                            }
+                        ],
+                        "description": "Labels for related resources which this trigger will match."
+                    },
+                    "after": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": true,
+                        "title": "After",
+                        "description": "The event(s) which must first been seen to fire this trigger.  If empty, then fire this trigger immediately.  Events may include trailing wildcards, like `prefect.flow-run.*`"
+                    },
+                    "expect": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": true,
+                        "title": "Expect",
+                        "description": "The event(s) this trigger is expecting to see.  If empty, this trigger will match any event.  Events may include trailing wildcards, like `prefect.flow-run.*`"
+                    },
+                    "for_each": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": true,
+                        "title": "For Each",
+                        "description": "Evaluate the trigger separately for each distinct value of these labels on the resource.  By default, labels refer to the primary resource of the triggering event.  You may also refer to labels from related resources by specifying `related:<role>:<label>`.  This will use the value of that label for the first related resource in that role.  For example, `\"for_each\": [\"related:flow:prefect.resource.id\"]` would evaluate the trigger for each flow."
+                    },
+                    "posture": {
+                        "type": "string",
+                        "enum": [
+                            "Reactive",
+                            "Proactive"
+                        ],
+                        "title": "Posture",
+                        "description": "The posture of this trigger, either Reactive or Proactive.  Reactive triggers respond to the _presence_ of the expected events, while Proactive triggers respond to the _absence_ of those expected events."
+                    },
+                    "threshold": {
+                        "type": "integer",
+                        "title": "Threshold",
+                        "description": "The number of events required for this trigger to fire (for Reactive triggers), or the number of events expected (for Proactive triggers)",
+                        "default": 1
+                    },
+                    "within": {
+                        "type": "number",
+                        "title": "Within",
+                        "description": "The time period over which the events must occur.  For Reactive triggers, this may be as low as 0 seconds, but must be at least 10 seconds for Proactive triggers",
+                        "default": 0.0
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "posture"
+                ],
+                "title": "EventTrigger",
+                "description": "A trigger that fires based on the presence or absence of events within a given\nperiod of time."
             },
             "Flow": {
                 "properties": {
@@ -20579,167 +20808,6 @@
                 "title": "LogSort",
                 "description": "Defines log sorting options."
             },
-            "MetricTrigger-Input": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "metric"
-                        ],
-                        "const": "metric",
-                        "title": "Type",
-                        "default": "metric"
-                    },
-                    "match": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ResourceSpecification"
-                            }
-                        ],
-                        "description": "Labels for resources which this trigger will match."
-                    },
-                    "match_related": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ResourceSpecification"
-                            }
-                        ],
-                        "description": "Labels for related resources which this trigger will match."
-                    },
-                    "posture": {
-                        "type": "string",
-                        "enum": [
-                            "Metric"
-                        ],
-                        "const": "Metric",
-                        "title": "Posture",
-                        "description": "Periodically evaluate the configured metric query.",
-                        "default": "Metric"
-                    },
-                    "metric": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/MetricTriggerQuery"
-                            }
-                        ],
-                        "description": "The metric query to evaluate for this trigger. "
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "metric"
-                ],
-                "title": "MetricTrigger",
-                "description": "A trigger that fires based on the results of a metric query."
-            },
-            "MetricTrigger-Output": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "metric"
-                        ],
-                        "const": "metric",
-                        "title": "Type",
-                        "default": "metric"
-                    },
-                    "match": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ResourceSpecification"
-                            }
-                        ],
-                        "description": "Labels for resources which this trigger will match."
-                    },
-                    "match_related": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ResourceSpecification"
-                            }
-                        ],
-                        "description": "Labels for related resources which this trigger will match."
-                    },
-                    "posture": {
-                        "type": "string",
-                        "enum": [
-                            "Metric"
-                        ],
-                        "const": "Metric",
-                        "title": "Posture",
-                        "description": "Periodically evaluate the configured metric query.",
-                        "default": "Metric"
-                    },
-                    "metric": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/MetricTriggerQuery"
-                            }
-                        ],
-                        "description": "The metric query to evaluate for this trigger. "
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "metric"
-                ],
-                "title": "MetricTrigger",
-                "description": "A trigger that fires based on the results of a metric query."
-            },
-            "MetricTriggerOperator": {
-                "type": "string",
-                "enum": [
-                    "<",
-                    "<=",
-                    ">",
-                    ">="
-                ],
-                "title": "MetricTriggerOperator"
-            },
-            "MetricTriggerQuery": {
-                "properties": {
-                    "name": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/PrefectMetric"
-                            }
-                        ],
-                        "description": "The name of the metric to query."
-                    },
-                    "threshold": {
-                        "type": "number",
-                        "title": "Threshold",
-                        "description": "The threshold value against which we'll compare the query result."
-                    },
-                    "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/MetricTriggerOperator"
-                            }
-                        ],
-                        "description": "The comparative operator (LT / LTE / GT / GTE) used to compare the query result against the threshold value."
-                    },
-                    "range": {
-                        "type": "number",
-                        "title": "Range",
-                        "description": "The lookback duration (seconds) for a metric query. This duration is used to determine the time range over which the query will be executed. The minimum value is 300 seconds (5 minutes).",
-                        "default": 300.0
-                    },
-                    "firing_for": {
-                        "type": "number",
-                        "title": "Firing For",
-                        "description": "The duration (seconds) for which the metric query must breach or resolve continuously before the state is updated and the automation is triggered. The minimum value is 300 seconds (5 minutes).",
-                        "default": 300.0
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "name",
-                    "threshold",
-                    "operator"
-                ],
-                "title": "MetricTriggerQuery",
-                "description": "Defines a subset of the Trigger subclass, which is specific\nto Metric automations, that specify the query configurations\nand breaching conditions for the Automation"
-            },
             "MinimalConcurrencyLimitResponse": {
                 "properties": {
                     "id": {
@@ -21076,15 +21144,6 @@
                 "type": "object",
                 "title": "PauseWorkQueue",
                 "description": "Pauses a Work Queue"
-            },
-            "PrefectMetric": {
-                "type": "string",
-                "enum": [
-                    "lateness",
-                    "duration",
-                    "successes"
-                ],
-                "title": "PrefectMetric"
             },
             "QueueFilter": {
                 "properties": {
@@ -21627,6 +21686,114 @@
                 ],
                 "title": "SendNotification",
                 "description": "Send a notification when an Automation is triggered"
+            },
+            "SequenceTrigger-Input": {
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "sequence"
+                        ],
+                        "const": "sequence",
+                        "title": "Type",
+                        "default": "sequence"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id",
+                        "description": "The unique ID of this trigger"
+                    },
+                    "triggers": {
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/EventTrigger"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/CompoundTrigger-Input"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/SequenceTrigger-Input"
+                                }
+                            ]
+                        },
+                        "type": "array",
+                        "title": "Triggers"
+                    },
+                    "within": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Within"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "triggers",
+                    "within"
+                ],
+                "title": "SequenceTrigger",
+                "description": "A composite trigger that requires some number of triggers to have fired\nwithin the given time period in a specific order"
+            },
+            "SequenceTrigger-Output": {
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "sequence"
+                        ],
+                        "const": "sequence",
+                        "title": "Type",
+                        "default": "sequence"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id",
+                        "description": "The unique ID of this trigger"
+                    },
+                    "triggers": {
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/EventTrigger"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/CompoundTrigger-Output"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/SequenceTrigger-Output"
+                                }
+                            ]
+                        },
+                        "type": "array",
+                        "title": "Triggers"
+                    },
+                    "within": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Within"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "triggers",
+                    "within"
+                ],
+                "title": "SequenceTrigger",
+                "description": "A composite trigger that requires some number of triggers to have fired\nwithin the given time period in a specific order"
             },
             "SetStateStatus": {
                 "type": "string",
@@ -25860,672 +26027,6 @@
                 ],
                 "title": "WorkerStatus",
                 "description": "Enumeration of worker statuses."
-            },
-            "prefect__events__schemas__automations__CompoundTrigger-Input": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "compound"
-                        ],
-                        "const": "compound",
-                        "title": "Type",
-                        "default": "compound"
-                    },
-                    "triggers": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__EventTrigger"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/MetricTrigger-Input"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__CompoundTrigger-Input"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__SequenceTrigger-Input"
-                                }
-                            ]
-                        },
-                        "type": "array",
-                        "title": "Triggers"
-                    },
-                    "within": {
-                        "anyOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Within",
-                        "description": "The time period over which the events must occur.  For Reactive triggers, this may be as low as 0 seconds, but must be at least 10 seconds for Proactive triggers"
-                    },
-                    "require": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "string",
-                                "enum": [
-                                    "any",
-                                    "all"
-                                ]
-                            }
-                        ],
-                        "title": "Require"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "triggers",
-                    "require"
-                ],
-                "title": "CompoundTrigger",
-                "description": "A composite trigger that requires some number of triggers to have\nfired within the given time period"
-            },
-            "prefect__events__schemas__automations__CompoundTrigger-Output": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "compound"
-                        ],
-                        "const": "compound",
-                        "title": "Type",
-                        "default": "compound"
-                    },
-                    "triggers": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__EventTrigger"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/MetricTrigger-Output"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__CompoundTrigger-Output"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__SequenceTrigger-Output"
-                                }
-                            ]
-                        },
-                        "type": "array",
-                        "title": "Triggers"
-                    },
-                    "within": {
-                        "anyOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Within",
-                        "description": "The time period over which the events must occur.  For Reactive triggers, this may be as low as 0 seconds, but must be at least 10 seconds for Proactive triggers"
-                    },
-                    "require": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "string",
-                                "enum": [
-                                    "any",
-                                    "all"
-                                ]
-                            }
-                        ],
-                        "title": "Require"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "triggers",
-                    "require"
-                ],
-                "title": "CompoundTrigger",
-                "description": "A composite trigger that requires some number of triggers to have\nfired within the given time period"
-            },
-            "prefect__events__schemas__automations__EventTrigger": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "event"
-                        ],
-                        "const": "event",
-                        "title": "Type",
-                        "default": "event"
-                    },
-                    "match": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ResourceSpecification"
-                            }
-                        ],
-                        "description": "Labels for resources which this trigger will match."
-                    },
-                    "match_related": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ResourceSpecification"
-                            }
-                        ],
-                        "description": "Labels for related resources which this trigger will match."
-                    },
-                    "after": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": true,
-                        "title": "After",
-                        "description": "The event(s) which must first been seen to fire this trigger.  If empty, then fire this trigger immediately.  Events may include trailing wildcards, like `prefect.flow-run.*`"
-                    },
-                    "expect": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": true,
-                        "title": "Expect",
-                        "description": "The event(s) this trigger is expecting to see.  If empty, this trigger will match any event.  Events may include trailing wildcards, like `prefect.flow-run.*`"
-                    },
-                    "for_each": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": true,
-                        "title": "For Each",
-                        "description": "Evaluate the trigger separately for each distinct value of these labels on the resource.  By default, labels refer to the primary resource of the triggering event.  You may also refer to labels from related resources by specifying `related:<role>:<label>`.  This will use the value of that label for the first related resource in that role.  For example, `\"for_each\": [\"related:flow:prefect.resource.id\"]` would evaluate the trigger for each flow."
-                    },
-                    "posture": {
-                        "type": "string",
-                        "enum": [
-                            "Reactive",
-                            "Proactive"
-                        ],
-                        "title": "Posture",
-                        "description": "The posture of this trigger, either Reactive or Proactive.  Reactive triggers respond to the _presence_ of the expected events, while Proactive triggers respond to the _absence_ of those expected events.",
-                        "default": "Reactive"
-                    },
-                    "threshold": {
-                        "type": "integer",
-                        "title": "Threshold",
-                        "description": "The number of events required for this trigger to fire (for Reactive triggers), or the number of events expected (for Proactive triggers)",
-                        "default": 1
-                    },
-                    "within": {
-                        "type": "number",
-                        "title": "Within",
-                        "description": "The time period over which the events must occur.  For Reactive triggers, this may be as low as 0 seconds, but must be at least 10 seconds for Proactive triggers",
-                        "default": 0.0
-                    }
-                },
-                "type": "object",
-                "title": "EventTrigger",
-                "description": "A trigger that fires based on the presence or absence of events within a given\nperiod of time."
-            },
-            "prefect__events__schemas__automations__SequenceTrigger-Input": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "sequence"
-                        ],
-                        "const": "sequence",
-                        "title": "Type",
-                        "default": "sequence"
-                    },
-                    "triggers": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__EventTrigger"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/MetricTrigger-Input"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__CompoundTrigger-Input"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__SequenceTrigger-Input"
-                                }
-                            ]
-                        },
-                        "type": "array",
-                        "title": "Triggers"
-                    },
-                    "within": {
-                        "anyOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Within",
-                        "description": "The time period over which the events must occur.  For Reactive triggers, this may be as low as 0 seconds, but must be at least 10 seconds for Proactive triggers"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "triggers"
-                ],
-                "title": "SequenceTrigger",
-                "description": "A composite trigger that requires some number of triggers to have fired\nwithin the given time period in a specific order"
-            },
-            "prefect__events__schemas__automations__SequenceTrigger-Output": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "sequence"
-                        ],
-                        "const": "sequence",
-                        "title": "Type",
-                        "default": "sequence"
-                    },
-                    "triggers": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__EventTrigger"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/MetricTrigger-Output"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__CompoundTrigger-Output"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__SequenceTrigger-Output"
-                                }
-                            ]
-                        },
-                        "type": "array",
-                        "title": "Triggers"
-                    },
-                    "within": {
-                        "anyOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Within",
-                        "description": "The time period over which the events must occur.  For Reactive triggers, this may be as low as 0 seconds, but must be at least 10 seconds for Proactive triggers"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "triggers"
-                ],
-                "title": "SequenceTrigger",
-                "description": "A composite trigger that requires some number of triggers to have fired\nwithin the given time period in a specific order"
-            },
-            "prefect__server__events__schemas__automations__CompoundTrigger-Input": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "compound"
-                        ],
-                        "const": "compound",
-                        "title": "Type",
-                        "default": "compound"
-                    },
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Id",
-                        "description": "The unique ID of this trigger"
-                    },
-                    "triggers": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__EventTrigger"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/MetricTrigger-Input"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__CompoundTrigger-Input"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__SequenceTrigger-Input"
-                                }
-                            ]
-                        },
-                        "type": "array",
-                        "title": "Triggers"
-                    },
-                    "within": {
-                        "anyOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Within"
-                    },
-                    "require": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "string",
-                                "enum": [
-                                    "any",
-                                    "all"
-                                ]
-                            }
-                        ],
-                        "title": "Require"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "triggers",
-                    "within",
-                    "require"
-                ],
-                "title": "CompoundTrigger",
-                "description": "A composite trigger that requires some number of triggers to have\nfired within the given time period"
-            },
-            "prefect__server__events__schemas__automations__CompoundTrigger-Output": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "compound"
-                        ],
-                        "const": "compound",
-                        "title": "Type",
-                        "default": "compound"
-                    },
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Id",
-                        "description": "The unique ID of this trigger"
-                    },
-                    "triggers": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__EventTrigger"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/MetricTrigger-Output"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__CompoundTrigger-Output"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__SequenceTrigger-Output"
-                                }
-                            ]
-                        },
-                        "type": "array",
-                        "title": "Triggers"
-                    },
-                    "within": {
-                        "anyOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Within"
-                    },
-                    "require": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "string",
-                                "enum": [
-                                    "any",
-                                    "all"
-                                ]
-                            }
-                        ],
-                        "title": "Require"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "triggers",
-                    "within",
-                    "require"
-                ],
-                "title": "CompoundTrigger",
-                "description": "A composite trigger that requires some number of triggers to have\nfired within the given time period"
-            },
-            "prefect__server__events__schemas__automations__EventTrigger": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "event"
-                        ],
-                        "const": "event",
-                        "title": "Type",
-                        "default": "event"
-                    },
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Id",
-                        "description": "The unique ID of this trigger"
-                    },
-                    "match": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ResourceSpecification"
-                            }
-                        ],
-                        "description": "Labels for resources which this trigger will match."
-                    },
-                    "match_related": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ResourceSpecification"
-                            }
-                        ],
-                        "description": "Labels for related resources which this trigger will match."
-                    },
-                    "after": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": true,
-                        "title": "After",
-                        "description": "The event(s) which must first been seen to fire this trigger.  If empty, then fire this trigger immediately.  Events may include trailing wildcards, like `prefect.flow-run.*`"
-                    },
-                    "expect": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": true,
-                        "title": "Expect",
-                        "description": "The event(s) this trigger is expecting to see.  If empty, this trigger will match any event.  Events may include trailing wildcards, like `prefect.flow-run.*`"
-                    },
-                    "for_each": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": true,
-                        "title": "For Each",
-                        "description": "Evaluate the trigger separately for each distinct value of these labels on the resource.  By default, labels refer to the primary resource of the triggering event.  You may also refer to labels from related resources by specifying `related:<role>:<label>`.  This will use the value of that label for the first related resource in that role.  For example, `\"for_each\": [\"related:flow:prefect.resource.id\"]` would evaluate the trigger for each flow."
-                    },
-                    "posture": {
-                        "type": "string",
-                        "enum": [
-                            "Reactive",
-                            "Proactive"
-                        ],
-                        "title": "Posture",
-                        "description": "The posture of this trigger, either Reactive or Proactive.  Reactive triggers respond to the _presence_ of the expected events, while Proactive triggers respond to the _absence_ of those expected events."
-                    },
-                    "threshold": {
-                        "type": "integer",
-                        "title": "Threshold",
-                        "description": "The number of events required for this trigger to fire (for Reactive triggers), or the number of events expected (for Proactive triggers)",
-                        "default": 1
-                    },
-                    "within": {
-                        "type": "number",
-                        "title": "Within",
-                        "description": "The time period over which the events must occur.  For Reactive triggers, this may be as low as 0 seconds, but must be at least 10 seconds for Proactive triggers",
-                        "default": 0.0
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "posture"
-                ],
-                "title": "EventTrigger",
-                "description": "A trigger that fires based on the presence or absence of events within a given\nperiod of time."
-            },
-            "prefect__server__events__schemas__automations__SequenceTrigger-Input": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "sequence"
-                        ],
-                        "const": "sequence",
-                        "title": "Type",
-                        "default": "sequence"
-                    },
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Id",
-                        "description": "The unique ID of this trigger"
-                    },
-                    "triggers": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__EventTrigger"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/MetricTrigger-Input"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__CompoundTrigger-Input"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__SequenceTrigger-Input"
-                                }
-                            ]
-                        },
-                        "type": "array",
-                        "title": "Triggers"
-                    },
-                    "within": {
-                        "anyOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Within"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "triggers",
-                    "within"
-                ],
-                "title": "SequenceTrigger",
-                "description": "A composite trigger that requires some number of triggers to have fired\nwithin the given time period in a specific order"
-            },
-            "prefect__server__events__schemas__automations__SequenceTrigger-Output": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "sequence"
-                        ],
-                        "const": "sequence",
-                        "title": "Type",
-                        "default": "sequence"
-                    },
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Id",
-                        "description": "The unique ID of this trigger"
-                    },
-                    "triggers": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__EventTrigger"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/MetricTrigger-Output"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__CompoundTrigger-Output"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/prefect__events__schemas__automations__SequenceTrigger-Output"
-                                }
-                            ]
-                        },
-                        "type": "array",
-                        "title": "Triggers"
-                    },
-                    "within": {
-                        "anyOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Within"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "triggers",
-                    "within"
-                ],
-                "title": "SequenceTrigger",
-                "description": "A composite trigger that requires some number of triggers to have fired\nwithin the given time period in a specific order"
             }
         }
     }

--- a/src/prefect/server/database/migrations/versions/postgresql/2024_04_03_112409_aeea5ee6f070_automations_models.py
+++ b/src/prefect/server/database/migrations/versions/postgresql/2024_04_03_112409_aeea5ee6f070_automations_models.py
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 from alembic import op
 
 import prefect
-from prefect.server.events.actions import ActionTypes
-from prefect.server.events.schemas.automations import Firing, TriggerTypes
+from prefect.server.events.actions import ServerActionTypes
+from prefect.server.events.schemas.automations import Firing, ServerTriggerTypes
 from prefect.server.events.schemas.events import ReceivedEvent
 
 # revision identifiers, used by Alembic.
@@ -32,23 +32,23 @@ def upgrade():
         sa.Column("enabled", sa.Boolean(), server_default="1", nullable=False),
         sa.Column(
             "trigger",
-            prefect.server.utilities.database.Pydantic(TriggerTypes),
+            prefect.server.utilities.database.Pydantic(ServerTriggerTypes),
             nullable=False,
         ),
         sa.Column(
             "actions",
-            prefect.server.utilities.database.Pydantic(List[ActionTypes]),
+            prefect.server.utilities.database.Pydantic(List[ServerActionTypes]),
             nullable=False,
         ),
         sa.Column(
             "actions_on_trigger",
-            prefect.server.utilities.database.Pydantic(List[ActionTypes]),
+            prefect.server.utilities.database.Pydantic(List[ServerActionTypes]),
             server_default="[]",
             nullable=False,
         ),
         sa.Column(
             "actions_on_resolve",
-            prefect.server.utilities.database.Pydantic(List[ActionTypes]),
+            prefect.server.utilities.database.Pydantic(List[ServerActionTypes]),
             server_default="[]",
             nullable=False,
         ),

--- a/src/prefect/server/database/migrations/versions/sqlite/2024_04_03_111618_07ed05dfd4ec_automations_models.py
+++ b/src/prefect/server/database/migrations/versions/sqlite/2024_04_03_111618_07ed05dfd4ec_automations_models.py
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 from alembic import op
 
 import prefect
-from prefect.server.events.actions import ActionTypes
-from prefect.server.events.schemas.automations import Firing, TriggerTypes
+from prefect.server.events.actions import ServerActionTypes
+from prefect.server.events.schemas.automations import Firing, ServerTriggerTypes
 from prefect.server.events.schemas.events import ReceivedEvent
 
 # revision identifiers, used by Alembic.
@@ -31,23 +31,23 @@ def upgrade():
         sa.Column("enabled", sa.Boolean(), server_default="1", nullable=False),
         sa.Column(
             "trigger",
-            prefect.server.utilities.database.Pydantic(TriggerTypes),
+            prefect.server.utilities.database.Pydantic(ServerTriggerTypes),
             nullable=False,
         ),
         sa.Column(
             "actions",
-            prefect.server.utilities.database.Pydantic(List[ActionTypes]),
+            prefect.server.utilities.database.Pydantic(List[ServerActionTypes]),
             nullable=False,
         ),
         sa.Column(
             "actions_on_trigger",
-            prefect.server.utilities.database.Pydantic(List[ActionTypes]),
+            prefect.server.utilities.database.Pydantic(List[ServerActionTypes]),
             server_default="[]",
             nullable=False,
         ),
         sa.Column(
             "actions_on_resolve",
-            prefect.server.utilities.database.Pydantic(List[ActionTypes]),
+            prefect.server.utilities.database.Pydantic(List[ServerActionTypes]),
             server_default="[]",
             nullable=False,
         ),

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -21,11 +21,11 @@ from sqlalchemy.sql.functions import coalesce
 
 import prefect
 import prefect.server.schemas as schemas
-from prefect.server.events.actions import ActionTypes
+from prefect.server.events.actions import ServerActionTypes
 from prefect.server.events.schemas.automations import (
     AutomationSort,
     Firing,
-    TriggerTypes,
+    ServerTriggerTypes,
 )
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.schemas.statuses import (
@@ -1318,14 +1318,20 @@ class Automation(Base):
 
     enabled = sa.Column(sa.Boolean, nullable=False, server_default="1", default=True)
 
-    trigger = sa.Column(Pydantic(TriggerTypes), nullable=False)
+    trigger = sa.Column(Pydantic(ServerTriggerTypes), nullable=False)
 
-    actions = sa.Column(Pydantic(List[ActionTypes]), nullable=False)
+    actions = sa.Column(Pydantic(List[ServerActionTypes]), nullable=False)
     actions_on_trigger = sa.Column(
-        Pydantic(List[ActionTypes]), server_default="[]", default=list, nullable=False
+        Pydantic(List[ServerActionTypes]),
+        server_default="[]",
+        default=list,
+        nullable=False,
     )
     actions_on_resolve = sa.Column(
-        Pydantic(List[ActionTypes]), server_default="[]", default=list, nullable=False
+        Pydantic(List[ServerActionTypes]),
+        server_default="[]",
+        default=list,
+        nullable=False,
     )
 
     related_resources = sa.orm.relationship(

--- a/src/prefect/server/events/actions.py
+++ b/src/prefect/server/events/actions.py
@@ -1575,7 +1575,7 @@ class ResumeAutomation(AutomationCommandAction):
 # The actual action types that we support.  It's important to update this
 # Union when adding new subclasses of Action so that they are available for clients
 # and in the OpenAPI docs
-ActionTypes: TypeAlias = Union[
+ServerActionTypes: TypeAlias = Union[
     DoNothing,
     RunDeployment,
     PauseDeployment,

--- a/src/prefect/server/events/schemas/automations.py
+++ b/src/prefect/server/events/schemas/automations.py
@@ -29,7 +29,7 @@ from pydantic_extra_types.pendulum_dt import DateTime
 from typing_extensions import Self, TypeAlias
 
 from prefect.logging import get_logger
-from prefect.server.events.actions import ActionTypes
+from prefect.server.events.actions import ServerActionTypes
 from prefect.server.events.schemas.events import (
     ReceivedEvent,
     RelatedResource,
@@ -115,7 +115,7 @@ class CompositeTrigger(Trigger, abc.ABC):
     """
 
     type: Literal["compound", "sequence"]
-    triggers: List["TriggerTypes"]
+    triggers: List["ServerTriggerTypes"]
     within: Optional[timedelta]
 
     def create_automation_state_change_event(
@@ -456,7 +456,7 @@ class EventTrigger(ResourceTrigger):
         )
 
 
-TriggerTypes: TypeAlias = Union[EventTrigger, CompoundTrigger, SequenceTrigger]
+ServerTriggerTypes: TypeAlias = Union[EventTrigger, CompoundTrigger, SequenceTrigger]
 """The union of all concrete trigger types that a user may actually create"""
 
 T = TypeVar("T", bound=Trigger)
@@ -471,7 +471,7 @@ class AutomationCore(PrefectBaseModel, extra="ignore"):
 
     enabled: bool = Field(True, description="Whether this automation will be evaluated")
 
-    trigger: TriggerTypes = Field(
+    trigger: ServerTriggerTypes = Field(
         ...,
         description=(
             "The criteria for which events this Automation covers and how it will "
@@ -479,17 +479,17 @@ class AutomationCore(PrefectBaseModel, extra="ignore"):
         ),
     )
 
-    actions: List[ActionTypes] = Field(
+    actions: List[ServerActionTypes] = Field(
         ...,
         description="The actions to perform when this Automation triggers",
     )
 
-    actions_on_trigger: List[ActionTypes] = Field(
+    actions_on_trigger: List[ServerActionTypes] = Field(
         default_factory=list,
         description="The actions to perform when an Automation goes into a triggered state",
     )
 
-    actions_on_resolve: List[ActionTypes] = Field(
+    actions_on_resolve: List[ServerActionTypes] = Field(
         default_factory=list,
         description="The actions to perform when an Automation goes into a resolving state",
     )
@@ -625,7 +625,7 @@ class Firing(PrefectBaseModel):
 
     id: UUID = Field(default_factory=uuid4)
 
-    trigger: TriggerTypes = Field(..., description="The trigger that is firing")
+    trigger: ServerTriggerTypes = Field(..., description="The trigger that is firing")
     trigger_states: Set[TriggerState] = Field(
         ...,
         description="The state changes represented by this Firing",
@@ -722,7 +722,7 @@ class TriggeredAction(PrefectBaseModel):
             "if there was one."
         ),
     )
-    action: ActionTypes = Field(
+    action: ServerActionTypes = Field(
         ...,
         description="The action to perform",
     )

--- a/src/prefect/server/events/triggers.py
+++ b/src/prefect/server/events/triggers.py
@@ -27,7 +27,7 @@ from prefect.logging import get_logger
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.events import messaging
-from prefect.server.events.actions import ActionTypes
+from prefect.server.events.actions import ServerActionTypes
 from prefect.server.events.models.automations import (
     automations_session,
     read_automation,
@@ -306,7 +306,7 @@ async def act(firing: Firing):
     await messaging.publish(state_change_events.values())
 
     # By default, all `automation.actions` are fired
-    source_actions: List[Tuple[Optional[ReceivedEvent], ActionTypes]] = [
+    source_actions: List[Tuple[Optional[ReceivedEvent], ServerActionTypes]] = [
         (firing.triggering_event, action) for action in automation.actions
     ]
 

--- a/tests/events/server/actions/test_calling_webhook.py
+++ b/tests/events/server/actions/test_calling_webhook.py
@@ -398,7 +398,7 @@ async def test_migrating_to_templates():
     assert isinstance(action.payload, str)
     assert action.payload == '{\n  "message": "hello world"\n}'
 
-    actions_adapter = TypeAdapter(actions.ActionTypes)
+    actions_adapter = TypeAdapter(actions.ServerActionTypes)
 
     # The form it will be when read from the database
     action = actions_adapter.validate_python(

--- a/tests/events/server/schemas/test_automations.py
+++ b/tests/events/server/schemas/test_automations.py
@@ -1,8 +1,10 @@
+import json
 from datetime import timedelta
 
 import pytest
 
 from prefect.server.events.schemas.automations import (
+    AutomationCreate,
     CompoundTrigger,
     EventTrigger,
     Posture,
@@ -62,3 +64,84 @@ async def test_compound_trigger_requires_too_big():
             require=3,
             within=timedelta(seconds=10),
         )
+
+
+def test_server_composite_triggers_validate_to_server_triggers():
+    """
+    Test that server-side composite triggers validate to server-side child triggers.
+
+    This is a regression test for an issue observed where the childrn in composite
+    triggers are parsed into their _client_ schemas, not their server ones.  Strangely,
+    this test does _not_ reproduce the issue when run as part of the test suite, but it
+    will when it is run from an Python isolated script.  This means the import order
+    may be relevant to the issue.
+    """
+
+    # An example of an integration test automation that failed
+
+    composite_trigger_info = {
+        "name": "a compound automation",
+        "trigger": {
+            "type": "compound",
+            "require": "all",
+            "within": 60,
+            "triggers": [
+                {
+                    "posture": "Reactive",
+                    "expect": ["integration.example.event.A"],
+                    "match": {
+                        "prefect.resource.id": "integration:compound:b7083807-cdc8-4c72-89ed-40927a67f731"
+                    },
+                    "threshold": 1,
+                    "within": 0,
+                },
+                {
+                    "posture": "Reactive",
+                    "expect": ["integration.example.event.B"],
+                    "match": {
+                        "prefect.resource.id": "integration:compound:b7083807-cdc8-4c72-89ed-40927a67f731"
+                    },
+                    "threshold": 1,
+                    "within": 0,
+                },
+            ],
+        },
+        "actions": [{"type": "do-nothing"}],
+    }
+    automation_as_json = json.dumps(composite_trigger_info)
+    trigger_as_json = json.dumps(composite_trigger_info["trigger"])
+
+    assert CompoundTrigger.__module__ == "prefect.server.events.schemas.automations"
+    assert EventTrigger.__module__ == "prefect.server.events.schemas.automations"
+
+    # Parse the automation
+    automation = AutomationCreate.model_validate(composite_trigger_info)
+    assert isinstance(automation.trigger, CompoundTrigger), type(automation.trigger)
+    assert isinstance(automation.trigger.triggers[0], EventTrigger), type(
+        automation.trigger.triggers[0]
+    )
+    assert isinstance(automation.trigger.triggers[1], EventTrigger), type(
+        automation.trigger.triggers[1]
+    )
+
+    # Parse from JSON
+    automation = AutomationCreate.model_validate_json(automation_as_json)
+    assert isinstance(automation.trigger, CompoundTrigger), type(automation.trigger)
+    assert isinstance(automation.trigger.triggers[0], EventTrigger), type(
+        automation.trigger.triggers[0]
+    )
+    assert isinstance(automation.trigger.triggers[1], EventTrigger), type(
+        automation.trigger.triggers[1]
+    )
+
+    # Parse the trigger itself
+    trigger = CompoundTrigger.model_validate(composite_trigger_info["trigger"])
+    assert isinstance(trigger, CompoundTrigger), type(trigger)
+    assert isinstance(trigger.triggers[0], EventTrigger), type(trigger.triggers[0])
+    assert isinstance(trigger.triggers[1], EventTrigger), type(trigger.triggers[1])
+
+    # And from JSON
+    trigger = CompoundTrigger.model_validate_json(trigger_as_json)
+    assert isinstance(trigger, CompoundTrigger), type(trigger)
+    assert isinstance(trigger.triggers[0], EventTrigger), type(trigger.triggers[0])
+    assert isinstance(trigger.triggers[1], EventTrigger), type(trigger.triggers[1])


### PR DESCRIPTION
During some internal testing of Prefect, we noticed a surprising bug, where
we could not create server-side automations that included composite triggers.
This was due to Pydantic parsing the server-side `CompositeTrigger.triggers` as
_client-side_ `EventTrigger`s, which don't include some of the necessary
server-side implementation.

I was unable to reproduce the problem in a unit test (if this were happening
during unit tests, many tests would fail), but I was able to reproduce it in
a simple standalone script using the same test code.  This is hinting to
import ordering as part of the problem.

```
Traceback (most recent call last):
  File "/home/chris/src/github.com/PrefectHQ/prefect/repro.py", line 92, in <module>
    test_server_composite_triggers_validate_to_server_triggers()
  File "/home/chris/src/github.com/PrefectHQ/prefect/repro.py", line 61, in test_server_composite_triggers_validate_to_server_triggers
    assert isinstance(automation.trigger.triggers[0], EventTrigger), type(
AssertionError: <class 'prefect.events.schemas.automations.EventTrigger'>
```

Unfortunately, I was unable to create a minimal repro using just plain Pydantic
models in order to send them a bug report, but it appears to be due to some
kind of caching relating to the `TriggerTypes` union.  Renaming the union
to `ServerTriggerTypes` resolved the problem, so there must be some kind of
caching by name in Pydantic that we're triggering.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
