### PR TITLE
Add `read` and `write` methods to `ResultFactory`

### DIFF
--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -258,7 +258,7 @@ class ResultFactory(BaseModel):
     @sync_compatible
     async def write(
         self,
-        obj: Any = None,
+        obj: Any,
         key: Optional[str] = None,
         expiration: Optional[DateTime] = None,
     ):
@@ -708,7 +708,9 @@ class PersistedResult(BaseResult):
         result_factory = ResultFactory(
             storage_block=storage_block, serializer=serializer
         )
-        await result_factory.write(self.storage_key, obj, expiration=self.expiration)
+        await result_factory.write(
+            obj=obj, key=self.storage_key, expiration=self.expiration
+        )
 
         self._persisted = True
 

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -227,7 +227,7 @@ class ResultFactory(BaseModel):
         return self.model_copy(update=update)
 
     @sync_compatible
-    async def read(self, key: str) -> Dict[str, Any]:
+    async def read(self, key: str) -> "ResultRecord":
         if self.storage_block is None:
             self.storage_block = await get_default_result_storage()
 
@@ -596,9 +596,12 @@ class PersistedResult(BaseResult):
         if self.has_cached_object():
             return self._cache
 
+        result_factory_kwargs = {}
+        if self._serializer:
+            result_factory_kwargs["serializer"] = resolve_serializer(self._serializer)
         storage_block = await self._get_storage_block(client=client)
         result_factory = ResultFactory(
-            storage_block=storage_block, serializer=self._serializer
+            storage_block=storage_block, **result_factory_kwargs
         )
 
         record = await result_factory.read(self.storage_key)

