### PR TITLE
Reduce test matrix

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -35,24 +35,6 @@ jobs:
         prefect-version:
           # These versions correspond to Prefect image tags, the patch version is
           # excluded to always pull the latest patch of each minor version.
-          - "2.0"
-          - "2.1"
-          - "2.2"
-          - "2.3"
-          - "2.4"
-          - "2.5"
-          - "2.6"
-          - "2.7"
-          - "2.8"
-          - "2.9"
-          - "2.10"
-          - "2.11"
-          - "2.12"
-          - "2.13"
-          - "2.14"
-          - "2.15"
-          - "2.16"
-          - "2.17"
           - "2.18"
           - "2.19"
 

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -172,8 +172,7 @@ jobs:
         database:
           - "postgres:14"
         python-version:
-          - "3.8"
-          - "3.12"
+          - "3.11"
 
       fail-fast: true
 
@@ -285,8 +284,7 @@ jobs:
         database:
           - "postgres:14"
         python-version:
-          - "3.8"
-          - "3.12"
+          - "3.11"
 
       fail-fast: true
 
@@ -409,8 +407,7 @@ jobs:
           - "postgres:14"
           - "sqlite"
         python-version:
-          - "3.8"
-          - "3.12"
+          - "3.11"
 
       fail-fast: true
 
@@ -550,124 +547,6 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ENGINEERING_REVIEW_SLACK_WEBHOOK_URL }}
 
-  run-tests-for-datadog:
-    name: DataDog CI Visibility
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on:
-      group: oss-larger-runners
-    strategy:
-      matrix:
-        database:
-          - "postgres:14"
-        python-version:
-          - "3.12"
-
-      fail-fast: true
-
-    timeout-minutes: 45
-
-    steps:
-      - name: Display current test matrix
-        run: echo '${{ toJSON(matrix) }}'
-
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: image=moby/buildkit:v0.12.5
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        id: setup_python
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: UV Cache
-        # Manually cache the uv cache directory
-        # until setup-python supports it:
-        # https://github.com/actions/setup-python/issues/822
-        uses: actions/cache@v4
-        id: cache-uv
-        with:
-          path: ~/.cache/uv
-          key: uvcache-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-client.txt', 'requirements.txt', 'requirements-dev.txt') }}
-
-      - name: Get image tag
-        id: get_image_tag
-        run: |
-          SHORT_SHA=$(git rev-parse --short=7 HEAD)
-          tmp="sha-$SHORT_SHA-python${{ matrix.python-version }}"
-          echo "image_tag=${tmp}" >> $GITHUB_OUTPUT
-
-      - name: Build test image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          build-args: |
-            PYTHON_VERSION=${{ matrix.python-version }}
-            PREFECT_EXTRAS=[dev]
-          tags: prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }}
-          outputs: type=docker,dest=/tmp/image.tar
-
-      - name: Test Docker image
-        run: |
-          docker load --input /tmp/image.tar
-          docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }} prefect version
-
-      - name: Install packages
-        run: |
-          python -m pip install -U uv
-          uv pip install --upgrade --system -e .[dev] 'pydantic>=2.4,<3'
-
-      - name: Start database container
-        run: >
-          docker run
-          --name "postgres"
-          --detach
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-          --publish 5432:5432
-          --tmpfs /var/lib/postgresql/data
-          --env POSTGRES_USER="prefect"
-          --env POSTGRES_PASSWORD="prefect"
-          --env POSTGRES_DB="prefect"
-          --env LANG="C.UTF-8"
-          --env LANGUAGE="C.UTF-8"
-          --env LC_ALL="C.UTF-8"
-          --env LC_COLLATE="C.UTF-8"
-          --env LC_CTYPE="C.UTF-8"
-          ${{ matrix.database }}
-          -c max_connections=250
-
-          ./scripts/wait-for-healthy-container.sh postgres 30
-
-          echo "PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://prefect:prefect@localhost/prefect" >> $GITHUB_ENV
-
-      - name: Run tests
-        run: >
-          pytest tests
-          --numprocesses auto
-          --maxprocesses 6
-          --ddtrace
-          --dist loadscope
-          --disable-docker-image-builds
-          --exclude-service kubernetes
-          --durations 26
-          --cov
-          --cov-config setup.cfg
-        env:
-          DD_CIVISIBILITY_AGENTLESS_ENABLED: true
-          DD_API_KEY: ${{ secrets.DD_API_KEY_CI_VISIBILITY }}
-          DD_SITE: datadoghq.com
-          DD_ENV: ci
-          DD_SERVICE: prefect
-
   run-docker-tests:
     runs-on:
       group: oss-larger-runners
@@ -677,11 +556,8 @@ jobs:
         database:
           - "postgres:14"
         python-version:
-          - "3.8"
-          - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12"
 
       fail-fast: true
 


### PR DESCRIPTION
Reduces 2.x test matrix due to brittle test failures; the reduction in scope is based on the fact that the overwhelming number of new installs for 2.20.* are on 3.11 with a large representation on 3.10 as well.

Note: I expect tests to fail until #15292 is merged which fixes issues from `pydantic>=2.9`