### PR TITLE
Fix test flake and add `uv` dev dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
       - id: generate-mintlify-openapi-docs
         name: Generating OpenAPI docs for Mintlify
         language: system
-        entry: ./scripts/generate_mintlify_openapi_docs.py
+        entry: uv run --with 'pydantic>=2.9.0' ./scripts/generate_mintlify_openapi_docs.py
         pass_filenames: false
         files: |
           (?x)^(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,6 +21,7 @@ pytest-xdist >= 3.6.1
 pyyaml
 redis>=5.0.1
 setuptools
+uv>=0.4.5
 vale
 vermin
 virtualenv

--- a/tests/records/test_filesystem.py
+++ b/tests/records/test_filesystem.py
@@ -53,23 +53,12 @@ class TestFileSystemRecordStore:
 
     async def test_read_locked_key(self, store, result):
         key = str(uuid4())
-
-        process = multiprocessing.Process(
-            target=read_locked_key,
-            args=(
-                key,
-                store,
-                (read_queue := multiprocessing.Queue()),
-            ),
-            daemon=True,
-        )
         assert store.acquire_lock(key, holder="holder1")
-        process.start()
+        assert store.read(key, holder="holder2", timeout=0) is None
         store.write(key, result=result, holder="holder1")
+        assert store.read(key, holder="holder2", timeout=1) is None
         store.release_lock(key, holder="holder1")
-        # the read should have been blocked until the lock was released
-        assert read_queue.get(timeout=10) == result
-        process.join(timeout=1)
+        assert store.read(key, holder="holder2")
 
     async def test_write_to_key_with_same_lock_holder(self, store, result):
         key = str(uuid4())


### PR DESCRIPTION
Closes #15077 

Additionally:
- adds `uv` as a dev dependency
- enforces `pydantic>=2.9.0` in generating openAPI schema to avoid noisy commits