### PR TITLE
Add Block Type registration for its nested block types in field annotations

### DIFF
--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -128,7 +128,7 @@ def _is_subclass(cls, parent_cls) -> bool:
     Checks if a given class is a subclass of another class. Unlike issubclass,
     this will not throw an exception if cls is an instance instead of a type.
     """
-    return inspect.isclass(cls) and issubclass(cls, parent_cls)
+    return inspect.isclass(cls) and inspect.isclass(parent_cls) and issubclass(cls, parent_cls)
 
 
 def _collect_secret_fields(

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -136,12 +136,12 @@ def _collect_secret_fields(
 ) -> None:
     """
     Recursively collects all secret fields from a given type and adds them to the
-    secrets list, supporting nested Union / BaseModel fields. Also, note, this function
-    mutates the input secrets list, thus does not return anything.
+    secrets list, supporting nested Union / Dict / Tuple / List / BaseModel fields.
+    Also, note, this function mutates the input secrets list, thus does not return anything.
     """
-    if get_origin(type_) is Union:
-        for union_type in get_args(type_):
-            _collect_secret_fields(name, union_type, secrets)
+    if get_origin(type_) in (Union, dict, list, tuple):
+        for nested_type in get_args(type_):
+            _collect_secret_fields(name, nested_type, secrets)
         return
     elif _is_subclass(type_, BaseModel):
         for field_name, field in type_.model_fields.items():

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -7,7 +7,6 @@ import warnings
 from abc import ABC
 from functools import partial
 from textwrap import dedent
-from types import UnionType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1070,7 +1069,7 @@ class Block(BaseModel, ABC):
             """Walk through the annotation and register any nested blocks."""
             if Block.is_block_class(annotation):
                 await annotation.register_type_and_schema(client=client)
-            elif get_origin(annotation) in (Union, UnionType, tuple, list, dict):
+            elif get_origin(annotation) in (Union, tuple, list, dict):
                 for inner_annotation in get_args(annotation):
                     await register_blocks_in_annotation(inner_annotation)
 

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -128,7 +128,11 @@ def _is_subclass(cls, parent_cls) -> bool:
     Checks if a given class is a subclass of another class. Unlike issubclass,
     this will not throw an exception if cls is an instance instead of a type.
     """
