### PR TITLE
fail correctly if `lookup_type` throws a `KeyError` in `BaseResult.__new__`

### DIFF
--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -1155,7 +1155,7 @@ class BaseResult(BaseModel, abc.ABC, Generic[R]):
             try:
                 subcls = lookup_type(cls, dispatch_key=kwargs["type"])
             except KeyError as exc:
-                raise ValidationError(errors=[exc], model=cls)
+                raise ValueError(f"Invalid type: {kwargs['type']}") from exc
             return super().__new__(subcls)
         else:
             return super().__new__(cls)

--- a/tests/results/test_base_result.py
+++ b/tests/results/test_base_result.py
@@ -1,0 +1,13 @@
+import pytest
+
+from prefect.results import BaseResult
+
+
+class ConcreteResult(BaseResult[int]):
+    def get(self) -> int:
+        return 1
+
+
+def test_lookup_type_fails_gracefully():
+    with pytest.raises(ValueError, match="Invalid type: test"):
+        ConcreteResult(type="test")


### PR DESCRIPTION
related to https://github.com/PrefectHQ/prefect/issues/15585