### PR TITLE
Notification security controls

### DIFF
--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -10,6 +10,7 @@ from prefect.logging import LogEavesdropper
 from prefect.types import SecretDict
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.templating import apply_values, find_placeholders
+from prefect.utilities.urls import validate_restricted_url
 
 PREFECT_NOTIFY_TYPE_DEFAULT = "prefect_default"
 
@@ -80,6 +81,21 @@ class AppriseNotificationBlock(AbstractAppriseNotificationBlock, ABC):
         description="Incoming webhook URL used to send notifications.",
         examples=["https://hooks.example.com/XXX"],
     )
+    allow_private_urls: bool = Field(
+        default=True,
+        description="Whether to allow notifications to private URLs. Defaults to True.",
+    )
+
+    @sync_compatible
+    async def notify(
+        self,
+        body: str,
+        subject: Optional[str] = None,
+    ):
+        if not self.allow_private_urls:
+            validate_restricted_url(self.url.get_secret_value())
+
+        await super().notify(body, subject)
 
 
 # TODO: Move to prefect-slack once collection block auto-registration is

--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -93,7 +93,12 @@ class AppriseNotificationBlock(AbstractAppriseNotificationBlock, ABC):
         subject: Optional[str] = None,
     ):
         if not self.allow_private_urls:
-            validate_restricted_url(self.url.get_secret_value())
+            try:
+                validate_restricted_url(self.url.get_secret_value())
+            except ValueError as exc:
+                if self._raise_on_failure:
+                    raise NotificationError(str(exc))
+                raise
 
         await super().notify(body, subject)
 

--- a/src/prefect/blocks/webhook.py
+++ b/src/prefect/blocks/webhook.py
@@ -6,6 +6,7 @@ from typing_extensions import Literal
 
 from prefect.blocks.core import Block
 from prefect.types import SecretDict
+from prefect.utilities.urls import validate_restricted_url
 
 # Use a global HTTP transport to maintain a process-wide connection pool for
 # interservice requests
@@ -39,6 +40,10 @@ class Webhook(Block):
         title="Webhook Headers",
         description="A dictionary of headers to send with the webhook request.",
     )
+    allow_private_urls: bool = Field(
+        default=True,
+        description="Whether to allow notifications to private URLs. Defaults to True.",
+    )
 
     def block_initialization(self):
         self._client = AsyncClient(transport=_http_transport)
