### PR TITLE
Docs for deployment concurrency limits

### DIFF
--- a/docs/3.0/deploy/index.mdx
+++ b/docs/3.0/deploy/index.mdx
@@ -230,6 +230,12 @@ class Deployment:
     paused: bool = False
     trigger: Trigger = None
 
+    # concurrency limiting
+    concurrency_limit: Optional[int] = None
+    concurrency_options: Optional[
+        ConcurrencyOptions(collision_strategy=Literal['ENQUEUE', 'CANCEL_NEW'])
+    ] = None
+
     # metadata for bookkeeping
     version: Optional[str] = None
     description: Optional[str] = None
@@ -327,6 +333,58 @@ passed to a flow run against the schema defined by `parameter_openapi_schema`.
 
 Pausing a schedule, updating your deployment, and other actions reset your auto-scheduled runs.
 </Tip>
+
+### Concurrency limiting
+
+Prefect supports managing concurrency at the deployment level to enable limiting how many runs of a
+deployment can be active at once. To enable this behavior, deployments have the following fields:
+
+- **`concurrency_limit`**: an integer that sets the maximum number of runs that can be active at once.
+- **`collision_strategy`**: configure the behavior for runs once the concurrency limit is reached.
+Falls back to `ENQUEUE` if unset.
+  - `ENQUEUE`: new runs transition to `AwaitingConcurrencySlot` and execute as slots become available.
+  - `CANCEL_NEW`: new runs are canceled until a slot becomes available.
+
+<CodeGroup>
+
+```sh prefect deploy
+prefect deploy ... --concurrency-limit 3 --collision-strategy ENQUEUE
+```
+
+```python flow.deploy()
+from prefect.client.schemas.objects import (
+    ConcurrencyLimitConfig, 
+    ConcurrencyLimitStrategy
+)
+
+my_flow.deploy(..., concurrency_limit=3)
+
+my_flow.deploy(
+    ...,
+    concurrency_limit=ConcurrencyLimitConfig(
+        limit=3, collision_strategy=ConcurrencyLimitStrategy.CANCEL_NEW
+    ),
+)
+```
+
+```python flow.serve()
+from prefect.client.schemas.objects import (
+    ConcurrencyLimitConfig, 
+    ConcurrencyLimitStrategy
+)
+
+my_flow.serve(..., global_limit=3)
+
+my_flow.serve(
+    ...,
+    global_limit=ConcurrencyLimitConfig(
+        limit=3, collision_strategy=ConcurrencyLimitStrategy.CANCEL_NEW
+    ),
+)
+```
+
+</CodeGroup>
+
 
 ### Metadata for bookkeeping
 

--- a/docs/3.0/deploy/index.mdx
+++ b/docs/3.0/deploy/index.mdx
@@ -339,7 +339,7 @@ Pausing a schedule, updating your deployment, and other actions reset your auto-
 Prefect supports managing concurrency at the deployment level to enable limiting how many runs of a
 deployment can be active at once. To enable this behavior, deployments have the following fields:
 
-- **`concurrency_limit`**: an integer that sets the maximum number of runs that can be active at once.
+- **`concurrency_limit`**: an integer that sets the maximum number of concurrent flow runs for the deployment.
 - **`collision_strategy`**: configure the behavior for runs once the concurrency limit is reached.
 Falls back to `ENQUEUE` if unset.
   - `ENQUEUE`: new runs transition to `AwaitingConcurrencySlot` and execute as slots become available.

--- a/docs/3.0/deploy/infrastructure-concepts/prefect-yaml.mdx
+++ b/docs/3.0/deploy/infrastructure-concepts/prefect-yaml.mdx
@@ -401,6 +401,7 @@ deployments:
   - "{{ prefect.variables.some_common_tag }}"
   description: null
   schedule: null
+  concurrency_limit: null
 
   # flow-specific fields
   entrypoint: null
@@ -608,6 +609,7 @@ These are fields you can add to each deployment declaration.
 | `tags`                                     | A list of strings to assign to the deployment as tags.                                                                                                                                                                                                                                   |
 | <span class="no-wrap">`description`</span> | An optional description for the deployment.                                                                                                                                                                                                                                              |
 | `schedule`                                 | An optional [schedule](/3.0/automate/add-schedules) to assign to the deployment. Fields for this section are documented in the [Schedule Fields](#schedule-fields) section.                                                                                                                      |
+| `concurrency_limit`                        | An optional [deployment concurrency limit](/3.0/deploy/index#concurrency-limiting). Fields for this section are documented in the [Concurrency Limit Fields](#concurrency-limit-fields) section.                                                                                                                      |
 | `triggers`                                  | An optional array of [triggers](/3.0/automate/events/automations-triggers/#custom-triggers) to assign to the deployment |
 | `entrypoint`                               | Required path to the `.py` file containing the flow you want to deploy (relative to the root directory of your development folder) combined with the name of the flow function. In the format `path/to/file.py:flow_function_name`. |
 | `parameters`                               | Optional default values to provide for the parameters of the deployed flow. Should be an object with key/value pairs.                                                                                                                                                                    |
@@ -626,6 +628,15 @@ These are fields you can add to a deployment declaration's `schedule` section.
 | `cron`                                     | A valid cron string. Cannot use in conjunction with `interval` or `rrule`.                                                                                                                                         |
 | `day_or`                                   | Boolean indicating how croniter handles day and day_of_week entries. Must use with `cron`. Defaults to `True`.                                                                                                     |
 | `rrule`                                    | String representation of an RRule schedule. See the [`rrulestr` examples](https://dateutil.readthedocs.io/en/stable/rrule.html#rrulestr-examples) for syntax. Cannot used them in conjunction with `interval` or `cron`. |
+
+#### Concurrency limit fields
+
+These are fields you can add to a deployment declaration's `concurrency_limit` section.
+
+| Property                                   | Description                                                                                                                                                                                                            |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `limit`                                    | The maximum number of concurrent flow runs for the deployment.                                                                                                                                                 |
+| `collision_strategy`                       | Configure the behavior for runs once the concurrency limit is reached. Options are `ENQUEUE`, and `CANCEL_NEW`. Defaults to `ENQUEUE`.                                                                                 |
 
 
 #### Work pool fields


### PR DESCRIPTION
This PR updates docs to include deployment concurrency limit fields.

Closes OSS-5617

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
