### PR TITLE
de-flake serve integration test

### DIFF
--- a/flows/serve_a_flow.py
+++ b/flows/serve_a_flow.py
@@ -23,10 +23,10 @@ def count_runs(counter_dir: Path):
 
 
 if __name__ == "__main__":
-    TIMEOUT: int = 11
+    TIMEOUT: int = 15
     INTERVAL_SECONDS: int = 3
 
-    EXPECTED_N_FLOW_RUNS: int = TIMEOUT // INTERVAL_SECONDS
+    MINIMUM_EXPECTED_N_FLOW_RUNS: int = 3
 
     signal.signal(signal.SIGALRM, timeout_handler)
     signal.alarm(TIMEOUT)
@@ -49,7 +49,7 @@ if __name__ == "__main__":
         actual_run_count = count_runs(counter_dir)
 
         assert (
-            actual_run_count >= EXPECTED_N_FLOW_RUNS
-        ), f"Expected at least {EXPECTED_N_FLOW_RUNS} flow runs, got {actual_run_count}"
+            actual_run_count >= MINIMUM_EXPECTED_N_FLOW_RUNS
+        ), f"Expected at least {MINIMUM_EXPECTED_N_FLOW_RUNS} flow runs, got {actual_run_count}"
 
         print(f"Successfully completed and audited {actual_run_count} flow runs")


### PR DESCRIPTION
because we're using scheduling and a runner poll frequency, we're still hitting some timing issues in the integration test even though its working as expected - this PR makes the test a bit more lenient wrt timing