### PR TITLE
Revert "Add optional "holder" semantics to global concurrency limits

### DIFF
--- a/docs/3.0rc/api-ref/rest-api/server/schema.json
+++ b/docs/3.0rc/api-ref/rest-api/server/schema.json
@@ -12548,17 +12548,6 @@
                         ],
                         "title": "Occupancy Seconds"
                     },
-                    "holder": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Holder"
-                    },
                     "create_if_missing": {
                         "type": "boolean",
                         "title": "Create If Missing",
@@ -12595,17 +12584,6 @@
                         ],
                         "title": "Mode",
                         "default": "concurrency"
-                    },
-                    "holder": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Holder"
                     },
                     "create_if_missing": {
                         "type": "boolean",
@@ -15262,20 +15240,6 @@
                             }
                         ],
                         "title": "Slot Decay Per Second"
-                    },
-                    "holders": {
-                        "anyOf": [
-                            {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Holders"
                     }
                 },
                 "additionalProperties": false,
@@ -20207,14 +20171,6 @@
                         "title": "Slot Decay Per Second",
                         "description": "The decay rate for active slots when used as a rate limit.",
                         "default": 2.0
-                    },
-                    "holders": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "title": "Holders",
-                        "description": "The holders of the global concurrency limit."
                     }
                 },
                 "type": "object",
@@ -20866,21 +20822,13 @@
                     "limit": {
                         "type": "integer",
                         "title": "Limit"
-                    },
-                    "holders": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "title": "Holders"
                     }
                 },
                 "type": "object",
                 "required": [
                     "id",
                     "name",
-                    "limit",
-                    "holders"
+                    "limit"
                 ],
                 "title": "MinimalConcurrencyLimitResponse"
             },

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2995,46 +2995,20 @@ class PrefectClient:
         return response.json()
 
     async def increment_concurrency_slots(
-        self,
-        names: List[str],
-        slots: int,
-        mode: str,
-        create_if_missing: Optional[bool] = True,
-        holder: Optional[str] = None,
+        self, names: List[str], slots: int, mode: str, create_if_missing: Optional[bool]
     ) -> httpx.Response:
-        """
-        Increment concurrency slots for the specified limits.
-
-        Args:
-            names (List[str]): A list of limit names for which to increment slots.
-            slots (int): The number of concurrency slots to increment.
-            mode (str): The mode of the increment operation.
-            create_if_missing (bool, optional): Whether to create the limit if it
-                does not exist. Defaults to True.
-            holder (str, optional): The name of the holder that is incrementing
-                the slots. Defaults to None.
-        """
-        data = {
-            "names": names,
-            "slots": slots,
-            "mode": mode,
-            "create_if_missing": create_if_missing,
-        }
-
-        if holder:
-            data["holder"] = holder
-
         return await self._client.post(
             "/v2/concurrency_limits/increment",
-            json=data,
+            json={
+                "names": names,
+                "slots": slots,
+                "mode": mode,
+                "create_if_missing": create_if_missing,
+            },
         )
 
     async def release_concurrency_slots(
-        self,
-        names: List[str],
-        slots: int,
-        occupancy_seconds: float,
-        holder: Optional[str] = None,
+        self, names: List[str], slots: int, occupancy_seconds: float
     ) -> httpx.Response:
         """
         Release concurrency slots for the specified limits.
@@ -3044,24 +3018,18 @@ class PrefectClient:
             slots (int): The number of concurrency slots to release.
             occupancy_seconds (float): The duration in seconds that the slots
                 were occupied.
-            holder (str, optional): The name of the holder that is releasing
-                the slots. Defaults to None.
 
         Returns:
             httpx.Response: The HTTP response from the server.
         """
