### PR TITLE
Fix labeler job

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,7 @@
 name: Labeler
 
-on: [pull_request]
+# see https://github.com/actions/labeler/issues/136#issuecomment-1357839196
+on: [pull_request_target]
 
 permissions:
   contents: read
@@ -12,6 +13,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
       - uses: actions/labeler@v5
         with:
           repo-token: "${{ github.token }}"


### PR DESCRIPTION
I noticed that the labeler job was failing on contributor PRs ([example here](https://github.com/PrefectHQ/prefect/actions/runs/10584311321/job/29328278417?pr=15070)).  I did some reading and found two things that needed fixing:
- we need to check out the repository so that the `labeler.yml` file could be found by the runner without an API call (it's not clear that this is critical but 🤷 )
- we need to use the `pull_request_target` event to enable write permissions back on the PR from forked PRs, which is safe in the context of a labeling job (see [documentation on `pull_request_target`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target))