### PR TITLE
Update sync artifact call to same as async

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -4147,7 +4147,7 @@ class SyncPrefectClient:
 
         response = self._client.post(
             "/artifacts/",
-            json=artifact.model_dump_json(exclude_unset=True),
+            json=artifact.model_dump(mode="json", exclude_unset=True),
         )
 
         return Artifact.model_validate(response.json())


### PR DESCRIPTION
The async client has a slightly different call from the sync client for the `create_artifact` route and I observed a 422 go by related to a failure to create an artifact - I think this may be why. 