### PR TITLE
chore: only trigger helm release workflows on 3.x.x version releases

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create prefect-helm release
+        if: startsWith(github.ref, 'refs/tags/3.')
         run: |
           gh workflow run helm-release.yaml \
             --repo PrefectHQ/prefect-helm \


### PR DESCRIPTION
Since we are no longer cutting releases of our `prefect-helm` charts packaged with `prefect 2`, we will only allow this repo to trigger a helm release on a 3.x version.

Supporting GHA workflow doc [here](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#startswith)
![Screenshot 2024-09-06 at 5 57 24 PM](https://github.com/user-attachments/assets/0727157c-33b9-4f6d-8edf-9e9f66c1b501)

Relates to PLA-237

