### PR TITLE
fix(runner.server): Pass lowercase log level to uvicorn server

### DIFF
--- a/src/prefect/runner/server.py
+++ b/src/prefect/runner/server.py
@@ -298,4 +298,13 @@ def start_webserver(runner: "Runner", log_level: Optional[str] = None) -> None:
     port = PREFECT_RUNNER_SERVER_PORT.value()
     log_level = log_level or PREFECT_RUNNER_SERVER_LOG_LEVEL.value()
     webserver = build_server(runner)
-    uvicorn.run(webserver, host=host, port=port, log_level=log_level)
+    uvicorn.run(webserver, host=host, port=port, log_level=log_level.lower()) #Uvicorn supports only lowercase log_level
+    # From the Uvicorn config file:
+    # LOG_LEVELS: dict[str, int] = {
+    #     "critical": logging.CRITICAL,
+    #     "error": logging.ERROR,
+    #     "warning": logging.WARNING,
+    #     "info": logging.INFO,
+    #     "debug": logging.DEBUG,
+    #     "trace": TRACE_LOG_LEVEL,
+    # }

--- a/src/prefect/runner/server.py
+++ b/src/prefect/runner/server.py
@@ -298,7 +298,9 @@ def start_webserver(runner: "Runner", log_level: Optional[str] = None) -> None:
     port = PREFECT_RUNNER_SERVER_PORT.value()
     log_level = log_level or PREFECT_RUNNER_SERVER_LOG_LEVEL.value()
     webserver = build_server(runner)
-    uvicorn.run(webserver, host=host, port=port, log_level=log_level.lower()) #Uvicorn supports only lowercase log_level
+    uvicorn.run(
+        webserver, host=host, port=port, log_level=log_level.lower()
+    )  # Uvicorn supports only lowercase log_level
     # From the Uvicorn config file:
     # LOG_LEVELS: dict[str, int] = {
     #     "critical": logging.CRITICAL,

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -38,7 +38,7 @@ from prefect.events.worker import EventsWorker
 from prefect.flows import load_flow_from_entrypoint
 from prefect.logging.loggers import flow_run_logger
 from prefect.runner.runner import Runner
-from prefect.runner.server import perform_health_check
+from prefect.runner.server import perform_health_check, start_webserver
 from prefect.settings import (
     PREFECT_DEFAULT_DOCKER_BUILD_NAMESPACE,
     PREFECT_DEFAULT_WORK_POOL_NAME,
@@ -265,6 +265,26 @@ class TestServe:
         serve(deployment)
 
         mock_runner_start.assert_awaited_once()
+
+    def test_log_level_lowercasing(self, monkeypatch):
+        runner_mock = mock.MagicMock()
+        log_level = "DEBUG"
+
+        # Mock build_server to return a webserver mock object
+        with mock.patch("your_module.build_server") as mock_build_server:
+            webserver_mock = mock.MagicMock()
+            mock_build_server.return_value = webserver_mock
+
+            # Patch uvicorn.run to verify it's called with the correct arguments
+            with mock.patch("uvicorn.run") as mock_uvicorn:
+                start_webserver(runner_mock, log_level=log_level)
+                # Assert build_server was called once with the runner
+                mock_build_server.assert_called_once_with(runner_mock)
+
+                # Assert uvicorn.run was called with the lowercase log_level and the webserver mock
+                mock_uvicorn.assert_called_once_with(
+                    webserver_mock, host=mock.ANY, port=mock.ANY, log_level="debug"
+                )
 
 
 class TestRunner:

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -271,7 +271,7 @@ class TestServe:
         log_level = "DEBUG"
 
         # Mock build_server to return a webserver mock object
-        with mock.patch("your_module.build_server") as mock_build_server:
+        with mock.patch("prefect.runner.server.build_server") as mock_build_server:
             webserver_mock = mock.MagicMock()
             mock_build_server.return_value = webserver_mock
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
# Initial Objective
Running a worker in k8s as a pod. We needed a /health entry point.
I notices the following feature:
flow_function.serve(name=snapshot_flow.name, webserver=True)

When tested It fails to create the uvicorn server. The log_level in uvicorn is case-sensitive (lower) and prefect works with upper.
Full comment and explanation in the code.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [V] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [V] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ V] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ V] If this pull request adds functions or classes, it includes helpful docstrings.

This is a very small fix, nothing was removed or added.
