### PR TITLE
update `prompt_select_from_table` 

### DIFF
--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -804,7 +804,7 @@ class TestProjectDeploy:
                 invoke_and_assert,
                 command=(
                     "deploy ./flows/hello.py:my_flow -n test-name -p"
-                    f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
+                    f" {work_pool.name} --version 1.0.0 -jv env=prod -t foo-bar"
                     " --interval 60"
                 ),
                 expected_code=0,
@@ -6339,7 +6339,7 @@ class TestDeployInfraOverrides:
             invoke_and_assert,
             command=(
                 "deploy ./flows/hello.py:my_flow -n test-name -p test-pool --version"
-                " 1.0.0 -v env=prod -t foo-bar --variable"
+                " 1.0.0 -v env=prod -t foo-bar --job-variable"
                 ' \'{"resources":{"limits":{"cpu": 1}}}\''
             ),
             expected_code=0,
@@ -6366,7 +6366,7 @@ class TestDeployInfraOverrides:
             invoke_and_assert,
             command=(
                 "deploy ./flows/hello.py:my_flow -n test-name -p test-pool --version"
-                " 1.0.0 -v env=prod -t foo-bar --variable 'my-variable'"
+                " 1.0.0 -v env=prod -t foo-bar --job-variable 'my-variable'"
             ),
             expected_code=1,
             expected_output_contains=[
@@ -6379,7 +6379,7 @@ class TestDeployInfraOverrides:
             invoke_and_assert,
             command=(
                 "deploy ./flows/hello.py:my_flow -n test-name -p test-pool --version"
-                " 1.0.0 -v env=prod -t foo-bar --variable ['my-variable']"
+                " 1.0.0 -v env=prod -t foo-bar --job-variable ['my-variable']"
             ),
             expected_code=1,
             expected_output_contains=[
@@ -6392,7 +6392,7 @@ class TestDeployInfraOverrides:
             invoke_and_assert,
             command=(
                 "deploy ./flows/hello.py:my_flow -n test-name -p test-pool --version"
-                " 1.0.0 -v env=prod -t foo-bar --variable "
+                " 1.0.0 -v env=prod -t foo-bar --job-variable "
                 ' \'{"resources":{"limits":{"cpu"}\''
             ),
             expected_code=1,


### PR DESCRIPTION
this PR updates `prompt_select_from_table` to display a rolling window of options instead of all of them at once.

for example, consider a `prefect work-pool create --provision-infra` with cloud run and I have 50 gcp projects, the current setup wouldn't let me select the bottom of the list if it ran off-screen downwards

<details>
<summary>before</summary>
all shown together, but you can't arrow down past the bottom of the screen

<img width="880" alt="image" src="https://github.com/user-attachments/assets/a2dd9d59-cc92-4bcf-b15f-3c940edaa198">

</details>

<details>
<summary>after</summary>

select from a rolling window of options (temporarily obscured values)

https://github.com/user-attachments/assets/b7cb70bc-91fe-4a25-8970-de70b429c936

</details>