### PR TITLE
Update global-concurrency-limits.mdx - Remove `await` for task submissions

### DIFF
--- a/docs/3.0/develop/global-concurrency-limits.mdx
+++ b/docs/3.0/develop/global-concurrency-limits.mdx
@@ -229,7 +229,7 @@ async def make_http_request():
 
 
 @flow
-async def my_flow():
+def my_flow():
     for _ in range(10):
         make_http_request.submit()
 

--- a/docs/3.0/develop/global-concurrency-limits.mdx
+++ b/docs/3.0/develop/global-concurrency-limits.mdx
@@ -162,7 +162,7 @@ async def process_data(x, y):
 
 
 @flow
-async def my_flow():
+def my_flow():
     for x, y in [(1, 2), (2, 3), (3, 4), (4, 5)]:
         process_data.submit(x, y)
 

--- a/docs/3.0/develop/global-concurrency-limits.mdx
+++ b/docs/3.0/develop/global-concurrency-limits.mdx
@@ -164,7 +164,7 @@ async def process_data(x, y):
 @flow
 async def my_flow():
     for x, y in [(1, 2), (2, 3), (3, 4), (4, 5)]:
-        await process_data.submit(x, y)
+        process_data.submit(x, y)
 
 
 if __name__ == "__main__":
@@ -231,7 +231,7 @@ async def make_http_request():
 @flow
 async def my_flow():
     for _ in range(10):
-        await make_http_request.submit()
+        make_http_request.submit()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Awaiting task submissions in the async code examples throws an error with Prefect 3.0. ie:

TypeError: object PrefectConcurrentFuture can't be used in 'await' expression

Updating the examples so that `await` is no longer included before submitting a task allows them to complete successfully.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
