### PR TITLE
update `Task.submit` / `Task.map` typing overloads

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -986,44 +986,42 @@ class Task(Generic[P, R]):
     @overload
     def submit(
         self: "Task[P, NoReturn]",
-        *args: P.args,
-        **kwargs: P.kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> PrefectFuture[NoReturn]:
-        # `NoReturn` matches if a type can't be inferred for the function which stops a
-        # sync function from matching the `Coroutine` overload
         ...
 
     @overload
     def submit(
         self: "Task[P, Coroutine[Any, Any, T]]",
-        *args: P.args,
-        **kwargs: P.kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> PrefectFuture[T]:
         ...
 
     @overload
     def submit(
         self: "Task[P, T]",
-        *args: P.args,
-        **kwargs: P.kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> PrefectFuture[T]:
         ...
 
     @overload
     def submit(
         self: "Task[P, Coroutine[Any, Any, T]]",
-        *args: P.args,
+        *args: Any,
         return_state: Literal[True],
-        **kwargs: P.kwargs,
+        **kwargs: Any,
     ) -> State[T]:
         ...
 
     @overload
     def submit(
         self: "Task[P, T]",
-        *args: P.args,
+        *args: Any,
         return_state: Literal[True],
-        **kwargs: P.kwargs,
+        **kwargs: Any,
     ) -> State[T]:
         ...
 
@@ -1152,52 +1150,52 @@ class Task(Generic[P, R]):
     @overload
     def map(
         self: "Task[P, NoReturn]",
-        *args: P.args,
-        **kwargs: P.kwargs,
+        *args: Iterable[Any],
+        **kwargs: Iterable[Any],
     ) -> PrefectFutureList[PrefectFuture[NoReturn]]:
         ...
 
     @overload
     def map(
         self: "Task[P, Coroutine[Any, Any, T]]",
-        *args: P.args,
-        **kwargs: P.kwargs,
+        *args: Iterable[Any],
+        **kwargs: Iterable[Any],
     ) -> PrefectFutureList[PrefectFuture[T]]:
         ...
 
     @overload
     def map(
         self: "Task[P, T]",
-        *args: P.args,
-        **kwargs: P.kwargs,
+        *args: Iterable[Any],
+        **kwargs: Iterable[Any],
     ) -> PrefectFutureList[PrefectFuture[T]]:
         ...
 
     @overload
     def map(
         self: "Task[P, Coroutine[Any, Any, T]]",
-        *args: P.args,
+        *args: Iterable[Any],
         return_state: Literal[True],
-        **kwargs: P.kwargs,
+        **kwargs: Iterable[Any],
     ) -> PrefectFutureList[State[T]]:
         ...
 
     @overload
     def map(
         self: "Task[P, T]",
-        *args: P.args,
+        *args: Iterable[Any],
         return_state: Literal[True],
-        **kwargs: P.kwargs,
+        **kwargs: Iterable[Any],
     ) -> PrefectFutureList[State[T]]:
         ...
 
     def map(
         self,
-        *args: Any,
+        *args: Iterable[Any],
         return_state: bool = False,
         wait_for: Optional[Iterable[PrefectFuture]] = None,
         deferred: bool = False,
-        **kwargs: Any,
+        **kwargs: Iterable[Any],
     ):
         """
         Submit a mapped run of the task to a worker.

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -993,36 +993,36 @@ class Task(Generic[P, R]):
 
     @overload
     def submit(
-        self: "Task[P, Coroutine[Any, Any, T]]",
+        self: "Task[P, Coroutine[Any, Any, R]]",
         *args: Any,
         **kwargs: Any,
-    ) -> PrefectFuture[T]:
+    ) -> PrefectFuture[R]:
         ...
 
     @overload
     def submit(
-        self: "Task[P, T]",
+        self: "Task[P, R]",
         *args: Any,
         **kwargs: Any,
-    ) -> PrefectFuture[T]:
+    ) -> PrefectFuture[R]:
         ...
 
     @overload
     def submit(
-        self: "Task[P, Coroutine[Any, Any, T]]",
+        self: "Task[P, Coroutine[Any, Any, R]]",
         *args: Any,
         return_state: Literal[True],
         **kwargs: Any,
-    ) -> State[T]:
+    ) -> State[R]:
         ...
 
     @overload
     def submit(
-        self: "Task[P, T]",
+        self: "Task[P, R]",
         *args: Any,
         return_state: Literal[True],
         **kwargs: Any,
-    ) -> State[T]:
+    ) -> State[R]:
         ...
 
     def submit(
@@ -1157,36 +1157,36 @@ class Task(Generic[P, R]):
 
     @overload
     def map(
-        self: "Task[P, Coroutine[Any, Any, T]]",
+        self: "Task[P, Coroutine[Any, Any, R]]",
         *args: Iterable[Any],
         **kwargs: Iterable[Any],
-    ) -> PrefectFutureList[PrefectFuture[T]]:
+    ) -> PrefectFutureList[PrefectFuture[R]]:
         ...
 
     @overload
     def map(
-        self: "Task[P, T]",
+        self: "Task[P, R]",
         *args: Iterable[Any],
         **kwargs: Iterable[Any],
-    ) -> PrefectFutureList[PrefectFuture[T]]:
+    ) -> PrefectFutureList[PrefectFuture[R]]:
         ...
 
     @overload
     def map(
-        self: "Task[P, Coroutine[Any, Any, T]]",
+        self: "Task[P, Coroutine[Any, Any, R]]",
         *args: Iterable[Any],
         return_state: Literal[True],
         **kwargs: Iterable[Any],
-    ) -> PrefectFutureList[State[T]]:
+    ) -> PrefectFutureList[State[R]]:
         ...
 
     @overload
     def map(
-        self: "Task[P, T]",
+        self: "Task[P, R]",
         *args: Iterable[Any],
         return_state: Literal[True],
         **kwargs: Iterable[Any],
-    ) -> PrefectFutureList[State[T]]:
+    ) -> PrefectFutureList[State[R]]:
         ...
 
     def map(


### PR DESCRIPTION
this PR fixes typing overloads on `Task.map` and `Task.submit`

consider the following example
```python
from pydantic import BaseModel
from prefect import flow, task

class Model(BaseModel):
    name: str

@task
def t(data: Model) -> Model:
    print(f"t: {data}")
    return data

@flow(log_prints=True)
def f():
    fut_1 = t.map([Model(name="first")] * 10)
    fut_2 = t.submit(fut_1)
    fut_3 = t.submit(fut_1.result())
    return [future.result() for future in [fut_1, fut_2, fut_3]]

f()
```

### on `main`
we get typing errors

- with `.map`, where it expects `T` instead of `Iterable[T]`
```python
    fut_1 = t.map([Model(name="first")] * 10)
    
# Argument of type "list[Model]" cannot be assigned to parameter "data" of type "Model" in function "map"
  "list[Model]" is incompatible with "Model"
```
- with `.submit`, where it doesnt understand you can pass futures
```python
    fut_2 = t.submit(fut_1)

# Argument of type "PrefectFutureList[PrefectFuture[Model]]" cannot be assigned to parameter "data" of type "Model" in function "submit"
  "PrefectFutureList[PrefectFuture[Model]]" is incompatible with "Model"
```

