### PR TITLE
Fix failing work queue test

### DIFF
--- a/tests/server/models/deprecated/test_work_queues.py
+++ b/tests/server/models/deprecated/test_work_queues.py
@@ -6,6 +6,7 @@ import pendulum
 import pytest
 
 from prefect.server import models, schemas
+from prefect.server.database import orm_models
 from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.models.deployments import check_work_queues_for_deployment
 from prefect.server.utilities.database import get_dialect
@@ -50,12 +51,14 @@ class TestUpdateWorkQueue:
         )
         assert result
 
+        queue = await session.get(
+            orm_models.WorkQueue, work_queue.id, populate_existing=True
+        )
         updated_queue = schemas.core.WorkQueue.model_validate(
-            await models.work_queues.read_work_queue(
-                session=session, work_queue_id=work_queue.id
-            ),
+            queue,
             from_attributes=True,
         )
+
         assert updated_queue.id == work_queue.id
 
         with pytest.warns(DeprecationWarning):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
Fixes a test that started failing on 3.9:
```
FAILED tests/server/models/deprecated/test_work_queues.py::TestUpdateWorkQueue::test_update_work_queue - pydantic_core._pydantic_core.ValidationError: 1 validation error for WorkQueue
updated
  Error extracting attribute: MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place? (Background on this error at: https://sqlalche.me/e/20/xd2s) [type=get_attribute_error, input_value=WorkQueue(id=ad3757a9-9c58-4adc-b355-9ffef3e1b730), input_type=WorkQueue]
    For further information visit https://errors.pydantic.dev/2.9/v/get_attribute_error
```
Something about the update and then read wasn't working, so I added `populate_existing=True` for this one test.
