### PR TITLE
Capture pod logs for `run_namespaced_job`

### DIFF
--- a/docs/integrations/prefect-kubernetes/index.mdx
+++ b/docs/integrations/prefect-kubernetes/index.mdx
@@ -54,6 +54,7 @@ customized_run_namespaced_job = run_namespaced_job.with_options(
 ### Specify and run a Kubernetes Job from a YAML file
 
 ```python
+from prefect import flow, get_run_logger
 from prefect_kubernetes.credentials import KubernetesCredentials
 from prefect_kubernetes.flows import run_namespaced_job # this is a flow
 from prefect_kubernetes.jobs import KubernetesJob
@@ -68,9 +69,17 @@ job = KubernetesJob.from_yaml_file( # or create in the UI with a dict manifest
 job.save("my-k8s-job", overwrite=True)
 
 
-if __name__ == "__main__":
-    # run the flow
-    run_namespaced_job(job)
+@flow
+def kubernetes_orchestrator():
+    # run the flow and send logs to the parent flow run's logger
+    logger = get_run_logger()
+    run_namespaced_job(job, print_func=logger.info)
+```
+
+As with all Prefect flows and tasks, you can call the underlying function directly if you don't need Prefect features:
+
+```python
+run_namespaced_job.fn(job, print_func=print)
 ```
 
 ### Generate a resource-specific client from `KubernetesClusterConfig`
@@ -104,32 +113,6 @@ def kubernetes_orchestrator():
     )
 ```
 
-### Patch an existing Kubernetes deployment
-
-```python
-from kubernetes.client.models import V1Deployment
-
-from prefect import flow
-from prefect_kubernetes.credentials import KubernetesCredentials
-from prefect_kubernetes.deployments import patch_namespaced_deployment
-from prefect_kubernetes.utilities import convert_manifest_to_model
-
-
-@flow
-def kubernetes_orchestrator():
-
-    v1_deployment_updates = convert_manifest_to_model(
-        manifest="path/to/manifest.yaml",
-        v1_model_name="V1Deployment",
-    )
-
-    v1_deployment = patch_namespaced_deployment(
-        kubernetes_credentials=KubernetesCredentials.load("k8s-creds"),
-        deployment_name="my-deployment",
-        deployment_updates=v1_deployment_updates,
-        namespace="my-namespace"
-    )
-```
 
 For assistance using Kubernetes, consult the [Kubernetes documentation](https://kubernetes.io/).
 

--- a/docs/integrations/prefect-kubernetes/index.mdx
+++ b/docs/integrations/prefect-kubernetes/index.mdx
@@ -74,6 +74,10 @@ def kubernetes_orchestrator():
     # run the flow and send logs to the parent flow run's logger
     logger = get_run_logger()
     run_namespaced_job(job, print_func=logger.info)
+
+
+if __name__ == "__main__":
+    kubernetes_orchestrator()
 ```
 
 As with all Prefect flows and tasks, you can call the underlying function directly if you don't need Prefect features:

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/jobs.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/jobs.py
@@ -356,6 +356,14 @@ class KubernetesJobRun(JobRun[Dict[str, Any]]):
         self._kubernetes_job = kubernetes_job
         self._v1_job_model = v1_job_model
 
+    @property
+    def v1_job_model(self) -> dict[str, Any]:
+        return (
+            self._v1_job_model
+            if isinstance(self._v1_job_model, dict)
+            else self._v1_job_model.to_dict()
+        )
+
     async def _cleanup(self):
         """Deletes the Kubernetes job resource."""
         job_name = self._v1_job_model.get("metadata", {}).get("name")
@@ -399,14 +407,14 @@ class KubernetesJobRun(JobRun[Dict[str, Any]]):
                     f"Job timed out after {elapsed_time} seconds."
                 )
 
