### PR TITLE
clarify variables docs

### DIFF
--- a/docs/3.0/api-ref/rest-api/server/schema.json
+++ b/docs/3.0/api-ref/rest-api/server/schema.json
@@ -279,12 +279,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_count_flows_flows_count_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_count_flows_flows_count_post"
                             }
                         }
                     }
@@ -391,12 +386,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_flows_flows_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_flows_flows_filter_post"
                             }
                         }
                     }
@@ -452,12 +442,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_paginate_flows_flows_paginate_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_paginate_flows_flows_paginate_post"
                             }
                         }
                     }
@@ -719,12 +704,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_count_flow_runs_flow_runs_count_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_count_flow_runs_flow_runs_count_post"
                             }
                         }
                     }
@@ -777,12 +757,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_average_flow_run_lateness_flow_runs_lateness_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_average_flow_run_lateness_flow_runs_lateness_post"
                             }
                         }
                     }
@@ -1038,12 +1013,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_resume_flow_run_flow_runs__id__resume_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_resume_flow_run_flow_runs__id__resume_post"
                             }
                         }
                     }
@@ -1095,12 +1065,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_flow_runs_flow_runs_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_flow_runs_flow_runs_filter_post"
                             }
                         }
                     }
@@ -1474,12 +1439,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_paginate_flow_runs_flow_runs_paginate_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_paginate_flow_runs_flow_runs_paginate_post"
                             }
                         }
                     }
@@ -1794,12 +1754,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_count_task_runs_task_runs_count_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_count_task_runs_task_runs_count_post"
                             }
                         }
                     }
@@ -1909,12 +1864,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_task_runs_task_runs_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_task_runs_task_runs_filter_post"
                             }
                         }
                     }
@@ -2469,12 +2419,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_flow_run_notification_policies_flow_run_notification_policies_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_flow_run_notification_policies_flow_run_notification_policies_filter_post"
                             }
                         }
                     }
@@ -2804,12 +2749,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_deployments_deployments_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_deployments_deployments_filter_post"
                             }
                         }
                     }
@@ -2865,12 +2805,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_paginate_deployments_deployments_paginate_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_paginate_deployments_deployments_paginate_post"
                             }
                         }
                     }
@@ -2979,12 +2914,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_count_deployments_deployments_count_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_count_deployments_deployments_count_post"
                             }
                         }
                     }
@@ -3049,12 +2979,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_schedule_deployment_deployments__id__schedule_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_schedule_deployment_deployments__id__schedule_post"
                             }
                         }
                     }
@@ -3488,13 +3413,8 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/DeploymentScheduleUpdate"
-                                    }
-                                ],
-                                "description": "The updated schedule",
-                                "title": "Schedule"
+                                "$ref": "#/components/schemas/DeploymentScheduleUpdate",
+                                "description": "The updated schedule"
                             }
                         }
                     }
@@ -3750,12 +3670,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_saved_searches_saved_searches_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_saved_searches_saved_searches_filter_post"
                             }
                         }
                     }
@@ -3866,12 +3781,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_logs_logs_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_logs_logs_filter_post"
                             }
                         }
                     }
@@ -4187,12 +4097,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_concurrency_limits_concurrency_limits_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_concurrency_limits_concurrency_limits_filter_post"
                             }
                         }
                     }
@@ -4258,12 +4163,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_reset_concurrency_limit_by_tag_concurrency_limits_tag__tag__reset_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_reset_concurrency_limit_by_tag_concurrency_limits_tag__tag__reset_post"
                             }
                         }
                     }
@@ -4645,12 +4545,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_all_concurrency_limits_v2_v2_concurrency_limits_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_all_concurrency_limits_v2_v2_concurrency_limits_filter_post"
                             }
                         }
                     }
@@ -5081,12 +4976,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_block_types_block_types_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_block_types_block_types_filter_post"
                             }
                         }
                     }
@@ -5384,12 +5274,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_block_documents_block_documents_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_block_documents_block_documents_filter_post"
                             }
                         }
                     }
@@ -5445,12 +5330,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_count_block_documents_block_documents_count_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_count_block_documents_block_documents_count_post"
                             }
                         }
                     }
@@ -5876,12 +5756,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_work_pools_work_pools_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_work_pools_work_pools_filter_post"
                             }
                         }
                     }
@@ -5937,12 +5812,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_count_work_pools_work_pools_count_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_count_work_pools_work_pools_count_post"
                             }
                         }
                     }
@@ -6006,12 +5876,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_get_scheduled_flow_runs_work_pools__name__get_scheduled_flow_runs_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_get_scheduled_flow_runs_work_pools__name__get_scheduled_flow_runs_post"
                             }
                         }
                     }
@@ -6329,12 +6194,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_work_queues_work_pools__work_pool_name__queues_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_work_queues_work_pools__work_pool_name__queues_filter_post"
                             }
                         }
                     }
