### PR TITLE
use internal logger for `get_lost_followers` retries

### DIFF
--- a/src/prefect/_internal/retries.py
+++ b/src/prefect/_internal/retries.py
@@ -2,10 +2,8 @@ import asyncio
 from functools import wraps
 from typing import Any, Callable, Tuple, Type
 
-from prefect.logging.loggers import get_logger
+from prefect._internal._logging import logger
 from prefect.utilities.math import clamped_poisson_interval
-
-logger = get_logger("retries")
 
 
 def exponential_backoff_with_jitter(


### PR DESCRIPTION
use the internal logger for this, so as not to confuse users

> Saw this in the logs, is this something to be concerned about?
WARNING | prefect.retries - Attempt 1 of function 'get_lost_followers' failed with OperationalError. Retrying in 0.87 seconds..