### PR TITLE
Set propagate to false for extra loggers

### DIFF
--- a/src/prefect/logging/configuration.py
+++ b/src/prefect/logging/configuration.py
@@ -104,7 +104,6 @@ def setup_logging(incremental: Optional[bool] = None) -> dict:
             if logger.level == logging.NOTSET:
                 logger.setLevel(extra_config.level)
             logger.propagate = extra_config.propagate
-        breakpoint()
 
     PROCESS_LOGGING_CONFIG = config
 

--- a/src/prefect/logging/configuration.py
+++ b/src/prefect/logging/configuration.py
@@ -104,6 +104,7 @@ def setup_logging(incremental: Optional[bool] = None) -> dict:
             if logger.level == logging.NOTSET:
                 logger.setLevel(extra_config.level)
             logger.propagate = extra_config.propagate
+        breakpoint()
 
     PROCESS_LOGGING_CONFIG = config
 

--- a/src/prefect/logging/logging.yml
+++ b/src/prefect/logging/logging.yml
@@ -77,6 +77,7 @@ loggers:
     prefect.extra:
         level: "${PREFECT_LOGGING_LEVEL}"
         handlers: [api]
+        propagate: false
 
     prefect.flow_runs:
         level: NOTSET


### PR DESCRIPTION
Closes #12518 and related to #11727 and #7851 

This PR sets `propagate: false` on any extra loggers configured through `PREFECT_LOGGING_EXTRA_LOGGERS`. This means that log records sent through these loggers will _not_ propagate to the `root` logger and therefore _not_ be handled by the `PrefectConsoleLogger`.  They will instead be handled by whatever handlers were explicitly configured + the `api` handler (which is necessary for sending logs to the API).

Adding this field to the default `logging.yml` file means that users can now customize this behavior through a setting / environment variable:
```
PREFECT_LOGGING_LOGGERS_PREFECT_EXTRA_PROPAGATE=true/false
```
whereas previously they needed to generate their own `logging.yml` file from scratch.

My choice of `false` for this setting is _technically_ a breaking change -- any user that _relied_ on the console logger to see their logs will now need to set this environment variable.  I'm open to push back on that, but I feel that given the reports we've seen over the years + my base expectations, it's more natural to expect extra loggers have their own `StreamHandler` already.