-        data = {
-            "names": names,
-            "slots": slots,
-            "occupancy_seconds": occupancy_seconds,
-        }
-
-        if holder:
-            data["holder"] = holder
 
         return await self._client.post(
             "/v2/concurrency_limits/decrement",
-            json=data,
+            json={
+                "names": names,
+                "slots": slots,
+                "occupancy_seconds": occupancy_seconds,
+            },
         )
 
     async def create_global_concurrency_limit(

--- a/src/prefect/client/schemas/responses.py
+++ b/src/prefect/client/schemas/responses.py
@@ -411,7 +411,6 @@ class MinimalConcurrencyLimitResponse(PrefectBaseModel):
     id: UUID
     name: str
     limit: int
-    holders: List[str]
 
 
 class GlobalConcurrencyLimitResponse(ObjectBaseModel):
@@ -430,7 +429,4 @@ class GlobalConcurrencyLimitResponse(ObjectBaseModel):
     slot_decay_per_second: float = Field(
         default=2.0,
         description="The decay rate for active slots when used as a rate limit.",
-    )
-    holders: List[str] = Field(
-        default_factory=list, description="The holders of the global concurrency limit."
     )

--- a/src/prefect/concurrency/asyncio.py
+++ b/src/prefect/concurrency/asyncio.py
@@ -37,7 +37,6 @@ async def concurrency(
     occupy: int = 1,
     timeout_seconds: Optional[float] = None,
     create_if_missing: Optional[bool] = True,
-    holder: Optional[str] = None,
 ) -> AsyncGenerator[None, None]:
     """A context manager that acquires and releases concurrency slots from the
     given concurrency limits.
@@ -48,7 +47,6 @@ async def concurrency(
         timeout_seconds: The number of seconds to wait for the slots to be acquired before
             raising a `TimeoutError`. A timeout of `None` will wait indefinitely.
         create_if_missing: Whether to create the concurrency limits if they do not exist.
-        holder: The name of the holder that is incrementing the slots.
 
     Raises:
         TimeoutError: If the slots are not acquired within the given timeout.
@@ -77,10 +75,9 @@ async def concurrency(
         occupy,
         timeout_seconds=timeout_seconds,
         create_if_missing=create_if_missing,
-        holder=holder,
     )
     acquisition_time = pendulum.now("UTC")
-    emitted_events = _emit_concurrency_acquisition_events(limits, occupy, holder=holder)
+    emitted_events = _emit_concurrency_acquisition_events(limits, occupy)
 
     try:
         yield
@@ -88,7 +85,7 @@ async def concurrency(
         occupancy_period = cast(Interval, (pendulum.now("UTC") - acquisition_time))
         try:
             await _release_concurrency_slots(
-                names, occupy, occupancy_period.total_seconds(), holder
+                names, occupy, occupancy_period.total_seconds()
             )
         except anyio.get_cancelled_exc_class():
             # The task was cancelled before it could release the slots. Add the
@@ -140,10 +137,9 @@ async def _acquire_concurrency_slots(
     mode: Union[Literal["concurrency"], Literal["rate_limit"]] = "concurrency",
     timeout_seconds: Optional[float] = None,
     create_if_missing: Optional[bool] = True,
-    holder: Optional[str] = None,
 ) -> List[MinimalConcurrencyLimitResponse]:
     service = ConcurrencySlotAcquisitionService.instance(frozenset(names))
-    future = service.send((slots, mode, timeout_seconds, create_if_missing, holder))
+    future = service.send((slots, mode, timeout_seconds, create_if_missing))
     response_or_exception = await asyncio.wrap_future(future)
 
     if isinstance(response_or_exception, Exception):
@@ -160,17 +156,11 @@ async def _acquire_concurrency_slots(
 
 
 async def _release_concurrency_slots(
-    names: List[str],
-    slots: int,
-    occupancy_seconds: float,
-    holder: Optional[str],
+    names: List[str], slots: int, occupancy_seconds: float
 ) -> List[MinimalConcurrencyLimitResponse]:
     async with get_client() as client:
         response = await client.release_concurrency_slots(
-            names=names,
-            slots=slots,
-            occupancy_seconds=occupancy_seconds,
-            holder=holder,
+            names=names, slots=slots, occupancy_seconds=occupancy_seconds
         )
         return _response_to_minimal_concurrency_limit_response(response)
 

--- a/src/prefect/concurrency/events.py
+++ b/src/prefect/concurrency/events.py
@@ -11,7 +11,6 @@ def _emit_concurrency_event(
     related_limits: List[MinimalConcurrencyLimitResponse],
     slots: int,
     follows: Union[Event, None] = None,
-    holder: Optional[str] = None,
 ) -> Union[Event, None]:
     resource: Dict[str, str] = {
         "prefect.resource.id": f"prefect.concurrency-limit.{primary_limit.id}",
@@ -19,9 +18,6 @@ def _emit_concurrency_event(
         "slots-acquired": str(slots),
         "limit": str(primary_limit.limit),
     }
-
-    if holder:
-        resource["holder"] = str(holder)
 
     related = [
         RelatedResource.model_validate(
@@ -45,13 +41,10 @@ def _emit_concurrency_event(
 def _emit_concurrency_acquisition_events(
     limits: List[MinimalConcurrencyLimitResponse],
     occupy: int,
-    holder: Optional[str] = None,
 ) -> Dict[UUID, Optional[Event]]:
     events = {}
     for limit in limits:
-        event = _emit_concurrency_event(
-            "acquired", limit, limits, occupy, holder=holder
-        )
+        event = _emit_concurrency_event("acquired", limit, limits, occupy)
         events[limit.id] = event
 
     return events
@@ -61,9 +54,6 @@ def _emit_concurrency_release_events(
     limits: List[MinimalConcurrencyLimitResponse],
     occupy: int,
     events: Dict[UUID, Optional[Event]],
-    holder: Optional[str] = None,
 ) -> None:
     for limit in limits:
-        _emit_concurrency_event(
-            "released", limit, limits, occupy, events[limit.id], holder=holder
-        )
+        _emit_concurrency_event("released", limit, limits, occupy, events[limit.id])

--- a/src/prefect/concurrency/sync.py
+++ b/src/prefect/concurrency/sync.py
@@ -41,7 +41,6 @@ def concurrency(
     occupy: int = 1,
     timeout_seconds: Optional[float] = None,
     create_if_missing: Optional[bool] = True,
-    holder: Optional[str] = None,
 ) -> Generator[None, None, None]:
     """A context manager that acquires and releases concurrency slots from the
     given concurrency limits.
@@ -52,7 +51,6 @@ def concurrency(
         timeout_seconds: The number of seconds to wait for the slots to be acquired before
             raising a `TimeoutError`. A timeout of `None` will wait indefinitely.
         create_if_missing: Whether to create the concurrency limits if they do not exist.
-        holder: An optional identifier for the holder of the slots.
 
     Raises:
         TimeoutError: If the slots are not acquired within the given timeout.
@@ -82,7 +80,6 @@ def concurrency(
         occupy,
         timeout_seconds=timeout_seconds,
         create_if_missing=create_if_missing,
-        holder=holder,
     )
     acquisition_time = pendulum.now("UTC")
     emitted_events = _emit_concurrency_acquisition_events(limits, occupy)
@@ -96,7 +93,6 @@ def concurrency(
             names,
             occupy,
             occupancy_period.total_seconds(),
-            holder,
         )
         _emit_concurrency_release_events(limits, occupy, emitted_events)
 

--- a/src/prefect/server/api/clients.py
+++ b/src/prefect/server/api/clients.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Optional
 from urllib.parse import quote
 from uuid import UUID
 
@@ -196,23 +196,6 @@ class OrchestrationClient(BaseClient):
     ) -> Response:
         return await self._http_client.get(
             f"/v2/concurrency_limits/{concurrency_limit_id}"
-        )
-
-    async def bulk_increment_active_slots(
-        self,
-        slots: int,
-        names: list[str],
-        mode: Literal["concurrency", "rate_limit"] = "concurrency",
-        holder: Optional[str] = None,
-    ) -> Response:
-        data = {"slots": slots, "names": names, "mode": mode, "holder": holder}
-
-        if holder:
-            data["holder"] = holder
-
-        return await self._http_client.post(
-            "/v2/concurrency_limits/increment",
-            json=data,
         )
 
 

--- a/src/prefect/server/events/actions.py
+++ b/src/prefect/server/events/actions.py
@@ -55,6 +55,7 @@ from prefect.server.events.schemas.labelling import LabelDiver
 from prefect.server.schemas.actions import DeploymentFlowRunCreate, StateCreate
 from prefect.server.schemas.core import (
     BlockDocument,
+    ConcurrencyLimitV2,
     Flow,
     TaskRun,
     WorkPool,
@@ -62,7 +63,6 @@ from prefect.server.schemas.core import (
 from prefect.server.schemas.responses import (
     DeploymentResponse,
     FlowRunResponse,
-    GlobalConcurrencyLimitResponse,
     OrchestrationResult,
     StateAcceptDetails,
     WorkQueueWithStatus,
@@ -458,7 +458,7 @@ class JinjaTemplateAction(ExternalDataAction):
                 ],
             ),
             "prefect.concurrency-limit": (
-                GlobalConcurrencyLimitResponse,
+                ConcurrencyLimitV2,
                 [orchestration_client.read_concurrency_limit_v2_raw],
             ),
         }
@@ -1592,6 +1592,7 @@ ServerActionTypes: TypeAlias = Union[
     PauseWorkPool,
     ResumeWorkPool,
 ]
+
 
 _recent_actions: MutableMapping[UUID, bool] = TTLCache(maxsize=10000, ttl=3600)
 

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -634,7 +634,6 @@ class ConcurrencyLimitV2Update(ActionBaseModel):
     active_slots: Optional[NonNegativeInteger] = Field(None)
     denied_slots: Optional[NonNegativeInteger] = Field(None)
     slot_decay_per_second: Optional[NonNegativeFloat] = Field(None)
-    holders: Optional[List[str]] = Field(None)
 
 
 class BlockTypeCreate(ActionBaseModel):

--- a/src/prefect/server/schemas/responses.py
+++ b/src/prefect/server/schemas/responses.py
@@ -551,9 +551,6 @@ class GlobalConcurrencyLimitResponse(ORMBaseModel):
         default=2.0,
         description="The decay rate for active slots when used as a rate limit.",
     )
