### PR TITLE
Update format for nightly dev release names

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -66,7 +66,7 @@ jobs:
         if: steps.check_changes.outputs.SHOULD_CREATE_RELEASE == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          name: "Nightly Development Release ${{ steps.get_latest_tag.outputs.next_tag }}"
+          name: "${{ steps.next_dev_version.outputs.next_tag }}: Nightly Development Release"
           tag_name: ${{ steps.next_dev_version.outputs.next_tag }}
           draft: false
           prerelease: true


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
Fixes the release name to include the correct version tag. Also updates the format to match other releases. Release names will now look like `3.0.5.dev2: Nightly Development Release`.
