### PR TITLE
Fix flow run parameters literally named `keys`

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -593,7 +593,7 @@ class Flow(Generic[P, R]):
         # Get the updated parameter dict with cast values from the model
         cast_parameters = {
             k: v
-            for k, v in model.model_dump().items()
+            for k, v in model.__dict__.items()
             if k in model.model_fields_set or model.model_fields[k].default_factory
         }
         return cast_parameters

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -593,7 +593,7 @@ class Flow(Generic[P, R]):
         # Get the updated parameter dict with cast values from the model
         cast_parameters = {
             k: v
-            for k, v in dict(model).items()
+            for k, v in model.model_dump().items()
             if k in model.model_fields_set or model.model_fields[k].default_factory
         }
         return cast_parameters

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1735,6 +1735,15 @@ class TestFlowParameterTypes:
         instance = my_flow(Test())
         assert isinstance(instance, Test)
 
+    def test_flow_parameter_kwarg_can_be_literally_keys(self):
+        """regression test for https://github.com/PrefectHQ/prefect/issues/15610"""
+
+        @flow
+        def my_flow(keys: str):
+            return keys
+
+        assert my_flow(keys="hello") == "hello"
+
 
 class TestSubflowTaskInputs:
     async def test_subflow_with_one_upstream_task_future(self, prefect_client):


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/15610

see upstream issue https://github.com/pydantic/pydantic/issues/10575