### PR TITLE
Allow tasks to write results without metadata when using a transaction record store separate from result storage 

### DIFF
--- a/src/prefect/records/base.py
+++ b/src/prefect/records/base.py
@@ -22,6 +22,16 @@ class TransactionRecord:
 
 
 class RecordStore(abc.ABC):
+    @property
+    def persists_result_data(self) -> bool:
+        """
+        Check if the record store persists result data.
+
+        Returns:
+            bool: True if the record store persists result data; False otherwise.
+        """
+        return False
+
     @abc.abstractmethod
     def read(
         self, key: str, holder: Optional[str] = None

--- a/src/prefect/records/filesystem.py
+++ b/src/prefect/records/filesystem.py
@@ -56,7 +56,6 @@ class FileSystemRecordStore(RecordStore):
     def _get_lock_info(self, key: str, use_cache=True) -> Optional[_LockInfo]:
         if use_cache:
             if (lock_info := self._locks.get(key)) is not None:
-                print("Got lock info from cache")
                 return lock_info
 
         lock_path = self._lock_path_for_key(key)
@@ -70,7 +69,6 @@ class FileSystemRecordStore(RecordStore):
                     pendulum.parse(expiration) if expiration is not None else None
                 )
             self._locks[key] = lock_info
-            print("Got lock info from file")
             return lock_info
         except FileNotFoundError:
             return None

--- a/src/prefect/records/filesystem.py
+++ b/src/prefect/records/filesystem.py
@@ -9,6 +9,7 @@ from typing_extensions import TypedDict
 from prefect.logging.loggers import get_logger
 from prefect.records.base import RecordStore, TransactionRecord
 from prefect.results import BaseResult
+from prefect.settings import PREFECT_HOME
 from prefect.transactions import IsolationLevel
 
 logger = get_logger(__name__)
@@ -41,8 +42,8 @@ class FileSystemRecordStore(RecordStore):
             `{PREFECT_HOME}/records`
     """
 
-    def __init__(self, records_directory: Path):
-        self.records_directory = records_directory
+    def __init__(self, records_directory: Optional[Path] = None):
+        self.records_directory = records_directory or PREFECT_HOME.value() / "records"
         self._locks: Dict[str, _LockInfo] = {}
 
     def _ensure_records_directory_exists(self):
@@ -98,7 +99,7 @@ class FileSystemRecordStore(RecordStore):
 
         record_path = self.records_directory.joinpath(key)
         record_path.touch(exist_ok=True)
-        record_data = result.model_dump_json()
+        record_data = result.model_dump_json(serialize_as_any=True)
         record_path.write_text(record_data)
 
     def exists(self, key: str) -> bool:

--- a/src/prefect/records/result_store.py
+++ b/src/prefect/records/result_store.py
@@ -42,7 +42,7 @@ class ResultFactoryStore(RecordStore):
             return TransactionRecord(key=key, result=self.cache)
         try:
             result = PersistedResult(
-                serializer_type=self.result_factory.serializer.type,
+                serializer=self.result_factory.serializer,
                 storage_block_id=self.result_factory.storage_block_id,
                 storage_key=key,
             )

--- a/src/prefect/records/result_store.py
+++ b/src/prefect/records/result_store.py
@@ -15,6 +15,10 @@ class ResultFactoryStore(RecordStore):
     result_factory: ResultFactory
     cache: Optional[PersistedResult] = None
 
+    @property
+    def persists_result_data(self) -> bool:
+        return True
+
     def exists(self, key: str) -> bool:
         try:
             record = self.read(key)

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -333,6 +333,7 @@ class ResultFactory(BaseModel):
         key: Optional[str] = None,
         expiration: Optional[DateTime] = None,
         defer_persistence: bool = False,
+        raw: bool = False,
     ) -> Union[R, "BaseResult[R]"]:
         """
         Create a result type for the given object.
@@ -366,6 +367,7 @@ class ResultFactory(BaseModel):
             cache_object=should_cache_object,
             expiration=expiration,
             defer_persistence=defer_persistence,
+            raw=raw,
         )
 
     @sync_compatible

--- a/src/prefect/serializers.py
+++ b/src/prefect/serializers.py
@@ -108,6 +108,12 @@ class Serializer(BaseModel, Generic[D], abc.ABC):
         type_str = cls.model_fields["type"].default
         return type_str if isinstance(type_str, str) else None
 
+    def __eq__(self, value: object) -> bool:
+        return (
+            isinstance(value, self.__class__)
+            and self.model_dump() == value.model_dump()
+        )
+
 
 class PickleSerializer(Serializer):
     """

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -343,6 +343,7 @@ async def return_value_to_state(
                 key=key,
                 expiration=expiration,
                 defer_persistence=defer_persistence,
+                raw=raw_result,
             ),
         )
 
@@ -362,6 +363,7 @@ async def return_value_to_state(
                 key=key,
                 expiration=expiration,
                 defer_persistence=defer_persistence,
+                raw=raw_result,
             )
         )
 

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -259,6 +259,7 @@ async def return_value_to_state(
     key: Optional[str] = None,
     expiration: Optional[datetime.datetime] = None,
     defer_persistence: bool = False,
+    raw_result: bool = False,
 ) -> State[R]:
     """
     Given a return value from a user's function, create a `State` the run should
@@ -296,6 +297,7 @@ async def return_value_to_state(
                 key=key,
                 expiration=expiration,
                 defer_persistence=defer_persistence,
+                raw=raw_result,
             )
 
         return state

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -464,7 +464,8 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 key=transaction.key,
                 expiration=expiration,
                 # defer persistence to transaction commit
-                defer_persistence=True,
+                defer_persistence=transaction.persists_result_data,
+                raw_result=not transaction.persists_result_data,
             )
         )
         transaction.stage(
@@ -965,7 +966,8 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             key=transaction.key,
             expiration=expiration,
             # defer persistence to transaction commit
-            defer_persistence=True,
+            defer_persistence=transaction.persists_result_data,
+            raw_result=not transaction.persists_result_data,
         )
         transaction.stage(
             terminal_state.data,

--- a/tests/results/test_result_factory.py
+++ b/tests/results/test_result_factory.py
@@ -45,7 +45,7 @@ async def factory(prefect_client):
 async def test_create_result_reference(factory):
     result = await factory.create_result({"foo": "bar"})
     assert isinstance(result, PersistedResult)
-    assert result.serializer_type == factory.serializer.type
+    assert result.serializer == factory.serializer
     assert result.storage_block_id == factory.storage_block_id
     assert await result.get() == {"foo": "bar"}
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

This PR enables tasks to persist results without metadata when using a record store that is separate from the results store. The metadata for a result (e.g., `expiration`, `serializer`, etc.) will be written to the record store. That metadata is used to load the result for caching and transaction idempotency.

### Example

The following script will write serialized results without metadata for task runs: 
```python
from prefect import flow, task
from prefect.cache_policies import INPUTS
from prefect.records.filesystem import FileSystemRecordStore


@task(cache_policy=INPUTS)
def t(x):
    return x


@flow(transaction_store=(FileSystemRecordStore()))
def f(x):
    return t(x * x)


if __name__ == "__main__":
    f(3)
```

You can see the raw serialized result in `$PREFECT_HOME/storage` and the result record with metadata in `$PREFECT_HOME/records`. Multiple runs of the script will use the persisted result for `t`.

Closes #7257

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
