### PR TITLE
Update cache isolation example to show different behavior between isolation levels

### DIFF
--- a/docs/3.0/develop/task-caching.mdx
+++ b/docs/3.0/develop/task-caching.mdx
@@ -265,7 +265,7 @@ if __name__ == "__main__":
     thread_2.join()
 ```
 
-When running this script, both tasks will execute in parallel and neither will be cached despite both tasks using the same cache key.
+When running this script, both tasks will execute in parallel and perform work despite both tasks using the same cache key.
 
 This is evidenced by seeing both `my_task_version_1 running` and `my_task_version_2 running` in the output:
 

--- a/docs/3.0/develop/task-caching.mdx
+++ b/docs/3.0/develop/task-caching.mdx
@@ -234,31 +234,106 @@ Cache isolation controls how concurrent task runs interact with cache records. P
 By default, cache records operate with a `READ_COMMITTED` isolation level. This guarantees that reading a cache record will see the latest committed cache value,
 but allows multiple executions of the same task to occur simultaneously.
 
+Consider the following example:
+
+```python
+from prefect import task
+from prefect.cache_policies import INPUTS
+import threading
+
+
+cache_policy = INPUTS
+
+@task(cache_policy=cache_policy)
+def my_task_version_1(x: int):
+    print("my_task_version_1 running")
+    return x + 42
+
+@task(cache_policy=cache_policy)
+def my_task_version_2(x: int):
+    print("my_task_version_2 running")
+    return x + 43
+
+if __name__ == "__main__":
+    thread_1 = threading.Thread(target=my_task_version_1, args=(1,))
+    thread_2 = threading.Thread(target=my_task_version_2, args=(1,))
+
+    thread_1.start()
+    thread_2.start()
+
+    thread_1.join()
+    thread_2.join()
+```
+
+When running this script, both tasks will execute in parallel and neither will be cached despite both tasks using the same cache key.
+
+This is evidenced by seeing both `my_task_version_1 running` and `my_task_version_2 running` in the output:
+
+```
+11:27:21.031 | INFO    | Task run 'my_task_version_2' - Created task run 'my_task_version_2' for task 'my_task_version_2'
+11:27:21.032 | INFO    | Task run 'my_task_version_1' - Created task run 'my_task_version_1' for task 'my_task_version_1'
+my_task_version_2 running
+my_task_version_1 running
+11:27:21.050 | INFO    | Task run 'my_task_version_2' - Finished in state Completed()
+11:27:21.051 | INFO    | Task run 'my_task_version_1' - Finished in state Completed()
+```
+
 For stricter isolation, you can use the `SERIALIZABLE` isolation level. This ensures that only one execution of a task occurs at a time for a given cache 
 record via a locking mechanism.
 
 To configure the isolation level, use the `.configure` method with an `isolation_level` argument on a cache policy. When using `SERIALIZABLE`, you must 
 also provide a `lock_manager` that implements locking logic for your system.
 
-For example:
+Here's an updated version of the previous example that uses `SERIALIZABLE` isolation:
 
 ```python
-from prefect import task
-from prefect.cache_policies import TASK_SOURCE, INPUTS
-from prefect.transactions import IsolationLevel
-from prefect.locking.filesystem import FileSystemLockManager
+import threading
 
-cache_policy = (INPUTS + TASK_SOURCE).configure(
+from prefect import task
+from prefect.cache_policies import INPUTS
+from prefect.locking.memory import MemoryLockManager
+from prefect.transactions import IsolationLevel
+
+cache_policy = INPUTS.configure(
     isolation_level=IsolationLevel.SERIALIZABLE,
-    lock_manager=FileSystemLockManager(lock_files_directory="path/to/lock/files"),
+    lock_manager=MemoryLockManager(),
 )
 
+
 @task(cache_policy=cache_policy)
-def my_cached_task(x: int):
+def my_task_version_1(x: int):
+    print("my_task_version_1 running")
     return x + 42
+
+
+@task(cache_policy=cache_policy)
+def my_task_version_2(x: int):
+    print("my_task_version_2 running")
+    return x + 43
+
+
+if __name__ == "__main__":
+    thread_1 = threading.Thread(target=my_task_version_1, args=(2,))
+    thread_2 = threading.Thread(target=my_task_version_2, args=(2,))
+
+    thread_1.start()
+    thread_2.start()
+
+    thread_1.join()
+    thread_2.join()
 ```
 
-This task will create a lock file in the specified directory whenever it is run to ensure that only one instance of the task is executed at a time.
+In the updated script, only one of the tasks will run and the other will use the cached value.
+
+This is evidenced by seeing only one of `my_task_version_1 running` or `my_task_version_2 running` in the output:
+
+```
+11:34:00.383 | INFO    | Task run 'my_task_version_1' - Created task run 'my_task_version_1' for task 'my_task_version_1'
+11:34:00.383 | INFO    | Task run 'my_task_version_2' - Created task run 'my_task_version_2' for task 'my_task_version_2'
+my_task_version_1 running
+11:34:00.402 | INFO    | Task run 'my_task_version_1' - Finished in state Completed()
+11:34:00.405 | INFO    | Task run 'my_task_version_2' - Finished in state Cached(type=COMPLETED)
+```
 
 <Note>
 **Locking in a distributed setting**


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
Updates example to better show the difference in behavior when tasks use a cache policy with a  `READ_COMMITTED` isolation level vs `SERIALIZABLE`.
