### PR TITLE
Use `ResultStore` by default for task transactions

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2158,7 +2158,10 @@ class PrefectClient:
         try:
             response = await self._client.post(
                 f"/flow_runs/{flow_run_id}/set_state",
-                json=dict(state=state_create.model_dump(mode="json"), force=force),
+                json=dict(
+                    state=state_create.model_dump(mode="json", serialize_as_any=True),
+                    force=force,
+                ),
             )
         except httpx.HTTPStatusError as e:
             if e.response.status_code == status.HTTP_404_NOT_FOUND:
@@ -3934,7 +3937,10 @@ class SyncPrefectClient:
         try:
             response = self._client.post(
                 f"/flow_runs/{flow_run_id}/set_state",
-                json=dict(state=state_create.model_dump(mode="json"), force=force),
+                json=dict(
+                    state=state_create.model_dump(mode="json", serialize_as_any=True),
+                    force=force,
+                ),
             )
         except httpx.HTTPStatusError as e:
             if e.response.status_code == status.HTTP_404_NOT_FOUND:

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -292,10 +292,12 @@ class State(ObjectBaseModel, Generic[R]):
         results should be sent to the API. Other data is only available locally.
         """
         from prefect.client.schemas.actions import StateCreate
-        from prefect.results import BaseResult
+        from prefect.results import BaseResult, ResultRecord, should_persist_result
 
-        if isinstance(self.data, BaseResult) and self.data.serialize_to_none is False:
+        if isinstance(self.data, BaseResult):
             data = self.data
+        elif isinstance(self.data, ResultRecord) and should_persist_result():
+            data = self.data.metadata
         else:
             data = None
 

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -3,6 +3,7 @@ import warnings
 from functools import partial
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Dict,
     Generic,
@@ -17,10 +18,12 @@ import orjson
 import pendulum
 from pydantic import (
     ConfigDict,
+    Discriminator,
     Field,
     HttpUrl,
     IPvAnyNetwork,
     SerializationInfo,
+    Tag,
     field_validator,
     model_serializer,
     model_validator,
@@ -59,7 +62,7 @@ from prefect.utilities.names import generate_slug
 from prefect.utilities.pydantic import handle_secret_render
 
 if TYPE_CHECKING:
-    from prefect.results import BaseResult
+    from prefect.results import BaseResult, ResultRecordMetadata
 
 
 R = TypeVar("R", default=Any)
@@ -158,6 +161,14 @@ class StateDetails(PrefectBaseModel):
     task_parameters_id: Optional[UUID] = None
 
 
+def data_discriminator(x: Any) -> str:
+    if isinstance(x, dict) and "type" in x:
+        return "BaseResult"
+    elif isinstance(x, dict) and "storage_key" in x:
+        return "ResultRecordMetadata"
+    return "Any"
+
+
 class State(ObjectBaseModel, Generic[R]):
     """
     The state of a run.
@@ -168,9 +179,14 @@ class State(ObjectBaseModel, Generic[R]):
     timestamp: DateTime = Field(default_factory=lambda: pendulum.now("UTC"))
     message: Optional[str] = Field(default=None, examples=["Run started"])
     state_details: StateDetails = Field(default_factory=StateDetails)
-    data: Union["BaseResult[R]", Any] = Field(
-        default=None,
-    )
+    data: Annotated[
+        Union[
+            Annotated["BaseResult[R]", Tag("BaseResult")],
+            Annotated["ResultRecordMetadata", Tag("ResultRecordMetadata")],
+            Annotated[Any, Tag("Any")],
+        ],
+        Discriminator(data_discriminator),
+    ] = Field(default=None)
 
     @overload
     def result(self: "State[R]", raise_on_failure: bool = True) -> R:

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -40,7 +40,7 @@ from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_c
 from prefect.client.schemas import FlowRun, TaskRun
 from prefect.events.worker import EventsWorker
 from prefect.exceptions import MissingContextError
-from prefect.results import ResultStore
+from prefect.results import ResultStore, get_default_persist_setting
 from prefect.settings import PREFECT_HOME, Profile, Settings
 from prefect.states import State
 from prefect.task_runners import TaskRunner
@@ -343,6 +343,7 @@ class EngineContext(RunContext):
 
     # Result handling
     result_store: ResultStore
+    persist_result: bool = Field(default_factory=get_default_persist_setting)
 
     # Counter for task calls allowing unique
     task_run_dynamic_keys: Dict[str, int] = Field(default_factory=dict)
@@ -372,6 +373,7 @@ class EngineContext(RunContext):
                 "start_time",
                 "input_keyset",
                 "result_store",
+                "persist_result",
             },
             exclude_unset=True,
         )
@@ -397,6 +399,7 @@ class TaskRunContext(RunContext):
 
     # Result handling
     result_store: ResultStore
+    persist_result: bool = Field(default_factory=get_default_persist_setting)
 
     __var__ = ContextVar("task_run")
 
@@ -410,6 +413,7 @@ class TaskRunContext(RunContext):
                 "start_time",
                 "input_keyset",
                 "result_store",
+                "persist_result",
             },
             exclude_unset=True,
         )

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -50,7 +50,7 @@ from prefect.logging.loggers import (
 from prefect.results import (
     BaseResult,
     ResultStore,
-    get_current_result_store,
+    get_result_store,
     should_persist_result,
 )
 from prefect.settings import PREFECT_DEBUG_MODE
@@ -207,7 +207,7 @@ class FlowRunEngine(Generic[P, R]):
                 self.handle_exception(
                     exc,
                     msg=message,
-                    result_store=get_current_result_store().update_for_flow(
+                    result_store=get_result_store().update_for_flow(
                         self.flow, _sync=True
                     ),
                 )
@@ -512,7 +512,7 @@ class FlowRunEngine(Generic[P, R]):
                     flow_run=self.flow_run,
                     parameters=self.parameters,
                     client=client,
-                    result_store=get_current_result_store().update_for_flow(
+                    result_store=get_result_store().update_for_flow(
                         self.flow, _sync=True
                     ),
                     task_runner=task_runner,

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -47,7 +47,12 @@ from prefect.logging.loggers import (
     get_run_logger,
     patch_print,
 )
-from prefect.results import BaseResult, ResultStore, get_current_result_store
+from prefect.results import (
+    BaseResult,
+    ResultStore,
+    get_current_result_store,
+    should_persist_result,
+)
 from prefect.settings import PREFECT_DEBUG_MODE
 from prefect.states import (
     Failed,
@@ -271,7 +276,7 @@ class FlowRunEngine(Generic[P, R]):
             return_value_to_state(
                 resolved_result,
                 result_store=result_store,
-                write_result=True,
+                write_result=should_persist_result(),
             )
         )
         self.set_state(terminal_state)
@@ -511,6 +516,9 @@ class FlowRunEngine(Generic[P, R]):
                         self.flow, _sync=True
                     ),
                     task_runner=task_runner,
+                    persist_result=self.flow.persist_result
+                    if self.flow.persist_result is not None
+                    else should_persist_result(),
                 )
             )
             stack.enter_context(ConcurrencyContextV1())

--- a/src/prefect/main.py
+++ b/src/prefect/main.py
@@ -7,7 +7,7 @@ from prefect.transactions import Transaction
 from prefect.tasks import task, Task
 from prefect.context import tags
 from prefect.utilities.annotations import unmapped, allow_failure
-from prefect.results import BaseResult
+from prefect.results import BaseResult, ResultRecordMetadata
 from prefect.flow_runs import pause_flow_run, resume_flow_run, suspend_flow_run
 from prefect.client.orchestration import get_client, PrefectClient
 from prefect.client.cloud import get_cloud_client, CloudClient
@@ -26,12 +26,26 @@ import prefect.context
 import prefect.client.schemas
 
 prefect.context.FlowRunContext.model_rebuild(
-    _types_namespace={"Flow": Flow, "BaseResult": BaseResult}
+    _types_namespace={
+        "Flow": Flow,
+        "BaseResult": BaseResult,
+        "ResultRecordMetadata": ResultRecordMetadata,
+    }
 )
-prefect.context.TaskRunContext.model_rebuild(_types_namespace={"Task": Task})
-prefect.client.schemas.State.model_rebuild(_types_namespace={"BaseResult": BaseResult})
+prefect.context.TaskRunContext.model_rebuild(
+    _types_namespace={"Task": Task, "BaseResult": BaseResult}
+)
+prefect.client.schemas.State.model_rebuild(
+    _types_namespace={
+        "BaseResult": BaseResult,
+        "ResultRecordMetadata": ResultRecordMetadata,
+    }
+)
 prefect.client.schemas.StateCreate.model_rebuild(
-    _types_namespace={"BaseResult": BaseResult}
+    _types_namespace={
+        "BaseResult": BaseResult,
+        "ResultRecordMetadata": ResultRecordMetadata,
+    }
 )
 Transaction.model_rebuild()
 

--- a/src/prefect/records/filesystem.py
+++ b/src/prefect/records/filesystem.py
@@ -56,7 +56,6 @@ class FileSystemRecordStore(RecordStore):
     def _get_lock_info(self, key: str, use_cache=True) -> Optional[_LockInfo]:
         if use_cache:
             if (lock_info := self._locks.get(key)) is not None:
-                print("Got lock info from cache")
                 return lock_info
 
         lock_path = self._lock_path_for_key(key)
@@ -70,7 +69,6 @@ class FileSystemRecordStore(RecordStore):
                     pendulum.parse(expiration) if expiration is not None else None
                 )
             self._locks[key] = lock_info
-            print("Got lock info from file")
             return lock_info
         except FileNotFoundError:
             return None

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -4,7 +4,7 @@ import os
 import socket
 import threading
 import uuid
-from functools import partial
+from functools import partial, wraps
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -17,6 +17,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    overload,
 )
 from uuid import UUID
 
@@ -60,6 +61,7 @@ from prefect.settings import (
 )
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import sync_compatible
+from prefect.utilities.callables import get_call_parameters
 from prefect.utilities.pydantic import get_dispatch_key, lookup_type, register_base_type
 
 if TYPE_CHECKING:
