### PR TITLE
Avoid crashing flows when Kubernetes job watch exits but the container is still running

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -977,13 +977,23 @@ class KubernetesWorker(BaseWorker):
         async with watch:
             while True:
                 try:
+                    if resource_version is None:
+                        # Initial list to get the current resource_version
+                        job_list = await batch_client.list_namespaced_job(
+                            namespace=namespace,
+                            field_selector=f"metadata.name={job_name}",
+                        )
+                        resource_version = job_list.metadata.resource_version
                     async for event in watch.stream(
                         func=batch_client.list_namespaced_job,
                         namespace=namespace,
                         field_selector=f"metadata.name={job_name}",
+                        resource_version=resource_version,
                         **watch_kwargs,
                     ):
                         yield event
+                        # Update resource_version with each event
+                        resource_version = event.object.metadata.resource_version
                 except ApiException as e:
                     if e.status == 410:
                         job_list = await batch_client.list_namespaced_job(
@@ -992,7 +1002,6 @@ class KubernetesWorker(BaseWorker):
                         )
 
                         resource_version = job_list.metadata.resource_version
-                        watch_kwargs["resource_version"] = resource_version
                     else:
                         raise
 
@@ -1063,34 +1072,40 @@ class KubernetesWorker(BaseWorker):
         # Create a list of tasks to run concurrently
         async with self._get_batch_client(client) as batch_client:
             tasks = [
-                self._monitor_job_events(
-                    batch_client,
-                    job_name,
-                    logger,
-                    configuration,
+                asyncio.create_task(
+                    self._monitor_job_events(
+                        batch_client,
+                        job_name,
+                        logger,
+                        configuration,
+                    ),
+                    name="monitor_job_events",
                 )
             ]
             try:
                 with timeout_async(seconds=configuration.job_watch_timeout_seconds):
                     if configuration.stream_output:
                         tasks.append(
-                            self._stream_job_logs(
-                                logger,
-                                pod.metadata.name,
-                                job_name,
-                                configuration,
-                                client,
-                            )
+                            asyncio.create_task(
+                                self._stream_job_logs(
+                                    logger,
+                                    pod.metadata.name,
+                                    job_name,
+                                    configuration,
+                                    client,
+                                ),
+                                name="stream_job_logs",
+                            ),
                         )
 
                     results = await asyncio.gather(*tasks, return_exceptions=True)
-                    if any(isinstance(result, Exception) for result in results):
-                        for result in results:
-                            if isinstance(result, Exception):
-                                logger.error(
-                                    f"Error during task execution: {result}",
-                                    exc_info=True,
-                                )
+                    for idx, result in enumerate(results):
+                        if isinstance(result, Exception):
+                            task_name = tasks[idx].get_name()
+                            logger.error(
+                                f"Error in task {task_name!r}: {result}",
+                                exc_info=result,
+                            )
             except TimeoutError:
                 logger.error(
                     f"Job {job_name!r}: Job did not complete within "
@@ -1117,6 +1132,18 @@ class KubernetesWorker(BaseWorker):
         if not first_container_status:
             logger.error(f"Job {job_name!r}: No pods found for job.")
             return -1
+        # In some cases, the pod will still be running at this point.
+        # We can assume that the job is still running and return 0 to prevent marking the flow run as crashed
+        elif first_container_status.state and (
+            first_container_status.state.running is not None
+            or first_container_status.state.waiting is not None
+        ):
+            logger.warning(
+                f"The worker's watch for job {job_name!r} has exited early. Check the logs for more information."
+                " The job is still running, but the worker will not wait for it to complete."
+            )
+            # Return 0 to prevent marking the flow run as crashed
+            return 0
         # In some cases, such as spot instance evictions, the pod will be forcibly
         # terminated and not report a status correctly.
         elif (

--- a/src/integrations/prefect-kubernetes/pyproject.toml
+++ b/src/integrations/prefect-kubernetes/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "pytest-asyncio",
     "pytest",
     "pytest-env",
+    "pytest-timeout",
     "pytest-xdist",
 ]
 
@@ -81,3 +82,4 @@ show_missing = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 env = ["PREFECT_TEST_MODE=1"]
+timeout = 30

--- a/src/integrations/prefect-kubernetes/tests/test_worker.py
+++ b/src/integrations/prefect-kubernetes/tests/test_worker.py
@@ -2200,6 +2200,16 @@ class TestKubernetesWorker:
             mock_pod,
             mock_job,
         ):
+            # job_pod = MagicMock(spec=kubernetes_asyncio.client.V1Pod)
+            # mock_container_status = MagicMock(
+            #     spec=kubernetes_asyncio.client.V1ContainerStatus
+            # )
+            # mock_container_status.state.running = None
+            # mock_container_status.state.waiting = None
+            # job_pod.status.container_statuses = [mock_container_status]
+            # mock_core_client.return_value.list_namespaced_pod.return_value.items = [
+            #     job_pod
+            # ]
             async def mock_stream(*args, **kwargs):
                 mock_job.status.conditions = [MagicMock(type="Complete", status="True")]
                 stream = [
@@ -2351,6 +2361,17 @@ class TestKubernetesWorker:
             mock_pod,
             mock_job,
         ):
+            job_pod = MagicMock(spec=kubernetes_asyncio.client.V1Pod)
+            mock_container_status = MagicMock(
+                spec=kubernetes_asyncio.client.V1ContainerStatus
+            )
+            mock_container_status.state.running = None
+            mock_container_status.state.waiting = None
+            job_pod.status.container_statuses = [mock_container_status]
+            mock_core_client.return_value.list_namespaced_pod.return_value.items = [
+                job_pod
+            ]
+
             async def mock_stream(*args, **kwargs):
                 mock_job.status.conditions = [MagicMock(type="Complete", status="True")]
                 stream = [
@@ -2435,6 +2456,16 @@ class TestKubernetesWorker:
 
             mock_core_client.return_value.read_namespaced_pod_log.return_value.stream = mock_log_stream
             mock_watch.return_value.stream = mock.Mock(side_effect=mock_stream)
+            job_pod = MagicMock(spec=kubernetes_asyncio.client.V1Pod)
+            mock_container_status = MagicMock(
+                spec=kubernetes_asyncio.client.V1ContainerStatus
+            )
+            mock_container_status.state.running = None
+            mock_container_status.state.waiting = None
+            job_pod.status.container_statuses = [mock_container_status]
+            mock_core_client.return_value.list_namespaced_pod.return_value.items = [
+                job_pod
+            ]
 
             default_configuration.job_watch_timeout_seconds = 100
             async with KubernetesWorker(work_pool_name="test") as k8s_worker:
@@ -2512,6 +2543,8 @@ class TestKubernetesWorker:
                 spec=kubernetes_asyncio.client.V1ContainerStatus
             )
             mock_container_status.state.terminated.exit_code = 137
+            mock_container_status.state.running = None
+            mock_container_status.state.waiting = None
             job_pod.status.container_statuses = [mock_container_status]
             mock_core_client.return_value.list_namespaced_pod.return_value.items = [
                 job_pod
@@ -2604,6 +2637,8 @@ class TestKubernetesWorker:
             # The container may exist but because it has been forcefully terminated
             # it will not have an exit code.
             mock_container_status.state.terminated = None
+            mock_container_status.state.running = None
+            mock_container_status.state.waiting = None
             job_pod.status.container_statuses = [mock_container_status]
             mock_core_client.return_value.list_namespaced_pod.return_value.items = [
                 job_pod


### PR DESCRIPTION

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR updates the Kubernetes worker to avoid marking a flow run as crashed if the container within the flow is still running when the job watch exits. This won't address the root cause of issues like https://github.com/PrefectHQ/prefect/issues/15259, but it will prevent flow runs from errantly being marked as crashed. 

This PR also improves the error logging when the job watch encounters an exception. In its current state, we can't see what error is causing the job watch to stop.
