### PR TITLE
Fix issue where transaction parent look up fails in rollback hooks

### DIFF
--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -284,11 +284,14 @@ class Transaction(ContextModel):
         self.children.append(transaction)
 
     def get_parent(self) -> Optional["Transaction"]:
-        prev_var = getattr(self._token, "old_value")
-        if prev_var != Token.MISSING:
-            parent = prev_var
+        parent = None
+        if self._token:
+            prev_var = getattr(self._token, "old_value")
+            if prev_var != Token.MISSING:
+                parent = prev_var
         else:
-            parent = None
+            # `_token` has been reset so we need to get the active transaction from the context var
+            parent = self.get_active()
         return parent
 
     def commit(self) -> bool:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
In the [_Access data in transactions_ example](https://docs.prefect.io/3.0/develop/transactions#access-data-within-transactions), the rollback hook of a task that completes attempts to get a value not available in its stored values, but fails to determine its parent transaction. When completing the child transaction, the reference to the transaction context variable is dropped, so the transaction errors when determining its parent. 

This PR fixes the error by falling back to the current transaction when the stored token for the transaction context variable has already been cleared. The example code runs as expected with this change.


Closes https://github.com/PrefectHQ/prefect/issues/15593