--- a/src/prefect/testing/utilities.py
+++ b/src/prefect/testing/utilities.py
@@ -198,7 +198,7 @@ async def assert_uses_result_serializer(
     )
     blob = await ResultFactory(
         storage_block=await state.data._get_storage_block()
-    ).read(state.data.storage_key)
+    ).aread(state.data.storage_key)
     assert (
         blob.metadata.serializer == serializer
         if isinstance(serializer, Serializer)

--- a/src/prefect/testing/utilities.py
+++ b/src/prefect/testing/utilities.py
@@ -18,7 +18,7 @@ from prefect.client.orchestration import get_client
 from prefect.client.schemas import sorting
 from prefect.client.utilities import inject_client
 from prefect.logging.handlers import APILogWorker
-from prefect.results import PersistedResult
+from prefect.results import PersistedResult, ResultFactory
 from prefect.serializers import Serializer
 from prefect.server.api.server import SubprocessASGIServer
 from prefect.states import State
@@ -196,9 +196,11 @@ async def assert_uses_result_serializer(
         if isinstance(serializer, str)
         else serializer.type
     )
-    blob = await state.data._read_result_record()
+    blob = await ResultFactory(
+        storage_block=await state.data._get_storage_block()
+    ).read(state.data.storage_key)
     assert (
-        blob.serializer == serializer
+        blob.metadata.serializer == serializer
         if isinstance(serializer, Serializer)
         else Serializer(type=serializer)
     )

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -98,7 +98,7 @@ class TestMattermostWebhook:
             AppriseMock.assert_called_once()
             apprise_instance_mock.add.assert_called_once_with(
                 f"mmost://{mm_block.hostname}/{mm_block.token.get_secret_value()}/"
-                "?image=yes&format=text&overflow=upstream&rto=4.0&cto=4.0&verify=yes"
+                "?image=yes&format=text&overflow=upstream"
             )
             apprise_instance_mock.async_notify.assert_awaited_once_with(
                 body="test", title=None, notify_type=PREFECT_NOTIFY_TYPE_DEFAULT
@@ -120,7 +120,7 @@ class TestMattermostWebhook:
             AppriseMock.assert_called_once()
             apprise_instance_mock.add.assert_called_once_with(
                 f"mmost://{mm_block.hostname}/{mm_block.token.get_secret_value()}/"
-                "?image=no&format=text&overflow=upstream&rto=4.0&cto=4.0&verify=yes"
+                "?image=no&format=text&overflow=upstream"
             )
             apprise_instance_mock.async_notify.assert_called_once_with(
                 body="test", title=None, notify_type=PREFECT_NOTIFY_TYPE_DEFAULT
@@ -146,7 +146,7 @@ class TestMattermostWebhook:
             AppriseMock.assert_called_once()
             apprise_instance_mock.add.assert_called_once_with(
                 f"mmost://{mm_block.hostname}/{mm_block.token.get_secret_value()}/"
-                "?image=no&format=text&overflow=upstream&rto=4.0&cto=4.0&verify=yes"
+                "?image=no&format=text&overflow=upstream"
                 "&channel=death-metal-anonymous%2Cgeneral"
             )
 
@@ -176,7 +176,7 @@ class TestDiscordWebhook:
             AppriseMock.assert_called_once()
             apprise_instance_mock.add.assert_called_once_with(
                 f"discord://{discord_block.webhook_id.get_secret_value()}/{discord_block.webhook_token.get_secret_value()}/"
-                "?tts=no&avatar=no&footer=no&footer_logo=yes&image=no&fields=yes&format=text&overflow=upstream&rto=4.0&cto=4.0&verify=yes"
+                "?tts=no&avatar=no&footer=no&footer_logo=yes&image=no&fields=yes&format=text&overflow=upstream"
             )
             apprise_instance_mock.async_notify.assert_awaited_once_with(
                 body="test", title=None, notify_type=PREFECT_NOTIFY_TYPE_DEFAULT
@@ -200,7 +200,7 @@ class TestDiscordWebhook:
             AppriseMock.assert_called_once()
             apprise_instance_mock.add.assert_called_once_with(
                 f"discord://{discord_block.webhook_id.get_secret_value()}/{discord_block.webhook_token.get_secret_value()}/"
-                "?tts=no&avatar=no&footer=no&footer_logo=yes&image=no&fields=yes&format=text&overflow=upstream&rto=4.0&cto=4.0&verify=yes"
+                "?tts=no&avatar=no&footer=no&footer_logo=yes&image=no&fields=yes&format=text&overflow=upstream"
             )
             apprise_instance_mock.async_notify.assert_called_once_with(
                 body="test", title=None, notify_type=PREFECT_NOTIFY_TYPE_DEFAULT
@@ -226,8 +226,9 @@ class TestOpsgenieWebhook:
 
             AppriseMock.assert_called_once()
             apprise_instance_mock.add.assert_called_once_with(
-                f"opsgenie://{self.API_KEY}//?region=us&priority=normal&batch=no&"
-                "format=text&overflow=upstream&rto=4.0&cto=4.0&verify=yes"
+                f"opsgenie://{self.API_KEY}//?action=map&region=us&priority=normal&"
+                "batch=no&%3Ainfo=note&%3Asuccess=close&%3Awarning=new&%3Afailure="
+                "new&format=text&overflow=upstream"
             )
 
             apprise_instance_mock.async_notify.assert_awaited_once_with(
@@ -237,7 +238,7 @@ class TestOpsgenieWebhook:
     def _test_notify_sync(self, targets="", params=None, **kwargs):
         with patch("apprise.Apprise", autospec=True) as AppriseMock:
             if params is None:
-                params = "region=us&priority=normal&batch=no"
+                params = "action=map&region=us&priority=normal&batch=no"
 
             apprise_instance_mock = AppriseMock.return_value
             apprise_instance_mock.async_notify = AsyncMock()
@@ -253,7 +254,7 @@ class TestOpsgenieWebhook:
             AppriseMock.assert_called_once()
             apprise_instance_mock.add.assert_called_once_with(
                 f"opsgenie://{self.API_KEY}/{targets}/?{params}"
-                "&format=text&overflow=upstream&rto=4.0&cto=4.0&verify=yes"
+                "&%3Ainfo=note&%3Asuccess=close&%3Awarning=new&%3Afailure=new&format=text&overflow=upstream"
             )
 
             apprise_instance_mock.async_notify.assert_awaited_once_with(
@@ -264,7 +265,7 @@ class TestOpsgenieWebhook:
         self._test_notify_sync()
 
     def test_notify_sync_params(self):
-        params = "region=eu&priority=low&batch=yes"
+        params = "action=map&region=eu&priority=low&batch=yes"
         self._test_notify_sync(params=params, region_name="eu", priority=1, batch=True)
 
     def test_notify_sync_targets(self):
@@ -282,7 +283,7 @@ class TestOpsgenieWebhook:
         self._test_notify_sync(targets=targets, target_user=["user1", "user2"])
 
     def test_notify_sync_details(self):
-        params = "region=us&priority=normal&batch=no&%2Bkey1=value1&%2Bkey2=value2"
+        params = "action=map&region=us&priority=normal&batch=no&%2Bkey1=value1&%2Bkey2=value2"
         self._test_notify_sync(
             params=params,
             details={
@@ -304,7 +305,7 @@ class TestPagerDutyWebhook:
             AppriseMock.assert_called_once()
             apprise_instance_mock.add.assert_called_once_with(
                 "pagerduty://int_key@api_key/Prefect/Notification?region=us&"
-                "image=yes&format=text&overflow=upstream&rto=4.0&cto=4.0&verify=yes"
+                "image=yes&format=text&overflow=upstream"
             )
 
             notify_type = "info"
@@ -328,7 +329,7 @@ class TestPagerDutyWebhook:
             AppriseMock.assert_called_once()
             apprise_instance_mock.add.assert_called_once_with(
                 "pagerduty://int_key@api_key/Prefect/Notification?region=us&"
-                "image=yes&format=text&overflow=upstream&rto=4.0&cto=4.0&verify=yes"
+                "image=yes&format=text&overflow=upstream"
             )
 
             notify_type = "info"
@@ -344,7 +345,7 @@ class TestTwilioSMS:
             "twilio://ACabcdefabcdefabcdefabcdef"
             ":XXXXXXXXXXXXXXXXXXXXXXXX"
             "@%2B15555555555/%2B15555555556/%2B15555555557/"
-            "?format=text&overflow=upstream&rto=4.0&cto=4.0&verify=yes"
+            "?format=text&overflow=upstream"
         )
 
     async def test_twilio_notify_async(self, valid_apprise_url):
@@ -619,12 +620,6 @@ class TestSendgridEmail:
         "format": "html",
         # default overflow mode
         "overflow": "upstream",
-        # socket read timeout
-        "rto": 4.0,
-        # socket connect timeout
-        "cto": 4.0,
-        # ssl certificate authority verification
-        "verify": "yes",
     }
 
     async def test_notify_async(self):
@@ -713,7 +708,7 @@ class TestMicrosoftTeamsWebhook:
             apprise_instance_mock.add.assert_called_once_with(
                 "workflow://prod-NO.LOCATION.logic.azure.com:443/WFID/SIGNATURE/"
                 "?image=yes&wrap=yes"
-                "&format=markdown&overflow=upstream&rto=4.0&cto=4.0&verify=yes"
+                "&format=markdown&overflow=upstream"
             )
             apprise_instance_mock.async_notify.assert_awaited_once_with(
                 body="test", title=None, notify_type=PREFECT_NOTIFY_TYPE_DEFAULT
@@ -736,7 +731,7 @@ class TestMicrosoftTeamsWebhook:
             apprise_instance_mock.add.assert_called_once_with(
                 "workflow://prod-NO.LOCATION.logic.azure.com:443/WFID/SIGNATURE/"
                 "?image=yes&wrap=yes"
-                "&format=markdown&overflow=upstream&rto=4.0&cto=4.0&verify=yes"
+                "&format=markdown&overflow=upstream"
             )
             apprise_instance_mock.async_notify.assert_called_once_with(
                 body="test", title=None, notify_type=PREFECT_NOTIFY_TYPE_DEFAULT

--- a/tests/results/test_persisted_result.py
+++ b/tests/results/test_persisted_result.py
@@ -209,7 +209,7 @@ async def test_write_is_idempotent(storage_block):
     obj = await result.get()
     assert obj == "test-defer"
 
-    await result.awrite(obj="new-object!")
+    await result.write(obj="new-object!")
     obj = await result.get()
     assert obj == "test-defer"
 

--- a/tests/results/test_persisted_result.py
+++ b/tests/results/test_persisted_result.py
@@ -209,7 +209,7 @@ async def test_write_is_idempotent(storage_block):
     obj = await result.get()
     assert obj == "test-defer"
 
-    await result.write(obj="new-object!")
+    await result.awrite(obj="new-object!")
     obj = await result.get()
     assert obj == "test-defer"
 

--- a/tests/results/test_persisted_result.py
+++ b/tests/results/test_persisted_result.py
@@ -203,15 +203,15 @@ async def test_write_is_idempotent(storage_block):
     )
 
     with pytest.raises(ValueError, match="does not exist"):
-        await result.get()
+        await result.get(ignore_cache=True)
 
     await result.write()
-    record = await result.get()
-    assert record.result == "test-defer"
+    obj = await result.get()
+    assert obj == "test-defer"
 
     await result.write(obj="new-object!")
-    record = await result.get()
-    assert record.result == "test-defer"
+    obj = await result.get()
+    assert obj == "test-defer"
 
 
 async def test_lifecycle_of_deferred_persistence(storage_block):
@@ -226,11 +226,11 @@ async def test_lifecycle_of_deferred_persistence(storage_block):
     assert await result.get() == "test-defer"
 
     with pytest.raises(ValueError, match="does not exist"):
-        await result.get()
+        await result.get(ignore_cache=True)
 
     await result.write()
-    record = await result.get()
-    assert record.result == "test-defer"
+    obj = await result.get()
+    assert obj == "test-defer"
 
 
 async def test_read_old_format_into_result_record():

--- a/tests/results/test_persisted_result.py
+++ b/tests/results/test_persisted_result.py
@@ -203,14 +203,14 @@ async def test_write_is_idempotent(storage_block):
     )
 
     with pytest.raises(ValueError, match="does not exist"):
-        await result._read_result_record()
+        await result.get()
 
     await result.write()
-    record = await result._read_result_record()
+    record = await result.get()
     assert record.result == "test-defer"
 
     await result.write(obj="new-object!")
-    record = await result._read_result_record()
+    record = await result.get()
     assert record.result == "test-defer"
 
 
@@ -226,10 +226,10 @@ async def test_lifecycle_of_deferred_persistence(storage_block):
     assert await result.get() == "test-defer"
 
     with pytest.raises(ValueError, match="does not exist"):
-        await result._read_result_record()
+        await result.get()
 
     await result.write()
-    record = await result._read_result_record()
+    record = await result.get()
     assert record.result == "test-defer"
 
 

--- a/tests/results/test_state_result.py
+++ b/tests/results/test_state_result.py
@@ -10,7 +10,12 @@ import pytest
 import prefect.states
 from prefect.exceptions import UnfinishedRun
 from prefect.filesystems import LocalFileSystem, WritableFileSystem
-from prefect.results import PersistedResult, ResultFactory, ResultRecord
+from prefect.results import (
+    PersistedResult,
+    ResultFactory,
+    ResultRecord,
+    ResultRecordMetadata,
+)
 from prefect.serializers import JSONSerializer
 from prefect.states import State, StateType
 from prefect.utilities.annotations import NotSet
@@ -132,8 +137,14 @@ async def test_graceful_retries_eventually_succeed_while(
 ):
     # now write the result so it's available
     await a_real_result.write()
-    expected_record = await a_real_result.get()
-    assert isinstance(expected_record, ResultRecord)
+    expected_record = ResultRecord(
+        result="test-graceful-retry",
+        metadata=ResultRecordMetadata(
+            storage_key=a_real_result.storage_key,
+            expiration=a_real_result.expiration,
+            serializer=JSONSerializer(),
+        ),
+    )
 
     # even if it misses a couple times, it will eventually return the data
     now = time.monotonic()

--- a/tests/results/test_state_result.py
+++ b/tests/results/test_state_result.py
@@ -132,7 +132,7 @@ async def test_graceful_retries_eventually_succeed_while(
 ):
     # now write the result so it's available
     await a_real_result.write()
-    expected_record = await a_real_result._read_result_record()
+    expected_record = await a_real_result.get()
     assert isinstance(expected_record, ResultRecord)
 
     # even if it misses a couple times, it will eventually return the data


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

This PR is the next step in the results refactor and adds `read` and `write` methods to `ResultFactory` to move towards the `ResultFactory` (soon to be the `ResultStore`) being the source of truth for reading and writing results. `PersistedResult` has been updated to delegate reads and writes to a `ResultFactory`. I think we'll soon be able to remove `PersistedResult` from the critical path.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
