### PR TITLE
Add deprecation warnings to all `RecordStore` implementations

### DIFF
--- a/src/prefect/records/base.py
+++ b/src/prefect/records/base.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 @deprecated.deprecated_class(
     start_date="Sep 2024",
     end_date="Nov 2024",
-    help="Use `ResultRecord` instead to represent a result and it's associated metadata.",
+    help="Use `ResultRecord` instead to represent a result and its associated metadata.",
 )
 @dataclass
 class TransactionRecord:

--- a/src/prefect/records/base.py
+++ b/src/prefect/records/base.py
@@ -6,11 +6,18 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
+from prefect._internal.compatibility import deprecated
+
 if TYPE_CHECKING:
     from prefect.results import BaseResult
     from prefect.transactions import IsolationLevel
 
 
+@deprecated.deprecated_class(
+    start_date="Sep 2024",
+    end_date="Nov 2024",
+    help="Use `ResultRecord` instead to represent a result and it's associated metadata.",
+)
 @dataclass
 class TransactionRecord:
     """
@@ -21,6 +28,11 @@ class TransactionRecord:
     result: "BaseResult"
 
 
+@deprecated.deprecated_class(
+    start_date="Sep 2024",
+    end_date="Nov 2024",
+    help="Use `ResultStore` and provide a `WritableFileSystem` for `metadata_storage` instead.",
+)
 class RecordStore(abc.ABC):
     @abc.abstractmethod
     def read(

--- a/src/prefect/records/filesystem.py
+++ b/src/prefect/records/filesystem.py
@@ -6,6 +6,7 @@ from typing import Dict, Optional
 import pendulum
 from typing_extensions import TypedDict
 
+from prefect._internal.compatibility import deprecated
 from prefect.logging.loggers import get_logger
 from prefect.records.base import RecordStore, TransactionRecord
 from prefect.results import BaseResult
@@ -29,6 +30,11 @@ class _LockInfo(TypedDict):
     path: Path
 
 
+@deprecated.deprecated_class(
+    start_date="Sep 2024",
+    end_date="Nov 2024",
+    help="Use `ResultStore` with a `LocalFileSystem` for `metadata_storage` and a `FileSystemLockManager` instead.",
+)
 class FileSystemRecordStore(RecordStore):
     """
     A record store that stores data on the local filesystem.

--- a/src/prefect/records/memory.py
+++ b/src/prefect/records/memory.py
@@ -1,6 +1,7 @@
 import threading
 from typing import Dict, Optional, TypedDict
 
+from prefect._internal.compatibility import deprecated
 from prefect.results import BaseResult
 from prefect.transactions import IsolationLevel
 
@@ -22,6 +23,11 @@ class _LockInfo(TypedDict):
     expiration_timer: Optional[threading.Timer]
 
 
+@deprecated.deprecated_class(
+    start_date="Sep 2024",
+    end_date="Nov 2024",
+    help="Use `ResultStore` with a `MemoryLockManager` instead.",
+)
 class MemoryRecordStore(RecordStore):
     """
     A record store that stores data in memory.

--- a/src/prefect/records/result_store.py
+++ b/src/prefect/records/result_store.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 
 import pendulum
 
+from prefect._internal.compatibility import deprecated
 from prefect.results import BaseResult, PersistedResult, ResultStore
 from prefect.transactions import IsolationLevel
 from prefect.utilities.asyncutils import run_coro_as_sync
@@ -10,6 +11,11 @@ from prefect.utilities.asyncutils import run_coro_as_sync
 from .base import RecordStore, TransactionRecord
 
 
+@deprecated.deprecated_class(
+    start_date="Sep 2024",
+    end_date="Nov 2024",
+    help="Use `ResultStore` directly instead.",
+)
 @dataclass
 class ResultRecordStore(RecordStore):
     """

--- a/tests/records/deprecation.py
+++ b/tests/records/deprecation.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import pytest
+
+from prefect.records.filesystem import FileSystemRecordStore
+from prefect.records.memory import MemoryRecordStore
+from prefect.records.result_store import ResultRecordStore
+from prefect.results import get_result_store
+
+
+def test_all_result_stores_emit_deprecation_warning():
+    with pytest.warns(DeprecationWarning):
+        ResultRecordStore(result_store=get_result_store())
+
+    with pytest.warns(DeprecationWarning):
+        MemoryRecordStore()
+
+    with pytest.warns(DeprecationWarning):
+        FileSystemRecordStore(records_directory=Path("foo"))


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR adds deprecation warnings to all released `RecordStore` implementations as they have been superseded by `ResultStore` and it's accompanying `LockManager` implementations.

This PR also updates the `transaction` context manager to use a `ResultStore` by default instead of a `ResultRecordStore`.

Related to https://github.com/PrefectHQ/prefect/issues/15208

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