-    holders: List[str] = Field(
-        default_factory=list, description="The holders of the global concurrency limit."
-    )
 
 
 class FlowPaginationResponse(BaseModel):

--- a/tests/concurrency/test_acquire_concurrency_slots.py
+++ b/tests/concurrency/test_acquire_concurrency_slots.py
@@ -9,9 +9,7 @@ from prefect.concurrency.asyncio import _acquire_concurrency_slots
 
 async def test_calls_increment_client_method():
     limits = [
-        MinimalConcurrencyLimitResponse(
-            id=uuid.uuid4(), name=f"test-{i}", limit=i, holders=[]
-        )
+        MinimalConcurrencyLimitResponse(id=uuid.uuid4(), name=f"test-{i}", limit=i)
         for i in range(1, 3)
     ]
 
@@ -31,15 +29,12 @@ async def test_calls_increment_client_method():
             slots=1,
             mode="concurrency",
             create_if_missing=True,
-            holder=None,
         )
 
 
 async def test_returns_minimal_concurrency_limit():
     limits = [
-        MinimalConcurrencyLimitResponse(
-            id=uuid.uuid4(), name=f"test-{i}", limit=i, holders=[]
-        )
+        MinimalConcurrencyLimitResponse(id=uuid.uuid4(), name=f"test-{i}", limit=i)
         for i in range(1, 3)
     ]
 

