### PR TITLE
some minor docs improvements

### DIFF
--- a/docs/3.0rc/develop/manage-states.mdx
+++ b/docs/3.0rc/develop/manage-states.mdx
@@ -56,23 +56,16 @@ The full list of states and state types includes:
 | Failed | FAILED | Yes | The run did not complete because of a code issue and had no remaining retry attempts. |
 | Crashed | CRASHED | Yes | The run did not complete because of an infrastructure issue. |
 
-## Returned values
+## Flow and task return values
 
 When calling a task or a flow, there are three types of returned values:
 
-- Data: A Python object (such as `int`, `str`, `dict`, `list`, and so on).
+- Data: A Python object (such as `int`, `str`, `dict`, `list`, `SomePydanticModel`, and so on).
 - `State`: A Prefect object indicating the state of a flow or task run.
-- [`PrefectFuture`](https://prefect-python-sdk-docs.netlify.app/prefect/futures/#prefect.futures.PrefectFuture): A Prefect object that contains both _data_ and _State_.
 
-Returning data is the default behavior any time you call `your_task()`.
+### Returning normal python objects
 
-Returning Prefect [`State`](https://prefect-python-sdk-docs.netlify.app/prefect/server/schemas/states/) occurs anytime you call your task or flow with the argument `return_state=True`.
-
-Returning [`PrefectFuture`](https://prefect-python-sdk-docs.netlify.app/prefect/futures/#prefect.futures.PrefectFuture) is achieved by calling `your_task.submit()`.
-
-### Return data
-
-By default, running a task returns data:
+By default, tasks `return` objects just like normal python functions:
 
 ```python
 from prefect import flow, task 
@@ -84,80 +77,27 @@ def add_one(x):
 
 @flow 
 def my_flow():
-    result = add_one(1) # return int
+    result = add_one(1)
+    assert isinstance(result, int) and result == 2
 ```
 
-The same rule applies for a nested flow:
 
-```python
-@flow 
-def nested_flow():
-    return 42 
-
-@flow 
-def my_flow():
-    result = nested_flow() # return data
-```
-
-### Return Prefect state
+### Return a Prefect `State`
 
 To return a `State` instead, add `return_state=True` as a parameter of your task call:
 
 ```python
 @flow 
 def my_flow():
-    state = add_one(1, return_state=True) # return State
+    state = add_one(1, return_state=True)
+    assert state.is_completed() is True
+    assert state.result() == 2
 ```
 
-To get data from a `State`, call `.result()`.
+<Tip>
+Returning a `State` via `return_state=True` is useful when you want to conditionally respond to the terminal states of a task or flow, i.e. `if state.is_failed(): ...`.
+</Tip>
 
-```python
-@flow 
-def my_flow():
-    state = add_one(1, return_state=True) # return State
-    result = state.result() # return int
-```
-
-The same rule applies for a nested flow:
-
-```python
-@flow 
-def nested_flow():
-    return 42 
-
-@flow 
-def my_flow():
-    state = nested_flow(return_state=True) # return State
-    result = state.result() # return int
-```
-
-### Return a PrefectFuture
-
-To get a `PrefectFuture`, add `.submit()` to your task call.
-
-```python
-@flow 
-def my_flow():
-    future = add_one.submit(1) # return PrefectFuture
-```
-
-To get data from a `PrefectFuture`, call `.result()`.
-
-```python
-@flow 
-def my_flow():
-    future = add_one.submit(1) # return PrefectFuture
-    result = future.result() # return data
-```
-
-To get a `State` from a `PrefectFuture`, call `.wait()`.
-
-```python
-@flow 
-def my_flow():
-    future = add_one.submit(1) # return PrefectFuture
-    state = future.wait() # return State
-```
 
 ## Final state determination
 

--- a/docs/3.0rc/develop/write-flows.mdx
+++ b/docs/3.0rc/develop/write-flows.mdx
@@ -700,6 +700,34 @@ I'm fail safe!
 
 If a flow run returns any other object, then it is recorded as `COMPLETED`
 
+#### Custom named states
+
+You can also create custom named states to provide more granularity in your flow run states.
+
+For example, we could create a `Skipped` state to indicate that a flow run was skipped.
+
+```python
+from prefect import flow
+from prefect.states import Completed
+
+@flow
+def my_flow(work_to_do: bool):
+    if not work_to_do:
+        return Completed(message="No work to do 💤", name="Skipped")
+    else:
+        return Completed(message="Work was done 💪")
+
+
+if __name__ == "__main__":
+    my_flow(work_to_do=False)
+```
+
+Running this flow produces the following result:
+
+```bash
+15:26:49.644 | INFO    | Flow run 'liberal-zebra' - Finished in state Skipped('No work to do', type=COMPLETED)
+```
+
 ## Retries
 
 Unexpected errors may occur in workflows. 

--- a/docs/3.0rc/develop/write-tasks.mdx
+++ b/docs/3.0rc/develop/write-tasks.mdx
@@ -526,7 +526,7 @@ Retries are often useful in cases that depend upon external systems, such as mak
 The example below uses the [`httpx`](https://www.python-httpx.org/) library to make an HTTP
 request.
 
-```python hl_lines="4"
+```python
 import httpx
 from prefect import flow, task
 


### PR DESCRIPTION
to
- manage states (fix confusing / odd language describing return values / dont recommend returning futures directly)
- write flows (section on Custom named states, ie Skipped)
- write tasks (remove incorrect mintlify syntax)
