### PR TITLE
add function name to `prefect-docker` cache key

### DIFF
--- a/src/integrations/prefect-docker/prefect_docker/deployments/steps.py
+++ b/src/integrations/prefect-docker/prefect_docker/deployments/steps.py
@@ -97,8 +97,9 @@ def cacheable(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         if ignore_cache := kwargs.pop("ignore_cache", False):
-            logger.debug("Ignoring `@cacheable` decorator for build_docker_image.")
+            logger.debug(f"Ignoring `@cacheable` decorator for {func.__name__}.")
         key = (
+            func.__name__,
             tuple(_make_hashable(arg) for arg in args),
             tuple((k, _make_hashable(v)) for k, v in sorted(kwargs.items())),
         )

--- a/src/integrations/prefect-docker/tests/deployments/test_steps.py
+++ b/src/integrations/prefect-docker/tests/deployments/test_steps.py
@@ -503,3 +503,22 @@ class TestCachedSteps:
         assert mock_docker_client.login.call_count == 3
         expected_push_calls = 1 + len(additional_tags)
         assert mock_docker_client.api.push.call_count == expected_push_calls * 3
+
+    def test_avoids_aggressive_caching(self, mock_docker_client):
+        image_name = "registry/repo"
+        tag = "latest"
+        credentials = {"username": "user", "password": "pass"}
+
+        build_docker_image(
+            image_name=image_name,
+            tag=tag,
+        )
+
+        # Push the image (this should not hit the cache)
+        push_docker_image(
+            image_name=image_name,
+            tag=tag,
+            credentials=credentials,
+        )
+
+        mock_docker_client.api.push.assert_called_once()


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/15258

will backport to 2.x