### PR TITLE
Create `FilesystemLockManager`

### DIFF
--- a/src/prefect/locking/filesystem.py
+++ b/src/prefect/locking/filesystem.py
@@ -1,0 +1,240 @@
+import json
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+import anyio
+import pendulum
+from typing_extensions import TypedDict
+
+from prefect.logging.loggers import get_logger
+
+from .protocol import LockManager
+
+logger = get_logger(__name__)
+
+
+class _LockInfo(TypedDict):
+    """
+    A dictionary containing information about a lock.
+
+    Attributes:
+        holder: The holder of the lock.
+        expiration: Datetime when the lock expires.
+        path: Path to the lock file.
+    """
+
+    holder: str
+    expiration: Optional[pendulum.DateTime]
+    path: Path
+
+
+class FileSystemLockManager(LockManager):
+    """
+    A lock manager that implements locking using local files.
+
+    Attributes:
+        lock_files_directory: the directory where lock files are stored
+    """
+
+    def __init__(self, lock_files_directory: Path):
+        self.lock_files_directory = lock_files_directory
+        self._locks: Dict[str, _LockInfo] = {}
+
+    def _ensure_records_directory_exists(self):
+        self.lock_files_directory.mkdir(parents=True, exist_ok=True)
+
+    def _lock_path_for_key(self, key: str) -> Path:
+        if (lock_info := self._locks.get(key)) is not None:
+            return lock_info["path"]
+        return self.lock_files_directory.joinpath(key).with_suffix(".lock")
+
+    def _get_lock_info(self, key: str, use_cache=True) -> Optional[_LockInfo]:
+        if use_cache:
+            if (lock_info := self._locks.get(key)) is not None:
+                return lock_info
+
+        lock_path = self._lock_path_for_key(key)
+
+        try:
+            with open(lock_path, "r") as lock_file:
+                lock_info = json.load(lock_file)
+                lock_info["path"] = lock_path
+                expiration = lock_info.get("expiration")
+                lock_info["expiration"] = (
+                    pendulum.parse(expiration) if expiration is not None else None
+                )
+            self._locks[key] = lock_info
+            return lock_info
+        except FileNotFoundError:
+            return None
+
+    async def _aget_lock_info(
+        self, key: str, use_cache: bool = True
+    ) -> Optional[_LockInfo]:
+        if use_cache:
+            if (lock_info := self._locks.get(key)) is not None:
+                return lock_info
+
+        lock_path = self._lock_path_for_key(key)
+
+        try:
+            lock_info = await anyio.Path(lock_path).read_text()
+            lock_info = json.loads(lock_info)
+            lock_info["path"] = lock_path
+            expiration = lock_info.get("expiration")
+            lock_info["expiration"] = (
+                pendulum.parse(expiration) if expiration is not None else None
+            )
+            self._locks[key] = lock_info
+            return lock_info
+        except FileNotFoundError:
+            return None
+
+    def acquire_lock(
+        self,
+        key: str,
+        holder: str,
+        acquire_timeout: Optional[float] = None,
+        hold_timeout: Optional[float] = None,
+    ) -> bool:
+        self._ensure_records_directory_exists()
+        lock_path = self._lock_path_for_key(key)
+
+        if self.is_locked(key) and not self.is_lock_holder(key, holder):
+            lock_free = self.wait_for_lock(key, acquire_timeout)
+            if not lock_free:
+                return False
+
+        try:
+            Path(lock_path).touch(exist_ok=False)
+        except FileExistsError:
+            if not self.is_lock_holder(key, holder):
+                logger.debug(
+                    f"Another actor acquired the lock for record with key {key}. Trying again."
+                )
+                return self.acquire_lock(key, holder, acquire_timeout, hold_timeout)
+        expiration = (
+            pendulum.now("utc") + pendulum.duration(seconds=hold_timeout)
+            if hold_timeout is not None
+            else None
+        )
+
+        with open(Path(lock_path), "w") as lock_file:
+            json.dump(
+                {
+                    "holder": holder,
+                    "expiration": str(expiration) if expiration is not None else None,
+                },
+                lock_file,
+            )
+
+        self._locks[key] = {
+            "holder": holder,
+            "expiration": expiration,
+            "path": lock_path,
+        }
+
+        return True
+
+    async def aacquire_lock(
+        self,
+        key: str,
+        holder: str,
+        acquire_timeout: float | None = None,
+        hold_timeout: float | None = None,
+    ) -> bool:
+        await anyio.Path(self.lock_files_directory).mkdir(parents=True, exist_ok=True)
+        lock_path = self._lock_path_for_key(key)
+
+        if self.is_locked(key) and not self.is_lock_holder(key, holder):
+            lock_free = self.wait_for_lock(key, acquire_timeout)
+            if not lock_free:
+                return False
+
+        try:
+            await anyio.Path(lock_path).touch(exist_ok=False)
+        except FileExistsError:
+            if not self.is_lock_holder(key, holder):
+                logger.debug(
+                    f"Another actor acquired the lock for record with key {key}. Trying again."
+                )
+                return self.acquire_lock(key, holder, acquire_timeout, hold_timeout)
+        expiration = (
+            pendulum.now("utc") + pendulum.duration(seconds=hold_timeout)
+            if hold_timeout is not None
+            else None
+        )
+
+        async with await anyio.Path(lock_path).open("w") as lock_file:
+            await lock_file.write(
+                json.dumps(
+                    {
+                        "holder": holder,
+                        "expiration": str(expiration)
+                        if expiration is not None
+                        else None,
+                    },
+                )
+            )
+
+        self._locks[key] = {
+            "holder": holder,
+            "expiration": expiration,
+            "path": lock_path,
+        }
+
+        return True
+
+    def release_lock(self, key: str, holder: str) -> None:
+        lock_path = self._lock_path_for_key(key)
+        if not self.is_locked(key):
+            ValueError(f"No lock for transaction with key {key}")
+        if self.is_lock_holder(key, holder):
+            Path(lock_path).unlink(missing_ok=True)
+            self._locks.pop(key, None)
+        else:
+            raise ValueError(f"No lock held by {holder} for transaction with key {key}")
+
+    def is_locked(self, key: str, use_cache: bool = False) -> bool:
+        if (lock_info := self._get_lock_info(key, use_cache=use_cache)) is None:
+            return False
+
+        if (expiration := lock_info.get("expiration")) is None:
+            return True
+
+        expired = expiration < pendulum.now("utc")
+        if expired:
+            Path(lock_info["path"]).unlink()
+            self._locks.pop(key, None)
+            return False
+        else:
+            return True
+
+    def is_lock_holder(self, key: str, holder: str) -> bool:
+        if not self.is_locked(key):
+            return False
+
+        if not self.is_locked(key):
+            return False
+        if (lock_info := self._get_lock_info(key)) is None:
+            return False
+        return lock_info["holder"] == holder
+
+    def wait_for_lock(self, key: str, timeout: Optional[float] = None) -> bool:
+        seconds_waited = 0
+        while self.is_locked(key, use_cache=False):
+            if timeout and seconds_waited >= timeout:
+                return False
+            seconds_waited += 0.1
+            time.sleep(0.1)
+        return True
+
+    async def await_for_lock(self, key: str, timeout: float | None = None) -> bool:
+        seconds_waited = 0
+        while self.is_locked(key, use_cache=False):
+            if timeout and seconds_waited >= timeout:
+                return False
+            seconds_waited += 0.1
+            await anyio.sleep(0.1)
+        return True

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -209,6 +209,13 @@ class TestFileSystemLockManager:
         store.release_lock(key, holder="holder1")
         assert not store.is_locked(key)
 
