### PR TITLE
Adds ability to write result metadata separate from data when using `ResultStore`

### DIFF
--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -315,13 +315,17 @@ class ResultStore(BaseModel):
             self.result_storage = await get_default_result_storage()
 
         if self.metadata_storage is not None:
-            metadata_content = await self.metadata_storage.read_path(f"{key}")
-            result_content = await self.result_storage.read_path(f"{key}")
+            metadata_content = await self.metadata_storage.read_path(key)
+            metadata = ResultRecordMetadata.load_bytes(metadata_content)
+            assert (
+                metadata.storage_key is not None
+            ), "Did not find storage key in metadata"
+            result_content = await self.result_storage.read_path(metadata.storage_key)
             return ResultRecord.deserialize_from_result_and_metadata(
                 result=result_content, metadata=metadata_content
             )
         else:
-            content = await self.result_storage.read_path(f"{key}")
+            content = await self.result_storage.read_path(key)
             return ResultRecord.deserialize(content)
 
     def read(self, key: str) -> "ResultRecord":

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -248,6 +248,56 @@ class ResultStore(BaseModel):
         return self.model_copy(update=update)
 
     @sync_compatible
+    async def _exists(self, key: str) -> bool:
+        """
+        Check if a result record exists in storage.
+
+        Args:
+            key: The key to check for the existence of a result record.
+
+        Returns:
+            bool: True if the result record exists, False otherwise.
+        """
+        if self.metadata_storage is not None:
+            # TODO: Add an `exists` method to commonly used storage blocks
+            # so the entire payload doesn't need to be read
+            try:
+                metadata_content = await self.metadata_storage.read_path(key)
+                return metadata_content is not None
+            except Exception:
+                return False
+        else:
+            try:
+                content = await self.result_storage.read_path(key)
+                return content is not None
+            except Exception:
+                return False
+
+    def exists(self, key: str) -> bool:
+        """
+        Check if a result record exists in storage.
+
+        Args:
+            key: The key to check for the existence of a result record.
+
+        Returns:
+            bool: True if the result record exists, False otherwise.
+        """
+        return self._exists(key=key, _sync=True)
+
+    async def aexists(self, key: str) -> bool:
+        """
+        Check if a result record exists in storage.
+
+        Args:
+            key: The key to check for the existence of a result record.
+
+        Returns:
+            bool: True if the result record exists, False otherwise.
+        """
+        return await self._exists(key=key, _sync=False)
+
+    @sync_compatible
     async def _read(self, key: str) -> "ResultRecord":
         """
         Read a result record from storage.

--- a/tests/results/test_result_store.py
+++ b/tests/results/test_result_store.py
@@ -731,3 +731,28 @@ async def test_result_store_from_task_takes_precedence_from_task(persist_result)
     result_store = foo()
 
     assert result_store.persist_result is persist_result
+
+
+async def test_result_store_read_and_write_with_metadata_storage(tmp_path):
+    metadata_storage = LocalFileSystem(basepath=tmp_path / "metadata")
+    result_storage = LocalFileSystem(basepath=tmp_path / "results")
+    result_store = ResultStore(
+        metadata_storage=metadata_storage, result_storage=result_storage
+    )
+
+    key = "test"
+    value = "test"
+    await result_store.awrite(key=key, obj=value)
+    read_value = await result_store.aread(key=key)
+    assert read_value.result == value
+
+    # Check that the result is written to the result storage
+    assert (
+        result_store.serializer.loads((tmp_path / "results" / key).read_bytes())
+        == value
+    )
+
+    # Check that the metadata is written to the metadata storage
+    assert (
+        tmp_path / "metadata" / key
+    ).read_text() == read_value.metadata.model_dump_json(serialize_as_any=True)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR adds the ability to configure `metadata_storage` for a `ResultStore`. Specifying `metadata_storage` will cause the `ResultStore` to write result metadata separate from the result data. The `ResultStore` will continue to operate as it did before if `result_metadata` is not provided.

Related to https://github.com/PrefectHQ/prefect/issues/15208

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