@@ -6457,12 +6317,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_workers_work_pools__work_pool_name__workers_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_workers_work_pools__work_pool_name__workers_filter_post"
                             }
                         }
                     }
@@ -6576,12 +6431,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_task_workers_task_workers_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_task_workers_task_workers_filter_post"
                             }
                         }
                     }
@@ -6932,12 +6782,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_work_queue_runs_work_queues__id__get_runs_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_work_queue_runs_work_queues__id__get_runs_post"
                             }
                         }
                     }
@@ -6993,12 +6838,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_work_queues_work_queues_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_work_queues_work_queues_filter_post"
                             }
                         }
                     }
@@ -7372,12 +7212,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_artifacts_artifacts_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_artifacts_artifacts_filter_post"
                             }
                         }
                     }
@@ -7433,12 +7268,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_latest_artifacts_artifacts_latest_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_latest_artifacts_artifacts_latest_filter_post"
                             }
                         }
                     }
@@ -7494,12 +7324,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_count_artifacts_artifacts_count_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_count_artifacts_artifacts_count_post"
                             }
                         }
                     }
@@ -7552,12 +7377,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_count_latest_artifacts_artifacts_latest_count_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_count_latest_artifacts_artifacts_latest_count_post"
                             }
                         }
                     }
@@ -7763,12 +7583,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_block_schemas_block_schemas_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_block_schemas_block_schemas_filter_post"
                             }
                         }
                     }
@@ -8338,12 +8153,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_variables_variables_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_variables_variables_filter_post"
                             }
                         }
                     }
@@ -8398,12 +8208,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_count_variables_variables_count_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_count_variables_variables_count_post"
                             }
                         }
                     }
@@ -8557,12 +8362,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_events_events_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_events_events_filter_post"
                             }
                         }
                     }
@@ -8983,12 +8783,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_automations_automations_filter_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_automations_automations_filter_post"
                             }
                         }
                     }
@@ -9360,12 +9155,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_flow_run_history_ui_flow_runs_history_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_flow_run_history_ui_flow_runs_history_post"
                             }
                         }
                     }
@@ -9587,12 +9377,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_read_task_run_counts_by_state_ui_task_runs_count_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_read_task_run_counts_by_state_ui_task_runs_count_post"
                             }
                         }
                     }
@@ -9731,12 +9516,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_clear_database_admin_database_clear_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_clear_database_admin_database_clear_post"
                             }
                         }
                     }
@@ -9781,12 +9561,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_drop_database_admin_database_drop_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_drop_database_admin_database_drop_post"
                             }
                         }
                     }
@@ -9831,12 +9606,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Body_create_database_admin_database_create_post"
-                                    }
-                                ],
-                                "title": "Body"
+                                "$ref": "#/components/schemas/Body_create_database_admin_database_create_post"
                             }
                         }
                     }
@@ -10198,11 +9968,7 @@
             "ArtifactCollectionFilter": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -10540,11 +10306,7 @@
             "ArtifactFilter": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -11281,11 +11043,7 @@
             "AutomationFilter": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -11758,11 +11516,7 @@
             "BlockDocumentFilter": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -12093,11 +11847,7 @@
             "BlockSchemaFilter": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -12722,11 +12472,7 @@
                         "$ref": "#/components/schemas/EventFilter"
                     },
                     "time_unit": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TimeUnit"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/TimeUnit",
                         "default": "day"
                     },
                     "time_interval": {
@@ -12745,39 +12491,19 @@
             "Body_count_artifacts_artifacts_count_post": {
                 "properties": {
                     "artifacts": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ArtifactFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/ArtifactFilter"
                     },
                     "flow_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowRunFilter"
                     },
                     "task_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TaskRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/TaskRunFilter"
                     },
                     "flows": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowFilter"
                     },
                     "deployments": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/DeploymentFilter"
                     }
                 },
                 "type": "object",
@@ -12840,46 +12566,22 @@
             "Body_count_deployments_deployments_count_post": {
                 "properties": {
                     "flows": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowFilter"
                     },
                     "flow_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowRunFilter"
                     },
                     "task_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TaskRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/TaskRunFilter"
                     },
                     "deployments": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/DeploymentFilter"
                     },
                     "work_pools": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkPoolFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkPoolFilter"
                     },
                     "work_pool_queues": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkQueueFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkQueueFilter"
                     }
                 },
                 "type": "object",
@@ -12888,46 +12590,22 @@
             "Body_count_flow_runs_flow_runs_count_post": {
                 "properties": {
                     "flows": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowFilter"
                     },
                     "flow_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowRunFilter"
                     },
                     "task_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TaskRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/TaskRunFilter"
                     },
                     "deployments": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/DeploymentFilter"
                     },
                     "work_pools": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkPoolFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkPoolFilter"
                     },
                     "work_pool_queues": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkQueueFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkQueueFilter"
                     }
                 },
                 "type": "object",
