### PR TITLE
Performance: Add defer_build to PrefectBaseModel

### DIFF
--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -35,6 +35,7 @@ class PrefectBaseModel(BaseModel):
 
     model_config = ConfigDict(
         ser_json_timedelta="float",
+        defer_build=True,
         extra=(
             "ignore"
             if os.getenv("PREFECT_TEST_MODE", "0").lower() not in ["true", "1"]

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -60,6 +60,7 @@ class PrefectBaseModel(BaseModel):
     _reset_fields: ClassVar[Set[str]] = set()
     model_config = ConfigDict(
         ser_json_timedelta="float",
+        defer_build=True,
         extra=(
             "ignore"
             if os.getenv("PREFECT_TEST_MODE", "0").lower() not in ["true", "1"]


### PR DESCRIPTION
Experiment with pydantic's [defer_build](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.defer_build)

This simply pushes Pydantic's creation of its serializer from the moment of _creation_ to the moment of _invocation_. 

This doesn't save us from some of bigger import sins, but it's a start!