### PR TITLE
Add `key_storage`, `isolation_level` and `lock_manager` configuration to cache policies

### DIFF
--- a/src/prefect/cache_policies.py
+++ b/src/prefect/cache_policies.py
@@ -98,15 +98,6 @@ class CompoundCachePolicy(CachePolicy):
             return None
         return hash_objects(*keys)
 
-    def __add__(self, other: "CachePolicy") -> "CachePolicy":
-        # adding _None is a no-op
-        if isinstance(other, _None):
-            return self
-        elif isinstance(other, CompoundCachePolicy):
-            return CompoundCachePolicy(policies=other.policies + self.policies)
-        else:
-            return CompoundCachePolicy(policies=self.policies + [other])
-
     def __sub__(self, other: str) -> "CompoundCachePolicy":
         if not isinstance(other, str):
             raise TypeError("Can only subtract strings from key policies.")

--- a/src/prefect/cache_policies.py
+++ b/src/prefect/cache_policies.py
@@ -98,6 +98,22 @@ class CompoundCachePolicy(CachePolicy):
             return None
         return hash_objects(*keys)
 
+    def __add__(self, other: "CachePolicy") -> "CachePolicy":
+        # adding _None is a no-op
+        if isinstance(other, _None):
+            return self
+        elif isinstance(other, CompoundCachePolicy):
+            return CompoundCachePolicy(policies=other.policies + self.policies)
+        else:
+            return CompoundCachePolicy(policies=self.policies + [other])
+
+    def __sub__(self, other: str) -> "CompoundCachePolicy":
+        if not isinstance(other, str):
+            raise TypeError("Can only subtract strings from key policies.")
+        new = Inputs(exclude=[other])
+        policies = self.policies
+        return CompoundCachePolicy(policies=policies + [new])
+
 
 @dataclass
 class _None(CachePolicy):

--- a/src/prefect/cache_policies.py
+++ b/src/prefect/cache_policies.py
@@ -98,13 +98,6 @@ class CompoundCachePolicy(CachePolicy):
             return None
         return hash_objects(*keys)
 
-    def __sub__(self, other: str) -> "CompoundCachePolicy":
-        if not isinstance(other, str):
-            raise TypeError("Can only subtract strings from key policies.")
-        new = Inputs(exclude=[other])
-        policies = self.policies
-        return CompoundCachePolicy(policies=policies + [new])
-
 
 @dataclass
 class _None(CachePolicy):

--- a/src/prefect/cache_policies.py
+++ b/src/prefect/cache_policies.py
@@ -24,8 +24,7 @@ class CachePolicy:
     isolation_level: Union[
         Literal["SERIALIZABLE", "READ_COMMITTED"],
         "IsolationLevel",
-        None,
-    ] = None
+    ] = "SERIALIZABLE"
     locks: Union[str, Path, "LockManager", None] = None
 
     @classmethod
@@ -57,13 +56,25 @@ class CachePolicy:
         if isinstance(other, _None):
             return self
 
-        if other.storage != self.storage:
+        if (
+            other.storage is not None
+            and self.storage is not None
+            and other.storage != self.storage
+        ):
             raise ValueError("Cannot add CachePolicies with different storages.")
-        if other.isolation_level != self.isolation_level:
+        if (
+            other.isolation_level is not None
+            and self.isolation_level is not None
+            and other.isolation_level != self.isolation_level
+        ):
             raise ValueError(
                 "Cannot add CachePolicies with different isolation levels."
             )
-        if other.locks != self.locks:
+        if (
+            other.locks is not None
+            and self.locks is not None
+            and other.locks != self.locks
+        ):
             raise ValueError(
                 "Cannot add CachePolicies with different lock implementations."
             )

