### PR TITLE
Avoid crashing flows when job watch exits but conatiner is still running

### DIFF
--- a/src/integrations/prefect-kubernetes/pyproject.toml
+++ b/src/integrations/prefect-kubernetes/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "pytest-asyncio",
     "pytest",
     "pytest-env",
+    "pytest-timeout",
     "pytest-xdist",
 ]
 
@@ -80,3 +81,4 @@ show_missing = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 env = ["PREFECT_TEST_MODE=1"]
+timeout = 30


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR replicates this https://github.com/PrefectHQ/prefect/pull/15525 Only difference is that this is created for main branch and for Prefect V3.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - https://github.com/PrefectHQ/prefect/pull/15525
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
