### PR TITLE
reintroduce job model for `prefect-databricks`

### DIFF
--- a/src/integrations/prefect-databricks/prefect_databricks/models/jobs.py
+++ b/src/integrations/prefect-databricks/prefect_databricks/models/jobs.py
@@ -746,6 +746,15 @@ class ListOrder(str, Enum):
     asc = "ASC"
 
 
+class RuntimeEngine(str, Enum):
+    """
+    Decides which runtime engine to be use, e.g. Standard vs. Photon. If unspecified, the runtime engine is inferred from spark_version.
+    """
+
+    standard = "STANDARD"
+    photon = "PHOTON"
+
+
 class LogSyncStatus(BaseModel):
     """
     See source code for the fields' description.


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/15308

this appears to have been dropped when moving this integration into `prefecthq/prefect`

I don't see any harm in reintroducing this, just for consistency