### PR TITLE
Add docs redirects to catch non-latest in slugs 

### DIFF
--- a/docs/3.0/deploy/infrastructure-examples/docker.mdx
+++ b/docs/3.0/deploy/infrastructure-examples/docker.mdx
@@ -3,7 +3,7 @@ title: Run flows in Docker containers
 description: Learn how to deploy a flow to a Docker work pool with workers
 ---
 
-In this tutorial, you will create a work pool and worker to deploy your tutorial flow, and then execute it with the Prefect API.
+In this example, you will create a work pool and worker to deploy your flow, and then execute it with the Prefect API.
 You must have [Docker](https://docs.docker.com/engine/install/) installed and running on your machine.
 
 ### Create a work pool

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -690,6 +690,30 @@
   ],
   "redirects": [
     {
+      "destination": "/latest/getting-started/:slug*",
+      "source": "/getting-started/:slug*"
+    },
+    {
+      "destination": "/latest/tutorial/:slug*",
+      "source": "/tutorial/:slug*"
+    },
+    {
+      "destination": "/latest/guides/:slug*",
+      "source": "/guides/:slug*"
+    },
+    {
+      "destination": "/latest/concepts/:slug*",
+      "source": "/concepts/:slug*"
+    },
+    {
+      "destination": "/latest/cloud/:slug*",
+      "source": "/cloud/:slug*"
+    },
+    {
+      "destination": "/latest/api-ref/:slug*",
+      "source": "/api-ref/:slug*"
+    },
+    {
       "destination": "/latest/get-started",
       "source": "/latest/tutorial"
     },
@@ -1254,20 +1278,20 @@
       "source": "/latest/integrations/prefect-slack/messages"
     },
     {
-      "destination": "/3.0/:slug*",
-      "source": "/latest/:slug*"
-    },
-    {
-      "destination": "/3.0/api-ref/python",
+      "destination": "/latest/api-ref/python",
       "source": "/latest/api-ref/prefect/:slug*"
     },
     {
-      "destination": "/3.0/api-ref/python",
+      "destination": "/latest/api-ref/python",
       "source": "/api-ref/prefect/:slug*"
     },
     {
-      "source": "/3.0rc/:slug*",
-      "destination": "/3.0/:slug*"
+      "destination": "/3.0/:slug*",
+      "source": "/3.0rc/:slug*"
+    },
+    {
+      "destination": "/3.0/:slug*",
+      "source": "/latest/:slug*"
     }
   ],
   "tabs": [


### PR DESCRIPTION
Most links to the 2.x docs had `/latest/` in them, but not all. This PR adds redirect rules to mint.json to catch many of those cases. Tested locally, and the redirects resolve as expected. 

For example /concepts/tasks now resolves appropriately to /3.0/develop/write-tasks.


<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
