### PR TITLE
dont ask to confirm non-existent deployment

### DIFF
--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -502,14 +502,17 @@ async def delete(
     """
     async with get_client() as client:
         try:
+            work_pool = await client.read_work_pool(work_pool_name=name)
             if is_interactive() and not typer.confirm(
-                (f"Are you sure you want to delete work pool with name {name!r}?"),
+                (
+                    f"Are you sure you want to delete work pool with name {work_pool.name!r}?"
+                ),
                 default=False,
             ):
                 exit_with_error("Deletion aborted.")
             await client.delete_work_pool(work_pool_name=name)
-        except ObjectNotFound as exc:
-            exit_with_error(exc)
+        except ObjectNotFound:
+            exit_with_error(f"Work pool {name!r} does not exist.")
 
         exit_with_success(f"Deleted work pool {name!r}")
 

--- a/tests/_internal/concurrency/test_waiters.py
+++ b/tests/_internal/concurrency/test_waiters.py
@@ -134,6 +134,7 @@ def test_sync_waiter_timeout_in_worker_thread():
     ), "The done callback should still be called on cancel"
 
 
+@pytest.mark.skip(reason="This test is flaky and should be rewritten")
 @pytest.mark.timeout(method="thread")  # pytest-timeout alarm interefres with this test
 def test_sync_waiter_timeout_in_main_thread():
     """

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -504,14 +504,23 @@ class TestResume:
 
 class TestDelete:
     async def test_delete(self, prefect_client, work_pool):
-        res = await run_sync_in_worker_thread(
+        await run_sync_in_worker_thread(
             invoke_and_assert,
             f"work-pool delete {work_pool.name}",
             user_input="y",
+            expected_code=0,
         )
-        assert res.exit_code == 0
         with pytest.raises(ObjectNotFound):
             await prefect_client.read_work_pool(work_pool.name)
+
+    async def test_delete_non_existent(self, prefect_client):
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            "work-pool delete non-existent",
+            expected_code=1,
+            expected_output_contains="Work pool 'non-existent' does not exist.",
+            expected_output_does_not_contain="Are you sure you want to delete work pool with name 'non-existent'?",
+        )
 
 
 class TestLS:


### PR DESCRIPTION
### before
```python
» prefect work-pool delete asdf
Are you sure you want to delete work pool with name 'asdf'? [y/N]: y
Deleted work pool 'asdf'
» prefect work-pool delete asdf
Are you sure you want to delete work pool with name 'asdf'? [y/N]: y
None
```

### after
```python
» pool delete asdf
Are you sure you want to delete work pool with name 'asdf'? [y/N]: y
Deleted work pool 'asdf'
» pool delete asdf
Work pool 'asdf' does not exist.
```

---
also skips [this](https://github.com/PrefectHQ/prefect/issues/15654) chronic flake