### PR TITLE
fix: move the github conditional to the appropriate level

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   create_helm_release:
+    if: startsWith(github.ref, 'refs/tags/3.')
     runs-on: ubuntu-latest
     steps:
       - name: Create prefect-helm release
-        if: startsWith(github.ref, 'refs/tags/3.')
         run: |
           gh workflow run helm-release.yaml \
             --repo PrefectHQ/prefect-helm \


### PR DESCRIPTION
As demonstrated on the most recent 2.X release, the [action](https://github.com/PrefectHQ/prefect/actions/runs/10837591865/job/30073865265) ran successfully. We don't want this. Moving the conditional to the correct level within the action.