### PR TITLE
Remove Redis record store settings

### DIFF
--- a/docs/3.0rc/api-ref/rest-api/server/schema.json
+++ b/docs/3.0rc/api-ref/rest-api/server/schema.json
@@ -22618,48 +22618,6 @@
                         "title": "Prefect Experimental Enable Schedule Concurrency",
                         "default": false
                     },
-                    "PREFECT_RECORD_STORE_REDIS_HOST": {
-                        "type": "string",
-                        "title": "Prefect Record Store Redis Host",
-                        "default": "localhost"
-                    },
-                    "PREFECT_RECORD_STORE_REDIS_PORT": {
-                        "type": "integer",
-                        "title": "Prefect Record Store Redis Port",
-                        "default": 6379
-                    },
-                    "PREFECT_RECORD_STORE_REDIS_DB": {
-                        "type": "integer",
-                        "title": "Prefect Record Store Redis Db",
-                        "default": 0
-                    },
-                    "PREFECT_RECORD_STORE_REDIS_USERNAME": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Prefect Record Store Redis Username"
-                    },
-                    "PREFECT_RECORD_STORE_REDIS_PASSWORD": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Prefect Record Store Redis Password"
-                    },
-                    "PREFECT_RECORD_STORE_REDIS_SSL": {
-                        "type": "boolean",
-                        "title": "Prefect Record Store Redis Ssl",
-                        "default": false
-                    },
                     "PREFECT_DEFAULT_RESULT_STORAGE_BLOCK": {
                         "anyOf": [
                             {

--- a/src/integrations/prefect-redis/prefect_redis/records.py
+++ b/src/integrations/prefect-redis/prefect_redis/records.py
@@ -8,14 +8,6 @@ from redis.lock import Lock
 from prefect.records import RecordStore
 from prefect.records.base import TransactionRecord
 from prefect.results import BaseResult
-from prefect.settings import (
-    PREFECT_RECORD_STORE_REDIS_DB,
-    PREFECT_RECORD_STORE_REDIS_HOST,
-    PREFECT_RECORD_STORE_REDIS_PASSWORD,
-    PREFECT_RECORD_STORE_REDIS_PORT,
-    PREFECT_RECORD_STORE_REDIS_SSL,
-    PREFECT_RECORD_STORE_REDIS_USERNAME,
-)
 from prefect.transactions import IsolationLevel
 
 
@@ -35,36 +27,28 @@ class RedisRecordStore(RecordStore):
 
     def __init__(
         self,
-        host: Optional[str] = None,
-        port: Optional[int] = None,
-        db: Optional[int] = None,
+        host: str = "localhost",
+        port: int = 6379,
+        db: int = 0,
         username: Optional[str] = None,
         password: Optional[str] = None,
-        ssl: Optional[bool] = None,
+        ssl: bool = False,
     ) -> None:
         """
         Args:
-            host: The host of the Redis server; defaults to the value of the
-                PREFECT_RECORD_STORE_REDIS_HOST setting if not provided
-            port: The port the Redis server is running on; defaults to the value of the
-                PREFECT_RECORD_STORE_REDIS_PORT setting if not provided
-            db: The database to write to and read from; defaults to the value of the
-                PREFECT_RECORD_STORE_REDIS_DB setting if not provided
-            username: The username to use when connecting to the Redis server; defaults
-                to the value of the PREFECT_RECORD_STORE_REDIS_USERNAME setting if not
-                provided
-            password: The password to use when connecting to the Redis server; defaults
-                to the value of the PREFECT_RECORD_STORE_REDIS_PASSWORD setting if not
-                provided
-            ssl: Whether to use SSL when connecting to the Redis server; defaults to the
-                value of the PREFECT_RECORD_STORE_REDIS_SSL setting if not provided
+            host: The host of the Redis server
+            port: The port the Redis server is running on
+            db: The database to write to and read from
+            username: The username to use when connecting to the Redis server
+            password: The password to use when connecting to the Redis server
+            ssl: Whether to use SSL when connecting to the Redis server
         """
-        self.host = host or PREFECT_RECORD_STORE_REDIS_HOST.value()
-        self.port = port or PREFECT_RECORD_STORE_REDIS_PORT.value()
-        self.db = db or PREFECT_RECORD_STORE_REDIS_DB.value()
-        self.username = username or PREFECT_RECORD_STORE_REDIS_USERNAME.value()
-        self.password = password or PREFECT_RECORD_STORE_REDIS_PASSWORD.value()
-        self.ssl = ssl or PREFECT_RECORD_STORE_REDIS_SSL.value()
+        self.host = host
+        self.port = port
+        self.db = db
+        self.username = username
+        self.password = password
+        self.ssl = ssl
         self.client = Redis(
             host=self.host,
             port=self.port,

--- a/src/integrations/prefect-redis/tests/test_records.py
+++ b/src/integrations/prefect-redis/tests/test_records.py
@@ -11,12 +11,6 @@ from prefect.filesystems import LocalFileSystem
 from prefect.results import ResultFactory
 from prefect.settings import (
     PREFECT_DEFAULT_RESULT_STORAGE_BLOCK,
-    PREFECT_RECORD_STORE_REDIS_DB,
-    PREFECT_RECORD_STORE_REDIS_HOST,
-    PREFECT_RECORD_STORE_REDIS_PASSWORD,
-    PREFECT_RECORD_STORE_REDIS_PORT,
-    PREFECT_RECORD_STORE_REDIS_SSL,
-    PREFECT_RECORD_STORE_REDIS_USERNAME,
     temporary_settings,
 )
 from prefect.transactions import IsolationLevel
@@ -46,31 +40,21 @@ class TestRedisRecordStore:
     def store(self):
         return RedisRecordStore()
 
-    def test_init_respects_settings(self, store):
-        assert store.host == PREFECT_RECORD_STORE_REDIS_HOST.value()
-        assert store.port == PREFECT_RECORD_STORE_REDIS_PORT.value()
-        assert store.db == PREFECT_RECORD_STORE_REDIS_DB.value()
-        assert store.username == PREFECT_RECORD_STORE_REDIS_USERNAME.value()
-        assert store.password == PREFECT_RECORD_STORE_REDIS_PASSWORD.value()
-        assert store.ssl == PREFECT_RECORD_STORE_REDIS_SSL.value()
-
-        with temporary_settings(
-            {
-                PREFECT_RECORD_STORE_REDIS_HOST: "new-host",
-                PREFECT_RECORD_STORE_REDIS_PORT: 1234,
-                PREFECT_RECORD_STORE_REDIS_DB: 1,
-                PREFECT_RECORD_STORE_REDIS_USERNAME: "new-username",
-                PREFECT_RECORD_STORE_REDIS_PASSWORD: "new-password",
-                PREFECT_RECORD_STORE_REDIS_SSL: True,
-            }
-        ):
-            store = RedisRecordStore()
-            assert store.host == "new-host"
-            assert store.port == 1234
-            assert store.db == 1
-            assert store.username == "new-username"
-            assert store.password == "new-password"
-            assert store.ssl
+    def test_init(self):
+        store = RedisRecordStore(
+            host="host",
+            port=1234,
+            db=1,
+            username="username",
+            password="password",
+            ssl=True,
+        )
+        assert store.host == "host"
+        assert store.port == 1234
+        assert store.db == 1
+        assert store.username == "username"
+        assert store.password == "password"
+        assert store.ssl
 
     def test_read_write(self, store, result):
         key = str(uuid4())

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1493,57 +1493,6 @@ PENDING for a while is a sign that the task worker may have crashed.
 
 PREFECT_EXPERIMENTAL_ENABLE_SCHEDULE_CONCURRENCY = Setting(bool, default=False)
 
-# Record store settings ----------------------------------------------------------------
-
-PREFECT_RECORD_STORE_REDIS_HOST = Setting(
-    str,
-    default="localhost",
-)
-"""
-The host address of the Redis server to use as the record store.
-"""
-
-PREFECT_RECORD_STORE_REDIS_PORT = Setting(
-    int,
-    default=6379,
-)
-"""
-The port of the Redis server to use as the record store.
-"""
-
-PREFECT_RECORD_STORE_REDIS_DB = Setting(
-    int,
-    default=0,
-)
-"""
-The Redis database index to use as the record store.
-"""
-
-PREFECT_RECORD_STORE_REDIS_USERNAME = Setting(
-    Optional[str],
-    default=None,
-)
-"""
-The username to use when connecting to the Redis server used as the record store.
-"""
-
-PREFECT_RECORD_STORE_REDIS_PASSWORD = Setting(
-    Optional[str],
-    default=None,
-    is_secret=True,
-)
-"""
-The password to use when connecting to the Redis server used as the record store.
-"""
-
-PREFECT_RECORD_STORE_REDIS_SSL = Setting(
-    bool,
-    default=False,
-)
-"""
-Whether or not to use SSL when connecting to the Redis server used as the record store.
-"""
-
 # Defaults -----------------------------------------------------------------------------
 
 PREFECT_DEFAULT_RESULT_STORAGE_BLOCK = Setting(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR removes the `PREFECT_RECORD_STORE_REDIS_` settings. After the exploration in https://github.com/PrefectHQ/prefect/pull/14987, I think that a more hierarchical structure for settings will be more ergonomic. The `RedisRecordStore` will be fully configurable via code and we'll introduce a more ergonomic way to configure defaults across environments once the settings mechanics can support it.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
