### PR TITLE
Add some missing upper bounds to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,17 @@
 -r requirements-client.txt
 
-aiosqlite >= 0.17.0
+aiosqlite >= 0.17.0, < 1.0.0
 alembic >= 1.7.5, < 2.0.0
 apprise >= 1.1.0, < 2.0.0
-asyncpg >= 0.23
+asyncpg >= 0.23, < 1.0.0
 click >= 8.0, < 8.2
 cryptography >= 36.0.1
 dateparser >= 1.1.1, < 2.0.0
-docker >= 4.0
+docker >= 4.0, < 8.0
 graphviz >= 0.20.1
 jinja2 >= 3.0.0, < 4.0.0
 jinja2-humanize-extension >= 0.4.0
-humanize >= 4.9.0
+humanize >= 4.9.0, < 5.0.0
 pytz >= 2021.1, < 2025
 readchar >= 4.0.0, < 5.0.0
 sqlalchemy[asyncio] >= 2.0, < 3.0.0


### PR DESCRIPTION
Given a few dependency issues that we've had, I think we should upper bound major version changes for packages that use semantic versioning. This will allow us to be more intentional about major version change support while accepting all minor versions along the way by default.

This PR will also serve as a test of #15000 