### PR TITLE
Fix ephemeral server start command for Windows

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -12,6 +12,7 @@ import shutil
 import socket
 import sqlite3
 import subprocess
+import sys
 import time
 from contextlib import asynccontextmanager
 from functools import partial, wraps
@@ -60,7 +61,6 @@ from prefect.settings import (
     get_current_settings,
 )
 from prefect.utilities.hashing import hash_objects
-from prefect.utilities.processutils import get_sys_executable
 
 TITLE = "Prefect Server"
 API_TITLE = "Prefect Prefect REST API"
@@ -821,18 +821,17 @@ class SubprocessASGIServer:
                 raise
 
     def _run_uvicorn_command(self) -> subprocess.Popen:
-        # used to turn off background services
+        # used to turn off serving the UI
         server_env = {
             "PREFECT_UI_ENABLED": "0",
         }
         return subprocess.Popen(
             args=[
-                get_sys_executable(),
+                sys.executable,
                 "-m",
                 "uvicorn",
                 "--app-dir",
-                # quote wrapping needed for windows paths with spaces
-                f'"{prefect.__module_path__.parent}"',
+                str(prefect.__module_path__.parent),
                 "--factory",
                 "prefect.server.api.server:create_app",
                 "--host",


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This is the same fix as https://github.com/PrefectHQ/prefect/pull/15103, but applied to the command used to start an ephemeral server.

I have verified the fix on a Windows 11 VM.

Closes https://github.com/PrefectHQ/prefect/issues/15414
