### PR TITLE
Add deprecation warnings to results classes and methods

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,10 +46,6 @@ filterwarnings =
     # SQLAlchemy leaves some cursors unawaited
     ignore:coroutine 'Connection.cursor' was never awaited:RuntimeWarning
     ignore:coroutine 'AsyncAdapt_asyncpg_cursor._prepare_and_execute' was never awaited:RuntimeWarning
-    # These task runners will be removed in future release
-    ignore:The `RayTaskRunner` has moved:DeprecationWarning
-    ignore:The `DaskTaskRunner` has moved:DeprecationWarning
-    ignore:`DeploymentSpec` has been replaced by `Deployment`:DeprecationWarning
     # This warning is raised on Windows by Python internals
     ignore:the imp module is deprecated:DeprecationWarning
     # Dockerpy is behind on this one

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -38,7 +38,7 @@ from prefect.utilities.collections import listrepr
 from prefect.utilities.pydantic import get_class_fields_only
 
 if TYPE_CHECKING:
-    from prefect.results import BaseResult
+    from prefect.results import BaseResult, ResultRecordMetadata
 
 R = TypeVar("R")
 
@@ -50,7 +50,7 @@ class StateCreate(ActionBaseModel):
     name: Optional[str] = Field(default=None)
     message: Optional[str] = Field(default=None, examples=["Run started"])
     state_details: StateDetails = Field(default_factory=StateDetails)
-    data: Union["BaseResult[R]", Any] = Field(
+    data: Union["BaseResult[R]", "ResultRecordMetadata", Any] = Field(
         default=None,
     )
 

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -36,6 +36,7 @@ from pydantic_extra_types.pendulum_dt import DateTime
 from typing_extensions import ParamSpec, Self
 
 import prefect
+from prefect._internal.compatibility import deprecated
 from prefect._internal.compatibility.deprecated import deprecated_field
 from prefect.blocks.core import Block
 from prefect.client.utilities import inject_client
@@ -755,6 +756,11 @@ class ResultStore(BaseModel):
             )
         return await self.lock_manager.await_for_lock(key, timeout)
 
+    @deprecated.deprecated_callable(
+        start_date="Sep 2024",
+        end_date="Nov 2024",
+        help="Use `create_result_record` instead.",
+    )
     @sync_compatible
     async def create_result(
         self,

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -874,6 +874,17 @@ class ResultRecordMetadata(BaseModel):
         """
         return cls.model_validate_json(data)
 
+    def __eq__(self, other):
+        if not isinstance(other, ResultRecordMetadata):
+            return False
+        return (
+            self.storage_key == other.storage_key
+            and self.expiration == other.expiration
+            and self.serializer == other.serializer
+            and self.prefect_version == other.prefect_version
+            and self.storage_block_id == other.storage_block_id
+        )
+
 
 class ResultRecord(BaseModel, Generic[R]):
     """
@@ -1032,6 +1043,11 @@ class ResultRecord(BaseModel, Generic[R]):
             metadata=result_record_metadata,
             result=result_record_metadata.serializer.loads(result),
         )
+
+    def __eq__(self, other):
+        if not isinstance(other, ResultRecord):
+            return False
+        return self.metadata == other.metadata and self.result == other.result
 
 
 @register_base_type

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -1050,6 +1050,9 @@ class ResultRecord(BaseModel, Generic[R]):
         return self.metadata == other.metadata and self.result == other.result
 
 
+@deprecated.deprecated_class(
+    start_date="Sep 2024", end_date="Nov 2024", help="Use `ResultRecord` instead."
+)
 @register_base_type
 class BaseResult(BaseModel, abc.ABC, Generic[R]):
     model_config = ConfigDict(extra="forbid")
@@ -1100,6 +1103,9 @@ class BaseResult(BaseModel, abc.ABC, Generic[R]):
         return cls.__name__ if isinstance(default, PydanticUndefinedType) else default
 
 
