### PR TITLE
Fix bug where task cache storage is misconfigured

### DIFF
--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -310,7 +310,7 @@ class ResultStore(BaseModel):
                 storage = task.cache_policy.key_storage
                 if isinstance(storage, str) and not len(storage.split("/")) == 2:
                     storage = Path(storage)
-                update["result_storage"] = await resolve_result_storage(storage)
+                update["metadata_storage"] = await resolve_result_storage(storage)
             if task.cache_policy.lock_manager is not None:
                 update["lock_manager"] = task.cache_policy.lock_manager
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import inspect
+import json
 import time
 from asyncio import Event, sleep
 from functools import partial
@@ -45,6 +46,7 @@ from prefect.runtime import task_run as task_run_ctx
 from prefect.server import models
 from prefect.settings import (
     PREFECT_DEBUG_MODE,
+    PREFECT_LOCAL_STORAGE_PATH,
     PREFECT_TASK_DEFAULT_RETRIES,
     PREFECT_TASKS_REFRESH_CACHE,
     PREFECT_UI_URL,
@@ -1919,7 +1921,12 @@ class TestTaskCaching:
             return x
 
         foo(1)
+        # make sure cache key file and result file are both created
         assert (tmp_path / expected_cache_key).exists()
+        assert "prefect_version" in json.loads(
+            (tmp_path / expected_cache_key).read_text()
+        )
+        assert (PREFECT_LOCAL_STORAGE_PATH.value() / expected_cache_key).exists()
 
     @pytest.mark.parametrize(
         "isolation_level", [IsolationLevel.SERIALIZABLE, "SERIALIZABLE"]


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
`ResultStore.from_task` mistakenly uses the `key_storage` from a cache policy to configure `result_storage` instead of `metadata_storage`. This PR rectifies that.