@@ -50,6 +55,9 @@ class Webhook(Block):
         Args:
             payload: an optional payload to send when calling the webhook.
         """
+        if not self.allow_private_urls:
+            validate_restricted_url(self.url.get_secret_value())
+
         async with self._client:
             return await self._client.request(
                 method=self.method,

--- a/src/prefect/utilities/urls.py
+++ b/src/prefect/utilities/urls.py
@@ -1,6 +1,9 @@
 import inspect
+import ipaddress
+import socket
 import urllib.parse
 from typing import Any, Literal, Optional, Union
+from urllib.parse import urlparse
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -56,6 +59,54 @@ API_URL_FORMATS = {
 
 URLType = Literal["ui", "api"]
 RUN_TYPES = {"flow-run", "task-run"}
+
+
+def validate_restricted_url(url: str):
+    """
+    Validate that the provided URL is safe for outbound requests.  This prevents
+    attacks like SSRF (Server Side Request Forgery), where an attacker can make
+    requests to internal services (like the GCP metadata service, localhost addresses,
+    or in-cluster Kubernetes services)
+
+    Args:
+        url: The URL to validate.
+
+    Raises:
+        ValueError: If the URL is a restricted URL.
+    """
+
+    try:
+        parsed_url = urlparse(url)
+    except ValueError:
+        raise ValueError(f"{url!r} is not a valid URL.")
+
+    if parsed_url.scheme not in ("http", "https"):
+        raise ValueError(
+            f"{url!r} is not a valid URL.  Only HTTP and HTTPS URLs are allowed."
+        )
+
+    hostname = parsed_url.hostname or ""
+
+    # Remove IPv6 brackets if present
+    if hostname.startswith("[") and hostname.endswith("]"):
+        hostname = hostname[1:-1]
+
+    if not hostname:
+        raise ValueError(f"{url!r} is not a valid URL.")
+
+    try:
+        ip_address = socket.gethostbyname(hostname)
+        ip = ipaddress.ip_address(ip_address)
+    except socket.gaierror:
+        try:
+            ip = ipaddress.ip_address(hostname)
+        except ValueError:
+            raise ValueError(f"{url!r} is not a valid URL.  It could not be resolved.")
+
+    if ip.is_private:
+        raise ValueError(
+            f"{url!r} is not a valid URL.  It resolves to the private address {ip}."
+        )
 
 
 def convert_class_to_name(obj: Any) -> str:

--- a/src/prefect/utilities/urls.py
+++ b/src/prefect/utilities/urls.py
@@ -2,19 +2,21 @@ import inspect
 import ipaddress
 import socket
 import urllib.parse
-from typing import Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 from urllib.parse import urlparse
 from uuid import UUID
 
 from pydantic import BaseModel
 
 from prefect import settings
-from prefect.blocks.core import Block
-from prefect.events.schemas.automations import Automation
-from prefect.events.schemas.events import ReceivedEvent, Resource
-from prefect.futures import PrefectFuture
 from prefect.logging.loggers import get_logger
-from prefect.variables import Variable
+
+if TYPE_CHECKING:
+    from prefect.blocks.core import Block
+    from prefect.events.schemas.automations import Automation
+    from prefect.events.schemas.events import ReceivedEvent, Resource
+    from prefect.futures import PrefectFuture
+    from prefect.variables import Variable
 
 logger = get_logger("utilities.urls")
 
@@ -120,12 +122,12 @@ def convert_class_to_name(obj: Any) -> str:
 
 def url_for(
     obj: Union[
-        PrefectFuture,
-        Block,
-        Variable,
-        Automation,
-        Resource,
-        ReceivedEvent,
+        "PrefectFuture",
+        "Block",
+        "Variable",
+        "Automation",
+        "Resource",
+        "ReceivedEvent",
         BaseModel,
         str,
     ],
@@ -156,6 +158,11 @@ def url_for(
         url_for(obj=my_flow_run)
         url_for("flow-run", obj_id="123e4567-e89b-12d3-a456-426614174000")
     """