+@deprecated.deprecated_class(
+    start_date="Sep 2024", end_date="Nov 2024", help="Use `ResultRecord` instead."
+)
 class PersistedResult(BaseResult):
     """
     Result type which stores a reference to a persisted result.

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -320,7 +320,7 @@ async def return_value_to_state(
         state = retval
         # Unless the user has already constructed a result explicitly, use the store
         # to update the data to the correct type
-        if not isinstance(state.data, BaseResult):
+        if not isinstance(state.data, (BaseResult, ResultRecord, ResultRecordMetadata)):
             result_record = result_store.create_result_record(
                 state.data,
                 key=key,

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -126,7 +126,7 @@ class Transaction(ContextModel):
             and not self.store.supports_isolation_level(self.isolation_level)
         ):
             raise ValueError(
-                f"Isolation level {self.isolation_level.name} is not supported by record store type {self.store.__class__.__name__}"
+                f"Isolation level {self.isolation_level.name} is not supported by provided result store."
             )
 
         # this needs to go before begin, which could set the state to committed

--- a/tests/blocks/test_core.py
+++ b/tests/blocks/test_core.py
@@ -14,7 +14,7 @@ from pydantic_core import to_json
 
 import prefect
 from prefect.blocks.core import Block, InvalidBlockRegistration
-from prefect.blocks.system import JSON, Secret
+from prefect.blocks.system import Secret
 from prefect.client.orchestration import PrefectClient
 from prefect.exceptions import PrefectHTTPStatusError
 from prefect.server import models
@@ -1089,9 +1089,9 @@ class TestAPICompatibility:
             uuid4().hex
         )  # represents a version that does not exist on the server
 
-        JSON._block_schema_version = mock_version
+        Secret._block_schema_version = mock_version
 
-        block_document_id = await JSON(value={"the_answer": 42}).save("test")
+        block_document_id = await Secret(value="secret").save("test")
 
         block_document = await prefect_client.read_block_document(block_document_id)
         assert block_document.block_schema.version == mock_version

--- a/tests/blocks/test_system.py
+++ b/tests/blocks/test_system.py
@@ -7,7 +7,7 @@ from pydantic_extra_types.pendulum_dt import DateTime as PydanticDateTime
 from prefect.blocks.system import DateTime, Secret
 
 
-def test_datetime():
+def test_datetime(ignore_prefect_deprecation_warnings):
     DateTime(value=PydanticDateTime(2022, 1, 1)).save(name="test")
     api_block = DateTime.load("test")
     assert api_block.value == pendulum.datetime(2022, 1, 1)

--- a/tests/cli/test_block.py
+++ b/tests/cli/test_block.py
@@ -195,18 +195,21 @@ def test_listing_blocks_when_none_are_registered():
 
 
 async def test_listing_blocks_after_saving_a_block():
-    block_id = await system.JSON(value="a casual test block").save("wildblock")
+    block_id = await system.Secret(value="a casual test block").save("wildblock")
 
     await run_sync_in_worker_thread(
         invoke_and_assert,
         command=["block", "ls"],
-        expected_output_contains=f"""
-            ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
-            ┃ ID                                   ┃ Type ┃ Name      ┃ Slug           ┃
-            ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━┩
-            │ {block_id} │ JSON │ wildblock │ json/wildblock │
-            └──────────────────────────────────────┴──────┴───────────┴────────────────┘
-            """,
+        expected_output_contains=[
+            "ID",
+            "Type",
+            "Name",
+            "Slug",
+            str(block_id),
+            "Secret",
+            "wildblock",
+            "secret/wildblock",
+        ],
     )
 
 
@@ -231,7 +234,7 @@ def test_listing_system_block_types(register_block_types):
     )
 
 
-async def test_inspecting_a_block():
+async def test_inspecting_a_block(ignore_prefect_deprecation_warnings):
     await system.JSON(value="a simple json blob").save("jsonblob")
 
     expected_output = ("Block Type", "Block id", "value", "a simple json blob")
@@ -253,18 +256,18 @@ def test_inspecting_a_block_malformed_slug():
 
 
 async def test_deleting_a_block():
-    await system.JSON(value="don't delete me please").save("pleasedonterase")
+    await system.Secret(value="don't delete me please").save("pleasedonterase")
 
     await run_sync_in_worker_thread(
         invoke_and_assert,
-        ["block", "delete", "json/pleasedonterase"],
+        ["block", "delete", "secret/pleasedonterase"],
         user_input="y",
         expected_code=0,
     )
 
     await run_sync_in_worker_thread(
         invoke_and_assert,
-        ["block", "inspect", "json/pleasedonterase"],
+        ["block", "inspect", "secret/pleasedonterase"],
         expected_code=1,
     )
 

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -4895,11 +4895,12 @@ class TestSaveUserInputs:
 
     @pytest.mark.usefixtures("project_dir", "interactive_console")
     async def test_deploy_resolves_block_references_in_deployments_section(
-        self, prefect_client, work_pool
+        self, prefect_client, work_pool, ignore_prefect_deprecation_warnings
     ):
         """
         Ensure block references are resolved in deployments section of prefect.yaml
         """
+        # TODO: Remove this test when `JSON` block is removed
         await JSON(value={"work_pool_name": work_pool.name}).save(
             name="test-json-block"
         )

--- a/tests/concurrency/test_concurrency_asyncio.py
+++ b/tests/concurrency/test_concurrency_asyncio.py
@@ -389,7 +389,7 @@ async def test_rate_limit_without_limit_names(names):
 
 
 async def test_concurrency_creates_new_limits_if_requested(
-    concurrency_limit: ConcurrencyLimitV2,
+    concurrency_limit: ConcurrencyLimitV2, ignore_prefect_deprecation_warnings
 ):
     executed = False
 

--- a/tests/fixtures/deprecation.py
+++ b/tests/fixtures/deprecation.py
@@ -11,7 +11,7 @@ import pytest
 from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def ignore_prefect_deprecation_warnings():
     """
     Ignore deprecation warnings from the agent module to avoid

