### PR TITLE
Touch up variable get and set

### DIFF
--- a/src/prefect/variables.py
+++ b/src/prefect/variables.py
@@ -74,7 +74,7 @@ class Variable(VariableRequest):
         cls,
         name: str,
         default: StrictVariableValue = None,
-    ) -> str:
+    ) -> StrictVariableValue:
         """
         Get a variable's value by name.
 

--- a/src/prefect/variables.py
+++ b/src/prefect/variables.py
@@ -1,9 +1,8 @@
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from prefect._internal.compatibility.migration import getattr_migration
 from prefect.client.schemas.actions import VariableCreate as VariableRequest
 from prefect.client.schemas.actions import VariableUpdate as VariableUpdateRequest
-from prefect.client.schemas.objects import Variable as VariableResponse
 from prefect.client.utilities import get_or_create_client
 from prefect.exceptions import ObjectNotFound
 from prefect.types import StrictVariableValue
@@ -29,19 +28,17 @@ class Variable(VariableRequest):
         value: StrictVariableValue,
         tags: Optional[List[str]] = None,
         overwrite: bool = False,
-        as_object: bool = False,
-    ):
+    ) -> "Variable":
         """
         Sets a new variable. If one exists with the same name, must pass `overwrite=True`
 
-        Returns the newly set value. If `as_object=True`, return the full Variable object
+        Returns the newly set variable object.
 
         Args:
             - name: The name of the variable to set.
             - value: The value of the variable to set.
             - tags: An optional list of strings to associate with the variable.
             - overwrite: Whether to overwrite the variable if it already exists.
-            - as_object: Whether to return the full Variable object.
 
         Example:
             Set a new variable and overwrite it if it already exists.
@@ -69,7 +66,7 @@ class Variable(VariableRequest):
                 variable=VariableRequest(**var_dict)
             )
 
-        return variable if as_object else variable.value
+        return variable
 
     @classmethod
     @sync_compatible
@@ -77,19 +74,15 @@ class Variable(VariableRequest):
         cls,
         name: str,
         default: StrictVariableValue = None,
-        as_object: bool = False,
-    ) -> Union[StrictVariableValue, VariableResponse]:
+    ) -> str:
         """
         Get a variable's value by name.
 
         If the variable does not exist, return the default value.
 
-        If `as_object=True`, return the full variable object. `default` is ignored in this case.
-
         Args:
-            - name: The name of the variable to get.
+            - name: The name of the variable value to get.
             - default: The default value to return if the variable does not exist.
-            - as_object: Whether to return the full variable object.
 
         Example:
             Get a variable's value by name.
@@ -105,7 +98,7 @@ class Variable(VariableRequest):
         client, _ = get_or_create_client()
         variable = await client.read_variable_by_name(name)
 
-        return variable if as_object else (variable.value if variable else default)
+        return variable.value if variable else default
 
     @classmethod
     @sync_compatible

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -6,9 +6,8 @@ from prefect.variables import Variable
 
 @pytest.fixture
 async def variable():
-    await Variable.set(name="my_variable", value="my-value", tags=["123", "456"])
-    model = await Variable.get("my_variable", as_object=True)
-    return model
+    var = await Variable.set(name="my_variable", value="my-value", tags=["123", "456"])
+    return var
 
 
 async def test_set_sync(variable):
@@ -23,7 +22,6 @@ async def test_set_sync(variable):
             name="my_new_variable",
             value="my_value",
             tags=["123", "456"],
-            as_object=True,
         )
         assert created.value == "my_value"
         assert created.tags == ["123", "456"]
@@ -41,7 +39,6 @@ async def test_set_sync(variable):
             value="other_value",
             tags=["new", "tags"],
             overwrite=True,
-            as_object=True,
         )
         assert updated.value == "other_value"
         assert updated.tags == ["new", "tags"]
@@ -56,7 +53,7 @@ async def test_set_async(variable):
 
     # create new
     created = await Variable.set(
-        name="my_new_variable", value="my_value", tags=["123", "456"], as_object=True
+        name="my_new_variable", value="my_value", tags=["123", "456"]
     )
     assert created.value == "my_value"
     assert created.tags == ["123", "456"]
@@ -74,7 +71,6 @@ async def test_set_async(variable):
         value="other_value",
         tags=["new", "tags"],
         overwrite=True,
-        as_object=True,
     )
     assert updated.value == "other_value"
     assert updated.tags == ["new", "tags"]
@@ -97,20 +93,13 @@ async def test_set_async(variable):
 )
 async def test_json_types(value):
     set_value = await Variable.set("json_variable", value=value)
-    assert set_value == value
+    assert set_value.value == value
 
 
 async def test_get(variable):
     # get value
     value = await Variable.get(variable.name)
     assert value == variable.value
-
-    # as_object=True returns the full variable object
-    obj = await Variable.get(variable.name, as_object=True)
-    assert obj
-    assert obj.id == variable.id
-    assert obj.name == variable.name
-    assert obj.value == variable.value
 
     # get value of a variable that doesn't exist
     doesnt_exist = await Variable.get("doesnt_exist")
@@ -125,13 +114,6 @@ async def test_get_async(variable):
     # get value
     value = await Variable.get(variable.name)
     assert value == variable.value
-
-    # as_object=True returns the full variable object
-    obj = await Variable.get(variable.name, as_object=True)
-    assert obj
-    assert obj.id == variable.id
-    assert obj.name == variable.name
-    assert obj.value == variable.value
 
     # get value of a variable that doesn't exist
     doesnt_exist = await Variable.get("doesnt_exist")
@@ -197,7 +179,7 @@ def test_set_in_sync_flow():
 
     res = foo()
     assert res
-    assert res == "my-value"
+    assert res.value == "my-value"
 
 
 async def test_set_in_async_flow():
@@ -207,7 +189,7 @@ async def test_set_in_async_flow():
 
     res = await foo()
     assert res
-    assert res == "my-value"
+    assert res.value == "my-value"
 
 
 async def test_unset_in_sync_flow(variable):


### PR DESCRIPTION
I'm just now seeing that the variables code is a bit all over the place (e.g., `as_object` for type dispatching, inheriting from a schema object instead of being a standalone class, etc.).

This PR attempts to get in a few minor breaking changes prior to 3.0 going GA for `Variable.get` and `Variable.set`; while it does feel a bit weird that `set -> Variable` and `get -> str`, I think it's justifiable as `set` is effectively `__init__ + create` and `get` is dictionary-semantics for value retrieval.  For users who want to load a full variable object we'll need to introduce `load/aload` methods but I'm comfortable waiting on those for another minor version release.