### PR TITLE
Fix check to prerelease tag to allow nightly builds to publish Docker images

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ github.event_name == 'release' && github.event.release.prerelease == true }}
         run: |
           TAG_NAME=${{ github.ref }}
-          if [[ ! "$TAG_NAME" =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9]+$ ]]; then
+          if [[ ! "$TAG_NAME" =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9]+|\.dev[0-9]+)$ ]]; then
             echo "Error: Tag $TAG_NAME does not match prerelease version pattern."
             exit 1
           fi


### PR DESCRIPTION
<!--
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
Fixes the error from [this job](https://github.com/PrefectHQ/prefect/actions/runs/11116907648) when attempting to publish Docker images for a nightly build.

This was the error:
```
Error: Tag refs/tags/3.0.4.dev1 does not match prerelease version pattern.
```
This check matches the one on the Publish Python Package workflow
