### PR TITLE
Concurrency limit UX enhancements: add `strict` mode

### DIFF
--- a/docs/3.0/api-ref/rest-api/server/schema.json
+++ b/docs/3.0/api-ref/rest-api/server/schema.json
@@ -12469,9 +12469,15 @@
                         "default": "concurrency"
                     },
                     "create_if_missing": {
-                        "type": "boolean",
-                        "title": "Create If Missing",
-                        "default": true
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Create If Missing"
                     }
                 },
                 "type": "object",

--- a/src/prefect/_internal/compatibility/deprecated.py
+++ b/src/prefect/_internal/compatibility/deprecated.py
@@ -30,7 +30,7 @@ M = TypeVar("M", bound=BaseModel)
 
 
 DEPRECATED_WARNING = (
-    "{name} has been deprecated{when}. It will not be available after {end_date}."
+    "{name} has been deprecated{when}. It will not be available in new releases after {end_date}."
     " {help}"
 )
 DEPRECATED_MOVED_WARNING = (

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -3055,7 +3055,11 @@ class PrefectClient:
         return response.json()
 
     async def increment_concurrency_slots(
-        self, names: List[str], slots: int, mode: str, create_if_missing: Optional[bool]
+        self,
+        names: List[str],
+        slots: int,
+        mode: str,
+        create_if_missing: Optional[bool] = None,
     ) -> httpx.Response:
         return await self._client.post(
             "/v2/concurrency_limits/increment",
@@ -3063,7 +3067,7 @@ class PrefectClient:
                 "names": names,
                 "slots": slots,
                 "mode": mode,
-                "create_if_missing": create_if_missing,
+                "create_if_missing": create_if_missing if create_if_missing else False,
             },
         )
 

--- a/src/prefect/concurrency/asyncio.py
+++ b/src/prefect/concurrency/asyncio.py
@@ -16,6 +16,7 @@ except ImportError:
 
 from prefect.client.orchestration import get_client
 from prefect.client.schemas.responses import MinimalConcurrencyLimitResponse
+from prefect.logging.loggers import get_run_logger
 from prefect.utilities.asyncutils import sync_compatible
 
 from .context import ConcurrencyContext
@@ -188,8 +189,13 @@ async def _acquire_concurrency_slots(
             f"Concurrency limits {names!r} must be created before acquiring slots"
         )
     elif not retval:
-        # add a warning log
-        return retval
+        try:
+            logger = get_run_logger()
+            logger.warning(
+                f"Concurrency limits {names!r} do not exist - skipping acquisition."
+            )
+        except Exception:
+            pass
     return retval
 
 

--- a/src/prefect/concurrency/services.py
+++ b/src/prefect/concurrency/services.py
@@ -63,7 +63,7 @@ class ConcurrencySlotAcquisitionService(QueueService):
         slots: int,
         mode: str,
         timeout_seconds: Optional[float] = None,
-        create_if_missing: Optional[bool] = False,
+        create_if_missing: Optional[bool] = None,
         max_retries: Optional[int] = None,
     ) -> httpx.Response:
         with timeout_async(seconds=timeout_seconds):

--- a/src/prefect/concurrency/sync.py
+++ b/src/prefect/concurrency/sync.py
@@ -35,7 +35,7 @@ def concurrency(
     names: Union[str, List[str]],
     occupy: int = 1,
     timeout_seconds: Optional[float] = None,
-    create_if_missing: bool = True,
+    create_if_missing: Optional[bool] = None,
     max_retries: Optional[int] = None,
 ) -> Generator[None, None, None]:
     """A context manager that acquires and releases concurrency slots from the
@@ -46,7 +46,6 @@ def concurrency(
         occupy: The number of slots to acquire and hold from each limit.
         timeout_seconds: The number of seconds to wait for the slots to be acquired before
             raising a `TimeoutError`. A timeout of `None` will wait indefinitely.
-        create_if_missing: Whether to create the concurrency limits if they do not exist.
         max_retries: The maximum number of retries to acquire the concurrency slots.
 
     Raises:
@@ -99,7 +98,7 @@ def rate_limit(
     names: Union[str, List[str]],
     occupy: int = 1,
     timeout_seconds: Optional[float] = None,
-    create_if_missing: Optional[bool] = True,
+    create_if_missing: Optional[bool] = None,
 ) -> None:
     """Block execution until an `occupy` number of slots of the concurrency
     limits given in `names` are acquired. Requires that all given concurrency
