### PR TITLE
restore job submission handler in `jobs_runs_submit_and_wait_for_completion`

### DIFF
--- a/src/integrations/prefect-databricks/prefect_databricks/flows.py
+++ b/src/integrations/prefect-databricks/prefect_databricks/flows.py
@@ -63,7 +63,7 @@ TERMINAL_STATUS_CODES = (
 )
 async def jobs_runs_submit_and_wait_for_completion(
     databricks_credentials: DatabricksCredentials,
-    tasks: List[RunSubmitTaskSettings] = None,
+    tasks: Optional[List[RunSubmitTaskSettings]] = None,
     run_name: Optional[str] = None,
     max_wait_seconds: int = 900,
     poll_frequency_seconds: int = 10,
@@ -74,7 +74,7 @@ async def jobs_runs_submit_and_wait_for_completion(
     return_metadata: bool = False,
     job_submission_handler: Optional[Callable] = None,
     **jobs_runs_submit_kwargs: Dict[str, Any],
-) -> Union[NotebookOutput, Tuple[NotebookOutput, JobMetadata]]:
+) -> Union[NotebookOutput, Tuple[NotebookOutput, JobMetadata], None]:
     """
     Flow that triggers a job run and waits for the triggered run to complete.
 

--- a/src/integrations/prefect-databricks/tests/test_flows.py
+++ b/src/integrations/prefect-databricks/tests/test_flows.py
@@ -413,6 +413,51 @@ class TestJobsRunsSubmitAndWaitForCompletion:
         )
         assert result == {"prefect-task": {"cell": "output"}}
 
+    @pytest.mark.parametrize(
+        "handler",
+        [
+            sync_handler,
+            async_handler,
+        ],
+    )
+    async def test_handler_invoked(
+        self,
+        common_mocks,
+        respx_mock_with_pass_through,
+        databricks_credentials,
+        handler,
+        global_state,
+    ):
+        respx_mock_with_pass_through.get(
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=36108",  # noqa
+            headers={"Authorization": "Bearer testing_token"},
+        ).mock(
+            return_value=Response(
+                200,
+                json={
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "state_message": "",
+                        "result_state": "SUCCESS",
+                    },
+                    "tasks": [{"run_id": 36260, "task_key": "prefect-task"}],
+                },
+            )
+        )
+
+        respx_mock_with_pass_through.get(
+            "https://dbc-abcdefgh-123d.cloud.databricks.com/api/2.1/jobs/runs/get-output",  # noqa
+            headers={"Authorization": "Bearer testing_token"},
+        ).mock(return_value=Response(200, json={"notebook_output": {"cell": "output"}}))
+
+        result = await jobs_runs_submit_and_wait_for_completion(
+            databricks_credentials=databricks_credentials,
+            run_name="prefect-job",
+            job_submission_handler=partial(handler, state=global_state),
+        )
+        assert result == {"prefect-task": {"cell": "output"}}
+        assert "result" in global_state
+
 
 class TestJobsRunsIdSubmitAndWaitForCompletion:
     @pytest.mark.respx(assert_all_called=False)


### PR DESCRIPTION
restores `job_submission_handler` to `prefect-databricks` pre-built flow `jobs_runs_submit_and_wait_for_completion`

3.x half of https://github.com/PrefectHQ/prefect/issues/15180