### PR TITLE
Deployment.concurrency_limit cannot be zero.

### DIFF
--- a/docs/3.0/api-ref/rest-api/server/schema.json
+++ b/docs/3.0/api-ref/rest-api/server/schema.json
@@ -15755,7 +15755,7 @@
                         "anyOf": [
                             {
                                 "type": "integer",
-                                "minimum": 0.0
+                                "exclusiveMinimum": 0.0
                             },
                             {
                                 "type": "null"
@@ -16994,7 +16994,7 @@
                         "anyOf": [
                             {
                                 "type": "integer",
-                                "minimum": 0.0
+                                "exclusiveMinimum": 0.0
                             },
                             {
                                 "type": "null"

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -169,7 +169,7 @@ class DeploymentCreate(ActionBaseModel):
         default_factory=list,
         description="A list of schedules for the deployment.",
     )
-    concurrency_limit: Optional[NonNegativeInteger] = Field(
+    concurrency_limit: Optional[PositiveInteger] = Field(
         default=None, description="The deployment's concurrency limit."
     )
     enforce_parameter_schema: bool = Field(
@@ -267,7 +267,7 @@ class DeploymentUpdate(ActionBaseModel):
         default_factory=list,
         description="A list of schedules for the deployment.",
     )
-    concurrency_limit: Optional[NonNegativeInteger] = Field(
+    concurrency_limit: Optional[PositiveInteger] = Field(
         default=None, description="The deployment's concurrency limit."
     )
     parameters: Optional[Dict[str, Any]] = Field(

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -546,7 +546,7 @@ class Deployment(ORMBaseModel):
     schedules: List[DeploymentSchedule] = Field(
         default_factory=list, description="A list of schedules for the deployment."
     )
-    concurrency_limit: Optional[NonNegativeInteger] = Field(
+    concurrency_limit: Optional[PositiveInteger] = Field(
         default=None, description="The concurrency limit for the deployment."
     )
     job_variables: Dict[str, Any] = Field(


### PR DESCRIPTION
This PR tweaks API schemas for the recently added `Deployment.concurrency_limit` field to narrow allowed values to exclude the literal value `0` as it's confusing how it intersects with `concurrency_limit=None` and disabling a deployment. 

> [!Important]
> This is technically a breaking api change and is also inconsistent with Work pool concurrency limits which similarly allow 0. 
> We want to do this while this feature is still rather new/in-development and to pre-empt confusion with disabling deployments. 
>
> Also worth noting that the UI will include client-side validation for this greater-than-0 behavior already
> 
> Happy to close this small PR though if we think this additional validation isn't worth it

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
