### PR TITLE
Fix resolution of implicit relative import when using `safe_load_namespace`

### DIFF
--- a/src/prefect/utilities/importtools.py
+++ b/src/prefect/utilities/importtools.py
@@ -398,6 +398,7 @@ def safe_load_namespace(
         # Save original sys.path and modify it
         original_sys_path = sys.path.copy()
         sys.path.insert(0, parent_dir)
+        sys.path.insert(0, file_dir)
 
         # Create a temporary module for import context
         temp_module = ModuleType(package_name)

--- a/tests/utilities/test_importtools.py
+++ b/tests/utilities/test_importtools.py
@@ -330,3 +330,15 @@ def test_safe_load_namespace_does_not_execute_function_body():
     namespace = safe_load_namespace(source_code)
 
     assert not namespace["you_done_goofed"]
+
+
+def test_safe_load_namespace_implicit_relative_imports():
+    """
+    Regression test for https://github.com/PrefectHQ/prefect/issues/15352
+    """
+    path = TEST_PROJECTS_DIR / "flat-project" / "implicit_relative.py"
+    source_code = path.read_text()
+
+    namespace = safe_load_namespace(source_code, filepath=str(path))
+    assert "get_foo" in namespace
+    assert "get_bar" in namespace


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
`safe_load_namespace` had trouble loading implicitly relative import (e.g. `from constants import FOO`) because the current working directory wasn't included in the sys path when attempting to resolve imports. This PR fixes that.


Closes https://github.com/PrefectHQ/prefect/issues/15352

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
