### PR TITLE
Add environment variables from GCP secrets to cloud run job v2 workers

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/models/cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/models/cloud_run_v2.py
@@ -9,9 +9,11 @@ from pydantic import BaseModel, Field
 class SecretKeySelector(BaseModel):
     """
     SecretKeySelector is a data model for specifying a GCP secret to inject
-    into a Cloud Run V2 Job. Follows Cloud Run V2 rest API, docs:
+    into a Cloud Run V2 Job as an environment variable.
+    Follows Cloud Run V2 rest API, docs:
     https://cloud.google.com/run/docs/reference/rest/v2/Container#SecretKeySelector
     """
+
     secret: str
     version: str
 

--- a/src/integrations/prefect-gcp/prefect_gcp/models/cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/models/cloud_run_v2.py
@@ -6,6 +6,16 @@ from googleapiclient.discovery import Resource
 from pydantic import BaseModel, Field
 
 
+class SecretKeySelector(BaseModel):
+    """
+    SecretKeySelector is a data model for specifying a GCP secret to inject
+    into a Cloud Run V2 Job. Follows Cloud Run V2 rest API, docs:
+    https://cloud.google.com/run/docs/reference/rest/v2/Container#SecretKeySelector
+    """
+    secret: str
+    version: str
+
+
 class JobV2(BaseModel):
     """
     JobV2 is a data model for a job that will be run on Cloud Run with the V2 API.

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
@@ -101,6 +101,11 @@ class CloudRunWorkerJobV2Configuration(BaseJobConfiguration):
             "the local environment."
         ),
     )
+    env_from_secrets: Dict[str, Any] = Field(
+        default_factory=dict,
+        title="Environment Variables from Secrets",
+        description="Environment variables to set from GCP secrets when starting a flow run.",
+    )
     job_body: Dict[str, Any] = Field(
         json_schema_extra=dict(template=_get_default_job_body_template()),
     )
@@ -191,6 +196,9 @@ class CloudRunWorkerJobV2Configuration(BaseJobConfiguration):
         Populates the job body with environment variables.
         """
         envs = [{"name": k, "value": v} for k, v in self.env.items()]
+        envs_from_secrets = [{"name": k, "valueSource": v} for k, v in self.env_from_secrets.items()]
+        envs.extend(envs_from_secrets)
+
 
         self.job_body["template"]["template"]["containers"][0]["env"] = envs
 

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
@@ -197,7 +197,10 @@ class CloudRunWorkerJobV2Configuration(BaseJobConfiguration):
         """
         envs = [{"name": k, "value": v} for k, v in self.env.items()]
         envs_from_secrets = [
-            {"name": k, "valueSource": v.model_dump()}
+            {
+                "name": k,
+                "valueSource": {"secretKeyRef": v.model_dump()},
+            }
             for k, v in self.env_from_secrets.items()
         ]
         envs.extend(envs_from_secrets)

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
@@ -340,6 +340,17 @@ class CloudRunWorkerV2Variables(BaseVariables):
             "The arguments to pass to the Cloud Run Job V2's entrypoint command."
         ),
     )
+    env_from_secrets: Dict[str, SecretKeySelector] = Field(
+        default_factory=dict,
+        title="Environment Variables from Secrets",
+        description="Environment variables to set from GCP secrets when starting a flow run.",
+        example={
+            "ENV_VAR_NAME": {
+                "secret": "SECRET_NAME",
+                "version": "latest",
+            }
+        },
+    )
     keep_job: bool = Field(
         default=False,
         title="Keep Job After Completion",

--- a/src/integrations/prefect-gcp/tests/test_cloud_run_worker_v2.py
+++ b/src/integrations/prefect-gcp/tests/test_cloud_run_worker_v2.py
@@ -1,5 +1,6 @@
 import pytest
 from prefect_gcp.credentials import GcpCredentials
+from prefect_gcp.models.cloud_run_v2 import SecretKeySelector
 from prefect_gcp.utilities import slugify_name
 from prefect_gcp.workers.cloud_run_v2 import CloudRunWorkerJobV2Configuration
 
@@ -98,6 +99,25 @@ class TestCloudRunWorkerJobV2Configuration:
         ][0]["env"] == [
             {"name": "ENV1", "value": "VALUE1"},
             {"name": "ENV2", "value": "VALUE2"},
+        ]
+
+    def test_populate_env_with_secrets(self, cloud_run_worker_v2_job_config):
+        cloud_run_worker_v2_job_config.env_from_secrets = {
+            "SECRET_ENV1": SecretKeySelector(secret="SECRET1", version="latest")
+        }
+        cloud_run_worker_v2_job_config._populate_env()
+
+        assert cloud_run_worker_v2_job_config.job_body["template"]["template"][
+            "containers"
+        ][0]["env"] == [
+            {"name": "ENV1", "value": "VALUE1"},
+            {"name": "ENV2", "value": "VALUE2"},
+            {
+                "name": "SECRET_ENV1",
+                "valueSource": {
+                    "secretKeyRef": {"secret": "SECRET1", "version": "latest"}
+                },
+            },
         ]
 
     def test_populate_image_if_not_present(self, cloud_run_worker_v2_job_config):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->
This PR adds the ability to create environment variables from GCP secrets in cloud run v2 prefect workers. To do so a new attribute was added to cloud run job v2 workers configurations, `env_from_secrets` which allows for the referencing of GCP secrets in a cloud run job v2 worker template with the following structure.
```json
{
  "job_configuration": {
    "env_from_secrets": "{{ env_from_secrets }}"
  },
  "variables": {
    "env_from_secrets": {
      "title": "Secrets as Environment Variables",
      "description": "Environment variables to set from GCP secrets when starting a flow run.",
      "type": "object",
      "additionalProperties": {
        "type": "string"
      }
    }
  }
}
```

Deployments can then set environment variables from secrets via job variables, e.g.
```json
"env_from_secrets": {
  "ENV_VAR": {
    "secret": "SECRET_NAME",
    "version": "latest"
  }
}
```

Closes https://github.com/PrefectHQ/prefect/issues/15406
<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
