### PR TITLE
[2.x] add function name to `prefect-docker` cache key

### DIFF
--- a/src/integrations/prefect-docker/prefect_docker/deployments/steps.py
+++ b/src/integrations/prefect-docker/prefect_docker/deployments/steps.py
@@ -100,6 +100,7 @@ def cacheable(func):
         if ignore_cache := kwargs.pop("ignore_cache", False):
             logger.debug("Ignoring `@cacheable` decorator for build_docker_image.")
         key = (
+            func.__name__,
             tuple(_make_hashable(arg) for arg in args),
             tuple((k, _make_hashable(v)) for k, v in sorted(kwargs.items())),
         )

--- a/src/integrations/prefect-docker/tests/deployments/test_steps.py
+++ b/src/integrations/prefect-docker/tests/deployments/test_steps.py
@@ -505,7 +505,6 @@ class TestCachedSteps:
     def test_avoids_aggressive_caching(self, mock_docker_client):
         image_name = "registry/repo"
         tag = "latest"
-        credentials = {"username": "user", "password": "pass"}
 
         build_docker_image(
             image_name=image_name,
@@ -516,7 +515,7 @@ class TestCachedSteps:
         push_docker_image(
             image_name=image_name,
             tag=tag,
-            credentials=credentials,
         )
 
+        mock_docker_client.api.build.assert_called_once()
         mock_docker_client.api.push.assert_called_once()

--- a/src/integrations/prefect-docker/tests/deployments/test_steps.py
+++ b/src/integrations/prefect-docker/tests/deployments/test_steps.py
@@ -503,6 +503,13 @@ class TestCachedSteps:
         assert mock_docker_client.api.push.call_count == expected_push_calls * 3
 
     def test_avoids_aggressive_caching(self, mock_docker_client):
+        """this is a regression test for https://github.com/PrefectHQ/prefect/issues/15258
+        where all decorated functions were sharing a cache, so dict(image=..., tag=...) passed to
+        build_docker_image and push_docker_image would hit the cache for push_docker_image,
+        even though the function was different and should not have been cached.
+
+        here we test that the caches are distinct for each decorated function.
+        """
         image_name = "registry/repo"
         tag = "latest"
 

--- a/src/integrations/prefect-docker/tests/deployments/test_steps.py
+++ b/src/integrations/prefect-docker/tests/deployments/test_steps.py
@@ -501,3 +501,22 @@ class TestCachedSteps:
         assert mock_docker_client.login.call_count == 3
         expected_push_calls = 1 + len(additional_tags)
         assert mock_docker_client.api.push.call_count == expected_push_calls * 3
+
+    def test_avoids_aggressive_caching(self, mock_docker_client):
+        image_name = "registry/repo"
+        tag = "latest"
+        credentials = {"username": "user", "password": "pass"}
+
+        build_docker_image(
+            image_name=image_name,
+            tag=tag,
+        )
+
+        # Push the image (this should not hit the cache)
+        push_docker_image(
+            image_name=image_name,
+            tag=tag,
+            credentials=credentials,
+        )
+
+        mock_docker_client.api.push.assert_called_once()


### PR DESCRIPTION
related to #15258

backport of #15262 