--- a/tests/concurrency/test_concurrency_asyncio.py
+++ b/tests/concurrency/test_concurrency_asyncio.py
@@ -37,18 +37,17 @@ async def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV
             await resource_heavy()
 
             acquire_spy.assert_called_once_with(
-                ["test"], 1, timeout_seconds=None, create_if_missing=True, holder=None
+                ["test"], 1, timeout_seconds=None, create_if_missing=True
             )
 
             # On release we calculate how many seconds the slots were occupied
             # for, so here we really just want to make sure that the value
             # passed as `occupy_seconds` is > 0.
 
-            names, occupy, occupy_seconds, holder = release_spy.call_args[0]
+            names, occupy, occupy_seconds = release_spy.call_args[0]
             assert names == ["test"]
             assert occupy == 1
             assert occupy_seconds > 0
-            assert holder is None
 
     assert executed
 
@@ -416,18 +415,17 @@ async def test_concurrency_creates_new_limits_if_requested(
             await resource_heavy()
 
             acquire_spy.assert_called_once_with(
-                ["test"], 1, timeout_seconds=None, create_if_missing=True, holder=None
+                ["test"], 1, timeout_seconds=None, create_if_missing=True
             )
 
             # On release we calculate how many seconds the slots were occupied
             # for, so here we really just want to make sure that the value
             # passed as `occupy_seconds` is > 0.
 
-            names, occupy, occupy_seconds, holder = release_spy.call_args[0]
+            names, occupy, occupy_seconds = release_spy.call_args[0]
             assert names == ["test"]
             assert occupy == 1
             assert occupy_seconds > 0
-            assert holder is None
 
     assert executed
 

--- a/tests/concurrency/test_concurrency_slot_acquisition_service.py
+++ b/tests/concurrency/test_concurrency_slot_acquisition_service.py
@@ -41,7 +41,7 @@ async def test_returns_successful_response(mocked_client):
     expected_mode = "concurrency"
 
     service = ConcurrencySlotAcquisitionService.instance(frozenset(expected_names))
-    future = service.send((expected_slots, expected_mode, None, True, None))
+    future = service.send((expected_slots, expected_mode, None, True))
     await service.drain()
     returned_response = await asyncio.wrap_future(future)
     assert returned_response == response
@@ -51,7 +51,6 @@ async def test_returns_successful_response(mocked_client):
         slots=expected_slots,
         mode=expected_mode,
         create_if_missing=True,
-        holder=None,
     )
 
 
@@ -71,8 +70,8 @@ async def test_retries_failed_call_respects_retry_after_header(mocked_client):
     service = ConcurrencySlotAcquisitionService.instance(frozenset(limit_names))
 
     with mock.patch("prefect.concurrency.asyncio.asyncio.sleep") as sleep:
-        future = service.send((1, "concurrency", None, True, None))
-        service.drain()
+        future = service.send((1, "concurrency", None, True))
+        await service.drain()
         returned_response = await asyncio.wrap_future(future)
 
         assert returned_response == responses[1]
