### PR TITLE
Add unit test for accessing `self` as normal arg when setting task run name

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -461,6 +461,18 @@ class TestTaskCall:
         # assert that the value IS the original and was never copied
         assert f.get_x() is f.x
 
+    def test_task_run_name_can_access_self_arg_for_instance_methods(self):
+        class Foo:
+            a = 10
+
+            @task(task_run_name="{self.a}|{x}")
+            def instance_method(self, x):
+                return TaskRunContext.get()
+
+        f = Foo()
+        context = f.instance_method(x=5)
+        assert context.task_run.name == "10|5"
+
     @pytest.mark.parametrize("T", [BaseFoo, BaseFooModel])
     async def test_task_supports_async_instance_methods(self, T):
         class Foo(T):


### PR DESCRIPTION
I used this functionality in some code and wanted to affirm that it's true -- because of the way instance methods are turned into task runs, the `self` param *SHOULD* be treated like any other argument (this is important for how params are passed around). That implies that it should also be available to any feature that uses task run parameters, like a string template for the task run name. This test proves that's true.