### PR TITLE
Refactor `ResultFactory` to have one creation mode and read context on result creation

### DIFF
--- a/src/integrations/prefect-redis/tests/test_records.py
+++ b/src/integrations/prefect-redis/tests/test_records.py
@@ -30,7 +30,7 @@ class TestRedisRecordStore:
 
     @pytest.fixture
     async def result(self, default_storage_setting):
-        factory = await ResultFactory.default_factory(
+        factory = await ResultFactory(
             persist_result=True,
         )
         result = await factory.create_result(obj={"test": "value"})

--- a/src/integrations/prefect-redis/tests/test_records.py
+++ b/src/integrations/prefect-redis/tests/test_records.py
@@ -30,9 +30,7 @@ class TestRedisRecordStore:
 
     @pytest.fixture
     async def result(self, default_storage_setting):
-        factory = await ResultFactory(
-            persist_result=True,
-        )
+        factory = ResultFactory(persist_result=True)
         result = await factory.create_result(obj={"test": "value"})
         return result
 

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -44,7 +44,6 @@ from prefect.results import ResultFactory
 from prefect.settings import PREFECT_HOME, Profile, Settings
 from prefect.states import State
 from prefect.task_runners import TaskRunner
-from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.services import start_client_metrics_server
 
 T = TypeVar("T")
@@ -95,20 +94,17 @@ def hydrated_context(
                 flow_run_context = FlowRunContext(
                     **flow_run_context,
                     client=client,
-                    result_factory=run_coro_as_sync(ResultFactory.from_flow(flow)),
+                    result_factory=ResultFactory(),
                     task_runner=task_runner,
                     detached=True,
                 )
                 stack.enter_context(flow_run_context)
             # Set up parent task run context
             if parent_task_run_context := serialized_context.get("task_run_context"):
-                parent_task = parent_task_run_context["task"]
                 task_run_context = TaskRunContext(
                     **parent_task_run_context,
                     client=client,
-                    result_factory=run_coro_as_sync(
-                        ResultFactory.from_autonomous_task(parent_task)
-                    ),
+                    result_factory=ResultFactory(),
                 )
                 stack.enter_context(task_run_context)
             # Set up tags context

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -202,7 +202,7 @@ class FlowRunEngine(Generic[P, R]):
                 self.handle_exception(
                     exc,
                     msg=message,
-                    result_factory=run_coro_as_sync(ResultFactory.from_flow(self.flow)),
+                    result_factory=ResultFactory(),
                 )
                 self.short_circuit = True
                 self.call_hooks()
@@ -506,7 +506,7 @@ class FlowRunEngine(Generic[P, R]):
                     flow_run=self.flow_run,
                     parameters=self.parameters,
                     client=client,
-                    result_factory=run_coro_as_sync(ResultFactory.from_flow(self.flow)),
+                    result_factory=ResultFactory(),
                     task_runner=task_runner,
                 )
             )

--- a/src/prefect/records/result_store.py
+++ b/src/prefect/records/result_store.py
@@ -44,7 +44,6 @@ class ResultFactoryStore(RecordStore):
             )
             return TransactionRecord(key=key, result=result)
         except Exception:
-            breakpoint()
             # this is a bit of a bandaid for functionality
             raise ValueError("Result could not be read")
 

--- a/src/prefect/records/result_store.py
+++ b/src/prefect/records/result_store.py
@@ -44,6 +44,7 @@ class ResultFactoryStore(RecordStore):
             )
             return TransactionRecord(key=key, result=result)
         except Exception:
+            breakpoint()
             # this is a bit of a bandaid for functionality
             raise ValueError("Result could not be read")
 

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -591,7 +591,8 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                     log_prints=log_prints,
                     task_run=self.task_run,
                     parameters=self.parameters,
-                    result_factory=run_coro_as_sync(ResultFactory.from_task(self.task)),  # type: ignore
+                    # TODO: Allow reuse of result factories
+                    result_factory=ResultFactory(),  # type: ignore
                     client=client,
                 )
             )
@@ -1096,7 +1097,8 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                     log_prints=log_prints,
                     task_run=self.task_run,
                     parameters=self.parameters,
-                    result_factory=await ResultFactory.from_task(self.task),  # type: ignore
+                    # TODO: Allow reuse of result factories
+                    result_factory=ResultFactory(),  # type: ignore
                     client=client,
                 )
             )

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -25,7 +25,7 @@ from prefect.client.orchestration import get_client
 from prefect.client.schemas.objects import TaskRun
 from prefect.client.subscriptions import Subscription
 from prefect.logging.loggers import get_logger