@@ -110,7 +109,6 @@ def rate_limit(
         occupy: The number of slots to acquire and hold from each limit.
         timeout_seconds: The number of seconds to wait for the slots to be acquired before
             raising a `TimeoutError`. A timeout of `None` will wait indefinitely.
-        create_if_missing: Whether to create the concurrency limits if they do not exist.
     """
     if not names:
         return

--- a/src/prefect/concurrency/sync.py
+++ b/src/prefect/concurrency/sync.py
@@ -35,8 +35,9 @@ def concurrency(
     names: Union[str, List[str]],
     occupy: int = 1,
     timeout_seconds: Optional[float] = None,
-    create_if_missing: Optional[bool] = None,
     max_retries: Optional[int] = None,
+    strict: bool = False,
+    create_if_missing: Optional[bool] = None,
 ) -> Generator[None, None, None]:
     """A context manager that acquires and releases concurrency slots from the
     given concurrency limits.
@@ -47,9 +48,12 @@ def concurrency(
         timeout_seconds: The number of seconds to wait for the slots to be acquired before
             raising a `TimeoutError`. A timeout of `None` will wait indefinitely.
         max_retries: The maximum number of retries to acquire the concurrency slots.
+        strict: A boolean specifying whether to raise an error if the concurrency limit does not exist.
+            Defaults to `False`.
 
     Raises:
         TimeoutError: If the slots are not acquired within the given timeout.
+        ConcurrencySlotAcquisitionError: If the concurrency limit does not exist and `strict` is `True`.
 
     Example:
     A simple example of using the sync `concurrency` context manager:
@@ -75,6 +79,7 @@ def concurrency(
         occupy,
         timeout_seconds=timeout_seconds,
         create_if_missing=create_if_missing,
+        strict=strict,
         max_retries=max_retries,
         _sync=True,
     )
@@ -99,6 +104,7 @@ def rate_limit(
     occupy: int = 1,
     timeout_seconds: Optional[float] = None,
     create_if_missing: Optional[bool] = None,
+    strict: bool = False,
 ) -> None:
     """Block execution until an `occupy` number of slots of the concurrency
     limits given in `names` are acquired. Requires that all given concurrency
@@ -109,6 +115,12 @@ def rate_limit(
         occupy: The number of slots to acquire and hold from each limit.
         timeout_seconds: The number of seconds to wait for the slots to be acquired before
             raising a `TimeoutError`. A timeout of `None` will wait indefinitely.
+        strict: A boolean specifying whether to raise an error if the concurrency limit does not exist.
+            Defaults to `False`.
+
+    Raises:
+        TimeoutError: If the slots are not acquired within the given timeout.
+        ConcurrencySlotAcquisitionError: If the concurrency limit does not exist and `strict` is `True`.
     """
     if not names:
         return
@@ -121,6 +133,7 @@ def rate_limit(
         mode="rate_limit",
         timeout_seconds=timeout_seconds,
         create_if_missing=create_if_missing,
+        strict=strict,
         _sync=True,
     )
     _emit_concurrency_acquisition_events(limits, occupy)

--- a/src/prefect/server/api/concurrency_limits_v2.py
+++ b/src/prefect/server/api/concurrency_limits_v2.py
@@ -150,7 +150,7 @@ async def bulk_increment_active_slots(
     slots: int = Body(..., gt=0),
     names: List[str] = Body(..., min_items=1),
     mode: Literal["concurrency", "rate_limit"] = Body("concurrency"),
-    create_if_missing: bool = Body(True),
+    create_if_missing: Optional[bool] = Body(None),
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> List[MinimalConcurrencyLimitResponse]:
     async with db.session_context(begin_transaction=True) as session:

--- a/src/prefect/server/models/concurrency_limits_v2.py
+++ b/src/prefect/server/models/concurrency_limits_v2.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
 import prefect.server.schemas as schemas
+from prefect._internal.compatibility.deprecated import deprecated_parameter
 from prefect.server.database import orm_models
 from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
@@ -185,10 +186,17 @@ async def delete_concurrency_limit(
     return result.rowcount > 0
 
 
+@deprecated_parameter(
+    name="create_if_missing",
+    start_date="Sep 2024",
+    end_date="Oct 2024",
+    when=lambda x: x is not None,
+    help="Limits must be explicitly created before acquiring concurrency slots.",
+)
 async def bulk_read_or_create_concurrency_limits(
     session: AsyncSession,
     names: List[str],
-    create_if_missing: Optional[bool] = True,
+    create_if_missing: Optional[bool] = None,
 ) -> List[orm_models.ConcurrencyLimitV2]:
     # Get all existing concurrency limits in `names`.
     existing_query = sa.select(orm_models.ConcurrencyLimitV2).where(

--- a/tests/_internal/compatibility/test_deprecated.py
+++ b/tests/_internal/compatibility/test_deprecated.py
@@ -18,7 +18,7 @@ def test_generate_deprecation_message():
         generate_deprecation_message(
             "test name", start_date="Jan 2022", help="test help"
         )
-        == "test name has been deprecated. It will not be available after Jul 2022."
+        == "test name has been deprecated. It will not be available in new releases after Jul 2022."
         " test help"
     )
 
@@ -28,7 +28,7 @@ def test_generate_deprecation_message_when():
         generate_deprecation_message(
             "test name", start_date="Jan 2022", help="test help", when="testing"
         )
-        == "test name has been deprecated when testing. It will not be available after"
+        == "test name has been deprecated when testing. It will not be available in new releases after"
         " Jul 2022. test help"
     )
 
@@ -41,7 +41,7 @@ def test_generate_deprecation_message_invalid_start_date():
 def test_generate_deprecation_message_end_date():
     assert (
         generate_deprecation_message("test name", end_date="Dec 2023")
-        == "test name has been deprecated. It will not be available after Dec 2023."
+        == "test name has been deprecated. It will not be available in new releases after Dec 2023."
     )
 
 
@@ -66,7 +66,7 @@ def test_deprecated_callable():
         PrefectDeprecationWarning,
         match=(
             "test_deprecated.test_deprecated_callable.<locals>.foo has been deprecated."
-            " It will not be available after Jul 2022. test help"
+            " It will not be available in new releases after Jul 2022. test help"
         ),
     ):
         foo()
@@ -87,7 +87,7 @@ def test_deprecated_parameter():
     with pytest.warns(
         PrefectDeprecationWarning,
         match=(
-            "The parameter 'y' for 'foo' has been deprecated. It will not be available"
+            "The parameter 'y' for 'foo' has been deprecated. It will not be available in new releases"
             " after Jul 2022. test help"
         ),
     ):
@@ -112,7 +112,7 @@ def test_deprecated_parameter_when():
     with pytest.warns(
         PrefectDeprecationWarning,
         match=(
-            "The parameter 'x' for 'foo' has been deprecated. It will not be available"
+            "The parameter 'x' for 'foo' has been deprecated. It will not be available in new releases"
             " after Jul 2022. test help"
         ),
     ):
@@ -140,7 +140,7 @@ def test_deprecated_field():
     with pytest.warns(
         PrefectDeprecationWarning,
         match=(
-            "The field 'y' in 'Foo' has been deprecated. It will not be available after"
+            "The field 'y' in 'Foo' has been deprecated. It will not be available in new releases after"
             " Jul 2022. test help"
         ),
     ):
@@ -163,7 +163,7 @@ def test_deprecated_field_when():
     with pytest.warns(
         PrefectDeprecationWarning,
         match=(
-            "The field 'x' in 'Foo' has been deprecated. It will not be available after"
+            "The field 'x' in 'Foo' has been deprecated. It will not be available in new releases after"
             " Jul 2022. test help"
         ),
     ):
@@ -181,7 +181,7 @@ def test_deprecated_class():
     with pytest.warns(
         PrefectDeprecationWarning,
         match=(
-            "MyClass has been deprecated. It will not be available after Jul 2022."
+            "MyClass has been deprecated. It will not be available in new releases after Jul 2022."
             " test help"
         ),
     ):

--- a/tests/concurrency/test_acquire_concurrency_slots.py
+++ b/tests/concurrency/test_acquire_concurrency_slots.py
@@ -28,7 +28,7 @@ async def test_calls_increment_client_method():
             names=["test-1", "test-2"],
             slots=1,
             mode="concurrency",
-            create_if_missing=True,
+            create_if_missing=None,
         )
 
 

--- a/tests/concurrency/test_concurrency_asyncio.py
+++ b/tests/concurrency/test_concurrency_asyncio.py
@@ -79,6 +79,28 @@ async def test_concurrency_can_be_used_within_a_flow(
     assert executed
 
 
+async def test_concurrency_can_be_used_within_a_flow(
+    concurrency_limit: ConcurrencyLimitV2,
+):
+    executed = False
+
+    @task
+    async def resource_heavy():
+        nonlocal executed
+        async with concurrency("test", occupy=1):
+            executed = True
+
+    @flow
+    async def my_flow():
+        await resource_heavy()
+
+    assert not executed
+
+    await my_flow()
+
+    assert executed
+
+
 async def test_concurrency_emits_events(
     concurrency_limit: ConcurrencyLimitV2,
     other_concurrency_limit: ConcurrencyLimitV2,

--- a/tests/concurrency/test_concurrency_asyncio.py
+++ b/tests/concurrency/test_concurrency_asyncio.py
@@ -41,7 +41,7 @@ async def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV
                 ["test"],
                 1,
                 timeout_seconds=None,
-                create_if_missing=True,
+                create_if_missing=None,
                 max_retries=None,
             )
 
@@ -218,7 +218,7 @@ async def test_rate_limit_orchestrates_api(
                 1,
                 mode="rate_limit",
                 timeout_seconds=None,
-                create_if_missing=True,
+                create_if_missing=None,
             )
 
             # When used as a rate limit concurrency slots are not explicitly

--- a/tests/concurrency/test_concurrency_asyncio.py
+++ b/tests/concurrency/test_concurrency_asyncio.py
@@ -43,6 +43,7 @@ async def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV
                 timeout_seconds=None,
                 create_if_missing=None,
                 max_retries=None,
+                strict=False,
             )
 
             # On release we calculate how many seconds the slots were occupied
@@ -235,6 +236,7 @@ async def test_rate_limit_orchestrates_api(
                 mode="rate_limit",
                 timeout_seconds=None,
                 create_if_missing=None,
+                strict=False,
             )
 
             # When used as a rate limit concurrency slots are not explicitly
@@ -414,6 +416,7 @@ async def test_concurrency_creates_new_limits_if_requested(
                 timeout_seconds=None,
                 create_if_missing=True,
                 max_retries=None,
+                strict=False,
             )
 
             # On release we calculate how many seconds the slots were occupied

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -8,6 +8,7 @@ from prefect import flow, task
 from prefect.concurrency.asyncio import (
     _acquire_concurrency_slots,
     _release_concurrency_slots,
+    ConcurrencySlotAcquisitionError,
 )
 from prefect.concurrency.sync import concurrency, rate_limit
 from prefect.events.clients import AssertingEventsClient
@@ -20,7 +21,7 @@ def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV2):
 
     def resource_heavy():
         nonlocal executed
