### PR TITLE
Lazy import `ray` to fix server startup issues

### DIFF
--- a/src/integrations/prefect-ray/prefect_ray/task_runners.py
+++ b/src/integrations/prefect-ray/prefect_ray/task_runners.py
@@ -395,17 +395,17 @@ class RayTaskRunner(TaskRunner[PrefectRayFuture]):
     def __enter__(self):
         super().__enter__()
 
-        if self.address and self.address != "auto":
-            self.logger.info(
-                f"Connecting to an existing Ray instance at {self.address}"
-            )
-            init_args = (self.address,)
-        elif ray.is_initialized():
+        if ray.is_initialized():
             self.logger.info(
                 "Local Ray instance is already initialized. "
                 "Using existing local instance."
             )
             return self
+        if self.address and self.address != "auto":
+            self.logger.info(
+                f"Connecting to an existing Ray instance at {self.address}"
+            )
+            init_args = (self.address,)
         else:
             self.logger.info("Creating a local Ray instance")
             init_args = ()

--- a/src/integrations/prefect-ray/prefect_ray/task_runners.py
+++ b/src/integrations/prefect-ray/prefect_ray/task_runners.py
@@ -74,6 +74,7 @@ Example:
 import asyncio  # noqa: I001
 import inspect
 from typing import (
+    TYPE_CHECKING,
     Any,
     Coroutine,
     Dict,
@@ -86,9 +87,6 @@ from typing import (
 from typing_extensions import ParamSpec
 from uuid import UUID, uuid4
 
-import ray
-from ray.exceptions import GetTimeoutError
-
 from prefect.client.schemas.objects import TaskRunInput
 from prefect.context import serialize_context
 from prefect.futures import PrefectFuture, PrefectFutureList, PrefectWrappedFuture
@@ -99,7 +97,13 @@ from prefect.task_runners import TaskRunner
 from prefect.tasks import Task
 from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.collections import visit_collection
+from prefect.utilities.importtools import lazy_import
 from prefect_ray.context import RemoteOptionsContext
+
+if TYPE_CHECKING:
+    import ray
+
+ray = lazy_import("ray")
 
 logger = get_logger(__name__)
 
@@ -109,11 +113,11 @@ F = TypeVar("F", bound=PrefectFuture)
 R = TypeVar("R")
 
 
-class PrefectRayFuture(PrefectWrappedFuture[R, ray.ObjectRef]):
+class PrefectRayFuture(PrefectWrappedFuture[R, "ray.ObjectRef"]):
     def wait(self, timeout: Optional[float] = None) -> None:
         try:
             result = ray.get(self.wrapped_future, timeout=timeout)
-        except GetTimeoutError:
+        except ray.exceptions.GetTimeoutError:
             return
         except Exception as exc:
             result = run_coro_as_sync(exception_to_crashed_state(exc))
@@ -128,7 +132,7 @@ class PrefectRayFuture(PrefectWrappedFuture[R, ray.ObjectRef]):
         if not self._final_state:
             try:
                 object_ref_result = ray.get(self.wrapped_future, timeout=timeout)
-            except GetTimeoutError as exc:
+            except ray.exceptions.GetTimeoutError as exc:
                 raise TimeoutError(
                     f"Task run {self.task_run_id} did not complete within {timeout} seconds"
                 ) from exc
@@ -164,7 +168,7 @@ class PrefectRayFuture(PrefectWrappedFuture[R, ray.ObjectRef]):
         try:
             ray.get(self.wrapped_future, timeout=0)
             return
-        except GetTimeoutError:
+        except ray.exceptions.GetTimeoutError:
             pass
 
         try:


### PR DESCRIPTION
This PR updates `prefect-ray` to lazily import `ray` to avoid issues when starting up a Prefect server in a virtual environment where `prefect-ray` is installed.

Also makes a fix to check if `ray` is initialized in all cases when `__enter__` is called on the `RayTaskRunner` to fix test failures.

Closes https://github.com/PrefectHQ/prefect/issues/14955
Closes https://github.com/PrefectHQ/prefect/issues/15226
