### PR TITLE
helpful message on 404 with deployment by name

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-skip = .git,*.pdf,*.svg,versioneer.py,package-lock.json,_vendor,*.css,.codespellrc
+skip = .git,*.pdf,*.svg,versioneer.py,package-lock.json,_vendor,*.css,.codespellrc,tests/utilities/test_text.py
 # from https://github.com/PrefectHQ/prefect/pull/10813#issuecomment-1732676130
 ignore-regex = .*lazy=\"selectin\"|.*e import Bloc$|America/Nome
 

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -1813,7 +1813,27 @@ class PrefectClient:
             response = await self._client.get(f"/deployments/name/{name}")
         except httpx.HTTPStatusError as e:
             if e.response.status_code == status.HTTP_404_NOT_FOUND:
-                raise prefect.exceptions.ObjectNotFound(http_exc=e) from e
+                from prefect.utilities.text import fuzzy_match_string
+
+                deployments = await self.read_deployments()
+                flow_name_map = {
+                    flow.id: flow.name
+                    for flow in await asyncio.gather(
+                        *[
+                            self.read_flow(flow_id)
+                            for flow_id in {d.flow_id for d in deployments}
+                        ]
+                    )
+                }
+                flow_slash_deployment_names = [
+                    f"{flow_name_map[d.flow_id]}/{d.name}" for d in deployments
+                ]
+
+                if fuzzy_match := fuzzy_match_string(name, flow_slash_deployment_names):
+                    raise prefect.exceptions.ObjectNotFound(
+                        http_exc=e,
+                        help_message=f"Deployment {name!r} not found; did you mean {fuzzy_match!r}?",
+                    ) from e
             else:
                 raise
 

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -1825,23 +1825,22 @@ class PrefectClient:
                         ]
                     )
                 }
-                flow_slash_deployment_names = [
-                    f"{flow_name_map[d.flow_id]}/{d.name}" for d in deployments
-                ]
-
-                help_message = (
-                    f"Deployment {name!r} not found; did you mean {fuzzy_match!r}?"
-                    if (
-                        fuzzy_match := fuzzy_match_string(
-                            name, flow_slash_deployment_names
-                        )
-                    )
-                    else f"Deployment {name!r} not found. Try `prefect deployment ls` to find available deployments."
-                )
 
                 raise prefect.exceptions.ObjectNotFound(
                     http_exc=e,
-                    help_message=help_message,
+                    help_message=(
+                        f"Deployment {name!r} not found; did you mean {fuzzy_match!r}?"
+                        if (
+                            fuzzy_match := fuzzy_match_string(
+                                name,
+                                [
+                                    f"{flow_name_map[d.flow_id]}/{d.name}"
+                                    for d in deployments
+                                ],
+                            )
+                        )
+                        else f"Deployment {name!r} not found. Try `prefect deployment ls` to find available deployments."
+                    ),
                 ) from e
             else:
                 raise

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -1829,11 +1829,20 @@ class PrefectClient:
                     f"{flow_name_map[d.flow_id]}/{d.name}" for d in deployments
                 ]
 
-                if fuzzy_match := fuzzy_match_string(name, flow_slash_deployment_names):
-                    raise prefect.exceptions.ObjectNotFound(
-                        http_exc=e,
-                        help_message=f"Deployment {name!r} not found; did you mean {fuzzy_match!r}?",
-                    ) from e
+                help_message = (
+                    f"Deployment {name!r} not found; did you mean {fuzzy_match!r}?"
+                    if (
+                        fuzzy_match := fuzzy_match_string(
+                            name, flow_slash_deployment_names
+                        )
+                    )
+                    else f"Deployment {name!r} not found. Try `prefect deployment ls` to find available deployments."
+                )
+
+                raise prefect.exceptions.ObjectNotFound(
+                    http_exc=e,
+                    help_message=help_message,
+                ) from e
             else:
                 raise
 