-        with concurrency("test", occupy=1):
+        with concurrency(concurrency_limit.name, occupy=1):
             executed = True
 
     assert not executed
@@ -41,6 +42,7 @@ def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV2):
                 timeout_seconds=None,
                 create_if_missing=None,
                 max_retries=None,
+                strict=False,
                 _sync=True,
             )
 
@@ -64,7 +66,9 @@ def test_concurrency_emits_events(
     reset_worker_events,
 ):
     def resource_heavy():
-        with concurrency(["test", "other"], occupy=1):
+        with concurrency(
+            [concurrency_limit.name, other_concurrency_limit.name], occupy=1
+        ):
             pass
 
     resource_heavy()
@@ -140,7 +144,7 @@ def test_concurrency_can_be_used_within_a_flow(
     @task
     def resource_heavy():
         nonlocal executed
-        with concurrency("test", occupy=1):
+        with concurrency(concurrency_limit.name, occupy=1):
             executed = True
 
     @flow
@@ -152,6 +156,22 @@ def test_concurrency_can_be_used_within_a_flow(
     my_flow()
 
     assert executed
+
+
+def test_concurrency_strict_within_a_flow():
+    @task
+    def resource_heavy():
+        with concurrency("doesnt-exist-for-sure", occupy=1, strict=True):
+            return
+
+    @flow
+    def my_flow():
+        resource_heavy()
+
+    state = my_flow(return_state=True)
+    assert state.is_failed()
+    with pytest.raises(ConcurrencySlotAcquisitionError):
+        state.result()
 
 
 @pytest.mark.parametrize("names", [[], None])
@@ -192,7 +212,7 @@ async def test_concurrency_can_be_used_while_event_loop_is_running(
 
     def resource_heavy():
         nonlocal executed
-        with concurrency("test", occupy=1):
+        with concurrency(concurrency_limit.name, occupy=1):
             executed = True
 
     assert not executed
@@ -233,7 +253,7 @@ def test_rate_limit_orchestrates_api(concurrency_limit_with_decay: ConcurrencyLi
 
     def resource_heavy():
         nonlocal executed
-        rate_limit("test", 1)
+        rate_limit(concurrency_limit_with_decay.name, 1)
         executed = True
 
     assert not executed
@@ -272,7 +292,7 @@ def test_rate_limit_can_be_used_within_a_flow(
     @task
     def resource_heavy():
         nonlocal executed
-        rate_limit("test", occupy=1)
+        rate_limit(concurrency_limit_with_decay.name, occupy=1)
         executed = True
 
     @flow
@@ -286,6 +306,21 @@ def test_rate_limit_can_be_used_within_a_flow(
     assert executed
 
 
+def test_rate_limit_can_be_used_within_a_flow_with_strict():
+    @task
+    def resource_heavy():
+        rate_limit(["definitely-doesnt-exist"], occupy=1, strict=True)
+
+    @flow
+    def my_flow():
+        resource_heavy()
+
+    state = my_flow(return_state=True)
+    assert state.is_failed()
+    with pytest.raises(ConcurrencySlotAcquisitionError):
+        state.result()
+
+
 def test_rate_limit_mixed_sync_async(
     concurrency_limit_with_decay: ConcurrencyLimitV2,
 ):
@@ -294,7 +329,7 @@ def test_rate_limit_mixed_sync_async(
     @task
     def resource_heavy():
         nonlocal executed
-        rate_limit("test", occupy=1)
+        rate_limit(concurrency_limit_with_decay.name, occupy=1)
         executed = True
 
     @flow
@@ -316,7 +351,13 @@ def test_rate_limit_emits_events(
     reset_worker_events,
 ):
     def resource_heavy():
-        rate_limit(["test", "other"], occupy=1)
+        rate_limit(
+            [
+                concurrency_limit_with_decay.name,
+                other_concurrency_limit_with_decay.name,
+            ],
+            occupy=1,
+        )
 
     resource_heavy()
 

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -274,6 +274,7 @@ def test_rate_limit_orchestrates_api(concurrency_limit_with_decay: ConcurrencyLi
                 mode="rate_limit",
                 timeout_seconds=None,
                 create_if_missing=None,
+                strict=False,
                 _sync=True,
             )
 

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -6,9 +6,9 @@ from starlette import status
 
 from prefect import flow, task
 from prefect.concurrency.asyncio import (
+    ConcurrencySlotAcquisitionError,
     _acquire_concurrency_slots,
     _release_concurrency_slots,
-    ConcurrencySlotAcquisitionError,
 )
 from prefect.concurrency.sync import concurrency, rate_limit
 from prefect.events.clients import AssertingEventsClient

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -39,7 +39,7 @@ def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV2):
                 ["test"],
                 1,
                 timeout_seconds=None,
-                create_if_missing=True,
+                create_if_missing=None,
                 max_retries=None,
                 _sync=True,
             )
@@ -253,7 +253,7 @@ def test_rate_limit_orchestrates_api(concurrency_limit_with_decay: ConcurrencyLi
                 1,
                 mode="rate_limit",
                 timeout_seconds=None,
-                create_if_missing=True,
+                create_if_missing=None,
                 _sync=True,
             )
 

--- a/tests/concurrency/v1/test_increment_concurrency_limits.py
+++ b/tests/concurrency/v1/test_increment_concurrency_limits.py
@@ -32,7 +32,7 @@ async def test_calls_increment_client_method():
             names=["test-1", "test-2"],
             slots=1,
             mode="concurrency",
-            create_if_missing=True,
+            create_if_missing=None,
         )
 
 

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -676,6 +676,7 @@ class TestRunner:
                     timeout_seconds=None,
                     create_if_missing=None,
                     max_retries=0,
+                    strict=False,
                 )
 
                 names, occupy, occupy_seconds = release_spy.call_args[0]
@@ -722,6 +723,7 @@ class TestRunner:
                 timeout_seconds=None,
                 create_if_missing=None,
                 max_retries=0,
+                strict=False,
             )
 
             flow_run = await prefect_client.read_flow_run(flow_run.id)

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -674,7 +674,7 @@ class TestRunner:
                     [f"deployment:{deployment_id}"],
                     1,
                     timeout_seconds=None,
-                    create_if_missing=True,
+                    create_if_missing=None,
                     max_retries=0,
                 )
 
@@ -720,7 +720,7 @@ class TestRunner:
                 [f"deployment:{deployment_id}"],
                 1,
                 timeout_seconds=None,
-                create_if_missing=True,
+                create_if_missing=None,
                 max_retries=0,
             )
 

