### PR TITLE
Add debug logging for server side event handling

### DIFF
--- a/src/prefect/server/events/messaging.py
+++ b/src/prefect/server/events/messaging.py
@@ -49,6 +49,13 @@ class EventPublisher(Publisher):
                 },
             )
             return
+
+        logger.debug(
+            "Publishing event: %s with id: %s for resource: %s",
+            event.event,
+            event.id,
+            event.resource.get("prefect.resource.id"),
+        )
         await self.publish_data(
             encoded,
             {

--- a/src/prefect/server/events/services/event_persister.py
+++ b/src/prefect/server/events/services/event_persister.py
@@ -149,6 +149,14 @@ async def create_handler(
             return
 
         event = ReceivedEvent.model_validate_json(message.data)
+
+        logger.debug(
+            "Received event: %s with id: %s for resource: %s",
+            event.event,
+            event.id,
+            event.resource.get("prefect.resource.id"),
+        )
+
         await queue.put(event)
 
         if queue.qsize() >= batch_size:

--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -162,7 +162,7 @@ async def record_task_run_event(event: ReceivedEvent, depth: int = 0):
             session, task_run, denormalized_state_attributes
         )
 
-    logger.info(
+    logger.debug(
         "Recorded task run state change",
         extra={
             "task_run_id": task_run.id,
@@ -219,8 +219,11 @@ async def consumer(
         if not event.resource.get("prefect.orchestration") == "client":
             return
 
-        logger.info(
-            f"Received event: {event.event} with id: {event.id} for resource: {event.resource.get('prefect.resource.id')}"
+        logger.debug(
+            "Received event: %s with id: %s for resource: %s",
+            event.event,
+            event.id,
+            event.resource.get("prefect.resource.id"),
         )
 
         try:

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -167,7 +167,7 @@ async def test_handle_client_orchestrated_task_run_event(
     client_orchestrated_task_run_event: ReceivedEvent,
     caplog: pytest.LogCaptureFixture,
 ):
-    with caplog.at_level("INFO"):
+    with caplog.at_level("DEBUG"):
         await task_run_recorder_handler(message(client_orchestrated_task_run_event))
 
     assert "Recorded task run state change" in caplog.text
@@ -179,7 +179,7 @@ async def test_skip_non_task_run_event(
     hello_event: ReceivedEvent,
     caplog: pytest.LogCaptureFixture,
 ):
-    with caplog.at_level("INFO"):
+    with caplog.at_level("DEBUG"):
         await task_run_recorder_handler(message(hello_event))
 
     assert "Received event" not in caplog.text


### PR DESCRIPTION
This PR adds some extra debug level logging on:
- when we publish an event
- when the `events-persister` receives an event
- when the `task-run-recorder` receives an event

This should give us the full picture of tracking an event from client side emit through persistence.

Related to ongoing investigations in https://github.com/PrefectHQ/prefect/issues/15153