### PR TITLE
quote type checked value

### DIFF
--- a/src/prefect/client/types/flexible_schedule_list.py
+++ b/src/prefect/client/types/flexible_schedule_list.py
@@ -7,5 +7,5 @@ if TYPE_CHECKING:
     from prefect.client.schemas.schedules import SCHEDULE_TYPES
 
 FlexibleScheduleList: TypeAlias = Sequence[
-    Union[DeploymentScheduleCreate, dict[str, Any], "SCHEDULE_TYPES"]
+    Union["DeploymentScheduleCreate", dict[str, Any], "SCHEDULE_TYPES"]
 ]


### PR DESCRIPTION
type checked value that was unquoted results in

```
  File "/Users/nate/github.com/prefecthq/prefect/src/prefect/client/types/flexible_schedule_list.py", line 10, in <module>
    Union[DeploymentScheduleCreate, dict[str, Any], "SCHEDULE_TYPES"]
          ^^^^^^^^^^^^^^^^^^^^^^^^
NameError: name 'DeploymentScheduleCreate' is not defined
```