--- a/tests/server/models/test_concurrency_limits_v2.py
+++ b/tests/server/models/test_concurrency_limits_v2.py
@@ -319,7 +319,33 @@ async def test_delete_concurrency_limit_by_name(
     )
 
 
-async def test_bulk_read_or_create_concurrency_limits(session: AsyncSession):
+async def test_bulk_read_or_create_concurrency_limits_with_deprecated_flag(
+    session: AsyncSession,
+):
+    names = ["Chase", "Marshall", "Skye", "Rubble", "Zuma", "Rocky", "Everest"]
+
+    pre_existing = names[:3]
+
+    for name in pre_existing:
+        await create_concurrency_limit(
+            session=session, concurrency_limit=ConcurrencyLimitV2(name=name, limit=1)
+        )
+
+    limits = await bulk_read_or_create_concurrency_limits(
+        session=session, names=names, create_if_missing=True
+    )
+
+    assert set(names) == {limit.name for limit in limits}
+
+    for limit in limits:
+        if limit.name in pre_existing:
+            assert limit.active
+        else:
+            assert not limit.active
+            assert limit.limit == 1
+
+
+async def test_bulk_read_or_create_concurrency_limits_default(session: AsyncSession):
     names = ["Chase", "Marshall", "Skye", "Rubble", "Zuma", "Rocky", "Everest"]
 
     pre_existing = names[:3]
