### PR TITLE
Fix tailwind warning about node_modules import 

### DIFF
--- a/ui/tailwind.config.ts
+++ b/ui/tailwind.config.ts
@@ -4,7 +4,7 @@ import type { Config } from 'tailwindcss'
 const config: Config = {
   content: [
     './index.html',
-    './**/*.{vue,js,ts,jsx,tsx}',
+    './src/**/*.vue',
   ],
   presets: [prefectDesignTailwindConfig],
 }


### PR DESCRIPTION
# Description
Make the import specific to the `src` and limits it to `.vue` files. 