@@ -199,6 +201,34 @@ def _format_user_supplied_storage_key(key: str) -> str:
     # yet; we'll need to split logic in the future or have two separate functions
     runtime_vars = {key: getattr(prefect.runtime, key) for key in dir(prefect.runtime)}
     return key.format(**runtime_vars, parameters=prefect.runtime.task_run.parameters)
+
+
+T = TypeVar("T")
+
+
+def _backwards_compatible_obj_key_order(func: Callable[..., T]) -> Callable[..., T]:
+    """
+    This decorator is used to make the `ResultStore` writing method
+    backwards compatible with the old-style call:
+    `create_result_record(key, obj)` and the new-style call: `create_result_record(obj, key)`.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        parameters = get_call_parameters(func, args, kwargs)
+
+        key = parameters.get("key", None)
+        if key is not None and not isinstance(key, str):
+            # If key is not a string, assume the old-style call: `create_result_record(key, obj)`
+            # and swap the key and obj values
+            obj = parameters["obj"]
+            parameters["obj"] = key
+            parameters["key"] = obj
+
+        # Call the original function with updated kwargs
+        return func(**parameters)
+
+    return wrapper
 
 
 @deprecated_field(
@@ -445,12 +475,31 @@ class ResultStore(BaseModel):
         holder = holder or self.generate_default_holder()
         return await self._read(key=key, holder=holder, _sync=False)
 
+    @overload
     def create_result_record(
         self,
         obj: Any,
         key: Optional[str] = None,
         expiration: Optional[DateTime] = None,
-    ):
+    ) -> "ResultRecord":
+        ...
+
+    @overload
+    def create_result_record(
+        self,
+        key: str,
+        obj: Any,
+        expiration: Optional[DateTime] = None,
+    ) -> "ResultRecord":
+        ...
+
+    @_backwards_compatible_obj_key_order
+    def create_result_record(
+        self,
+        obj: Any,
+        key: Optional[str] = None,
+        expiration: Optional[DateTime] = None,
+    ) -> "ResultRecord":
         """
         Create a result record.
 
@@ -478,6 +527,28 @@ class ResultStore(BaseModel):
             ),
         )
 
+    @overload
+    def write(
+        self,
+        obj: Any,
+        key: Optional[str] = None,
+        expiration: Optional[DateTime] = None,
+        holder: Optional[str] = None,
+    ) -> None:
+        ...
+
+    # for backwards compatibility
+    @overload
+    def write(
+        self,
+        key: str,
+        obj: Any,
+        expiration: Optional[DateTime] = None,
+        holder: Optional[str] = None,
+    ) -> None:
+        ...
+
+    @_backwards_compatible_obj_key_order
     def write(
         self,
         obj: Any,
@@ -505,6 +576,28 @@ class ResultStore(BaseModel):
             holder=holder,
         )
 
