### PR TITLE
create `PREFECT_HOME` in `root_settings_context`

### DIFF
--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -645,6 +645,7 @@ def root_settings_context():
     if not (settings := Settings()).home.exists():
         try:
             settings.home.mkdir(mode=0o0700, exist_ok=True)
+            print(f"Created Prefect home directory at {settings.home}", file=sys.stdout)
         except OSError:
             warnings.warn(
                 (f"Failed to create the Prefect home directory at {settings.home}"),

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -645,7 +645,6 @@ def root_settings_context():
     if not (settings := Settings()).home.exists():
         try:
             settings.home.mkdir(mode=0o0700, exist_ok=True)
-            print(f"Created Prefect home directory at {settings.home}", file=sys.stdout)
         except OSError:
             warnings.warn(
                 (f"Failed to create the Prefect home directory at {settings.home}"),

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1517,18 +1517,6 @@ class Settings(BaseSettings):
             values = warn_on_misconfigured_api_url(values)
         return self
 
-    @model_validator(mode="after")
-    def set_home(self) -> Self:
-        """Set the home directory for the settings."""
-        try:
-            self.home.mkdir(mode=0o0700, exist_ok=True)
-        except OSError:
-            warnings.warn(
-                (f"Failed to create the Prefect home directory at {self.home}"),
-                stacklevel=2,
-            )
-        return self
-
     ##########################################################################
     # Settings methods
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -213,14 +213,6 @@ class TestSettingsContext:
         with pytest.raises(MissingContextError, match="No settings context found"):
             get_settings_context()
 
-    def test_creates_home(self, tmp_path):
-        home = tmp_path / "home"
-        assert not home.exists()
-        with temporary_settings(updates={PREFECT_HOME: home}):
-            pass
-
-        assert home.exists()
-
     def test_settings_context_uses_settings(self, temporary_profiles_path):
         temporary_profiles_path.write_text(
             textwrap.dedent(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -231,6 +231,12 @@ class TestSettingsContext:
                 source=temporary_profiles_path,
             )
 
+    def test_settings_context_creates_home(self, tmpdir, monkeypatch):
+        monkeypatch.setenv("PREFECT_HOME", str(tmpdir / "testing"))
+        with root_settings_context() as ctx:
+            assert ctx.settings.home == tmpdir / "testing"
+            assert ctx.settings.home.exists()
+
     def test_settings_context_does_not_setup_logging(self, monkeypatch):
         setup_logging = MagicMock()
         monkeypatch.setattr(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -231,7 +231,7 @@ class TestSettingsContext:
                 source=temporary_profiles_path,
             )
 
-    def test_settings_context_creates_home(self, tmpdir, monkeypatch):
+    def test_root_settings_context_creates_home(self, tmpdir, monkeypatch):
         monkeypatch.setenv("PREFECT_HOME", str(tmpdir / "testing"))
         with root_settings_context() as ctx:
             assert ctx.settings.home == tmpdir / "testing"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -460,11 +460,6 @@ class TestSettingsClass:
             set(Settings().valid_setting_names()) == set(SUPPORTED_SETTINGS.keys())
         ), "valid_setting_names output did not match supported settings. Please update SUPPORTED_SETTINGS if you are adding or removing a setting."
 
-    def test_instantiation_creates_home(self, tmp_path):
-        settings = Settings(home=tmp_path)
-        assert settings.home == tmp_path
-        assert settings.home.exists()
-
 
 class TestSettingAccess:
     def test_get_value_root_setting(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -460,6 +460,11 @@ class TestSettingsClass:
             set(Settings().valid_setting_names()) == set(SUPPORTED_SETTINGS.keys())
         ), "valid_setting_names output did not match supported settings. Please update SUPPORTED_SETTINGS if you are adding or removing a setting."
 
+    def test_instantiation_creates_home(self, tmp_path):
+        settings = Settings(home=tmp_path)
+        assert settings.home == tmp_path
+        assert settings.home.exists()
+
 
 class TestSettingAccess:
     def test_get_value_root_setting(self):


### PR DESCRIPTION
This PR makes sure the `PREFECT_HOME` directory exists. Previously, directory creation was handled in the `__enter__` method of `SettingsContext`. The logic has now been moved to `root_settings_context`

this got past the test suite because the test we used to check that home was created used `temporary_settings`, which will enter a `SettingsContext`. we circumvented `use_profile` in https://github.com/PrefectHQ/prefect/pull/15565, meaning that in more normal use we don't enter a context and ensure `PREFECT_HOME` in all necessary cases

### tested with

```bash
docker build -t test .
docker run --rm test -- prefect server start --host 0.0.0.0
```

or just
```
» PREFECT_HOME=/tmp/foo prefect server start&
[1] 93881
π prefect 3.12.5 ። ~/github.com/prefecthq/prefect create-home-with-settings                                        19 minutes ago
» Switched to profile 'local'

 ___ ___ ___ ___ ___ ___ _____
| _ \ _ \ __| __| __/ __|_   _|
|  _/   / _|| _|| _| (__  | |
|_| |_|_\___|_| |___\___| |_|

Configure Prefect to communicate with the server with:

    prefect config set PREFECT_API_URL=http://127.0.0.1:4200/api

View the API reference documentation at http://127.0.0.1:4200/docs

Check out the dashboard at http://127.0.0.1:4200


» ls /tmp/foo/
memo_store.toml prefect.db      profiles.toml
```