### PR TITLE
Ensure `TaskWorker` creates a `anyio.TaskGroup` in an `async` context

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -237,6 +237,13 @@ jobs:
           tmp="sha-$SHORT_SHA-python${{ matrix.python-version }}"
           echo "image_tag=${tmp}" >> $GITHUB_OUTPUT
 
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build test image
         uses: docker/build-push-action@v6
         with:

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -41,6 +41,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+from contextlib import AsyncExitStack
 from copy import deepcopy
 from functools import partial
 from pathlib import Path
@@ -185,6 +186,7 @@ class Runner:
         self.query_seconds = query_seconds or PREFECT_RUNNER_POLL_FREQUENCY.value()
         self._prefetch_seconds = prefetch_seconds
 
+        self._exit_stack = AsyncExitStack()
         self._limiter: Optional[anyio.CapacityLimiter] = None
         self._client = get_client()
         self._submitting_flow_run_ids = set()
@@ -398,38 +400,37 @@ class Runner:
         start_client_metrics_server()
 
         async with self as runner:
-            async with self._loops_task_group as tg:
-                for storage in self._storage_objs:
-                    if storage.pull_interval:
-                        tg.start_soon(
-                            partial(
-                                critical_service_loop,
-                                workload=storage.pull_code,
-                                interval=storage.pull_interval,
-                                run_once=run_once,
-                                jitter_range=0.3,
-                            )
+            for storage in self._storage_objs:
+                if storage.pull_interval:
+                    self._runs_task_group.start_soon(
+                        partial(
+                            critical_service_loop,
+                            workload=storage.pull_code,
+                            interval=storage.pull_interval,
+                            run_once=run_once,
+                            jitter_range=0.3,
                         )
-                    else:
-                        tg.start_soon(storage.pull_code)
-                tg.start_soon(
-                    partial(
-                        critical_service_loop,
-                        workload=runner._get_and_submit_flow_runs,
-                        interval=self.query_seconds,
-                        run_once=run_once,
-                        jitter_range=0.3,
                     )
+                else:
+                    self._runs_task_group.start_soon(storage.pull_code)
+            self._runs_task_group.start_soon(
+                partial(
+                    critical_service_loop,
+                    workload=runner._get_and_submit_flow_runs,
+                    interval=self.query_seconds,
+                    run_once=run_once,
+                    jitter_range=0.3,
                 )
-                tg.start_soon(
-                    partial(
-                        critical_service_loop,
-                        workload=runner._check_for_cancelled_flow_runs,
-                        interval=self.query_seconds * 2,
-                        run_once=run_once,
-                        jitter_range=0.3,
-                    )
+            )
+            self._runs_task_group.start_soon(
+                partial(
+                    critical_service_loop,
+                    workload=runner._check_for_cancelled_flow_runs,
+                    interval=self.query_seconds * 2,
+                    run_once=run_once,
+                    jitter_range=0.3,
                 )
+            )
 
     def execute_in_background(self, func, *args, **kwargs):
         """
@@ -1264,14 +1265,16 @@ class Runner:
         if not hasattr(self, "_loop") or not self._loop:
             self._loop = asyncio.get_event_loop()
 
+        await self._exit_stack.__aenter__()
+
+        await self._exit_stack.enter_async_context(self._client)
         if not hasattr(self, "_runs_task_group") or not self._runs_task_group:
             self._runs_task_group: anyio.abc.TaskGroup = anyio.create_task_group()
+        await self._exit_stack.enter_async_context(self._runs_task_group)
 
         if not hasattr(self, "_loops_task_group") or not self._loops_task_group:
             self._loops_task_group: anyio.abc.TaskGroup = anyio.create_task_group()
-
-        await self._client.__aenter__()
-        await self._runs_task_group.__aenter__()
+        await self._exit_stack.enter_async_context(self._loops_task_group)
 
         self.started = True
         return self
@@ -1283,11 +1286,9 @@ class Runner:
         self.started = False
         for scope in self._scheduled_task_scopes:
             scope.cancel()
-        if self._runs_task_group:
-            await self._runs_task_group.__aexit__(*exc_info)
-        if self._client:
-            await self._client.__aexit__(*exc_info)
+        await self._exit_stack.__aexit__(*exc_info)
         shutil.rmtree(str(self._tmp_dir))
+        del self._runs_task_group, self._loops_task_group
 
     def __repr__(self):
         return f"Runner(name={self.name!r})"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
Fixes test failures I was seeing in https://github.com/PrefectHQ/prefect/pull/15682. This is likely caused by the `TaskWorker` creating a task group in `__init__` (which is a `sync` context) instead of `__aenter__` (which is an `async` context). 

