### PR TITLE
Docs Prefect logo link to prefect.io

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -40,7 +40,8 @@
   },
   "logo": {
     "dark": "/logos/logo-word-white.svg",
-    "light": "/logos/logo-word-black.svg"
+    "light": "/logos/logo-word-black.svg",
+    "href": "https://prefect.io"
   },
   "modeToggle": {
     "default": "light",


### PR DESCRIPTION
Link to prefect.io from the logo in the top left of the docs.
We didn't have a link to the site.
Now clicking on the logo behaves as one would expect.

Looking at the first five libraries I thought of in the orchestration space, the logos on their docs sites all link to their primary non-docs websites. 

cc: @seanpwlms - thank you for raising!

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