+    async def test_acquire_lock_async(self, store):
+        key = str(uuid4())
+        assert await store.aacquire_lock(key, holder="holder1")
+        assert store.is_locked(key)
+        store.release_lock(key, holder="holder1")
+        assert not store.is_locked(key)
+
     def test_acquire_lock_idempotent(self, store):
         key = str(uuid4())
         assert store.acquire_lock(key, holder="holder1")
@@ -278,6 +285,29 @@ class TestFileSystemLockManager:
         key = str(uuid4())
         assert not store.is_locked(key)
         assert store.wait_for_lock(key)
+
+    async def test_wait_for_lock_async(self, store):
+        key = str(uuid4())
+        assert await store.aacquire_lock(key, holder="holder1")
+        assert store.is_locked(key)
+        assert not await store.await_for_lock(key, timeout=0.1)
+        assert store.is_locked(key)
+        store.release_lock(key, holder="holder1")
+        assert not store.is_locked(key)
+
+    async def test_wait_for_lock_async_with_timeout(self, store):
+        key = str(uuid4())
+        assert await store.aacquire_lock(key, holder="holder1")
+        assert store.is_locked(key)
+        assert not await store.await_for_lock(key, timeout=0.1)
+        assert store.is_locked(key)
+        store.release_lock(key, holder="holder1")
+        assert not store.is_locked(key)
+
+    async def test_wait_for_lock_async_never_been_locked(self, store):
+        key = str(uuid4())
+        assert not store.is_locked(key)
+        assert await store.await_for_lock(key)
 
     def test_locking_works_across_threads(self, store):
         key = str(uuid4())

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import pytest
 
