### PR TITLE
Do not delete flow runs awaiting retry on deployment changes

### DIFF
--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -38,8 +38,8 @@ async def _delete_scheduled_runs(
     auto_scheduled_only: bool = False,
 ) -> None:
     """
-    This utility function deletes all of a deployment's scheduled runs that are
-    still in a Scheduled state It should be run any time a deployment is created or
+    This utility function deletes all of a deployment's runs that are in a Scheduled state
+    and haven't run yet. It should be run any time a deployment is created or
     modified in order to ensure that future runs comply with the deployment's latest values.
 
     Args:
@@ -49,6 +49,7 @@ async def _delete_scheduled_runs(
     delete_query = sa.delete(orm_models.FlowRun).where(
         orm_models.FlowRun.deployment_id == deployment_id,
         orm_models.FlowRun.state_type == schemas.states.StateType.SCHEDULED.value,
+        orm_models.FlowRun.run_count == 0,
     )
 
     if auto_scheduled_only:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

Previously, creating, updating or deleting deployments would delete any flow run associated with that deployment in a `Scheduled` state, including runs that were `AwaitingRetry`.

Only scheduled flow runs that haven't had a chance to run should be deleted.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
