### PR TITLE
Unbound griffe to 2.0

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -7,7 +7,7 @@ croniter >= 1.0.12, < 3.0.0
 fsspec >= 2022.5.0
 exceptiongroup >= 1.2.1
 graphviz >= 0.20.1
-griffe >= 0.20.0, <0.48.0
+griffe >= 0.20.0, <2.0.0
 httpcore >=1.0.5, < 2.0.0
 httpx[http2] >= 0.23, != 0.23.2
 importlib_metadata >= 4.4; python_version < '3.10'

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -7,7 +7,7 @@ croniter >= 1.0.12, < 3.0.0
 fsspec >= 2022.5.0
 exceptiongroup >= 1.2.1
 graphviz >= 0.20.1
-griffe >= 0.20.0, <2.0.0
+griffe >= 0.49.0, <2.0.0
 httpcore >=1.0.5, < 2.0.0
 httpx[http2] >= 0.23, != 0.23.2
 importlib_metadata >= 4.4; python_version < '3.10'

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -18,9 +18,7 @@ from typing import (
 )
 from uuid import UUID, uuid4
 
-from griffe.dataclasses import Docstring
-from griffe.docstrings.dataclasses import DocstringSection, DocstringSectionKind
-from griffe.docstrings.parsers import Parser, parse
+from griffe import Docstring, DocstringSection, DocstringSectionKind, Parser, parse
 from packaging.version import InvalidVersion, Version
 
 from prefect._internal.pydantic import HAS_PYDANTIC_V2

--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -24,9 +24,7 @@ if HAS_PYDANTIC_V2:
 else:
     import pydantic
 
-from griffe.dataclasses import Docstring
-from griffe.docstrings.dataclasses import DocstringSectionKind
-from griffe.docstrings.parsers import Parser, parse
+from griffe import Docstring, DocstringSectionKind, Parser, parse
 from typing_extensions import Literal
 
 from prefect.exceptions import (


### PR DESCRIPTION
Updates our requirements and code to be compatible with `griffe 1.0`.

Closes #14975 