### PR TITLE
Add some more nuance to labeler

### DIFF
--- a/.github/workflows/copy-linked-issue-labels.yml
+++ b/.github/workflows/copy-linked-issue-labels.yml
@@ -11,4 +11,12 @@ jobs:
       - name: copy-labels
         uses: michalvankodev/copy-issue-labels@v1.3.0
         with:
+          custom-keywords: |
+            in
+            references
+            reference
+            to
+          labels-to-exclude: |
+            great writeup
+            good first issue
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR:
- doesn't port the labels "great writeup" or "good first issue" from referenced issues to the PR
- in addition to [GitHub's automatic linking through special keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), adds a few new linking words that will trigger the auto-labeling of a PR; these words are to support phrases like "related to", "as mentioned in", etc. which usually mean the issue labels will have meaning for the PR as well