### PR TITLE
Adds option to create active concurrency limits

### DIFF
--- a/docs/3.0/api-ref/rest-api/server/schema.json
+++ b/docs/3.0/api-ref/rest-api/server/schema.json
@@ -12695,6 +12695,11 @@
                         "type": "boolean",
                         "title": "Create If Missing",
                         "default": true
+                    },
+                    "active": {
+                        "type": "boolean",
+                        "title": "Active",
+                        "default": false
                     }
                 },
                 "type": "object",

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -3054,7 +3054,12 @@ class PrefectClient:
         return response.json()
 
     async def increment_concurrency_slots(
-        self, names: List[str], slots: int, mode: str, create_if_missing: Optional[bool]
+        self,
+        names: List[str],
+        slots: int,
+        mode: str,
+        create_if_missing: Optional[bool],
+        active: Optional[bool] = False,
     ) -> httpx.Response:
         return await self._client.post(
             "/v2/concurrency_limits/increment",
@@ -3063,6 +3068,7 @@ class PrefectClient:
                 "slots": slots,
                 "mode": mode,
                 "create_if_missing": create_if_missing,
+                "active": active,
             },
         )
 

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -3059,7 +3059,7 @@ class PrefectClient:
         slots: int,
         mode: str,
         create_if_missing: Optional[bool],