@@ -12936,39 +12614,19 @@
             "Body_count_flows_flows_count_post": {
                 "properties": {
                     "flows": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowFilter"
                     },
                     "flow_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowRunFilter"
                     },
                     "task_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TaskRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/TaskRunFilter"
                     },
                     "deployments": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/DeploymentFilter"
                     },
                     "work_pools": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkPoolFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkPoolFilter"
                     }
                 },
                 "type": "object",
@@ -12977,39 +12635,19 @@
             "Body_count_latest_artifacts_artifacts_latest_count_post": {
                 "properties": {
                     "artifacts": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ArtifactCollectionFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/ArtifactCollectionFilter"
                     },
                     "flow_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowRunFilter"
                     },
                     "task_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TaskRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/TaskRunFilter"
                     },
                     "flows": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowFilter"
                     },
                     "deployments": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/DeploymentFilter"
                     }
                 },
                 "type": "object",
@@ -13036,32 +12674,16 @@
             "Body_count_task_runs_task_runs_count_post": {
                 "properties": {
                     "flows": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowFilter"
                     },
                     "flow_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowRunFilter"
                     },
                     "task_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TaskRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/TaskRunFilter"
                     },
                     "deployments": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/DeploymentFilter"
                     }
                 },
                 "type": "object",
@@ -13230,46 +12852,22 @@
                         "description": "The size of each history interval, in seconds. Must be at least 1 second."
                     },
                     "flows": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowFilter"
                     },
                     "flow_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowRunFilter"
                     },
                     "task_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TaskRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/TaskRunFilter"
                     },
                     "deployments": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/DeploymentFilter"
                     },
                     "work_pools": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkPoolFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkPoolFilter"
                     },
                     "work_queues": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkQueueFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkQueueFilter"
                     }
                 },
                 "type": "object",
@@ -13391,53 +12989,25 @@
                         "default": 1
                     },
                     "flows": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowFilter"
                     },
                     "flow_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowRunFilter"
                     },
                     "task_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TaskRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/TaskRunFilter"
                     },
                     "deployments": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/DeploymentFilter"
                     },
                     "work_pools": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkPoolFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkPoolFilter"
                     },
                     "work_pool_queues": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkQueueFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkQueueFilter"
                     },
                     "sort": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentSort"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/DeploymentSort",
                         "default": "NAME_ASC"
                     },
                     "limit": {
@@ -13452,11 +13022,7 @@
             "Body_paginate_flow_runs_flow_runs_paginate_post": {
                 "properties": {
                     "sort": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunSort"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/FlowRunSort",
                         "default": "ID_DESC"
                     },
                     "page": {
@@ -13593,11 +13159,7 @@
                         ]
                     },
                     "sort": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowSort"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/FlowSort",
                         "default": "NAME_ASC"
                     },
                     "limit": {
@@ -13629,11 +13191,7 @@
             "Body_read_artifacts_artifacts_filter_post": {
                 "properties": {
                     "sort": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ArtifactSort"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/ArtifactSort",
                         "default": "ID_DESC"
                     },
                     "offset": {
@@ -13643,39 +13201,19 @@
                         "default": 0
                     },
                     "artifacts": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ArtifactFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/ArtifactFilter"
                     },
                     "flow_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowRunFilter"
                     },
                     "task_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TaskRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/TaskRunFilter"
                     },
                     "flows": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowFilter"
                     },
                     "deployments": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/DeploymentFilter"
                     },
                     "limit": {
                         "type": "integer",
@@ -13689,11 +13227,7 @@
             "Body_read_automations_automations_filter_post": {
                 "properties": {
                     "sort": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/AutomationSort"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/AutomationSort",
                         "default": "NAME_ASC"
                     },
                     "offset": {
@@ -13937,53 +13471,25 @@
                         "default": 0
                     },
                     "flows": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowFilter"
                     },
                     "flow_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowRunFilter"
                     },
                     "task_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TaskRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/TaskRunFilter"
                     },
                     "deployments": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/DeploymentFilter"
                     },
                     "work_pools": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkPoolFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkPoolFilter"
                     },
                     "work_pool_queues": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkQueueFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkQueueFilter"
                     },
                     "sort": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentSort"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/DeploymentSort",
                         "default": "NAME_ASC"
                     },
                     "limit": {
@@ -14023,11 +13529,7 @@
             "Body_read_flow_run_history_ui_flow_runs_history_post": {
                 "properties": {
                     "sort": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunSort"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/FlowRunSort",
                         "default": "EXPECTED_START_TIME_DESC"
                     },
                     "limit": {
@@ -14043,39 +13545,19 @@
                         "default": 0
                     },
                     "flows": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowFilter"
                     },
                     "flow_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowRunFilter"
                     },
                     "task_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TaskRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/TaskRunFilter"
                     },
                     "deployments": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/DeploymentFilter"
                     },
                     "work_pools": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkPoolFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkPoolFilter"
                     }
                 },
                 "type": "object",
