### PR TITLE
Docs note about accessing flow run logs

### DIFF
--- a/docs/3.0/develop/logging.mdx
+++ b/docs/3.0/develop/logging.mdx
@@ -336,3 +336,17 @@ and SciPy logging statements with your flow and task run logs, use:
 
 Configure this setting as an environment variable or in a profile. See
 [Settings](/3.0/manage/settings-and-profiles/) for more details about how to use settings.
+
+## Access logs from the command line
+
+You can retrieve logs for a specific flow run ID using Prefect's CLI:
+
+```bash
+prefect flow-run logs $ID
+```
+
+This can be particularly helpful if you want to access the logs as a local file:
+
+```bash
+prefect flow-run logs $ID > flow.log
+```

--- a/docs/3.0/develop/logging.mdx
+++ b/docs/3.0/develop/logging.mdx
@@ -342,11 +342,11 @@ Configure this setting as an environment variable or in a profile. See
 You can retrieve logs for a specific flow run ID using Prefect's CLI:
 
 ```bash
-prefect flow-run logs $ID
+prefect flow-run logs MY-FLOW-RUN-ID
 ```
 
 This can be particularly helpful if you want to access the logs as a local file:
 
 ```bash
-prefect flow-run logs $ID > flow.log
+prefect flow-run logs  MY-FLOW-RUN-ID > flow.log
 ```


### PR DESCRIPTION
Documents a newer work around for [this Discourse article](https://discourse.prefect.io/t/how-to-stream-prefect-logs-to-a-file/1963).