### PR TITLE
Rm "default" profile migration

### DIFF
--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -38,7 +38,7 @@ def ls():
     """
     List profile names.
     """
-    profiles = prefect.settings.load_profiles()
+    profiles = prefect.settings.load_profiles(include_defaults=False)
     current_profile = prefect.context.get_settings_context().profile
     current_name = current_profile.name if current_profile is not None else None
 

--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -22,7 +22,7 @@ from prefect.client.base import determine_server_type
 from prefect.client.orchestration import ServerType, get_client
 from prefect.context import use_profile
 from prefect.exceptions import ObjectNotFound
-from prefect.settings import Profile, ProfilesCollection
+from prefect.settings import ProfilesCollection
 from prefect.utilities.collections import AutoEnum
 
 profile_app = PrefectTyper(name="profile", help="Select and manage Prefect profiles.")
@@ -319,24 +319,6 @@ def populate_defaults():
     if not typer.confirm(f"\nUpdate profiles at {user_path}?"):
         app.console.print("Operation cancelled.")
         return
-
-    # Apply changes
-    if "default" in user_profiles:
-        default_settings = user_profiles["default"].settings
-        if "ephemeral" not in user_profiles:
-            user_profiles.add_profile(
-                Profile(name="ephemeral", settings=default_settings)
-            )
-        else:
-            merged_settings = {
-                **user_profiles["ephemeral"].settings,
-                **default_settings,
-            }
-            user_profiles.update_profile("ephemeral", merged_settings)
-
-        if user_profiles.active_name == "default":
-            user_profiles.set_active("ephemeral")
-        user_profiles.remove_profile("default")
 
     for name, profile in default_profiles.items():
         if name not in user_profiles:

--- a/src/prefect/cli/profile.py
+++ b/src/prefect/cli/profile.py
@@ -265,9 +265,6 @@ def show_profile_changes(
 ):
     changes = []
 
-    if "default" in user_profiles:
-        changes.append(("migrate", "default", "ephemeral"))
-
     for name in default_profiles.names:
         if name not in user_profiles:
             changes.append(("add", name))

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -2192,6 +2192,8 @@ def _write_profiles_to(path: Path, profiles: ProfilesCollection) -> None:
 
 
 def load_profiles() -> ProfilesCollection:
+    if not PREFECT_PROFILES_PATH.value().exists():
+        return ProfilesCollection([])
     return _read_profiles_from(PREFECT_PROFILES_PATH.value())
 
 

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -2192,27 +2192,7 @@ def _write_profiles_to(path: Path, profiles: ProfilesCollection) -> None:
 
 
 def load_profiles() -> ProfilesCollection:
-    """
-    Load all profiles from the default and current profile paths.
-    """
-    profiles = _read_profiles_from(DEFAULT_PROFILES_PATH)
-
-    user_profiles_path = PREFECT_PROFILES_PATH.value()
-    if user_profiles_path.exists():
-        user_profiles = _read_profiles_from(user_profiles_path)
-
-        # Merge all of the user profiles with the defaults
-        for name in user_profiles:
-            profiles.update_profile(
-                name,
-                settings=user_profiles[name].settings,
-                source=user_profiles[name].source,
-            )
-
-        if user_profiles.active_name:
-            profiles.set_active(user_profiles.active_name, check=False)
-
-    return profiles
+    return _read_profiles_from(PREFECT_PROFILES_PATH.value())
 
 
 def load_current_profile():

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -2196,12 +2196,15 @@ def load_profiles(include_defaults: bool = True) -> ProfilesCollection:
     Load profiles from the current profile path. Optionally include profiles from the
     default profile path.
     """
+    default_profiles = _read_profiles_from(DEFAULT_PROFILES_PATH)
+
     if not include_defaults:
+        if not PREFECT_PROFILES_PATH.value().exists():
+            return ProfilesCollection([])
         return _read_profiles_from(PREFECT_PROFILES_PATH.value())
 
-    profiles = _read_profiles_from(DEFAULT_PROFILES_PATH)
-
     user_profiles_path = PREFECT_PROFILES_PATH.value()
+    profiles = default_profiles
     if user_profiles_path.exists():
         user_profiles = _read_profiles_from(user_profiles_path)
 

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -219,13 +219,6 @@ class TestChangingProfileAndCheckingServerConnection:
         assert profiles.active_name == "ephemeral"
 
 
-def test_ls_default_profiles():
-    # 'ephemeral' is not the current profile because we have a temporary profile in-use
-    # during tests
-
-    invoke_and_assert(["profile", "ls"], expected_output_contains="ephemeral")
-
-
 def test_ls_additional_profiles():
     # 'ephemeral' is not the current profile because we have a temporary profile in-use
     # during tests
@@ -243,7 +236,6 @@ def test_ls_additional_profiles():
     invoke_and_assert(
         ["profile", "ls"],
         expected_output_contains=(
-            "ephemeral",
             "foo",
             "bar",
         ),
@@ -262,10 +254,7 @@ def test_ls_respects_current_from_profile_flag():
 
     invoke_and_assert(
         ["--profile", "foo", "profile", "ls"],
-        expected_output_contains=(
-            "ephemeral",
-            "* foo",
-        ),
+        expected_output_contains=("* foo",),
     )
 
 
@@ -284,7 +273,6 @@ def test_ls_respects_current_from_context():
         invoke_and_assert(
             ["profile", "ls"],
             expected_output_contains=(
-                "ephemeral",
                 "foo",
                 "* bar",
             ),
@@ -671,7 +659,6 @@ class TestProfilesPopulateDefaults:
         output = captured.out
 
         assert "Proposed Changes:" in output
-        assert "Migrate 'default' to 'ephemeral'" in output
         assert "Add 'ephemeral'" in output
         assert "Add 'local'" in output
         assert "Add 'cloud'" in output


### PR DESCRIPTION
as in https://github.com/PrefectHQ/prefect/issues/15153, switching `default` -> `ephemeral` can create some confusing situations

there's no strong reason to be special casing any of the profiles anymore, better to document best practices