### PR TITLE
link to docs on starting ephemeral server

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -775,7 +775,7 @@ class SubprocessASGIServer:
                 self.port = self.find_available_port()
             assert self.port is not None, "Port must be provided or available"
             help_message = (
-                f"Starting ephemeral server on {self.address} - see "
+                f"Starting temporary server on {self.address}\nSee "
                 "https://docs.prefect.io/3.0/manage/self-host#self-host-a-prefect-server "
                 "for more information on running a dedicated Prefect server."
             )

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -857,7 +857,7 @@ class SubprocessASGIServer:
     def stop(self):
         if self.server_process:
             subprocess_server_logger.info(
-                f"Stopping ephemeral server on {self.address}"
+                f"Stopping temporary server on {self.address}"
             )
             self.server_process.terminate()
             try:

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -774,7 +774,12 @@ class SubprocessASGIServer:
             if self.port is None:
                 self.port = self.find_available_port()
             assert self.port is not None, "Port must be provided or available"
-            subprocess_server_logger.info(f"Starting server on {self.address}")
+            help_message = (
+                f"Starting ephemeral server on {self.address} - see "
+                "https://docs.prefect.io/3.0/manage/self-host#self-host-a-prefect-server "
+                "for more information on running a dedicated Prefect server."
+            )
+            subprocess_server_logger.info(help_message)
             try:
                 self.running = True
                 self.server_process = self._run_uvicorn_command()
@@ -851,7 +856,9 @@ class SubprocessASGIServer:
 
     def stop(self):
         if self.server_process:
-            subprocess_server_logger.info(f"Stopping server on {self.address}")
+            subprocess_server_logger.info(
+                f"Stopping ephemeral server on {self.address}"
+            )
             self.server_process.terminate()
             try:
                 self.server_process.wait(timeout=5)


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/15597

open to suggestions on these exact log messages

```python
In [1]: from prefect import flow

In [2]: @flow
   ...: def f(): pass

In [3]: f()
16:16:42.932 | INFO    | prefect - Starting ephemeral server on http://127.0.0.1:8095 - see https://docs.prefect.io/3.0/manage/self-host#self-host-a-prefect-server for more information on running a dedicated Prefect server.
16:16:45.015 | INFO    | prefect.engine - Created flow run 'khaki-wildcat' for flow 'f'
16:16:45.066 | INFO    | Flow run 'khaki-wildcat' - Finished in state Completed()

In [4]: exit
16:16:48.660 | INFO    | prefect - Stopping ephemeral server on http://127.0.0.1:8095
```