--- a/src/prefect/locking/filesystem.py
+++ b/src/prefect/locking/filesystem.py
@@ -38,10 +38,10 @@ class FileSystemLockManager(LockManager):
     """
 
     def __init__(self, lock_files_directory: Path):
-        self.lock_files_directory = lock_files_directory
+        self.lock_files_directory = lock_files_directory.expanduser().resolve()
         self._locks: Dict[str, _LockInfo] = {}
 
-    def _ensure_records_directory_exists(self):
+    def _ensure_lock_files_directory_exists(self):
         self.lock_files_directory.mkdir(parents=True, exist_ok=True)
 
     def _lock_path_for_key(self, key: str) -> Path:
@@ -98,7 +98,7 @@ class FileSystemLockManager(LockManager):
         acquire_timeout: Optional[float] = None,
         hold_timeout: Optional[float] = None,
     ) -> bool:
-        self._ensure_records_directory_exists()
+        self._ensure_lock_files_directory_exists()
         lock_path = self._lock_path_for_key(key)
 
         if self.is_locked(key) and not self.is_lock_holder(key, holder):

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -103,7 +103,7 @@ async def get_default_result_storage() -> WritableFileSystem:
 
 @sync_compatible
 async def resolve_result_storage(
-    result_storage: Union[ResultStorage, UUID],
+    result_storage: Union[ResultStorage, UUID, Path],
 ) -> WritableFileSystem:
     """
     Resolve one of the valid `ResultStorage` input types into a saved block
@@ -120,6 +120,8 @@ async def resolve_result_storage(
             storage_block_id = storage_block._block_document_id
         else:
             storage_block_id = None
+    elif isinstance(result_storage, Path):
+        storage_block = LocalFileSystem(basepath=str(result_storage))
     elif isinstance(result_storage, str):
         try:
             storage_block = await Block.load(result_storage, client=client)

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -298,8 +298,8 @@ class ResultStore(BaseModel):
                 _format_user_supplied_storage_key, task.result_storage_key
             )
         if task.cache_policy is not None and task.cache_policy is not NotSet:
-            if task.cache_policy.storage is not None:
-                storage = task.cache_policy.storage
+            if task.cache_policy.key_storage is not None:
+                storage = task.cache_policy.key_storage
                 if isinstance(storage, str) and not len(storage.split("/")) == 2:
                     storage = Path(storage)
                 update["result_storage"] = await resolve_result_storage(storage)

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -725,17 +725,21 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             else PREFECT_TASKS_REFRESH_CACHE.value()
         )
 
+        isolation_level = (
+            IsolationLevel(self.task.cache_policy.isolation_level)
+            if self.task.cache_policy
+            and self.task.cache_policy is not NotSet
+            and self.task.cache_policy.isolation_level is not None
+            else None
+        )
+
         with transaction(
             key=self.compute_transaction_key(),
             store=get_result_store(),
             overwrite=overwrite,
             logger=self.logger,
             write_on_commit=should_persist_result(),
-            isolation_level=(
-                IsolationLevel(self.task.cache_policy.isolation_level)
-                if self.task.cache_policy and self.task.cache_policy is not NotSet
-                else None
-            ),
+            isolation_level=isolation_level,
         ) as txn:
             yield txn
 
@@ -1229,6 +1233,13 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             if self.task.refresh_cache is not None
             else PREFECT_TASKS_REFRESH_CACHE.value()
         )
+        isolation_level = (
+            IsolationLevel(self.task.cache_policy.isolation_level)
+            if self.task.cache_policy
+            and self.task.cache_policy is not NotSet
+            and self.task.cache_policy.isolation_level is not None
+            else None
+        )
 
         with transaction(
             key=self.compute_transaction_key(),
@@ -1236,11 +1247,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             overwrite=overwrite,
             logger=self.logger,
             write_on_commit=should_persist_result(),
-            isolation_level=(
-                IsolationLevel(self.task.cache_policy.isolation_level)
-                if self.task.cache_policy and self.task.cache_policy is not NotSet
-                else None
-            ),
+            isolation_level=isolation_level,
         ) as txn:
             yield txn
 

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -77,7 +77,7 @@ from prefect.states import (
     exception_to_failed_state,
     return_value_to_state,
 )
