### PR TITLE
add image digest as related resource

### DIFF
--- a/src/prefect/utilities/dockerutils.py
+++ b/src/prefect/utilities/dockerutils.py
@@ -607,3 +607,15 @@ def generate_default_dockerfile(context: Optional[Path] = None):
         yield temp_dockerfile
     finally:
         temp_dockerfile.unlink()
+
+
+def get_image_index_digest(image: str) -> Optional[str]:
+    """
+    Get the image index digest for a given image.
+    """
+    try:
+        client = docker.from_env()
+        image_info = client.images.get(image)
+        return image_info.attrs["RepoDigests"][0]  # Get the first digest
+    except Exception:
+        return None

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1162,6 +1162,7 @@ class BaseWorker(abc.ABC):
         if configuration:
             related += configuration._related_resources()
 
+        if self._work_pool:
             related.append(
                 object_as_related_resource(
                     kind="work-pool", role="work-pool", object=self._work_pool
@@ -1172,15 +1173,16 @@ class BaseWorker(abc.ABC):
                 from prefect.utilities.dockerutils import get_image_index_digest
 
                 if image_digest := get_image_index_digest(image):
-                    related_image = RelatedResource.model_validate(
-                        {
-                            "prefect.resource.id": f"prefect.image.{image}",
-                            "prefect.resource.role": "image",
-                            "prefect.resource.name": image,
-                            "prefect.resource.index_digest": image_digest,
-                        }
+                    related.append(
+                        RelatedResource.model_validate(
+                            {
+                                "prefect.resource.id": f"prefect.image.{image}",
+                                "prefect.resource.role": "image",
+                                "prefect.resource.name": image,
+                                "prefect.resource.index_digest": image_digest,
+                            }
+                        )
                     )
-                    related.append(related_image)
 
         if include_self:
             worker_resource = self._event_resource()

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1162,12 +1162,25 @@ class BaseWorker(abc.ABC):
         if configuration:
             related += configuration._related_resources()
 
-        if self._work_pool:
             related.append(
                 object_as_related_resource(
                     kind="work-pool", role="work-pool", object=self._work_pool
                 )
             )
+
+            if image := getattr(configuration, "image", None):
+                from prefect.utilities.dockerutils import get_image_index_digest
+
+                if image_digest := get_image_index_digest(image):
+                    related_image = RelatedResource.model_validate(
+                        {
+                            "prefect.resource.id": f"prefect.image.{image}",
+                            "prefect.resource.role": "image",
+                            "prefect.resource.name": image,
+                            "prefect.resource.index_digest": image_digest,
+                        }
+                    )
+                    related.append(related_image)
 
         if include_self:
             worker_resource = self._event_resource()

--- a/tests/events/client/instrumentation/test_events_workers_instrumentation.py
+++ b/tests/events/client/instrumentation/test_events_workers_instrumentation.py
@@ -366,7 +366,8 @@ async def test_dockerish_worker_includes_image_related_resource(
         "prefect.resource.index_digest": "sha256:mock_digest",
     }
 
-    assert any(r.get("prefect.resource.role") == "deployment" for r in related)
-    assert any(r.get("prefect.resource.role") == "flow" for r in related)
-    assert any(r.get("prefect.resource.role") == "flow-run" for r in related)
-    assert any(r.get("prefect.resource.role") == "work-pool" for r in related)
+    expected_roles = {"deployment", "flow", "flow-run", "work-pool", "image", "tag"}
+    actual_roles = {r.get("prefect.resource.role") for r in related}
+    assert (
+        actual_roles == expected_roles
+    ), f"Mismatch in roles. Expected: {expected_roles}, Got: {actual_roles}"


### PR DESCRIPTION
closes #15432

very open to other suggestions, but it seemed like an easy win to inject often relevant information to the related resources of worker events. I'd love if I didn't have to make the network call for example, which maybe I could swing but not sure as of writing