### PR TITLE
use `docker/login-action` for python tests

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -257,6 +257,12 @@ jobs:
           python -m pip install -U uv
           uv pip install --upgrade --system -e .[dev]
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Start database container
         if: ${{ startsWith(matrix.database, 'postgres') }}
         run: >
@@ -305,8 +311,6 @@ jobs:
         # Do not run Kubernetes service tests, we do not have a cluster available
         # maxprocesses 6 is based on empirical testing; higher than 6 sees diminishing returns
       - name: Run tests
-        env:
-          PREFECT_EXPERIMENTAL_ENABLE_PYDANTIC_V2_INTERNALS: "1"
         run: >
           pytest tests
           --numprocesses auto


### PR DESCRIPTION
use docker login for python tests to increase our rate limit