@@ -14084,11 +13566,7 @@
             "Body_read_flow_run_notification_policies_flow_run_notification_policies_filter_post": {
                 "properties": {
                     "flow_run_notification_policy_filter": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunNotificationPolicyFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowRunNotificationPolicyFilter"
                     },
                     "offset": {
                         "type": "integer",
@@ -14108,11 +13586,7 @@
             "Body_read_flow_runs_flow_runs_filter_post": {
                 "properties": {
                     "sort": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunSort"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/FlowRunSort",
                         "default": "ID_DESC"
                     },
                     "offset": {
@@ -14199,46 +13673,22 @@
                         "default": 0
                     },
                     "flows": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowFilter"
                     },
                     "flow_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowRunFilter"
                     },
                     "task_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TaskRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/TaskRunFilter"
                     },
                     "deployments": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/DeploymentFilter"
                     },
                     "work_pools": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkPoolFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkPoolFilter"
                     },
                     "sort": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowSort"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/FlowSort",
                         "default": "NAME_ASC"
                     },
                     "limit": {
@@ -14253,11 +13703,7 @@
             "Body_read_latest_artifacts_artifacts_latest_filter_post": {
                 "properties": {
                     "sort": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ArtifactCollectionSort"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/ArtifactCollectionSort",
                         "default": "ID_DESC"
                     },
                     "offset": {
@@ -14267,39 +13713,19 @@
                         "default": 0
                     },
                     "artifacts": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ArtifactCollectionFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/ArtifactCollectionFilter"
                     },
                     "flow_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowRunFilter"
                     },
                     "task_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TaskRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/TaskRunFilter"
                     },
                     "flows": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowFilter"
                     },
                     "deployments": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/DeploymentFilter"
                     },
                     "limit": {
                         "type": "integer",
@@ -14319,18 +13745,10 @@
                         "default": 0
                     },
                     "logs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LogFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/LogFilter"
                     },
                     "sort": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LogSort"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/LogSort",
                         "default": "TIMESTAMP_ASC"
                     },
                     "limit": {
@@ -14408,11 +13826,7 @@
             "Body_read_task_runs_task_runs_filter_post": {
                 "properties": {
                     "sort": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TaskRunSort"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/TaskRunSort",
                         "default": "ID_DESC"
                     },
                     "offset": {
@@ -14506,11 +13920,7 @@
                         ]
                     },
                     "sort": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/VariableSort"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/VariableSort",
                         "default": "NAME_ASC"
                     },
                     "limit": {
@@ -14582,11 +13992,7 @@
             "Body_read_work_queues_work_pools__work_pool_name__queues_filter_post": {
                 "properties": {
                     "work_queues": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkQueueFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkQueueFilter"
                     },
                     "offset": {
                         "type": "integer",
@@ -14612,11 +14018,7 @@
                         "default": 0
                     },
                     "work_queues": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkQueueFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkQueueFilter"
                     },
                     "limit": {
                         "type": "integer",
@@ -14630,11 +14032,7 @@
             "Body_read_workers_work_pools__work_pool_name__workers_filter_post": {
                 "properties": {
                     "workers": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkerFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/WorkerFilter"
                     },
                     "offset": {
                         "type": "integer",
@@ -14727,11 +14125,7 @@
             "Body_set_flow_run_state_flow_runs__id__set_state_post": {
                 "properties": {
                     "state": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/StateCreate"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/StateCreate",
                         "description": "The intended state."
                     },
                     "force": {
@@ -14750,11 +14144,7 @@
             "Body_set_task_run_state_task_runs__id__set_state_post": {
                 "properties": {
                     "state": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/StateCreate"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/StateCreate",
                         "description": "The intended state."
                     },
                     "force": {
@@ -14791,32 +14181,16 @@
                         "description": "The size of each history interval, in seconds. Must be at least 1 second."
                     },
                     "flows": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowFilter"
                     },
                     "flow_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/FlowRunFilter"
                     },
                     "task_runs": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TaskRunFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/TaskRunFilter"
                     },
                     "deployments": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeploymentFilter"
-                            }
-                        ]
+                        "$ref": "#/components/schemas/DeploymentFilter"
                     }
                 },
                 "type": "object",
