### PR TITLE
Refactors `__add__` and `__sub__` on cache policies

### DIFF
--- a/src/prefect/cache_policies.py
+++ b/src/prefect/cache_policies.py
@@ -98,13 +98,6 @@ class CompoundCachePolicy(CachePolicy):
             return None
         return hash_objects(*keys)
 
-    def __sub__(self, other: str) -> "CompoundCachePolicy":
-        if not isinstance(other, str):
-            raise TypeError("Can only subtract strings from key policies.")
-        new = Inputs(exclude=[other])
-        policies = self.policies
-        return CompoundCachePolicy(policies=policies + [new])
-
 
 @dataclass
 class _None(CachePolicy):

--- a/src/prefect/cache_policies.py
+++ b/src/prefect/cache_policies.py
@@ -40,10 +40,7 @@ class CachePolicy:
         # adding _None is a no-op
         if isinstance(other, _None):
             return self
-        elif isinstance(other, CompoundCachePolicy):
-            return CompoundCachePolicy(policies=other.policies + [self])
-        else:
-            return CompoundCachePolicy(policies=[self, other])
+        return CompoundCachePolicy(policies=[self, other])
 
 
 @dataclass
@@ -100,15 +97,6 @@ class CompoundCachePolicy(CachePolicy):
         if not keys:
             return None
         return hash_objects(*keys)
-
-    def __add__(self, other: "CachePolicy") -> "CachePolicy":
-        # adding _None is a no-op
-        if isinstance(other, _None):
-            return self
-        elif isinstance(other, CompoundCachePolicy):
-            return CompoundCachePolicy(policies=other.policies + self.policies)
-        else:
-            return CompoundCachePolicy(policies=self.policies + [other])
 
     def __sub__(self, other: str) -> "CompoundCachePolicy":
         if not isinstance(other, str):

--- a/src/prefect/cache_policies.py
+++ b/src/prefect/cache_policies.py
@@ -1,6 +1,6 @@
 import inspect
-from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
 
 from prefect.context import TaskRunContext
 from prefect.utilities.hashing import hash_objects
@@ -30,33 +30,18 @@ class CachePolicy:
     ) -> Optional[str]:
         raise NotImplementedError
 
-    def __sub__(self, other: str) -> "CompoundCachePolicy":
+    def __sub__(self, other: str) -> "CachePolicy":
         if not isinstance(other, str):
             raise TypeError("Can only subtract strings from key policies.")
-        if isinstance(self, Inputs):
-            exclude = self.exclude or []
-            return Inputs(exclude=exclude + [other])
-        elif isinstance(self, CompoundCachePolicy):
-            new = Inputs(exclude=[other])
-            policies = self.policies or []
-            return CompoundCachePolicy(policies=policies + [new])
-        else:
-            new = Inputs(exclude=[other])
-            return CompoundCachePolicy(policies=[self, new])
+        new = Inputs(exclude=[other])
+        return CompoundCachePolicy(policies=[self, new])
 
-    def __add__(self, other: "CachePolicy") -> "CompoundCachePolicy":
+    def __add__(self, other: "CachePolicy") -> "CachePolicy":
         # adding _None is a no-op
         if isinstance(other, _None):
             return self
-        elif isinstance(self, _None):
-            return other
-
-        if isinstance(self, CompoundCachePolicy):
-            policies = self.policies or []
-            return CompoundCachePolicy(policies=policies + [other])
         elif isinstance(other, CompoundCachePolicy):
-            policies = other.policies or []
-            return CompoundCachePolicy(policies=policies + [self])
+            return CompoundCachePolicy(policies=other.policies + [self])
         else:
             return CompoundCachePolicy(policies=[self, other])
 
@@ -93,7 +78,7 @@ class CompoundCachePolicy(CachePolicy):
     Any keys that return `None` will be ignored.
     """
 
-    policies: Optional[list] = None
+    policies: List[CachePolicy] = field(default_factory=list)
 
     def compute_key(
         self,
@@ -103,7 +88,7 @@ class CompoundCachePolicy(CachePolicy):
         **kwargs,
     ) -> Optional[str]:
         keys = []
-        for policy in self.policies or []:
+        for policy in self.policies:
             policy_key = policy.compute_key(
                 task_ctx=task_ctx,
                 inputs=inputs,
@@ -115,6 +100,22 @@ class CompoundCachePolicy(CachePolicy):
         if not keys:
             return None
         return hash_objects(*keys)
+
+    def __add__(self, other: "CachePolicy") -> "CachePolicy":
+        # adding _None is a no-op
+        if isinstance(other, _None):
+            return self
+        elif isinstance(other, CompoundCachePolicy):
+            return CompoundCachePolicy(policies=other.policies + self.policies)
+        else:
+            return CompoundCachePolicy(policies=self.policies + [other])
+
+    def __sub__(self, other: str) -> "CompoundCachePolicy":
+        if not isinstance(other, str):
+            raise TypeError("Can only subtract strings from key policies.")
+        new = Inputs(exclude=[other])
+        policies = self.policies
+        return CompoundCachePolicy(policies=policies + [new])
 
 
 @dataclass
@@ -132,6 +133,10 @@ class _None(CachePolicy):
         **kwargs,
     ) -> Optional[str]:
         return None
+
+    def __add__(self, other: "CachePolicy") -> "CachePolicy":
+        # adding _None is a no-op
+        return other
 
 
 @dataclass
@@ -208,7 +213,7 @@ class Inputs(CachePolicy):
     Policy that computes a cache key based on a hash of the runtime inputs provided to the task..
     """
 
-    exclude: Optional[list] = None
+    exclude: List[str] = field(default_factory=list)
 
     def compute_key(
         self,
@@ -229,6 +234,11 @@ class Inputs(CachePolicy):
                 hashed_inputs[key] = val
 
         return hash_objects(hashed_inputs)
+
+    def __sub__(self, other: str) -> "CachePolicy":
+        if not isinstance(other, str):
+            raise TypeError("Can only subtract strings from key policies.")
+        return Inputs(exclude=self.exclude + [other])
 
 
 INPUTS = Inputs()

--- a/tests/test_cache_policies.py
+++ b/tests/test_cache_policies.py
@@ -138,8 +138,14 @@ class TestCompoundPolicy:
 
     def test_creation_via_subtraction(self):
         one = RunId()
-        policy = one - "foo"
+        policy = one - "y"
         assert isinstance(policy, CompoundCachePolicy)
+
+        assert policy.compute_key(
+            task_ctx=None, inputs={"x": 42, "y": "foo"}, flow_parameters=None
+        ) == (RunId() + Inputs(exclude=["y"])).compute_key(
+            task_ctx=None, inputs={"x": 42, "y": "foo"}, flow_parameters=None
+        )
 
     def test_nones_are_ignored(self):
         one, two = _None(), _None()


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
Refactors `__add__` and `__sub__` on `CachePolicy` and its subclasses to remove `if isinstance(self, ...)` calls. Instead, `CachePolicy` subclasses implement new versions of `__add__` and `__sub__` so that logic is located on the appropriate classes.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