-from prefect.results import ResultFactory
+from prefect.results import ResultFactory, get_or_create_default_task_scheduling_storage
 from prefect.settings import (
     PREFECT_API_URL,
     PREFECT_TASK_SCHEDULING_DELETE_FAILED_SUBMISSIONS,
@@ -273,7 +273,9 @@ class TaskWorker:
         if should_try_to_read_parameters(task, task_run):
             parameters_id = task_run.state.state_details.task_parameters_id
             task.persist_result = True
-            factory = await ResultFactory.from_autonomous_task(task)
+            factory = ResultFactory(
+                result_storage=await get_or_create_default_task_scheduling_storage()
+            )
             try:
                 run_data = await factory.read_parameters(parameters_id)
                 parameters = run_data.get("parameters", {})

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -50,7 +50,12 @@ from prefect.context import (
 )
 from prefect.futures import PrefectDistributedFuture, PrefectFuture, PrefectFutureList
 from prefect.logging.loggers import get_logger
-from prefect.results import ResultFactory, ResultSerializer, ResultStorage
+from prefect.results import (
+    ResultFactory,
+    ResultSerializer,
+    ResultStorage,
+    get_or_create_default_task_scheduling_storage,
+)
 from prefect.settings import (
     PREFECT_TASK_DEFAULT_RETRIES,
     PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS,
@@ -752,7 +757,9 @@ class Task(Generic[P, R]):
                 # TODO: Improve use of result storage for parameter storage / reference
                 self.persist_result = True
 
-                factory = await ResultFactory.from_autonomous_task(self, client=client)
+                factory = ResultFactory(
+                    result_storage=await get_or_create_default_task_scheduling_storage()
+                )
                 context = serialize_context()
                 data: Dict[str, Any] = {"context": context}
                 if parameters:
@@ -853,7 +860,9 @@ class Task(Generic[P, R]):
                 # TODO: Improve use of result storage for parameter storage / reference
                 self.persist_result = True
 
-                factory = await ResultFactory.from_autonomous_task(self, client=client)
+                factory = ResultFactory(
+                    result_storage=await get_or_create_default_task_scheduling_storage()
+                )
                 context = serialize_context()
                 data: Dict[str, Any] = {"context": context}
                 if parameters:

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -24,7 +24,6 @@ from prefect.records import RecordStore
 from prefect.results import (
     BaseResult,
     ResultFactory,
-    get_default_result_storage,
 )
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.collections import AutoEnum
@@ -368,26 +367,12 @@ def transaction(
 
         new_factory: ResultFactory
         if existing_factory and existing_factory.storage_block_id:
-            new_factory = existing_factory.model_copy(
-                update={
-                    "persist_result": True,
-                }
-            )
+            existing_factory.persist_result = True
+            new_factory = existing_factory
         else:
-            default_storage = get_default_result_storage(_sync=True)
-            if existing_factory:
-                new_factory = existing_factory.model_copy(
-                    update={
-                        "persist_result": True,
-                        "storage_block": default_storage,
-                        "storage_block_id": default_storage._block_document_id,
-                    }
-                )
-            else:
-                new_factory = ResultFactory(
-                    persist_result=True,
-                    result_storage=default_storage,
-                )
+            new_factory = ResultFactory(
+                persist_result=True,
+            )
         from prefect.records.result_store import ResultFactoryStore
 
         store = ResultFactoryStore(

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -27,7 +27,6 @@ from prefect.results import (
     get_default_result_storage,
 )
 from prefect.utilities.annotations import NotSet
-from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.collections import AutoEnum
 from prefect.utilities.engine import _get_hook_name
 
@@ -385,11 +384,9 @@ def transaction(
                     }
                 )
             else:
-                new_factory = run_coro_as_sync(
-                    ResultFactory.default_factory(
-                        persist_result=True,
-                        result_storage=default_storage,
-                    )
+                new_factory = ResultFactory(
+                    persist_result=True,
+                    result_storage=default_storage,
                 )
         from prefect.records.result_store import ResultFactoryStore
 

--- a/tests/records/test_filesystem.py
+++ b/tests/records/test_filesystem.py
@@ -35,7 +35,7 @@ class TestFileSystemRecordStore:
 
     @pytest.fixture
     async def result(self, default_storage_setting):
-        factory = await ResultFactory.default_factory(
+        factory = ResultFactory(
             persist_result=True,
         )
         result = await factory.create_result(obj={"test": "value"})

--- a/tests/records/test_memory.py
+++ b/tests/records/test_memory.py
@@ -20,7 +20,7 @@ class TestInMemoryRecordStore:
         key = str(uuid4())
         store = MemoryRecordStore()
         assert store.read(key) is None
-        factory = await ResultFactory.default_factory(
+        factory = ResultFactory(
             persist_result=True,
         )
         result = await factory.create_result(obj={"test": "value"})
@@ -32,7 +32,7 @@ class TestInMemoryRecordStore:
     async def test_read_locked_key(self):
         key = str(uuid4())
         store = MemoryRecordStore()
-        factory = await ResultFactory.default_factory(
+        factory = ResultFactory(
             persist_result=True,
         )
         result = await factory.create_result(obj={"test": "value"})
@@ -57,7 +57,7 @@ class TestInMemoryRecordStore:
         key = str(uuid4())
         store = MemoryRecordStore()
         assert store.acquire_lock(key)
-        factory = await ResultFactory.default_factory(
+        factory = ResultFactory(
             persist_result=True,
         )
         result = await factory.create_result(obj={"test": "value"})
@@ -70,7 +70,7 @@ class TestInMemoryRecordStore:
         key = str(uuid4())
         store = MemoryRecordStore()
         assert store.acquire_lock(key, holder="holder1")
-        factory = await ResultFactory.default_factory(
+        factory = ResultFactory(
             persist_result=True,
         )
         result = await factory.create_result(obj={"test": "value"})
@@ -84,7 +84,7 @@ class TestInMemoryRecordStore:
         key = str(uuid4())
         store = MemoryRecordStore()
         assert not store.exists(key)
-        factory = await ResultFactory.default_factory(
+        factory = ResultFactory(
             persist_result=True,
         )
         result = await factory.create_result(obj={"test": "value"})

--- a/tests/results/test_result_factory.py
+++ b/tests/results/test_result_factory.py
@@ -89,89 +89,119 @@ def test_root_flow_default_persist_result_can_be_overriden_by_setting():
 def test_root_flow_can_opt_out_when_persist_result_default_is_overriden_by_setting():
     @flow(persist_result=False)
     def foo():
-        return get_run_context().result_factory
+        return get_run_context().result_factory.persist_result
 
     with temporary_settings({PREFECT_RESULTS_PERSIST_BY_DEFAULT: True}):
-        result_factory = foo()
+        persist_result = foo()
 
-    assert result_factory.persist_result is False
+    assert persist_result is False
 
 
 @pytest.mark.parametrize("toggle", [True, False])
 def test_root_flow_custom_persist_setting(toggle):
     @flow(persist_result=toggle)
     def foo():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return (
+            result_factory.persist_result,
+            result_factory.serializer,
+            result_factory.storage_block,
+        )
 
-    result_factory = foo()
-    assert result_factory.persist_result is toggle
-    assert result_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
+    persist_result, serializer, storage_block = foo()
+    assert persist_result is toggle
+    assert serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(storage_block, DEFAULT_STORAGE())
 
 
 def test_root_flow_persists_results_when_flow_uses_feature():
     @flow(cache_result_in_memory=False, persist_result=True)
     def foo():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return (
+            result_factory.persist_result,
+            result_factory.serializer,
+            result_factory.storage_block,
+        )
 
-    result_factory = foo()
-    assert result_factory.persist_result is True
-    assert result_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
+    persist_result, serializer, storage_block = foo()
+    assert persist_result is True
+    assert serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(storage_block, DEFAULT_STORAGE())
 
 
 def test_root_flow_can_opt_out_of_persistence_when_flow_uses_feature():
-    result_factory = None
-
     @flow(cache_result_in_memory=False, persist_result=False)
     def foo():
-        nonlocal result_factory
         result_factory = get_run_context().result_factory
+        return (
+            result_factory.persist_result,
+            result_factory.serializer,
+            result_factory.storage_block,
+            result_factory.storage_block_id,
+        )
 
-    foo()
-    assert result_factory.persist_result is False
-    assert result_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
-    assert result_factory.storage_block_id is None
+    persist_result, serializer, storage_block, storage_block_id = foo()
+    assert persist_result is False
+    assert serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(storage_block, DEFAULT_STORAGE())
+    assert storage_block_id is None
 
 
 @pytest.mark.parametrize("toggle", [True, False])
 def test_root_flow_custom_cache_setting(toggle, default_persistence_off):
-    result_factory = None
+    cache_result_in_memory = None
+    serializer = None
+    storage_block = None
 
     @flow(cache_result_in_memory=toggle)
     def foo():
-        nonlocal result_factory
+        nonlocal cache_result_in_memory, serializer, storage_block
         result_factory = get_run_context().result_factory
+        cache_result_in_memory = result_factory.cache_result_in_memory
+        serializer = result_factory.serializer
+        storage_block = result_factory.storage_block
 
     foo()
-    assert result_factory.cache_result_in_memory is toggle
-    assert result_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
+    assert cache_result_in_memory is toggle
+    assert serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(storage_block, DEFAULT_STORAGE())
 
 
 def test_root_flow_custom_serializer_by_type_string():
     @flow(result_serializer="json", persist_result=False)
     def foo():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return (
+            result_factory.persist_result,
+            result_factory.serializer,
+            result_factory.storage_block,
+            result_factory.storage_block_id,
+        )
 
-    result_factory = foo()
-    assert result_factory.persist_result is False
-    assert result_factory.serializer == JSONSerializer()
-    assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
-    assert result_factory.storage_block_id is None
+    persist_result, serializer, storage_block, storage_block_id = foo()
+    assert persist_result is False
+    assert serializer == JSONSerializer()
+    assert_blocks_equal(storage_block, DEFAULT_STORAGE())
+    assert storage_block_id is None
 
 
 def test_root_flow_custom_serializer_by_instance(default_persistence_off):
     @flow(persist_result=False, result_serializer=JSONSerializer(jsonlib="orjson"))
     def foo():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return (
+            result_factory.persist_result,
+            result_factory.serializer,
+            result_factory.storage_block,
+            result_factory.storage_block_id,
+        )
 
-    result_factory = foo()
-    assert result_factory.persist_result is False
-    assert result_factory.serializer == JSONSerializer(jsonlib="orjson")
-    assert_blocks_equal(result_factory.storage_block, DEFAULT_STORAGE())
-    assert result_factory.storage_block_id is None
+    persist_result, serializer, storage_block, storage_block_id = foo()
+    assert persist_result is False
+    assert serializer == JSONSerializer(jsonlib="orjson")
+    assert_blocks_equal(storage_block, DEFAULT_STORAGE())
+    assert storage_block_id is None
 
 
 async def test_root_flow_custom_storage_by_slug(tmp_path, default_persistence_off):
@@ -180,13 +210,19 @@ async def test_root_flow_custom_storage_by_slug(tmp_path, default_persistence_of
 
     @flow(result_storage="local-file-system/test")
     def foo():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return (
+            result_factory.persist_result,
+            result_factory.serializer,
+            result_factory.storage_block,
+            result_factory.storage_block_id,
+        )
 
-    result_factory = foo()
-    assert result_factory.persist_result is True  # inferred from the storage
-    assert result_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(result_factory.storage_block, storage)
-    assert result_factory.storage_block_id == storage_id
+    persist_result, serializer, storage_block, storage_block_id = foo()
+    assert persist_result is True  # inferred from the storage
+    assert serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(storage_block, storage)
+    assert storage_block_id == storage_id
 
 
 async def test_root_flow_custom_storage_by_instance_presaved(
@@ -197,30 +233,42 @@ async def test_root_flow_custom_storage_by_instance_presaved(
 
     @flow(result_storage=storage)
     def foo():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return (
+            result_factory.persist_result,
+            result_factory.serializer,
+            result_factory.storage_block,
+            result_factory.storage_block_id,
+        )
 
-    result_factory = foo()
-    assert result_factory.persist_result is True  # inferred from the storage
-    assert result_factory.serializer == DEFAULT_SERIALIZER()
-    assert result_factory.storage_block == storage
-    assert result_factory.storage_block._is_anonymous is False
-    assert result_factory.storage_block_id == storage_id
+    persist_result, serializer, storage_block, storage_block_id = foo()
+    assert persist_result is True  # inferred from the storage
+    assert serializer == DEFAULT_SERIALIZER()
+    assert storage_block == storage
+    assert storage_block._is_anonymous is False
+    assert storage_block_id == storage_id
 
 
 def test_child_flow_inherits_default_result_settings(default_persistence_off):
     @flow
     def foo():
-        return get_run_context().result_factory, bar()
+        return bar()
 
     @flow
     def bar():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return (
+            result_factory.persist_result,
+            result_factory.serializer,
+            result_factory.storage_block,
+            result_factory.storage_block_id,
+        )
 
-    _, child_factory = foo()
-    assert child_factory.persist_result is False
-    assert child_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert child_factory.storage_block_id is None
+    persist_result, serializer, storage_block, storage_block_id = foo()
+    assert persist_result is False
+    assert serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(storage_block, DEFAULT_STORAGE())
+    assert storage_block_id is None
 
 
 def test_child_flow_default_result_serializer_can_be_overriden_by_setting(
@@ -228,83 +276,115 @@ def test_child_flow_default_result_serializer_can_be_overriden_by_setting(
 ):
     @flow
     def foo():
-        return get_run_context().result_factory, bar()
+        return bar()
 
     @flow
     def bar():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return result_factory.serializer
 
     with temporary_settings({PREFECT_RESULTS_DEFAULT_SERIALIZER: "json"}):
-        _, child_factory = foo()
+        serializer = foo()
 
-    assert child_factory.serializer == JSONSerializer()
+    assert serializer == JSONSerializer()
 
 
 def test_child_flow_default_persist_result_can_be_overriden_by_setting():
     @flow
     def foo():
-        return get_run_context().result_factory, bar()
+        return bar()
 
     @flow
     def bar():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return result_factory.persist_result
 
     with temporary_settings({PREFECT_RESULTS_PERSIST_BY_DEFAULT: True}):
-        _, child_factory = foo()
+        persist_result = foo()
 
-    assert child_factory.persist_result is True
+    assert persist_result is True
 
 
 def test_child_flow_can_opt_out_when_persist_result_default_is_overriden_by_setting():
     @flow
     def foo():
-        return get_run_context().result_factory, bar()
+        return bar()
 
     @flow(persist_result=False)
     def bar():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return result_factory.persist_result
 
     with temporary_settings({PREFECT_RESULTS_PERSIST_BY_DEFAULT: True}):
-        _, child_factory = foo()
+        persist_result = foo()
 
-    assert child_factory.persist_result is False
+    assert persist_result is False
 
 
 def test_child_flow_custom_persist_setting(default_persistence_off):
     @flow
     def foo():
-        return get_run_context().result_factory, bar()
+        result_factory = get_run_context().result_factory
+        child_persist_result, child_serializer, child_storage_block = bar()
+        return (
+            result_factory.persist_result,
+            child_persist_result,
+            child_serializer,
+            child_storage_block,
+        )
 
     @flow(persist_result=True)
     def bar():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return (
+            result_factory.persist_result,
+            result_factory.serializer,
+            result_factory.storage_block,
+        )
 
-    parent_factory, child_factory = foo()
-    assert parent_factory.persist_result is False
-    assert child_factory.persist_result is True
-    assert child_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
+    (
+        parent_persist_result,
+        child_persist_result,
+        child_serializer,
+        child_storage_block,
+    ) = foo()
+    assert parent_persist_result is False
+    assert child_persist_result is True
+    assert child_serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(child_storage_block, DEFAULT_STORAGE())
 
 
 @pytest.mark.parametrize("toggle", [True, False])
 def test_child_flow_custom_cache_setting(toggle, default_persistence_off):
-    child_factory = None
-
     @flow
     def foo():
-        bar(return_state=True)
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        child_cache_result_in_memory, child_serializer, child_storage_block = bar()
+        return (
+            result_factory.cache_result_in_memory,
+            child_cache_result_in_memory,
+            child_serializer,
+            child_storage_block,
+        )
 
     @flow(cache_result_in_memory=toggle)
     def bar():
-        nonlocal child_factory
-        child_factory = get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        child_cache_result_in_memory = result_factory.cache_result_in_memory
+        child_serializer = result_factory.serializer
+        child_storage_block = result_factory.storage_block
+        return child_cache_result_in_memory, child_serializer, child_storage_block
 
-    parent_factory = foo()
-    assert parent_factory.cache_result_in_memory is True
-    assert child_factory.cache_result_in_memory is toggle
-    assert child_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
+    (
+        parent_cache_result_in_memory,
+        child_cache_result_in_memory,
+        child_serializer,
+        child_storage_block,
+    ) = foo()
+    assert parent_cache_result_in_memory is True
+    assert child_cache_result_in_memory is toggle
+    assert child_serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(child_storage_block, DEFAULT_STORAGE())
 
 
 def test_child_flow_can_opt_out_of_result_persistence_when_parent_uses_feature(
@@ -329,17 +409,42 @@ def test_child_flow_can_opt_out_of_result_persistence_when_parent_uses_feature(
 def test_child_flow_inherits_custom_serializer(default_persistence_off):
     @flow(persist_result=False, result_serializer="json")
     def foo():
-        return get_run_context().result_factory, bar()
+        result_factory = get_run_context().result_factory
+        (
+            child_persist_result,
+            child_serializer,
+            child_storage_block,
+            child_storage_block_id,
+        ) = bar()
+        return (
+            result_factory.serializer,
+            child_persist_result,
+            child_serializer,
+            child_storage_block,
+            child_storage_block_id,
+        )
 
     @flow()
     def bar():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return (
+            result_factory.persist_result,
+            result_factory.serializer,
+            result_factory.storage_block,
+            result_factory.storage_block_id,
+        )
 
-    parent_factory, child_factory = foo()
-    assert child_factory.persist_result is False
-    assert child_factory.serializer == parent_factory.serializer
-    assert_blocks_equal(child_factory.storage_block, DEFAULT_STORAGE())
-    assert child_factory.storage_block_id is None
+    (
+        parent_serializer,
+        child_persist_result,
+        child_serializer,
+        child_storage_block,
+        child_storage_block_id,
+    ) = foo()
+    assert child_persist_result is False
+    assert child_serializer == parent_serializer
+    assert_blocks_equal(child_storage_block, DEFAULT_STORAGE())
+    assert child_storage_block_id is None
 
 
 async def test_child_flow_inherits_custom_storage(tmp_path, default_persistence_off):
@@ -348,17 +453,42 @@ async def test_child_flow_inherits_custom_storage(tmp_path, default_persistence_
 
     @flow(result_storage="local-file-system/test")
     def foo():
-        return get_run_context().result_factory, bar()
+        result_factory = get_run_context().result_factory
+        (
+            child_persist_result,
+            child_serializer,
+            child_storage_block,
+            child_storage_block_id,
+        ) = bar()
+        return (
+            result_factory.serializer,
+            child_persist_result,
+            child_serializer,
+            child_storage_block,
+            child_storage_block_id,
+        )
 
     @flow
     def bar():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return (
+            result_factory.persist_result,
+            result_factory.serializer,
+            result_factory.storage_block,
+            result_factory.storage_block_id,
+        )
 
-    parent_factory, child_factory = foo()
-    assert child_factory.persist_result is False
-    assert child_factory.serializer == DEFAULT_SERIALIZER()
-    assert child_factory.storage_block == parent_factory.storage_block
-    assert child_factory.storage_block_id == storage_id
+    (
+        parent_serializer,
+        child_persist_result,
+        child_serializer,
+        child_storage_block,
+        child_storage_block_id,
+    ) = foo()
+    assert child_persist_result is True
+    assert child_serializer == parent_serializer
+    assert_blocks_equal(child_storage_block, storage)
+    assert child_storage_block_id == storage_id
 
 
 async def test_child_flow_custom_storage(tmp_path, default_persistence_off):
@@ -367,18 +497,43 @@ async def test_child_flow_custom_storage(tmp_path, default_persistence_off):
 
     @flow()
     def foo():
-        return get_run_context().result_factory, bar()
+        result_factory = get_run_context().result_factory
+        (
+            child_persist_result,
+            child_serializer,
+            child_storage_block,
+            child_storage_block_id,
+        ) = bar()
+        return (
+            result_factory.storage_block,
+            child_persist_result,
+            child_serializer,
+            child_storage_block,
+            child_storage_block_id,
+        )
 
     @flow(result_storage="local-file-system/test")
     def bar():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return (
+            result_factory.persist_result,
+            result_factory.serializer,
+            result_factory.storage_block,
+            result_factory.storage_block_id,
+        )
 
-    parent_factory, child_factory = foo()
-    assert_blocks_equal(parent_factory.storage_block, DEFAULT_STORAGE())
-    assert child_factory.persist_result is True  # inferred from the storage
-    assert child_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(child_factory.storage_block, storage)
-    assert child_factory.storage_block_id == storage_id
+    (
+        parent_storage_block,
+        child_persist_result,
+        child_serializer,
+        child_storage_block,
+        child_storage_block_id,
+    ) = foo()
+    assert_blocks_equal(parent_storage_block, DEFAULT_STORAGE())
+    assert child_persist_result is True  # inferred from the storage
+    assert child_serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(child_storage_block, storage)
+    assert child_storage_block_id == storage_id
 
 
 def test_task_inherits_default_result_settings():
@@ -413,53 +568,91 @@ def test_task_default_persist_result_can_be_overriden_by_setting():
 
         @flow
         def foo():
-            return get_run_context().result_factory, bar()
+            return bar()
 
         @task
         def bar():
-            return get_run_context().result_factory
+            result_factory = get_run_context().result_factory
+            return result_factory.persist_result
 
-        _, task_factory = foo()
+        task_persist_result = foo()
 
-    assert task_factory.persist_result is True
+    assert task_persist_result is True
 
 
 def test_nested_flow_custom_persist_setting():
     @flow(persist_result=True)
     def foo():
-        return get_run_context().result_factory, bar()
+        result_factory = get_run_context().result_factory
+        (
+            child_persist_result,
+            child_serializer,
+            child_storage_block,
+            child_storage_block_id,
+        ) = bar()
+        return (
+            result_factory.persist_result,
+            child_persist_result,
+            child_serializer,
+            child_storage_block,
+            child_storage_block_id,
+        )
 
     @flow(persist_result=False)
     def bar():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return (
+            result_factory.persist_result,
+            result_factory.serializer,
+            result_factory.storage_block,
+            result_factory.storage_block_id,
+        )
 
-    flow_factory, task_factory = foo()
-    assert flow_factory.persist_result is True
-    assert task_factory.persist_result is False
-    assert task_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
-    assert task_factory.storage_block_id is None
+    (
+        parent_persist_result,
+        child_persist_result,
+        child_serializer,
+        child_storage_block,
+        child_storage_block_id,
+    ) = foo()
+    assert parent_persist_result is True
+    assert child_persist_result is False
+    assert child_serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(child_storage_block, DEFAULT_STORAGE())
+    assert child_storage_block_id is None
 
 
 @pytest.mark.parametrize("toggle", [True, False])
 def test_task_custom_cache_setting(toggle):
-    task_factory = None
-
     @flow
     def foo():
-        bar()
-        return get_run_context().result_factory
+        task_persist_result, task_serializer, task_storage_block = bar()
+        return (
+            get_run_context().result_factory.cache_result_in_memory,
+            task_persist_result,
+            task_serializer,
+            task_storage_block,
+        )
 
     @task(cache_result_in_memory=toggle)
     def bar():
-        nonlocal task_factory
         task_factory = get_run_context().result_factory
+        return (
+            task_factory.cache_result_in_memory,
+            task_factory.serializer,
+            task_factory.storage_block,
+        )
 
-    flow_factory = foo()
-    assert flow_factory.cache_result_in_memory is True
-    assert task_factory.cache_result_in_memory is toggle
-    assert task_factory.serializer == DEFAULT_SERIALIZER()
-    assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
+    (
+        flow_cache_result_in_memory,
+        task_persist_result,
+        task_serializer,
+        task_storage_block,
+    ) = foo()
+    assert flow_cache_result_in_memory is True
+    assert task_persist_result is toggle
+    assert task_serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(task_storage_block, DEFAULT_STORAGE())
 
 
 def test_task_can_opt_out_of_result_persistence_when_flow_uses_feature(
@@ -484,32 +677,57 @@ def test_task_can_opt_out_of_result_persistence_when_flow_uses_feature(
 def test_task_can_opt_out_when_persist_result_default_is_overriden_by_setting():
     @flow
     def foo():
-        return get_run_context().result_factory, bar()
+        return bar()
 
     @task(persist_result=False)
     def bar():
-        return get_run_context().result_factory
+        task_factory = get_run_context().result_factory
+        return task_factory.persist_result
 
     with temporary_settings({PREFECT_RESULTS_PERSIST_BY_DEFAULT: True}):
-        _, task_factory = foo()
+        task_persist_result = foo()
 
-    assert task_factory.persist_result is False
+    assert task_persist_result is False
 
 
 def test_task_inherits_custom_serializer(default_persistence_off):
     @flow(result_serializer="json", persist_result=False)
     def foo():
-        return get_run_context().result_factory, bar()
+        (
+            task_persist_result,
+            task_serializer,
+            task_storage_block,
+            task_storage_block_id,
+        ) = bar()
+        return (
+            get_run_context().result_factory.serializer,
+            task_persist_result,
+            task_serializer,
+            task_storage_block,
+            task_storage_block_id,
+        )
 
     @flow()
     def bar():
-        return get_run_context().result_factory
+        child_factory = get_run_context().result_factory
+        return (
+            child_factory.persist_result,
+            child_factory.serializer,
+            child_factory.storage_block,
+            child_factory.storage_block_id,
+        )
 
-    flow_factory, task_factory = foo()
-    assert task_factory.persist_result is False
-    assert task_factory.serializer == flow_factory.serializer
-    assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
-    assert task_factory.storage_block_id is None
+    (
+        flow_serializer,
+        task_persist_result,
+        task_serializer,
+        task_storage_block,
+        task_storage_block_id,
+    ) = foo()
+    assert task_persist_result is False
+    assert task_serializer == flow_serializer
+    assert_blocks_equal(task_storage_block, DEFAULT_STORAGE())
+    assert task_storage_block_id is None
 
 
 async def test_task_inherits_custom_storage(tmp_path):
@@ -518,34 +736,69 @@ async def test_task_inherits_custom_storage(tmp_path):
 
     @flow(result_storage="local-file-system/test", persist_result=True)
     def foo():
-        return get_run_context().result_factory, bar()
+        return bar()
 
     @task(persist_result=True)
     def bar():
-        return get_run_context().result_factory
+        task_factory = get_run_context().result_factory
+        return (
+            task_factory.persist_result,
+            task_factory.serializer,
+            task_factory.storage_block,
+            task_factory.storage_block_id,
+        )
 
-    flow_factory, task_factory = foo()
-    assert task_factory.persist_result
-    assert task_factory.serializer == DEFAULT_SERIALIZER()
-    assert task_factory.storage_block == flow_factory.storage_block
-    assert task_factory.storage_block_id == storage_id
+    (
+        task_persist_result,
+        task_serializer,
+        task_storage_block,
+        task_storage_block_id,
+    ) = foo()
+    assert task_persist_result is True
+    assert task_serializer == DEFAULT_SERIALIZER()
+    assert_blocks_equal(task_storage_block, storage)
+    assert task_storage_block_id == storage_id
 
 
 def test_task_custom_serializer(default_persistence_off):
     @flow
     def foo():
-        return get_run_context().result_factory, bar()
+        (
+            child_persist_result,
+            child_serializer,
+            child_storage_block,
+            child_storage_block_id,
+        ) = bar()
+        return (
+            get_run_context().result_factory.serializer,
+            child_persist_result,
+            child_serializer,
+            child_storage_block,
+            child_storage_block_id,
+        )
 
     @flow(result_serializer="json", persist_result=False)
     def bar():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return (
+            result_factory.persist_result,
+            result_factory.serializer,
+            result_factory.storage_block,
+            result_factory.storage_block_id,
+        )
 
-    flow_factory, task_factory = foo()
-    assert flow_factory.serializer == DEFAULT_SERIALIZER()
-    assert task_factory.persist_result is False
-    assert task_factory.serializer == JSONSerializer()
-    assert_blocks_equal(task_factory.storage_block, DEFAULT_STORAGE())
-    assert task_factory.storage_block_id is None
+    (
+        parent_serializer,
+        child_persist_result,
+        child_serializer,
+        child_storage_block,
+        child_storage_block_id,
+    ) = foo()
+    assert parent_serializer == DEFAULT_SERIALIZER()
+    assert child_persist_result is False
+    assert child_serializer == JSONSerializer()
+    assert_blocks_equal(child_storage_block, DEFAULT_STORAGE())
+    assert child_storage_block_id is None
 
 
 async def test_nested_flow_custom_storage(tmp_path):
@@ -554,18 +807,42 @@ async def test_nested_flow_custom_storage(tmp_path):
 
     @flow(persist_result=True)
     def foo():
-        return get_run_context().result_factory, bar()
+        (
+            child_persist_result,
+            child_serializer,
+            child_storage_block,
+            child_storage_block_id,
+        ) = bar()
+        return (
+            get_run_context().result_factory.storage_block,
+            child_persist_result,
+            child_serializer,
+            child_storage_block,
+            child_storage_block_id,
+        )
 
     @flow(result_storage="local-file-system/test", persist_result=True)
     def bar():
-        return get_run_context().result_factory
+        result_factory = get_run_context().result_factory
+        return (
+            result_factory.persist_result,
+            result_factory.serializer,
+            result_factory.storage_block,
+            result_factory.storage_block_id,
+        )
 
-    flow_factory, task_factory = foo()
-    assert_blocks_equal(flow_factory.storage_block, DEFAULT_STORAGE())
-    assert_blocks_equal(task_factory.storage_block, storage)
-    assert task_factory.persist_result is True
-    assert task_factory.serializer == DEFAULT_SERIALIZER()
-    assert task_factory.storage_block_id == storage_id
+    (
+        parent_storage_block,
+        child_persist_result,
+        child_serializer,
+        child_storage_block,
+        child_storage_block_id,
+    ) = foo()
+    assert_blocks_equal(parent_storage_block, DEFAULT_STORAGE())
+    assert_blocks_equal(child_storage_block, storage)
+    assert child_persist_result is True
+    assert child_serializer == DEFAULT_SERIALIZER()
+    assert child_storage_block_id == storage_id
 
 
 async def _verify_default_storage_creation_with_persistence(
@@ -596,52 +873,50 @@ async def test_default_storage_creation_for_flow_with_persistence_features(
     prefect_client,
 ):
     @flow(persist_result=True)
-    def foo():
-        return get_run_context().result_factory
+    async def foo():
+        await _verify_default_storage_creation_with_persistence(
+            prefect_client, get_run_context().result_factory
+        )
 
-    result_factory = foo()
-    await _verify_default_storage_creation_with_persistence(
-        prefect_client, result_factory
-    )
+    foo()
 
 
 async def test_default_storage_creation_for_flow_without_persistence_features():
     @flow(persist_result=False)
     def foo():
-        return get_run_context().result_factory
+        _verify_default_storage_creation_without_persistence(
+            get_run_context().result_factory
+        )
 
-    result_factory = foo()
-    await _verify_default_storage_creation_without_persistence(result_factory)
+    foo()
 
 
 async def test_default_storage_creation_for_task_with_persistence_features(
     prefect_client,
 ):
     @task(persist_result=True)
-    def my_task_1():
-        return get_run_context().result_factory
+    async def my_task_1():
+        await _verify_default_storage_creation_with_persistence(
+            prefect_client, get_run_context().result_factory
+        )
 
     @flow(retries=2, persist_result=True)
-    def my_flow_1():
-        return my_task_1()
+    async def my_flow_1():
+        await my_task_1()
 
-    result_factory = my_flow_1()
-    await _verify_default_storage_creation_with_persistence(
-        prefect_client, result_factory
-    )
+    my_flow_1()
 
     @task(cache_key_fn=lambda *_: "always", persist_result=True)
-    def my_task_2():
-        return get_run_context().result_factory
+    async def my_task_2():
+        await _verify_default_storage_creation_with_persistence(
+            prefect_client, get_run_context().result_factory
+        )
 
     @flow(persist_result=True)
-    def my_flow_2():
-        return my_task_2()
+    async def my_flow_2():
+        await my_task_2()
 
-    result_factory = my_flow_2()
-    await _verify_default_storage_creation_with_persistence(
-        prefect_client, result_factory
-    )
+    my_flow_2()
 
 
 async def test_default_storage_creation_for_task_without_persistence_features():
@@ -714,27 +989,27 @@ async def test_result_factory_from_task_loads_persist_result_from_flow_factory(
 ):
     @task
     def my_task():
-        return get_run_context().result_factory
+        return get_run_context().result_factory.persist_result
 
     @flow(persist_result=persist_result)
     def foo():
         return my_task()
 
-    result_factory = foo()
+    persist_result = foo()
 
-    assert result_factory.persist_result is persist_result
+    assert persist_result is persist_result
 
 
 @pytest.mark.parametrize("persist_result", [True, False])
 async def test_result_factory_from_task_takes_precedence_from_task(persist_result):
     @task(persist_result=persist_result)
     def my_task():
-        return get_run_context().result_factory
+        return get_run_context().result_factory.persist_result
 
     @flow(persist_result=not persist_result)
     def foo():
         return my_task()
 
-    result_factory = foo()
+    persist_result = foo()
 
-    assert result_factory.persist_result is persist_result
+    assert persist_result is persist_result

--- a/tests/results/test_state_result.py
+++ b/tests/results/test_state_result.py
@@ -38,9 +38,7 @@ async def test_unfinished_states_raise_on_result_retrieval(
 async def test_finished_states_allow_result_retrieval(
     prefect_client, state_type: StateType
 ):
-    factory = await ResultFactory.default_factory(
-        client=prefect_client, persist_result=True
-    )
+    factory = ResultFactory(persist_result=True)
     state = State(type=state_type, data=await factory.create_result("test"))
 
     assert await state.result(raise_on_failure=False) == "test"

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -12,7 +12,7 @@ from prefect.blocks.core import Block
 from prefect.client.orchestration import get_client
 from prefect.client.schemas import TaskRun
 from prefect.filesystems import LocalFileSystem
-from prefect.results import ResultFactory
+from prefect.results import ResultFactory, get_or_create_default_task_scheduling_storage
 from prefect.server.api.task_runs import TaskQueue
 from prefect.server.schemas.core import TaskRun as ServerTaskRun
 from prefect.settings import (
@@ -25,7 +25,9 @@ if TYPE_CHECKING:
 
 
 async def result_factory_from_task(task) -> ResultFactory:
-    return await ResultFactory.from_autonomous_task(task)
+    return ResultFactory(
+        result_storage=await get_or_create_default_task_scheduling_storage()
+    )
 
 
 @pytest.fixture

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -96,7 +96,7 @@ async def test_flow_run_context(prefect_client):
 
     test_task_runner = ThreadPoolTaskRunner()
     flow_run = await prefect_client.create_flow_run(foo)
-    result_factory = await ResultFactory.from_flow(foo)
+    result_factory = ResultFactory()
 
     with FlowRunContext(
         flow=foo,
@@ -122,7 +122,7 @@ async def test_task_run_context(prefect_client, flow_run):
         pass
 
     task_run = await prefect_client.create_task_run(foo, flow_run.id, dynamic_key="")
-    result_factory = await ResultFactory.default_factory()
+    result_factory = ResultFactory()
 
     with TaskRunContext(
         task=foo,
@@ -172,7 +172,7 @@ async def test_get_run_context(prefect_client, local_filesystem):
         flow_run=flow_run,
         client=prefect_client,
         task_runner=test_task_runner,
-        result_factory=await ResultFactory.from_flow(foo, client=prefect_client),
+        result_factory=ResultFactory(),
         parameters={"x": "y"},
     ) as flow_ctx:
         assert get_run_context() is flow_ctx
@@ -181,7 +181,7 @@ async def test_get_run_context(prefect_client, local_filesystem):
             task=bar,
             task_run=task_run,
             client=prefect_client,
-            result_factory=await ResultFactory.from_task(bar, client=prefect_client),
+            result_factory=ResultFactory(),
             parameters={"foo": "bar"},
         ) as task_ctx:
             assert get_run_context() is task_ctx, "Task context takes precedence"
@@ -419,7 +419,7 @@ class TestSerializeContext:
 
         test_task_runner = ThreadPoolTaskRunner()
         flow_run = await prefect_client.create_flow_run(foo)
-        result_factory = await ResultFactory.from_flow(foo)
+        result_factory = ResultFactory()
 
         with FlowRunContext(
             flow=foo,
@@ -450,7 +450,7 @@ class TestSerializeContext:
             task=bar,
             task_run=task_run,
             client=prefect_client,
-            result_factory=await ResultFactory.from_task(bar, client=prefect_client),
+            result_factory=ResultFactory(),
             parameters={"foo": "bar"},
         ) as task_ctx:
             serialized = serialize_context()
@@ -509,7 +509,7 @@ class TestHydratedContext:
 
         test_task_runner = ThreadPoolTaskRunner()
         flow_run = await prefect_client.create_flow_run(foo)
-        result_factory = await ResultFactory.from_flow(foo)
+        result_factory = ResultFactory()
         flow_run_context = FlowRunContext(
             flow=foo,
             flow_run=flow_run,
@@ -560,7 +560,7 @@ class TestHydratedContext:
 
         test_task_runner = ThreadPoolTaskRunner()
         flow_run = await prefect_client.create_flow_run(foo, state=Running())
-        result_factory = await ResultFactory.from_flow(foo)
+        result_factory = ResultFactory()
         flow_run_context = FlowRunContext(
             flow=foo,
             flow_run=flow_run,
@@ -593,7 +593,7 @@ class TestHydratedContext:
             task=bar,
             task_run=task_run,
             client=prefect_client,
-            result_factory=await ResultFactory.from_task(bar, client=prefect_client),
+            result_factory=ResultFactory(),
             parameters={"foo": "bar"},
         )
 

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -132,19 +132,15 @@ class TestRaiseStateException:
 
 class TestReturnValueToState:
     @pytest.fixture
-    async def factory(self, prefect_client):
-        return await ResultFactory.default_factory(client=prefect_client)
+    def factory(self):
+        return ResultFactory()
 
     async def test_returns_single_state_unaltered(self, factory):
         state = Completed(data="hello!")
         assert await return_value_to_state(state, factory) is state
 
-    async def test_returns_single_state_with_null_data_and_persist_off(
-        self, prefect_client
-    ):
-        factory = await ResultFactory.default_factory(
-            client=prefect_client, persist_result=False
-        )
+    async def test_returns_single_state_with_null_data_and_persist_off(self):
+        factory = ResultFactory(persist_result=False)
         state = Completed(data=None)
         result_state = await return_value_to_state(state, factory)
         assert result_state is state
@@ -152,20 +148,16 @@ class TestReturnValueToState:
         assert result_state.data._persisted is False
         assert await result_state.result() is None
 
-    async def test_returns_single_state_with_data_to_persist(self, prefect_client):
-        factory = await ResultFactory.default_factory(
-            client=prefect_client, persist_result=True
-        )
+    async def test_returns_single_state_with_data_to_persist(self):
+        factory = ResultFactory(persist_result=True)
         state = Completed(data=1)
         result_state = await return_value_to_state(state, factory)
         assert result_state is state
         assert isinstance(result_state.data, PersistedResult)
         assert await result_state.result() == 1
 
-    async def test_returns_persisted_results_unaltered(self, prefect_client):
-        factory = await ResultFactory.default_factory(
-            client=prefect_client, persist_result=True
-        )
+    async def test_returns_persisted_results_unaltered(self):
+        factory = ResultFactory(persist_result=True)
         result = await factory.create_result(42)
         result_state = await return_value_to_state(result, factory)
         assert result_state.data == result

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -126,7 +126,7 @@ class TestRunTask:
         test_task_runner = ThreadPoolTaskRunner()
         flow_run = await prefect_client.create_flow_run(f)
         await propose_state(prefect_client, Running(), flow_run_id=flow_run.id)
-        result_factory = await ResultFactory.from_flow(f)
+        result_factory = ResultFactory()
         flow_run_context = EngineContext(
             flow=f,
             flow_run=flow_run,
@@ -174,7 +174,7 @@ class TestTaskRunsAsync:
         test_task_runner = ThreadPoolTaskRunner()
         flow_run = await prefect_client.create_flow_run(f)
         await propose_state(prefect_client, Running(), flow_run_id=flow_run.id)
-        result_factory = await ResultFactory.from_flow(f)
+        result_factory = ResultFactory()
         flow_run_context = EngineContext(
             flow=f,
             flow_run=flow_run,
@@ -1497,7 +1497,7 @@ class TestRunCountTracking:
         flow_run = await prefect_client.read_flow_run(flow_run.id)
         assert flow_run.run_count == 1
 
-        result_factory = await ResultFactory.from_flow(f)
+        result_factory = ResultFactory()
         return EngineContext(
             flow=f,
             flow_run=flow_run,
@@ -1646,12 +1646,10 @@ class TestTimeout:
 
 
 class TestPersistence:
-    async def test_task_can_return_persisted_result(self, prefect_client):
+    async def test_task_can_return_persisted_result(self):
         @task
         async def async_task():
-            factory = await ResultFactory.default_factory(
-                client=prefect_client, persist_result=True
-            )
+            factory = ResultFactory(persist_result=True)
             result = await factory.create_result(42)
             await result.write()
             return result
@@ -1660,12 +1658,8 @@ class TestPersistence:
         state = await async_task(return_state=True)
         assert await state.result() == 42
 
-    async def test_task_loads_result_if_exists_using_result_storage_key(
-        self, prefect_client
-    ):
-        factory = await ResultFactory.default_factory(
-            client=prefect_client, persist_result=True
-        )
+    async def test_task_loads_result_if_exists_using_result_storage_key(self):
+        factory = ResultFactory(persist_result=True)
         result = await factory.create_result(-92, key="foo-bar")
         await result.write()
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -863,7 +863,7 @@ class TestTaskSubmit:
         with pytest.raises(ValueError, match="deadlock"):
             my_flow()
 
-    @pytest.mark.xfail(
+    @pytest.mark.skip(
         reason="This test is not compatible with the current state of client side task orchestration"
     )
     def test_logs_message_when_submitted_tasks_end_in_pending(self, caplog):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -32,7 +32,7 @@ from prefect.filesystems import LocalFileSystem
 from prefect.futures import PrefectDistributedFuture
 from prefect.futures import PrefectFuture as NewPrefectFuture
 from prefect.logging import get_run_logger
-from prefect.results import ResultFactory
+from prefect.results import ResultFactory, get_or_create_default_task_scheduling_storage
 from prefect.runtime import task_run as task_run_ctx
 from prefect.server import models
 from prefect.settings import (
@@ -82,7 +82,10 @@ def timeout_test_flow():
 
 
 async def get_background_task_run_parameters(task, parameters_id):
-    factory = await ResultFactory.from_autonomous_task(task)
+    factory = ResultFactory(
+        result_storage=task.result_storage
+        or await get_or_create_default_task_scheduling_storage()
+    )
     return await factory.read_parameters(parameters_id)
 
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -27,7 +27,6 @@ from prefect.transactions import (
     get_transaction,
     transaction,
 )
-from prefect.utilities.asyncutils import run_coro_as_sync
 
 
 def test_basic_init():
@@ -387,12 +386,12 @@ class TestWithMemoryRecordStore:
 
     @pytest.fixture
     async def result_1(self, default_storage_setting):
-        result_factory = await ResultFactory.default_factory(persist_result=True)
+        result_factory = ResultFactory(persist_result=True)
         return await result_factory.create_result(obj={"foo": "bar"})
 
     @pytest.fixture
     async def result_2(self, default_storage_setting):
-        result_factory = await ResultFactory.default_factory(persist_result=True)
+        result_factory = ResultFactory(persist_result=True)
         return await result_factory.create_result(obj={"fizz": "buzz"})
 
     async def test_basic_transaction(self, result_1):
@@ -527,9 +526,7 @@ class TestIsolationLevel:
         ):
             with transaction(
                 key="test",
-                store=ResultFactoryStore(
-                    result_factory=run_coro_as_sync(ResultFactory.default_factory())
-                ),
+                store=ResultFactoryStore(result_factory=ResultFactory()),
                 isolation_level=IsolationLevel.SERIALIZABLE,
             ):
                 pass


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR is the next step in the results refactor. This PR removes all creation methods from `ResultFactory` and adds a standard `__init__` method instead. In lieu of the different creation methods, `ResultFactory` will read the current run context to determine what settings to use when creating results. This will allow better reuse of `ResultFactory` instances.

After this, I will explore creating a context to make sharing a `ResultFactory` instance easier and removing the `result_factory` attribute from `FlowRunContext` and `TaskRunContext`.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