@@ -14942,11 +14316,7 @@
                         "description": "The name of the state to change the flow run to"
                     },
                     "state": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/StateType"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/StateType",
                         "description": "The type of the state to change the flow run to"
                     },
                     "message": {
@@ -15927,11 +15297,7 @@
             "DeploymentFilter": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -16153,11 +15519,7 @@
             "DeploymentFilterTags": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -16283,11 +15645,7 @@
                         "title": "Infrastructure Document Id"
                     },
                     "empirical_policy": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunPolicy"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/FlowRunPolicy",
                         "description": "The empirical policy for the flow run."
                     },
                     "tags": {
@@ -17175,11 +16533,7 @@
                         "description": "The name of the event that happened"
                     },
                     "resource": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Resource"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Resource",
                         "description": "The primary Resource this event concerns"
                     },
                     "related": {
@@ -17317,11 +16671,7 @@
             "EventFilter": {
                 "properties": {
                     "occurred": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/EventOccurredFilter"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/EventOccurredFilter",
                         "description": "Filter criteria for when the events occurred"
                     },
                     "event": {
@@ -17369,19 +16719,11 @@
                         "description": "Filter criteria for the related resources of the event"
                     },
                     "id": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/EventIDFilter"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/EventIDFilter",
                         "description": "Filter criteria for the events' ID"
                     },
                     "order": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/EventOrder"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/EventOrder",
                         "description": "The order to return filtered events",
                         "default": "DESC"
                     }
@@ -17691,19 +17033,11 @@
                         "description": "The unique ID of this trigger"
                     },
                     "match": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ResourceSpecification"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/ResourceSpecification",
                         "description": "Labels for resources which this trigger will match."
                     },
                     "match_related": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ResourceSpecification"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/ResourceSpecification",
                         "description": "Labels for related resources which this trigger will match."
                     },
                     "after": {
@@ -17861,11 +17195,7 @@
             "FlowFilter": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -17922,11 +17252,7 @@
             "FlowFilterDeployment": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -18019,11 +17345,7 @@
             "FlowFilterTags": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -18530,11 +17852,7 @@
                         "title": "Infrastructure Document Id"
                     },
                     "empirical_policy": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/FlowRunPolicy"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/FlowRunPolicy",
                         "description": "The empirical policy for the flow run."
                     },
                     "tags": {
@@ -18589,11 +17907,7 @@
             "FlowRunFilter": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -18749,11 +18063,7 @@
             "FlowRunFilterDeploymentId": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -19007,11 +18317,7 @@
             "FlowRunFilterParentFlowRunId": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -19040,11 +18346,7 @@
             "FlowRunFilterParentTaskRunId": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -19131,11 +18433,7 @@
             "FlowRunFilterState": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -19246,11 +18544,7 @@
             "FlowRunFilterTags": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -19296,11 +18590,7 @@
             "FlowRunFilterWorkQueueName": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -20536,11 +19826,7 @@
             "HistoryResponseState": {
                 "properties": {
                     "state_type": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/StateType"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/StateType",
                         "description": "The state type."
                     },
                     "state_name": {
@@ -20763,11 +20049,7 @@
             "LogFilter": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -21383,11 +20665,7 @@
                         "description": "The name of the event that happened"
                     },
                     "resource": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Resource"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Resource",
                         "description": "The primary Resource this event concerns"
                     },
                     "related": {
@@ -22886,11 +22164,7 @@
                         "description": "The flow run id."
                     },
                     "state_type": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/StateType"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/StateType",
                         "description": "The state type."
                     },
                     "timestamp": {
@@ -22945,11 +22219,7 @@
                         "description": "The state name."
                     },
                     "state_type": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/StateType"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/StateType",
                         "description": "The state type."
                     },
                     "next_scheduled_start_time": {
@@ -23080,11 +22350,7 @@
             "StateCreate": {
                 "properties": {
                     "type": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/StateType"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/StateType",
                         "description": "The type of the state to create"
                     },
                     "name": {
@@ -23122,11 +22388,7 @@
                         "description": "The data of the state to create"
                     },
                     "state_details": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/StateDetails"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/StateDetails",
                         "description": "The details of the state to create"
                     }
                 },
@@ -23840,11 +23102,7 @@
             "TaskRunFilter": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -23979,11 +23237,7 @@
             "TaskRunFilterFlowRunId": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -24139,11 +23393,7 @@
             "TaskRunFilterState": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -24244,11 +23494,7 @@
             "TaskRunFilterTags": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -24699,11 +23945,7 @@
             "VariableFilter": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -24811,11 +24053,7 @@
             "VariableFilterTags": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -25118,11 +24356,7 @@
             "WorkPoolFilter": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -25497,11 +24731,7 @@
             "WorkQueueFilter": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -25820,11 +25050,7 @@
                         "description": "The last time an agent polled this queue for work."
                     },
                     "health_check_policy": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkQueueHealthPolicy"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/WorkQueueHealthPolicy",
                         "description": "The policy used to determine whether or not the work queue is healthy."
                     }
                 },
@@ -25922,11 +25148,7 @@
             "WorkerFilter": {
                 "properties": {
                     "operator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/Operator",
                         "description": "Operator for combining filter criteria. Defaults to 'and_'.",
                         "default": "and_"
                     },
@@ -26115,11 +25337,7 @@
                         "description": "The number of seconds to expect between heartbeats sent by the worker."
                     },
                     "status": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/WorkerStatus"