-from prefect.transactions import Transaction, transaction
+from prefect.transactions import IsolationLevel, Transaction, transaction
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.callables import call_with_parameters, parameters_to_args_kwargs
@@ -731,6 +731,11 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             overwrite=overwrite,
             logger=self.logger,
             write_on_commit=should_persist_result(),
+            isolation_level=(
+                IsolationLevel(self.task.cache_policy.isolation_level)
+                if self.task.cache_policy and self.task.cache_policy is not NotSet
+                else None
+            ),
         ) as txn:
             yield txn
 
@@ -1231,6 +1236,11 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             overwrite=overwrite,
             logger=self.logger,
             write_on_commit=should_persist_result(),
+            isolation_level=(
+                IsolationLevel(self.task.cache_policy.isolation_level)
+                if self.task.cache_policy and self.task.cache_policy is not NotSet
+                else None
+            ),
         ) as txn:
             yield txn
 

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -195,7 +195,9 @@ class Transaction(ContextModel):
             and not self.store.supports_isolation_level(self.isolation_level)
         ):
             raise ValueError(
-                f"Isolation level {self.isolation_level.name} is not supported by provided result store."
+                f"Isolation level {self.isolation_level.name} is not supported by provided "
+                "configuration. Please ensure you've provided a lock file directory or lock "
+                "manager when using the SERIALIZABLE isolation level."
             )
 
         # this needs to go before begin, which could set the state to committed

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -18,7 +18,11 @@ from pydantic import Field, PrivateAttr
 from typing_extensions import Self
 
 from prefect.context import ContextModel
-from prefect.exceptions import MissingContextError, SerializationError
+from prefect.exceptions import (
+    ConfigurationError,
+    MissingContextError,
+    SerializationError,
+)
 from prefect.logging.loggers import get_logger, get_run_logger
 from prefect.records import RecordStore
 from prefect.records.base import TransactionRecord
@@ -194,7 +198,7 @@ class Transaction(ContextModel):
             and self.key
             and not self.store.supports_isolation_level(self.isolation_level)
         ):
