### PR TITLE
Fix bug in nightly release workflow

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -58,6 +58,7 @@ jobs:
           fi
 
           next_tag=${major}.${minor}.${micro}.dev${counter}
+          echo "next_tag=$next_tag" >> $GITHUB_OUTPUT
           echo "Next tag is $next_tag"
 
       - name: Create development release


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
I forgot to set `next_tag` in `$GITHUB_OUTPUT` to make it available in the last step. This PR fixes that.

