### PR TITLE
Update `versioneer.py` to ignore uncommited changes

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -1,3 +1,4 @@
+import versioneer
 from setuptools import find_packages, setup
 
 install_requires = open("requirements-client.txt").read().strip().split("\n")
@@ -18,7 +19,8 @@ setup(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     # Versioning
-    use_scm_version=True,
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
     # Package setup
     packages=find_packages(where="src"),
     package_dir={"": "src"},

--- a/client/setup.py
+++ b/client/setup.py
@@ -1,4 +1,3 @@
-import versioneer
 from setuptools import find_packages, setup
 
 install_requires = open("requirements-client.txt").read().strip().split("\n")
@@ -19,8 +18,7 @@ setup(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     # Versioning
-    version=versioneer.get_version(),
-    cmdclass=versioneer.get_cmdclass(),
+    use_scm_version=True,
     # Package setup
     packages=find_packages(where="src"),
     package_dir={"": "src"},
@@ -29,6 +27,7 @@ setup(
     python_requires=">=3.9",
     install_requires=install_requires,
     extras_require={"notifications": ["apprise>=1.1.0, <2.0.0"]},
+    setup_requires=["setuptools_scm"],
     classifiers=[
         "Natural Language :: English",
         "Intended Audience :: Developers",

--- a/client/setup.py
+++ b/client/setup.py
@@ -29,7 +29,6 @@ setup(
     python_requires=">=3.9",
     install_requires=install_requires,
     extras_require={"notifications": ["apprise>=1.1.0, <2.0.0"]},
-    setup_requires=["setuptools_scm"],
     classifiers=[
         "Natural Language :: English",
         "Intended Audience :: Developers",

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ ignore_missing_imports = True
 
 [versioneer]
 VCS = git
-style = pep440-pre
+style = pep440
 versionfile_source = src/prefect/_version.py
 versionfile_build = prefect/_version.py
 version_regex = ^(\d+\.\d+\.\d+(?:[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?)$

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,7 @@ style = pep440
 versionfile_source = src/prefect/_version.py
 versionfile_build = prefect/_version.py
 version_regex = ^(\d+\.\d+\.\d+(?:[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?)$
-tag_prefix =
+tag_prefix = 
 parentdir_prefix =
 
 [coverage:run]

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,7 @@ style = pep440
 versionfile_source = src/prefect/_version.py
 versionfile_build = prefect/_version.py
 version_regex = ^(\d+\.\d+\.\d+(?:[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?)$
-tag_prefix = 
+tag_prefix =
 parentdir_prefix =
 
 [coverage:run]

--- a/src/prefect/_version.py
+++ b/src/prefect/_version.py
@@ -609,7 +609,6 @@ def render_git_describe_long(pieces: Dict[str, Any]) -> str:
     Exceptions:
     1: no tags. HEX[-dirty]  (note: no 'g' prefix)
     """
-
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         rendered += "-%d-g%s" % (pieces["distance"], pieces["short"])

--- a/src/prefect/_version.py
+++ b/src/prefect/_version.py
@@ -431,6 +431,8 @@ def render_pep440(pieces: Dict[str, Any]) -> str:
         if pieces["distance"] or pieces["dirty"]:
             rendered += plus_or_dot(pieces)
             rendered += "%d.g%s" % (pieces["distance"], pieces["short"])
+            if pieces["dirty"]:
+                rendered += ".dirty"
     else:
         # exception #1
         rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])

--- a/src/prefect/_version.py
+++ b/src/prefect/_version.py
@@ -49,7 +49,7 @@ def get_config() -> VersioneerConfig:
     # _version.py
     cfg = VersioneerConfig()
     cfg.VCS = "git"
-    cfg.style = "pep440-pre"
+    cfg.style = "pep440"
     cfg.tag_prefix = ""
     cfg.parentdir_prefix = ""
     cfg.versionfile_source = "src/prefect/_version.py"
@@ -431,8 +431,6 @@ def render_pep440(pieces: Dict[str, Any]) -> str:
         if pieces["distance"] or pieces["dirty"]:
             rendered += plus_or_dot(pieces)
             rendered += "%d.g%s" % (pieces["distance"], pieces["short"])
-            if pieces["dirty"]:
-                rendered += ".dirty"
     else:
         # exception #1
         rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
@@ -611,6 +609,7 @@ def render_git_describe_long(pieces: Dict[str, Any]) -> str:
     Exceptions:
     1: no tags. HEX[-dirty]  (note: no 'g' prefix)
     """
+
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         rendered += "-%d-g%s" % (pieces["distance"], pieces["short"])

--- a/src/prefect/utilities/dockerutils.py
+++ b/src/prefect/utilities/dockerutils.py
@@ -57,7 +57,7 @@ def get_prefect_image_name(
         flavor: An optional alternative image flavor to build, like 'conda'
     """
     parsed_version = Version(prefect_version or prefect.__version__)
-    is_prod_build = parsed_version.post is None
+    is_prod_build = parsed_version.local is None
     prefect_version = (
         parsed_version.base_version
         if is_prod_build

--- a/tests/test_versioneer.py
+++ b/tests/test_versioneer.py
@@ -1,0 +1,45 @@
+"""Tests custom changes to versioneer.py"""
+
+from versioneer import render_pep440
+
+
+def test_render_pep440_ignores_dirty():
+    """
+    Tests that versioneer.py's render_pep440 ignores dirty.
+    """
+    assert (
+        render_pep440(
+            {
+                "long": "3452196e283815332768b084467cba17d6d40ffa",
+                "short": "3452196e28",
+                "error": None,
+                "branch": "test",
+                "dirty": True,
+                "closest-tag": "0.0.1",
+                "distance": 0,
+                "date": "2024-10-12T23:30:05-0500",
+            }
+        )
+        == "0.0.1"
+    )
+
+
+def test_render_pep440_ignores_respects_distance():
+    """
+    Tests that versioneer.py's render_pep440 still respects distance.
+    """
+    assert (
+        render_pep440(
+            {
+                "long": "3452196e283815332768b084467cba17d6d40ffa",
+                "short": "3452196e28",
+                "error": None,
+                "branch": "test",
+                "dirty": False,
+                "closest-tag": "0.0.1",
+                "distance": 1,
+                "date": "2024-10-12T23:30:05-0500",
+            }
+        )
+        == "0.0.1+1.g3452196e28"
+    )

--- a/tests/utilities/test_dockerutils.py
+++ b/tests/utilities/test_dockerutils.py
@@ -31,7 +31,7 @@ PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
         ),
         ("3.0.0", None, None, f"prefecthq/prefect:3.0.0-python{PYTHON_VERSION}"),
         (
-            "3.0.0.post0.dev1",
+            f"3.0.0+1.g{COMMIT_SHA}",
             None,
             None,
             f"prefecthq/prefect-dev:sha-{COMMIT_SHA}-python{PYTHON_VERSION}",

--- a/versioneer.py
+++ b/versioneer.py
@@ -923,8 +923,6 @@ def render_pep440(pieces: Dict[str, Any]) -> str:
         if pieces["distance"] or pieces["dirty"]:
             rendered += plus_or_dot(pieces)
             rendered += "%%d.g%%s" %% (pieces["distance"], pieces["short"])
-            if pieces["dirty"]:
-                rendered += ".dirty"
     else:
         # exception #1
         rendered = "0+untagged.%%d.g%%s" %% (pieces["distance"],
@@ -1584,8 +1582,6 @@ def render_pep440(pieces: Dict[str, Any]) -> str:
         if pieces["distance"] or pieces["dirty"]:
             rendered += plus_or_dot(pieces)
             rendered += "%d.g%s" % (pieces["distance"], pieces["short"])
-            if pieces["dirty"]:
-                rendered += ".dirty"
     else:
         # exception #1
         rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])

--- a/versioneer.py
+++ b/versioneer.py
@@ -1579,7 +1579,7 @@ def render_pep440(pieces: Dict[str, Any]) -> str:
     """
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
-        if pieces["distance"] or pieces["dirty"]:
+        if pieces["distance"]:
             rendered += plus_or_dot(pieces)
             rendered += "%d.g%s" % (pieces["distance"], pieces["short"])
     else:


### PR DESCRIPTION
This PR updates the version rendering in our vendored version of `versioneer` to ignore uncommitted changes. These updates will prevent `versioneer` from including `.dirty` suffix in the `prefect-client` version due to file changes we make during CI for packaging. These changes shouldn't affect the core package or development because `_version,py` is left unchanged. I included a couple of tests covering the changes to prevent regression if/when we upgrade `versioneer`.
