### PR TITLE
Adds acquire/release endpoints for task run concurrency limits

### DIFF
--- a/docs/3.0rc/api-ref/rest-api/server/concurrency-limits/decrement-concurrency-limits-v1.mdx
+++ b/docs/3.0rc/api-ref/rest-api/server/concurrency-limits/decrement-concurrency-limits-v1.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /api/concurrency_limits/decrement
+---

--- a/docs/3.0rc/api-ref/rest-api/server/concurrency-limits/increment-concurrency-limits-v1.mdx
+++ b/docs/3.0rc/api-ref/rest-api/server/concurrency-limits/increment-concurrency-limits-v1.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /api/concurrency_limits/increment
+---

--- a/docs/3.0rc/api-ref/rest-api/server/schema.json
+++ b/docs/3.0rc/api-ref/rest-api/server/schema.json
@@ -4290,6 +4290,106 @@
                 }
             }
         },
+        "/api/concurrency_limits/increment": {
+            "post": {
+                "tags": [
+                    "Concurrency Limits"
+                ],
+                "summary": "Increment Concurrency Limits V1",
+                "operationId": "increment_concurrency_limits_v1_concurrency_limits_increment_post",
+                "parameters": [
+                    {
+                        "name": "x-prefect-api-version",
+                        "in": "header",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "title": "X-Prefect-Api-Version"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_increment_concurrency_limits_v1_concurrency_limits_increment_post"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/concurrency_limits/decrement": {
+            "post": {
+                "tags": [
+                    "Concurrency Limits"
+                ],
+                "summary": "Decrement Concurrency Limits V1",
+                "operationId": "decrement_concurrency_limits_v1_concurrency_limits_decrement_post",
+                "parameters": [
+                    {
+                        "name": "x-prefect-api-version",
+                        "in": "header",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "title": "X-Prefect-Api-Version"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Body_decrement_concurrency_limits_v1_concurrency_limits_decrement_post"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v2/concurrency_limits/": {
             "post": {
                 "tags": [
@@ -13060,6 +13160,30 @@
                 ],
                 "title": "Body_create_flow_run_input_flow_runs__id__input_post"
             },
+            "Body_decrement_concurrency_limits_v1_concurrency_limits_decrement_post": {
+                "properties": {
+                    "names": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Names",
+                        "description": "The tags to release a slot for"
+                    },
+                    "task_run_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Task Run Id",
+                        "description": "The ID of the task run releasing the slot"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "names",
+                    "task_run_id"
+                ],
+                "title": "Body_decrement_concurrency_limits_v1_concurrency_limits_decrement_post"
+            },
             "Body_drop_database_admin_database_drop_post": {
                 "properties": {
                     "confirm": {
@@ -13231,6 +13355,30 @@
                 },
                 "type": "object",
                 "title": "Body_get_scheduled_flow_runs_work_pools__name__get_scheduled_flow_runs_post"
+            },
+            "Body_increment_concurrency_limits_v1_concurrency_limits_increment_post": {
+                "properties": {
+                    "names": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Names",
+                        "description": "The tags to acquire a slot for"
+                    },
+                    "task_run_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Task Run Id",
+                        "description": "The ID of the task run acquiring the slot"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "names",
+                    "task_run_id"
+                ],
+                "title": "Body_increment_concurrency_limits_v1_concurrency_limits_increment_post"
             },
             "Body_next_runs_by_flow_ui_flows_next_runs_post": {
                 "properties": {

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -487,7 +487,9 @@
                     "3.0rc/api-ref/rest-api/server/concurrency-limits/read-concurrency-limit-by-tag",
                     "3.0rc/api-ref/rest-api/server/concurrency-limits/delete-concurrency-limit-by-tag",
                     "3.0rc/api-ref/rest-api/server/concurrency-limits/read-concurrency-limits",
-                    "3.0rc/api-ref/rest-api/server/concurrency-limits/reset-concurrency-limit-by-tag"
+                    "3.0rc/api-ref/rest-api/server/concurrency-limits/reset-concurrency-limit-by-tag",
+                    "3.0rc/api-ref/rest-api/server/concurrency-limits/increment-concurrency-limits-v1",
+                    "3.0rc/api-ref/rest-api/server/concurrency-limits/decrement-concurrency-limits-v1"
                   ]
                 },
                 {

--- a/tests/server/orchestration/api/test_concurrency_limits.py
+++ b/tests/server/orchestration/api/test_concurrency_limits.py
@@ -1,9 +1,13 @@
+from typing import List
 from uuid import uuid4
 
+import pytest
+from httpx import AsyncClient
 from starlette import status
 
 from prefect.server import schemas
 from prefect.server.schemas.actions import ConcurrencyLimitCreate
+from prefect.settings import PREFECT_TASK_RUN_TAG_CONCURRENCY_SLOT_WAIT_SECONDS
 
 
 class TestConcurrencyLimits:
@@ -99,3 +103,170 @@ class TestConcurrencyLimits:
 
         post_reset = await client.get(f"/concurrency_limits/{cl_id}")
         assert len(post_reset.json()["active_slots"]) == 0
+
+
+class TestAcquiringAndReleasing:
+    @pytest.fixture
+    async def tags_with_limits(
+        self,
+        client: AsyncClient,
+    ) -> List[str]:
+        tags = ["tag1", "tag2"]
+
+        for tag in tags:
+            await client.post(
+                "/concurrency_limits/",
+                json=ConcurrencyLimitCreate(
+                    tag=tag,
+                    concurrency_limit=2,
+                ).model_dump(mode="json"),
+            )
+
+        return tags
+
+    async def test_acquiring_and_releasing_limits(
+        self,
+        client: AsyncClient,
+        tags_with_limits: List[str],
+    ):
+        task_run_id = uuid4()
+        tags = tags_with_limits + ["does-not-exist"]
+
+        response = await client.post(
+            "/concurrency_limits/increment",
+            json={"names": tags, "task_run_id": str(task_run_id)},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        for tag in tags_with_limits:
+            read_response = await client.get(f"/concurrency_limits/tag/{tag}")
+            concurrency_limit = schemas.core.ConcurrencyLimit.model_validate(
+                read_response.json()
+            )
+            assert concurrency_limit.active_slots == [task_run_id]
+
+        response = await client.post(
+            "/concurrency_limits/decrement",
+            json={"names": tags, "task_run_id": str(task_run_id)},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        # confirm the slots have been released
+
+        for tag in tags_with_limits:
+            read_response = await client.get(f"/concurrency_limits/tag/{tag}")
+            concurrency_limit = schemas.core.ConcurrencyLimit.model_validate(
+                read_response.json()
+            )
+            assert concurrency_limit.active_slots == []
+
+    async def test_failing_to_acquire_one_slot(
+        self,
+        client: AsyncClient,
+        tags_with_limits: List[str],
+    ):
+        task_run_id = uuid4()
+        tags = tags_with_limits + ["does-not-exist"]
+
+        # Acquire the slots by two random other task runs
+        for i in range(2):
+            response = await client.post(
+                "/concurrency_limits/increment",
+                json={"names": tags_with_limits[:1], "task_run_id": str(uuid4())},
+            )
+            assert response.status_code == status.HTTP_200_OK
+
+        response = await client.post(
+            "/concurrency_limits/increment",
+            json={"names": tags, "task_run_id": str(task_run_id)},
+        )
+        assert response.status_code == status.HTTP_423_LOCKED
+        assert "Retry-After" in response.headers
+        assert (
+            0.0
+            <= float(response.headers["Retry-After"])
+            <= PREFECT_TASK_RUN_TAG_CONCURRENCY_SLOT_WAIT_SECONDS.value() * 2
+        )
+        assert (
+            "Concurrency limit for the tag1 tag has been reached"
+            in response.json()["detail"]
+        )
+
+        for tag in tags_with_limits:
+            read_response = await client.get(f"/concurrency_limits/tag/{tag}")
+            concurrency_limit = schemas.core.ConcurrencyLimit.model_validate(
+                read_response.json()
+            )
+            assert task_run_id not in concurrency_limit.active_slots
+
+        response = await client.post(
+            "/concurrency_limits/decrement",
+            json={"names": tags, "task_run_id": str(task_run_id)},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        # confirm the slots have been released
+
+        for tag in tags_with_limits:
+            read_response = await client.get(f"/concurrency_limits/tag/{tag}")
+            concurrency_limit = schemas.core.ConcurrencyLimit.model_validate(
+                read_response.json()
+            )
+            assert task_run_id not in concurrency_limit.active_slots
+
+    @pytest.fixture
+    async def tag_with_zero_concurrency(
+        self,
+        client: AsyncClient,
+    ) -> str:
+        await client.post(
+            "/concurrency_limits/",
+            json=ConcurrencyLimitCreate(
+                tag="zero",
+                concurrency_limit=0,
+            ).model_dump(mode="json"),
+        )
+
+        return "zero"
+
+    async def test_setting_tag_to_zero_concurrency(
+        self,
+        client: AsyncClient,
+        tags_with_limits: List[str],
+        tag_with_zero_concurrency: str,
+    ):
+        task_run_id = uuid4()
+        tags = tags_with_limits + [tag_with_zero_concurrency] + ["does-not-exist"]
+
+        response = await client.post(
+            "/concurrency_limits/increment",
+            json={"names": tags, "task_run_id": str(task_run_id)},
+        )
+        assert response.status_code == status.HTTP_423_LOCKED
+        assert "Retry-After" not in response.headers
+        assert (
+            'The concurrency limit on tag "zero" is 0 and will deadlock if the task '
+            "tries to run again." in response.json()["detail"]
+        )
+
+        for tag in tags_with_limits + [tag_with_zero_concurrency]:
+            read_response = await client.get(f"/concurrency_limits/tag/{tag}")
+            concurrency_limit = schemas.core.ConcurrencyLimit.model_validate(
+                read_response.json()
+            )
+            assert concurrency_limit.active_slots == []
+
+        response = await client.post(
+            "/concurrency_limits/decrement",
+            json={"names": tags, "task_run_id": str(task_run_id)},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        # confirm the slots have been released
+
+        for tag in tags_with_limits + [tag_with_zero_concurrency]:
+            read_response = await client.get(f"/concurrency_limits/tag/{tag}")
+            concurrency_limit = schemas.core.ConcurrencyLimit.model_validate(
+                read_response.json()
+            )
+            assert concurrency_limit.active_slots == []


### PR DESCRIPTION
In support of client-side task run orchestration, we need to expose these two
endpoints so that clients may acquire and release tag-based concurrency limits
for the task runs they are orchestrating.

The design of this API is intended to be closer to V2 concurrency terminology,
hence the `increment`/`decrement` paths and the `names` parameter.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
