### PR TITLE
Changed `TaskSource` key computation to handle `OSError("source not available")`

### DIFF
--- a/src/prefect/cache_policies.py
+++ b/src/prefect/cache_policies.py
@@ -219,7 +219,7 @@ class TaskSource(CachePolicy):
         except TypeError:
             lines = inspect.getsource(task_ctx.task.fn.__class__)
         except OSError as exc:
-            if str(exc) in {"could not get source code", "source code not available"}:
+            if "source code" in str(exc):
                 lines = task_ctx.task.fn.__code__.co_code
             else:
                 raise

--- a/src/prefect/cache_policies.py
+++ b/src/prefect/cache_policies.py
@@ -219,7 +219,7 @@ class TaskSource(CachePolicy):
         except TypeError:
             lines = inspect.getsource(task_ctx.task.fn.__class__)
         except OSError as exc:
-            if "could not get source code" in str(exc):
+            if str(exc) in {"could not get source code", "source code not available"}:
                 lines = task_ctx.task.fn.__code__.co_code
             else:
                 raise

--- a/tests/test_cache_policies.py
+++ b/tests/test_cache_policies.py
@@ -210,18 +210,17 @@ class TestTaskSourcePolicy:
         task_ctx_a = TaskRunContext.model_construct(task=mock_task_a)
         task_ctx_b = TaskRunContext.model_construct(task=mock_task_b)
 
-        with patch(
-            "inspect.getsource", side_effect=OSError("could not get source code")
-        ):
-            fallback_key_a = policy.compute_key(
-                task_ctx=task_ctx_a, inputs=None, flow_parameters=None
-            )
-            fallback_key_b = policy.compute_key(
-                task_ctx=task_ctx_b, inputs=None, flow_parameters=None
-            )
+        for os_error_msg in {"could not get source code", "source code not available"}:
+            with patch("inspect.getsource", side_effect=OSError(os_error_msg)):
+                fallback_key_a = policy.compute_key(
+                    task_ctx=task_ctx_a, inputs=None, flow_parameters=None
+                )
+                fallback_key_b = policy.compute_key(
+                    task_ctx=task_ctx_b, inputs=None, flow_parameters=None
+                )
 
-        assert fallback_key_a and fallback_key_b
-        assert fallback_key_a != fallback_key_b
+            assert fallback_key_a and fallback_key_b
+            assert fallback_key_a != fallback_key_b
 
 
 class TestDefaultPolicy:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

In some cases, `inspect.getsource` can raise `OSError("source not available")`, in addition to `OSError("could not find source")` (see: https://github.com/python/cpython/blob/3.12/Lib/inspect.py#L1088 and https://github.com/python/cpython/blob/3.12/Lib/inspect.py#L1096)

It seems appropriate to handle both instances of `OSError` with the same fallback. This commit simply expands the fallback handler to also check for `source not available` errors.

Closes https://github.com/PrefectHQ/prefect/issues/15384

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