-                            }
-                        ],
+                        "$ref": "#/components/schemas/WorkerStatus",
                         "description": "Current status of the worker.",
                         "default": "OFFLINE"
                     }

--- a/docs/3.0/develop/variables.mdx
+++ b/docs/3.0/develop/variables.mdx
@@ -87,8 +87,8 @@ You can use `overwrite=True` to update the value of an existing variable.
 <Warning>
 **Contextual Behavior**
 
-In a sync context (like an `if __name__ == "__main__"` block or simple `def` scope), these methods are used synchronously.
-In an async context (like an `async def` scope), they are used asynchronously.
+In a sync context (such as an `if __name__ == "__main__"` block or simple `def` scope), these methods are used synchronously.
+In an async context (such as an `async def` scope), they are used asynchronously.
 </Warning>
 
 <CodeGroup>

--- a/docs/3.0/develop/variables.mdx
+++ b/docs/3.0/develop/variables.mdx
@@ -75,10 +75,14 @@ assert Variable.set("answer", 42) == Variable(name="answer", value=42, tags=[])
 
 assert Variable.get("answer") == 42
 
+assert Variable.set("answer", 9001, overwrite=True) == Variable(name="answer", value=9001, tags=[])
+
 assert Variable.unset("answer") is True
 
 assert Variable.get("answer", "fallback") == "fallback"
 ```
+
+You can use `overwrite=True` to update the value of an existing variable.
 
 <Warning>
 **Contextual Behavior**

--- a/docs/3.0/develop/variables.mdx
+++ b/docs/3.0/develop/variables.mdx
@@ -68,74 +68,79 @@ In addition to the UI and API, you can reference variables in code and in certai
 
 You can interact with variables through the Python SDK using the `get`, `set`, and `unset` methods. 
 
+```python
+from prefect.variables import Variable
+
+assert Variable.set("answer", 42) == Variable(name="answer", value=42, tags=[])
+
+assert Variable.get("answer") == 42
+
+assert Variable.unset("answer") is True
+
+assert Variable.get("answer", "fallback") == "fallback"
+```
+
 <Warning>
 **Contextual Behavior**
 
-In a sync context (like an `if __name__ == "__main__"` block or simple `def` scope), these methods are synchronous.
-In an async context (like an `async def` scope or ipython), they are are asynchronous.
+In a sync context (like an `if __name__ == "__main__"` block or simple `def` scope), these methods are used synchronously.
+In an async context (like an `async def` scope), they are used asynchronously.
 </Warning>
 
 <CodeGroup>
 ```python Synchronous
+
 from prefect import flow
 from prefect.variables import Variable
 
-@flow
-def my_sync_flow():
-    # set a variable
-    answer = Variable.set(name="the_answer", value="42")
-    print(answer) # 42
-    
-    # get a variable
-    answer = Variable.get("the_answer")
-    print(answer) # 42
-    
-    # overwrite an existing variable
-    answer = Variable.set(name="the_answer", value="43", overwrite=True)
-    print(answer) # 43
-    
-    # unset a variable
-    Variable.unset("the_answer")
-    
-    # get a variable that doesn't exist
-    answer = Variable.get("not_the_answer")
-    print(answer) # None
-    
-    # get a variable that doesn't exist with a default
-    answer = Variable.get("not_the_answer", default="42")
-    print(answer) # 42
+@flow(log_prints=True)
+def space_mission_sync():
+    # retrieve native python values from variables
+    mission = Variable.get("mission")
+    crew = Variable.get("crew_members")
+
+    for member in crew:
+        print(f"Meet {member}!")
+
+    budget = Variable.get("budget", default=100)
+    per_member_budget = budget / len(crew)
+    print(f"Budget: ${budget} billion")
+    print(f"Budget per member: ${per_member_budget:.2f} billion")
+
+if __name__ == "__main__":
+    Variable.set("mission", "Mars Expedition")
+    Variable.set("crew_members", ["Zaphod", "Arthur", "Trillian"])
+    Variable.set("budget", 100_000_000)
+
+    space_mission_sync()
 ```
 
 ```python Asynchronous
+import asyncio
 from prefect import flow
 from prefect.variables import Variable
 
