### PR TITLE
rebuild `StateCreate` model

### DIFF
--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -327,7 +327,11 @@ class State(ObjectBaseModel, Generic[R]):
         results should be sent to the API. Other data is only available locally.
         """
         from prefect.client.schemas.actions import StateCreate
-        from prefect.results import BaseResult, ResultRecord, should_persist_result
+        from prefect.results import (
+            BaseResult,
+            ResultRecord,
+            should_persist_result,
+        )
 
         if isinstance(self.data, BaseResult):
             data = self.data

--- a/src/prefect/deployments/flow_runs.py
+++ b/src/prefect/deployments/flow_runs.py
@@ -5,10 +5,12 @@ from uuid import UUID
 import anyio
 import pendulum
 
+import prefect
 from prefect.client.schemas import FlowRun
 from prefect.client.utilities import inject_client
 from prefect.context import FlowRunContext, TaskRunContext
 from prefect.logging import get_logger
+from prefect.results import BaseResult, ResultRecordMetadata
 from prefect.states import Pending, Scheduled
 from prefect.tasks import Task
 from prefect.utilities.asyncutils import sync_compatible
@@ -18,6 +20,12 @@ if TYPE_CHECKING:
     from prefect.client.orchestration import PrefectClient
     from prefect.client.schemas.objects import FlowRun
 
+prefect.client.schemas.StateCreate.model_rebuild(
+    _types_namespace={
+        "BaseResult": BaseResult,
+        "ResultRecordMetadata": ResultRecordMetadata,
+    }
+)
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/15591


Rebuilt `StateCreate` model to resolve runtime errors during deployment execution caused by incomplete model definitions / circular import woes