### PR TITLE
Fix three broken image links

### DIFF
--- a/docs/integrations/prefect-aws/ecs_guide.mdx
+++ b/docs/integrations/prefect-aws/ecs_guide.mdx
@@ -113,7 +113,7 @@ prefect work-pool create --type ecs my-ecs-pool
 ```
 
 Or from the Prefect UI:
-![WorkPool](images/Workpool_UI.png)
+![WorkPool](/images/Workpool_UI.png)
 
 Because this guide uses Fargate as the capacity provider and the default VPC and ECS cluster, no further configuration is needed.
 

--- a/docs/integrations/prefect-gcp/gcp-worker-guide.mdx
+++ b/docs/integrations/prefect-gcp/gcp-worker-guide.mdx
@@ -94,11 +94,11 @@ There are many ways to customize the base job template for the work pool. Modify
 
 Specify the region for the cloud run job.
 
-![region](images/cloud-run-work-pool-region.png)
+![region](/images/cloud-run-work-pool-region.png)
 
 Save the name of the service account created in first step of this guide.
 
-![name](images/cloud-run-work-pool-service-account-name.png)
+![name](/images/cloud-run-work-pool-service-account-name.png)
 
 Your work pool is now ready to receive scheduled flow runs!
 


### PR DESCRIPTION
A relative link in the docs needs a `/` at the start of it. 

Broken image links aren't caught by Mintlify's broken-link checker and the images render ok in local dev.

Checked all docs image links in the `img` and `images` folders.

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
