### PR TITLE
Add section on client-side task run orchestration to `write tasks` guide.

### DIFF
--- a/docs/3.0rc/develop/write-tasks.mdx
+++ b/docs/3.0rc/develop/write-tasks.mdx
@@ -78,7 +78,7 @@ Prefect uses client-side task run orchestration by default, which significantly 
 <Tip>
 Tasks are always executed in the main thread by default, unless a specific [task runner](/3.0rc/develop/task-runners) is used to execute them on different threads, processes, or infrastructure. This facilitates native Python debugging and profiling.
 </Tip>
-Task updates are logged in batch, which introduces eventual consistency for task states in the UI and API queries. While this means there may be a slight delay in seeing the most up-to-date task states, it allows for substantial performance improvements and increased workflow scale.
+Task updates are logged in batch, leading to eventual consistency for task states in the UI and API queries. While this means there may be a slight delay in seeing the most up-to-date task states, it allows for substantial performance improvements and increased workflow scale.
 
 ### Synchronous functions
 


### PR DESCRIPTION
This PR adds some copy to the `write tasks` section on CSTRO.

Leads with performance gains, notes eventual consistency in the UI. cc @jakekaplan