### PR TITLE
Move expensive filter to AND

### DIFF
--- a/src/prefect/server/services/cancellation_cleanup.py
+++ b/src/prefect/server/services/cancellation_cleanup.py
@@ -87,8 +87,8 @@ class CancellationCleanup(LoopService):
                         orm_models.FlowRun.state_type == states.StateType.RUNNING,
                         orm_models.FlowRun.state_type == states.StateType.PAUSED,
                         orm_models.FlowRun.state_type == states.StateType.CANCELLING,
-                        orm_models.FlowRun.id > high_water_mark,
                     ),
+                    orm_models.FlowRun.id > high_water_mark,
                     orm_models.FlowRun.parent_task_run_id.is_not(None),
                 )
                 .order_by(orm_models.FlowRun.id)


### PR DESCRIPTION
A user identified that this was a problematic expression to include in the OR as it risks returning massive numbers of subflow runs; this PR correctly moves the expression to the AND of the where clause, which will _hopefully_ close #15231 