### PR TITLE
Fix use of deprecated field on `websockets.exceptions.ConnectionClosedError`

### DIFF
--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -473,11 +473,11 @@ class PrefectEventSubscriber:
                 f"Reason: {e.args[0]}"
             )
         except ConnectionClosedError as e:
-            raise Exception(
-                "Unable to authenticate to the event stream. Please ensure the "
-                "provided api_key you are using is valid for this environment. "
-                f"Reason: {e.reason}"
-            ) from e
+            reason = getattr(e.rcvd, "reason", None)
+            msg = "Unable to authenticate to the event stream. Please ensure the "
+            msg += "provided api_key you are using is valid for this environment. "
+            msg += f"Reason: {reason}" if reason else ""
+            raise Exception(msg) from e
 
         from prefect.events.filters import EventOccurredFilter
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
Port of #15467 to the `2.x` branch
