### PR TITLE
Updates the worker integration tests for post-GA

### DIFF
--- a/flows/worker.py
+++ b/flows/worker.py
@@ -5,7 +5,7 @@ import sys
 # Checks to make sure that collections are loaded prior to attempting to start a worker
 def main():
     subprocess.check_call(
-        ["python", "-m", "pip", "install", "prefect-kubernetes>0.5.0"],
+        ["python", "-m", "pip", "install", "prefect-kubernetes>=0.5.0"],
         stdout=sys.stdout,
         stderr=sys.stderr,
     )

--- a/flows/worker.py
+++ b/flows/worker.py
@@ -4,12 +4,8 @@ import sys
 
 # Checks to make sure that collections are loaded prior to attempting to start a worker
 def main():
-    raise NotImplementedError(
-        "The prefect-kubernetes package hasn't been updated for prefect>=3.0 yet"
-    )
-
     subprocess.check_call(
-        ["python", "-m", "pip", "install", "prefect-kubernetes<3"],
+        ["python", "-m", "pip", "install", "prefect-kubernetes>0.5.0"],
         stdout=sys.stdout,
         stderr=sys.stderr,
     )


### PR DESCRIPTION
This test was disabled while we got the integrations package versions worked out
with `prefect>3`.  Now that `prefect-kubernetes` has 3.0 support, we can use
this test again.

<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
