### PR TITLE
Test `experimental_defer_build_mode` with `defer_build=True`

### DIFF
--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -4,7 +4,7 @@ Utilities for creating and working with Prefect REST API schemas.
 
 import datetime
 import os
-from typing import Any, ClassVar, Literal, Optional, Set, TypeVar
+from typing import Any, ClassVar, Optional, Set, TypeVar
 from uuid import UUID, uuid4
 
 import pendulum
@@ -32,12 +32,10 @@ class PrefectBaseModel(BaseModel):
     """
 
     _reset_fields: ClassVar[Set[str]] = set()
-    experimental_defer_build_mode: ClassVar[
-        tuple[Literal["model", "type_adapter"], ...]
-    ] = ("model", "type_adapter")
 
     model_config = ConfigDict(
         ser_json_timedelta="float",
+        experimental_defer_build_mode=("model", "type_adapter"),
         defer_build=True,
         extra=(
             "ignore"

--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -35,7 +35,6 @@ class PrefectBaseModel(BaseModel):
 
     model_config = ConfigDict(
         ser_json_timedelta="float",
-        experimental_defer_build_mode=("model", "type_adapter"),
         defer_build=True,
         extra=(
             "ignore"

--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -4,7 +4,7 @@ Utilities for creating and working with Prefect REST API schemas.
 
 import datetime
 import os
-from typing import Any, ClassVar, Optional, Set, TypeVar
+from typing import Any, ClassVar, Literal, Optional, Set, TypeVar
 from uuid import UUID, uuid4
 
 import pendulum
@@ -32,7 +32,9 @@ class PrefectBaseModel(BaseModel):
     """
 
     _reset_fields: ClassVar[Set[str]] = set()
-    experimental_defer_build_mode = ("model", "type_adapter")
+    experimental_defer_build_mode: ClassVar[
+        tuple[Literal["model", "type_adapter"], ...]
+    ] = ("model", "type_adapter")
 
     model_config = ConfigDict(
         ser_json_timedelta="float",

--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -32,9 +32,11 @@ class PrefectBaseModel(BaseModel):
     """
 
     _reset_fields: ClassVar[Set[str]] = set()
+    experimental_defer_build_mode = ("model", "type_adapter")
 
     model_config = ConfigDict(
         ser_json_timedelta="float",
+        defer_build=True,
         extra=(
             "ignore"
             if os.getenv("PREFECT_TEST_MODE", "0").lower() not in ["true", "1"]

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -60,7 +60,6 @@ class PrefectBaseModel(BaseModel):
     _reset_fields: ClassVar[Set[str]] = set()
     model_config = ConfigDict(
         ser_json_timedelta="float",
-        defer_build=True,
         extra=(
             "ignore"
             if os.getenv("PREFECT_TEST_MODE", "0").lower() not in ["true", "1"]

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -5,6 +5,7 @@ from typing import (
     Any,
     ClassVar,
     Dict,
+    Literal,
     Optional,
     Set,
     Type,
@@ -58,7 +59,9 @@ class PrefectBaseModel(BaseModel):
     """
 
     _reset_fields: ClassVar[Set[str]] = set()
-    experimental_defer_build_mode = ("model", "type_adapter")
+    experimental_defer_build_mode: ClassVar[
+        tuple[Literal["model", "type_adapter"], ...]
+    ] = ("model", "type_adapter")
 
     model_config = ConfigDict(
         ser_json_timedelta="float",

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -5,7 +5,6 @@ from typing import (
     Any,
     ClassVar,
     Dict,
-    Literal,
     Optional,
     Set,
     Type,
@@ -59,12 +58,10 @@ class PrefectBaseModel(BaseModel):
     """
 
     _reset_fields: ClassVar[Set[str]] = set()
-    experimental_defer_build_mode: ClassVar[
-        tuple[Literal["model", "type_adapter"], ...]
-    ] = ("model", "type_adapter")
 
     model_config = ConfigDict(
         ser_json_timedelta="float",
+        experimental_defer_build_mode=("model", "type_adapter"),
         defer_build=True,
         extra=(
             "ignore"

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -58,8 +58,11 @@ class PrefectBaseModel(BaseModel):
     """
 
     _reset_fields: ClassVar[Set[str]] = set()
+    experimental_defer_build_mode = ("model", "type_adapter")
+
     model_config = ConfigDict(
         ser_json_timedelta="float",
+        defer_build=True,
         extra=(
             "ignore"
             if os.getenv("PREFECT_TEST_MODE", "0").lower() not in ["true", "1"]


### PR DESCRIPTION
Adding `defer_build=True` may have contributed to FastAPI server-specific test instability in Python 3.12. Here, we also set `experimental_defer_build_mode`, which the [Pydantic docs](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.defer_build) suggest is needed to use `defer_build=True` with FastAPI.

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
