### PR TITLE
README: fix link to Slack community

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,5 +92,5 @@ If your use case is geared towards communicating with Prefect Cloud or a remote 
 ## Next steps
 
 - Check out the [Docs](https://docs.prefect.io/).
-- Join the {Prefect Slack community](https://prefect.io/slack).
+- Join the [Prefect Slack community](https://prefect.io/slack).
 - Learn how to [contribute to Prefect](https://docs.prefect.io/contributing/overview/).


### PR DESCRIPTION
Fixes the markdown link to the Slack community, which should have a bracket instead of a curly brace.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<img width="484" alt="image" src="https://github.com/user-attachments/assets/994ae362-bc38-4c65-99c4-f29a511bbe53">