-            raise ValueError(
+            raise ConfigurationError(
                 f"Isolation level {self.isolation_level.name} is not supported by provided "
                 "configuration. Please ensure you've provided a lock file directory or lock "
                 "manager when using the SERIALIZABLE isolation level."

--- a/tests/test_cache_policies.py
+++ b/tests/test_cache_policies.py
@@ -300,8 +300,8 @@ class TestDefaultPolicy:
 
 class TestPolicyConfiguration:
     def test_configure_changes_storage(self):
-        policy = Inputs().configure(storage="/path/to/storage")
-        assert policy.storage == "/path/to/storage"
+        policy = Inputs().configure(key_storage="/path/to/storage")
+        assert policy.key_storage == "/path/to/storage"
 
     def test_configure_changes_locks(self):
         policy = Inputs().configure(lock_manager="/path/to/locks")
@@ -313,17 +313,17 @@ class TestPolicyConfiguration:
 
     def test_configure_changes_all_attributes(self):
         policy = Inputs().configure(
-            storage="/path/to/storage",
+            key_storage="/path/to/storage",
             lock_manager="/path/to/locks",
             isolation_level="SERIALIZABLE",
         )
-        assert policy.storage == "/path/to/storage"
+        assert policy.key_storage == "/path/to/storage"
         assert policy.lock_manager == "/path/to/locks"
         assert policy.isolation_level == "SERIALIZABLE"
 
     def test_configure_with_none_is_noop(self):
         policy = Inputs().configure(
-            storage=None, lock_manager=None, isolation_level=None
+            key_storage=None, lock_manager=None, isolation_level=None
         )
         assert policy == Inputs()
 
@@ -331,16 +331,16 @@ class TestPolicyConfiguration:
         policy = Inputs() + TaskSource().configure(
             lock_manager="/path/to/locks",
             isolation_level="SERIALIZABLE",
-            storage="/path/to/storage",
+            key_storage="/path/to/storage",
         )
         assert policy.lock_manager == "/path/to/locks"
         assert policy.isolation_level == "SERIALIZABLE"
-        assert policy.storage == "/path/to/storage"
+        assert policy.key_storage == "/path/to/storage"
 
     def test_add_policy_with_conflict_raises(self):
         policy = Inputs() + TaskSource().configure(
             lock_manager="original_locks",
-            storage="original_storage",
+            key_storage="original_storage",
             isolation_level="SERIALIZABLE",
         )
         with pytest.raises(
@@ -353,10 +353,15 @@ class TestPolicyConfiguration:
             ValueError,
             match="Cannot add CachePolicies with different storage locations.",
         ):
-            _policy = policy + TaskSource().configure(storage="other_storage")
+            _policy = policy + TaskSource().configure(key_storage="other_storage")
 
         with pytest.raises(
             ValueError,
             match="Cannot add CachePolicies with different isolation levels.",
         ):
             _policy = policy + TaskSource().configure(isolation_level="READ_COMMITTED")
+
+    def test_configure_returns_new_policy(self):
+        policy = Inputs()
+        new_policy = policy.configure(key_storage="new_storage")
+        assert policy is not new_policy

--- a/tests/test_cache_policies.py
+++ b/tests/test_cache_policies.py
@@ -304,8 +304,8 @@ class TestPolicyConfiguration:
         assert policy.storage == "/path/to/storage"
 
     def test_configure_changes_locks(self):
-        policy = DEFAULT.configure(locks="/path/to/locks")
-        assert policy.locks == "/path/to/locks"
+        policy = DEFAULT.configure(lock_manager="/path/to/locks")
+        assert policy.lock_manager == "/path/to/locks"
 
     def test_configure_changes_isolation_level(self):
         policy = DEFAULT.configure(isolation_level="SERIALIZABLE")
@@ -314,30 +314,32 @@ class TestPolicyConfiguration:
     def test_configure_changes_all_attributes(self):
         policy = DEFAULT.configure(
             storage="/path/to/storage",
-            locks="/path/to/locks",
+            lock_manager="/path/to/locks",
             isolation_level="SERIALIZABLE",
         )
         assert policy.storage == "/path/to/storage"
-        assert policy.locks == "/path/to/locks"
+        assert policy.lock_manager == "/path/to/locks"
         assert policy.isolation_level == "SERIALIZABLE"
 
     def test_configure_with_none_is_noop(self):
-        policy = DEFAULT.configure(storage=None, locks=None, isolation_level=None)
+        policy = DEFAULT.configure(
+            storage=None, lock_manager=None, isolation_level=None
+        )
         assert policy == DEFAULT
 
     def test_add_policy_with_configuration(self):
         policy = DEFAULT + TaskSource().configure(
-            locks="/path/to/locks",
+            lock_manager="/path/to/locks",
             isolation_level="SERIALIZABLE",
             storage="/path/to/storage",
         )
-        assert policy.locks == "/path/to/locks"
+        assert policy.lock_manager == "/path/to/locks"
         assert policy.isolation_level == "SERIALIZABLE"
         assert policy.storage == "/path/to/storage"
 
     def test_add_policy_with_conflict_raises(self):
         policy = DEFAULT + TaskSource().configure(
-            locks="original_locks",
+            lock_manager="original_locks",
             storage="original_storage",
             isolation_level="SERIALIZABLE",
         )
@@ -345,7 +347,7 @@ class TestPolicyConfiguration:
             ValueError,
             match="Cannot add CachePolicies with different lock implementations.",
         ):
-            _policy = policy + TaskSource().configure(locks="other_locks")
+            _policy = policy + TaskSource().configure(lock_manager="other_locks")
 
         with pytest.raises(
             ValueError,

--- a/tests/test_cache_policies.py
+++ b/tests/test_cache_policies.py
@@ -296,3 +296,65 @@ class TestDefaultPolicy:
         )
 
         assert key_one != key_two
+
+
+class TestPolicyConfiguration:
+    def test_configure_changes_storage(self):
+        policy = DEFAULT.configure(storage="/path/to/storage")
+        assert policy.storage == "/path/to/storage"
+
+    def test_configure_changes_locks(self):
+        policy = DEFAULT.configure(locks="/path/to/locks")
+        assert policy.locks == "/path/to/locks"
+
+    def test_configure_changes_isolation_level(self):
+        policy = DEFAULT.configure(isolation_level="SERIALIZABLE")
+        assert policy.isolation_level == "SERIALIZABLE"
+
+    def test_configure_changes_all_attributes(self):
+        policy = DEFAULT.configure(
+            storage="/path/to/storage",
+            locks="/path/to/locks",
+            isolation_level="SERIALIZABLE",
+        )
+        assert policy.storage == "/path/to/storage"
+        assert policy.locks == "/path/to/locks"
+        assert policy.isolation_level == "SERIALIZABLE"
+
+    def test_configure_with_none_is_noop(self):
+        policy = DEFAULT.configure(storage=None, locks=None, isolation_level=None)
+        assert policy == DEFAULT
+
+    def test_add_policy_with_configuration(self):
+        policy = DEFAULT + TaskSource().configure(
+            locks="/path/to/locks",
+            isolation_level="SERIALIZABLE",
+            storage="/path/to/storage",
+        )
+        assert policy.locks == "/path/to/locks"
+        assert policy.isolation_level == "SERIALIZABLE"
+        assert policy.storage == "/path/to/storage"
+
+    def test_add_policy_with_conflict_raises(self):
+        policy = DEFAULT + TaskSource().configure(
+            locks="original_locks",
+            storage="original_storage",
+            isolation_level="SERIALIZABLE",
+        )
+        with pytest.raises(
+            ValueError,
+            match="Cannot add CachePolicies with different lock implementations.",
+        ):
+            _policy = policy + TaskSource().configure(locks="other_locks")
+
+        with pytest.raises(
+            ValueError,
+            match="Cannot add CachePolicies with different storage locations.",
+        ):
+            _policy = policy + TaskSource().configure(storage="other_storage")
+
+        with pytest.raises(
+            ValueError,
+            match="Cannot add CachePolicies with different isolation levels.",
+        ):
+            _policy = policy + TaskSource().configure(isolation_level="READ_COMMITTED")

--- a/tests/test_cache_policies.py
+++ b/tests/test_cache_policies.py
@@ -300,19 +300,19 @@ class TestDefaultPolicy:
 
 class TestPolicyConfiguration:
     def test_configure_changes_storage(self):
-        policy = DEFAULT.configure(storage="/path/to/storage")
+        policy = Inputs().configure(storage="/path/to/storage")
         assert policy.storage == "/path/to/storage"
 
     def test_configure_changes_locks(self):
-        policy = DEFAULT.configure(lock_manager="/path/to/locks")
+        policy = Inputs().configure(lock_manager="/path/to/locks")
         assert policy.lock_manager == "/path/to/locks"
 
     def test_configure_changes_isolation_level(self):
-        policy = DEFAULT.configure(isolation_level="SERIALIZABLE")
+        policy = Inputs().configure(isolation_level="SERIALIZABLE")
         assert policy.isolation_level == "SERIALIZABLE"
 
     def test_configure_changes_all_attributes(self):
-        policy = DEFAULT.configure(
+        policy = Inputs().configure(
             storage="/path/to/storage",
             lock_manager="/path/to/locks",
             isolation_level="SERIALIZABLE",
@@ -322,13 +322,13 @@ class TestPolicyConfiguration:
         assert policy.isolation_level == "SERIALIZABLE"
 
     def test_configure_with_none_is_noop(self):
-        policy = DEFAULT.configure(
+        policy = Inputs().configure(
             storage=None, lock_manager=None, isolation_level=None
         )
-        assert policy == DEFAULT
+        assert policy == Inputs()
 
     def test_add_policy_with_configuration(self):
-        policy = DEFAULT + TaskSource().configure(
+        policy = Inputs() + TaskSource().configure(
             lock_manager="/path/to/locks",
             isolation_level="SERIALIZABLE",
             storage="/path/to/storage",
@@ -338,7 +338,7 @@ class TestPolicyConfiguration:
         assert policy.storage == "/path/to/storage"
 
     def test_add_policy_with_conflict_raises(self):
-        policy = DEFAULT + TaskSource().configure(
+        policy = Inputs() + TaskSource().configure(
             lock_manager="original_locks",
             storage="original_storage",
             isolation_level="SERIALIZABLE",

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1880,7 +1880,7 @@ class TestTaskCaching:
         )
 
     def test_cache_policy_storage_path(self, tmp_path):
-        cache_policy = Inputs().configure(storage=tmp_path)
+        cache_policy = Inputs().configure(key_storage=tmp_path)
         expected_cache_key = cache_policy.compute_key(
             task_ctx=None, inputs={"x": 1}, flow_parameters=None
         )
@@ -1893,7 +1893,7 @@ class TestTaskCaching:
         assert (tmp_path / expected_cache_key).exists()
 
     def test_cache_policy_storage_str(self, tmp_path):
-        cache_policy = Inputs().configure(storage=str(tmp_path))
+        cache_policy = Inputs().configure(key_storage=str(tmp_path))
         expected_cache_key = cache_policy.compute_key(
             task_ctx=None, inputs={"x": 1}, flow_parameters=None
         )
@@ -1907,7 +1907,7 @@ class TestTaskCaching:
 
     def test_cache_policy_storage_storage_block(self, tmp_path):
         cache_policy = Inputs().configure(
-            storage=LocalFileSystem(basepath=str(tmp_path))
+            key_storage=LocalFileSystem(basepath=str(tmp_path))
         )
         expected_cache_key = cache_policy.compute_key(
             task_ctx=None, inputs={"x": 1}, flow_parameters=None

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -30,6 +30,7 @@ from prefect.exceptions import (
 )
 from prefect.filesystems import LocalFileSystem
 from prefect.futures import PrefectDistributedFuture, PrefectFuture
+from prefect.locking.filesystem import FileSystemLockManager
 from prefect.logging import get_run_logger
 from prefect.results import ResultStore, get_or_create_default_task_scheduling_storage
 from prefect.runtime import task_run as task_run_ctx
@@ -44,7 +45,7 @@ from prefect.settings import (
 from prefect.states import State
 from prefect.tasks import Task, task, task_input_hash
 from prefect.testing.utilities import exceptions_equal
-from prefect.transactions import CommitMode, Transaction, transaction
+from prefect.transactions import CommitMode, IsolationLevel, Transaction, transaction
 from prefect.utilities.annotations import allow_failure, unmapped
 from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.collections import quote
@@ -1869,6 +1870,102 @@ class TestTaskCaching:
             "Ignoring `cache_policy` because `persist_result` is False"
             not in caplog.text
         )
+
+    def test_cache_policy_storage_path(self, tmp_path):
+        cache_policy = INPUTS.configure(storage=tmp_path)
+        expected_cache_key = cache_policy.compute_key(
+            task_ctx=None, inputs={"x": 1}, flow_parameters=None
+        )
+
+        @task(cache_policy=cache_policy)
+        def foo(x):
+            return x
+
+        foo(1)
+        assert (tmp_path / expected_cache_key).exists()
+
+    def test_cache_policy_storage_str(self, tmp_path):
+        cache_policy = INPUTS.configure(storage=str(tmp_path))
+        expected_cache_key = cache_policy.compute_key(
+            task_ctx=None, inputs={"x": 1}, flow_parameters=None
+        )
+
+        @task(cache_policy=cache_policy)
+        def foo(x):
+            return x
+
+        foo(1)
+        assert (tmp_path / expected_cache_key).exists()
+
+    def test_cache_policy_storage_storage_block(self, tmp_path):
+        cache_policy = INPUTS.configure(storage=LocalFileSystem(basepath=str(tmp_path)))
+        expected_cache_key = cache_policy.compute_key(
+            task_ctx=None, inputs={"x": 1}, flow_parameters=None
+        )
+
+        @task(cache_policy=cache_policy)
+        def foo(x):
+            return x
+
+        foo(1)
+        assert (tmp_path / expected_cache_key).exists()
+
+    @pytest.mark.parametrize(
+        "isolation_level", [IsolationLevel.SERIALIZABLE, "SERIALIZABLE"]
+    )
+    def test_cache_policy_locks_path(self, tmp_path, isolation_level):
+        cache_policy = INPUTS.configure(locks=tmp_path, isolation_level=isolation_level)
+        expected_cache_key = cache_policy.compute_key(
+            task_ctx=None, inputs={"x": 1}, flow_parameters=None
+        )
+
+        @task(cache_policy=cache_policy)
+        def foo(x):
+            assert (tmp_path / f"{expected_cache_key}.lock").exists()
+            return x
+
+        assert foo(1) == 1
+
+    def test_cache_policy_locks_str(self, tmp_path):
+        cache_policy = INPUTS.configure(
+            locks=str(tmp_path), isolation_level=IsolationLevel.SERIALIZABLE
+        )
+        expected_cache_key = cache_policy.compute_key(
+            task_ctx=None, inputs={"x": 1}, flow_parameters=None
+        )
+
+        @task(cache_policy=cache_policy)
+        def foo(x):
+            assert (tmp_path / f"{expected_cache_key}.lock").exists()
+            return x
+
+        assert foo(1) == 1
+
+    def test_cache_policy_locks_lock_manager(self, tmp_path):
+        cache_policy = INPUTS.configure(
+            locks=FileSystemLockManager(lock_files_directory=tmp_path),
+            isolation_level=IsolationLevel.SERIALIZABLE,
+        )
+        expected_cache_key = cache_policy.compute_key(
+            task_ctx=None, inputs={"x": 1}, flow_parameters=None
+        )
+
+        @task(cache_policy=cache_policy)
+        def foo(x):
+            assert (tmp_path / f"{expected_cache_key}.lock").exists()
+            return x
+
+        assert foo(1) == 1
+
+    def test_cache_policy_serializable_isolation_level_with_no_locks(self):
+        cache_policy = INPUTS.configure(isolation_level=IsolationLevel.SERIALIZABLE)
+
+        @task(cache_policy=cache_policy)
+        def foo(x):
+            return x
+
+        with pytest.raises(ValueError, match="not supported by provided configuration"):
+            foo(1)
 
 
 class TestCacheFunctionBuiltins:

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -3,6 +3,7 @@ import uuid
 
 import pytest
 
+from prefect.exceptions import ConfigurationError
 from prefect.filesystems import LocalFileSystem
 from prefect.flows import flow
 from prefect.locking.memory import MemoryLockManager
@@ -664,7 +665,7 @@ class TestIsolationLevel:
 
     def test_raises_on_unsupported_isolation_level(self):
         with pytest.raises(
-            ValueError,
+            ConfigurationError,
             match="Isolation level SERIALIZABLE is not supported by provided configuration",
         ):
             with transaction(

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -665,7 +665,7 @@ class TestIsolationLevel:
     def test_raises_on_unsupported_isolation_level(self):
         with pytest.raises(
             ValueError,
-            match="Isolation level SERIALIZABLE is not supported by provided result store.",
+            match="Isolation level SERIALIZABLE is not supported by provided configuration",
         ):
             with transaction(
                 key="test",


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR adds the ability to specify a storage location for cache entries via a `CachePolicy`. The isolation level for the cache and locking mechanism are also configurable via a `CachePolicy`.

## Example
Cache task results based on the input and source code a task. Store those cache entries at `~/.prefect/cache`. Allow only one actor to access a cache entry at a time and store lock files to enforce that at `~.prefect/locks`.
```python
from prefect import task
from prefect.cache_policies import INPUTS, TASK_SOURCE
from prefect.transactions import IsolationLevel


@task(
    cache_policy=(INPUTS + TASK_SOURCE).configure(
        key_storage="~/.prefect/cache",
        lock_manager="~/.prefect/locks",
        isolation_level=IsolationLevel.SERIALIZABLE,
    )
)
def my_task(x):
    return x


if __name__ == "__main__":
    print(my_task(10))
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
