### PR TITLE
Improve logging on result serialization errors

### DIFF
--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -412,3 +412,9 @@ class PrefectImportError(ImportError):
 
     def __init__(self, message: str) -> None:
         super().__init__(message)
+
+
+class SerializationError(PrefectException):
+    """
+    Raised when an object cannot be serialized.
+    """

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -520,7 +520,11 @@ class ResultRecord(BaseModel, Generic[R]):
             bytes: the serialized record
 
         """
-        return self.model_dump_json(serialize_as_any=True).encode()
+        return (
+            self.model_copy(update={"result": self.serialize_result()})
+            .model_dump_json(serialize_as_any=True)
+            .encode()
+        )
 
     @classmethod
     def deserialize(cls, data: bytes) -> "ResultRecord[R]":

--- a/tests/results/test_state_result.py
+++ b/tests/results/test_state_result.py
@@ -147,7 +147,7 @@ async def test_graceful_retries_eventually_succeed_while(
             side_effect=[
                 FileNotFoundError,
                 TimeoutError,
-                expected_record.model_dump_json().encode(),
+                expected_record.serialize(),
             ]
         ),
     ) as m:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

This PR updates the transaction context manager to log a warning when result serialization fails instead of a big traceback. This PR also avoids logging when the default rollback hook that updates the tasks state runs.

Very open to changing the verbiage of the warning message.

### Example output

```
15:42:51.769 | WARNING | Task run 'create_db_and_cur-5c1' - Encountered an error while serializing result for transaction '159ef706744b2d7edd395d9458f3d2ec': Failed to serialize object of type 'tuple' with serializer 'pickle'. You can try a different serializer (e.g. result_serializer="json") or disabling persistence (persist_result=False) for this flow or task. Code execution will continue, but the transaction will not be committed.
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
