### PR TITLE
rm poorly rendered line in contributing guide

### DIFF
--- a/docs/contribute/styles-practices.mdx
+++ b/docs/contribute/styles-practices.mdx
@@ -144,8 +144,6 @@ Avoid circular dependencies. They often reveal entanglement in the design.
 
 Place all deferred imports at the top of the function.
 
-##### With type annotations
-
 If you are just using the imported object for a type signature, use the `TYPE_CHECKING` flag:
 
 ```python


### PR DESCRIPTION
![Screenshot 2024-08-30 at 11 18 29 AM](https://github.com/user-attachments/assets/6cd9a470-ba7e-411e-9cdf-40654585e0cd)
