### PR TITLE
Don't acquire a concurrency slot for worker-based deployments

### DIFF
--- a/src/integrations/prefect-docker/tests/test_worker.py
+++ b/src/integrations/prefect-docker/tests/test_worker.py
@@ -420,6 +420,7 @@ async def test_uses_env_setting(
     assert call_env == {
         **get_current_settings().to_environment_variables(exclude_unset=True),
         "PREFECT__FLOW_RUN_ID": str(flow_run.id),
+        "PREFECT__DISABLE_CONCURRENCY_SLOT_ACQUISITION": "true",
         "foo": "FOO",
         "bar": "BAR",
     }

--- a/src/integrations/prefect-kubernetes/tests/test_worker.py
+++ b/src/integrations/prefect-kubernetes/tests/test_worker.py
@@ -237,6 +237,7 @@ from_template_and_values_cases = [
             env={
                 **get_current_settings().to_environment_variables(exclude_unset=True),
                 "PREFECT__FLOW_RUN_ID": str(flow_run.id),
+                "PREFECT__DISABLE_CONCURRENCY_SLOT_ACQUISITION": "true",
             },
             labels={
                 "prefect.io/flow-run-id": str(flow_run.id),
@@ -292,6 +293,10 @@ from_template_and_values_cases = [
                                         {
                                             "name": "PREFECT__FLOW_RUN_ID",
                                             "value": str(flow_run.id),
+                                        },
+                                        {
+                                            "name": "PREFECT__DISABLE_CONCURRENCY_SLOT_ACQUISITION",
+                                            "value": "true",
                                         },
                                     ],
                                     "image": get_prefect_image_name(),
@@ -522,6 +527,7 @@ from_template_and_values_cases = [
             env={
                 **get_current_settings().to_environment_variables(exclude_unset=True),
                 "PREFECT__FLOW_RUN_ID": str(flow_run.id),
+                "PREFECT__DISABLE_CONCURRENCY_SLOT_ACQUISITION": "true",
             },
             labels={
                 "prefect.io/flow-run-id": str(flow_run.id),
@@ -577,6 +583,10 @@ from_template_and_values_cases = [
                                         {
                                             "name": "PREFECT__FLOW_RUN_ID",
                                             "value": str(flow_run.id),
+                                        },
+                                        {
+                                            "name": "PREFECT__DISABLE_CONCURRENCY_SLOT_ACQUISITION",
+                                            "value": "true",
                                         },
                                         {
                                             "name": "TEST_ENV",
@@ -679,6 +689,7 @@ from_template_and_values_cases = [
             env={
                 **get_current_settings().to_environment_variables(exclude_unset=True),
                 "PREFECT__FLOW_RUN_ID": str(flow_run.id),
+                "PREFECT__DISABLE_CONCURRENCY_SLOT_ACQUISITION": "true",
                 "TEST_ENV": "test",
             },
             labels={
@@ -739,6 +750,10 @@ from_template_and_values_cases = [
                                         {
                                             "name": "PREFECT__FLOW_RUN_ID",
                                             "value": str(flow_run.id),
+                                        },
+                                        {
+                                            "name": "PREFECT__DISABLE_CONCURRENCY_SLOT_ACQUISITION",
+                                            "value": "true",
                                         },
                                         {
                                             "name": "TEST_ENV",
@@ -961,6 +976,7 @@ from_template_and_values_cases = [
             env={
                 **get_current_settings().to_environment_variables(exclude_unset=True),
                 "PREFECT__FLOW_RUN_ID": str(flow_run.id),
+                "PREFECT__DISABLE_CONCURRENCY_SLOT_ACQUISITION": "true",
                 "TEST_ENV": "test",
             },
             labels={
@@ -1016,6 +1032,10 @@ from_template_and_values_cases = [
                                         {
                                             "name": "PREFECT__FLOW_RUN_ID",
                                             "value": str(flow_run.id),
+                                        },
+                                        {
+                                            "name": "PREFECT__DISABLE_CONCURRENCY_SLOT_ACQUISITION",
+                                            "value": "true",
                                         },
                                         {
                                             "name": "TEST_ENV",

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -1049,7 +1049,11 @@ class Runner:
 
         if flow_run.deployment_id:
             deployment = await self._client.read_deployment(flow_run.deployment_id)
-        if deployment and deployment.global_concurrency_limit:
+        if (
+            deployment
+            and deployment.global_concurrency_limit
+            and not deployment.work_queue_id  # Workers apply limits separately
+        ):
             limit_name = deployment.global_concurrency_limit.name
             concurrency_ctx = concurrency
         else:

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -265,7 +265,12 @@ class BaseJobConfiguration(BaseModel):
         """
         Generate a dictionary of environment variables for a flow run job.
         """
-        return {"PREFECT__FLOW_RUN_ID": str(flow_run.id)}
+        return {
+            "PREFECT__FLOW_RUN_ID": str(flow_run.id),
+            # Workers handle concurrency separately, so we disable it for the flow run's
+            # runner. Without a worker, the runner will attempt to acquire a slot.
+            "PREFECT__DISABLE_CONCURRENCY_SLOT_ACQUISITION": "true",
+        }
 
     @staticmethod
     def _base_deployment_labels(deployment: "DeploymentResponse") -> Dict[str, str]:

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -1522,6 +1522,7 @@ class TestPrepareForFlowRun:
             **get_current_settings().to_environment_variables(exclude_unset=True),
             "MY_VAR": "foo",
             "PREFECT__FLOW_RUN_ID": str(flow_run.id),
+            "PREFECT__DISABLE_CONCURRENCY_SLOT_ACQUISITION": "true",
         }
         assert job_config.labels == {
             "my-label": "foo",
@@ -1539,6 +1540,7 @@ class TestPrepareForFlowRun:
             **get_current_settings().to_environment_variables(exclude_unset=True),
             "MY_VAR": "foo",
             "PREFECT__FLOW_RUN_ID": str(flow_run.id),
+            "PREFECT__DISABLE_CONCURRENCY_SLOT_ACQUISITION": "true",
         }
         assert job_config.labels == {
             "my-label": "foo",
@@ -1559,6 +1561,7 @@ class TestPrepareForFlowRun:
             **get_current_settings().to_environment_variables(exclude_unset=True),
             "MY_VAR": "foo",
             "PREFECT__FLOW_RUN_ID": str(flow_run.id),
+            "PREFECT__DISABLE_CONCURRENCY_SLOT_ACQUISITION": "true",
         }
         assert job_config.labels == {
             "my-label": "foo",


### PR DESCRIPTION
Runners should not attempt to acquire a deployment concurrency slot for flow runs from worker-based deployments. Workers already acquire a slot, and if both the runner and worker acquire a slot, they could deadlock.

Closes OSS-5612.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