-            v1_job_status = await read_namespaced_job_status.fn(
+            v1_job = await read_namespaced_job.fn(
                 kubernetes_credentials=self._kubernetes_job.credentials,
-                job_name=self._v1_job_model.get("metadata", {}).get("name"),
+                job_name=self.v1_job_model.get("metadata", {}).get("name"),
                 namespace=self._kubernetes_job.namespace,
                 **self._kubernetes_job.api_kwargs,
             )
             pod_selector = (
-                "controller-uid=" f"{v1_job_status.metadata.labels['controller-uid']}"
+                "controller-uid=" f"{v1_job.metadata.labels['controller-uid']}"
             )
             v1_pod_list = await list_namespaced_pod.fn(
                 kubernetes_credentials=self._kubernetes_job.credentials,
@@ -426,36 +434,36 @@ class KubernetesJobRun(JobRun[Dict[str, Any]]):
                 self.pod_logs[pod_name] = await read_namespaced_pod_log.fn(
                     kubernetes_credentials=self._kubernetes_job.credentials,
                     pod_name=pod_name,
-                    container=v1_job_status.spec.template.spec.containers[0].name,
+                    container=v1_job.spec.template.spec.containers[0].name,
                     namespace=self._kubernetes_job.namespace,
                     print_func=print_func,
                     **self._kubernetes_job.api_kwargs,
                 )
 
-            if v1_job_status.status.active:
+            if v1_job.status.active:
                 await sleep(self._kubernetes_job.interval_seconds)
                 if self._kubernetes_job.timeout_seconds:
                     elapsed_time += self._kubernetes_job.interval_seconds
-            elif v1_job_status.status.conditions:
+            elif v1_job.status.conditions:
                 final_completed_conditions = [
                     condition.type == "Complete"
-                    for condition in v1_job_status.status.conditions
+                    for condition in v1_job.status.conditions
                     if condition.status == "True"
                 ]
                 if final_completed_conditions and any(final_completed_conditions):
                     self._completed = True
                     self.logger.info(
-                        f"Job {v1_job_status.metadata.name!r} has "
-                        f"completed with {v1_job_status.status.succeeded} pods."
+                        f"Job {v1_job.metadata.name!r} has "
+                        f"completed with {v1_job.status.succeeded} pods."
                     )
                 elif final_completed_conditions:
                     failed_conditions = [
                         condition.reason
-                        for condition in v1_job_status.status.conditions
+                        for condition in v1_job.status.conditions
                         if condition.type == "Failed"
                     ]
                     raise RuntimeError(
-                        f"Job {v1_job_status.metadata.name!r} failed due to "
+                        f"Job {v1_job.metadata.name!r} failed due to "
                         f"{failed_conditions}, check the Kubernetes pod logs "
                         f"for more information."
                     )

--- a/src/integrations/prefect-kubernetes/tests/conftest.py
+++ b/src/integrations/prefect-kubernetes/tests/conftest.py
@@ -144,35 +144,6 @@ def mock_create_namespaced_job(monkeypatch):
 
 
 @pytest.fixture
-def mock_read_namespaced_job_status(monkeypatch):
-    mock_v1_job_status = AsyncMock(
-        return_value=models.V1Job(
-            metadata=models.V1ObjectMeta(
-                name="test", labels={"controller-uid": "test"}
-            ),
-            spec=models.V1JobSpec(
-                template=models.V1PodTemplateSpec(
-                    spec=models.V1PodSpec(containers=[models.V1Container(name="test")])
-                )
-            ),
-            status=models.V1JobStatus(
-                active=0,
-                failed=0,
-                succeeded=1,
-                conditions=[
-                    models.V1JobCondition(type="Complete", status="True"),
-                ],
-            ),
-        )
-    )
-    monkeypatch.setattr(
-        "kubernetes_asyncio.client.BatchV1Api.read_namespaced_job_status",
-        mock_v1_job_status,
-    )
-    return mock_v1_job_status
-
-
-@pytest.fixture
 def mock_delete_namespaced_job(monkeypatch):
     mock_v1_job = AsyncMock(
         return_value=models.V1Job(metadata=models.V1ObjectMeta(name="test"))
@@ -239,3 +210,33 @@ def valid_kubernetes_job_block(kubernetes_credentials):
         credentials=kubernetes_credentials,
         v1_job=job_dict,
     )
+
+
+@pytest.fixture
+def mock_read_namespaced_job(monkeypatch):
+    mock_v1_job = AsyncMock(
+        return_value=models.V1Job(
+            metadata=models.V1ObjectMeta(
+                name="test",
+            ),
+            spec=models.V1JobSpec(
+                template=models.V1PodTemplateSpec(
+                    metadata=models.V1ObjectMeta(labels={"controller-uid": "test-uid"}),
+                    spec=models.V1PodSpec(containers=[models.V1Container(name="test")]),
+                )
+            ),
+            status=models.V1JobStatus(
+                active=0,
+                failed=0,
+                succeeded=1,
+                conditions=[
+                    models.V1JobCondition(type="Complete", status="True"),
+                ],
+            ),
+        )
+    )
+    monkeypatch.setattr(
+        "kubernetes_asyncio.client.BatchV1Api.read_namespaced_job",
+        mock_v1_job,
+    )
+    return mock_v1_job

--- a/src/integrations/prefect-kubernetes/tests/test_flows.py
+++ b/src/integrations/prefect-kubernetes/tests/test_flows.py
@@ -8,7 +8,7 @@ from prefect import flow
 async def test_run_namespaced_job_timeout_respected(
     valid_kubernetes_job_block,
     mock_create_namespaced_job,
-    mock_read_namespaced_job_status,
+    mock_read_namespaced_job,
     mock_list_namespaced_pod,
     read_pod_logs,
     successful_job_status,
@@ -16,7 +16,7 @@ async def test_run_namespaced_job_timeout_respected(
     successful_job_status.status.active = 1
     successful_job_status.status.succeeded = None
     successful_job_status.status.conditions = []
-    mock_read_namespaced_job_status.return_value = successful_job_status
+    mock_read_namespaced_job.return_value = successful_job_status
 
     valid_kubernetes_job_block.timeout_seconds = 1
 
@@ -30,13 +30,13 @@ async def test_run_namespaced_job_timeout_respected(
         == "pi"
     )
 
-    assert mock_read_namespaced_job_status.call_count == 1
+    assert mock_read_namespaced_job.call_count == 1
 
 
 async def test_run_namespaced_job_successful(
     valid_kubernetes_job_block,
     mock_create_namespaced_job,
-    mock_read_namespaced_job_status,
+    mock_read_namespaced_job,
     mock_delete_namespaced_job,
     mock_list_namespaced_pod,
     read_pod_logs,
@@ -52,7 +52,7 @@ async def test_run_namespaced_job_successful(
 
     assert read_pod_logs.call_count == 1
 
-    assert mock_read_namespaced_job_status.call_count == 1
+    assert mock_read_namespaced_job.call_count == 1
 
     assert mock_delete_namespaced_job.call_count == 1
 
@@ -60,13 +60,13 @@ async def test_run_namespaced_job_successful(
 async def test_run_namespaced_job_successful_no_delete_after_completion(
     valid_kubernetes_job_block,
     mock_create_namespaced_job,
-    mock_read_namespaced_job_status,
+    mock_read_namespaced_job,
     mock_delete_namespaced_job,
     successful_job_status,
     mock_list_namespaced_pod,
     read_pod_logs,
 ):
-    mock_read_namespaced_job_status.return_value = successful_job_status
+    mock_read_namespaced_job.return_value = successful_job_status
 
     valid_kubernetes_job_block.delete_after_completion = False
 
@@ -79,7 +79,7 @@ async def test_run_namespaced_job_successful_no_delete_after_completion(
         == "pi"
     )
 
-    assert mock_read_namespaced_job_status.call_count == 1
+    assert mock_read_namespaced_job.call_count == 1
 
     assert mock_delete_namespaced_job.call_count == 0
 
@@ -87,13 +87,13 @@ async def test_run_namespaced_job_successful_no_delete_after_completion(
 async def test_run_namespaced_job_unsuccessful(
     valid_kubernetes_job_block,
     mock_create_namespaced_job,
-    mock_read_namespaced_job_status,
+    mock_read_namespaced_job,
     mock_delete_namespaced_job,
     unsuccessful_job_status,
     mock_list_namespaced_pod,
     read_pod_logs,
 ):
-    mock_read_namespaced_job_status.return_value = unsuccessful_job_status
+    mock_read_namespaced_job.return_value = unsuccessful_job_status
 
     with pytest.raises(RuntimeError, match=", check the Kubernetes pod logs"):
         await run_namespaced_job_async(kubernetes_job=valid_kubernetes_job_block)
@@ -105,7 +105,7 @@ async def test_run_namespaced_job_unsuccessful(
         == "pi"
     )
 
-    assert mock_read_namespaced_job_status.call_count == 1
+    assert mock_read_namespaced_job.call_count == 1
 
     assert mock_delete_namespaced_job.call_count == 0
 
@@ -113,7 +113,7 @@ async def test_run_namespaced_job_unsuccessful(
 def test_run_namespaced_job_sync_subflow(
     valid_kubernetes_job_block,
     mock_create_namespaced_job,
-    mock_read_namespaced_job_status,
+    mock_read_namespaced_job,
     mock_delete_namespaced_job,
     successful_job_status,
     mock_list_namespaced_pod,
@@ -134,7 +134,7 @@ def test_run_namespaced_job_sync_subflow(
 
     assert read_pod_logs.call_count == 1
 
-    assert mock_read_namespaced_job_status.call_count == 1
+    assert mock_read_namespaced_job.call_count == 1
 
     assert mock_delete_namespaced_job.call_count == 1
 
@@ -142,7 +142,7 @@ def test_run_namespaced_job_sync_subflow(
 async def test_run_namespaced_job_successful_with_evictions(
     valid_kubernetes_job_block,
     mock_create_namespaced_job,
-    mock_read_namespaced_job_status,
+    mock_read_namespaced_job,
     mock_delete_namespaced_job,
     successful_job_status,
     mock_list_namespaced_pod,
@@ -150,7 +150,7 @@ async def test_run_namespaced_job_successful_with_evictions(
 ):
     successful_job_status.status.active = 0
     successful_job_status.status.failed = 1
-    mock_read_namespaced_job_status.return_value = successful_job_status
+    mock_read_namespaced_job.return_value = successful_job_status
 
     await run_namespaced_job_async(kubernetes_job=valid_kubernetes_job_block)
 
@@ -163,7 +163,7 @@ async def test_run_namespaced_job_successful_with_evictions(
 
     assert read_pod_logs.call_count == 1
 
-    assert mock_read_namespaced_job_status.call_count == 1
+    assert mock_read_namespaced_job.call_count == 1
 
     assert mock_delete_namespaced_job.call_count == 1
 
@@ -171,7 +171,7 @@ async def test_run_namespaced_job_successful_with_evictions(
 def test_run_namespaced_job_sync_stream_logs(
     valid_kubernetes_job_block,
     mock_create_namespaced_job,
-    mock_read_namespaced_job_status,
+    mock_read_namespaced_job,
     mock_delete_namespaced_job,
     successful_job_status,
     mock_list_namespaced_pod,
@@ -196,7 +196,7 @@ def test_run_namespaced_job_sync_stream_logs(
 
     assert read_pod_logs.call_count == 1
 
-    assert mock_read_namespaced_job_status.call_count == 1
+    assert mock_read_namespaced_job.call_count == 1
 
     assert mock_delete_namespaced_job.call_count == 1
 


### PR DESCRIPTION
fixes an issue where the `controller-uid` was being selected off the job status instead of the freshly retrieved `Job` object. the fact that that we were looking in the wrong place meant that the pod logs were not returned from `run_namespaced_job`

as discussed with @mitchnielsen, the injected label should always be present at the job's `spec.template.metadata.labels`, so we now look there, and fail if we cannot find it