### PR TITLE
Fixes init of cloud client when no profiles are set

### DIFF
--- a/src/prefect/client/cloud.py
+++ b/src/prefect/client/cloud.py
@@ -73,9 +73,10 @@ class CloudClient:
             **httpx_settings, enable_csrf_support=False
         )
 
+        api_url = prefect.settings.PREFECT_API_URL.value() or ""
         if match := (
             re.search(PARSE_API_URL_REGEX, host)
-            or re.search(PARSE_API_URL_REGEX, prefect.settings.PREFECT_API_URL.value())
+            or re.search(PARSE_API_URL_REGEX, api_url)
         ):
             self.account_id, self.workspace_id = match.groups()
 

--- a/tests/client/test_cloud_client.py
+++ b/tests/client/test_cloud_client.py
@@ -45,6 +45,12 @@ async def mock_work_pool_types():
         yield
 
 
+async def test_cloud_client_init_with_no_api():
+    with temporary_settings({PREFECT_API_URL: None}):
+        async with get_cloud_client() as client:
+            assert client
+
+
 async def test_cloud_client_follow_redirects():
     httpx_settings = {"follow_redirects": True}
     async with get_cloud_client(httpx_settings=httpx_settings) as client:


### PR DESCRIPTION
This PR fixes an edge case in which a first-time user (with no profiles) calls `prefect cloud login`; previously, the lack of `PREFECT_API_URL` would cause a `TypeError` error from `re.search`.  This PR avoids the typing error.