### PR TITLE
Allow using `flow` and `flow_run` properties in base job template placeholders

### DIFF
--- a/src/prefect/utilities/templating.py
+++ b/src/prefect/utilities/templating.py
@@ -91,7 +91,10 @@ def find_placeholders(template: T) -> Set[Placeholder]:
 
 
 def apply_values(
-    template: T, values: Dict[str, Any], remove_notset: bool = True
+    template: T,
+    values: Dict[str, Any],
+    ctx: Optional[Dict[str, Any]] = None,
+    remove_notset: bool = True,
 ) -> Union[T, Type[NotSet]]:
     """
     Replaces placeholders in a template with values from a supplied dictionary.
@@ -115,11 +118,14 @@ def apply_values(
     Args:
         template: template to discover and replace values in
         values: The values to apply to placeholders in the template
+        ctx: A set of prefect supplied values for templating
         remove_notset: If True, remove keys with an unset value
 
     Returns:
         The template with the values applied
     """
+    if ctx:
+        values["ctx"] = ctx
     if isinstance(template, (int, float, bool, type(NotSet), type(None))):
         return template
     if isinstance(template, str):
@@ -157,7 +163,9 @@ def apply_values(
     elif isinstance(template, dict):
         updated_template = {}
         for key, value in template.items():
-            updated_value = apply_values(value, values, remove_notset=remove_notset)
+            updated_value = apply_values(
+                value, values, ctx=ctx, remove_notset=remove_notset
+            )
             if updated_value is not NotSet:
                 updated_template[key] = updated_value
             elif not remove_notset:
@@ -167,7 +175,9 @@ def apply_values(
     elif isinstance(template, list):
         updated_list = []
         for value in template:
-            updated_value = apply_values(value, values, remove_notset=remove_notset)
+            updated_value = apply_values(
+                value, values, ctx=ctx, remove_notset=remove_notset
+            )
             if updated_value is not NotSet:
                 updated_list.append(updated_value)
         return updated_list

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -95,6 +95,7 @@ class BaseJobConfiguration(BaseModel):
     )
 
     _related_objects: Dict[str, Any] = PrivateAttr(default_factory=dict)
+    _ctx: Dict[str, Any] = PrivateAttr(default_factory=dict)
 
     @property
     def is_using_a_runner(self):
@@ -152,7 +153,11 @@ class BaseJobConfiguration(BaseModel):
         ):
             job_config["env"] = hardcoded_env | job_config.get("env")
 
-        populated_configuration = apply_values(template=job_config, values=variables)
+        populated_configuration = apply_values(
+            template=job_config,
+            values=variables,
+            ctx=cls._ctx,
+        )
         populated_configuration = await resolve_block_document_references(
             template=populated_configuration, client=client
         )
@@ -207,6 +212,11 @@ class BaseJobConfiguration(BaseModel):
             "deployment": deployment,
             "flow": flow,
             "flow-run": flow_run,
+        }
+        self._ctx = {
+            "deployment": deployment.model_dump(),
+            "flow": flow.model_dump(),
+            "flow_run": flow_run.model_dump(),
         }
         if deployment is not None:
             deployment_labels = self._base_deployment_labels(deployment)

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -214,8 +214,8 @@ class BaseJobConfiguration(BaseModel):
             "flow-run": flow_run,
         }
         self._ctx = {
-            "deployment": deployment.model_dump(),
-            "flow": flow.model_dump(),
+            "deployment": deployment.model_dump() if deployment is not None else None,
+            "flow": flow.model_dump() if flow is not None else None,
             "flow_run": flow_run.model_dump(),
         }
         if deployment is not None:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

Fixes issue #14646 -- this actually ended up being a bit more involved than I initially thought because I wanted to try and have this populate safely.  I try to capture a few edge cases and create tests for them but also want to see how everyone else who is more familiar with the codebase finds these changes 

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [X] If this pull request adds functions or classes, it includes helpful docstrings.
