### PR TITLE
Add tests for cloning a real repository

### DIFF
--- a/src/integrations/prefect-github/tests/test_repository.py
+++ b/src/integrations/prefect-github/tests/test_repository.py
@@ -189,3 +189,30 @@ class TestGitHubRepository:
 
                 assert set(os.listdir(tmp_dst)) == set([sub_dir_name])
                 assert set(os.listdir(Path(tmp_dst) / sub_dir_name)) == child_contents
+
+    async def test_get_directory_clones_a_repo(self):
+        """Check that `get_directory` is able to clone a repo"""
+
+        with TemporaryDirectory() as tmp_dst:
+            g = GitHubRepository(
+                repository_url="https://github.com/PrefectHQ/prefect-operator",
+            )
+            await g.get_directory(local_path=tmp_dst)
+
+            dir_list = set(os.listdir(tmp_dst))
+            assert ".git" in dir_list
+
+    async def test_get_directory_clones_a_private_repo(self):
+        """Check that `get_directory` is able to clone a private repo"""
+
+        credential = GitHubCredentials(token="XYZ")
+        with TemporaryDirectory() as tmp_dst:
+            g = GitHubRepository(
+                repository_url="https://github.com/PrefectHQ/prefect-operator",
+                credentials=credential,
+            )
+            await g.get_directory(local_path=tmp_dst)
+
+            dir_list = set(os.listdir(tmp_dst))
+            assert "README.md" in dir_list
+            assert ".git" in dir_list


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

Fixes issue #15241 -- the issue made note of testing for a private repository, but I don't know how to mock a private repository easily.  I found an old repo in js that does this: https://github.com/rexxars/mock-private-registry but i didn't know if we wanted to go down this route fully 

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
