### PR TITLE
correctly await `config.load_kube_config`

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/credentials.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/credentials.py
@@ -186,7 +186,7 @@ class KubernetesCredentials(Block):
                 config.load_incluster_config(client_configuration=client_configuration)
             except config.ConfigException:
                 # If in-cluster config fails, load the local kubeconfig
-                config.load_kube_config(
+                await config.load_kube_config(
                     client_configuration=client_configuration,
                 )
         async with ApiClient(configuration=client_configuration) as api_client:

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/jobs.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/jobs.py
@@ -11,15 +11,12 @@ from typing_extensions import Self, TypeAlias
 
 from prefect import task
 from prefect.blocks.abstract import JobBlock, JobRun
-from prefect.logging import get_logger
 from prefect.utilities.asyncutils import sync_compatible
 from prefect_kubernetes.credentials import KubernetesCredentials
 from prefect_kubernetes.exceptions import KubernetesJobTimeoutError
 from prefect_kubernetes.pods import list_namespaced_pod, read_namespaced_pod_log
 
 KubernetesManifest: TypeAlias = Union[Dict, Path, str]
-
-logger = get_logger(__name__)
 
 
 @task

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/jobs.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/jobs.py
@@ -7,16 +7,19 @@ from typing import Any, Callable, Dict, Optional, Type, Union
 import yaml
 from kubernetes_asyncio.client.models import V1DeleteOptions, V1Job, V1JobList, V1Status
 from pydantic import Field
-from typing_extensions import Self
+from typing_extensions import Self, TypeAlias
 
 from prefect import task
 from prefect.blocks.abstract import JobBlock, JobRun
+from prefect.logging import get_logger
 from prefect.utilities.asyncutils import sync_compatible
 from prefect_kubernetes.credentials import KubernetesCredentials
 from prefect_kubernetes.exceptions import KubernetesJobTimeoutError
 from prefect_kubernetes.pods import list_namespaced_pod, read_namespaced_pod_log
 
-KubernetesManifest = Union[Dict, Path, str]
+KubernetesManifest: TypeAlias = Union[Dict, Path, str]
+
+logger = get_logger(__name__)
 
 
 @task
@@ -502,7 +505,8 @@ class KubernetesJob(JobBlock):
         examples=[{"pretty": "true"}],
     )
     credentials: KubernetesCredentials = Field(
-        default=..., description="The credentials to configure a client from."
+        default_factory=KubernetesCredentials,
+        description="The credentials to configure a client from.",
     )
     delete_after_completion: bool = Field(
         default=True,

--- a/src/integrations/prefect-kubernetes/tests/test_jobs.py
+++ b/src/integrations/prefect-kubernetes/tests/test_jobs.py
@@ -210,3 +210,9 @@ async def test_job_block_wait_never_called_raises(
         ValueError, match="The Kubernetes Job run is not in a completed state"
     ):
         await job_run.fetch_result()
+
+
+async def test_job_block_generates_default_credentials():
+    job_block = KubernetesJob(v1_job=dict(metadata=dict(name="test-job")))
+    assert job_block.credentials is not None
+    assert job_block.credentials.cluster_config is None


### PR DESCRIPTION
introduced by https://github.com/PrefectHQ/prefect/pull/13910, we fail to await the async method, silently skipping to load the config from the local kube-config

also adds a default factory for `KubernetesCredentials` since in many cases you just want the default behavior from it anyways