### PR TITLE
more correct upgrade recommendation

### DIFF
--- a/docs/3.0/resources/upgrade-to-prefect-3.mdx
+++ b/docs/3.0/resources/upgrade-to-prefect-3.mdx
@@ -23,7 +23,7 @@ prefect server database upgrade
 If you use a Prefect integration or extra, remember to upgrade it as well. For example:
 
 ```bash
-pip install 'prefect[aws]'
+pip install -U 'prefect[aws]'
 ```
 
 ## Upgrade notes


### PR DESCRIPTION
amends https://github.com/PrefectHQ/prefect/pull/15192 since `pip install 'prefect[aws]'` would no op with a 2.x version of prefect and prefect-aws installed