### PR TITLE
Update `model_rebuild` in `main.py` to explicitly pass namespace types

### DIFF
--- a/src/prefect/main.py
+++ b/src/prefect/main.py
@@ -25,10 +25,14 @@ import prefect.context
 # Perform any forward-ref updates needed for Pydantic models
 import prefect.client.schemas
 
-prefect.context.FlowRunContext.model_rebuild()
-prefect.context.TaskRunContext.model_rebuild()
-prefect.client.schemas.State.model_rebuild()
-prefect.client.schemas.StateCreate.model_rebuild()
+prefect.context.FlowRunContext.model_rebuild(
+    _types_namespace={"Flow": Flow, "BaseResult": BaseResult}
+)
+prefect.context.TaskRunContext.model_rebuild(_types_namespace={"Task": Task})
+prefect.client.schemas.State.model_rebuild(_types_namespace={"BaseResult": BaseResult})
+prefect.client.schemas.StateCreate.model_rebuild(
+    _types_namespace={"BaseResult": BaseResult}
+)
 Transaction.model_rebuild()
 
 # Configure logging

--- a/src/prefect/utilities/dispatch.py
+++ b/src/prefect/utilities/dispatch.py
@@ -162,17 +162,22 @@ def register_type(cls: T) -> T:
     key = get_dispatch_key(cls)
     existing_value = registry.get(key)
     if existing_value is not None and id(existing_value) != id(cls):
-        # Get line numbers for debugging
-        file = inspect.getsourcefile(cls)
-        line_number = inspect.getsourcelines(cls)[1]
-        existing_file = inspect.getsourcefile(existing_value)
-        existing_line_number = inspect.getsourcelines(existing_value)[1]
-        warnings.warn(
-            f"Type {cls.__name__!r} at {file}:{line_number} has key {key!r} that "
-            f"matches existing registered type {existing_value.__name__!r} from "
-            f"{existing_file}:{existing_line_number}. The existing type will be "
-            "overridden."
-        )
+        try:
+            # Get line numbers for debugging
+            file = inspect.getsourcefile(cls)
+            line_number = inspect.getsourcelines(cls)[1]
+            existing_file = inspect.getsourcefile(existing_value)
+            existing_line_number = inspect.getsourcelines(existing_value)[1]
+            warnings.warn(
+                f"Type {cls.__name__!r} at {file}:{line_number} has key {key!r} that "
+                f"matches existing registered type {existing_value.__name__!r} from "
+                f"{existing_file}:{existing_line_number}. The existing type will be "
+                "overridden."
+            )
+        except OSError:
+            # If we can't get the source, another actor is loading this class via eval
+            # and we shouldn't update the registry
+            return cls
 
     # Add to the registry
     registry[key] = cls


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR updates `.model_rebuild` calls in `main.py` to explicitly pass namespace types. Version `2.9.0b1` of `pydantic` no longer implicitly loads the parent namespace when rebuilding models and this approach was suggested [here](https://github.com/pydantic/pydantic/pull/10113#issuecomment-2314573655). This update will ensure `prefect` doesn't break when version `2.9.0` of `pydantic` is released.

Closes https://github.com/PrefectHQ/prefect/issues/15112
Closes https://github.com/PrefectHQ/prefect/issues/15092

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
