### PR TITLE
Enhancement: Add `end_time` to flow run filters

### DIFF
--- a/docs/3.0/api-ref/rest-api/server/schema.json
+++ b/docs/3.0/api-ref/rest-api/server/schema.json
@@ -18107,6 +18107,17 @@
                         ],
                         "description": "Filter criteria for `FlowRun.start_time`"
                     },
+                    "end_time": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/FlowRunFilterEndTime"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Filter criteria for `FlowRun.end_time`"
+                    },
                     "expected_start_time": {
                         "anyOf": [
                             {
@@ -18208,6 +18219,52 @@
                 "type": "object",
                 "title": "FlowRunFilterDeploymentId",
                 "description": "Filter by `FlowRun.deployment_id`."
+            },
+            "FlowRunFilterEndTime": {
+                "properties": {
+                    "before_": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Before ",
+                        "description": "Only include flow runs ending at or before this time"
+                    },
+                    "after_": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "After ",
+                        "description": "Only include flow runs ending at or after this time"
+                    },
+                    "is_null_": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Is Null ",
+                        "description": "If true, only return flow runs without an end time"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "title": "FlowRunFilterEndTime",
+                "description": "Filter by `FlowRun.end_time`."
             },
             "FlowRunFilterExpectedStartTime": {
                 "properties": {

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -423,6 +423,7 @@ class FlowRunFilterStartTime(PrefectFilterBaseModel):
             )
         return filters
 
+
 class FlowRunFilterEndTime(PrefectFilterBaseModel):
     """Filter by `FlowRun.end_time`."""
 

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -423,6 +423,35 @@ class FlowRunFilterStartTime(PrefectFilterBaseModel):
             )
         return filters
 
+class FlowRunFilterEndTime(PrefectFilterBaseModel):
+    """Filter by `FlowRun.end_time`."""
+
+    before_: Optional[DateTime] = Field(
+        default=None,
+        description="Only include flow runs ending at or before this time",
+    )
+    after_: Optional[DateTime] = Field(
+        default=None,
+        description="Only include flow runs ending at or after this time",
+    )
+    is_null_: Optional[bool] = Field(
+        default=None, description="If true, only return flow runs without an end time"
+    )
+
+    def _get_filter_list(self) -> List:
+        filters = []
+        if self.before_ is not None:
+            filters.append(orm_models.FlowRun.end_time <= self.before_)
+        if self.after_ is not None:
+            filters.append(orm_models.FlowRun.end_time >= self.after_)
+        if self.is_null_ is not None:
+            filters.append(
+                orm_models.FlowRun.end_time.is_(None)
+                if self.is_null_
+                else orm_models.FlowRun.end_time.is_not(None)
+            )
+        return filters
+
 
 class FlowRunFilterExpectedStartTime(PrefectFilterBaseModel):
     """Filter by `FlowRun.expected_start_time`."""
@@ -568,6 +597,9 @@ class FlowRunFilter(PrefectOperatorFilterBaseModel):
     start_time: Optional[FlowRunFilterStartTime] = Field(
         default=None, description="Filter criteria for `FlowRun.start_time`"
     )
+    end_time: Optional[FlowRunFilterEndTime] = Field(
+        default=None, description="Filter criteria for `FlowRun.end_time`"
+    )
     expected_start_time: Optional[FlowRunFilterExpectedStartTime] = Field(
         default=None, description="Filter criteria for `FlowRun.expected_start_time`"
     )
@@ -596,6 +628,7 @@ class FlowRunFilter(PrefectOperatorFilterBaseModel):
             and self.state is None
             and self.flow_version is None
             and self.start_time is None
+            and self.end_time is None
             and self.expected_start_time is None
             and self.next_scheduled_start_time is None
             and self.parent_flow_run_id is None
@@ -622,6 +655,8 @@ class FlowRunFilter(PrefectOperatorFilterBaseModel):
             filters.append(self.state.as_sql_filter())
         if self.start_time is not None:
             filters.append(self.start_time.as_sql_filter())
+        if self.end_time is not None:
+            filters.append(self.end_time.as_sql_filter())
         if self.expected_start_time is not None:
             filters.append(self.expected_start_time.as_sql_filter())
         if self.next_scheduled_start_time is not None:

--- a/tests/server/schemas/test_filters.py
+++ b/tests/server/schemas/test_filters.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 import pendulum
 import sqlalchemy as sa
 
-from prefect.server.schemas.filters import LogFilter
+from prefect.server.schemas.filters import LogFilter, FlowRunFilter
 
 NOW = pendulum.now("UTC")
 
@@ -48,3 +48,20 @@ class TestLogFilters:
         assert sql_filter.compare(
             sa.and_(db.Log.task_run_id.in_([task_run_id]), db.Log.level >= 20)
         )
+
+
+class TestFlowRunFilters:
+    def test_applies_flow_run_end_time_filter_before(self, db):
+        flow_run_filter = FlowRunFilter(end_time={"before_": NOW})
+        sql_filter = flow_run_filter.as_sql_filter()
+        assert sql_filter.compare(sa.and_(db.FlowRun.end_time <= NOW))
+    
+    def test_applies_flow_run_end_time_filter_after(self, db):
+        flow_run_filter = FlowRunFilter(end_time={"after_": NOW})
+        sql_filter = flow_run_filter.as_sql_filter()
+        assert sql_filter.compare(sa.and_(db.FlowRun.end_time >= NOW))
+
+    def test_applies_flow_run_end_time_filter_null(self, db):
+        flow_run_filter = FlowRunFilter(end_time={"is_null_": True})
+        sql_filter = flow_run_filter.as_sql_filter()
+        assert sql_filter.compare(sa.and_(db.FlowRun.end_time == None))

--- a/tests/server/schemas/test_filters.py
+++ b/tests/server/schemas/test_filters.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 import pendulum
 import sqlalchemy as sa
 
-from prefect.server.schemas.filters import LogFilter, FlowRunFilter
+from prefect.server.schemas.filters import FlowRunFilter, LogFilter
 
 NOW = pendulum.now("UTC")
 

--- a/tests/server/schemas/test_filters.py
+++ b/tests/server/schemas/test_filters.py
@@ -64,4 +64,4 @@ class TestFlowRunFilters:
     def test_applies_flow_run_end_time_filter_null(self, db):
         flow_run_filter = FlowRunFilter(end_time={"is_null_": True})
         sql_filter = flow_run_filter.as_sql_filter()
-        assert sql_filter.compare(sa.and_(db.FlowRun.end_time == None))
+        assert sql_filter.compare(sa.and_(db.FlowRun.end_time is None))

--- a/tests/server/schemas/test_filters.py
+++ b/tests/server/schemas/test_filters.py
@@ -64,4 +64,4 @@ class TestFlowRunFilters:
     def test_applies_flow_run_end_time_filter_null(self, db):
         flow_run_filter = FlowRunFilter(end_time={"is_null_": True})
         sql_filter = flow_run_filter.as_sql_filter()
-        assert sql_filter.compare(sa.and_(db.FlowRun.end_time is None))
+        assert sql_filter.compare(sa.and_(db.FlowRun.end_time.is_(None)))

--- a/tests/server/schemas/test_filters.py
+++ b/tests/server/schemas/test_filters.py
@@ -55,7 +55,7 @@ class TestFlowRunFilters:
         flow_run_filter = FlowRunFilter(end_time={"before_": NOW})
         sql_filter = flow_run_filter.as_sql_filter()
         assert sql_filter.compare(sa.and_(db.FlowRun.end_time <= NOW))
-    
+
     def test_applies_flow_run_end_time_filter_after(self, db):
         flow_run_filter = FlowRunFilter(end_time={"after_": NOW})
         sql_filter = flow_run_filter.as_sql_filter()


### PR DESCRIPTION
This'll help us better catch edge cases where a run should be included in a list because it ended within a certain window or outside of a certain window.