@@ -95,7 +94,7 @@ async def test_failed_call_status_code_not_retryable_returns_exception(mocked_cl
     limit_names = sorted(["api", "database"])
     service = ConcurrencySlotAcquisitionService.instance(frozenset(limit_names))
 
-    future = service.send((1, "concurrency", None, True, None))
+    future = service.send((1, "concurrency", None, True))
     await service.drain()
     exception = await asyncio.wrap_future(future)
 
@@ -110,7 +109,7 @@ async def test_basic_exception_returns_exception(mocked_client):
     limit_names = sorted(["api", "database"])
     service = ConcurrencySlotAcquisitionService.instance(frozenset(limit_names))
 
-    future = service.send((1, "concurrency", None, True, None))
+    future = service.send((1, "concurrency", None, True))
     await service.drain()
     exception = await asyncio.wrap_future(future)
 

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -36,18 +36,17 @@ def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV2):
             resource_heavy()
 
             acquire_spy.assert_called_once_with(
-                ["test"], 1, timeout_seconds=None, create_if_missing=True, holder=None
+                ["test"], 1, timeout_seconds=None, create_if_missing=True
             )
 
             # On release we calculate how many seconds the slots were occupied
             # for, so here we really just want to make sure that the value
             # passed as `occupy_seconds` is > 0.
 
-            names, occupy, occupy_seconds, holder = release_spy.call_args[0]
+            names, occupy, occupy_seconds = release_spy.call_args[0]
             assert names == ["test"]
             assert occupy == 1
             assert occupy_seconds > 0
-            assert holder is None
 
     assert executed
 

--- a/tests/concurrency/test_release_concurrency_slots.py
+++ b/tests/concurrency/test_release_concurrency_slots.py
@@ -9,9 +9,7 @@ from prefect.concurrency.asyncio import _release_concurrency_slots
 
 async def test_calls_release_client_method():
     limits = [
-        MinimalConcurrencyLimitResponse(
-            id=uuid.uuid4(), name=f"test-{i}", limit=i, holders=[]
-        )
+        MinimalConcurrencyLimitResponse(id=uuid.uuid4(), name=f"test-{i}", limit=i)
         for i in range(1, 3)
     ]
 
@@ -24,21 +22,18 @@ async def test_calls_release_client_method():
         client_release_concurrency_slots.return_value = response
 
         await _release_concurrency_slots(
-            names=["test-1", "test-2"], slots=1, occupancy_seconds=1.0, holder=None
+            names=["test-1", "test-2"], slots=1, occupancy_seconds=1.0
         )
         client_release_concurrency_slots.assert_called_once_with(
             names=["test-1", "test-2"],
             slots=1,
             occupancy_seconds=1.0,
-            holder=None,
         )
 
 
 async def test_returns_minimal_concurrency_limit():
     limits = [
-        MinimalConcurrencyLimitResponse(
-            id=uuid.uuid4(), name=f"test-{i}", limit=i, holders=[]
-        )
+        MinimalConcurrencyLimitResponse(id=uuid.uuid4(), name=f"test-{i}", limit=i)
         for i in range(1, 3)
     ]
 
@@ -50,7 +45,5 @@ async def test_returns_minimal_concurrency_limit():
         )
         client_release_concurrency_slots.return_value = response
 
-        result = await _release_concurrency_slots(
-            ["test-1", "test-2"], 1, 1.0, holder=None
-        )
+        result = await _release_concurrency_slots(["test-1", "test-2"], 1, 1.0)
         assert result == limits

--- a/tests/server/models/test_concurrency_limits_v2.py
+++ b/tests/server/models/test_concurrency_limits_v2.py
@@ -1,5 +1,5 @@
 import asyncio
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import pytest
 from pydantic import ValidationError
