### PR TITLE
handle unnamed lambdas for consistency

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -258,11 +258,11 @@ class Flow(Generic[P, R]):
         if not callable(fn):
             raise TypeError("'fn' must be callable")
 
-        # Validate name if given
-        if name:
-            _raise_on_name_with_banned_characters(name)
-
-        self.name = name or fn.__name__.replace("_", "-")
+        self.name = name or fn.__name__.replace("_", "-").replace(
+            "<lambda>",
+            "unknown-lambda",  # prefect API will not accept "<" or ">" in flow names
+        )
+        _raise_on_name_with_banned_characters(self.name)
 
         if flow_run_name is not None:
             if not isinstance(flow_run_name, str) and not callable(flow_run_name):
@@ -1623,7 +1623,7 @@ def flow(
         )
 
 
-def _raise_on_name_with_banned_characters(name: str) -> str:
+def _raise_on_name_with_banned_characters(name: Optional[str]) -> Optional[str]:
     """
     Raise an InvalidNameError if the given name contains any invalid
     characters.

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -195,6 +195,10 @@ class TestFlow:
         with pytest.raises(InvalidNameError, match="contains an invalid character"):
             Flow(fn=lambda: 1, name=name)
 
+    def test_lambda_name_coerced_to_legal_characters(self):
+        f = Flow(fn=lambda: 42)
+        assert f.name == "unknown-lambda"
+
     def test_invalid_run_name(self):
         class InvalidFlowRunNameArg:
             def format(*args, **kwargs):


### PR DESCRIPTION
this PR reorders the validation to catch invalid `fn` name fallbacks before attempting to create the flow in the API, and renames a `fn` set to an unnamed lambda (which currently falls back to `<lambda>`) to `unknown-lambda` to handle this case

---

besides disallowing `<` and `>` in names of `Flow` objects in the API, the `flow` decorator just works with lambdas (though granted its not recommended) and IMO we should either handle this case or explicitly not support lambdas (which we do already use for `fn` in the tests)

### before
```python
» python -c "from prefect import flow; flow(log_prints=True)(lambda: print(42))()"
Traceback (most recent call last):
...
prefect.exceptions.PrefectHTTPStatusError: Client error '422 Unprocessable Entity' for url 'https://api.prefect.cloud/api/accounts/xxx/workspaces/xxx/flows/'
Response: {'exception_message': 'Invalid request received.', 'exception_detail': [{'loc': ['body', 'name'], 'msg': "Name '<lambda>' contains an invalid character. Must not contain any of: ['/', '%', '&', '>', '<'].", 'type': 'value_error.invalidname'}], 'request_body': {'name': '<lambda>', 'tags': []}}
```

### after
```python
» python -c "from prefect import flow; flow(log_prints=True)(lambda: print(42))()"
21:34:07.570 | INFO    | prefect.engine - Created flow run 'psychedelic-bullmastiff' for flow 'unknown-lambda'
21:34:07.861 | INFO    | Flow run 'psychedelic-bullmastiff' - 42
21:34:08.022 | INFO    | Flow run 'psychedelic-bullmastiff' - Finished in state Completed()
```