### PR TITLE
Improve docstring result for when used with `run_deployment`

### DIFF
--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -231,7 +231,9 @@ class State(ObjectBaseModel, Generic[R]):
 
         Args:
             raise_on_failure: a boolean specifying whether to raise an exception
-                if the state is of type `FAILED` and the underlying data is an exception
+                if the state is of type `FAILED` and the underlying data is an exception. When flow
+                was run in a different memory space (using `run_deployment`), this will only raise
+                if `fetch` is `True`.
             fetch: a boolean specifying whether to resolve references to persisted
                 results into data. For synchronous users, this defaults to `True`.
                 For asynchronous users, this defaults to `False` for backwards
@@ -297,6 +299,15 @@ class State(ObjectBaseModel, Generic[R]):
             >>> state = await my_flow(return_state=True)
             >>> await state.result()
             hello
+
+            Get the result with `raise_on_failure` from a flow run in a different memory space
+
+            >>> @flow
+            >>> async def my_flow():
+            >>>     raise ValueError("oh no!")
+            >>> my_flow.deploy("my_deployment/my_flow")
+            >>> flow_run = run_deployment("my_deployment/my_flow")
+            >>> await flow_run.state.result(raise_on_failure=True, fetch=True) # Raises `ValueError("oh no!")`
         """
         from prefect.states import get_state_result
 


### PR DESCRIPTION
To give light on the complex behaviour of `state.result` when used with `run_deployment`.

Closes https://github.com/PrefectHQ/prefect/issues/15276

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.