### PR TITLE
add `get_current_workspace` cloud client method

### DIFF
--- a/src/prefect/cli/cloud/__init__.py
+++ b/src/prefect/cli/cloud/__init__.py
@@ -557,7 +557,12 @@ async def logout():
     exit_with_success("Logged out from Prefect Cloud.")
 
 
-@cloud_app.command()
+@cloud_app.command(
+    deprecated=True,
+    deprecated_name="prefect cloud open",
+    deprecated_start_date="Oct 2024",
+    deprecated_help="Use `prefect dashboard open` to open the Prefect UI.",
+)
 async def open():
     """
     Open the Prefect Cloud UI in the browser.
@@ -570,10 +575,9 @@ async def open():
             "There is no current profile set - set one with `prefect profile create"
             " <name>` and `prefect profile use <name>`."
         )
+    async with get_cloud_client() as client:
+        current_workspace = await client.read_current_workspace()
 
-    current_workspace = get_current_workspace(
-        await prefect.client.cloud.get_cloud_client().read_workspaces()
-    )
     if current_workspace is None:
         exit_with_error(
             "There is no current workspace set - set one with `prefect cloud workspace"

--- a/src/prefect/client/cloud.py
+++ b/src/prefect/client/cloud.py
@@ -17,6 +17,7 @@ from prefect.client.schemas.objects import (
 from prefect.exceptions import ObjectNotFound, PrefectException
 from prefect.settings import (
     PREFECT_API_KEY,
+    PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
     PREFECT_UNIT_TEST_MODE,
 )
@@ -109,6 +110,14 @@ class CloudClient:
             await self.get("/me/workspaces")
         )
         return workspaces
+
+    async def read_current_workspace(self) -> Workspace:
+        workspaces = await self.read_workspaces()
+        current_api_url = PREFECT_API_URL.value()
+        for workspace in workspaces:
+            if workspace.api_url() == current_api_url.rstrip("/"):
+                return workspace
+        raise ValueError("Current workspace not found")
 
     async def read_worker_metadata(self) -> Dict[str, Any]:
         response = await self.get(


### PR DESCRIPTION
this PR adds a cloud client method to read the current workspace. it also deprecates `prefect cloud open` in favor of the more general `prefect dashboard open`

---
copilot summary

### Deprecation and Command Updates:
* [`src/prefect/cli/cloud/__init__.py`](diffhunk://#diff-7a5d84ab59363d3aaed9feb4cd5415cf97129147328588935c36047d897b0eaeL560-R565): Deprecated the `prefect cloud open` command and added a deprecation message suggesting the use of `prefect dashboard open` instead.

### Workspace Management:
* [`src/prefect/cli/cloud/__init__.py`](diffhunk://#diff-7a5d84ab59363d3aaed9feb4cd5415cf97129147328588935c36047d897b0eaeR578-L576): Updated the `open` function to use an asynchronous context manager for retrieving the current workspace.
* [`src/prefect/client/cloud.py`](diffhunk://#diff-5a511ac64f00b69748c693dfcb62f815958978fea3a9abe42e0698d298f55d13R114-R121): Added a new method `read_current_workspace` to retrieve the current workspace based on the `PREFECT_API_URL` setting.

### Testing Enhancements:
* [`tests/client/test_cloud_client.py`](diffhunk://#diff-d7b213fb4e26ccf36e613305661d2df905ed40013cd56ef316155356bc752b4fR101-R132): Added a new test `test_read_current_workspace` to ensure the `read_current_workspace` method correctly retrieves the current workspace.