@@ -331,14 +357,8 @@ async def test_bulk_read_or_create_concurrency_limits(session: AsyncSession):
 
     limits = await bulk_read_or_create_concurrency_limits(session=session, names=names)
 
-    assert set(names) == {limit.name for limit in limits}
-
-    for limit in limits:
-        if limit.name in pre_existing:
-            assert limit.active
-        else:
-            assert not limit.active
-            assert limit.limit == 1
+    assert set(pre_existing) == {limit.name for limit in limits}
+    assert all(limit.active for limit in limits)
 
 
 async def test_increment_active_slots_success(

--- a/tests/server/orchestration/api/test_concurrency_limits_v2.py
+++ b/tests/server/orchestration/api/test_concurrency_limits_v2.py
@@ -227,6 +227,17 @@ async def test_increment_concurrency_limit_slots_gt_zero_422(
     assert response.status_code == 422
 
 
+async def test_increment_concurrency_limit_slots_with_unknown_name(
+    client: AsyncClient,
+):
+    response = await client.post(
+        "/v2/concurrency_limits/increment",
+        json={"names": ["foo-bar-limit"], "slots": 1, "mode": "concurrency"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
 async def test_increment_concurrency_limit_simple(
     concurrency_limit: ConcurrencyLimitV2,
     client: AsyncClient,

--- a/tests/server/orchestration/api/test_concurrency_limits_v2.py
+++ b/tests/server/orchestration/api/test_concurrency_limits_v2.py
@@ -448,12 +448,14 @@ async def test_increment_concurrency_limit_rate_limit_mode_implicitly_created_li
     client: AsyncClient,
     session: AsyncSession,
 ):
+    # DEPRECATED BEHAVIOR
     response = await client.post(
         "/v2/concurrency_limits/increment",
         json={
             "names": ["implicitly_created_limit"],
             "slots": 1,
             "mode": "rate_limit",
+            "create_if_missing": True,
         },
     )
 
@@ -468,6 +470,27 @@ async def test_increment_concurrency_limit_rate_limit_mode_implicitly_created_li
     assert refreshed_limit
     assert not bool(refreshed_limit.active)
     assert refreshed_limit.active_slots == 0  # Inactive limits are not incremented
+
+
+async def test_increment_concurrency_limit_rate_limit_mode_doesnt_create_by_default(
+    client: AsyncClient,
+    session: AsyncSession,
+):
+    response = await client.post(
+        "/v2/concurrency_limits/increment",
+        json={
+            "names": ["ignored_limit"],
+            "slots": 1,
+            "mode": "rate_limit",
+        },
+    )
+
+    assert response.status_code == 200
+
+    refreshed_limit = await read_concurrency_limit(
+        session=session, name="ignored_limit"
+    )
+    assert refreshed_limit is None
 
 
 async def test_increment_concurrency_limit_rate_limit_mode_limit_without_decay(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -431,7 +431,7 @@ class TestAPILogHandler:
                 PrefectDeprecationWarning,
                 match=(
                     'The "send_to_orion" option has been deprecated. It will not be'
-                    ' available after Nov 2023. Use "send_to_api" instead.'
+                    ' available in new releases after Nov 2023. Use "send_to_api" instead.'
                 ),
             ):
                 PrefectLogAdapter(logger, extra={}).info(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -85,7 +85,7 @@ class TestSettingClass:
             DeprecationWarning,
             match=(
                 "Setting 'PREFECT_TEST_SETTING' has been deprecated. It will not be"
-                " available after Jul 2023. test help"
+                " available in new releases after Jul 2023. test help"
             ),
         ):
             PREFECT_TEST_SETTING.value()
@@ -114,7 +114,7 @@ class TestSettingClass:
                 DeprecationWarning,
                 match=(
                     "Setting 'PREFECT_TEST_SETTING' has been deprecated when the value"
-                    " is foo. It will not be available after Jul 2023."
+                    " is foo. It will not be available in new releases after Jul 2023."
                 ),
             ):
                 PREFECT_TEST_SETTING.value()

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -379,6 +379,7 @@ async def test_worker_with_deployment_concurrency_limit_uses_limit(
                 timeout_seconds=None,
                 create_if_missing=None,
                 max_retries=0,
+                strict=False,
             )
 
             names, occupy, occupy_seconds = release_spy.call_args[0]
@@ -418,6 +419,7 @@ async def test_worker_with_deployment_concurrency_limit_proposes_awaiting_limit_
             timeout_seconds=None,
             create_if_missing=None,
             max_retries=0,
+            strict=False,
         )
 
         flow_run = await prefect_client.read_flow_run(flow_run.id)

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -377,7 +377,7 @@ async def test_worker_with_deployment_concurrency_limit_uses_limit(
                 [f"deployment:{worker_deployment_wq1_cl1.id}"],
                 1,
                 timeout_seconds=None,
-                create_if_missing=True,
+                create_if_missing=None,
                 max_retries=0,
             )
 
@@ -416,7 +416,7 @@ async def test_worker_with_deployment_concurrency_limit_proposes_awaiting_limit_
             [f"deployment:{worker_deployment_wq1_cl1.id}"],
             1,
             timeout_seconds=None,
-            create_if_missing=True,
+            create_if_missing=None,
             max_retries=0,
         )
 


### PR DESCRIPTION
This PR deprecates `create_if_missing` which causes an ill-posed problem: creating a limit _implicitly_ has no obvious default limit value.

Instead, the behavior we want is:
- taking concurrency from a limit name that doesn't exist in the backend should be functionally equivalent to taking concurrency from a limit name that has a limit of `None` or from a limit that is "inactive" and therefore - at this instant - might as well not exist, i.e., it allows execution without creating any new object in the backend (and we log a `WARNING` to alert users)
- for users who want stricter control, we have a new kwarg `strict: bool` that specifies whether to raise an error if the limit name doesn't exist in the backend; this defaults to `False` but can be set to `True`. Setting this to `True` is satisfying the need of "I really want to make sure I have full control over the circumstance in which this runs" and if the limit doesn't exist, we don't yet know those circumstances and so we prevent execution through a raised exception

I believe I need to revisit the docs for these utilities, but in the meantime wanted to get some eyes on the code.