### PR TITLE
Fix dev nightly release errors

### DIFF
--- a/.github/workflows/markdown-tests.yaml
+++ b/.github/workflows/markdown-tests.yaml
@@ -90,7 +90,8 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e '.[markdown-tests]'
+          uv pip install --upgrade --system -e .
+          uv pip install -r requirements-markdown-tests.txt
 
       - name: Start server
         run: |

--- a/.github/workflows/markdown-tests.yaml
+++ b/.github/workflows/markdown-tests.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e .
+          uv pip install --upgrade --system -e '.[dev]'
           uv pip install --upgrade --system -r requirements-markdown-tests.txt
 
       - name: Start server

--- a/.github/workflows/markdown-tests.yaml
+++ b/.github/workflows/markdown-tests.yaml
@@ -91,7 +91,7 @@ jobs:
         run: |
           python -m pip install -U uv
           uv pip install --upgrade --system -e .
-          uv pip install -r requirements-markdown-tests.txt
+          uv pip install --upgrade --system -r requirements-markdown-tests.txt
 
       - name: Start server
         run: |

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -66,7 +66,7 @@ jobs:
         if: steps.check_changes.outputs.SHOULD_CREATE_RELEASE == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          name: "Nightly Development Release ${{ steps.get_latest_tag.outputs.latest_tag }}"
+          name: "Nightly Development Release ${{ steps.get_latest_tag.outputs.next_tag }}"
           tag_name: ${{ steps.next_dev_version.outputs.next_tag }}
           draft: false
           prerelease: true

--- a/requirements-markdown-tests.txt
+++ b/requirements-markdown-tests.txt
@@ -1,5 +1,3 @@
-from pytest_markdown_docs import plugin
-
 pytest-markdown-docs @ git+https://github.com/PrefectHQ/pytest-markdown-docs@mdx-comment-support
 
 pandas
@@ -18,4 +16,4 @@ prefect-ray
 prefect-shell
 prefect-slack
 prefect-snowflake
-prefect_sqlalchemy
+prefect-sqlalchemy

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,6 @@ def read_requirements(file):
 client_requires = read_requirements("requirements-client.txt")
 install_requires = read_requirements("requirements.txt")[1:] + client_requires
 dev_requires = read_requirements("requirements-dev.txt")
-markdown_requirements = read_requirements("requirements-markdown-tests.txt")
-markdown_tests_requires = dev_requires + markdown_requirements[1:]
 
 setup(
     # Package metadata
@@ -51,7 +49,6 @@ setup(
     install_requires=install_requires,
     extras_require={
         "dev": dev_requires,
-        "markdown-tests": markdown_tests_requires,
         # Infrastructure extras
         "aws": "prefect-aws>=0.5.0rc1",
         "azure": "prefect-azure>=0.4.0rc1",


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR fixes the name for created releases in GitHub to use the next tag. This PR also removes the `markdown-tests` extra because I saw this error when trying to publish to PyPI:
```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         Can't have direct dependency: pytest-markdown-docs@                    
         git+https://github.com/PrefectHQ/pytest-markdown-docs@mdx-comment-suppo
         rt ; extra == "markdown-tests". See                                    
         https://packaging.python.org/specifications/core-metadata for more     
         information.    
```
I think once we are using a published version of `pytest-markdown-docs`, we can add that extra back, but I removed it for now to unblock publishing to PyPI.

