### PR TITLE
Include env defaults from `variables.properties.env` in deep merge

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -137,6 +137,10 @@ class BaseJobConfiguration(BaseModel):
         variables = cls._get_base_config_defaults(
             variables_schema.get("properties", {})
         )
+
+        if variables.get("env"):
+            job_config["env"] = variables.get("env")
+
         variables.update(values)
 
         # deep merge `env`
@@ -152,6 +156,7 @@ class BaseJobConfiguration(BaseModel):
         populated_configuration = await resolve_variables(
             template=populated_configuration, client=client
         )
+        print(populated_configuration)
         return cls(**populated_configuration)
 
     @classmethod

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -156,7 +156,6 @@ class BaseJobConfiguration(BaseModel):
         populated_configuration = await resolve_variables(
             template=populated_configuration, client=client
         )
-        print(populated_configuration)
         return cls(**populated_configuration)
 
     @classmethod

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -138,6 +138,8 @@ class BaseJobConfiguration(BaseModel):
             variables_schema.get("properties", {})
         )
 
+        # copy variable defaults for `env` to job config before they're replaced by
+        # deployment overrides
         if variables.get("env"):
             job_config["env"] = variables.get("env")
 

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -1724,6 +1724,11 @@ class TestBaseWorkerStart:
         "try_overwrite_with_empty_str",
     ],
 )
+@pytest.mark.parametrize(
+    "use_variable_defaults",
+    [True, False],
+    ids=["with_defaults", "without_defaults"],
+)
 async def test_env_merge_logic_is_deep(
     prefect_client,
     session,
@@ -1733,115 +1738,27 @@ async def test_env_merge_logic_is_deep(
     deployment_env,
     flow_run_env,
     expected_env,
+    use_variable_defaults,
 ):
     if work_pool_env:
+        base_job_template = (
+            {
+                "job_configuration": {"env": "{{ env }}"},
+                "variables": {
+                    "properties": {"env": {"type": "object", "default": work_pool_env}}
+                },
+            }
+            if use_variable_defaults
+            else {
+                "job_configuration": {"env": work_pool_env},
+                "variables": {"properties": {"env": {"type": "object"}}},
+            }
+        )
         await models.workers.update_work_pool(
             session=session,
             work_pool_id=work_pool.id,
             work_pool=ServerWorkPoolUpdate(
-                base_job_template={
-                    "job_configuration": {"env": work_pool_env},
-                    "variables": {"properties": {"env": {"type": "object"}}},
-                },
-                description="test",
-                is_paused=False,
-                concurrency_limit=None,
-            ),
-        )
-        await session.commit()
-
-    deployment = await models.deployments.create_deployment(
-        session=session,
-        deployment=Deployment(
-            name="env-testing",
-            tags=["test"],
-            flow_id=flow.id,
-            path="./subdir",
-            entrypoint="/file.py:flow",
-            parameter_openapi_schema={},
-            job_variables={"env": deployment_env},
-            work_queue_id=work_pool.default_queue_id,
-        ),
-    )
-    await session.commit()
-
-    flow_run = await prefect_client.create_flow_run_from_deployment(
-        deployment.id,
-        state=Pending(),
-        job_variables={"env": flow_run_env},
-    )
-
-    async with WorkerTestImpl(
-        name="test",
-        work_pool_name=work_pool.name if work_pool_env else "test-work-pool",
-    ) as worker:
-        await worker.sync_with_backend()
-        config = await worker._get_configuration(
-            flow_run, schemas.responses.DeploymentResponse.model_validate(deployment)
-        )
-
-    for key, value in expected_env.items():
-        assert config.env[key] == value
-
-
-@pytest.mark.parametrize(
-    "work_pool_env, deployment_env, flow_run_env, expected_env",
-    [
-        (
-            {},
-            {"test-var": "foo"},
-            {"another-var": "boo"},
-            {"test-var": "foo", "another-var": "boo"},
-        ),
-        (
-            {"A": "1", "B": "2"},
-            {"C": "3", "D": "4"},
-            {},
-            {"A": "1", "B": "2", "C": "3", "D": "4"},
-        ),
-        (
-            {"A": "1", "B": "2"},
-            {"C": "42"},
-            {"C": "3", "D": "4"},
-            {"A": "1", "B": "2", "C": "3", "D": "4"},
-        ),
-        (
-            {"A": "1", "B": "2"},
-            {"B": ""},  # will be treated as unset and not apply
-            {},
-            {"A": "1", "B": "2"},
-        ),
-    ],
-    ids=[
-        "flow_run_into_deployment",
-        "deployment_into_work_pool",
-        "flow_run_into_work_pool",
-        "try_overwrite_with_empty_str",
-    ],
-)
-async def test_env_merge_logic_is_deep_template_with_default(
-    prefect_client,
-    session,
-    flow,
-    work_pool,
-    work_pool_env,
-    deployment_env,
-    flow_run_env,
-    expected_env,
-):
-    if work_pool_env:
-        await models.workers.update_work_pool(
-            session=session,
-            work_pool_id=work_pool.id,
-            work_pool=ServerWorkPoolUpdate(
-                base_job_template={
-                    "job_configuration": {"env": "{{ env }}"},
-                    "variables": {
-                        "properties": {
-                            "env": {"type": "object", "default": work_pool_env}
-                        }
-                    },
-                },
+                base_job_template=base_job_template,
                 description="test",
                 is_paused=False,
                 concurrency_limit=None,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

The deep merge for `env` from the deployment->work pool only worked if the env vars were written directly into the template. This copies down the defaults to include them in the deep merge as well.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
