### PR TITLE
Update tasks to inherit the lock manager from a parent transaction if present

### DIFF
--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -294,6 +294,8 @@ class ResultStore(BaseModel):
         Returns:
             An updated result store.
         """
+        from prefect.transactions import get_transaction
+
         update = {}
         if task.result_storage is not None:
             update["result_storage"] = await resolve_result_storage(task.result_storage)
@@ -305,12 +307,20 @@ class ResultStore(BaseModel):
             update["storage_key_fn"] = partial(
                 _format_user_supplied_storage_key, task.result_storage_key
             )
+
+        # use the lock manager from a parent transaction if it exists
+        if (current_txn := get_transaction()) and isinstance(
+            current_txn.store, ResultStore
+        ):
+            update["lock_manager"] = current_txn.store.lock_manager
+
         if task.cache_policy is not None and task.cache_policy is not NotSet:
             if task.cache_policy.key_storage is not None:
                 storage = task.cache_policy.key_storage
                 if isinstance(storage, str) and not len(storage.split("/")) == 2:
                     storage = Path(storage)
                 update["metadata_storage"] = await resolve_result_storage(storage)
+            # if the cache policy has a lock manager, it takes precedence over the parent transaction
             if task.cache_policy.lock_manager is not None:
                 update["lock_manager"] = task.cache_policy.lock_manager
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR fixes errors raised when a task is run in a `SERIALIZABLE` transaction without a lock manager specified within a task's cache policy.

There's a larger question of how much of the `store` a child transaction should inherit from its parent. I think the most intuitive approach might be to have a child transaction use the parent's `store` if it isn't given one, but this change would still be necessary in that case since the task engine provides a `ResultStore` to each task's transaction.

Closes https://github.com/PrefectHQ/prefect/issues/15503