### PR TITLE
Update `transaction` context manager to default `write_on_commit` to `True`

### DIFF
--- a/docs/3.0/develop/transactions.mdx
+++ b/docs/3.0/develop/transactions.mdx
@@ -154,7 +154,7 @@ def write_data(data: str):
 
 @flow(log_prints=True)
 def pipeline():
-    with transaction(key="download-and-write-data", write_on_commit=True) as txn:
+    with transaction(key="download-and-write-data") as txn:
         if txn.is_committed():
             print("Data file has already been written. Exiting early.")
             return
@@ -168,7 +168,7 @@ if __name__ == "__main__":
 
 If you run this flow, it will write data to a file the first time, but it will exit early on subsequent runs because the transaction has already been committed.
 
-Giving the transaction a `key` and setting `write_on_commit=True` will cause the transaction to write a record on commit signifying that the transaction has completed.
+Giving the transaction a `key` will cause the transaction to write a record on commit signifying that the transaction has completed.
 The call to `txn.is_committed()` will return `True` only if the persisted record exists.
 
 ### Handling race conditions
@@ -202,7 +202,7 @@ def write_file(contents: str):
 
 @flow
 def pipeline(transaction_key: str):
-    with transaction(key=transaction_key, write_on_commit=True) as txn:
+    with transaction(key=transaction_key) as txn:
         if txn.is_committed():
             print("Data file has already been written. Exiting early.")
             return
@@ -257,7 +257,6 @@ def write_file(contents: str):
 def pipeline(transaction_key: str):
     with transaction(
         key=transaction_key,
-        write_on_commit=True,
         isolation_level=IsolationLevel.SERIALIZABLE,
         store=ResultStore(
             lock_manager=FileSystemLockManager(

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -31,7 +31,6 @@ from prefect.results import (
     ResultRecord,
     ResultStore,
     get_result_store,
-    should_persist_result,
 )
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.collections import AutoEnum
@@ -438,7 +437,7 @@ def transaction(
     commit_mode: Optional[CommitMode] = None,
     isolation_level: Optional[IsolationLevel] = None,
     overwrite: bool = False,
-    write_on_commit: Optional[bool] = None,
+    write_on_commit: bool = True,
     logger: Union[logging.Logger, logging.LoggerAdapter, None] = None,
 ) -> Generator[Transaction, None, None]:
     """
@@ -473,9 +472,7 @@ def transaction(
         commit_mode=commit_mode,
         isolation_level=isolation_level,
         overwrite=overwrite,
-        write_on_commit=write_on_commit
-        if write_on_commit is not None
-        else should_persist_result(),
+        write_on_commit=write_on_commit,
         logger=logger,
     ) as txn:
         yield txn


### PR DESCRIPTION
This PR updates `write_on_commit` to default to `True` on the `transaction` context manager. 

Previously, it defaulted to the value of `PREFECT_RESULTS_PERSIST_BY_DEFAULT` outside of a task or flow, which defaults to `False`. In most cases, user-defined transactions must explicitly set `write_on_commit` to `True`. 

This behavior feels unintuitive, so this PR changes that. This change doesn't affect task transactions since they explicitly provide a value for `write_on_commit` based on the context in which they are run.