### PR TITLE
Dont propagate extra loggers through root logger

### DIFF
--- a/src/prefect/logging/logging.yml
+++ b/src/prefect/logging/logging.yml
@@ -77,6 +77,7 @@ loggers:
     prefect.extra:
         level: "${PREFECT_LOGGING_LEVEL}"
         handlers: [api]
+        propagate: false
 
     prefect.flow_runs:
         level: NOTSET


### PR DESCRIPTION
2.x version of #15348 -- stops propagating extra logs through root logger by default