### PR TITLE
Adds the ability to run a server in the background

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -212,7 +212,7 @@ jobs:
           #       https://github.com/PrefectHQ/prefect/issues/6989
           docker stop "prefect-server-${{ matrix.prefect-version }}" || echo "That's okay!"
 
-          prefect server start --analytics-off > server-logs.txt 2>&1 &
+          prefect server start --port 4201 --analytics-off > server-logs.txt 2>&1 &
           ./scripts/wait-for-server.py
 
       - name: Run integration flows with client@${{ matrix.prefect-version }}, server@dev
@@ -220,7 +220,7 @@ jobs:
           docker run
           --env TEST_SERVER_VERSION=$(python -c 'import prefect; print(prefect.__version__)')
           --env TEST_CLIENT_VERSION=${{ matrix.client_version }}
-          --env PREFECT_API_URL="http://127.0.0.1:4200/api"
+          --env PREFECT_API_URL="http://127.0.0.1:4201/api"
           --env PREFECT_EXPERIMENTAL_EVENTS=True
           --volume $(pwd)/flows:/opt/prefect/integration/flows
           --volume $(pwd)/scripts:/opt/prefect/integration/scripts

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -207,7 +207,9 @@ async def stop():
     try:
         os.kill(pid, 15)
     except ProcessLookupError:
-        exit_with_error("No server running in the background.")
+        exit_with_success(
+            "The server process is not running. Cleaning up stale PID file."
+        )
     finally:
         await pid_file.unlink()
     app.console.print("Server stopped!")

--- a/tests/cli/test_start_server.py
+++ b/tests/cli/test_start_server.py
@@ -9,6 +9,7 @@ import anyio
 import httpx
 import pytest
 
+from prefect.cli.server import PID_FILE
 from prefect.settings import PREFECT_HOME, get_current_settings
 from prefect.testing.cli import invoke_and_assert
 from prefect.testing.fixtures import is_port_in_use
@@ -169,44 +170,25 @@ class TestBackgroundServer:
             )
 
     def test_start_port_in_use_by_background_server(self, unused_tcp_port):
-        invoke_and_assert(
-            command=[
-                "server",
-                "start",
-                "--port",
-                str(unused_tcp_port),
-                "--background",
-            ],
-            expected_code=0,
-        )
+        pid_file = PREFECT_HOME.value() / PID_FILE
+        pid_file.write_text("99999")
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", unused_tcp_port))
 
-        # Wait for the server to start and bind the port
-        while not is_port_in_use(unused_tcp_port):
-            pass
-
-        invoke_and_assert(
-            command=[
-                "server",
-                "start",
-                "--port",
-                str(unused_tcp_port),
-                "--background",
-            ],
-            expected_output_contains=f"A background server process is already running on port {unused_tcp_port}.",
-            expected_code=1,
-        )
-
-        invoke_and_assert(
-            command=[
-                "server",
-                "stop",
-            ],
-            expected_output_contains="Server stopped!",
-            expected_code=0,
-        )
+            invoke_and_assert(
+                command=[
+                    "server",
+                    "start",
+                    "--port",
+                    str(unused_tcp_port),
+                    "--background",
+                ],
+                expected_output_contains=f"A background server process is already running on port {unused_tcp_port}.",
+                expected_code=1,
+            )
 
     def test_stop_stale_pid_file(self, unused_tcp_port):
