### PR TITLE
Thread pool task runner max worker configurable via environment variable

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1525,7 +1525,7 @@ class Settings(PrefectBaseSettings):
         description="Which cache implementation to use for the events system.  Should point to a module that exports a Cache class.",
     )
 
-    thread_pool_task_runner_max_workers: Optional[int] = Field(
+    task_runner_thread_pool_max_workers: Optional[int] = Field(
         default=None,
         gt=0,
         description="The maximum number of workers for ThreadPoolTaskRunner.",

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1525,6 +1525,12 @@ class Settings(PrefectBaseSettings):
         description="Which cache implementation to use for the events system.  Should point to a module that exports a Cache class.",
     )
 
+    thread_pool_task_runner_max_workers: Optional[int] = Field(
+        default=None,
+        gt=0,
+        description="The maximum number of workers for ThreadPoolTaskRunner.",
+    )
+
     ###########################################################################
     # allow deprecated access to PREFECT_SOME_SETTING_NAME
 

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -29,7 +29,7 @@ from prefect.futures import (
     PrefectFutureList,
 )
 from prefect.logging.loggers import get_logger, get_run_logger
-from prefect.settings import PREFECT_THREAD_POOL_TASK_RUNNER_MAX_WORKERS
+from prefect.settings import PREFECT_TASK_RUNNER_THREAD_POOL_MAX_WORKERS
 from prefect.utilities.annotations import allow_failure, quote, unmapped
 from prefect.utilities.callables import (
     collapse_variadic_parameters,
@@ -222,7 +222,7 @@ class ThreadPoolTaskRunner(TaskRunner[PrefectConcurrentFuture]):
         super().__init__()
         self._executor: Optional[ThreadPoolExecutor] = None
         self._max_workers = (
-            (PREFECT_THREAD_POOL_TASK_RUNNER_MAX_WORKERS.value() or sys.maxsize)
+            (PREFECT_TASK_RUNNER_THREAD_POOL_MAX_WORKERS.value() or sys.maxsize)
             if max_workers is None
             else max_workers
         )

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -29,6 +29,7 @@ from prefect.futures import (
     PrefectFutureList,
 )
 from prefect.logging.loggers import get_logger, get_run_logger
+from prefect.settings import PREFECT_THREAD_POOL_TASK_RUNNER_MAX_WORKERS
 from prefect.utilities.annotations import allow_failure, quote, unmapped
 from prefect.utilities.callables import (
     collapse_variadic_parameters,
@@ -220,7 +221,11 @@ class ThreadPoolTaskRunner(TaskRunner[PrefectConcurrentFuture]):
     def __init__(self, max_workers: Optional[int] = None):
         super().__init__()
         self._executor: Optional[ThreadPoolExecutor] = None
-        self._max_workers = sys.maxsize if max_workers is None else max_workers
+        self._max_workers = (
+            (PREFECT_THREAD_POOL_TASK_RUNNER_MAX_WORKERS.value() or sys.maxsize)
+            if max_workers is None
+            else max_workers
+        )
         self._cancel_events: Dict[uuid.UUID, threading.Event] = {}
 
     def duplicate(self) -> "ThreadPoolTaskRunner":

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -222,7 +222,7 @@ SUPPORTED_SETTINGS = {
     "PREFECT_WORKER_QUERY_SECONDS": {"test_value": 10.0},
     "PREFECT_WORKER_WEBSERVER_HOST": {"test_value": "host"},
     "PREFECT_WORKER_WEBSERVER_PORT": {"test_value": 8080},
-    "PREFECT_THREAD_POOL_TASK_RUNNER_MAX_WORKERS": {"test_value": 5},
+    "PREFECT_TASK_RUNNER_THREAD_POOL_MAX_WORKERS": {"test_value": 5},
 }
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -222,6 +222,7 @@ SUPPORTED_SETTINGS = {
     "PREFECT_WORKER_QUERY_SECONDS": {"test_value": 10.0},
     "PREFECT_WORKER_WEBSERVER_HOST": {"test_value": "host"},
     "PREFECT_WORKER_WEBSERVER_PORT": {"test_value": 8080},
+    "PREFECT_THREAD_POOL_TASK_RUNNER_MAX_WORKERS": {"test_value": 5},
 }
 
 

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -15,8 +15,8 @@ from prefect.futures import PrefectFuture, PrefectWrappedFuture
 from prefect.results import _default_storages
 from prefect.settings import (
     PREFECT_DEFAULT_RESULT_STORAGE_BLOCK,
+    PREFECT_TASK_RUNNER_THREAD_POOL_MAX_WORKERS,
     PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK,
-    PREFECT_THREAD_POOL_TASK_RUNNER_MAX_WORKERS,
     temporary_settings,
 )
 from prefect.states import Completed, Running
@@ -97,7 +97,7 @@ class TestThreadPoolTaskRunner:
             assert runner._executor._max_workers == 2
 
     def test_set_max_workers_through_settings(self):
-        with temporary_settings({PREFECT_THREAD_POOL_TASK_RUNNER_MAX_WORKERS: 5}):
+        with temporary_settings({PREFECT_TASK_RUNNER_THREAD_POOL_MAX_WORKERS: 5}):
             with ThreadPoolTaskRunner() as runner:
                 assert runner._executor._max_workers == 5
 

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -16,6 +16,7 @@ from prefect.results import _default_storages
 from prefect.settings import (
     PREFECT_DEFAULT_RESULT_STORAGE_BLOCK,
     PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK,
+    PREFECT_THREAD_POOL_TASK_RUNNER_MAX_WORKERS,
     temporary_settings,
 )
 from prefect.states import Completed, Running
@@ -94,6 +95,11 @@ class TestThreadPoolTaskRunner:
     def test_set_max_workers(self):
         with ThreadPoolTaskRunner(max_workers=2) as runner:
             assert runner._executor._max_workers == 2
+
+    def test_set_max_workers_through_settings(self):
+        with temporary_settings({PREFECT_THREAD_POOL_TASK_RUNNER_MAX_WORKERS: 5}):
+            with ThreadPoolTaskRunner() as runner:
+                assert runner._executor._max_workers == 5
 
     def test_submit_sync_task(self):
         with ThreadPoolTaskRunner() as runner:


### PR DESCRIPTION
Added prefect setting `THREAD_POOL_TASK_RUNNER_MAX_WORKERS` to configure the `max_workers` parameter in `ThreadPoolTaskRunner`. The default value is `None`.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