--- a/tests/fixtures/deprecation.py
+++ b/tests/fixtures/deprecation.py
@@ -5,10 +5,35 @@ Deprecations should be specifically tested to ensure they are emitted as expecte
 """
 
 import warnings
+from datetime import datetime
 
 import pytest
 
 from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
+
+
+def should_reraise_warning(warning):
+    """
+    Determine if a deprecation warning should be reraised based on the date.
+
+    Deprecation warnings that have passed the date threshold should be reraised to
+    ensure the deprecated code paths are removed.
+    """
+    message = str(warning.message)
+    try:
+        # Extract the date from the new message format
+        date_str = message.split("not be available in new releases after ")[1].strip(
+            "."
+        )
+        # Parse the date
+        deprecation_date = datetime.strptime(date_str, "%b %Y").date().replace(day=1)
+
+        # Check if the current date is after the start of the month following the deprecation date
+        current_date = datetime.now().date().replace(day=1)
+        return current_date > deprecation_date
+    except Exception:
+        # Reraise in cases of failure
+        return True
 
 
 @pytest.fixture
@@ -17,6 +42,10 @@ def ignore_prefect_deprecation_warnings():
     Ignore deprecation warnings from the agent module to avoid
     test failures.
     """
-    with warnings.catch_warnings():
+    with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("ignore", category=PrefectDeprecationWarning)
         yield
+        for warning in w:
+            if isinstance(warning.message, PrefectDeprecationWarning):
+                if should_reraise_warning(warning):
+                    warnings.warn(warning.message, warning.category, stacklevel=2)

--- a/tests/records/test_filesystem.py
+++ b/tests/records/test_filesystem.py
@@ -21,6 +21,11 @@ def read_locked_key(key, store, queue: multiprocessing.Queue):
     queue.put(record.result, block=False)
 
 
+@pytest.fixture(autouse=True)
+def ignore_deprecations(ignore_prefect_deprecation_warnings):
+    """This file will be removed in a future release when FileSystemRecordStore is removed."""
+
+
 class TestFileSystemRecordStore:
     @pytest.fixture()
     def default_storage_setting(self, tmp_path):

--- a/tests/records/test_memory.py
+++ b/tests/records/test_memory.py
@@ -10,6 +10,11 @@ from prefect.results import ResultStore
 from prefect.transactions import IsolationLevel
 
 
+@pytest.fixture(autouse=True)
+def ignore_deprecations(ignore_prefect_deprecation_warnings):
+    """This file will be removed in a future release when MemoryRecordStore is removed."""
+
+
 class TestInMemoryRecordStore:
     def test_singleton(self):
         store1 = MemoryRecordStore()

