### PR TITLE
Refactor `ResultFactory` to no longer be run context aware

### DIFF
--- a/src/integrations/prefect-redis/tests/test_records.py
+++ b/src/integrations/prefect-redis/tests/test_records.py
@@ -30,7 +30,7 @@ class TestRedisRecordStore:
 
     @pytest.fixture
     async def result(self, default_storage_setting):
-        factory = await ResultFactory.default_factory(
+        factory = ResultFactory(
             persist_result=True,
         )
         result = await factory.create_result(obj={"test": "value"})

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -44,7 +44,6 @@ from prefect.results import ResultFactory
 from prefect.settings import PREFECT_HOME, Profile, Settings
 from prefect.states import State
 from prefect.task_runners import TaskRunner
-from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.services import start_client_metrics_server
 
 T = TypeVar("T")
@@ -95,20 +94,15 @@ def hydrated_context(
                 flow_run_context = FlowRunContext(
                     **flow_run_context,
                     client=client,
-                    result_factory=run_coro_as_sync(ResultFactory.from_flow(flow)),
                     task_runner=task_runner,
                     detached=True,
                 )
                 stack.enter_context(flow_run_context)
             # Set up parent task run context
             if parent_task_run_context := serialized_context.get("task_run_context"):
-                parent_task = parent_task_run_context["task"]
                 task_run_context = TaskRunContext(
                     **parent_task_run_context,
                     client=client,
-                    result_factory=run_coro_as_sync(
-                        ResultFactory.from_autonomous_task(parent_task)
-                    ),
                 )
                 stack.enter_context(task_run_context)
             # Set up tags context

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -369,6 +369,7 @@ class EngineContext(RunContext):
                 "log_prints",
                 "start_time",
                 "input_keyset",
+                "result_factory",
             },
             exclude_unset=True,
         )
@@ -406,6 +407,7 @@ class TaskRunContext(RunContext):
                 "log_prints",
                 "start_time",
                 "input_keyset",
+                "result_factory",
             },
             exclude_unset=True,
         )

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -47,7 +47,7 @@ from prefect.logging.loggers import (
     get_run_logger,
     patch_print,
 )
-from prefect.results import BaseResult, ResultFactory
+from prefect.results import BaseResult, ResultFactory, get_current_result_factory
 from prefect.settings import PREFECT_DEBUG_MODE
 from prefect.states import (
     Failed,
@@ -202,7 +202,9 @@ class FlowRunEngine(Generic[P, R]):
                 self.handle_exception(
                     exc,
                     msg=message,
-                    result_factory=run_coro_as_sync(ResultFactory.from_flow(self.flow)),
+                    result_factory=get_current_result_factory().update_for_flow(
+                        self.flow
+                    ),
                 )
                 self.short_circuit = True
                 self.call_hooks()
@@ -506,7 +508,9 @@ class FlowRunEngine(Generic[P, R]):
                     flow_run=self.flow_run,
                     parameters=self.parameters,
                     client=client,
-                    result_factory=run_coro_as_sync(ResultFactory.from_flow(self.flow)),
+                    result_factory=get_current_result_factory().update_for_flow(
+                        self.flow, _sync=True
+                    ),
                     task_runner=task_runner,
                 )
             )

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -203,7 +203,7 @@ class FlowRunEngine(Generic[P, R]):
                     exc,
                     msg=message,
                     result_factory=get_current_result_factory().update_for_flow(
-                        self.flow
+                        self.flow, _sync=True
                     ),
                 )
                 self.short_circuit = True

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -5,7 +5,6 @@ from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
-    Awaitable,
     Callable,
     Dict,
     Generic,
@@ -33,7 +32,7 @@ from typing_extensions import ParamSpec, Self
 import prefect
 from prefect.blocks.core import Block
 from prefect.client.utilities import inject_client
