### PR TITLE
Disable HTTP2 by default

### DIFF
--- a/docs/3.0/api-ref/rest-api/server/schema.json
+++ b/docs/3.0/api-ref/rest-api/server/schema.json
@@ -21379,7 +21379,7 @@
                     "PREFECT_API_ENABLE_HTTP2": {
                         "type": "boolean",
                         "title": "Prefect Api Enable Http2",
-                        "default": true
+                        "default": false
                     },
                     "PREFECT_CLIENT_MAX_RETRIES": {
                         "type": "integer",

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -637,7 +637,7 @@ PREFECT_API_KEY = Setting(
 )
 """API key used to authenticate with a the Prefect API. Defaults to `None`."""
 
-PREFECT_API_ENABLE_HTTP2 = Setting(bool, default=True)
+PREFECT_API_ENABLE_HTTP2 = Setting(bool, default=False)
 """
 If true, enable support for HTTP/2 for communicating with an API.
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR updates `PREFECT_API_ENABLE_HTTP2` to disable HTTP2 by default, improving client throughput and stability.

### Load Testing
To test the effect of HTTP2, we used a single client machine and an over-resourced Prefect Cloud environment.
When enabling HTTP2, we observe very high server side response times. `p50` around 2s and `p99` at our server side timeout of 9s.

Upon digging into the data, it appears the increased response times are due to the server waiting on the client to send the full request, overwhelming server side resources. The client machine (my laptop)'s CPU resources were also overwhelmed.

After disabling HTTP2, we observed higher throughput with faster response times. `p50` around 60ms and `p99` around 250ms. And the client machine (my laptop) did not need all of it's CPU resources to complete the task.

From what I've read, likely causes of this behavior are
1. CPU overhead: HTTP/2's binary framing layer requires more CPU processing compared to HTTP/1.1. If the client is overwhelmed, it could be struggling with this additional processing.
2. TLS performance: Since HTTP/2 requires TLS, poor performance in Python's SSL library could contribute to high CPU usage, especially during connection establishment
3. Connection pooling and concurrency: If the client is trying to manage many concurrent streams or connections, it could be overwhelming the CPU with context switching and connection management.

### httpx and httpcore recommendations
[From the maintainer of httpx](https://github.com/encode/httpx/discussions/3100#discussioncomment-8516342)

> First up don't compare HTTP/2 requests vs. HTTP/1.1 requests.
We deliberately don't have HTTP/2 on by default in httpx, and it shouldn't be assumed to have better response characteristics.

[httpcore docs](https://www.encode.io/httpcore/http2/#enabling-http2)

> Switching to HTTP/2 should not necessarily be considered an "upgrade". It is more complex, and requires more computational power, and so particularly in an interpreted language like Python it could be slower in some instances. Moreover, utilising multiple connections may end up connecting to multiple hosts, and could sometimes appear faster to the client, at the cost of requiring more server resources. Enabling HTTP/2 is most likely to be beneficial if you are sending requests in high concurrency, and may often be more well suited to an async context, rather than multi-threading.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
