### PR TITLE
Fix use of deprecated field on `websockets.exceptions.ConnectionClosedError`

### DIFF
--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -527,11 +527,11 @@ class PrefectEventSubscriber:
                 f"Reason: {e.args[0]}"
             )
         except ConnectionClosedError as e:
-            raise Exception(
-                "Unable to authenticate to the event stream. Please ensure the "
-                "provided api_key you are using is valid for this environment. "
-                f"Reason: {e.reason}"
-            ) from e
+            reason = getattr(e.rcvd, "reason", None)
+            msg = "Unable to authenticate to the event stream. Please ensure the "
+            msg += "provided api_key you are using is valid for this environment. "
+            msg += f"Reason: {reason}" if reason else ""
+            raise Exception(msg) from e
 
         from prefect.events.filters import EventOccurredFilter
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
Fixes these new test errors that we've seen in CI:
```
>       with pytest.raises(Exception, match="Unable to authenticate"):
E       AssertionError: Regex pattern did not match.
E        Regex: 'Unable to authenticate'
E        Input: 'ConnectionClosed.reason is deprecated; use Protocol.close_reason or ConnectionClosed.rcvd.reason'
```
