### PR TITLE
check api compatibility when entering a client context

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -3352,8 +3352,8 @@ class PrefectClient:
 
         if api_version.major != client_version.major:
             raise RuntimeError(
-                f"Client version {client_version} is incompatible with api version {api_version}. "
-                f"Both client and api must be on the same major version."
+                f"Client version {client_version} is incompatible with API version {api_version}. "
+                f"Both client and API must be on the same major version."
             )
 
     async def __aenter__(self):
@@ -3671,8 +3671,8 @@ class SyncPrefectClient:
 
         if api_version.major != client_version.major:
             raise RuntimeError(
-                f"Client version {client_version} is incompatible with api version {api_version}. "
-                f"Both client and api must be on the same major version."
+                f"Client version {client_version} is incompatible with API version {api_version}. "
+                f"Both client and API must be on the same major version."
             )
 
     def create_flow(self, flow: "FlowObject") -> UUID:

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -3337,7 +3337,7 @@ class PrefectClient:
     def client_version(self) -> str:
         return prefect.__version__
 
-    async def api_compatible(self):
+    async def raise_for_api_version_mismatch(self):
         # Cloud is always compatible as a server
         if self.server_type == ServerType.CLOUD:
             return
@@ -3656,7 +3656,7 @@ class SyncPrefectClient:
     def client_version(self) -> str:
         return prefect.__version__
 
-    def api_compatible(self):
+    def raise_for_api_version_mismatch(self):
         # Cloud is always compatible as a server
         if self.server_type == ServerType.CLOUD:
             return

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -3352,8 +3352,8 @@ class PrefectClient:
 
         if api_version.major != client_version.major:
             raise RuntimeError(
-                f"Client version {client_version} is incompatible with API version {api_version}. "
-                f"Both client and API must be on the same major version."
+                f"Found incompatible versions: client: {client_version}, server: {api_version}. "
+                f"Major versions must match."
             )
 
     async def __aenter__(self):
@@ -3671,8 +3671,8 @@ class SyncPrefectClient:
 
         if api_version.major != client_version.major:
             raise RuntimeError(
-                f"Client version {client_version} is incompatible with API version {api_version}. "
-                f"Both client and API must be on the same major version."
+                f"Found incompatible versions: client: {client_version}, server: {api_version}. "
+                f"Major versions must match."
             )
 
     def create_flow(self, flow: "FlowObject") -> UUID:

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -210,6 +210,7 @@ class SyncClientContext(ContextModel):
         self._context_stack += 1
         if self._context_stack == 1:
             self.client.__enter__()
+            self.client.api_compatible()
             return super().__enter__()
         else:
             return self
@@ -267,6 +268,7 @@ class AsyncClientContext(ContextModel):
         self._context_stack += 1
         if self._context_stack == 1:
             await self.client.__aenter__()
+            await self.client.api_compatible()
             return super().__enter__()
         else:
             return self

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -210,7 +210,7 @@ class SyncClientContext(ContextModel):
         self._context_stack += 1
         if self._context_stack == 1:
             self.client.__enter__()
-            self.client.api_compatible()
+            self.client.raise_for_api_version_mismatch()
             return super().__enter__()
         else:
             return self
@@ -268,7 +268,7 @@ class AsyncClientContext(ContextModel):
         self._context_stack += 1
         if self._context_stack == 1:
             await self.client.__aenter__()
-            await self.client.api_compatible()
+            await self.client.raise_for_api_version_mismatch()
             return super().__enter__()
         else:
             return self

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -2607,7 +2607,7 @@ class TestPrefectClientAPICompatibility:
             await prefect_client.api_compatible()
 
         assert (
-            f"Client version {client_version} is incompatible with api version {api_version}"
+            f"Client version {client_version} is incompatible with API version {api_version}"
             in str(e.value)
         )
 
@@ -2674,6 +2674,6 @@ class TestSyncClientAPICompatible:
             sync_prefect_client.api_compatible()
 
         assert (
-            f"Client version {client_version} is incompatible with api version {api_version}"
+            f"Client version {client_version} is incompatible with API version {api_version}"
             in str(e.value)
         )

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -2607,7 +2607,7 @@ class TestPrefectClientAPICompatibility:
             await prefect_client.api_compatible()
 
         assert (
-            f"Client version {client_version} is incompatible with API version {api_version}"
+            f"Found incompatible versions: client: {client_version}, server: {api_version}. "
             in str(e.value)
         )
 
@@ -2674,6 +2674,6 @@ class TestSyncClientAPICompatible:
             sync_prefect_client.api_compatible()
 
         assert (
-            f"Client version {client_version} is incompatible with API version {api_version}"
+            f"Found incompatible versions: client: {client_version}, server: {api_version}. "
             in str(e.value)
         )

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -2563,11 +2563,11 @@ class TestPrefectClientCsrfSupport:
                 assert not prefect_client._client.enable_csrf_support
 
 