-from prefect.exceptions import SerializationError
+from prefect.exceptions import MissingContextError, SerializationError
 from prefect.filesystems import (
     LocalFileSystem,
     WritableFileSystem,
@@ -80,11 +79,59 @@ async def get_default_result_storage() -> ResultStorage:
     default_block = PREFECT_DEFAULT_RESULT_STORAGE_BLOCK.value()
 
     if default_block is not None:
-        return await Block.load(default_block)
+        return await resolve_result_storage(default_block)
 
     # otherwise, use the local file system
     basepath = PREFECT_LOCAL_STORAGE_PATH.value()
-    return LocalFileSystem(basepath=basepath)
+    return LocalFileSystem(basepath=str(basepath))
+
+
+@sync_compatible
+async def resolve_result_storage(
+    result_storage: ResultStorage,
+) -> WritableFileSystem:
+    """
+    Resolve one of the valid `ResultStorage` input types into a saved block
+    document id and an instance of the block.
+    """
+    from prefect.client.orchestration import get_client
+
+    client = get_client()
+    if isinstance(result_storage, Block):
+        storage_block = result_storage
+
+        if storage_block._block_document_id is not None:
+            # Avoid saving the block if it already has an identifier assigned
+            storage_block_id = storage_block._block_document_id
+        else:
+            storage_block_id = None
+    elif isinstance(result_storage, str):
+        storage_block = await Block.load(result_storage, client=client)
+        storage_block_id = storage_block._block_document_id
+        assert storage_block_id is not None, "Loaded storage blocks must have ids"
+    else:
+        raise TypeError(
+            "Result storage must be one of the following types: 'UUID', 'Block', "
+            f"'str'. Got unsupported type {type(result_storage).__name__!r}."
+        )
+
+    return storage_block
+
+
+def resolve_serializer(serializer: ResultSerializer) -> Serializer:
+    """
+    Resolve one of the valid `ResultSerializer` input types into a serializer
+    instance.
+    """
+    if isinstance(serializer, Serializer):
+        return serializer
+    elif isinstance(serializer, str):
+        return Serializer(type=serializer)
+    else:
+        raise TypeError(
+            "Result serializer must be one of the following types: 'Serializer', "
+            f"'str'. Got unsupported type {type(serializer).__name__!r}."
+        )
 
 
 async def get_or_create_default_task_scheduling_storage() -> ResultStorage:
@@ -101,11 +148,11 @@ async def get_or_create_default_task_scheduling_storage() -> ResultStorage:
     return LocalFileSystem(basepath=basepath)
 
 
-def get_default_result_serializer() -> ResultSerializer:
+def get_default_result_serializer() -> Serializer:
     """
     Generate a default file system for result storage.
     """
-    return PREFECT_RESULTS_DEFAULT_SERIALIZER.value()
+    return resolve_serializer(PREFECT_RESULTS_DEFAULT_SERIALIZER.value())
 
 
 def get_default_persist_setting() -> bool:
@@ -127,212 +174,57 @@ class ResultFactory(BaseModel):
     A utility to generate `Result` types.
     """
 
-    persist_result: bool
-    cache_result_in_memory: bool
-    serializer: Serializer
-    storage_block_id: Optional[uuid.UUID] = None
-    storage_block: WritableFileSystem
-    storage_key_fn: Callable[[], str]
+    storage_block: Optional[WritableFileSystem] = Field(default=None)
+    persist_result: bool = Field(default_factory=get_default_persist_setting)
+    cache_result_in_memory: bool = Field(default=True)
+    serializer: Serializer = Field(default_factory=get_default_result_serializer)
+    storage_key_fn: Callable[[], str] = Field(default=DEFAULT_STORAGE_KEY_FN)
 
-    @classmethod
-    @inject_client
-    async def default_factory(cls, client: "PrefectClient" = None, **kwargs):
+    @property
+    def storage_block_id(self) -> Optional[UUID]:
+        if self.storage_block is None:
+            return None
+        return self.storage_block._block_document_id
+
+    @sync_compatible
+    async def update_for_flow(self, flow: "Flow") -> Self:
         """
-        Create a new result factory with default options.
-
-        Keyword arguments may be provided to override defaults. Null keys will be
-        ignored.
+        Create a new result factory for a flow with updated settings.
         """
-        # Remove any null keys so `setdefault` can do its magic
-        for key, value in tuple(kwargs.items()):
-            if value is None:
-                kwargs.pop(key)
+        update = {}
+        if flow.result_storage is not None:
+            update["storage_block"] = await resolve_result_storage(flow.result_storage)
+        if flow.result_serializer is not None:
+            update["serializer"] = resolve_serializer(flow.result_serializer)
+        if flow.persist_result is not None:
+            update["persist_result"] = flow.persist_result
+        if flow.cache_result_in_memory is not None:
+            update["cache_result_in_memory"] = flow.cache_result_in_memory
+        if self.storage_block is None and update.get("storage_block") is None:
+            update["storage_block"] = await get_default_result_storage()
+        return self.model_copy(update=update)
 
-        # Apply defaults
-        kwargs.setdefault("result_storage", await get_default_result_storage())
-        kwargs.setdefault("result_serializer", get_default_result_serializer())
-        kwargs.setdefault("persist_result", get_default_persist_setting())
-        kwargs.setdefault("cache_result_in_memory", True)
-        kwargs.setdefault("storage_key_fn", DEFAULT_STORAGE_KEY_FN)
-
-        return await cls.from_settings(**kwargs, client=client)
-
-    @classmethod
-    @inject_client
-    async def from_flow(
-        cls: Type[Self], flow: "Flow", client: "PrefectClient" = None
-    ) -> Self:
-        """
-        Create a new result factory for a flow.
-        """
-        from prefect.context import FlowRunContext
-
-        ctx = FlowRunContext.get()
-        if ctx:
-            # This is a child flow run
-            return await cls.from_settings(
-                result_storage=flow.result_storage or ctx.result_factory.storage_block,
-                result_serializer=flow.result_serializer
-                or ctx.result_factory.serializer,
-                persist_result=flow.persist_result,
-                cache_result_in_memory=flow.cache_result_in_memory,
-                storage_key_fn=DEFAULT_STORAGE_KEY_FN,
-                client=client,
-            )
-        else:
-            # This is a root flow run
-            # Pass the flow settings up to the default which will replace nulls with
-            # our default options
-            return await cls.default_factory(
-                client=client,
-                result_storage=flow.result_storage,
-                result_serializer=flow.result_serializer,
-                persist_result=flow.persist_result,
-                cache_result_in_memory=flow.cache_result_in_memory,
-                storage_key_fn=DEFAULT_STORAGE_KEY_FN,
-            )
-
-    @classmethod
-    @inject_client
-    async def from_task(
-        cls: Type[Self], task: "Task", client: "PrefectClient" = None
-    ) -> Self:
+    @sync_compatible
+    async def update_for_task(self: Self, task: "Task") -> Self:
         """
         Create a new result factory for a task.
         """
-        return await cls._from_task(task, get_default_result_storage, client=client)
-
-    @classmethod
-    @inject_client
-    async def from_autonomous_task(
-        cls: Type[Self], task: "Task[P, R]", client: "PrefectClient" = None
-    ) -> Self:
-        """
-        Create a new result factory for an autonomous task.
-        """
-        return await cls._from_task(
-            task, get_or_create_default_task_scheduling_storage, client=client
-        )
-
-    @classmethod
-    @inject_client
-    async def _from_task(
-        cls: Type[Self],
-        task: "Task",
-        default_storage_getter: Callable[[], Awaitable[ResultStorage]],
-        client: "PrefectClient" = None,
-    ) -> Self:
-        from prefect.context import FlowRunContext
-
-        ctx = FlowRunContext.get()
-
-        result_storage = task.result_storage or (
-            ctx.result_factory.storage_block
-            if ctx and ctx.result_factory
-            else await default_storage_getter()
-        )
-        result_serializer = task.result_serializer or (
-            ctx.result_factory.serializer
-            if ctx and ctx.result_factory
-            else get_default_result_serializer()
-        )
-        if task.persist_result is None:
-            persist_result = (
-                ctx.result_factory.persist_result
-                if ctx and ctx.result_factory
-                else get_default_persist_setting()
+        update = {}
+        if task.result_storage is not None:
+            update["storage_block"] = await resolve_result_storage(task.result_storage)
+        if task.result_serializer is not None:
+            update["serializer"] = resolve_serializer(task.result_serializer)
+        if task.persist_result is not None:
+            update["persist_result"] = task.persist_result
+        if task.cache_result_in_memory is not None:
+            update["cache_result_in_memory"] = task.cache_result_in_memory
+        if task.result_storage_key is not None:
+            update["storage_key_fn"] = partial(
+                _format_user_supplied_storage_key, task.result_storage_key
             )
-        else:
-            persist_result = task.persist_result
-
-        cache_result_in_memory = task.cache_result_in_memory
-
-        return await cls.from_settings(
-            result_storage=result_storage,
-            result_serializer=result_serializer,
-            persist_result=persist_result,
-            cache_result_in_memory=cache_result_in_memory,
-            client=client,
-            storage_key_fn=(
-                partial(_format_user_supplied_storage_key, task.result_storage_key)
-                if task.result_storage_key is not None
-                else DEFAULT_STORAGE_KEY_FN
-            ),
-        )
-
-    @classmethod
-    @inject_client
-    async def from_settings(
-        cls: Type[Self],
-        result_storage: ResultStorage,
-        result_serializer: ResultSerializer,
-        persist_result: Optional[bool],
-        cache_result_in_memory: bool,
-        storage_key_fn: Callable[[], str],
-        client: "PrefectClient",
-    ) -> Self:
-        if persist_result is None:
-            persist_result = get_default_persist_setting()
-
-        storage_block_id, storage_block = await cls.resolve_storage_block(
-            result_storage, client=client, persist_result=persist_result
-        )
-        serializer = cls.resolve_serializer(result_serializer)
-
-        return cls(
-            storage_block=storage_block,
-            storage_block_id=storage_block_id,
-            serializer=serializer,
-            persist_result=persist_result,
-            cache_result_in_memory=cache_result_in_memory,
-            storage_key_fn=storage_key_fn,
-        )
-
-    @staticmethod
-    async def resolve_storage_block(
-        result_storage: ResultStorage,
-        client: "PrefectClient",
-        persist_result: bool = True,
-    ) -> Tuple[Optional[uuid.UUID], WritableFileSystem]:
-        """
-        Resolve one of the valid `ResultStorage` input types into a saved block
-        document id and an instance of the block.
-        """
-        if isinstance(result_storage, Block):
-            storage_block = result_storage
-
-            if storage_block._block_document_id is not None:
-                # Avoid saving the block if it already has an identifier assigned
-                storage_block_id = storage_block._block_document_id
-            else:
-                storage_block_id = None
-        elif isinstance(result_storage, str):
-            storage_block = await Block.load(result_storage, client=client)
-            storage_block_id = storage_block._block_document_id
-            assert storage_block_id is not None, "Loaded storage blocks must have ids"
-        else:
-            raise TypeError(
-                "Result storage must be one of the following types: 'UUID', 'Block', "
-                f"'str'. Got unsupported type {type(result_storage).__name__!r}."
-            )
-
-        return storage_block_id, storage_block
-
-    @staticmethod
-    def resolve_serializer(serializer: ResultSerializer) -> Serializer:
-        """
-        Resolve one of the valid `ResultSerializer` input types into a serializer
-        instance.
-        """
-        if isinstance(serializer, Serializer):
-            return serializer
-        elif isinstance(serializer, str):
-            return Serializer(type=serializer)
-        else:
-            raise TypeError(
-                "Result serializer must be one of the following types: 'Serializer', "
-                f"'str'. Got unsupported type {type(serializer).__name__!r}."
-            )
+        if self.storage_block is None and update.get("storage_block") is None:
+            update["storage_block"] = await get_default_result_storage()
+        return self.model_copy(update=update)
 
     @sync_compatible
     async def create_result(
@@ -357,6 +249,9 @@ class ResultFactory(BaseModel):
             storage_key_fn = key_fn
         else:
             storage_key_fn = self.storage_key_fn
+
+        if self.storage_block is None:
+            self.storage_block = await get_default_result_storage()
 
         return await PersistedResult.create(
             obj,
@@ -389,6 +284,21 @@ class ResultFactory(BaseModel):
             await self.storage_block.read_path(f"parameters/{identifier}")
         )
         return record.result
+
+
+def get_current_result_factory() -> ResultFactory:
+    """
+    Get the current result factory.
+    """
+    from prefect.context import get_run_context
+
+    try:
+        run_context = get_run_context()
+    except MissingContextError:
+        result_factory = ResultFactory()
+    else:
+        result_factory = run_context.result_factory
+    return result_factory
 
 
 class ResultRecordMetadata(BaseModel):

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -72,7 +72,7 @@ _default_storages: Dict[Tuple[str, str], WritableFileSystem] = {}
 
 
 @sync_compatible
-async def get_default_result_storage() -> ResultStorage:
+async def get_default_result_storage() -> WritableFileSystem:
     """
     Generate a default file system for result storage.
     """

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -56,7 +56,11 @@ from prefect.exceptions import (
 from prefect.futures import PrefectFuture
 from prefect.logging.loggers import get_logger, patch_print, task_run_logger
 from prefect.records.result_store import ResultFactoryStore
-from prefect.results import BaseResult, ResultFactory, _format_user_supplied_storage_key
+from prefect.results import (
+    BaseResult,
+    _format_user_supplied_storage_key,
+    get_current_result_factory,
+)
 from prefect.settings import (
     PREFECT_DEBUG_MODE,
     PREFECT_TASKS_REFRESH_CACHE,
@@ -591,7 +595,9 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                     log_prints=log_prints,
                     task_run=self.task_run,
                     parameters=self.parameters,
-                    result_factory=run_coro_as_sync(ResultFactory.from_task(self.task)),  # type: ignore
+                    result_factory=get_current_result_factory().update_for_task(
+                        self.task, _sync=True
+                    ),
                     client=client,
                 )
             )
@@ -1096,7 +1102,9 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                     log_prints=log_prints,
                     task_run=self.task_run,
                     parameters=self.parameters,
-                    result_factory=await ResultFactory.from_task(self.task),  # type: ignore
+                    result_factory=await get_current_result_factory().update_for_task(
+                        self.task
+                    ),
                     client=client,
                 )
             )

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -1103,7 +1103,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                     task_run=self.task_run,
                     parameters=self.parameters,
                     result_factory=await get_current_result_factory().update_for_task(
-                        self.task
+                        self.task, _sync=False
                     ),
                     client=client,
                 )

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -25,7 +25,7 @@ from prefect.client.orchestration import get_client
 from prefect.client.schemas.objects import TaskRun
 from prefect.client.subscriptions import Subscription
 from prefect.logging.loggers import get_logger
-from prefect.results import ResultFactory
+from prefect.results import ResultFactory, get_or_create_default_task_scheduling_storage
 from prefect.settings import (
     PREFECT_API_URL,
     PREFECT_TASK_SCHEDULING_DELETE_FAILED_SUBMISSIONS,
@@ -273,7 +273,9 @@ class TaskWorker:
         if should_try_to_read_parameters(task, task_run):
             parameters_id = task_run.state.state_details.task_parameters_id
             task.persist_result = True
-            factory = await ResultFactory.from_autonomous_task(task)
+            factory = await ResultFactory(
+                storage_block=await get_or_create_default_task_scheduling_storage()
+            ).update_for_task(task)
             try:
                 run_data = await factory.read_parameters(parameters_id)
                 parameters = run_data.get("parameters", {})

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -759,7 +759,7 @@ class Task(Generic[P, R]):
 
                 factory = await ResultFactory(
                     storage_block=await get_or_create_default_task_scheduling_storage()
-                ).update_for_task(task)
+                ).update_for_task(self)
                 context = serialize_context()
                 data: Dict[str, Any] = {"context": context}
                 if parameters:

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -50,7 +50,12 @@ from prefect.context import (
 )
 from prefect.futures import PrefectDistributedFuture, PrefectFuture, PrefectFutureList
 from prefect.logging.loggers import get_logger
-from prefect.results import ResultFactory, ResultSerializer, ResultStorage
+from prefect.results import (
+    ResultFactory,
+    ResultSerializer,
+    ResultStorage,
+    get_or_create_default_task_scheduling_storage,
+)
 from prefect.settings import (
     PREFECT_TASK_DEFAULT_RETRIES,
     PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS,
@@ -752,7 +757,9 @@ class Task(Generic[P, R]):
                 # TODO: Improve use of result storage for parameter storage / reference
                 self.persist_result = True
 
-                factory = await ResultFactory.from_autonomous_task(self, client=client)
+                factory = await ResultFactory(
+                    storage_block=await get_or_create_default_task_scheduling_storage()
+                ).update_for_task(task)
                 context = serialize_context()
                 data: Dict[str, Any] = {"context": context}
                 if parameters:
@@ -853,7 +860,9 @@ class Task(Generic[P, R]):
                 # TODO: Improve use of result storage for parameter storage / reference
                 self.persist_result = True
 
-                factory = await ResultFactory.from_autonomous_task(self, client=client)
+                factory = await ResultFactory(
+                    storage_block=await get_or_create_default_task_scheduling_storage()
+                ).update_for_task(task)
                 context = serialize_context()
                 data: Dict[str, Any] = {"context": context}
                 if parameters:

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -27,7 +27,6 @@ from prefect.results import (
     get_default_result_storage,
 )
 from prefect.utilities.annotations import NotSet
-from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.collections import AutoEnum
 from prefect.utilities.engine import _get_hook_name
 
@@ -385,11 +384,9 @@ def transaction(
                     }
                 )
             else:
-                new_factory = run_coro_as_sync(
-                    ResultFactory.default_factory(
-                        persist_result=True,
-                        result_storage=default_storage,
-                    )
+                new_factory = ResultFactory(
+                    persist_result=True,
+                    storage_block=default_storage,
                 )
         from prefect.records.result_store import ResultFactoryStore
 

--- a/tests/records/test_filesystem.py
+++ b/tests/records/test_filesystem.py
@@ -35,9 +35,7 @@ class TestFileSystemRecordStore:
 
     @pytest.fixture
     async def result(self, default_storage_setting):
-        factory = await ResultFactory.default_factory(
-            persist_result=True,
-        )
+        factory = ResultFactory(persist_result=True)
         result = await factory.create_result(obj={"test": "value"})
         return result
 

--- a/tests/records/test_memory.py
+++ b/tests/records/test_memory.py
@@ -20,9 +20,7 @@ class TestInMemoryRecordStore:
         key = str(uuid4())
         store = MemoryRecordStore()
         assert store.read(key) is None
-        factory = await ResultFactory.default_factory(
-            persist_result=True,
-        )
+        factory = ResultFactory(persist_result=True)
         result = await factory.create_result(obj={"test": "value"})
         store.write(key, result=result)
         assert (record := store.read(key)) is not None
@@ -32,9 +30,7 @@ class TestInMemoryRecordStore:
     async def test_read_locked_key(self):
         key = str(uuid4())
         store = MemoryRecordStore()
-        factory = await ResultFactory.default_factory(
-            persist_result=True,
-        )
+        factory = ResultFactory(persist_result=True)
         result = await factory.create_result(obj={"test": "value"})
 
         def read_locked_key(queue):
@@ -57,9 +53,7 @@ class TestInMemoryRecordStore:
         key = str(uuid4())
         store = MemoryRecordStore()
         assert store.acquire_lock(key)
-        factory = await ResultFactory.default_factory(
-            persist_result=True,
-        )
+        factory = ResultFactory(persist_result=True)
         result = await factory.create_result(obj={"test": "value"})
         # can write to key because holder is the same
         store.write(key, result=result)
@@ -70,9 +64,7 @@ class TestInMemoryRecordStore:
         key = str(uuid4())
         store = MemoryRecordStore()
         assert store.acquire_lock(key, holder="holder1")
-        factory = await ResultFactory.default_factory(
-            persist_result=True,
-        )
+        factory = ResultFactory(persist_result=True)
         result = await factory.create_result(obj={"test": "value"})
         with pytest.raises(
             ValueError,
@@ -84,9 +76,7 @@ class TestInMemoryRecordStore:
         key = str(uuid4())
         store = MemoryRecordStore()
         assert not store.exists(key)
-        factory = await ResultFactory.default_factory(
-            persist_result=True,
-        )
+        factory = ResultFactory(persist_result=True)
         result = await factory.create_result(obj={"test": "value"})
         store.write(key, result=result)
         assert store.exists(key)

--- a/tests/results/test_result_factory.py
+++ b/tests/results/test_result_factory.py
@@ -37,9 +37,7 @@ def default_persistence_off():
 
 @pytest.fixture
 async def factory(prefect_client):
-    return await ResultFactory.default_factory(
-        client=prefect_client, persist_result=True
-    )
+    return ResultFactory(persist_result=True)
 
 
 async def test_create_result_reference(factory):
@@ -357,7 +355,7 @@ async def test_child_flow_inherits_custom_storage(tmp_path, default_persistence_
         return get_run_context().result_factory
 
     parent_factory, child_factory = foo()
-    assert child_factory.persist_result is False
+    assert child_factory.persist_result is True
     assert child_factory.serializer == DEFAULT_SERIALIZER()
     assert child_factory.storage_block == parent_factory.storage_block
     assert child_factory.storage_block_id == storage_id
@@ -695,7 +693,7 @@ async def test_result_factory_from_task_with_no_flow_run_context(options, expect
 
     assert FlowRunContext.get() is None
 
-    result_factory = await ResultFactory.from_task(task=my_task)
+    result_factory = await ResultFactory().update_for_task(task=my_task)
 
     assert result_factory.persist_result == expected["persist_result"]
     assert result_factory.cache_result_in_memory == expected["cache_result_in_memory"]

--- a/tests/results/test_state_result.py
+++ b/tests/results/test_state_result.py
@@ -35,12 +35,8 @@ async def test_unfinished_states_raise_on_result_retrieval(
     "state_type",
     [StateType.CRASHED, StateType.COMPLETED, StateType.FAILED, StateType.CANCELLED],
 )
-async def test_finished_states_allow_result_retrieval(
-    prefect_client, state_type: StateType
-):
-    factory = await ResultFactory.default_factory(
-        client=prefect_client, persist_result=True
-    )
+async def test_finished_states_allow_result_retrieval(state_type: StateType):
+    factory = ResultFactory(persist_result=True)
     state = State(type=state_type, data=await factory.create_result("test"))
 
     assert await state.result(raise_on_failure=False) == "test"

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -12,7 +12,7 @@ from prefect.blocks.core import Block
 from prefect.client.orchestration import get_client
 from prefect.client.schemas import TaskRun
 from prefect.filesystems import LocalFileSystem
-from prefect.results import ResultFactory
+from prefect.results import ResultFactory, get_or_create_default_task_scheduling_storage
 from prefect.server.api.task_runs import TaskQueue
 from prefect.server.schemas.core import TaskRun as ServerTaskRun
 from prefect.settings import (
@@ -25,7 +25,9 @@ if TYPE_CHECKING:
 
 
 async def result_factory_from_task(task) -> ResultFactory:
-    return await ResultFactory.from_autonomous_task(task)
+    return await ResultFactory(
+        storage_block=await get_or_create_default_task_scheduling_storage()
+    ).update_for_task(task)
 
 
 @pytest.fixture

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -181,7 +181,9 @@ async def test_get_run_context(prefect_client, local_filesystem):
             task=bar,
             task_run=task_run,
             client=prefect_client,
-            result_factory=await get_current_result_factory().update_for_task(bar),
+            result_factory=await get_current_result_factory().update_for_task(
+                bar, _sync=False
+            ),
             parameters={"foo": "bar"},
         ) as task_ctx:
             assert get_run_context() is task_ctx, "Task context takes precedence"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -122,7 +122,7 @@ async def test_task_run_context(prefect_client, flow_run):
         pass
 
     task_run = await prefect_client.create_task_run(foo, flow_run.id, dynamic_key="")
-    result_factory = await ResultFactory.default_factory()
+    result_factory = ResultFactory()
 
     with TaskRunContext(
         task=foo,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -24,7 +24,7 @@ from prefect.context import (
     use_profile,
 )
 from prefect.exceptions import MissingContextError
-from prefect.results import ResultFactory
+from prefect.results import ResultFactory, get_current_result_factory
 from prefect.settings import (
     DEFAULT_PROFILES_PATH,
     PREFECT_API_KEY,
@@ -96,7 +96,7 @@ async def test_flow_run_context(prefect_client):
 
     test_task_runner = ThreadPoolTaskRunner()
     flow_run = await prefect_client.create_flow_run(foo)
-    result_factory = await ResultFactory.from_flow(foo)
+    result_factory = await ResultFactory().update_for_flow(foo)
 
     with FlowRunContext(
         flow=foo,
@@ -172,7 +172,7 @@ async def test_get_run_context(prefect_client, local_filesystem):
         flow_run=flow_run,
         client=prefect_client,
         task_runner=test_task_runner,
-        result_factory=await ResultFactory.from_flow(foo, client=prefect_client),
+        result_factory=await ResultFactory().update_for_flow(foo),
         parameters={"x": "y"},
     ) as flow_ctx:
         assert get_run_context() is flow_ctx
@@ -181,7 +181,7 @@ async def test_get_run_context(prefect_client, local_filesystem):
             task=bar,
             task_run=task_run,
             client=prefect_client,
-            result_factory=await ResultFactory.from_task(bar, client=prefect_client),
+            result_factory=await get_current_result_factory().update_for_task(bar),
             parameters={"foo": "bar"},
         ) as task_ctx:
             assert get_run_context() is task_ctx, "Task context takes precedence"
@@ -419,7 +419,7 @@ class TestSerializeContext:
 
         test_task_runner = ThreadPoolTaskRunner()
         flow_run = await prefect_client.create_flow_run(foo)
-        result_factory = await ResultFactory.from_flow(foo)
+        result_factory = await ResultFactory().update_for_flow(foo)
 
         with FlowRunContext(
             flow=foo,
@@ -450,7 +450,7 @@ class TestSerializeContext:
             task=bar,
             task_run=task_run,
             client=prefect_client,
-            result_factory=await ResultFactory.from_task(bar, client=prefect_client),
+            result_factory=await get_current_result_factory().update_for_task(bar),
             parameters={"foo": "bar"},
         ) as task_ctx:
             serialized = serialize_context()
@@ -509,7 +509,7 @@ class TestHydratedContext:
 
         test_task_runner = ThreadPoolTaskRunner()
         flow_run = await prefect_client.create_flow_run(foo)
-        result_factory = await ResultFactory.from_flow(foo)
+        result_factory = await ResultFactory().update_for_flow(foo)
         flow_run_context = FlowRunContext(
             flow=foo,
             flow_run=flow_run,
@@ -560,7 +560,7 @@ class TestHydratedContext:
 
         test_task_runner = ThreadPoolTaskRunner()
         flow_run = await prefect_client.create_flow_run(foo, state=Running())
-        result_factory = await ResultFactory.from_flow(foo)
+        result_factory = await ResultFactory().update_for_flow(foo)
         flow_run_context = FlowRunContext(
             flow=foo,
             flow_run=flow_run,
@@ -593,7 +593,7 @@ class TestHydratedContext:
             task=bar,
             task_run=task_run,
             client=prefect_client,
-            result_factory=await ResultFactory.from_task(bar, client=prefect_client),
+            result_factory=await get_current_result_factory().update_for_task(bar),
             parameters={"foo": "bar"},
         )
 

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -132,19 +132,15 @@ class TestRaiseStateException:
 
 class TestReturnValueToState:
     @pytest.fixture
-    async def factory(self, prefect_client):
-        return await ResultFactory.default_factory(client=prefect_client)
+    async def factory(self):
+        return ResultFactory()
 
     async def test_returns_single_state_unaltered(self, factory):
         state = Completed(data="hello!")
         assert await return_value_to_state(state, factory) is state
 
-    async def test_returns_single_state_with_null_data_and_persist_off(
-        self, prefect_client
-    ):
-        factory = await ResultFactory.default_factory(
-            client=prefect_client, persist_result=False
-        )
+    async def test_returns_single_state_with_null_data_and_persist_off(self):
+        factory = ResultFactory(persist_result=False)
         state = Completed(data=None)
         result_state = await return_value_to_state(state, factory)
         assert result_state is state
@@ -152,20 +148,16 @@ class TestReturnValueToState:
         assert result_state.data._persisted is False
         assert await result_state.result() is None
 
-    async def test_returns_single_state_with_data_to_persist(self, prefect_client):
-        factory = await ResultFactory.default_factory(
-            client=prefect_client, persist_result=True
-        )
+    async def test_returns_single_state_with_data_to_persist(self):
+        factory = ResultFactory(persist_result=True)
         state = Completed(data=1)
         result_state = await return_value_to_state(state, factory)
         assert result_state is state
         assert isinstance(result_state.data, PersistedResult)
         assert await result_state.result() == 1
 
-    async def test_returns_persisted_results_unaltered(self, prefect_client):
-        factory = await ResultFactory.default_factory(
-            client=prefect_client, persist_result=True
-        )
+    async def test_returns_persisted_results_unaltered(self):
+        factory = ResultFactory(persist_result=True)
         result = await factory.create_result(42)
         result_state = await return_value_to_state(result, factory)
         assert result_state.data == result

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -126,7 +126,7 @@ class TestRunTask:
         test_task_runner = ThreadPoolTaskRunner()
         flow_run = await prefect_client.create_flow_run(f)
         await propose_state(prefect_client, Running(), flow_run_id=flow_run.id)
-        result_factory = await ResultFactory.from_flow(f)
+        result_factory = await ResultFactory().update_for_flow(f)
         flow_run_context = EngineContext(
             flow=f,
             flow_run=flow_run,
@@ -174,7 +174,7 @@ class TestTaskRunsAsync:
         test_task_runner = ThreadPoolTaskRunner()
         flow_run = await prefect_client.create_flow_run(f)
         await propose_state(prefect_client, Running(), flow_run_id=flow_run.id)
-        result_factory = await ResultFactory.from_flow(f)
+        result_factory = await ResultFactory().update_for_flow(f)
         flow_run_context = EngineContext(
             flow=f,
             flow_run=flow_run,
@@ -1497,7 +1497,7 @@ class TestRunCountTracking:
         flow_run = await prefect_client.read_flow_run(flow_run.id)
         assert flow_run.run_count == 1
 
-        result_factory = await ResultFactory.from_flow(f)
+        result_factory = await ResultFactory().update_for_flow(f)
         return EngineContext(
             flow=f,
             flow_run=flow_run,

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -1646,12 +1646,10 @@ class TestTimeout:
 
 
 class TestPersistence:
-    async def test_task_can_return_persisted_result(self, prefect_client):
+    async def test_task_can_return_persisted_result(self):
         @task
         async def async_task():
-            factory = await ResultFactory.default_factory(
-                client=prefect_client, persist_result=True
-            )
+            factory = ResultFactory(persist_result=True)
             result = await factory.create_result(42)
             await result.write()
             return result
@@ -1660,12 +1658,8 @@ class TestPersistence:
         state = await async_task(return_state=True)
         assert await state.result() == 42
 
-    async def test_task_loads_result_if_exists_using_result_storage_key(
-        self, prefect_client
-    ):
-        factory = await ResultFactory.default_factory(
-            client=prefect_client, persist_result=True
-        )
+    async def test_task_loads_result_if_exists_using_result_storage_key(self):
+        factory = ResultFactory(persist_result=True)
         result = await factory.create_result(-92, key="foo-bar")
         await result.write()
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -862,7 +862,7 @@ class TestTaskSubmit:
         with pytest.raises(ValueError, match="deadlock"):
             my_flow()
 
-    @pytest.mark.xfail(
+    @pytest.mark.skip(
         reason="This test is not compatible with the current state of client side task orchestration"
     )
     def test_logs_message_when_submitted_tasks_end_in_pending(self, caplog):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -32,7 +32,7 @@ from prefect.filesystems import LocalFileSystem
 from prefect.futures import PrefectDistributedFuture
 from prefect.futures import PrefectFuture as NewPrefectFuture
 from prefect.logging import get_run_logger
-from prefect.results import ResultFactory
+from prefect.results import ResultFactory, get_or_create_default_task_scheduling_storage
 from prefect.runtime import task_run as task_run_ctx
 from prefect.server import models
 from prefect.settings import (
@@ -82,7 +82,9 @@ def timeout_test_flow():
 
 
 async def get_background_task_run_parameters(task, parameters_id):
-    factory = await ResultFactory.from_autonomous_task(task)
+    factory = await ResultFactory(
+        storage_block=await get_or_create_default_task_scheduling_storage()
+    ).update_for_task(task)
     return await factory.read_parameters(parameters_id)
 
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -27,7 +27,6 @@ from prefect.transactions import (
     get_transaction,
     transaction,
 )
-from prefect.utilities.asyncutils import run_coro_as_sync
 
 
 def test_basic_init():
@@ -387,12 +386,12 @@ class TestWithMemoryRecordStore:
 
     @pytest.fixture
     async def result_1(self, default_storage_setting):
-        result_factory = await ResultFactory.default_factory(persist_result=True)
+        result_factory = ResultFactory(persist_result=True)
         return await result_factory.create_result(obj={"foo": "bar"})
 
     @pytest.fixture
     async def result_2(self, default_storage_setting):
-        result_factory = await ResultFactory.default_factory(persist_result=True)
+        result_factory = ResultFactory(persist_result=True)
         return await result_factory.create_result(obj={"fizz": "buzz"})
 
     async def test_basic_transaction(self, result_1):
@@ -527,9 +526,7 @@ class TestIsolationLevel:
         ):
             with transaction(
                 key="test",
-                store=ResultFactoryStore(
-                    result_factory=run_coro_as_sync(ResultFactory.default_factory())
-                ),
+                store=ResultFactoryStore(result_factory=ResultFactory()),
                 isolation_level=IsolationLevel.SERIALIZABLE,
             ):
                 pass


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR refactors `ResultFactory` to no longer depend on flow and task run context. It builds off of what I learned working on #15155 and the feedback given there to decrease the complexity of `ResultFactory`. 

`ResultFactory` instances are created with a standard `__init__`, and the model handles the defaults directly. When a new `ResultFactory` is needed for a new context, the new context should copy the existing `ResultFactory` and make the needed changes on the copy. Some convenience methods, `update_for_flow` and `update_for_task`, have been added for use in the flow and task engines. 

I also added a `get_current_result_factory` utility method to make it easy to get the result factory for a given context. This should be useful when we add more methods to `ResultFactory` for interacting with results.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