+from prefect.locking.filesystem import FileSystemLockManager
 from prefect.locking.memory import MemoryLockManager
 from prefect.results import ResultStore
 
@@ -156,4 +157,142 @@ class TestMemoryLockManager:
         thread.join()
 
         # the lock should have been acquired by the thread
-        assert manager.is_locked
+        assert manager.is_locked(key)
+
+
+class TestFileSystemLockManager:
+    @pytest.fixture
+    def store(self, tmp_path):
+        return FileSystemLockManager(lock_files_directory=tmp_path)
+
+    async def test_read_locked_key(self, store):
+        key = str(uuid4())
+        store = ResultStore(lock_manager=store)
+        read_queue = queue.Queue()
+
+        def read_locked_key():
+            record = store.read(key)
+            read_queue.put(record.result)
+
+        thread = threading.Thread(target=read_locked_key)
+        assert store.acquire_lock(key, holder="holder1")
+        thread.start()
+        await store.awrite(key=key, obj={"test": "value"}, holder="holder1")
+        store.release_lock(key, holder="holder1")
+        thread.join()
+        # the read should have been blocked until the lock was released
+        assert read_queue.get_nowait() == {"test": "value"}
+
+    async def test_write_to_key_with_same_lock_holder(self, store):
+        key = str(uuid4())
+        store = ResultStore(lock_manager=store)
+        assert store.acquire_lock(key)
+        # can write to key because holder is the same
+        store.write(key=key, obj={"test": "value"})
+        assert (record := store.read(key)) is not None
+        assert record.result == {"test": "value"}
+
+    async def test_write_to_key_with_different_lock_holder(self, store):
+        key = str(uuid4())
+        store = ResultStore(lock_manager=store)
+        assert store.acquire_lock(key, holder="holder1")
+        with pytest.raises(
+            RuntimeError,
+            match=f"Cannot write to result record with key {key} because it is locked by another holder.",
+        ):
+            store.write(key=key, obj={"test": "value"}, holder="holder2")
+
+    def test_acquire_lock(self, store):
+        key = str(uuid4())
+        assert store.acquire_lock(key, holder="holder1")
+        assert store.is_locked(key)
+        store.release_lock(key, holder="holder1")
+        assert not store.is_locked(key)
+
+    def test_acquire_lock_idempotent(self, store):
+        key = str(uuid4())
+        assert store.acquire_lock(key, holder="holder1")
+        assert store.acquire_lock(key, holder="holder1")
+        assert store.is_locked(key)
+        store.release_lock(key, holder="holder1")
+        assert not store.is_locked(key)
+
+    def test_acquire_lock_with_hold_timeout(self, store):
+        key = str(uuid4())
+        assert store.acquire_lock(key=key, holder="holder1", hold_timeout=0.1)
+        assert store.is_locked(key)
+        sleep(0.2)
+        assert not store.is_locked(key)
+
+    def test_acquire_lock_with_acquire_timeout(self, store):
+        key = str(uuid4())
+        assert store.acquire_lock(key=key, holder="holder1")
+        assert store.is_locked(key)
+        assert not store.acquire_lock(key=key, holder="holder2", acquire_timeout=0.1)
+        store.release_lock(key=key, holder="holder1")
+        assert not store.is_locked(key=key)
+
+    def test_acquire_lock_when_previously_holder_timed_out(self, store):
+        key = str(uuid4())
+        assert store.acquire_lock(key=key, holder="holder1", hold_timeout=0.1)
+        assert store.is_locked(key=key)
+        # blocks and acquires the lock
+        assert store.acquire_lock(key=key, holder="holder2")
+        assert store.is_locked(key=key)
+        store.release_lock(key=key, holder="holder2")
+        assert not store.is_locked(key=key)
+
+    def test_raises_if_releasing_with_wrong_holder(self, store):
+        key = str(uuid4())
+        assert store.acquire_lock(key=key, holder="holder1")
+        assert store.is_locked(key=key)
+        with pytest.raises(
+            ValueError, match=f"No lock held by holder2 for transaction with key {key}"
+        ):
+            store.release_lock(key=key, holder="holder2")
+
+    def test_is_lock_holder(self, store):
+        key = str(uuid4())
+        assert not store.is_lock_holder(key, holder="holder1")
+        assert store.acquire_lock(key, holder="holder1")
+        assert store.is_lock_holder(key, holder="holder1")
+        assert not store.is_lock_holder(key, holder="holder2")
+
+    def test_wait_for_lock(self, store):
+        key = str(uuid4())
+        assert store.acquire_lock(key, holder="holder1", hold_timeout=0.1)
+        assert store.is_locked(key)
+        assert store.wait_for_lock(key)
+        assert not store.is_locked(key)
+
+    def test_wait_for_lock_with_timeout(self, store):
+        key = str(uuid4())
+        assert store.acquire_lock(key, holder="holder1")
+        assert store.is_locked(key)
+        assert not store.wait_for_lock(key, timeout=0.1)
+        assert store.is_locked(key)
+        store.release_lock(key, holder="holder1")
+        assert not store.is_locked(key)
+
+    def test_wait_for_lock_never_been_locked(self, store):
+        key = str(uuid4())
+        assert not store.is_locked(key)
+        assert store.wait_for_lock(key)
+
+    def test_locking_works_across_threads(self, store):
+        key = str(uuid4())
+        assert store.acquire_lock(key, holder="holder1")
+        assert store.is_locked(key)
+
+        def get_lock():
+            assert store.acquire_lock(key, holder="holder2")
+            assert store.is_locked(key)
+
+        thread = threading.Thread(target=get_lock)
+        thread.start()
+
+        store.release_lock(key, holder="holder1")
+        thread.join()
+
+        # the lock should have been acquired by the thread
+        assert store.is_locked(key)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR adds a `FileSystemLockManager`, a port of `FileSystemRecordStore`. This lock manager can be used to provide locking capabilities to a `ResultStore`.

With this PR, all released `RecordStore` implementations have been ported to `LockManger` implementations. I will add a deprecation notice to `RecordStore` implementations in a subsequent PR.

Related to https://github.com/PrefectHQ/prefect/issues/15208

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