+    @overload
+    async def awrite(
+        self,
+        obj: Any,
+        key: Optional[str] = None,
+        expiration: Optional[DateTime] = None,
+        holder: Optional[str] = None,
+    ) -> None:
+        ...
+
+    # for backwards compatibility
+    @overload
+    async def awrite(
+        self,
+        key: str,
+        obj: Any,
+        expiration: Optional[DateTime] = None,
+        holder: Optional[str] = None,
+    ) -> None:
+        ...
+
+    @_backwards_compatible_obj_key_order
     async def awrite(
         self,
         obj: Any,

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -180,7 +180,10 @@ def get_default_persist_setting() -> bool:
 
 def should_persist_result() -> bool:
     """
-    Return the default option for result persistence (False).
+    Return the default option for result persistence determined by the current run context.
+
+    If there is no current run context, the default value set by
+    `PREFECT_RESULTS_PERSIST_BY_DEFAULT` will be returned.
     """
     from prefect.context import FlowRunContext, TaskRunContext
 

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -946,7 +946,18 @@ class ResultRecord(BaseModel, Generic[R]):
         return value
 
     @classmethod
-    async def from_metadata(cls, metadata: ResultRecordMetadata) -> "ResultRecord[R]":
+    async def _from_metadata(cls, metadata: ResultRecordMetadata) -> "ResultRecord[R]":
+        """
+        Create a result record from metadata.
+
+        Will use the result record metadata to fetch data via a result store.
+
+        Args:
+            metadata: The metadata to create the result record from.
+
+        Returns:
+            ResultRecord: The result record.
+        """
         if metadata.storage_block_id is None:
             storage_block = None
         else:

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -815,7 +815,7 @@ class ResultStore(BaseModel):
         return record.result
 
 
-def get_current_result_store() -> ResultStore:
+def get_result_store() -> ResultStore:
     """
     Get the current result store.
     """

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -140,7 +140,7 @@ async def _get_state_result(
     elif isinstance(state.data, ResultRecord):
         result = state.data.result
     elif isinstance(state.data, ResultRecordMetadata):
-        record = await ResultRecord.from_metadata(state.data)
+        record = await ResultRecord._from_metadata(state.data)
         result = record.result
 
     elif state.data is None:
@@ -456,7 +456,7 @@ async def get_state_exception(state: State) -> BaseException:
     elif isinstance(state.data, ResultRecord):
         result = state.data.result
     elif isinstance(state.data, ResultRecordMetadata):
-        record = await ResultRecord.from_metadata(state.data)
+        record = await ResultRecord._from_metadata(state.data)
         result = record.result
     elif state.data is None:
         result = None

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -455,6 +455,9 @@ async def get_state_exception(state: State) -> BaseException:
         result = await _get_state_result_data_with_retries(state)
     elif isinstance(state.data, ResultRecord):
         result = state.data.result
+    elif isinstance(state.data, ResultRecordMetadata):
+        record = await ResultRecord.from_metadata(state.data)
+        result = record.result
     elif state.data is None:
         result = None
     else:

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -25,7 +25,7 @@ from prefect.exceptions import (
     UnfinishedRun,
 )
 from prefect.logging.loggers import get_logger, get_run_logger
-from prefect.results import BaseResult, R, ResultStore
+from prefect.results import BaseResult, R, ResultRecord, ResultStore
 from prefect.settings import PREFECT_ASYNC_FETCH_STATE_RESULT
 from prefect.utilities.annotations import BaseAnnotation
 from prefect.utilities.asyncutils import in_async_main_thread, sync_compatible
@@ -131,6 +131,8 @@ async def _get_state_result(
         result = await _get_state_result_data_with_retries(
             state, retry_result_failure=retry_result_failure
         )
+    elif isinstance(state.data, ResultRecord):
+        result = state.data.result
 
     elif state.data is None:
         if state.is_failed() or state.is_crashed() or state.is_cancelled():
@@ -207,7 +209,7 @@ async def exception_to_crashed_state(
         )
 
     if result_store:
-        data = await result_store.create_result(exc)
+        data = result_store.create_result_record(exc)
     else:
         # Attach the exception for local usage, will not be available when retrieved
         # from the API
@@ -240,10 +242,10 @@ async def exception_to_failed_state(
         pass
 
     if result_store:
-        data = await result_store.create_result(exc)
+        data = result_store.create_result_record(exc)
         if write_result:
             try:
-                await data.write()
+                await result_store.apersist_result_record(data)
             except Exception as exc:
                 local_logger.warning(
                     "Failed to write result: %s Execution will continue, but the result has not been written",
@@ -310,20 +312,20 @@ async def return_value_to_state(
         # Unless the user has already constructed a result explicitly, use the store
         # to update the data to the correct type
         if not isinstance(state.data, BaseResult):
-            result = await result_store.create_result(
+            result_record = result_store.create_result_record(
                 state.data,
                 key=key,
                 expiration=expiration,
             )
             if write_result:
                 try:
-                    await result.write()
+                    await result_store.apersist_result_record(result_record)
                 except Exception as exc:
                     local_logger.warning(
                         "Encountered an error while persisting result: %s Execution will continue, but the result has not been persisted",
                         exc,
                     )
-            state.data = result
+            state.data = result_record
         return state
 
     # Determine a new state from the aggregate of contained states
@@ -359,14 +361,14 @@ async def return_value_to_state(
         # TODO: We may actually want to set the data to a `StateGroup` object and just
         #       allow it to be unpacked into a tuple and such so users can interact with
         #       it
-        result = await result_store.create_result(
+        result_record = result_store.create_result_record(
             retval,
             key=key,
             expiration=expiration,
         )
         if write_result:
             try:
-                await result.write()
+                await result_store.apersist_result_record(result_record)
             except Exception as exc:
                 local_logger.warning(
                     "Encountered an error while persisting result: %s Execution will continue, but the result has not been persisted",
@@ -375,7 +377,7 @@ async def return_value_to_state(
         return State(
             type=new_state_type,
             message=message,
-            data=result,
+            data=result_record,
         )
 
     # Generators aren't portable, implicitly convert them to a list.
@@ -385,23 +387,23 @@ async def return_value_to_state(
         data = retval
 
     # Otherwise, they just gave data and this is a completed retval
-    if isinstance(data, BaseResult):
+    if isinstance(data, (BaseResult, ResultRecord)):
         return Completed(data=data)
     else:
-        result = await result_store.create_result(
+        result_record = result_store.create_result_record(
             data,
             key=key,
             expiration=expiration,
         )
         if write_result:
             try:
-                await result.write()
+                await result_store.apersist_result_record(result_record)
             except Exception as exc:
                 local_logger.warning(
                     "Encountered an error while persisting result: %s Execution will continue, but the result has not been persisted",
                     exc,
                 )
-        return Completed(data=result)
+        return Completed(data=result_record)
 
 
 @sync_compatible
@@ -442,6 +444,8 @@ async def get_state_exception(state: State) -> BaseException:
 
     if isinstance(state.data, BaseResult):
         result = await _get_state_result_data_with_retries(state)
+    elif isinstance(state.data, ResultRecord):
+        result = state.data.result
     elif state.data is None:
         result = None
     else:

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -25,7 +25,13 @@ from prefect.exceptions import (
     UnfinishedRun,
 )
 from prefect.logging.loggers import get_logger, get_run_logger
-from prefect.results import BaseResult, R, ResultRecord, ResultStore
+from prefect.results import (
+    BaseResult,
+    R,
+    ResultRecord,
+    ResultRecordMetadata,
+    ResultStore,
+)
 from prefect.settings import PREFECT_ASYNC_FETCH_STATE_RESULT
 from prefect.utilities.annotations import BaseAnnotation
 from prefect.utilities.asyncutils import in_async_main_thread, sync_compatible
@@ -133,6 +139,9 @@ async def _get_state_result(
         )
     elif isinstance(state.data, ResultRecord):
         result = state.data.result
+    elif isinstance(state.data, ResultRecordMetadata):
+        record = await ResultRecord.from_metadata(state.data)
+        result = record.result
 
     elif state.data is None:
         if state.is_failed() or state.is_crashed() or state.is_cancelled():

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -59,7 +59,7 @@ from prefect.results import (
     BaseResult,
     ResultRecord,
     _format_user_supplied_storage_key,
-    get_current_result_store,
+    get_result_store,
     should_persist_result,
 )
 from prefect.settings import (
@@ -466,7 +466,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
         terminal_state = run_coro_as_sync(
             return_value_to_state(
                 result,
-                result_store=get_current_result_store(),
+                result_store=get_result_store(),
                 key=transaction.key,
                 expiration=expiration,
             )
@@ -542,7 +542,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 exception_to_failed_state(
                     exc,
                     message="Task run encountered an exception",
-                    result_store=get_current_result_store(),
+                    result_store=get_result_store(),
                     write_result=True,
                 )
             )
@@ -594,7 +594,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                     log_prints=log_prints,
                     task_run=self.task_run,
                     parameters=self.parameters,
-                    result_store=get_current_result_store().update_for_task(
+                    result_store=get_result_store().update_for_task(
                         self.task, _sync=True
                     ),
                     client=client,
@@ -727,7 +727,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
         with transaction(
             key=self.compute_transaction_key(),
-            store=get_current_result_store(),
+            store=get_result_store(),
             overwrite=overwrite,
             logger=self.logger,
             write_on_commit=should_persist_result(),
@@ -973,7 +973,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
         terminal_state = await return_value_to_state(
             result,
-            result_store=get_current_result_store(),
+            result_store=get_result_store(),
             key=transaction.key,
             expiration=expiration,
         )
@@ -1047,7 +1047,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             state = await exception_to_failed_state(
                 exc,
                 message="Task run encountered an exception",
-                result_store=get_current_result_store(),
+                result_store=get_result_store(),
             )
             self.record_terminal_state_timing(state)
             await self.set_state(state)
@@ -1097,7 +1097,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                     log_prints=log_prints,
                     task_run=self.task_run,
                     parameters=self.parameters,
-                    result_store=await get_current_result_store().update_for_task(
+                    result_store=await get_result_store().update_for_task(
                         self.task, _sync=False
                     ),
                     client=client,
@@ -1227,7 +1227,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
         with transaction(
             key=self.compute_transaction_key(),
-            store=get_current_result_store(),
+            store=get_result_store(),
             overwrite=overwrite,
             logger=self.logger,
             write_on_commit=should_persist_result(),

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -443,7 +443,8 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 if inspect.isawaitable(_result):
                     _result = run_coro_as_sync(_result)
                 return _result
-
+            elif isinstance(self._return_value, ResultRecord):
+                return self._return_value.result
             # otherwise, return the value as is
             return self._return_value
 
@@ -946,7 +947,8 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             # if the return value is a BaseResult, we need to fetch it
             if isinstance(self._return_value, BaseResult):
                 return await self._return_value.get()
-
+            elif isinstance(self._return_value, ResultRecord):
+                return self._return_value.result
             # otherwise, return the value as is
             return self._return_value
 

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -60,6 +60,7 @@ from prefect.results import (
     ResultRecord,
     _format_user_supplied_storage_key,
     get_current_result_store,
+    should_persist_result,
 )
 from prefect.settings import (
     PREFECT_DEBUG_MODE,
@@ -597,6 +598,9 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                         self.task, _sync=True
                     ),
                     client=client,
+                    persist_result=self.task.persist_result
+                    if self.task.persist_result is not None
+                    else should_persist_result(),
                 )
             )
             stack.enter_context(ConcurrencyContextV1())
@@ -726,6 +730,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             store=get_current_result_store(),
             overwrite=overwrite,
             logger=self.logger,
+            write_on_commit=should_persist_result(),
         ) as txn:
             yield txn
 
@@ -1096,6 +1101,9 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                         self.task, _sync=False
                     ),
                     client=client,
+                    persist_result=self.task.persist_result
+                    if self.task.persist_result is not None
+                    else should_persist_result(),
                 )
             )
             stack.enter_context(ConcurrencyContext())
@@ -1222,6 +1230,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             store=get_current_result_store(),
             overwrite=overwrite,
             logger=self.logger,
+            write_on_commit=should_persist_result(),
         ) as txn:
             yield txn
 

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -55,9 +55,9 @@ from prefect.exceptions import (
 )
 from prefect.futures import PrefectFuture
 from prefect.logging.loggers import get_logger, patch_print, task_run_logger
-from prefect.records.result_store import ResultRecordStore
 from prefect.results import (
     BaseResult,
+    ResultRecord,
     _format_user_supplied_storage_key,
     get_current_result_store,
 )
@@ -418,6 +418,8 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 result = state.result(raise_on_failure=False, fetch=True)
                 if inspect.isawaitable(result):
                     result = run_coro_as_sync(result)
+            elif isinstance(state.data, ResultRecord):
+                result = state.data.result
             else:
                 result = state.data
 
@@ -454,10 +456,6 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             return self._raised
 
     def handle_success(self, result: R, transaction: Transaction) -> R:
-        result_store = getattr(TaskRunContext.get(), "result_store", None)
-        if result_store is None:
-            raise ValueError("Result store is not set")
-
         if self.task.cache_expiration is not None:
             expiration = pendulum.now("utc") + self.task.cache_expiration
         else:
@@ -466,7 +464,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
         terminal_state = run_coro_as_sync(
             return_value_to_state(
                 result,
-                result_store=result_store,
+                result_store=get_current_result_store(),
                 key=transaction.key,
                 expiration=expiration,
             )
@@ -538,12 +536,11 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
         # If the task fails, and we have retries left, set the task to retrying.
         if not self.handle_retry(exc):
             # If the task has no retries left, or the retry condition is not met, set the task to failed.
-            context = TaskRunContext.get()
             state = run_coro_as_sync(
                 exception_to_failed_state(
                     exc,
                     message="Task run encountered an exception",
-                    result_store=getattr(context, "result_store", None),
+                    result_store=get_current_result_store(),
                     write_result=True,
                 )
             )
@@ -723,15 +720,9 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             else PREFECT_TASKS_REFRESH_CACHE.value()
         )
 
-        result_store = getattr(TaskRunContext.get(), "result_store", None)
-        if result_store and result_store.persist_result:
-            store = ResultRecordStore(result_store=result_store)
-        else:
-            store = None
-
         with transaction(
             key=self.compute_transaction_key(),
-            store=store,
+            store=get_current_result_store(),
             overwrite=overwrite,
             logger=self.logger,
         ) as txn:
@@ -933,6 +924,8 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 # Avoid fetching the result unless it is cached, otherwise we defeat
                 # the purpose of disabling `cache_result_in_memory`
                 result = await new_state.result(raise_on_failure=False, fetch=True)
+            elif isinstance(new_state.data, ResultRecord):
+                result = new_state.data.result
             else:
                 result = new_state.data
 
@@ -966,10 +959,6 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             return self._raised
 
     async def handle_success(self, result: R, transaction: Transaction) -> R:
-        result_store = getattr(TaskRunContext.get(), "result_store", None)
-        if result_store is None:
-            raise ValueError("Result store is not set")
-
         if self.task.cache_expiration is not None:
             expiration = pendulum.now("utc") + self.task.cache_expiration
         else:
@@ -977,7 +966,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
         terminal_state = await return_value_to_state(
             result,
-            result_store=result_store,
+            result_store=get_current_result_store(),
             key=transaction.key,
             expiration=expiration,
         )
@@ -1048,11 +1037,10 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
         # If the task fails, and we have retries left, set the task to retrying.
         if not await self.handle_retry(exc):
             # If the task has no retries left, or the retry condition is not met, set the task to failed.
-            context = TaskRunContext.get()
             state = await exception_to_failed_state(
                 exc,
                 message="Task run encountered an exception",
-                result_store=getattr(context, "result_store", None),
+                result_store=get_current_result_store(),
             )
             self.record_terminal_state_timing(state)
             await self.set_state(state)
@@ -1226,15 +1214,10 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             if self.task.refresh_cache is not None
             else PREFECT_TASKS_REFRESH_CACHE.value()
         )
-        result_store = getattr(TaskRunContext.get(), "result_store", None)
-        if result_store and result_store.persist_result:
-            store = ResultRecordStore(result_store=result_store)
-        else:
-            store = None
 
         with transaction(
             key=self.compute_transaction_key(),
-            store=store,
+            store=get_current_result_store(),
             overwrite=overwrite,
             logger=self.logger,
         ) as txn:

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -237,13 +237,17 @@ class Transaction(ContextModel):
             if self.store and self.key and self.write_on_commit:
                 if isinstance(self.store, ResultStore):
                     if isinstance(self._staged_value, BaseResult):
-                        self.store.write(self.key, self._staged_value.get(_sync=True))
+                        self.store.write(
+                            key=self.key, obj=self._staged_value.get(_sync=True)
+                        )
                     elif isinstance(self._staged_value, ResultRecord):
-                        self.store.persist_result_record(self._staged_value)
+                        self.store.persist_result_record(
+                            result_record=self._staged_value
+                        )
                     else:
-                        self.store.write(self.key, self._staged_value)
+                        self.store.write(key=self.key, obj=self._staged_value)
                 else:
-                    self.store.write(self.key, self._staged_value)
+                    self.store.write(key=self.key, result=self._staged_value)
 
             self.state = TransactionState.COMMITTED
             if (

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -233,6 +233,8 @@ class Transaction(ContextModel):
                 if isinstance(self.store, ResultStore):
                     if isinstance(self._staged_value, BaseResult):
                         self.store.write(self.key, self._staged_value.get(_sync=True))
+                    elif isinstance(self._staged_value, ResultRecord):
+                        self.store.persist_result_record(self._staged_value)
                     else:
                         self.store.write(self.key, self._staged_value)
                 else:

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -48,7 +48,7 @@ from prefect.logging.loggers import (
     get_logger,
     task_run_logger,
 )
-from prefect.results import BaseResult, ResultRecord
+from prefect.results import BaseResult, ResultRecord, should_persist_result
 from prefect.settings import (
     PREFECT_LOGGING_LOG_PRINTS,
 )
@@ -737,7 +737,7 @@ def emit_task_run_state_change_event(
 
     if isinstance(validated_state.data, ResultRecord):
         data = validated_state.data.metadata.model_dump(mode="json")
-    elif isinstance(validated_state.data, BaseResult):
+    elif isinstance(validated_state.data, BaseResult) and should_persist_result():
         data = validated_state.data.model_dump(mode="json")
     else:
         data = None

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -735,9 +735,9 @@ def emit_task_run_state_change_event(
 ) -> Event:
     state_message_truncation_length = 100_000
 
-    if isinstance(validated_state.data, ResultRecord):
+    if isinstance(validated_state.data, ResultRecord) and should_persist_result():
         data = validated_state.data.metadata.model_dump(mode="json")
-    elif isinstance(validated_state.data, BaseResult) and should_persist_result():
+    elif isinstance(validated_state.data, BaseResult):
         data = validated_state.data.model_dump(mode="json")
     else:
         data = None

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -735,6 +735,13 @@ def emit_task_run_state_change_event(
 ) -> Event:
     state_message_truncation_length = 100_000
 
+    if isinstance(validated_state.data, ResultRecord):
+        data = validated_state.data.metadata.model_dump(mode="json")
+    elif isinstance(validated_state.data, BaseResult):
+        data = validated_state.data.model_dump(mode="json")
+    else:
+        data = None
+
     return emit_event(
         id=validated_state.id,
         occurred=validated_state.timestamp,
@@ -773,9 +780,7 @@ def emit_task_run_state_change_event(
                     exclude_unset=True,
                     exclude={"flow_run_id", "task_run_id"},
                 ),
-                "data": validated_state.data.model_dump(mode="json")
-                if isinstance(validated_state.data, BaseResult)
-                else None,
+                "data": data,
             },
             "task_run": task_run.model_dump(
                 mode="json",

--- a/tests/results/test_flow_results.py
+++ b/tests/results/test_flow_results.py
@@ -8,8 +8,8 @@ from prefect.context import get_run_context
 from prefect.exceptions import MissingResult
 from prefect.filesystems import LocalFileSystem
 from prefect.results import (
-    PersistedResult,
     ResultRecord,
+    get_current_result_store,
 )
 from prefect.serializers import (
     CompressedSerializer,
@@ -75,12 +75,16 @@ async def test_flow_with_uncached_and_unpersisted_null_result(prefect_client):
 
 
 async def test_flow_with_uncached_but_persisted_result(prefect_client):
+    store = None
+
     @flow(persist_result=True, cache_result_in_memory=False)
     def foo():
+        nonlocal store
+        store = get_current_result_store()
         return 1
 
     state = foo(return_state=True)
-    assert not state.data.has_cached_object()
+    assert state.data.metadata.storage_key not in store.cache
     assert await state.result() == 1
 
     api_state = (
@@ -161,13 +165,13 @@ async def test_flow_result_serializer(serializer, prefect_client):
 
     state = foo(return_state=True)
     assert await state.result() == 1
-    await assert_uses_result_serializer(state, serializer)
+    await assert_uses_result_serializer(state, serializer, prefect_client)
 
     api_state = (
         await prefect_client.read_flow_run(state.state_details.flow_run_id)
     ).state
     assert await api_state.result() == 1
-    await assert_uses_result_serializer(api_state, serializer)
+    await assert_uses_result_serializer(api_state, serializer, prefect_client)
 
 
 async def test_flow_result_storage_by_instance(prefect_client):
@@ -245,13 +249,13 @@ async def test_child_flow_result_serializer(prefect_client, source):
     parent_state = foo(return_state=True)
     child_state = await parent_state.result()
     assert await child_state.result() == 1
-    await assert_uses_result_serializer(child_state, serializer)
+    await assert_uses_result_serializer(child_state, serializer, prefect_client)
 
     api_state = (
         await prefect_client.read_flow_run(child_state.state_details.flow_run_id)
     ).state
     assert await api_state.result() == 1
-    await assert_uses_result_serializer(api_state, serializer)
+    await assert_uses_result_serializer(api_state, serializer, prefect_client)
 
 
 @pytest.mark.parametrize("source", ["child", "parent"])
@@ -290,8 +294,7 @@ async def test_child_flow_result_missing_with_null_return(prefect_client):
 
     parent_state = foo(return_state=True)
     child_state = await parent_state.result()
-    assert isinstance(child_state.data, PersistedResult)
-    assert child_state.data._persisted is False
+    assert isinstance(child_state.data, ResultRecord)
     assert await child_state.result() is None
 
     api_state = (

--- a/tests/results/test_flow_results.py
+++ b/tests/results/test_flow_results.py
@@ -9,7 +9,7 @@ from prefect.exceptions import MissingResult
 from prefect.filesystems import LocalFileSystem
 from prefect.results import (
     ResultRecord,
-    get_current_result_store,
+    get_result_store,
 )
 from prefect.serializers import (
     CompressedSerializer,
@@ -80,7 +80,7 @@ async def test_flow_with_uncached_but_persisted_result(prefect_client):
     @flow(persist_result=True, cache_result_in_memory=False)
     def foo():
         nonlocal store
-        store = get_current_result_store()
+        store = get_result_store()
         return 1
 
     state = foo(return_state=True)

--- a/tests/results/test_result_store.py
+++ b/tests/results/test_result_store.py
@@ -9,6 +9,7 @@ from prefect.locking.memory import MemoryLockManager
 from prefect.results import (
     PersistedResult,
     ResultStore,
+    should_persist_result,
 )
 from prefect.serializers import JSONSerializer, PickleSerializer
 from prefect.settings import (
@@ -58,10 +59,10 @@ async def test_create_result_reference_has_cached_object(store):
 def test_root_flow_default_result_store():
     @flow
     def foo():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    result_store = foo()
-    assert result_store.persist_result is False
+    result_store, persist_result = foo()
+    assert persist_result is False
     assert result_store.cache_result_in_memory is True
     assert result_store.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_store.result_storage, DEFAULT_STORAGE())
@@ -81,32 +82,32 @@ def test_root_flow_default_result_serializer_can_be_overriden_by_setting():
 def test_root_flow_default_persist_result_can_be_overriden_by_setting():
     @flow
     def foo():
-        return get_run_context().result_store
+        return should_persist_result()
 
     with temporary_settings({PREFECT_RESULTS_PERSIST_BY_DEFAULT: True}):
-        result_store = foo()
-    assert result_store.persist_result is True
+        persist_result = foo()
+    assert persist_result is True
 
 
 def test_root_flow_can_opt_out_when_persist_result_default_is_overriden_by_setting():
     @flow(persist_result=False)
     def foo():
-        return get_run_context().result_store
+        return should_persist_result()
 
     with temporary_settings({PREFECT_RESULTS_PERSIST_BY_DEFAULT: True}):
-        result_store = foo()
+        persist_result = foo()
 
-    assert result_store.persist_result is False
+    assert persist_result is False
 
 
 @pytest.mark.parametrize("toggle", [True, False])
 def test_root_flow_custom_persist_setting(toggle):
     @flow(persist_result=toggle)
     def foo():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    result_store = foo()
-    assert result_store.persist_result is toggle
+    result_store, persist_result = foo()
+    assert persist_result is toggle
     assert result_store.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_store.result_storage, DEFAULT_STORAGE())
 
@@ -114,24 +115,27 @@ def test_root_flow_custom_persist_setting(toggle):
 def test_root_flow_persists_results_when_flow_uses_feature():
     @flow(cache_result_in_memory=False, persist_result=True)
     def foo():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    result_store = foo()
-    assert result_store.persist_result is True
+    result_store, persist_result = foo()
+    assert persist_result is True
     assert result_store.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_store.result_storage, DEFAULT_STORAGE())
 
 
 def test_root_flow_can_opt_out_of_persistence_when_flow_uses_feature():
     result_store = None
+    persist_result = None
 
     @flow(cache_result_in_memory=False, persist_result=False)
     def foo():
         nonlocal result_store
+        nonlocal persist_result
+        persist_result = should_persist_result()
         result_store = get_run_context().result_store
 
     foo()
-    assert result_store.persist_result is False
+    assert persist_result is False
     assert result_store.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_store.result_storage, DEFAULT_STORAGE())
     assert result_store.result_storage_block_id is None
@@ -155,10 +159,10 @@ def test_root_flow_custom_cache_setting(toggle, default_persistence_off):
 def test_root_flow_custom_serializer_by_type_string():
     @flow(result_serializer="json", persist_result=False)
     def foo():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    result_store = foo()
-    assert result_store.persist_result is False
+    result_store, persist_result = foo()
+    assert persist_result is False
     assert result_store.serializer == JSONSerializer()
     assert_blocks_equal(result_store.result_storage, DEFAULT_STORAGE())
     assert result_store.result_storage_block_id is None
@@ -167,10 +171,10 @@ def test_root_flow_custom_serializer_by_type_string():
 def test_root_flow_custom_serializer_by_instance(default_persistence_off):
     @flow(persist_result=False, result_serializer=JSONSerializer(jsonlib="orjson"))
     def foo():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    result_store = foo()
-    assert result_store.persist_result is False
+    result_store, persist_result = foo()
+    assert persist_result is False
     assert result_store.serializer == JSONSerializer(jsonlib="orjson")
     assert_blocks_equal(result_store.result_storage, DEFAULT_STORAGE())
     assert result_store.result_storage_block_id is None
@@ -182,10 +186,10 @@ async def test_root_flow_custom_storage_by_slug(tmp_path, default_persistence_of
 
     @flow(result_storage="local-file-system/test")
     def foo():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    result_store = foo()
-    assert result_store.persist_result is True  # inferred from the storage
+    result_store, persist_result = foo()
+    assert persist_result is True  # inferred from the storage
     assert result_store.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(result_store.result_storage, storage)
     assert result_store.result_storage_block_id == storage_id
@@ -199,10 +203,10 @@ async def test_root_flow_custom_storage_by_instance_presaved(
 
     @flow(result_storage=storage)
     def foo():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    result_store = foo()
-    assert result_store.persist_result is True  # inferred from the storage
+    result_store, persist_result = foo()
+    assert persist_result is True  # inferred from the storage
     assert result_store.serializer == DEFAULT_SERIALIZER()
     assert result_store.result_storage == storage
     assert result_store.result_storage._is_anonymous is False
@@ -212,14 +216,15 @@ async def test_root_flow_custom_storage_by_instance_presaved(
 def test_child_flow_inherits_default_result_settings(default_persistence_off):
     @flow
     def foo():
-        return get_run_context().result_store, bar()
+        child_store, persist_result = bar()
+        return child_store, persist_result
 
     @flow
     def bar():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    _, child_store = foo()
-    assert child_store.persist_result is False
+    child_store, persist_result = foo()
+    assert persist_result is False
     assert child_store.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(child_store.result_storage, DEFAULT_STORAGE())
     assert child_store.result_storage_block_id is None
@@ -245,45 +250,51 @@ def test_child_flow_default_result_serializer_can_be_overriden_by_setting(
 def test_child_flow_default_persist_result_can_be_overriden_by_setting():
     @flow
     def foo():
-        return get_run_context().result_store, bar()
+        return bar()
 
     @flow
     def bar():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
     with temporary_settings({PREFECT_RESULTS_PERSIST_BY_DEFAULT: True}):
-        _, child_store = foo()
+        child_store, persist_result = foo()
 
-    assert child_store.persist_result is True
+    assert persist_result is True
 
 
 def test_child_flow_can_opt_out_when_persist_result_default_is_overriden_by_setting():
     @flow
     def foo():
-        return get_run_context().result_store, bar()
+        return bar()
 
     @flow(persist_result=False)
     def bar():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
     with temporary_settings({PREFECT_RESULTS_PERSIST_BY_DEFAULT: True}):
-        _, child_store = foo()
+        child_store, persist_result = foo()
 
-    assert child_store.persist_result is False
+    assert persist_result is False
 
 
 def test_child_flow_custom_persist_setting(default_persistence_off):
     @flow
     def foo():
-        return get_run_context().result_store, bar()
+        child_store, persist_result = bar()
+        return (
+            get_run_context().result_store,
+            should_persist_result(),
+            child_store,
+            persist_result,
+        )
 
     @flow(persist_result=True)
     def bar():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    parent_store, child_store = foo()
-    assert parent_store.persist_result is False
-    assert child_store.persist_result is True
+    parent_store, parent_persist_result, child_store, child_persist_result = foo()
+    assert parent_persist_result is False
+    assert child_persist_result is True
     assert child_store.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(child_store.result_storage, DEFAULT_STORAGE())
 
@@ -314,15 +325,21 @@ def test_child_flow_can_opt_out_of_result_persistence_when_parent_uses_feature(
 ):
     @flow(retries=3)
     def foo():
-        return get_run_context().result_store, bar()
+        child_store, child_persist_result = bar()
+        return (
+            get_run_context().result_store,
+            should_persist_result(),
+            child_persist_result,
+            child_store,
+        )
 
     @flow(persist_result=False)
     def bar():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    parent_store, child_store = foo()
-    assert parent_store.persist_result is False
-    assert child_store.persist_result is False
+    parent_store, parent_persist_result, child_persist_result, child_store = foo()
+    assert parent_persist_result is False
+    assert child_persist_result is False
     assert child_store.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(child_store.result_storage, DEFAULT_STORAGE())
     assert child_store.result_storage_block_id is None
@@ -331,14 +348,15 @@ def test_child_flow_can_opt_out_of_result_persistence_when_parent_uses_feature(
 def test_child_flow_inherits_custom_serializer(default_persistence_off):
     @flow(persist_result=False, result_serializer="json")
     def foo():
-        return get_run_context().result_store, bar()
+        child_store, child_persist_result = bar()
+        return get_run_context().result_store, child_persist_result, child_store
 
-    @flow()
+    @flow(persist_result=False, result_serializer="json")
     def bar():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    parent_store, child_store = foo()
-    assert child_store.persist_result is False
+    parent_store, child_persist_result, child_store = foo()
+    assert child_persist_result is False
     assert child_store.serializer == parent_store.serializer
     assert_blocks_equal(child_store.result_storage, DEFAULT_STORAGE())
     assert child_store.result_storage_block_id is None
@@ -350,14 +368,15 @@ async def test_child_flow_inherits_custom_storage(tmp_path, default_persistence_
 
     @flow(result_storage="local-file-system/test")
     def foo():
-        return get_run_context().result_store, bar()
+        child_store, child_persist_result = bar()
+        return get_run_context().result_store, child_persist_result, child_store
 
     @flow
     def bar():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    parent_store, child_store = foo()
-    assert child_store.persist_result is True
+    parent_store, child_persist_result, child_store = foo()
+    assert child_persist_result is True
     assert child_store.serializer == DEFAULT_SERIALIZER()
     assert child_store.result_storage == parent_store.result_storage
     assert child_store.result_storage_block_id == storage_id
@@ -369,15 +388,16 @@ async def test_child_flow_custom_storage(tmp_path, default_persistence_off):
 
     @flow()
     def foo():
-        return get_run_context().result_store, bar()
+        child_store, child_persist_result = bar()
+        return get_run_context().result_store, child_persist_result, child_store
 
     @flow(result_storage="local-file-system/test")
     def bar():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    parent_store, child_store = foo()
+    parent_store, child_persist_result, child_store = foo()
     assert_blocks_equal(parent_store.result_storage, DEFAULT_STORAGE())
-    assert child_store.persist_result is True  # inferred from the storage
+    assert child_persist_result is True  # inferred from the storage
     assert child_store.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(child_store.result_storage, storage)
     assert child_store.result_storage_block_id == storage_id
@@ -386,14 +406,14 @@ async def test_child_flow_custom_storage(tmp_path, default_persistence_off):
 def test_task_inherits_default_result_settings():
     @flow
     def foo():
-        return get_run_context().result_store, bar()
+        return bar()
 
     @task
     def bar():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    _, task_store = foo()
-    assert task_store.persist_result is False
+    task_store, task_persist_result = foo()
+    assert task_persist_result is False
     assert task_store.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(task_store.result_storage, DEFAULT_STORAGE())
     assert task_store.result_storage_block_id is None
@@ -415,29 +435,30 @@ def test_task_default_persist_result_can_be_overriden_by_setting():
 
         @flow
         def foo():
-            return get_run_context().result_store, bar()
+            return bar()
 
         @task
         def bar():
-            return get_run_context().result_store
+            return should_persist_result()
 
-        _, task_store = foo()
+        persist_result = foo()
 
-    assert task_store.persist_result is True
+    assert persist_result is True
 
 
 def test_nested_flow_custom_persist_setting():
     @flow(persist_result=True)
     def foo():
-        return get_run_context().result_store, bar()
+        child_store, child_persist_result = bar()
+        return should_persist_result(), child_persist_result, child_store
 
     @flow(persist_result=False)
     def bar():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    flow_store, task_store = foo()
-    assert flow_store.persist_result is True
-    assert task_store.persist_result is False
+    flow_persist_result, task_persist_result, task_store = foo()
+    assert flow_persist_result is True
+    assert task_persist_result is False
     assert task_store.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(task_store.result_storage, DEFAULT_STORAGE())
     assert task_store.result_storage_block_id is None
@@ -469,15 +490,16 @@ def test_task_can_opt_out_of_result_persistence_when_flow_uses_feature(
 ):
     @flow(retries=3)
     def foo():
-        return get_run_context().result_store, bar()
+        child_store, child_persist_result = bar()
+        return should_persist_result(), child_persist_result, child_store
 
     @flow(persist_result=False)
     def bar():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    flow_store, task_store = foo()
-    assert flow_store.persist_result is False
-    assert task_store.persist_result is False
+    flow_persist_result, task_persist_result, task_store = foo()
+    assert flow_persist_result is False
+    assert task_persist_result is False
     assert task_store.serializer == DEFAULT_SERIALIZER()
     assert_blocks_equal(task_store.result_storage, DEFAULT_STORAGE())
     assert task_store.result_storage_block_id is None
@@ -486,29 +508,30 @@ def test_task_can_opt_out_of_result_persistence_when_flow_uses_feature(
 def test_task_can_opt_out_when_persist_result_default_is_overriden_by_setting():
     @flow
     def foo():
-        return get_run_context().result_store, bar()
+        return bar()
 
     @task(persist_result=False)
     def bar():
-        return get_run_context().result_store
+        return should_persist_result()
 
     with temporary_settings({PREFECT_RESULTS_PERSIST_BY_DEFAULT: True}):
-        _, task_store = foo()
+        persist_result = foo()
 
-    assert task_store.persist_result is False
+    assert persist_result is False
 
 
 def test_task_inherits_custom_serializer(default_persistence_off):
     @flow(result_serializer="json", persist_result=False)
     def foo():
-        return get_run_context().result_store, bar()
+        child_store, child_persist_result = bar()
+        return get_run_context().result_store, child_persist_result, child_store
 
     @flow()
     def bar():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    flow_store, task_store = foo()
-    assert task_store.persist_result is False
+    flow_store, task_persist_result, task_store = foo()
+    assert task_persist_result is False
     assert task_store.serializer == flow_store.serializer
     assert_blocks_equal(task_store.result_storage, DEFAULT_STORAGE())
     assert task_store.result_storage_block_id is None
@@ -520,14 +543,15 @@ async def test_task_inherits_custom_storage(tmp_path):
 
     @flow(result_storage="local-file-system/test", persist_result=True)
     def foo():
-        return get_run_context().result_store, bar()
+        child_store, child_persist_result = bar()
+        return get_run_context().result_store, child_persist_result, child_store
 
     @task(persist_result=True)
     def bar():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    flow_store, task_store = foo()
-    assert task_store.persist_result
+    flow_store, task_persist_result, task_store = foo()
+    assert task_persist_result is True
     assert task_store.serializer == DEFAULT_SERIALIZER()
     assert task_store.result_storage == flow_store.result_storage
     assert task_store.result_storage_block_id == storage_id
@@ -536,18 +560,19 @@ async def test_task_inherits_custom_storage(tmp_path):
 def test_task_custom_serializer(default_persistence_off):
     @flow
     def foo():
-        return get_run_context().result_store, bar()
+        child_store, child_persist_result = bar()
+        return get_run_context().result_store, child_persist_result, child_store
 
     @flow(result_serializer="json", persist_result=False)
     def bar():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    flow_store, task_store = foo()
-    assert flow_store.serializer == DEFAULT_SERIALIZER()
-    assert task_store.persist_result is False
-    assert task_store.serializer == JSONSerializer()
-    assert_blocks_equal(task_store.result_storage, DEFAULT_STORAGE())
-    assert task_store.result_storage_block_id is None
+    parent_store, child_persist_result, child_store = foo()
+    assert parent_store.serializer == DEFAULT_SERIALIZER()
+    assert child_persist_result is False
+    assert child_store.serializer == JSONSerializer()
+    assert_blocks_equal(child_store.result_storage, DEFAULT_STORAGE())
+    assert child_store.result_storage_block_id is None
 
 
 async def test_nested_flow_custom_storage(tmp_path):
@@ -556,18 +581,19 @@ async def test_nested_flow_custom_storage(tmp_path):
 
     @flow(persist_result=True)
     def foo():
-        return get_run_context().result_store, bar()
+        child_store, child_persist_result = bar()
+        return get_run_context().result_store, child_persist_result, child_store
 
     @flow(result_storage="local-file-system/test", persist_result=True)
     def bar():
-        return get_run_context().result_store
+        return get_run_context().result_store, should_persist_result()
 
-    flow_store, task_store = foo()
-    assert_blocks_equal(flow_store.result_storage, DEFAULT_STORAGE())
-    assert_blocks_equal(task_store.result_storage, storage)
-    assert task_store.persist_result is True
-    assert task_store.serializer == DEFAULT_SERIALIZER()
-    assert task_store.result_storage_block_id == storage_id
+    parent_store, child_persist_result, child_store = foo()
+    assert_blocks_equal(parent_store.result_storage, DEFAULT_STORAGE())
+    assert_blocks_equal(child_store.result_storage, storage)
+    assert child_persist_result is True
+    assert child_store.serializer == DEFAULT_SERIALIZER()
+    assert child_store.result_storage_block_id == storage_id
 
 
 async def _verify_default_storage_creation_with_persistence(
@@ -579,7 +605,6 @@ async def _verify_default_storage_creation_with_persistence(
     assert_blocks_equal(result_store.result_storage, DEFAULT_STORAGE())
 
     # verify storage settings are correctly set
-    assert result_store.persist_result is True
     assert result_store.result_storage_block_id is None
 
 
@@ -590,7 +615,6 @@ async def _verify_default_storage_creation_without_persistence(
     assert_blocks_equal(result_store.result_storage, DEFAULT_STORAGE())
 
     # verify storage settings are correctly set
-    assert result_store.persist_result is False
     assert result_store.result_storage_block_id is None
 
 
@@ -697,7 +721,6 @@ async def test_result_store_from_task_with_no_flow_run_context(options, expected
 
     result_store = await ResultStore().update_for_task(task=my_task)
 
-    assert result_store.persist_result == expected["persist_result"]
     assert result_store.cache_result_in_memory == expected["cache_result_in_memory"]
     assert result_store.serializer == expected["serializer"]
     assert_blocks_equal(result_store.result_storage, DEFAULT_STORAGE())
@@ -709,30 +732,30 @@ async def test_result_store_from_task_loads_persist_result_from_flow_store(
 ):
     @task
     def my_task():
-        return get_run_context().result_store
+        return should_persist_result()
 
     @flow(persist_result=persist_result)
     def foo():
         return my_task()
 
-    result_store = foo()
+    persist_result = foo()
 
-    assert result_store.persist_result is persist_result
+    assert persist_result is persist_result
 
 
 @pytest.mark.parametrize("persist_result", [True, False])
 async def test_result_store_from_task_takes_precedence_from_task(persist_result):
     @task(persist_result=persist_result)
     def my_task():
-        return get_run_context().result_store
+        return should_persist_result()
 
     @flow(persist_result=not persist_result)
     def foo():
         return my_task()
 
-    result_store = foo()
+    persist_result = foo()
 
-    assert result_store.persist_result is persist_result
+    assert persist_result is persist_result
 
 
 async def test_result_store_read_and_write_with_metadata_storage(tmp_path):
@@ -771,15 +794,15 @@ async def test_result_store_exists_with_metadata_storage(tmp_path):
     value = "test"
     await result_store.awrite(key=key, obj=value)
 
-    assert await result_store.aexists(key=key) is True
-    assert await result_store.aexists(key="nonexistent") is False
-    assert result_store.exists(key=key) is True
-    assert result_store.exists(key="nonexistent") is False
+    assert await result_store.aexists(key=key)
+    assert not await result_store.aexists(key="nonexistent")
+    assert result_store.exists(key=key)
+    assert not result_store.exists(key="nonexistent")
 
     # Remove the metadata file and check that the result is not found
     (tmp_path / "metadata" / key).unlink()
-    assert await result_store.aexists(key=key) is False
-    assert result_store.exists(key=key) is False
+    assert not await result_store.aexists(key=key)
+    assert not result_store.exists(key=key)
 
 
 async def test_result_store_exists_with_no_metadata_storage(tmp_path):
@@ -789,13 +812,13 @@ async def test_result_store_exists_with_no_metadata_storage(tmp_path):
     key = "test"
     value = "test"
     await result_store.awrite(key=key, obj=value)
-    assert await result_store.aexists(key=key) is True
-    assert result_store.exists(key=key) is True
+    assert await result_store.aexists(key=key)
+    assert result_store.exists(key=key)
 
     # Remove the result file and check that the result is not found
     (tmp_path / "results" / key).unlink()
-    assert await result_store.aexists(key=key) is False
-    assert result_store.exists(key=key) is False
+    assert not await result_store.aexists(key=key)
+    assert not result_store.exists(key=key)
 
 
 async def test_supports_isolation_level():

--- a/tests/results/test_result_store.py
+++ b/tests/results/test_result_store.py
@@ -1,3 +1,6 @@
+from inspect import isawaitable
+
+import pendulum
 import pytest
 
 import prefect.exceptions
@@ -836,3 +839,70 @@ async def test_supports_isolation_level():
     assert not store_without_lock_manager.supports_isolation_level(
         IsolationLevel.SERIALIZABLE
     )
+
+
+@pytest.mark.parametrize("method", ["awrite", "write"])
+async def test_handles_key_and_obj_args_in_different_order_writes(tmp_path, method):
+    store = ResultStore(result_storage=LocalFileSystem(basepath=tmp_path / "results"))
+
+    method = getattr(store, method)
+
+    key = "test-awrite"
+    ret = method(key, {"obj": "obj-second"})
+    if isawaitable(ret):
+        await ret
+    result = await store.aread(key)
+    assert result.result == {"obj": "obj-second"}
+
+    ret = method({"obj": "obj-first"}, key)
+    if isawaitable(ret):
+        await ret
+    result = await store.aread(key)
+    assert result.result == {"obj": "obj-first"}
+
+    ret = method(key=key, obj={"obj": "obj-kwarg"})
+    if isawaitable(ret):
+        await ret
+    result = await store.aread(key)
+    assert result.result == {"obj": "obj-kwarg"}
+
+    ret = method({"obj": "obj-first"}, key=key)
+    if isawaitable(ret):
+        await ret
+    result = await store.aread(key)
+    assert result.result == {"obj": "obj-first"}
+
+    ret = method({"obj": "obj-first-with-extra-arg"}, key, pendulum.now(), "holder")
+    if isawaitable(ret):
+        await ret
+    result = await store.aread(key)
+    assert result.result == {"obj": "obj-first-with-extra-arg"}
+
+
+async def test_handles_key_and_obj_args_in_different_order_create_result_record(
+    tmp_path,
+):
+    store = ResultStore(result_storage=LocalFileSystem(basepath=tmp_path / "results"))
+
+    key = "test-awrite"
+    ret = store.create_result_record(key, {"obj": "obj-second"})
+    assert key in ret.metadata.storage_key
+    assert ret.result == {"obj": "obj-second"}
+
+    ret = store.create_result_record({"obj": "obj-first"}, key)
+    assert key in ret.metadata.storage_key
+    assert ret.result == {"obj": "obj-first"}
+
+    ret = store.create_result_record(key=key, obj={"obj": "obj-kwarg"})
+    assert key in ret.metadata.storage_key
+    assert ret.result == {"obj": "obj-kwarg"}
+
+    ret = store.create_result_record({"obj": "obj-first"}, key=key)
+    assert key in ret.metadata.storage_key
+    assert ret.result == {"obj": "obj-first"}
+
+    ret = store.create_result_record(
+        {"obj": "obj-first-with-extra-arg"}, key, pendulum.now()
+    )
+    assert key in ret.metadata.storage_key
+    assert ret.result == {"obj": "obj-first-with-extra-arg"}

--- a/tests/results/test_task_results.py
+++ b/tests/results/test_task_results.py
@@ -4,7 +4,7 @@ import pytest
 
 from prefect.filesystems import LocalFileSystem
 from prefect.flows import flow
-from prefect.results import get_current_result_store
+from prefect.results import get_result_store
 from prefect.serializers import JSONSerializer, PickleSerializer
 from prefect.settings import (
     PREFECT_HOME,
@@ -96,7 +96,7 @@ async def test_task_result_is_cached_in_memory_by_default(prefect_client):
     @task(persist_result=True)
     def bar():
         nonlocal store
-        store = get_current_result_store()
+        store = get_result_store()
         return 1
 
     flow_state = foo(return_state=True)
@@ -115,7 +115,7 @@ async def test_task_with_uncached_but_persisted_result(prefect_client, events_pi
     @task(persist_result=True, cache_result_in_memory=False)
     def bar():
         nonlocal store
-        store = get_current_result_store()
+        store = get_result_store()
         return 1
 
     flow_state = foo(return_state=True)
@@ -140,7 +140,7 @@ async def test_task_with_uncached_but_persisted_result_not_cached_during_flow(
     def foo():
         state = bar(return_state=True)
         nonlocal store
-        store = get_current_result_store()
+        store = get_result_store()
         assert state.data.metadata.storage_key not in store.cache
         assert state.result() == 1
         assert state.data.metadata.storage_key not in store.cache

--- a/tests/results/test_task_results.py
+++ b/tests/results/test_task_results.py
@@ -4,6 +4,7 @@ import pytest
 
 from prefect.filesystems import LocalFileSystem
 from prefect.flows import flow
+from prefect.results import get_current_result_store
 from prefect.serializers import JSONSerializer, PickleSerializer
 from prefect.settings import (
     PREFECT_HOME,
@@ -85,18 +86,41 @@ async def test_task_persisted_result_due_to_opt_in(prefect_client, events_pipeli
     assert await api_state.result() == 1
 
 
+async def test_task_result_is_cached_in_memory_by_default(prefect_client):
+    store = None
+
+    @flow
+    def foo():
+        return bar(return_state=True)
+
+    @task(persist_result=True)
+    def bar():
+        nonlocal store
+        store = get_current_result_store()
+        return 1
+
+    flow_state = foo(return_state=True)
+    task_state = await flow_state.result()
+    assert task_state.data.metadata.storage_key in store.cache
+    assert await task_state.result() == 1
+
+
 async def test_task_with_uncached_but_persisted_result(prefect_client, events_pipeline):
+    store = None
+
     @flow
     def foo():
         return bar(return_state=True)
 
     @task(persist_result=True, cache_result_in_memory=False)
     def bar():
+        nonlocal store
+        store = get_current_result_store()
         return 1
 
     flow_state = foo(return_state=True)
     task_state = await flow_state.result()
-    assert not task_state.data.has_cached_object()
+    assert task_state.data.metadata.storage_key not in store.cache
     assert await task_state.result() == 1
 
     await events_pipeline.process_events()
@@ -110,12 +134,16 @@ async def test_task_with_uncached_but_persisted_result(prefect_client, events_pi
 async def test_task_with_uncached_but_persisted_result_not_cached_during_flow(
     prefect_client, events_pipeline
 ):
+    store = None
+
     @flow
     def foo():
         state = bar(return_state=True)
-        assert not state.data.has_cached_object()
+        nonlocal store
+        store = get_current_result_store()
+        assert state.data.metadata.storage_key not in store.cache
         assert state.result() == 1
-        assert not state.data.has_cached_object()
+        assert state.data.metadata.storage_key not in store.cache
         assert state.result() == 1
         return state
 
@@ -125,20 +153,10 @@ async def test_task_with_uncached_but_persisted_result_not_cached_during_flow(
 
     flow_state = foo(return_state=True)
     task_state = await flow_state.result()
-    assert not task_state.data.has_cached_object()
+    assert task_state.data.metadata.storage_key not in store.cache
     assert await task_state.result() == 1
 
     await events_pipeline.process_events()
-
-    api_state = (
-        await prefect_client.read_task_run(task_state.state_details.task_run_id)
-    ).state
-    assert not api_state.data.has_cached_object()
-    assert await api_state.result() == 1
-    # After retrieval from the API, the "cache_result_in_memory" setting is dropped
-    # and caching is enabled by default
-    assert api_state.data.has_cached_object()
-    assert await api_state.result() == 1
 
 
 @pytest.mark.parametrize(
@@ -177,7 +195,7 @@ async def test_task_result_serializer(
     flow_state = foo(return_state=True)
     task_state = await flow_state.result()
     assert await task_state.result() == 1
-    await assert_uses_result_serializer(task_state, serializer)
+    await assert_uses_result_serializer(task_state, serializer, prefect_client)
 
     await events_pipeline.process_events()
 
@@ -185,7 +203,7 @@ async def test_task_result_serializer(
         await prefect_client.read_task_run(task_state.state_details.task_run_id)
     ).state
     assert await api_state.result() == 1
-    await assert_uses_result_serializer(api_state, serializer)
+    await assert_uses_result_serializer(api_state, serializer, prefect_client)
 
 
 @pytest.mark.parametrize("source", ["child", "parent"])
@@ -232,7 +250,7 @@ async def test_task_result_static_storage_key(
     flow_state = foo(return_state=True)
     task_state = await flow_state.result()
     assert await task_state.result() == 1
-    assert task_state.data.storage_key == "test"
+    assert task_state.data.metadata.storage_key == "test"
 
     await events_pipeline.process_events()
 
@@ -240,7 +258,7 @@ async def test_task_result_static_storage_key(
         await prefect_client.read_task_run(task_state.state_details.task_run_id)
     ).state
     assert await api_state.result() == 1
-    assert task_state.data.storage_key == "test"
+    assert task_state.data.metadata.storage_key == "test"
 
 
 async def test_task_result_parameter_formatted_storage_key(
@@ -264,7 +282,7 @@ async def test_task_result_parameter_formatted_storage_key(
     flow_state = foo(return_state=True)
     task_state = await flow_state.result()
     assert await task_state.result() == 1
-    assert task_state.data.storage_key == "1-foo-bar"
+    assert task_state.data.metadata.storage_key == "1-foo-bar"
 
     await events_pipeline.process_events()
 
@@ -272,7 +290,7 @@ async def test_task_result_parameter_formatted_storage_key(
         await prefect_client.read_task_run(task_state.state_details.task_run_id)
     ).state
     assert await api_state.result() == 1
-    assert task_state.data.storage_key == "1-foo-bar"
+    assert task_state.data.metadata.storage_key == "1-foo-bar"
 
 
 async def test_task_result_flow_run_formatted_storage_key(
@@ -296,7 +314,7 @@ async def test_task_result_flow_run_formatted_storage_key(
     flow_state = foo(return_state=True)
     task_state = await flow_state.result()
     assert await task_state.result() == 1
-    assert task_state.data.storage_key == "foo__bar"
+    assert task_state.data.metadata.storage_key == "foo__bar"
 
     await events_pipeline.process_events()
 
@@ -304,7 +322,7 @@ async def test_task_result_flow_run_formatted_storage_key(
         await prefect_client.read_task_run(task_state.state_details.task_run_id)
     ).state
     assert await api_state.result() == 1
-    assert task_state.data.storage_key == "foo__bar"
+    assert task_state.data.metadata.storage_key == "foo__bar"
 
 
 async def test_task_result_with_null_return(prefect_client, events_pipeline):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -24,7 +24,7 @@ from prefect.context import (
     use_profile,
 )
 from prefect.exceptions import MissingContextError
-from prefect.results import ResultStore, get_current_result_store
+from prefect.results import ResultStore, get_result_store
 from prefect.settings import (
     DEFAULT_PROFILES_PATH,
     PREFECT_API_KEY,
@@ -181,9 +181,7 @@ async def test_get_run_context(prefect_client, local_filesystem):
             task=bar,
             task_run=task_run,
             client=prefect_client,
-            result_store=await get_current_result_store().update_for_task(
-                bar, _sync=False
-            ),
+            result_store=await get_result_store().update_for_task(bar, _sync=False),
             parameters={"foo": "bar"},
         ) as task_ctx:
             assert get_run_context() is task_ctx, "Task context takes precedence"
@@ -452,7 +450,7 @@ class TestSerializeContext:
             task=bar,
             task_run=task_run,
             client=prefect_client,
-            result_store=await get_current_result_store().update_for_task(bar),
+            result_store=await get_result_store().update_for_task(bar),
             parameters={"foo": "bar"},
         ) as task_ctx:
             serialized = serialize_context()
@@ -595,7 +593,7 @@ class TestHydratedContext:
             task=bar,
             task_run=task_run,
             client=prefect_client,
-            result_store=await get_current_result_store().update_for_task(bar),
+            result_store=await get_result_store().update_for_task(bar),
             parameters={"foo": "bar"},
         )
 

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -27,7 +27,7 @@ class TestMemoryLockManager:
         thread = threading.Thread(target=read_locked_key)
         assert store.acquire_lock(key, holder="holder1")
         thread.start()
-        await store.awrite(key, obj={"test": "value"}, holder="holder1")
+        await store.awrite(key=key, obj={"test": "value"}, holder="holder1")
         store.release_lock(key, holder="holder1")
         thread.join()
         # the read should have been blocked until the lock was released
@@ -38,7 +38,7 @@ class TestMemoryLockManager:
         store = ResultStore(lock_manager=MemoryLockManager())
         assert store.acquire_lock(key)
         # can write to key because holder is the same
-        store.write(key, obj={"test": "value"})
+        store.write(key=key, obj={"test": "value"})
         assert (record := store.read(key)) is not None
         assert record.result == {"test": "value"}
 
@@ -50,7 +50,7 @@ class TestMemoryLockManager:
             RuntimeError,
             match=f"Cannot write to result record with key {key} because it is locked by another holder.",
         ):
-            store.write(key, obj={"test": "value"}, holder="holder2")
+            store.write(key=key, obj={"test": "value"}, holder="holder2")
 
     def test_acquire_lock(self):
         key = str(uuid4())

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -1659,9 +1659,8 @@ class TestPersistence:
         assert await state.result() == 42
 
     async def test_task_loads_result_if_exists_using_result_storage_key(self):
-        store = ResultStore(persist_result=True)
-        result = await store.create_result(-92, key="foo-bar")
-        await result.write()
+        store = ResultStore()
+        store.write(obj=-92, key="foo-bar")
 
         @task(result_storage_key="foo-bar", persist_result=True)
         async def async_task():

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -29,8 +29,7 @@ from prefect.exceptions import (
     ReservedArgumentError,
 )
 from prefect.filesystems import LocalFileSystem
-from prefect.futures import PrefectDistributedFuture
-from prefect.futures import PrefectFuture as NewPrefectFuture
+from prefect.futures import PrefectDistributedFuture, PrefectFuture
 from prefect.logging import get_run_logger
 from prefect.results import ResultStore, get_or_create_default_task_scheduling_storage
 from prefect.runtime import task_run as task_run_ctx
@@ -635,7 +634,7 @@ class TestTaskSubmit:
         @flow
         def bar():
             future = foo.submit(1)
-            assert isinstance(future, NewPrefectFuture)
+            assert isinstance(future, PrefectFuture)
             return future
 
         task_state = bar()
@@ -677,7 +676,7 @@ class TestTaskSubmit:
         @flow
         async def bar():
             future = foo.submit(1)
-            assert isinstance(future, NewPrefectFuture)
+            assert isinstance(future, PrefectFuture)
             return future
 
         task_state = await bar()
@@ -691,7 +690,7 @@ class TestTaskSubmit:
         @flow
         async def bar():
             future = foo.submit(1)
-            assert isinstance(future, NewPrefectFuture)
+            assert isinstance(future, PrefectFuture)
             return future
 
         task_state = await bar()
@@ -705,7 +704,7 @@ class TestTaskSubmit:
         @flow
         def bar():
             future = foo.submit(1)
-            assert isinstance(future, NewPrefectFuture)
+            assert isinstance(future, PrefectFuture)
             return future
 
         task_state = bar()
@@ -3449,7 +3448,7 @@ class TestTaskMap:
         @flow
         def my_flow():
             futures = TestTaskMap.add_one.map([1, 2, 3])
-            assert all(isinstance(f, NewPrefectFuture) for f in futures)
+            assert all(isinstance(f, PrefectFuture) for f in futures)
             return futures
 
         task_states = my_flow()
@@ -3469,7 +3468,7 @@ class TestTaskMap:
         @flow
         def my_flow():
             futures = TestTaskMap.add_one.map((1, 2, 3))
-            assert all(isinstance(f, NewPrefectFuture) for f in futures)
+            assert all(isinstance(f, PrefectFuture) for f in futures)
             return futures
 
         task_states = my_flow()
@@ -3485,7 +3484,7 @@ class TestTaskMap:
         @flow
         def my_flow():
             futures = TestTaskMap.add_one.map(generate_numbers())
-            assert all(isinstance(f, NewPrefectFuture) for f in futures)
+            assert all(isinstance(f, PrefectFuture) for f in futures)
             return futures
 
         task_states = my_flow()
@@ -3508,7 +3507,7 @@ class TestTaskMap:
         @flow
         def my_flow():
             futures = TestTaskMap.add_together.map(quote(1), [1, 2, 3])
-            assert all(isinstance(f, NewPrefectFuture) for f in futures)
+            assert all(isinstance(f, PrefectFuture) for f in futures)
             return futures
 
         task_states = my_flow()
@@ -3518,7 +3517,7 @@ class TestTaskMap:
         @flow
         def my_flow():
             futures = TestTaskMap.add_one.map(quote([1, 2, 3]))
-            assert all(isinstance(f, NewPrefectFuture) for f in futures)
+            assert all(isinstance(f, PrefectFuture) for f in futures)
             return futures
 
         task_states = my_flow()

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -273,7 +273,9 @@ class TestDefaultTransactionStorage:
             yield
 
     async def test_transaction_outside_of_run(self):
-        with transaction(key="test_transaction_outside_of_run") as txn:
+        with transaction(
+            key="test_transaction_outside_of_run", write_on_commit=True
+        ) as txn:
             assert isinstance(txn.store, ResultRecordStore)
             result = await txn.store.result_store.create_result(
                 obj={"foo": "bar"}, key=txn.key
@@ -400,7 +402,9 @@ class TestWithMemoryRecordStore:
 
     async def test_basic_transaction(self, result_1):
         store = MemoryRecordStore()
-        with transaction(key="test_basic_transaction", store=store) as txn:
+        with transaction(
+            key="test_basic_transaction", store=store, write_on_commit=True
+        ) as txn:
             assert isinstance(txn.store, MemoryRecordStore)
             txn.stage(result_1)
 
@@ -424,6 +428,7 @@ class TestWithMemoryRecordStore:
                 key="test_competing_read_transaction",
                 store=store,
                 isolation_level=IsolationLevel.SERIALIZABLE,
+                write_on_commit=True,
             ) as txn:
                 transaction_1_open.set()
                 transaction_2_open.wait()
@@ -432,7 +437,9 @@ class TestWithMemoryRecordStore:
         thread = threading.Thread(target=writing_transaction)
         thread.start()
         transaction_1_open.wait()
-        with transaction(key="test_competing_read_transaction", store=store) as txn:
+        with transaction(
+            key="test_competing_read_transaction", store=store, write_on_commit=True
+        ) as txn:
             transaction_2_open.set()
             read_result = txn.read()
 
@@ -448,6 +455,7 @@ class TestWithMemoryRecordStore:
                 key="test_competing_write_transaction",
                 store=store,
                 isolation_level=IsolationLevel.SERIALIZABLE,
+                write_on_commit=True,
             ) as txn:
                 transaction_1_open.set()
                 txn.stage(result_1)
@@ -459,6 +467,7 @@ class TestWithMemoryRecordStore:
             key="test_competing_write_transaction",
             store=store,
             isolation_level=IsolationLevel.SERIALIZABLE,
+            write_on_commit=True,
         ) as txn:
             txn.stage(result_2)
 
@@ -491,7 +500,9 @@ class TestWithResultStore:
         return result_store
 
     async def test_basic_transaction(self, result_store):
-        with transaction(key="test_basic_transaction", store=result_store) as txn:
+        with transaction(
+            key="test_basic_transaction", store=result_store, write_on_commit=True
+        ) as txn:
             assert isinstance(txn.store, ResultStore)
             txn.stage({"foo": "bar"})
 
@@ -513,6 +524,7 @@ class TestWithResultStore:
                 key="test_competing_read_transaction",
                 store=result_store,
                 isolation_level=IsolationLevel.SERIALIZABLE,
+                write_on_commit=True,
             ) as txn:
                 write_transaction_open.set()
                 txn.stage({"foo": "bar"})
@@ -536,6 +548,7 @@ class TestWithResultStore:
                 key="test_competing_write_transaction",
                 store=result_store,
                 isolation_level=IsolationLevel.SERIALIZABLE,
+                write_on_commit=True,
             ) as txn:
                 transaction_1_open.set()
                 txn.stage({"foo": "bar"})
@@ -547,6 +560,7 @@ class TestWithResultStore:
             key="test_competing_write_transaction",
             store=result_store,
             isolation_level=IsolationLevel.SERIALIZABLE,
+            write_on_commit=True,
         ) as txn:
             txn.stage({"fizz": "buzz"})
 
@@ -560,7 +574,9 @@ class TestWithResultStore:
     async def test_can_handle_staged_base_result(self, result_store):
         result_1 = await result_store.create_result(obj={"foo": "bar"})
         with transaction(
-            key="test_can_handle_staged_base_result", store=result_store
+            key="test_can_handle_staged_base_result",
+            store=result_store,
+            write_on_commit=True,
         ) as txn:
             txn.stage(result_1)
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR updates the `Transaction` used for a task run to use a `ResultStore` instead of a `RecordStore`. Once a top-level method of `ResultStore` configuration is exposed, users will be able to configure result persistence, metadata persistence, and locking for task runs by changing the storage blocks and lock manager given to a `ResultStore`.

As a result of these changes, a JSON representation of `ResultMetadata` is stored in the `data` column of the `task_run_state` table. This replaces the JSON representation of `PersistedResult` that was used before. This maintains the current functionality to retrieve a persisted result from a state. The existing mechanics are kept for backwards compatibility.

A couple of key API additions/changes to make this possible:
- `should_persist_result`
    - The context for if results should be persisted or not is moved to the `FlowRunContext` and `TaskRunContext` models. This removes the responsibility of whether or not to persist from the `ResultStore`. Consumers of a `ResultStore` need to choose if `.write` or `.persist_result_record` should be called, and `should_persist_result` helps with that. The `persist_result` attribute is kept on `ResultStore` for backwards compatibility, but it has been marked as deprecated.
- `ResultRecord.from_metadata`
    - This method is the equivalent of `PersistedResult.get` and is used to fetch persisted results from their persisted location.
- `Transaction.write_on_commit`
    - This attribute controls whether a transaction should write a result record based on its staged value on commit. Since `Transaction` is a consumer of `ResultStore`, it is responsible for choosing when to delegate writes to the `ResultStore`.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