-@flow
-async def my_async_flow():
-    # set a variable
-    answer = await Variable.set(name="the_answer", value="42")
-    print(answer) # 42
-    
-    # get a variable
-    answer = await Variable.get("the_answer")
-    print(answer) # 42
-    
-    # overwrite an existing variable
-    answer = await Variable.set(name="the_answer", value="43", overwrite=True)
-    print(answer) # 43
-    
-    # unset a variable
-    await Variable.unset("the_answer")
-    
-    # get a variable that doesn't exist
-    answer = await Variable.get("not_the_answer")
-    print(answer) # None
-    
-    # get a variable that doesn't exist with a default
-    answer = await Variable.get("not_the_answer", default="42")
-    print(answer) # 42
-```
+@flow(log_prints=True)
+async def space_mission_async():
+    # retrieve native python values from variables
+    mission = await Variable.get("mission")
+    crew = await Variable.get("crew_members")
 
+    for member in crew:
+        print(f"Meet {member}!")
+
+    budget = await Variable.get("budget", default=100)
+    per_member_budget = budget / len(crew)
+    print(f"Budget: ${budget} billion")
+    print(f"Budget per member: ${per_member_budget:.2f} billion")
+
+if __name__ == "__main__":
+    Variable.set("mission", "Mars Expedition")
+    Variable.set("crew_members", ["Zaphod", "Arthur", "Trillian"])
+    Variable.set("budget", 100_000_000)
+
+    asyncio.run(space_mission_async())
+```
 </CodeGroup>
 
 ### In `prefect.yaml` deployment steps

