### PR TITLE
prefect-dbt - fix dbt cli argument list for multipart commands

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py
@@ -131,9 +131,6 @@ async def trigger_dbt_cli_command(
     if profiles_dir is None:
         profiles_dir = os.getenv("DBT_PROFILES_DIR", str(Path.home()) + "/.dbt")
 
-    if command.startswith("dbt"):
-        command = command.split(" ", 1)[1]
-
     # https://docs.getdbt.com/dbt-cli/configure-your-profile
     # Note that the file always needs to be called profiles.yml,
     # regardless of which directory it is in.
@@ -160,7 +157,7 @@ async def trigger_dbt_cli_command(
         )
 
     # append the options
-    cli_args = [command]
+    cli_args = [arg for arg in command.split() if arg != "dbt"]
     cli_args.append("--profiles-dir")
     cli_args.append(profiles_dir)
     if project_dir is not None:

--- a/src/integrations/prefect-dbt/tests/cli/test_commands.py
+++ b/src/integrations/prefect-dbt/tests/cli/test_commands.py
@@ -250,6 +250,7 @@ def dbt_runner_freshness_success(monkeypatch, mock_dbt_runner_freshness_success)
     monkeypatch.setattr(
         "dbt.cli.main.dbtRunner.invoke", _mock_dbt_runner_freshness_success
     )
+    return _mock_dbt_runner_freshness_success
 
 
 @pytest.fixture
@@ -281,6 +282,23 @@ def test_trigger_dbt_cli_command(profiles_dir, dbt_cli_profile_bare):
 
     result = test_flow()
     assert isinstance(result, dbtRunnerResult)
+
+
+def test_trigger_dbt_cli_command_cli_argument_list(
+    profiles_dir, dbt_cli_profile_bare, dbt_runner_freshness_success
+):
+    @flow
+    def test_flow():
+        return trigger_dbt_cli_command(
+            command="dbt source freshness",
+            profiles_dir=profiles_dir,
+            dbt_cli_profile=dbt_cli_profile_bare,
+        )
+
+    test_flow()
+    dbt_runner_freshness_success.assert_called_with(
+        ["source", "freshness", "--profiles-dir", profiles_dir]
+    )
 
 
 @pytest.mark.usefixtures("dbt_runner_freshness_error")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This is a minor fix for prefect-dbt integration. For dbt commands that are multipart such as `dbt source freshness`, `trigger_dbt_cli_command` function did not separate the individual command parts into list of arguments, causing the following error:

`DbtUsageException("No such command 'source freshness'.")`

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