@@ -9,16 +9,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.models.concurrency_limits_v2 import (
     MINIMUM_OCCUPANCY_SECONDS_PER_SLOT,
-    _limit_holders,
     bulk_decrement_active_slots,
     bulk_increment_active_slots,
     bulk_read_or_create_concurrency_limits,
     bulk_update_denied_slots,
     create_concurrency_limit,
-    decrement_limit_holder,
     delete_concurrency_limit,
-    get_limit_holders,
-    increment_limit_holder,
     read_all_concurrency_limits,
     read_concurrency_limit,
     update_concurrency_limit,
@@ -76,12 +72,6 @@ async def locked_concurrency_limit(session: AsyncSession) -> ConcurrencyLimitV2:
     await session.commit()
 
     return ConcurrencyLimitV2.model_validate(concurrency_limit, from_attributes=True)
-
-
-@pytest.fixture
-def clear_holders():
-    """Fixture to clear the global holders before each test."""
-    _limit_holders.clear()
 
 
 async def test_create_concurrency_limit(session: AsyncSession):
@@ -600,104 +590,3 @@ async def test_bulk_update_denied_slots(
     )
     assert refreshed
     assert refreshed.denied_slots == 10
-
-
-def test_increment_limit_holder_single_holder(clear_holders):
-    limit_id = uuid4()
-    holder = "holder1"
-
-    increment_limit_holder(holder, 3, limit_id)
-
-    assert _limit_holders[limit_id][holder] == 3
-    assert list(_limit_holders[limit_id]) == [holder]
-
-
-def test_increment_limit_holder_multiple_holders(clear_holders):
-    limit_id = uuid4()
-    holder1 = "holder1"
-    holder2 = "holder2"
-
-    increment_limit_holder(holder1, 2, limit_id)
-    increment_limit_holder(holder2, 1, limit_id)
-
-    assert _limit_holders[limit_id][holder1] == 2
-    assert _limit_holders[limit_id][holder2] == 1
-    assert list(_limit_holders[limit_id]) == [holder1, holder2]
-
-
-def test_decrement_limit_holder_known_holder(clear_holders):
-    limit_id = uuid4()
-    holder = "holder1"
-
-    increment_limit_holder(holder, 3, limit_id)
-    decrement_limit_holder(holder, 2, 3, limit_id)
-
-    assert _limit_holders[limit_id][holder] == 1
-    assert list(_limit_holders[limit_id]) == [holder]
-
-
-def test_decrement_limit_holder_removes_holder_when_slots_are_zero(clear_holders):
-    limit_id = uuid4()
-    holder = "holder1"
-
-    increment_limit_holder(holder, 2, limit_id)
-    decrement_limit_holder(holder, 2, 2, limit_id)
-
-    assert holder not in _limit_holders[limit_id]
-
-
-def test_get_limit_holders(clear_holders):
-    limit_id = uuid4()
-    holder1 = "holder1"
-    holder2 = "holder2"
-
-    increment_limit_holder(holder1, 2, limit_id)
-    increment_limit_holder(holder2, 3, limit_id)
-
-    holders = get_limit_holders(limit_id)
-    assert holders == {limit_id: [holder1, holder2]}
-
-
-def test_decrement_all_slots_should_clear_holders(clear_holders):
-    limit_id = uuid4()
-    holder1 = "holder1"
-    holder2 = "holder2"
-
-    increment_limit_holder(holder1, 1, limit_id)
-    increment_limit_holder(holder2, 1, limit_id)
-
-    # Decrement all slots, this should clear all holders
-    decrement_limit_holder(None, 2, 2, limit_id)
-
-    assert _limit_holders[limit_id] == {}
-
-
-def test_increment_and_decrement_holder_multiple_slots(clear_holders):
-    limit_id = uuid4()
-    holder = "holder1"
-
-    increment_limit_holder(holder, 5, limit_id)
-    decrement_limit_holder(holder, 3, 5, limit_id)
-
-    assert _limit_holders[limit_id][holder] == 2
-    assert list(_limit_holders[limit_id]) == [holder]
-
-
-def test_decrement_unknown_holder_should_spread_slots_across_existing_holders(
-    clear_holders,
-):
-    limit_id = uuid4()
-    holder1 = "holder1"
-    holder2 = "holder2"
-    holder3 = "holder3"
-
-    increment_limit_holder(holder1, 3, limit_id)
-    increment_limit_holder(holder2, 2, limit_id)
-
-    # Try to decrement a holder that wasn't incremented
-    decrement_limit_holder(holder3, 4, 3, limit_id)
-
-    assert _limit_holders[limit_id][holder1] == 1
-    assert "holder2" not in _limit_holders[limit_id]
-    assert holder3 not in _limit_holders[limit_id]
-    assert list(_limit_holders[limit_id]) == [holder1]

--- a/tests/server/orchestration/api/test_concurrency_limits_v2.py
+++ b/tests/server/orchestration/api/test_concurrency_limits_v2.py
@@ -9,7 +9,6 @@ from prefect.server.database.interface import PrefectDBInterface
 from prefect.server.models.concurrency_limits_v2 import (
     bulk_update_denied_slots,
     create_concurrency_limit,
-    increment_limit_holder,
     read_concurrency_limit,
 )
 from prefect.server.schemas.core import ConcurrencyLimitV2
@@ -106,32 +105,6 @@ async def test_read_concurrency_limit_by_name(
 
     data = response.json()
     assert data["id"] == str(concurrency_limit.id)
-    assert data["holders"] == []
-
-
-async def test_read_concurrency_limit_by_name_with_holders(
-    session: AsyncSession,
-    client: AsyncClient,
-):
-    concurrency_limit = await create_concurrency_limit(
-        session=session,
-        concurrency_limit=ConcurrencyLimitV2(
-            name="test_limit",
-            limit=1,
-            active_slots=1,
-        ),
-    )
-    await session.commit()
-
-    increment_limit_holder("test-holder", 1, concurrency_limit.id)
-
-    response = await client.get(f"/v2/concurrency_limits/{concurrency_limit.name}")
-    assert response.status_code == 200
-
-    data = response.json()
-    assert data["id"] == str(concurrency_limit.id)
-    assert data["holders"] == ["test-holder"]
-    assert data["active_slots"] == 1
 
 
 async def test_read_concurrency_non_existent_limit(
@@ -344,22 +317,6 @@ async def test_increment_concurrency_limit_inactive(
     )
     assert refreshed_limit
     assert refreshed_limit.active_slots == 0  # Inactive limits are not incremented
-
-
-async def test_increment_concurrency_limit_with_holder(
-    concurrency_limit: ConcurrencyLimitV2,
-    client: AsyncClient,
-):
-    response = await client.get(f"/v2/concurrency_limits/{concurrency_limit.name}")
-    assert response.status_code == 200
-    assert response.json()["holders"] == []
-
-    response = await client.post(
-        "/v2/concurrency_limits/increment",
-        json={"names": [concurrency_limit.name], "holder": "test-holder", "slots": 1},
-    )
-    assert response.status_code == 200
-    assert response.json()[0]["holders"] == ["test-holder"]
 
 
 async def test_increment_concurrency_limit_locked(
@@ -585,169 +542,3 @@ async def test_decrement_concurrency_limit(
     )
     assert refreshed_limit
     assert refreshed_limit.active_slots == refreshed_limit.limit - 1
-
-
-async def test_decrement_concurrency_limit_with_holder(
-    concurrency_limit: ConcurrencyLimitV2,
-    client: AsyncClient,
-):
-    response = await client.get(f"/v2/concurrency_limits/{concurrency_limit.name}")
-    assert response.status_code == 200
-    assert response.json()["holders"] == []
-
-    response = await client.post(
-        "/v2/concurrency_limits/increment",
-        json={"names": [concurrency_limit.name], "holder": "test-holder", "slots": 1},
-    )
-    assert response.status_code == 200
-    assert response.json()[0]["holders"] == ["test-holder"]
-
-    response = await client.post(
-        "/v2/concurrency_limits/decrement",
-        json={"names": [concurrency_limit.name], "holder": "test-holder", "slots": 1},
-    )
-    assert response.status_code == 200
-    assert response.json()[0]["holders"] == []
-
-
-async def test_decrement_concurrency_limit_without_holder_removes_horder_in_lifo_order(
-    concurrency_limit: ConcurrencyLimitV2,
-    client: AsyncClient,
-):
-    response = await client.get(f"/v2/concurrency_limits/{concurrency_limit.name}")
-    assert response.status_code == 200
-    assert response.json()["holders"] == []
-
-    response = await client.post(
-        "/v2/concurrency_limits/increment",
-        json={"names": [concurrency_limit.name], "holder": "holder-1", "slots": 1},
-    )
-    assert response.status_code == 200
-    response = await client.post(
-        "/v2/concurrency_limits/increment",
-        json={"names": [concurrency_limit.name], "holder": "holder-2", "slots": 1},
-    )
-    assert response.status_code == 200
-    assert response.json()[0]["holders"] == ["holder-1", "holder-2"]
-
-    response = await client.post(
-        "/v2/concurrency_limits/decrement",
-        json={"names": [concurrency_limit.name], "slots": 1},
-    )
-    assert response.status_code == 200
-    assert response.json()[0]["holders"] == ["holder-2"]
-
-
-async def test_decrement_concurrency_limit_unknown_holder(
-    concurrency_limit: ConcurrencyLimitV2,
-    client: AsyncClient,
-):
-    response = await client.get(f"/v2/concurrency_limits/{concurrency_limit.name}")
-    assert response.status_code == 200
-    assert response.json()["holders"] == []
-    assert response.json()["active_slots"] == 0
-
-    response = await client.post(
-        "/v2/concurrency_limits/increment",
-        json={"names": [concurrency_limit.name], "slots": 1},
-    )
-    assert response.status_code == 200
-
-    response = await client.post(
-        "/v2/concurrency_limits/increment",
-        json={"names": [concurrency_limit.name], "holder": "test-holder-1", "slots": 1},
-    )
-    assert response.status_code == 200
-    assert response.json()[0]["holders"] == ["test-holder-1"]
-
-    response = await client.post(
-        "/v2/concurrency_limits/increment",
-        json={"names": [concurrency_limit.name], "holder": "test-holder-2", "slots": 1},
-    )
-    assert response.status_code == 200
-    assert response.json()[0]["holders"] == ["test-holder-1", "test-holder-2"]
-
-    # This one is the unknown holder, the others were just setup
-    response = await client.post(
-        "/v2/concurrency_limits/decrement",
-        json={
-            "names": [concurrency_limit.name],
-            "holder": "unknown-holder",
-            "slots": 1,
-        },
-    )
-    assert response.status_code == 200
-
-    response = await client.get(f"/v2/concurrency_limits/{concurrency_limit.name}")
-    assert response.status_code == 200
-
-    # We err on the side of preserving the correct active slot count even if
-    # we lose track of the holders when incoming data is incorrect. Here,
-    # we received a decrement for a holder that didn't exist. Instead of
-    # ignoring it, we decrement a different holder so that the counts are
-    # correct.
-    assert response.json()["active_slots"] == 2
-    assert response.json()["holders"] == ["test-holder-2"]
-
-
-async def test_decrement_concurrency_limit_resets_holders_without_holder_if_active_limits_is_zero(
-    concurrency_limit: ConcurrencyLimitV2,
-    client: AsyncClient,
-):
-    response = await client.get(f"/v2/concurrency_limits/{concurrency_limit.name}")
-    assert response.status_code == 200
-    assert response.json()["active_slots"] == 0
-    assert response.json()["holders"] == []
-
-    response = await client.post(
-        "/v2/concurrency_limits/increment",
-        json={"names": [concurrency_limit.name], "holder": "test-holder", "slots": 1},
-    )
-    assert response.status_code == 200
-    assert response.json()[0]["holders"] == ["test-holder"]
-
-    response = await client.post(
-        "/v2/concurrency_limits/decrement",
-        json={
-            "names": [concurrency_limit.name],
-            "slots": 1,
-        },
-    )
-    assert response.status_code == 200
-
-    response = await client.get(f"/v2/concurrency_limits/{concurrency_limit.name}")
-    assert response.status_code == 200
-    assert response.json()["active_slots"] == 0
-    assert response.json()["holders"] == []
-
-
-async def test_decrement_concurrency_limit_resets_holders_if_active_limits_is_zero(
-    concurrency_limit: ConcurrencyLimitV2,
-    client: AsyncClient,
-):
-    response = await client.get(f"/v2/concurrency_limits/{concurrency_limit.name}")
-    assert response.status_code == 200
-    assert response.json()["active_slots"] == 0
-    assert response.json()["holders"] == []
-
-    response = await client.post(
-        "/v2/concurrency_limits/increment",
-        json={"names": [concurrency_limit.name], "holder": "test-holder", "slots": 1},
-    )
-    assert response.status_code == 200
-    assert response.json()[0]["holders"] == ["test-holder"]
-
-    response = await client.post(
-        "/v2/concurrency_limits/decrement",
-        json={
-            "names": [concurrency_limit.name],
-            "holder": "unknown-holder",
-            "slots": 1,
-        },
-    )
-    assert response.status_code == 200
-
-    response = await client.get(f"/v2/concurrency_limits/{concurrency_limit.name}")
-    assert response.status_code == 200
-    assert response.json()["active_slots"] == 0
-    assert response.json()["holders"] == []

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -2286,18 +2286,13 @@ class TestTaskConcurrencyLimits:
                 await bar()
 
                 acquire_spy.assert_called_once_with(
-                    ["limit-tag"],
-                    1,
-                    timeout_seconds=None,
-                    create_if_missing=False,
-                    holder=None,
+                    ["limit-tag"], 1, timeout_seconds=None, create_if_missing=False
                 )
 
-                names, occupy, occupy_seconds, holder = release_spy.call_args[0]
+                names, occupy, occupy_seconds = release_spy.call_args[0]
                 assert names == ["limit-tag"]
                 assert occupy == 1
                 assert occupy_seconds > 0
-                assert holder is None
 
     def test_tag_concurrency_sync(self):
         @task(tags=["limit-tag"])
@@ -2315,18 +2310,13 @@ class TestTaskConcurrencyLimits:
                 bar()
 
                 acquire_spy.assert_called_once_with(
-                    ["limit-tag"],
-                    1,
-                    timeout_seconds=None,
-                    create_if_missing=False,
-                    holder=None,
+                    ["limit-tag"], 1, timeout_seconds=None, create_if_missing=False
                 )
 
-                names, occupy, occupy_seconds, holder = release_spy.call_args[0]
+                names, occupy, occupy_seconds = release_spy.call_args[0]
                 assert names == ["limit-tag"]
                 assert occupy == 1
                 assert occupy_seconds > 0
-                assert holder is None
 
     async def test_no_tags_no_concurrency(self):
         @task
@@ -2376,11 +2366,7 @@ class TestTaskConcurrencyLimits:
             await bar()
 
             acquire_spy.assert_called_once_with(
-                ["limit-tag"],
-                1,
-                timeout_seconds=None,
-                create_if_missing=False,
-                holder=None,
+                ["limit-tag"], 1, timeout_seconds=None, create_if_missing=False
             )
 
             limits = await prefect_client.read_concurrency_limits(10, 0)


### PR DESCRIPTION
This reverts commit 4da5da207b126639998917cb1e246f7b15484405 in favor of a different approach.
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