-class TestPrefectClientAPICompatibility:
-    async def test_api_compatible(self, prefect_client):
-        await prefect_client.api_compatible()
+class TestPrefectClientRaiseForAPIVersionMismatch:
+    async def test_raise_for_api_version_mismatch(self, prefect_client):
+        await prefect_client.raise_for_api_version_mismatch()
 
-    async def test_api_compatible_when_api_unreachable(
+    async def test_raise_for_api_version_mismatch_when_api_unreachable(
         self, prefect_client, monkeypatch
     ):
         async def something_went_wrong(*args, **kwargs):
@@ -2575,25 +2575,27 @@ class TestPrefectClientAPICompatibility:
 
         monkeypatch.setattr(prefect_client, "api_version", something_went_wrong)
         with pytest.raises(RuntimeError) as e:
-            await prefect_client.api_compatible()
+            await prefect_client.raise_for_api_version_mismatch()
 
         assert "Failed to reach API" in str(e.value)
 
-    async def test_api_compatible_against_cloud(self, prefect_client, monkeypatch):
+    async def test_raise_for_api_version_mismatch_against_cloud(
+        self, prefect_client, monkeypatch
+    ):
         # manually set the server type to cloud
         monkeypatch.setattr(prefect_client, "server_type", ServerType.CLOUD)
 
         api_version_mock = AsyncMock()
         monkeypatch.setattr(prefect_client, "api_version", api_version_mock)
 
-        await prefect_client.api_compatible()
+        await prefect_client.raise_for_api_version_mismatch()
 
         api_version_mock.assert_not_called()
 
     @pytest.mark.parametrize(
         "client_version, api_version", [("3.0.0", "2.0.0"), ("2.0.0", "3.0.0")]
     )
-    async def test_api_compatible_with_incompatible_versions(
+    async def test_raise_for_api_version_mismatch_with_incompatible_versions(
         self, prefect_client, monkeypatch, client_version, api_version
     ):
         monkeypatch.setattr(
@@ -2604,7 +2606,7 @@ class TestPrefectClientAPICompatibility:
         )
 
         with pytest.raises(RuntimeError) as e:
-            await prefect_client.api_compatible()
+            await prefect_client.raise_for_api_version_mismatch()
 
         assert (
             f"Found incompatible versions: client: {client_version}, server: {api_version}. "
@@ -2630,11 +2632,11 @@ class TestSyncClient:
         assert version == prefect.__version__
 
 
-class TestSyncClientAPICompatible:
-    def test_api_compatible(self, sync_prefect_client):
-        sync_prefect_client.api_compatible()
+class TestSyncClientRaiseForAPIVersionMismatch:
+    def test_raise_for_api_version_mismatch(self, sync_prefect_client):
+        sync_prefect_client.raise_for_api_version_mismatch()
 
-    def test_api_compatible_when_api_unreachable(
+    def test_raise_for_api_version_mismatch_when_api_unreachable(
         self, sync_prefect_client, monkeypatch
     ):
         def something_went_wrong(*args, **kwargs):
@@ -2642,25 +2644,27 @@ class TestSyncClientAPICompatible:
 
         monkeypatch.setattr(sync_prefect_client, "api_version", something_went_wrong)
         with pytest.raises(RuntimeError) as e:
-            sync_prefect_client.api_compatible()
+            sync_prefect_client.raise_for_api_version_mismatch()
 
         assert "Failed to reach API" in str(e.value)
 
-    def test_api_compatible_against_cloud(self, sync_prefect_client, monkeypatch):
+    def test_raise_for_api_version_mismatch_against_cloud(
+        self, sync_prefect_client, monkeypatch
+    ):
         # manually set the server type to cloud
         monkeypatch.setattr(sync_prefect_client, "server_type", ServerType.CLOUD)
 
         api_version_mock = Mock()
         monkeypatch.setattr(sync_prefect_client, "api_version", api_version_mock)
 
-        sync_prefect_client.api_compatible()
+        sync_prefect_client.raise_for_api_version_mismatch()
 
         api_version_mock.assert_not_called()
 
     @pytest.mark.parametrize(
         "client_version, api_version", [("3.0.0", "2.0.0"), ("2.0.0", "3.0.0")]
     )
-    def test_api_compatible_with_incompatible_versions(
+    def test_raise_for_api_version_mismatch_with_incompatible_versions(
         self, sync_prefect_client, monkeypatch, client_version, api_version
     ):
         monkeypatch.setattr(
@@ -2671,7 +2675,7 @@ class TestSyncClientAPICompatible:
         )
 
         with pytest.raises(RuntimeError) as e:
-            sync_prefect_client.api_compatible()
+            sync_prefect_client.raise_for_api_version_mismatch()
 
         assert (
             f"Found incompatible versions: client: {client_version}, server: {api_version}. "


### PR DESCRIPTION
When entering a `SyncClientContext` or `AsyncClientContext` for the first time, check if the client and server are compatible. 

This PR defines compatibility as both the client and server must be on the same major version. The goal of this pr is specifically to flag incompatibility between `2.x` and `3.x` clients and servers (in both directions). I'm very open to changing this in anyway that makes it more useful and future proof for the direction of the package.