### PR TITLE
Switch to profile with matching `PREFECT_API_URL` on server start

### DIFF
--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -101,14 +101,53 @@ def generate_welcome_blurb(base_url, ui_enabled: bool):
     return blurb
 
 
-def prestart_check():
+def prestart_check(base_url: str):
     """
     Check if `PREFECT_API_URL` is set in the current profile. If not, prompt the user to set it.
+
+    Args:
+        base_url: The base URL the server will be running on
     """
+    api_url = f"{base_url}/api"
     current_profile = load_current_profile()
-    if PREFECT_API_URL not in current_profile.settings:
+    profiles = load_profiles()
+    if current_profile and PREFECT_API_URL not in current_profile.settings:
+        profiles_with_matching_url = [
+            name
+            for name, profile in profiles.items()
+            if profile.settings.get(PREFECT_API_URL) == api_url
+        ]
+        if len(profiles_with_matching_url) == 1:
+            profiles.set_active(profiles_with_matching_url[0])
+            save_profiles(profiles)
+            app.console.print(
+                f"Switched to profile {profiles_with_matching_url[0]!r}",
+                style="green",
+            )
+            return
+        elif len(profiles_with_matching_url) > 1:
+            app.console.print(
+                "Your current profile doesn't have `PREFECT_API_URL` set to the address"
+                " of the server that's running. Some of your other profiles do."
+            )
+            selected_profile = prompt_select_from_list(
+                app.console,
+                "Which profile would you like to switch to?",
+                sorted(
+                    [profile for profile in profiles_with_matching_url],
+                ),
+            )
+            profiles.set_active(selected_profile)
+            save_profiles(profiles)
+            app.console.print(
+                f"Switched to profile {selected_profile!r}", style="green"
+            )
+            return
+
         app.console.print(
-            "`PREFECT_API_URL` is not set. You need to set it to communicate with the server.",
+            "The `PREFECT_API_URL` setting for your current profile doesn't match the"
+            " address of the server that's running. You need to set it to communicate"
+            " with the server.",
             style="yellow",
         )
 
@@ -126,7 +165,6 @@ def prestart_check():
                 ),
             ],
         )
-        profiles = load_profiles()
 
         if choice == "create":
             while True:
@@ -137,13 +175,12 @@ def prestart_check():
                         style="red",
                     )
                 else:
-                    api_url = prompt(
-                        "Enter the `PREFECT_API_URL` value",
-                        default="http://127.0.0.1:4200/api",
-                    )
                     break
+
             profiles.add_profile(
-                Profile(name=profile_name, settings={"PREFECT_API_URL": api_url})
+                Profile(
+                    name=profile_name, settings={PREFECT_API_URL: f"{base_url}/api"}
+                )
             )
             profiles.set_active(profile_name)
             save_profiles(profiles)
@@ -155,8 +192,7 @@ def prestart_check():
             api_url = prompt(
                 "Enter the `PREFECT_API_URL` value", default="http://127.0.0.1:4200/api"
             )
-            prefect_api_url_setting = {"PREFECT_API_URL": api_url}
-            update_current_profile(prefect_api_url_setting)
+            update_current_profile({PREFECT_API_URL: api_url})
             app.console.print(
                 f"Set `PREFECT_API_URL` to {api_url!r} in the current profile {current_profile.name!r}",
                 style="green",
@@ -182,12 +218,13 @@ async def start(
     """
     Start a Prefect server instance
     """
-
+    base_url = f"http://{host}:{port}"
     if is_interactive():
-        try:
-            prestart_check()
-        except Exception:
-            pass
+        # try:
+        prestart_check(base_url)
+        # except Exception as exc:
+        #     app.console.print(f"Error: {exc}", style="red")
+        #     pass
 
     server_env = os.environ.copy()
     server_env["PREFECT_API_SERVICES_SCHEDULER_ENABLED"] = str(scheduler)
@@ -196,8 +233,6 @@ async def start(
     server_env["PREFECT_API_SERVICES_UI"] = str(ui)
     server_env["PREFECT_UI_ENABLED"] = str(ui)
     server_env["PREFECT_LOGGING_SERVER_LEVEL"] = log_level
-
-    base_url = f"http://{host}:{port}"
 
     pid_file = anyio.Path(PREFECT_HOME.value() / PID_FILE)
     # check if port is already in use

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -220,11 +220,10 @@ async def start(
     """
     base_url = f"http://{host}:{port}"
     if is_interactive():
-        # try:
-        prestart_check(base_url)
-        # except Exception as exc:
-        #     app.console.print(f"Error: {exc}", style="red")
-        #     pass
+        try:
+            prestart_check(base_url)
+        except Exception:
+            pass
 
     server_env = os.environ.copy()
     server_env["PREFECT_API_SERVICES_SCHEDULER_ENABLED"] = str(scheduler)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR updates the `prefect server start` command to consider existing profiles when checking if the client is set up to communicate with the started server. If a profile with a matching `PREFECT_API_URL` exists, that profile will automatically be made active. 

In the default case, new users will automatically switch to the `local` profile when they start a local server for the first time.

If there are multiple valid profiles, the user is prompted to choose between them.

Users can skip all prompts with `prefect --no-prompt server start`.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