+    from prefect.blocks.core import Block
+    from prefect.events.schemas.automations import Automation
+    from prefect.events.schemas.events import ReceivedEvent, Resource
+    from prefect.futures import PrefectFuture
+
     if isinstance(obj, PrefectFuture):
         name = "task-run"
     elif isinstance(obj, Block):

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -39,7 +39,6 @@ RESTRICTED_URLS = [
     ("not a url", ""),
     ("http://", ""),
     ("https://", ""),
-    ("http://[]/foo/bar", ""),
     ("ftp://example.com", "HTTP and HTTPS"),
     ("gopher://example.com", "HTTP and HTTPS"),
     ("https://localhost", "private address"),

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -31,6 +31,42 @@ notification_classes = sorted(
     key=lambda cls: cls.__name__,
 )
 
+RESTRICTED_URLS = [
+    ("", ""),
+    (" ", ""),
+    ("[]", ""),
+    ("not a url", ""),
+    ("http://", ""),
+    ("https://", ""),
+    ("http://[]/foo/bar", ""),
+    ("ftp://example.com", "HTTP and HTTPS"),
+    ("gopher://example.com", "HTTP and HTTPS"),
+    ("https://localhost", "private address"),
+    ("https://127.0.0.1", "private address"),
+    ("https://[::1]", "private address"),
+    ("https://[fc00:1234:5678:9abc::10]", "private address"),
+    ("https://[fd12:3456:789a:1::1]", "private address"),
+    ("https://[fe80::1234:5678:9abc]", "private address"),
+    ("https://10.0.0.1", "private address"),
+    ("https://10.255.255.255", "private address"),
+    ("https://172.16.0.1", "private address"),
+    ("https://172.31.255.255", "private address"),
+    ("https://192.168.1.1", "private address"),
+    ("https://192.168.1.255", "private address"),
+    ("https://169.254.0.1", "private address"),
+    ("https://169.254.169.254", "private address"),
+    ("https://169.254.254.255", "private address"),
+    # These will resolve to a private address in production, but not in tests,
+    # so we'll use "resolve" as the reason to catch both cases
+    ("https://metadata.google.internal", "resolve"),
+    ("https://anything.privatecloud", "resolve"),
+    ("https://anything.privatecloud.svc", "resolve"),
+    ("https://anything.privatecloud.svc.cluster.local", "resolve"),
+    ("https://cluster-internal", "resolve"),
+    ("https://network-internal.cloud.svc", "resolve"),
+    ("https://private-internal.cloud.svc.cluster.local", "resolve"),
+]
+
 
 @pytest.mark.parametrize("block_class", notification_classes)
 class TestAppriseNotificationBlock:
@@ -80,6 +116,15 @@ class TestAppriseNotificationBlock:
         pickled = cloudpickle.dumps(block)
         unpickled = cloudpickle.loads(pickled)
         assert isinstance(unpickled, block_class)
+
+    @pytest.mark.parametrize("value, reason", RESTRICTED_URLS)
+    async def test_notification_can_prevent_restricted_urls(
+        self, block_class, value: str, reason: str
+    ):
+        notification = block_class(url=value, allow_private_urls=False)
+
+        with pytest.raises(ValueError, match=f"is not a valid URL.*{reason}"):
+            await notification.notify(subject="example", body="example")
 
 
 class TestMattermostWebhook:

--- a/tests/blocks/test_webhook.py
+++ b/tests/blocks/test_webhook.py
@@ -3,6 +3,42 @@ import pytest
 from prefect.blocks.webhook import Webhook
 from prefect.testing.utilities import AsyncMock
 
+RESTRICTED_URLS = [
+    ("", ""),
+    (" ", ""),
+    ("[]", ""),
+    ("not a url", ""),
+    ("http://", ""),
+    ("https://", ""),
+    ("http://[]/foo/bar", ""),
+    ("ftp://example.com", "HTTP and HTTPS"),
+    ("gopher://example.com", "HTTP and HTTPS"),
+    ("https://localhost", "private address"),
+    ("https://127.0.0.1", "private address"),
+    ("https://[::1]", "private address"),
+    ("https://[fc00:1234:5678:9abc::10]", "private address"),
+    ("https://[fd12:3456:789a:1::1]", "private address"),
+    ("https://[fe80::1234:5678:9abc]", "private address"),
+    ("https://10.0.0.1", "private address"),
+    ("https://10.255.255.255", "private address"),
+    ("https://172.16.0.1", "private address"),
+    ("https://172.31.255.255", "private address"),
+    ("https://192.168.1.1", "private address"),
+    ("https://192.168.1.255", "private address"),
+    ("https://169.254.0.1", "private address"),
+    ("https://169.254.169.254", "private address"),
+    ("https://169.254.254.255", "private address"),
+    # These will resolve to a private address in production, but not in tests,
+    # so we'll use "resolve" as the reason to catch both cases
+    ("https://metadata.google.internal", "resolve"),
+    ("https://anything.privatecloud", "resolve"),
+    ("https://anything.privatecloud.svc", "resolve"),
+    ("https://anything.privatecloud.svc.cluster.local", "resolve"),
+    ("https://cluster-internal", "resolve"),
+    ("https://network-internal.cloud.svc", "resolve"),
+    ("https://private-internal.cloud.svc.cluster.local", "resolve"),
+]
+
 
 class TestWebhook:
     def test_webhook_raises_error_on_bad_request_method(self):
@@ -12,6 +48,15 @@ class TestWebhook:
         for bad_method in ["get", "BLAH", ""]:
             with pytest.raises(ValueError):
                 Webhook(method=bad_method, url="http://google.com")
+
+    @pytest.mark.parametrize("value, reason", RESTRICTED_URLS)
+    async def test_webhook_must_not_point_to_restricted_urls(
+        self, value: str, reason: str
+    ):
+        webhook = Webhook(url=value, allow_private_urls=False)
+
+        with pytest.raises(ValueError, match=f"is not a valid URL.*{reason}"):
+            await webhook.call(payload="some payload")
 
     async def test_webhook_sends(self, monkeypatch):
         send_mock = AsyncMock()

--- a/tests/utilities/test_urls.py
+++ b/tests/utilities/test_urls.py
@@ -13,11 +13,47 @@ from prefect.futures import PrefectConcurrentFuture, PrefectDistributedFuture
 from prefect.server.schemas.core import FlowRun, TaskRun
 from prefect.server.schemas.states import State
 from prefect.settings import PREFECT_API_URL, PREFECT_UI_URL, temporary_settings
-from prefect.utilities.urls import url_for
+from prefect.utilities.urls import url_for, validate_restricted_url
 from prefect.variables import Variable
 
 MOCK_PREFECT_UI_URL = "https://ui.prefect.io"
 MOCK_PREFECT_API_URL = "https://api.prefect.io"
+
+RESTRICTED_URLS = [
+    ("", ""),
+    (" ", ""),
+    ("[]", ""),
+    ("not a url", ""),
+    ("http://", ""),
+    ("https://", ""),
+    ("http://[]/foo/bar", ""),
+    ("ftp://example.com", "HTTP and HTTPS"),
+    ("gopher://example.com", "HTTP and HTTPS"),
+    ("https://localhost", "private address"),
+    ("https://127.0.0.1", "private address"),
+    ("https://[::1]", "private address"),
+    ("https://[fc00:1234:5678:9abc::10]", "private address"),
+    ("https://[fd12:3456:789a:1::1]", "private address"),
+    ("https://[fe80::1234:5678:9abc]", "private address"),
+    ("https://10.0.0.1", "private address"),
+    ("https://10.255.255.255", "private address"),
+    ("https://172.16.0.1", "private address"),
+    ("https://172.31.255.255", "private address"),
+    ("https://192.168.1.1", "private address"),
+    ("https://192.168.1.255", "private address"),
+    ("https://169.254.0.1", "private address"),
+    ("https://169.254.169.254", "private address"),
+    ("https://169.254.254.255", "private address"),
+    # These will resolve to a private address in production, but not in tests,
+    # so we'll use "resolve" as the reason to catch both cases
+    ("https://metadata.google.internal", "resolve"),
+    ("https://anything.privatecloud", "resolve"),
+    ("https://anything.privatecloud.svc", "resolve"),
+    ("https://anything.privatecloud.svc.cluster.local", "resolve"),
+    ("https://cluster-internal", "resolve"),
+    ("https://network-internal.cloud.svc", "resolve"),
+    ("https://private-internal.cloud.svc.cluster.local", "resolve"),
+]
 
 
 @pytest.fixture
@@ -103,6 +139,12 @@ def received_event():
 @pytest.fixture
 def resource():
     return Resource({"prefect.resource.id": f"prefect.flow-run.{uuid.uuid4()}"})
+
+
+@pytest.mark.parametrize("value, reason", RESTRICTED_URLS)
+def test_validate_restricted_url_validates(value: str, reason: str):
+    with pytest.raises(ValueError, match=f"is not a valid URL.*{reason}"):
+        validate_restricted_url(url=value)
 
 
 @pytest.mark.parametrize("url_type", ["ui", "api"])


### PR DESCRIPTION
(I'm just the messenger here, all of the work here was actually done by @chrisguidry)

If a user is self-hosting a Prefect API that they expose to "external" users of any kind, it's possible for a malicious user to configure a notification URL that points to an internal API (e.g., an internal Cloud provider API), which could result in comprising information exposure. This PR adds an optional flag for users in this situation that will restrict notification URLs to only public IP addresses. Note that validation occurs at notification runtime because DNS records could be altered post-validation if it occurred prior to the webhook firing.