--- a/docs/3.0/develop/variables.mdx
+++ b/docs/3.0/develop/variables.mdx
@@ -59,7 +59,7 @@ See the [REST reference](https://app.prefect.cloud/api/docs#tag/Variables) for m
 - `prefect variable unset` deletes a variable.
 - `prefect variable ls` lists all variables.
 - `prefect variable inspect` shows a variable's details.
-- 
+
 ## Access variables
 
 In addition to the UI and API, you can reference variables in code and in certain Prefect configuration files.

--- a/docs/3.0/develop/variables.mdx
+++ b/docs/3.0/develop/variables.mdx
@@ -98,25 +98,13 @@ from prefect import flow
 from prefect.variables import Variable
 
 @flow(log_prints=True)
-def space_mission_sync():
-    # retrieve native python values from variables
-    mission = Variable.get("mission")
-    crew = Variable.get("crew_members")
-
-    for member in crew:
-        print(f"Meet {member}!")
-
-    budget = Variable.get("budget", default=100)
-    per_member_budget = budget / len(crew)
-    print(f"Budget: ${budget} billion")
-    print(f"Budget per member: ${per_member_budget:.2f} billion")
+def space_mission_sync(mission_name: str):
+    crew = Variable.get("crew_members", default=["Backup1", "Backup2"])
+    print(f"Launching {mission_name} with crew: {', '.join(crew)}")
 
 if __name__ == "__main__":
-    Variable.set("mission", "Mars Expedition")
     Variable.set("crew_members", ["Zaphod", "Arthur", "Trillian"])
-    Variable.set("budget", 100_000_000)
-
-    space_mission_sync()
+    space_mission_sync("Mars Expedition")
 ```
 
 ```python Asynchronous
@@ -125,25 +113,13 @@ from prefect import flow
 from prefect.variables import Variable
 
 @flow(log_prints=True)
-async def space_mission_async():
-    # retrieve native python values from variables
-    mission = await Variable.get("mission")
-    crew = await Variable.get("crew_members")
-
-    for member in crew:
-        print(f"Meet {member}!")
-
-    budget = await Variable.get("budget", default=100)
-    per_member_budget = budget / len(crew)
-    print(f"Budget: ${budget} billion")
-    print(f"Budget per member: ${per_member_budget:.2f} billion")
+async def space_mission_async(mission_name: str):
+    crew = await Variable.get("crew_members", default=["Backup1", "Backup2"])
+    print(f"Launching {mission_name} with crew: {', '.join(crew)}")
 
 if __name__ == "__main__":
-    Variable.set("mission", "Mars Expedition")
     Variable.set("crew_members", ["Zaphod", "Arthur", "Trillian"])
-    Variable.set("budget", 100_000_000)
-
-    asyncio.run(space_mission_async())
+    asyncio.run(space_mission_async("Mars Expedition"))
 ```
 </CodeGroup>
 

--- a/docs/3.0/develop/variables.mdx
+++ b/docs/3.0/develop/variables.mdx
@@ -68,44 +68,15 @@ In addition to the UI and API, you can reference variables in code and in certai
 
 You can interact with variables through the Python SDK using the `get`, `set`, and `unset` methods. 
 
-Outside of a `flow` or `task`, these methods are always invoked asynchronously.
+<Warning>
+**Contextual Behavior**
 
-#### In an asynchronous context
-```python
-from prefect import flow
-from prefect.variables import Variable
+In a sync context (like an `if __name__ == "__main__"` block or simple `def` scope), these methods are synchronous.
+In an async context (like an `async def` scope or ipython), they are are asynchronous.
+</Warning>
 
-@flow
-async def my_async_flow():
-    # set a variable
-    answer = await Variable.set(name="the_answer", value="42")
-    print(answer) # 42
-    
-    # get a variable
-    answer = await Variable.get("the_answer")
-    print(answer) # 42
-    
-    # overwrite an existing variable
-    answer = await Variable.set(name="the_answer", value="43", overwrite=True)
-    print(answer) # 43
-    
-    # unset a variable
-    await Variable.unset("the_answer")
-    
-    # get a variable that doesn't exist
-    answer = await Variable.get("not_the_answer")
-    print(answer) # None
-    
-    # get a variable that doesn't exist with a default
-    answer = await Variable.get("not_the_answer", default="42")
-    print(answer) # 42
-```
-
-While inside a `flow` or `task`, variables should be invoked synchronously or asynchronously 
-depending on whether the current context is synchronous or asynchronous.
-
-#### In a synchronous context
-```python
+<CodeGroup>
+```python Synchronous
 from prefect import flow
 from prefect.variables import Variable
 
@@ -135,10 +106,46 @@ def my_sync_flow():
     print(answer) # 42
 ```
 
+```python Asynchronous
+from prefect import flow
+from prefect.variables import Variable
+
+@flow
+async def my_async_flow():
+    # set a variable
+    answer = await Variable.set(name="the_answer", value="42")
+    print(answer) # 42
+    
+    # get a variable
+    answer = await Variable.get("the_answer")
+    print(answer) # 42
+    
+    # overwrite an existing variable
+    answer = await Variable.set(name="the_answer", value="43", overwrite=True)
+    print(answer) # 43
+    
+    # unset a variable
+    await Variable.unset("the_answer")
+    
+    # get a variable that doesn't exist
+    answer = await Variable.get("not_the_answer")
+    print(answer) # None
+    
+    # get a variable that doesn't exist with a default
+    answer = await Variable.get("not_the_answer", default="42")
+    print(answer) # 42
+```
+
+</CodeGroup>
+
 ### In `prefect.yaml` deployment steps
 
-In `.yaml` files, variables are denoted by quotes and double curly brackets, such as: 
-`"{{ prefect.variables.my_variable }}"`. Use variables to templatize deployment steps by 
+In `.yaml` files, variables are expressed as strings wrapped in quotes and double curly brackets: 
+```
+"{{ prefect.variables.my_variable }}"
+```
+
+Use variables to templatize deployment steps by 
 referencing them in the `prefect.yaml` file that creates the deployments.
 
 For example, you can pass in a variable to specify a branch for a git repo in a deployment `pull` step:


### PR DESCRIPTION
adds note that `overwrite` exists as a kwarg in the SDK

also updates language on sync/async, because `Variable` methods are `sync_compatible` so how they're called is [dually contextual](https://github.com/PrefectHQ/prefect/pull/15233#discussion_r1744814829) but from a user perspective has nothing to do with a run context. the current docs make some incorrect statements that further confuse that status quo. `def` vs `async def` seems like the most direct way to convey this behavior

<details>
<summary>for example</summary>

```python
In [1]: from prefect import flow, task

In [2]: from prefect.variables import Variable

In [3]: @task
   ...: def t():
   ...:     print(Variable.get('answer'))
   ...:
   ...: @task
   ...: async def at():
   ...:     print(await Variable.get('answer'))
   ...:
   ...: @flow
   ...: def f():
   ...:     print(Variable.get('answer'))
   ...:
   ...: @flow
   ...: async def af():
   ...:     print(await Variable.get('answer'))
   ...:

In [4]: t(), await at(), f(), await af()
01:00:16.858 | INFO    | Task run 't' - Created task run 't' for task 't'
9001
01:00:17.142 | INFO    | Task run 't' - Finished in state Completed()
01:00:17.150 | INFO    | Task run 'at' - Created task run 'at' for task 'at'
9001
01:00:17.456 | INFO    | Task run 'at' - Finished in state Completed()
01:00:17.812 | INFO    | prefect.engine - Created flow run 'benign-skua' for flow 'f'
01:00:17.814 | INFO    | prefect.engine - View at https://app.prefect.cloud/account/12242a57-9f05-4bf5-8853-9bff595d4bab/workspace/bedd4e29-9dbf-4a31-a377-114eb13d5ab7/runs/flow-run/1dd2cbda-e72c-4047-8315-30fa5944a0b9
9001
01:00:18.483 | INFO    | Flow run 'benign-skua' - Finished in state Completed()
01:00:18.814 | INFO    | prefect.engine - Created flow run 'hairy-narwhal' for flow 'af'
01:00:18.815 | INFO    | prefect.engine - View at https://app.prefect.cloud/account/12242a57-9f05-4bf5-8853-9bff595d4bab/workspace/bedd4e29-9dbf-4a31-a377-114eb13d5ab7/runs/flow-run/6718a3b5-03ac-4b9d-9e85-3427e1e02fd0
9001
01:00:19.583 | INFO    | Flow run 'hairy-narwhal' - Finished in state Completed()
Out[4]: (None, None, None, None)
```
</details>

this PR also updates the example to use `CodeGroup` since the example code is not different besides sync/async and its easier to spot the differences with the tabs anyways imo