-        active: Optional[bool] = False,
+        active: bool = False,
     ) -> httpx.Response:
         return await self._client.post(
             "/v2/concurrency_limits/increment",

--- a/src/prefect/concurrency/asyncio.py
+++ b/src/prefect/concurrency/asyncio.py
@@ -37,6 +37,7 @@ async def concurrency(
     occupy: int = 1,
     timeout_seconds: Optional[float] = None,
     create_if_missing: bool = True,
+    active: bool = False,
     max_retries: Optional[int] = None,
 ) -> AsyncGenerator[None, None]:
     """A context manager that acquires and releases concurrency slots from the
@@ -78,6 +79,7 @@ async def concurrency(
         timeout_seconds=timeout_seconds,
         create_if_missing=create_if_missing,
         max_retries=max_retries,
+        active=active,
     )
     acquisition_time = pendulum.now("UTC")
     emitted_events = _emit_concurrency_acquisition_events(limits, occupy)
@@ -141,10 +143,11 @@ async def _acquire_concurrency_slots(
     timeout_seconds: Optional[float] = None,
     create_if_missing: Optional[bool] = True,
     max_retries: Optional[int] = None,
+    active: Optional[bool] = False,
 ) -> List[MinimalConcurrencyLimitResponse]:
     service = ConcurrencySlotAcquisitionService.instance(frozenset(names))
     future = service.send(
-        (slots, mode, timeout_seconds, create_if_missing, max_retries)
+        (slots, mode, timeout_seconds, create_if_missing, max_retries, active)
     )
     response_or_exception = await asyncio.wrap_future(future)
 

--- a/src/prefect/concurrency/asyncio.py
+++ b/src/prefect/concurrency/asyncio.py
@@ -143,7 +143,7 @@ async def _acquire_concurrency_slots(
     timeout_seconds: Optional[float] = None,
     create_if_missing: Optional[bool] = True,
     max_retries: Optional[int] = None,
-    active: Optional[bool] = False,
+    active: bool = False,
 ) -> List[MinimalConcurrencyLimitResponse]:
     service = ConcurrencySlotAcquisitionService.instance(frozenset(names))
     future = service.send(

--- a/src/prefect/concurrency/sync.py
+++ b/src/prefect/concurrency/sync.py
@@ -42,6 +42,7 @@ def concurrency(
     timeout_seconds: Optional[float] = None,
     create_if_missing: bool = True,
     max_retries: Optional[int] = None,
+    active: bool = False,
 ) -> Generator[None, None, None]:
     """A context manager that acquires and releases concurrency slots from the
     given concurrency limits.
@@ -83,6 +84,7 @@ def concurrency(
         timeout_seconds=timeout_seconds,
         create_if_missing=create_if_missing,
         max_retries=max_retries,
+        active=active,
     )
     acquisition_time = pendulum.now("UTC")
     emitted_events = _emit_concurrency_acquisition_events(limits, occupy)

--- a/src/prefect/server/api/concurrency_limits_v2.py
+++ b/src/prefect/server/api/concurrency_limits_v2.py
@@ -151,6 +151,7 @@ async def bulk_increment_active_slots(
     names: List[str] = Body(..., min_items=1),
     mode: Literal["concurrency", "rate_limit"] = Body("concurrency"),
     create_if_missing: bool = Body(True),
+    active: bool = Body(False),
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> List[MinimalConcurrencyLimitResponse]:
     async with db.session_context(begin_transaction=True) as session:
@@ -158,7 +159,10 @@ async def bulk_increment_active_slots(
             schemas.core.ConcurrencyLimitV2.model_validate(limit)
             for limit in (
                 await models.concurrency_limits_v2.bulk_read_or_create_concurrency_limits(
-                    session=session, names=names, create_if_missing=create_if_missing
+                    session=session,
+                    names=names,
+                    create_if_missing=create_if_missing,
+                    active=active,
                 )
             )
         ]

--- a/src/prefect/server/models/concurrency_limits_v2.py
+++ b/src/prefect/server/models/concurrency_limits_v2.py
@@ -185,32 +185,6 @@ async def delete_concurrency_limit(
     return result.rowcount > 0
 
 
-async def create_or_update_concurrency_limit(
-    session: AsyncSession,
-    concurrency_limit: Union[
-        schemas.actions.ConcurrencyLimitV2Create, schemas.core.ConcurrencyLimitV2
-    ],
-    concurrency_limit_id: Optional[UUID] = None,
-    name: Optional[str] = None,
-) -> orm_models.ConcurrencyLimitV2:
-    if not concurrency_limit_id and not name:
-        raise ValueError("Must provide either concurrency_limit_id or name")
-
-    current_concurrency_limit = await read_concurrency_limit(
-        session, concurrency_limit_id=concurrency_limit_id, name=name
-    )
-
-    if not current_concurrency_limit:
-        return await create_concurrency_limit(session, concurrency_limit)
-    else:
-        return await update_concurrency_limit(
-            session,
-            concurrency_limit,
-            concurrency_limit_id=concurrency_limit_id,
-            name=name,
-        )
-
-
 async def bulk_read_or_create_concurrency_limits(
     session: AsyncSession,
     names: List[str],

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -874,7 +874,7 @@ class BaseWorker(abc.ABC):
 
         try:
             async with concurrency_ctx(
-                limit_name, occupy=concurrency_limit, max_retries=0
+                limit_name, occupy=concurrency_limit, max_retries=0, active=True
             ):
                 configuration = await self._get_configuration(flow_run, deployment)
                 submitted_event = self._emit_flow_run_submitted_event(configuration)

--- a/tests/concurrency/test_acquire_concurrency_slots.py
+++ b/tests/concurrency/test_acquire_concurrency_slots.py
@@ -29,6 +29,7 @@ async def test_calls_increment_client_method():
             slots=1,
             mode="concurrency",
             create_if_missing=True,
+            active=False,
         )
 
 

--- a/tests/concurrency/test_concurrency_asyncio.py
+++ b/tests/concurrency/test_concurrency_asyncio.py
@@ -43,6 +43,7 @@ async def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV
                 timeout_seconds=None,
                 create_if_missing=True,
                 max_retries=None,
+                active=False,
             )
 
             # On release we calculate how many seconds the slots were occupied
@@ -411,7 +412,7 @@ async def test_concurrency_creates_new_limits_if_requested(
 
     async def resource_heavy():
         nonlocal executed
-        async with concurrency("test", occupy=1, create_if_missing=True):
+        async with concurrency("test", occupy=1, create_if_missing=True, active=True):
             executed = True
 
     assert not executed
@@ -432,6 +433,7 @@ async def test_concurrency_creates_new_limits_if_requested(
                 timeout_seconds=None,
                 create_if_missing=True,
                 max_retries=None,
+                active=True,
             )
 
             # On release we calculate how many seconds the slots were occupied

--- a/tests/concurrency/test_concurrency_slot_acquisition_service.py
+++ b/tests/concurrency/test_concurrency_slot_acquisition_service.py
@@ -41,7 +41,7 @@ async def test_returns_successful_response(mocked_client):
     expected_mode = "concurrency"
 
     service = ConcurrencySlotAcquisitionService.instance(frozenset(expected_names))
-    future = service.send((expected_slots, expected_mode, None, True, None))
+    future = service.send((expected_slots, expected_mode, None, True, None, False))
     await service.drain()
     returned_response = await asyncio.wrap_future(future)
     assert returned_response == response
@@ -51,6 +51,7 @@ async def test_returns_successful_response(mocked_client):
         slots=expected_slots,
         mode=expected_mode,
         create_if_missing=True,
+        active=False,
     )
 
 
@@ -70,7 +71,7 @@ async def test_retries_failed_call_respects_retry_after_header(mocked_client):
     service = ConcurrencySlotAcquisitionService.instance(frozenset(limit_names))
 
     with mock.patch("prefect.concurrency.asyncio.asyncio.sleep") as sleep:
-        future = service.send((1, "concurrency", None, True, None))
+        future = service.send((1, "concurrency", None, True, None, False))
         await service.drain()
         returned_response = await asyncio.wrap_future(future)
 
@@ -94,7 +95,7 @@ async def test_failed_call_status_code_not_retryable_returns_exception(mocked_cl
     limit_names = sorted(["api", "database"])
     service = ConcurrencySlotAcquisitionService.instance(frozenset(limit_names))
 
-    future = service.send((1, "concurrency", None, True, None))
+    future = service.send((1, "concurrency", None, True, None, False))
     await service.drain()
     exception = await asyncio.wrap_future(future)
 
@@ -109,7 +110,7 @@ async def test_basic_exception_returns_exception(mocked_client):
     limit_names = sorted(["api", "database"])
     service = ConcurrencySlotAcquisitionService.instance(frozenset(limit_names))
 
-    future = service.send((1, "concurrency", None, True, None))
+    future = service.send((1, "concurrency", None, True, None, False))
     await service.drain()
     exception = await asyncio.wrap_future(future)
 

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -41,6 +41,7 @@ def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV2):
                 timeout_seconds=None,
                 create_if_missing=True,
                 max_retries=None,
+                active=False,
             )
 
             # On release we calculate how many seconds the slots were occupied

--- a/tests/concurrency/v1/test_increment_concurrency_limits.py
+++ b/tests/concurrency/v1/test_increment_concurrency_limits.py
@@ -33,6 +33,7 @@ async def test_calls_increment_client_method():
             slots=1,
             mode="concurrency",
             create_if_missing=True,
+            active=False,
         )
 
 

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -379,6 +379,7 @@ async def test_worker_with_deployment_concurrency_limit_uses_limit(
                 timeout_seconds=None,
                 create_if_missing=True,
                 max_retries=0,
+                active=True,
             )
 
             names, occupy, occupy_seconds = release_spy.call_args[0]
@@ -418,6 +419,7 @@ async def test_worker_with_deployment_concurrency_limit_proposes_awaiting_limit_
             timeout_seconds=None,
             create_if_missing=True,
             max_retries=0,
+            active=True,
         )
 
         flow_run = await prefect_client.read_flow_run(flow_run.id)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->
Adds an `active` field to `bulk_read_or_create_concurrency_limits` to support creating active limits. This field also gets added to api, client and `concurrency` contex. This supports creating active limits for deployments and not rely on users to activate limits.
Related: #14934 
<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
