### PR TITLE
Include exception info when logging timeout errors

### DIFF
--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -557,7 +557,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 message = f"Task run exceeded timeout of {self.task.timeout_seconds} second(s)"
             else:
                 message = f"Task run failed due to timeout: {exc!r}"
-            self.logger.error(message)
+            self.logger.error(message, exc_info=exc)
             state = Failed(
                 data=exc,
                 message=message,
@@ -1071,7 +1071,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                 message = f"Task run exceeded timeout of {self.task.timeout_seconds} second(s)"
             else:
                 message = f"Task run failed due to timeout: {exc!r}"
-            self.logger.error(message)
+            self.logger.error(message, exc_info=exc)
             state = Failed(
                 data=exc,
                 message=message,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
When a `TimeoutError` is raised from the source of a flow run, the error message that Prefect logs doesn't include a stack trace, which makes figuring out where the timeout is coming from incredibly difficult. Example:

![Screenshot 2024-10-09 at 11 47 26 AM](https://github.com/user-attachments/assets/4dff4db6-769d-4812-80b0-dbbacaac0832)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
