### PR TITLE
Add a few more label rules to help keep things organized

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,13 @@
 migration:
   - changed-files:
       - any-glob-to-any-file: src/**/migrations/**/*.py
+
+upstream dependency:
+  - changed-files:
+      - any-glob-to-any-file: 
+        - requirements.txt
+        - requirements-client.txt
+        - requirements-dev.txt
+
+2.x:
+  - base-branch: '2.x'


### PR DESCRIPTION
This PR adds two more auto-labeling rules:
- label any change to our `requirements*.txt` files with `upstream dependency`: this should help us audit changes for our [conda-forge feedstock](https://github.com/conda-forge/prefect-feedstock) (we routinely miss requirement updates over there)
- label any PR to `2.x` with `2.x` so we can quickly see the affected version lineage