--- a/src/prefect/exceptions.py
+++ b/src/prefect/exceptions.py
@@ -227,9 +227,19 @@ class ObjectNotFound(PrefectException):
     Raised when the client receives a 404 (not found) from the API.
     """
 
-    def __init__(self, http_exc: Exception, *args, **kwargs):
+    def __init__(
+        self,
+        http_exc: Exception,
+        help_message: Optional[str] = None,
+        *args,
+        **kwargs,
+    ):
         self.http_exc = http_exc
-        super().__init__(*args, **kwargs)
+        self.help_message = help_message
+        super().__init__(help_message, *args, **kwargs)
+
+    def __str__(self):
+        return self.help_message or super().__str__()
 
 
 class ObjectAlreadyExists(PrefectException):

--- a/src/prefect/utilities/text.py
+++ b/src/prefect/utilities/text.py
@@ -1,4 +1,5 @@
-from typing import Optional
+import difflib
+from typing import Iterable, Optional
 
 
 def truncated_to(length: int, value: Optional[str]) -> str:
@@ -17,3 +18,14 @@ def truncated_to(length: int, value: Optional[str]) -> str:
     proposed = f"{beginning}...{omitted} additional characters...{end}"
 
     return proposed if len(proposed) < len(value) else value
+
+
+def fuzzy_match_string(
+    word: str,
+    possibilities: Iterable[str],
+    *,
+    n: int = 1,
+    cutoff: float = 0.6,
+) -> Optional[str]:
+    match = difflib.get_close_matches(word, possibilities, n=n, cutoff=cutoff)
+    return match[0] if match else None

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -766,6 +766,8 @@ async def test_read_deployment_by_name(prefect_client):
 
 
 async def test_read_deployment_by_name_fails_with_helpful_suggestion(prefect_client):
+    """this is a regression test for https://github.com/PrefectHQ/prefect/issues/15571"""
+
     @flow
     def moo_deng():
         pass

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -765,6 +765,25 @@ async def test_read_deployment_by_name(prefect_client):
     assert lookup.name == "test-deployment"
 
 
+async def test_read_deployment_by_name_fails_with_helpful_suggestion(prefect_client):
+    @flow
+    def moo_deng():
+        pass
+
+    flow_id = await prefect_client.create_flow(moo_deng)
+
+    await prefect_client.create_deployment(
+        flow_id=flow_id,
+        name="moisturized-deployment",
+    )
+
+    with pytest.raises(
+        prefect.exceptions.ObjectNotFound,
+        match="Deployment 'moo_deng/moisturized-deployment' not found; did you mean 'moo-deng/moisturized-deployment'?",
+    ):
+        await prefect_client.read_deployment_by_name("moo_deng/moisturized-deployment")
+
+
 async def test_create_then_delete_deployment(prefect_client):
     @flow
     def foo():

--- a/tests/utilities/test_text.py
+++ b/tests/utilities/test_text.py
@@ -1,0 +1,26 @@
+import pytest
+
+from prefect.utilities.text import fuzzy_match_string
+
+
+@pytest.mark.parametrize(
+    "word, possibilities, expected",
+    [
+        ("hello", ["hello", "world"], "hello"),
+        ("Hello", ["hello", "world"], "hello"),
+        ("colour", ["color", "flavour"], "color"),
+        ("progam", ["program", "progress"], "program"),  # noqa
+        ("pythn", ["python", "cython"], "python"),
+        ("cat", ["dog", "pig", "cow"], None),
+    ],
+    ids=[
+        "Exact match",
+        "Case insensitive match",
+        "Close match - British vs American spelling",
+        "Missing character",
+        "Multiple close matches",
+        "No close matches within threshold",
+    ],
+)
+def test_fuzzy_match_string(word, possibilities, expected):
+    assert fuzzy_match_string(word, possibilities) == expected


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/15571


uses `difflib` to get fuzzy string matching
```python
ObjectNotFound: Deployment 'hello/hello-moo-deng' not found; did you mean 'hello/hello'?
```

---

this might be over-wraught, but I do think it will be helpful. very open to suggestions