--- a/tests/results/test_persisted_result.py
+++ b/tests/results/test_persisted_result.py
@@ -14,7 +14,7 @@ from prefect.results import (
 from prefect.serializers import JSONSerializer, PickleSerializer
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def ignore_deprecation(ignore_prefect_deprecation_warnings):
     """Remove this test file when deprecation warning period is over"""
     pass

--- a/tests/results/test_persisted_result.py
+++ b/tests/results/test_persisted_result.py
@@ -15,6 +15,12 @@ from prefect.serializers import JSONSerializer, PickleSerializer
 
 
 @pytest.fixture
+def ignore_deprecation(ignore_prefect_deprecation_warnings):
+    """Remove this test file when deprecation warning period is over"""
+    pass
+
+
+@pytest.fixture
 async def storage_block(tmp_path):
     block = LocalFileSystem(basepath=tmp_path)
     await block._save(is_anonymous=True)

--- a/tests/results/test_result_store.py
+++ b/tests/results/test_result_store.py
@@ -7,7 +7,7 @@ from prefect.context import FlowRunContext, get_run_context
 from prefect.filesystems import LocalFileSystem
 from prefect.locking.memory import MemoryLockManager
 from prefect.results import (
-    PersistedResult,
+    ResultRecord,
     ResultStore,
     should_persist_result,
 )
@@ -40,20 +40,15 @@ def default_persistence_off():
 
 @pytest.fixture
 async def store(prefect_client):
-    return ResultStore(persist_result=True)
+    return ResultStore()
 
 
-async def test_create_result_reference(store):
-    result = await store.create_result({"foo": "bar"})
-    assert isinstance(result, PersistedResult)
-    assert result.serializer_type == store.serializer.type
-    assert result.storage_block_id == store.result_storage_block_id
-    assert await result.get() == {"foo": "bar"}
-
-
-async def test_create_result_reference_has_cached_object(store):
-    result = await store.create_result({"foo": "bar"})
-    assert result.has_cached_object()
+async def test_create_result_record(store):
+    record = store.create_result_record({"foo": "bar"})
+    assert isinstance(record, ResultRecord)
+    assert record.metadata.serializer.type == store.serializer.type
+    assert record.metadata.storage_block_id == store.result_storage_block_id
+    assert record.result == {"foo": "bar"}
 
 
 def test_root_flow_default_result_store():

--- a/tests/results/test_state_result.py
+++ b/tests/results/test_state_result.py
@@ -41,8 +41,8 @@ async def test_unfinished_states_raise_on_result_retrieval(
     [StateType.CRASHED, StateType.COMPLETED, StateType.FAILED, StateType.CANCELLED],
 )
 async def test_finished_states_allow_result_retrieval(state_type: StateType):
-    store = ResultStore(persist_result=True)
-    state = State(type=state_type, data=await store.create_result("test"))
+    store = ResultStore()
+    state = State(type=state_type, data=store.create_result_record("test"))
 
     assert await state.result(raise_on_failure=False) == "test"
 

--- a/tests/results/test_state_result.py
+++ b/tests/results/test_state_result.py
@@ -11,14 +11,12 @@ import prefect.states
 from prefect.exceptions import UnfinishedRun
 from prefect.filesystems import LocalFileSystem, WritableFileSystem
 from prefect.results import (
-    PersistedResult,
     ResultRecord,
     ResultRecordMetadata,
     ResultStore,
 )
 from prefect.serializers import JSONSerializer
 from prefect.states import State, StateType
-from prefect.utilities.annotations import NotSet
 
 
 @pytest.mark.parametrize(
@@ -63,25 +61,24 @@ async def storage_block(tmp_path):
 
 
 @pytest.fixture
-async def a_real_result(storage_block: WritableFileSystem) -> PersistedResult:
-    return await PersistedResult.create(
-        "test-graceful-retry",
-        storage_block_id=storage_block._block_document_id,
-        storage_block=storage_block,
-        storage_key_fn=lambda: "test-graceful-retry-path",
+def store(storage_block: WritableFileSystem) -> ResultStore:
+    return ResultStore(
+        result_storage=storage_block,
         serializer=JSONSerializer(),
+        storage_key_fn=lambda: "test-graceful-retry-path",
     )
 
 
 @pytest.fixture
-def completed_state(a_real_result: PersistedResult) -> State[str]:
-    assert a_real_result.has_cached_object()
+async def a_real_result(store) -> ResultRecord:
+    return store.create_result_record(
+        "test-graceful-retry",
+    )
 
-    result_copy = a_real_result.model_copy()
-    result_copy._cache = NotSet
-    assert not result_copy.has_cached_object()
 
-    return State(type=StateType.COMPLETED, data=result_copy)
+@pytest.fixture
+def completed_state(a_real_result: ResultRecord) -> State[str]:
+    return State(type=StateType.COMPLETED, data=a_real_result.metadata)
 
 
 async def test_graceful_retries_are_finite_while_retrieving_missing_results(
@@ -132,16 +129,17 @@ async def test_graceful_retries_reraise_last_error_while_retrieving_missing_resu
 
 async def test_graceful_retries_eventually_succeed_while(
     shorter_result_retries: None,
-    a_real_result: PersistedResult,
+    a_real_result: ResultRecord,
     completed_state: State[str],
+    store: ResultStore,
 ):
     # now write the result so it's available
-    await a_real_result.write()
+    await store.apersist_result_record(a_real_result)
     expected_record = ResultRecord(
         result="test-graceful-retry",
         metadata=ResultRecordMetadata(
-            storage_key=a_real_result.storage_key,
-            expiration=a_real_result.expiration,
+            storage_key=a_real_result.metadata.storage_key,
+            expiration=a_real_result.metadata.expiration,
             serializer=JSONSerializer(),
         ),
     )

--- a/tests/server/models/test_concurrency_limits_v2.py
+++ b/tests/server/models/test_concurrency_limits_v2.py
@@ -320,7 +320,7 @@ async def test_delete_concurrency_limit_by_name(
 
 
 async def test_bulk_read_or_create_concurrency_limits_with_deprecated_flag(
-    session: AsyncSession,
+    session: AsyncSession, ignore_prefect_deprecation_warnings
 ):
     names = ["Chase", "Marshall", "Skye", "Rubble", "Zuma", "Rocky", "Everest"]
 

--- a/tests/server/orchestration/api/test_block_types.py
+++ b/tests/server/orchestration/api/test_block_types.py
@@ -491,7 +491,9 @@ class TestSystemBlockTypes:
         await client.post("/block_types/install_system_block_types")
         await client.post("/block_types/install_system_block_types")
 
-    async def test_create_system_block_type(self, hosted_api_client, session):
+    async def test_create_system_block_type(
+        self, hosted_api_client, session, ignore_prefect_deprecation_warnings
+    ):
         # install system blocks
         await hosted_api_client.post("/block_types/install_system_block_types")
 

--- a/tests/server/orchestration/api/test_concurrency_limits_v2.py
+++ b/tests/server/orchestration/api/test_concurrency_limits_v2.py
@@ -458,6 +458,7 @@ async def test_increment_concurrency_limit_rate_limit_mode(
 async def test_increment_concurrency_limit_rate_limit_mode_implicitly_created_limit(
     client: AsyncClient,
     session: AsyncSession,
+    ignore_prefect_deprecation_warnings,
 ):
     # DEPRECATED BEHAVIOR
     response = await client.post(
@@ -546,6 +547,7 @@ async def test_decrement_concurrency_limit(
     concurrency_limit: ConcurrencyLimitV2,
     client: AsyncClient,
     session: AsyncSession,
+    ignore_prefect_deprecation_warnings,
 ):
     assert concurrency_limit.active_slots == 0
     response = await client.post(

--- a/tests/server/orchestration/test_core_policy.py
+++ b/tests/server/orchestration/test_core_policy.py
@@ -8,9 +8,7 @@ from uuid import uuid4
 import pendulum
 import pytest
 
-from prefect.results import (
-    PersistedResult,
-)
+from prefect.results import ResultRecordMetadata
 from prefect.server import schemas
 from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.models import concurrency_limits, flow_runs
@@ -1337,7 +1335,7 @@ class TestTransitionsFromTerminalStatesRule:
             session,
             run_type,
             *intended_transition,
-            initial_state_data=PersistedResult.model_construct().model_dump(),
+            initial_state_data=ResultRecordMetadata.model_construct().model_dump(),
         )
 
         if run_type == "task":

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -158,7 +158,10 @@ class TestReturnValueToState:
         assert Path(result_state.data.metadata.storage_key).exists()
         assert await result_state.result() == 1
 
-    async def test_returns_persisted_results_unaltered(self):
+    async def test_returns_persisted_results_unaltered(
+        self, ignore_prefect_deprecation_warnings
+    ):
+        # TODO: This test will be removed in a future release when PersistedResult is removed
         store = ResultStore(persist_result=True)
         result = await store.create_result(42)
         result_state = await return_value_to_state(result, store)

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -178,7 +178,7 @@ class TestReturnValueToState:
     async def test_returns_single_state_unaltered_with_user_created_reference(
         self, store
     ):
-        result = await store.create_result("test")
+        result = store.create_result_record("test")
         state = Completed(data=result)
         result_state = await return_value_to_state(state, store)
         assert result_state is state

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -141,7 +141,7 @@ class TestReturnValueToState:
         assert await return_value_to_state(state, store) is state
 
     async def test_returns_single_state_with_null_data_and_persist_off(self):
-        store = ResultStore(persist_result=False)
+        store = ResultStore()
         state = Completed(data=None)
         result_state = await return_value_to_state(state, store)
         assert result_state is state
@@ -150,7 +150,7 @@ class TestReturnValueToState:
         assert await result_state.result() is None
 
     async def test_returns_single_state_with_data_to_persist(self):
-        store = ResultStore(persist_result=True)
+        store = ResultStore()
         state = Completed(data=1)
         result_state = await return_value_to_state(state, store, write_result=True)
         assert result_state is state
@@ -169,7 +169,7 @@ class TestReturnValueToState:
         assert await result_state.result() == 42
 
     async def test_returns_persisted_result_records_unaltered(self):
-        store = ResultStore(persist_result=True)
+        store = ResultStore()
         record = store.create_result_record(42)
         result_state = await return_value_to_state(record, store)
         assert result_state.data == record

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -1646,13 +1646,13 @@ class TestTimeout:
 
 
 class TestPersistence:
-    async def test_task_can_return_persisted_result(self):
+    async def test_task_can_return_result_record(self):
         @task
         async def async_task():
-            store = ResultStore(persist_result=True)
-            result = await store.create_result(42)
-            await result.write()
-            return result
+            store = ResultStore()
+            record = store.create_result_record(42)
+            store.persist_result_record(record)
+            return record
 
         assert await async_task() == 42
         state = await async_task(return_state=True)

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -6,9 +6,7 @@ import pytest
 from prefect.filesystems import LocalFileSystem
 from prefect.flows import flow
 from prefect.locking.memory import MemoryLockManager
-from prefect.records import RecordStore
 from prefect.records.memory import MemoryRecordStore
-from prefect.records.result_store import ResultRecordStore
 from prefect.results import (
     ResultRecord,
     ResultStore,
@@ -236,7 +234,7 @@ class TestTransactionState:
 
 
 def test_overwrite_ignores_existing_record():
-    class Store(RecordStore):
+    class Store(ResultStore):
         def exists(self, **kwargs):
             return True
 
@@ -561,7 +559,9 @@ class TestWithResultStore:
         # and the second transaction should not have written on exit
         assert record.result == {"foo": "bar"}
 
-    async def test_can_handle_staged_base_result(self, result_store):
+    async def test_can_handle_staged_base_result(
+        self, result_store, ignore_prefect_deprecation_warnings
+    ):
         result_1 = await result_store.create_result(obj={"foo": "bar"})
         with transaction(
             key="test_can_handle_staged_base_result",
@@ -619,10 +619,12 @@ class TestIsolationLevel:
     def test_inherited_isolation_level(self):
         with transaction(
             key="test",
-            store=MemoryRecordStore(),
+            store=ResultStore(lock_manager=MemoryLockManager()),
             isolation_level=IsolationLevel.SERIALIZABLE,
         ) as top:
-            with transaction(key="nested", store=MemoryRecordStore()) as inner:
+            with transaction(
+                key="nested", store=ResultStore(lock_manager=MemoryLockManager())
+            ) as inner:
                 assert (
                     inner.isolation_level
                     == top.isolation_level
@@ -632,11 +634,11 @@ class TestIsolationLevel:
     def test_raises_on_unsupported_isolation_level(self):
         with pytest.raises(
             ValueError,
-            match="Isolation level SERIALIZABLE is not supported by record store type ResultRecordStore",
+            match="Isolation level SERIALIZABLE is not supported by provided result store.",
         ):
             with transaction(
                 key="test",
-                store=ResultRecordStore(result_store=ResultStore()),
+                store=ResultStore(),
                 isolation_level=IsolationLevel.SERIALIZABLE,
             ):
                 pass

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -366,6 +366,10 @@ class TestDefaultTransactionStorage:
 
 
 class TestWithMemoryRecordStore:
+    @pytest.fixture(autouse=True)
+    def ignore_deprecations(self, ignore_prefect_deprecation_warnings):
+        """This file will be removed in a future release when MemoryRecordStore is removed."""
+
     @pytest.fixture()
     def default_storage_setting(self, tmp_path):
         name = str(uuid.uuid4())

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -486,9 +486,7 @@ class TestWithResultStore:
 
     @pytest.fixture
     async def result_store(self, default_storage_setting):
-        result_store = ResultStore(
-            persist_result=True, lock_manager=MemoryLockManager()
-        )
+        result_store = ResultStore(lock_manager=MemoryLockManager())
         return result_store
 
     async def test_basic_transaction(self, result_store):

--- a/tests/utilities/test_templating.py
+++ b/tests/utilities/test_templating.py
@@ -253,6 +253,11 @@ class TestApplyValues:
 
 
 class TestResolveBlockDocumentReferences:
+    @pytest.fixture(autouse=True)
+    def ignore_deprecation_warnings(self, ignore_prefect_deprecation_warnings):
+        """Remove references to deprecated blocks when deprecation period is over."""
+        pass
+
     @pytest.fixture()
     async def block_document_id(self):
         class ArbitraryBlock(Block):

--- a/tests/utilities/test_urls.py
+++ b/tests/utilities/test_urls.py
@@ -6,7 +6,7 @@ from typing import Literal
 import pendulum
 import pytest
 
-from prefect.blocks.system import DateTime
+from prefect.blocks.webhook import Webhook
 from prefect.events.schemas.automations import Automation, EventTrigger, Posture
 from prefect.events.schemas.events import ReceivedEvent, Resource
 from prefect.futures import PrefectConcurrentFuture, PrefectDistributedFuture
@@ -95,8 +95,8 @@ def prefect_distributed_future(task_run):
 
 @pytest.fixture
 def block():
-    block = DateTime(value="2022-01-01T00:00:00Z")
-    block.save("my-date-block", overwrite=True)
+    block = Webhook(url="https://example.com")
+    block.save("my-webhook-block", overwrite=True)
     return block
 
 
@@ -194,9 +194,7 @@ def test_url_for_prefect_future(
 
 
 @pytest.mark.parametrize("url_type", ["ui", "api"])
-def test_url_for_block(
-    block, url_type: Literal["ui", "api"], ignore_prefect_deprecation_warnings
-):
+def test_url_for_block(block, url_type: Literal["ui", "api"]):
     expected_url = (
         f"{MOCK_PREFECT_UI_URL}/blocks/block/{block._block_document_id}"
         if url_type == "ui"

--- a/tests/utilities/test_urls.py
+++ b/tests/utilities/test_urls.py
@@ -194,7 +194,9 @@ def test_url_for_prefect_future(
 
 
 @pytest.mark.parametrize("url_type", ["ui", "api"])
-def test_url_for_block(block, url_type: Literal["ui", "api"]):
+def test_url_for_block(
+    block, url_type: Literal["ui", "api"], ignore_prefect_deprecation_warnings
+):
     expected_url = (
         f"{MOCK_PREFECT_UI_URL}/blocks/block/{block._block_document_id}"
         if url_type == "ui"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR adds deprecation warning to following because they have been superseded by new results mechanics:
- `ResultStore.create_result`
- `BaseResult`
- `PersistedResult`

This PR also updates our testing logic to fail whenever a `PrefectDeprecationWarning` is raised. A fixture `ignore_prefect_deprecation_warnings` can suppress failures until the deprecation period has passed. Once the deprecation period has passed, the warnings will cause test failures again, prompting us to remove the deprecated code.

Related to https://github.com/PrefectHQ/prefect/issues/15208

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
