### PR TITLE
Change root settings context to include profile settings

### DIFF
--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -642,16 +642,17 @@ def root_settings_context():
         )
         active_name = "ephemeral"
 
-    if not (settings := Settings()).home.exists():
-        try:
-            settings.home.mkdir(mode=0o0700, exist_ok=True)
-        except OSError:
-            warnings.warn(
-                (f"Failed to create the Prefect home directory at {settings.home}"),
-                stacklevel=2,
-            )
+    with use_profile(profiles[active_name], include_current_context=False) as ctx:
+        if not ctx.settings.home.exists():
+            try:
+                ctx.settings.home.mkdir(mode=0o0700, exist_ok=True)
+            except OSError:
+                warnings.warn(
+                    f"Failed to create the Prefect home directory at {ctx.settings.home}",
+                    stacklevel=2,
+                )
 
-    return SettingsContext(profile=profiles[active_name], settings=settings)
+    return ctx
 
     # Note the above context is exited and the global settings context is used by
     # an override in the `SettingsContext.get` method.

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -958,7 +958,9 @@ class Settings(PrefectBaseSettings):
 
     logging_extra_loggers: Annotated[
         Union[str, list[str], None],
-        AfterValidator(lambda v: [n.strip() for n in v.split(",")] if v else []),
+        AfterValidator(
+            lambda v: [n.strip() for n in v.split(",")] if isinstance(v, str) else v or []
+        ),
     ] = Field(
         default=None,
         description="Additional loggers to attach to Prefect logging at runtime.",


### PR DESCRIPTION
This PR proposes a change for root settings context to include profile settings loaded from different profiles path.

With this change, setting different PREFECT_HOME or PREFECT_PROFILES_PATH will properly load profile settings.

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
