### PR TITLE
fix install command

### DIFF
--- a/docs/3.0rc/resources/upgrade-to-prefect-3.mdx
+++ b/docs/3.0rc/resources/upgrade-to-prefect-3.mdx
@@ -10,7 +10,7 @@ Prefect 3 introduces exciting new features and improvements while maintaining co
 To upgrade to Prefect 3, run:
 
 ```bash
-pip install prefect>=3.0.0rc1 --pre
+pip install 'prefect>=3.0.0rc1' --pre
 ```
 
 Note that the `--pre` flag is required to install the release candidate until the final release is available.
@@ -25,7 +25,7 @@ prefect server database upgrade
 If you use a Prefect integration or extra, remember to upgrade it as well. For example:
 
 ```bash
-pip install prefect[aws]>=3.0.0rc1 --pre
+pip install 'prefect[aws]>=3.0.0rc1' --pre
 ```
 
 ## Upgrade notes


### PR DESCRIPTION
on many systems the current recommendation fails like
```bash
» pip install prefect>=3.0.0rc1 --pre
zsh: 3.0.0rc1 not found

» uv pip install prefect>=3.0.0rc1 --pre                                                              1 ↵

zsh: 3.0.0rc1 not found

» pip install 'prefect>=3.0.0rc1' --pre                                                               1 ↵
... (success)

» uv pip install 'prefect>=3.0.0rc1' --pre
Audited 1 package in 18ms
```