### PR TITLE
Fix block reference load in async flow

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -535,7 +535,7 @@ class Flow(Generic[P, R]):
 
         def resolve_block_reference(data: Any) -> Any:
             if isinstance(data, dict) and "$ref" in data:
-                return Block.load_from_ref(data["$ref"])
+                return Block.load_from_ref(data["$ref"], _sync=True)
             return data
 
         try:

--- a/tests/blocks/test_block_reference.py
+++ b/tests/blocks/test_block_reference.py
@@ -1,7 +1,8 @@
+import asyncio
 import warnings
 from typing import Type
 from uuid import UUID, uuid4
-import asyncio
+
 import pydantic
 import pytest
 
@@ -199,12 +200,16 @@ class TestFlowWithBlockParam:
             return block.a
 
         assert (
-            asyncio.run(flow_with_block_param({"$ref": str(ref_block._block_document_id)}))
+            asyncio.run(
+                flow_with_block_param({"$ref": str(ref_block._block_document_id)})
+            )
             == ref_block.a
         )
         assert (
-            asyncio.run(flow_with_block_param(
-                {"$ref": {"block_document_id": str(ref_block._block_document_id)}}
-            ))
+            asyncio.run(
+                flow_with_block_param(
+                    {"$ref": {"block_document_id": str(ref_block._block_document_id)}}
+                )
+            )
             == ref_block.a
         )

--- a/tests/blocks/test_block_reference.py
+++ b/tests/blocks/test_block_reference.py
@@ -1,7 +1,7 @@
 import warnings
 from typing import Type
 from uuid import UUID, uuid4
-
+import asyncio
 import pydantic
 import pytest
 
@@ -188,4 +188,23 @@ class TestFlowWithBlockParam:
                 }
             )
             == param_block.a
+        )
+
+    def test_async_flow_with_block_params(self, ParamBlock):
+        ref_block = ParamBlock(a=10, b="foo")
+        ref_block.save("param-block")
+
+        @flow
+        async def flow_with_block_param(block: ParamBlock) -> int:
+            return block.a
+
+        assert (
+            asyncio.run(flow_with_block_param({"$ref": str(ref_block._block_document_id)}))
+            == ref_block.a
+        )
+        assert (
+            asyncio.run(flow_with_block_param(
+                {"$ref": {"block_document_id": str(ref_block._block_document_id)}}
+            ))
+            == ref_block.a
         )


### PR DESCRIPTION
This PR fixes loading block references in async flows. For async flows it throws `ParameterTypeError` as the sync compatible `Block.load_from_ref` call does not runs the coroutine.

Related to no existing issue (or i could not find any) and i assumed that it might not need one.

### Checklist

- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
