### PR TITLE
add `/api` to `PREFECT_UI_API_URL` in default case

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1559,12 +1559,10 @@ class Settings(PrefectBaseSettings):
         if self.ui_api_url is None:
             if self.api.url:
                 self.ui_api_url = self.api.url
-            if self.api.url:
-                self.ui_api_url = self.api.url
                 self.__pydantic_fields_set__.remove("ui_api_url")
             else:
                 self.ui_api_url = (
-                    f"http://{self.server_api_host}:{self.server_api_port}"
+                    f"http://{self.server_api_host}:{self.server_api_port}/api"
                 )
                 self.__pydantic_fields_set__.remove("ui_api_url")
         if self.profiles_path is None or "PREFECT_HOME" in str(self.profiles_path):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -39,6 +39,7 @@ from prefect.settings import (
     PREFECT_SERVER_API_PORT,
     PREFECT_TEST_MODE,
     PREFECT_TEST_SETTING,
+    PREFECT_UI_API_URL,
     PREFECT_UI_URL,
     PREFECT_UNIT_TEST_MODE,
     SETTING_VARIABLES,
@@ -550,6 +551,21 @@ class TestSettingAccess:
     def test_cloud_ui_url_set_directly(self):
         with temporary_settings({PREFECT_CLOUD_UI_URL: "test"}):
             assert PREFECT_CLOUD_UI_URL.value() == "test"
+
+    def test_ui_api_url_inferred_from_api_url(self):
+        with temporary_settings({PREFECT_API_URL: "http://my-domain/api"}):
+            assert PREFECT_UI_API_URL.value() == "http://my-domain/api"
+
+    def test_ui_api_url_set_directly(self):
+        with temporary_settings({PREFECT_UI_API_URL: "http://my-foo-domain/api"}):
+            assert PREFECT_UI_API_URL.value() == "http://my-foo-domain/api"
+
+    def test_ui_api_url_default(self):
+        default_api_url = PREFECT_API_URL.value()
+        assert PREFECT_UI_API_URL.value() == default_api_url
+
+        assert default_api_url.startswith("http://localhost")
+        assert default_api_url.endswith("/api")
 
     @pytest.mark.parametrize(
         "extra_codes,expected",


### PR DESCRIPTION
fixes a bug with the default value of `PREFECT_UI_API_URL`