### PR TITLE
Fix errors loading settings when profiles file can't be read

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -370,6 +370,9 @@ class ProfileSettingsTomlLoader(PydanticBaseSettingsSource):
     def _load_profile_settings(self) -> Dict[str, Any]:
         """Helper method to load the profile settings from the profiles.toml file"""
 
+        if not self.profiles_path.exists():
+            return {}
+
         all_profile_data = toml.load(self.profiles_path)
 
         if (

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -373,7 +373,13 @@ class ProfileSettingsTomlLoader(PydanticBaseSettingsSource):
         if not self.profiles_path.exists():
             return {}
 
-        all_profile_data = toml.load(self.profiles_path)
+        try:
+            all_profile_data = toml.load(self.profiles_path)
+        except toml.TomlDecodeError:
+            warnings.warn(
+                f"Failed to load profiles from {self.profiles_path}. Please ensure the file is valid TOML."
+            )
+            return {}
 
         if (
             sys.argv[0].endswith("/prefect")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -254,6 +254,23 @@ class TestSettingsClass:
             == "test"
         )
 
+    def test_loads_when_profile_path_does_not_exist(self, monkeypatch):
+        monkeypatch.setenv("PREFECT_PROFILES_PATH", str(Path.home() / "nonexistent"))
+        monkeypatch.delenv("PREFECT_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_UNIT_TEST_MODE", raising=False)
+        assert Settings().test_setting == "FOO"
+
+    def test_loads_when_profile_path_is_not_a_toml_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("PREFECT_PROFILES_PATH", str(tmp_path / "profiles.toml"))
+        monkeypatch.delenv("PREFECT_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_UNIT_TEST_MODE", raising=False)
+
+        with open(tmp_path / "profiles.toml", "w") as f:
+            f.write("Ceci n'est pas un fichier toml")
+
+        with pytest.warns(UserWarning, match="Failed to load profiles from"):
+            assert Settings().test_setting == "FOO"
+
 
 class TestSettingAccess:
     def test_get_value_root_setting(self):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

Fixes a bug where settings fail to load when there is no file at the path specified via `PREFECT_PROFILES_PATH`. Also adds handling if the profiles file is not valid TOML.