-    return inspect.isclass(cls) and inspect.isclass(parent_cls) and issubclass(cls, parent_cls)
+    return (
+        inspect.isclass(cls)
+        and inspect.isclass(parent_cls)
+        and issubclass(cls, parent_cls)
+    )
 
 
 def _collect_secret_fields(

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -128,11 +128,9 @@ def _is_subclass(cls, parent_cls) -> bool:
     Checks if a given class is a subclass of another class. Unlike issubclass,
     this will not throw an exception if cls is an instance instead of a type.
     """
-    return (
-        inspect.isclass(cls)
-        and inspect.isclass(parent_cls)
-        and issubclass(cls, parent_cls)
-    )
+    # For python<=3.11 inspect.isclass() will return True for parametrized types (e.g. list[str])
+    # so we need to check for get_origin() to avoid TypeError for issubclass.
+    return inspect.isclass(cls) and not get_origin(cls) and issubclass(cls, parent_cls)
 
 
 def _collect_secret_fields(

--- a/tests/blocks/test_core.py
+++ b/tests/blocks/test_core.py
@@ -2,7 +2,7 @@ import abc
 import json
 import warnings
 from textwrap import dedent
-from typing import Any, Dict, List, Type, Union, Tuple
+from typing import Any, Dict, List, Tuple, Type, Union
 from unittest.mock import Mock
 from uuid import UUID, uuid4
 
@@ -1348,8 +1348,10 @@ class TestRegisterBlockTypeAndSchema:
         )
         assert c_block_schema is not None
 
-        tuple_collection_block_type = await prefect_client.read_block_schema_by_checksum(
-            checksum=TupleCollection._calculate_schema_checksum()
+        tuple_collection_block_type = (
+            await prefect_client.read_block_schema_by_checksum(
+                checksum=TupleCollection._calculate_schema_checksum()
+            )
         )
         assert tuple_collection_block_type is not None
 
@@ -1389,7 +1391,9 @@ class TestRegisterBlockTypeAndSchema:
         )
         assert dict_collection_block_type is not None
 
-    async def test_register_nested_block_type_nested(self, prefect_client: PrefectClient):
+    async def test_register_nested_block_type_nested(
+        self, prefect_client: PrefectClient
+    ):
         class A(Block):
             a: str
 
@@ -1400,7 +1404,7 @@ class TestRegisterBlockTypeAndSchema:
             c: str
 
         class Depth(Block):
-            depths: List[Union[A, List[Union[B, Tuple[C,...]]]]]
+            depths: List[Union[A, List[Union[B, Tuple[C, ...]]]]]
 
         await Depth.register_type_and_schema()
 
@@ -1411,9 +1415,7 @@ class TestRegisterBlockTypeAndSchema:
         c_block_type = await prefect_client.read_block_type_by_slug(slug="c")
         assert c_block_type is not None
 
-        depth_block_type = await prefect_client.read_block_type_by_slug(
-            slug="depth"
-        )
+        depth_block_type = await prefect_client.read_block_type_by_slug(slug="depth")
         assert depth_block_type is not None
 
         a_block_schema = await prefect_client.read_block_schema_by_checksum(

--- a/tests/blocks/test_core.py
+++ b/tests/blocks/test_core.py
@@ -2,7 +2,7 @@ import abc
 import json
 import warnings
 from textwrap import dedent
-from typing import Any, Dict, List, Type, Union
+from typing import Any, Dict, List, Type, Union, Tuple
 from unittest.mock import Mock
 from uuid import UUID, uuid4
 
@@ -1268,6 +1268,214 @@ class TestRegisterBlockTypeAndSchema:
             checksum=Umbrella._calculate_schema_checksum()
         )
         assert umbrella_block_schema is not None
+
+    async def test_register_nested_block_union_type(self, prefect_client: PrefectClient):
+        class A(Block):
+            a: str
+
+        class B(Block):
+            b: str
+
+        class C(Block):
+            c: str
+
+        class Umbrella(Block):
+            a_b_or_c: A | B | C
+
+        await Umbrella.register_type_and_schema()
+
+        a_block_type = await prefect_client.read_block_type_by_slug(slug="a")
+        assert a_block_type is not None
+        b_block_type = await prefect_client.read_block_type_by_slug(slug="b")
+        assert b_block_type is not None
+        c_block_type = await prefect_client.read_block_type_by_slug(slug="c")
+        assert c_block_type is not None
+        umbrella_block_type = await prefect_client.read_block_type_by_slug(
+            slug="umbrella"
+        )
+        assert umbrella_block_type is not None
+
+        a_block_schema = await prefect_client.read_block_schema_by_checksum(
+            checksum=A._calculate_schema_checksum()
+        )
+        assert a_block_schema is not None
+        b_block_schema = await prefect_client.read_block_schema_by_checksum(
+            checksum=B._calculate_schema_checksum()
+        )
+        assert b_block_schema is not None
+        c_block_schema = await prefect_client.read_block_schema_by_checksum(
+            checksum=C._calculate_schema_checksum()
+        )
+        assert c_block_schema is not None
+        umbrella_block_schema = await prefect_client.read_block_schema_by_checksum(
+            checksum=Umbrella._calculate_schema_checksum()
+        )
+        assert umbrella_block_schema is not None
+
+    async def test_register_nested_block_list(self, prefect_client: PrefectClient):
+        class A(Block):
+            a: str
+
+        class B(Block):
+            b: str
+
+        class ListCollection(Block):
+            a_list: list[A]
+            b_list: List[B]
+
+        await ListCollection.register_type_and_schema()
+
+        a_block_type = await prefect_client.read_block_type_by_slug(slug="a")
+        assert a_block_type is not None
+        b_block_type = await prefect_client.read_block_type_by_slug(slug="b")
+        assert b_block_type is not None
+
+        list_collection_block_type = await prefect_client.read_block_type_by_slug(
+            slug="listcollection"
+        )
+        assert list_collection_block_type is not None
+
+        a_block_schema = await prefect_client.read_block_schema_by_checksum(
+            checksum=A._calculate_schema_checksum()
+        )
+        assert a_block_schema is not None
+        b_block_schema = await prefect_client.read_block_schema_by_checksum(
+            checksum=B._calculate_schema_checksum()
+        )
+        assert b_block_schema is not None
+
+        list_collection_block_type = await prefect_client.read_block_schema_by_checksum(
+            checksum=ListCollection._calculate_schema_checksum()
+        )
+        assert list_collection_block_type is not None
+
+    async def test_register_nested_block_tuple(self, prefect_client: PrefectClient):
+        class A(Block):
+            a: str
+
+        class B(Block):
+            b: str
+
+        class C(Block):
+            c: str
+
+        class TupleCollection(Block):
+            a_tuple: tuple[A]
+            b_tuple: tuple[B, ...]
+            c_tuple: Tuple[C, ...]
+
+        await TupleCollection.register_type_and_schema()
+
+        a_block_type = await prefect_client.read_block_type_by_slug(slug="a")
+        assert a_block_type is not None
+        b_block_type = await prefect_client.read_block_type_by_slug(slug="b")
+        assert b_block_type is not None
+        c_block_type = await prefect_client.read_block_type_by_slug(slug="c")
+        assert c_block_type is not None
+
+        tuple_collection_block_type = await prefect_client.read_block_type_by_slug(
+            slug="tuplecollection"
+        )
+        assert tuple_collection_block_type is not None
+
+        a_block_schema = await prefect_client.read_block_schema_by_checksum(
+            checksum=A._calculate_schema_checksum()
+        )
+        assert a_block_schema is not None
+        b_block_schema = await prefect_client.read_block_schema_by_checksum(
+            checksum=B._calculate_schema_checksum()
+        )
+        assert b_block_schema is not None
+        c_block_schema = await prefect_client.read_block_schema_by_checksum(
+            checksum=C._calculate_schema_checksum()
+        )
+        assert c_block_schema is not None
+
+        tuple_collection_block_type = await prefect_client.read_block_schema_by_checksum(
+            checksum=TupleCollection._calculate_schema_checksum()
+        )
+        assert tuple_collection_block_type is not None
+
+    async def test_register_nested_block_dict(self, prefect_client: PrefectClient):
+        class A(Block):
+            a: str
+
+        class B(Block):
+            b: str
+
+        class DictCollection(Block):
+            block_dict: dict[A, B]
+
+        await DictCollection.register_type_and_schema()
+
+        a_block_type = await prefect_client.read_block_type_by_slug(slug="a")
+        assert a_block_type is not None
+        b_block_type = await prefect_client.read_block_type_by_slug(slug="b")
+        assert b_block_type is not None
+
+        dict_collection_block_type = await prefect_client.read_block_type_by_slug(
+            slug="dictcollection"
+        )
+        assert dict_collection_block_type is not None
+
+        a_block_schema = await prefect_client.read_block_schema_by_checksum(
+            checksum=A._calculate_schema_checksum()
+        )
+        assert a_block_schema is not None
+        b_block_schema = await prefect_client.read_block_schema_by_checksum(
+            checksum=B._calculate_schema_checksum()
+        )
+        assert b_block_schema is not None
+
+        dict_collection_block_type = await prefect_client.read_block_schema_by_checksum(
+            checksum=DictCollection._calculate_schema_checksum()
+        )
+        assert dict_collection_block_type is not None
+
+    async def test_register_nested_block_type_nested(self, prefect_client: PrefectClient):
+        class A(Block):
+            a: str
+
+        class B(Block):
+            b: str
+
+        class C(Block):
+            c: str
+
+        class Depth(Block):
+            depths: List[Union[A, List[Union[B, Tuple[C,...]]]]]
+
+        await Depth.register_type_and_schema()
+
+        a_block_type = await prefect_client.read_block_type_by_slug(slug="a")
+        assert a_block_type is not None
+        b_block_type = await prefect_client.read_block_type_by_slug(slug="b")
+        assert b_block_type is not None
+        c_block_type = await prefect_client.read_block_type_by_slug(slug="c")
+        assert c_block_type is not None
+
+        depth_block_type = await prefect_client.read_block_type_by_slug(
+            slug="depth"
+        )
+        assert depth_block_type is not None
+
+        a_block_schema = await prefect_client.read_block_schema_by_checksum(
+            checksum=A._calculate_schema_checksum()
+        )
+        assert a_block_schema is not None
+        b_block_schema = await prefect_client.read_block_schema_by_checksum(
+            checksum=B._calculate_schema_checksum()
+        )
+        assert b_block_schema is not None
+        c_block_schema = await prefect_client.read_block_schema_by_checksum(
+            checksum=C._calculate_schema_checksum()
+        )
+        assert c_block_schema is not None
+
+        depth_block_type = await prefect_client.read_block_schema_by_checksum(
+            checksum=Depth._calculate_schema_checksum()
+        )
+        assert depth_block_type is not None
 
     async def test_register_raises_block_base_class(self):
         with pytest.raises(

--- a/tests/blocks/test_core.py
+++ b/tests/blocks/test_core.py
@@ -1269,49 +1269,6 @@ class TestRegisterBlockTypeAndSchema:
         )
         assert umbrella_block_schema is not None
 
-    async def test_register_nested_block_union_type(self, prefect_client: PrefectClient):
-        class A(Block):
-            a: str
-
-        class B(Block):
-            b: str
-
-        class C(Block):
-            c: str
-
-        class Umbrella(Block):
-            a_b_or_c: A | B | C
-
-        await Umbrella.register_type_and_schema()
-
-        a_block_type = await prefect_client.read_block_type_by_slug(slug="a")
-        assert a_block_type is not None
-        b_block_type = await prefect_client.read_block_type_by_slug(slug="b")
-        assert b_block_type is not None
-        c_block_type = await prefect_client.read_block_type_by_slug(slug="c")
-        assert c_block_type is not None
-        umbrella_block_type = await prefect_client.read_block_type_by_slug(
-            slug="umbrella"
-        )
-        assert umbrella_block_type is not None
-
-        a_block_schema = await prefect_client.read_block_schema_by_checksum(
-            checksum=A._calculate_schema_checksum()
-        )
-        assert a_block_schema is not None
-        b_block_schema = await prefect_client.read_block_schema_by_checksum(
-            checksum=B._calculate_schema_checksum()
-        )
-        assert b_block_schema is not None
-        c_block_schema = await prefect_client.read_block_schema_by_checksum(
-            checksum=C._calculate_schema_checksum()
-        )
-        assert c_block_schema is not None
-        umbrella_block_schema = await prefect_client.read_block_schema_by_checksum(
-            checksum=Umbrella._calculate_schema_checksum()
-        )
-        assert umbrella_block_schema is not None
-
     async def test_register_nested_block_list(self, prefect_client: PrefectClient):
         class A(Block):
             a: str


### PR DESCRIPTION
Closes #15009 

This PR proposes modification of `prefect.blocks.core.Block.register_type_and_schema()` to registers nested block types in its field annotations. Nested block types are searched only in Dict, List, Tuple and Union types.

Additionally `prefect.blocks.core._collect_secret_fields()` has been updated to collect secret fields in nested types as well as `prefect.blocks.core.schema_extra()` for block schemas. 

Small fix applied to `prefect.blocks.core._is_subclass()` to check if passed `cls` is parametrized type using `typing.get_origin()`. Without this, `inspect.isclass()` returns True for parametrized types for python<=3.11 and this results in `TypeError` raised by `issubclass()`.

This implementation also fixes any race conditions when registering Blocks with CLI, as shown in related issue.

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"(https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
