### PR TITLE
[2.x] preserve `flow.name` with `RunnerDeployment.from_storage`

### DIFF
--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -580,6 +580,7 @@ class RunnerDeployment(BaseModel):
         cls,
         entrypoint: str,
         name: str,
+        flow_name: Optional[str] = None,
         interval: Optional[
             Union[Iterable[Union[int, float, timedelta]], int, float, timedelta]
         ] = None,
@@ -606,6 +607,7 @@ class RunnerDeployment(BaseModel):
             entrypoint:  The path to a file containing a flow and the name of the flow function in
                 the format `./path/to/file.py:flow_func_name`.
             name: A name for the deployment
+            flow_name: The name of the flow to deploy
             interval: An interval on which to execute the current flow. Accepts either a number
                 or a timedelta object. If a number is given, it will be interpreted as seconds.
             cron: A cron schedule of when to execute runs of this flow.
@@ -649,7 +651,7 @@ class RunnerDeployment(BaseModel):
 
         deployment = cls(
             name=Path(name).stem,
-            flow_name=flow.name,
+            flow_name=flow_name or flow.name,
             schedule=schedule,
             schedules=constructed_schedules,
             paused=paused,
@@ -678,6 +680,7 @@ class RunnerDeployment(BaseModel):
         storage: RunnerStorage,
         entrypoint: str,
         name: str,
+        flow_name: Optional[str] = None,
         interval: Optional[
             Union[Iterable[Union[int, float, timedelta]], int, float, timedelta]
         ] = None,
@@ -705,6 +708,7 @@ class RunnerDeployment(BaseModel):
             entrypoint:  The path to a file containing a flow and the name of the flow function in
                 the format `./path/to/file.py:flow_func_name`.
             name: A name for the deployment
+            flow_name: The name of the flow to deploy
             storage: A storage object to use for retrieving flow code. If not provided, a
                 URL must be provided.
             interval: An interval on which to execute the current flow. Accepts either a number
@@ -755,7 +759,7 @@ class RunnerDeployment(BaseModel):
 
         deployment = cls(
             name=Path(name).stem,
-            flow_name=flow.name,
+            flow_name=flow_name or flow.name,
             schedule=schedule,
             schedules=constructed_schedules,
             paused=paused,

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -679,6 +679,7 @@ class Flow(Generic[P, R]):
                 storage=self._storage,
                 entrypoint=self._entrypoint,
                 name=name,
+                flow_name=self.name,
                 interval=interval,
                 cron=cron,
                 rrule=rrule,
@@ -698,7 +699,7 @@ class Flow(Generic[P, R]):
             )
         else:
             return RunnerDeployment.from_flow(
-                self,
+                flow=self,
                 name=name,
                 interval=interval,
                 cron=cron,


### PR DESCRIPTION
backports https://github.com/PrefectHQ/prefect/pull/15393
related to https://github.com/PrefectHQ/prefect/issues/15380