-        pid_file = PREFECT_HOME.value() / "server.pid"
+        pid_file = PREFECT_HOME.value() / PID_FILE
         pid_file.write_text("99999")
 
         invoke_and_assert(

--- a/tests/cli/test_start_server.py
+++ b/tests/cli/test_start_server.py
@@ -1,6 +1,7 @@
 import contextlib
 import os
 import signal
+import socket
 import sys
 import tempfile
 
@@ -8,7 +9,8 @@ import anyio
 import httpx
 import pytest
 
-from prefect.settings import get_current_settings
+from prefect.settings import PREFECT_HOME, get_current_settings
+from prefect.testing.cli import invoke_and_assert
 from prefect.testing.fixtures import is_port_in_use
 from prefect.utilities.processutils import open_process
 
@@ -83,6 +85,88 @@ async def start_server_process():
         yield process
 
     out.close()
+
+
+class TestBackgroundServer:
+    def test_start_and_stop_background_server(self, unused_tcp_port):
+        invoke_and_assert(
+            command=[
+                "server",
+                "start",
+                "--port",
+                str(unused_tcp_port),
+                "--background",
+            ],
+            expected_output_contains="The Prefect server is running in the background.",
+            expected_code=0,
+        )
+
+        pid_file = PREFECT_HOME.value() / "server.pid"
+        assert pid_file.exists(), "Server PID file does not exist"
+
+        invoke_and_assert(
+            command=[
+                "server",
+                "stop",
+            ],
+            expected_output_contains="Server stopped!",
+            expected_code=0,
+        )
+
+        assert not (
+            PREFECT_HOME.value() / "server.pid"
+        ).exists(), "Server PID file exists"
+
+    def test_start_duplicate_background_server(self, unused_tcp_port_factory):
+        port_1 = unused_tcp_port_factory()
+        invoke_and_assert(
+            command=[
+                "server",
+                "start",
+                "--port",
+                str(port_1),
+                "--background",
+            ],
+            expected_output_contains="The Prefect server is running in the background.",
+            expected_code=0,
+        )
+
+        port_2 = unused_tcp_port_factory()
+        invoke_and_assert(
+            command=[
+                "server",
+                "start",
+                "--port",
+                str(port_2),
+                "--background",
+            ],
+            expected_output_contains="A server is already running in the background.",
+            expected_code=1,
+        )
+
+        invoke_and_assert(
+            command=[
+                "server",
+                "stop",
+            ],
+            expected_output_contains="Server stopped!",
+            expected_code=0,
+        )
+
+    def test_start_port_in_use(self, unused_tcp_port):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", unused_tcp_port))
+            invoke_and_assert(
+                command=[
+                    "server",
+                    "start",
+                    "--port",
+                    str(unused_tcp_port),
+                    "--background",
+                ],
+                expected_output_contains=f"Port {unused_tcp_port} is already in use.",
+                expected_code=1,
+            )
 
 
 @pytest.mark.service("process")

--- a/tests/cli/test_start_server.py
+++ b/tests/cli/test_start_server.py
@@ -168,6 +168,24 @@ class TestBackgroundServer:
                 expected_code=1,
             )
 
+    def test_stop_stale_pid_file(self, unused_tcp_port):
+        pid_file = PREFECT_HOME.value() / "server.pid"
+        pid_file.write_text("99999")
+
+        invoke_and_assert(
+            command=[
+                "server",
+                "stop",
+            ],
+            expected_output_contains="Cleaning up stale PID file.",
+            expected_output_does_not_contain="Server stopped!",
+            expected_code=0,
+        )
+
+        assert not (
+            PREFECT_HOME.value() / "server.pid"
+        ).exists(), "Server PID file exists"
+
 
 @pytest.mark.service("process")
 class TestUvicornSignalForwarding:

--- a/tests/cli/test_start_server.py
+++ b/tests/cli/test_start_server.py
@@ -168,6 +168,43 @@ class TestBackgroundServer:
                 expected_code=1,
             )
 
+    def test_start_port_in_use_by_background_server(self, unused_tcp_port):
+        invoke_and_assert(
+            command=[
+                "server",
+                "start",
+                "--port",
+                str(unused_tcp_port),
+                "--background",
+            ],
+            expected_code=0,
+        )
+
+        # Wait for the server to start and bind the port
+        while not is_port_in_use(unused_tcp_port):
+            pass
+
+        invoke_and_assert(
+            command=[
+                "server",
+                "start",
+                "--port",
+                str(unused_tcp_port),
+                "--background",
+            ],
+            expected_output_contains=f"A background server process is already running on port {unused_tcp_port}.",
+            expected_code=1,
+        )
+
+        invoke_and_assert(
+            command=[
+                "server",
+                "stop",
+            ],
+            expected_output_contains="Server stopped!",
+            expected_code=0,
+        )
+
     def test_stop_stale_pid_file(self, unused_tcp_port):
         pid_file = PREFECT_HOME.value() / "server.pid"
         pid_file.write_text("99999")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

Adds a `--background` (or `-b`) flag to `prefect server start` to allow running a server in a background process. A server started with `--background` can be stopped with `prefect server stop`.

When starting a background server, a `server.pid` file is written to the `PREFECT_HOME` directory with the process ID of the background server. This lets `prefect server stop` know which process to interrupt. Currently, only one background server can be started at a time. Allowing more simultaneous background servers will likely require an update to `prefect server stop`.

Closes https://github.com/PrefectHQ/prefect/issues/6989

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
