### PR TITLE
Allow child transactions to access parent values set after child transaction opens

### DIFF
--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -146,18 +146,16 @@ class Transaction(ContextModel):
         """
         value = self._stored_values.get(name, NotSet)
         if value is NotSet:
+            # if there's a parent transaction, get the value from the parent
             parent = self.get_parent()
             if parent is not None:
-                try:
-                    value = parent.get(name)
-                except ValueError:
-                    pass
-
-        if value is NotSet:
-            if default is not NotSet:
+                value = parent.get(name, default)
+            # if there's no parent transaction, use the default
+            elif default is not NotSet:
                 value = default
             else:
                 raise ValueError(f"Could not retrieve value for unknown key: {name}")
+        # deepcopy to prevent mutation of stored values
         return copy.deepcopy(value)
 
     def is_committed(self) -> bool:

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -144,7 +144,8 @@ class Transaction(ContextModel):
                 assert txn.get("key") == [1, 2, 3, 4]
             ```
         """
-        value = self._stored_values.get(name, NotSet)
+        # deepcopy to prevent mutation of stored values
+        value = copy.deepcopy(self._stored_values.get(name, NotSet))
         if value is NotSet:
             # if there's a parent transaction, get the value from the parent
             parent = self.get_parent()
@@ -155,8 +156,7 @@ class Transaction(ContextModel):
                 value = default
             else:
                 raise ValueError(f"Could not retrieve value for unknown key: {name}")
-        # deepcopy to prevent mutation of stored values
-        return copy.deepcopy(value)
+        return value
 
     def is_committed(self) -> bool:
         return self.state == TransactionState.COMMITTED


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

This PR enables child transactions to access parent stored values set after the child transaction opened. This behavior is achieved by having child transactions delegate `.get` calls to their parent if they don't have a stored value for the provided key. The value from the parent transaction is copied and stored on the child transaction to avoid accidental mutation.

These changes resolve the issue in https://github.com/PrefectHQ/prefect/issues/15309 where a value set on a parent was accessed in a rollback hook since the rollback hook gets the task's transaction. These changes also mean that we don't have to copy all stored values from parent to child, which should reduce memory usage in some scenarios.

Closes https://github.com/PrefectHQ/prefect/issues/15309

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
