### PR TITLE
Improve type hinting docs for sync_compatible

### DIFF
--- a/src/prefect/utilities/asyncutils.py
+++ b/src/prefect/utilities/asyncutils.py
@@ -341,6 +341,13 @@ def sync_compatible(
         will submit the async method to the event loop.
     - If we cannot find an event loop, we will create a new one and run the async method
         then tear down the loop.
+
+    Note: Type checkers will infer functions decorated with `@sync_compatible` are synchronous. If
+    you want to use the decorated function in an async context, you will need to ignore the types
+    and "cast" the return type to a coroutine. For example:
+    ```
+    python result: Coroutine = sync_compatible(my_async_function)(arg1, arg2) # type: ignore
+    ```
     """
 
     @wraps(async_fn)


### PR DESCRIPTION
This PR aims to improve the docs so that if a user is typing the return of a function that is decorated by `@sync_compatible` they are aware of its behaviour.

It is a quick fix for the issue:
Closes: https://github.com/PrefectHQ/prefect/issues/15275

