### PR TITLE
Disable griffe logging entirely when used

### DIFF
--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -555,10 +555,9 @@ class Block(BaseModel, ABC):
         `<module>:11: No type or annotation for parameter 'write_json'`
         because griffe is unable to parse the types from pydantic.BaseModel.
         """
-        with disable_logger("griffe.docstrings.google"):
-            with disable_logger("griffe.agents.nodes"):
-                docstring = Docstring(cls.__doc__)
-                parsed = parse(docstring, Parser.google)
+        with disable_logger("griffe"):
+            docstring = Docstring(cls.__doc__)
+            parsed = parse(docstring, Parser.google)
         return parsed
 
     @classmethod

--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -263,9 +263,7 @@ def parameter_docstrings(docstring: Optional[str]) -> Dict[str, str]:
     if not docstring:
         return param_docstrings
 
-    with disable_logger("griffe.docstrings.google"), disable_logger(
-        "griffe.agents.nodes"
-    ):
+    with disable_logger("griffe"):
         parsed = parse(Docstring(docstring), Parser.google)
         for section in parsed:
             if section.kind != DocstringSectionKind.parameters:


### PR DESCRIPTION
Closes #15090 

Will backport to 2.x as well