### PR TITLE
Ensure Python executable is quoted in runner command on Windows

### DIFF
--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -97,7 +97,11 @@ from prefect.utilities.asyncutils import (
     sync_compatible,
 )
 from prefect.utilities.engine import propose_state
-from prefect.utilities.processutils import _register_signal, run_process
+from prefect.utilities.processutils import (
+    _register_signal,
+    get_sys_executable,
+    run_process,
+)
 from prefect.utilities.services import critical_service_loop
 
 __all__ = ["Runner"]
@@ -533,7 +537,7 @@ class Runner:
             task_status: anyio task status used to send a message to the caller
                 than the flow run process has started.
         """
-        command = f"{shlex.quote(sys.executable)} -m prefect.engine"
+        command = f"{get_sys_executable()} -m prefect.engine"
 
         flow_run_logger = self._get_flow_run_logger(flow_run)
 

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -536,7 +536,7 @@ class Runner:
             task_status: anyio task status used to send a message to the caller
                 than the flow run process has started.
         """
-        command = [get_sys_executable(), "-m" "prefect.engine"]
+        command = [get_sys_executable(), "-m", "prefect.engine"]
 
         flow_run_logger = self._get_flow_run_logger(flow_run)
 

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -35,7 +35,6 @@ import datetime
 import inspect
 import logging
 import os
-import shlex
 import shutil
 import signal
 import subprocess
@@ -537,7 +536,7 @@ class Runner:
             task_status: anyio task status used to send a message to the caller
                 than the flow run process has started.
         """
-        command = f"{get_sys_executable()} -m prefect.engine"
+        command = [get_sys_executable(), "-m" "prefect.engine"]
 
         flow_run_logger = self._get_flow_run_logger(flow_run)
 
@@ -584,7 +583,7 @@ class Runner:
                 setattr(storage, "last_adhoc_pull", datetime.datetime.now())
 
         process = await run_process(
-            shlex.split(command),
+            command=command,
             stream_output=True,
             task_status=task_status,
             env=env,

--- a/src/prefect/utilities/processutils.py
+++ b/src/prefect/utilities/processutils.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -416,6 +417,6 @@ def get_sys_executable() -> str:
     if os.name == "nt":
         executable_path = f'"{sys.executable}"'
     else:
-        executable_path = sys.executable
+        executable_path = shlex.quote(sys.executable)
 
     return executable_path

--- a/src/prefect/utilities/processutils.py
+++ b/src/prefect/utilities/processutils.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import shlex
 import signal
 import subprocess
 import sys
@@ -417,6 +416,6 @@ def get_sys_executable() -> str:
     if os.name == "nt":
         executable_path = f'"{sys.executable}"'
     else:
-        executable_path = shlex.quote(sys.executable)
+        executable_path = sys.executable
 
     return executable_path

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -671,8 +671,8 @@ class TestRunner:
 
         # Previously the command would have been
         # ["C:/Program", "Files/Python38/python.exe", "-m", "prefect.engine"]
-        assert mock_run_process_call.call_args[0][0] == [
-            "C:/Program Files/Python38/python.exe",
+        assert mock_run_process_call.call_args[1]["command"] == [
+            "'C:/Program Files/Python38/python.exe'",
             "-m",
             "prefect.engine",
         ]

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -672,7 +672,7 @@ class TestRunner:
         # Previously the command would have been
         # ["C:/Program", "Files/Python38/python.exe", "-m", "prefect.engine"]
         assert mock_run_process_call.call_args[1]["command"] == [
-            "'C:/Program Files/Python38/python.exe'",
+            "C:/Program Files/Python38/python.exe",
             "-m",
             "prefect.engine",
         ]


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

This PR ensures that the Python executable path used by the `Runner` when starting a flow run is quoted to avoid issues with spaces.I tested on a Windows setup via Parallels
Closes https://github.com/PrefectHQ/prefect/issues/15014

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
