### PR TITLE
Wraps run_dbt_ function in sync_compatible

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py
@@ -398,6 +398,7 @@ class DbtCoreOperation(ShellOperation):
 
 
 @task
+@sync_compatible
 async def run_dbt_build(
     profiles_dir: Optional[Union[Path, str]] = None,
     project_dir: Optional[Union[Path, str]] = None,
@@ -471,6 +472,7 @@ async def run_dbt_build(
 
 
 @task
+@sync_compatible
 async def run_dbt_model(
     profiles_dir: Optional[Union[Path, str]] = None,
     project_dir: Optional[Union[Path, str]] = None,
@@ -545,6 +547,7 @@ async def run_dbt_model(
 
 
 @task
+@sync_compatible
 async def run_dbt_test(
     profiles_dir: Optional[Union[Path, str]] = None,
     project_dir: Optional[Union[Path, str]] = None,
@@ -619,6 +622,7 @@ async def run_dbt_test(
 
 
 @task
+@sync_compatible
 async def run_dbt_snapshot(
     profiles_dir: Optional[Union[Path, str]] = None,
     project_dir: Optional[Union[Path, str]] = None,
@@ -693,6 +697,7 @@ async def run_dbt_snapshot(
 
 
 @task
+@sync_compatible
 async def run_dbt_seed(
     profiles_dir: Optional[Union[Path, str]] = None,
     project_dir: Optional[Union[Path, str]] = None,
@@ -767,6 +772,7 @@ async def run_dbt_seed(
 
 
 @task
+@sync_compatible
 async def run_dbt_source_freshness(
     profiles_dir: Optional[Union[Path, str]] = None,
     project_dir: Optional[Union[Path, str]] = None,

--- a/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py
@@ -397,8 +397,8 @@ class DbtCoreOperation(ShellOperation):
         return super(type(self), modified_self)._compile_kwargs(**open_kwargs)
 
 
-@task
 @sync_compatible
+@task
 async def run_dbt_build(
     profiles_dir: Optional[Union[Path, str]] = None,
     project_dir: Optional[Union[Path, str]] = None,
@@ -471,8 +471,8 @@ async def run_dbt_build(
     return results
 
 
-@task
 @sync_compatible
+@task
 async def run_dbt_model(
     profiles_dir: Optional[Union[Path, str]] = None,
     project_dir: Optional[Union[Path, str]] = None,
@@ -546,8 +546,8 @@ async def run_dbt_model(
     return results
 
 
-@task
 @sync_compatible
+@task
 async def run_dbt_test(
     profiles_dir: Optional[Union[Path, str]] = None,
     project_dir: Optional[Union[Path, str]] = None,
@@ -621,8 +621,8 @@ async def run_dbt_test(
     return results
 
 
-@task
 @sync_compatible
+@task
 async def run_dbt_snapshot(
     profiles_dir: Optional[Union[Path, str]] = None,
     project_dir: Optional[Union[Path, str]] = None,
@@ -696,8 +696,8 @@ async def run_dbt_snapshot(
     return results
 
 
-@task
 @sync_compatible
+@task
 async def run_dbt_seed(
     profiles_dir: Optional[Union[Path, str]] = None,
     project_dir: Optional[Union[Path, str]] = None,
@@ -771,8 +771,8 @@ async def run_dbt_seed(
     return results
 
 
-@task
 @sync_compatible
+@task
 async def run_dbt_source_freshness(
     profiles_dir: Optional[Union[Path, str]] = None,
     project_dir: Optional[Union[Path, str]] = None,

--- a/src/integrations/prefect-dbt/tests/cli/test_commands.py
+++ b/src/integrations/prefect-dbt/tests/cli/test_commands.py
@@ -561,7 +561,7 @@ class TestDbtCoreOperation:
 async def test_run_dbt_build_creates_artifact(profiles_dir, dbt_cli_profile_bare):
     @flow
     async def test_flow():
-        return await run_dbt_build(
+        return run_dbt_build(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -580,7 +580,7 @@ async def test_run_dbt_build_creates_artifact(profiles_dir, dbt_cli_profile_bare
 async def test_run_dbt_test_creates_artifact(profiles_dir, dbt_cli_profile_bare):
     @flow
     async def test_flow():
-        return await run_dbt_test(
+        return run_dbt_test(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -599,7 +599,7 @@ async def test_run_dbt_test_creates_artifact(profiles_dir, dbt_cli_profile_bare)
 async def test_run_dbt_snapshot_creates_artifact(profiles_dir, dbt_cli_profile_bare):
     @flow
     async def test_flow():
-        return await run_dbt_snapshot(
+        return run_dbt_snapshot(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -618,7 +618,7 @@ async def test_run_dbt_snapshot_creates_artifact(profiles_dir, dbt_cli_profile_b
 async def test_run_dbt_seed_creates_artifact(profiles_dir, dbt_cli_profile_bare):
     @flow
     async def test_flow():
-        return await run_dbt_seed(
+        return run_dbt_seed(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -637,7 +637,7 @@ async def test_run_dbt_seed_creates_artifact(profiles_dir, dbt_cli_profile_bare)
 async def test_run_dbt_model_creates_artifact(profiles_dir, dbt_cli_profile_bare):
     @flow
     async def test_flow():
-        return await run_dbt_model(
+        return run_dbt_model(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -658,7 +658,7 @@ async def test_run_dbt_source_freshness_creates_artifact(
 ):
     @flow
     async def test_flow():
-        return await run_dbt_source_freshness(
+        return run_dbt_source_freshness(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -685,7 +685,7 @@ async def test_run_dbt_model_creates_unsuccessful_artifact(
 ):
     @flow
     async def test_flow():
-        return await run_dbt_model(
+        return run_dbt_model(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -709,7 +709,7 @@ async def test_run_dbt_source_freshness_creates_unsuccessful_artifact(
 ):
     @flow
     async def test_flow():
-        return await run_dbt_source_freshness(
+        return run_dbt_source_freshness(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -731,7 +731,7 @@ async def test_run_dbt_source_freshness_creates_unsuccessful_artifact(
 async def test_run_dbt_model_throws_error(profiles_dir, dbt_cli_profile_bare):
     @flow
     async def test_flow():
-        return await run_dbt_model(
+        return run_dbt_model(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",

--- a/src/integrations/prefect-dbt/tests/cli/test_commands.py
+++ b/src/integrations/prefect-dbt/tests/cli/test_commands.py
@@ -561,7 +561,7 @@ class TestDbtCoreOperation:
 async def test_run_dbt_build_creates_artifact(profiles_dir, dbt_cli_profile_bare):
     @flow
     async def test_flow():
-        return run_dbt_build(
+        return await run_dbt_build(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -580,7 +580,7 @@ async def test_run_dbt_build_creates_artifact(profiles_dir, dbt_cli_profile_bare
 async def test_run_dbt_test_creates_artifact(profiles_dir, dbt_cli_profile_bare):
     @flow
     async def test_flow():
-        return run_dbt_test(
+        return await run_dbt_test(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -599,7 +599,7 @@ async def test_run_dbt_test_creates_artifact(profiles_dir, dbt_cli_profile_bare)
 async def test_run_dbt_snapshot_creates_artifact(profiles_dir, dbt_cli_profile_bare):
     @flow
     async def test_flow():
-        return run_dbt_snapshot(
+        return await run_dbt_snapshot(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -618,7 +618,7 @@ async def test_run_dbt_snapshot_creates_artifact(profiles_dir, dbt_cli_profile_b
 async def test_run_dbt_seed_creates_artifact(profiles_dir, dbt_cli_profile_bare):
     @flow
     async def test_flow():
-        return run_dbt_seed(
+        return await run_dbt_seed(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -637,7 +637,7 @@ async def test_run_dbt_seed_creates_artifact(profiles_dir, dbt_cli_profile_bare)
 async def test_run_dbt_model_creates_artifact(profiles_dir, dbt_cli_profile_bare):
     @flow
     async def test_flow():
-        return run_dbt_model(
+        return await run_dbt_model(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -658,7 +658,7 @@ async def test_run_dbt_source_freshness_creates_artifact(
 ):
     @flow
     async def test_flow():
-        return run_dbt_source_freshness(
+        return await run_dbt_source_freshness(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -685,7 +685,7 @@ async def test_run_dbt_model_creates_unsuccessful_artifact(
 ):
     @flow
     async def test_flow():
-        return run_dbt_model(
+        return await run_dbt_model(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -709,7 +709,7 @@ async def test_run_dbt_source_freshness_creates_unsuccessful_artifact(
 ):
     @flow
     async def test_flow():
-        return run_dbt_source_freshness(
+        return await run_dbt_source_freshness(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",
@@ -731,7 +731,7 @@ async def test_run_dbt_source_freshness_creates_unsuccessful_artifact(
 async def test_run_dbt_model_throws_error(profiles_dir, dbt_cli_profile_bare):
     @flow
     async def test_flow():
-        return run_dbt_model(
+        return await run_dbt_model(
             profiles_dir=profiles_dir,
             dbt_cli_profile=dbt_cli_profile_bare,
             summary_artifact_key="foo",


### PR DESCRIPTION
Closes #15647

This PR wraps each of the `run_dbt_` functions with `sync_compatible`. Not sure if that's a desirable fix, so open to suggestions.

Currently, the functions never execute (at least when called from a sync context):
```py
from dbt.cli.main import dbtRunner
from prefect import flow, task

@task
async def trigger_dbt_cli_command():
    dbtRunner().invoke(["debug"])

@flow
def main():
    trigger_dbt_cli_command()

if __name__ == "__main__":
    main()
```

```
11:32:09.538 | INFO    | prefect.engine - Created flow run 'spectral-marmoset' for flow 'main'
11:32:09.539 | INFO    | prefect.engine - View at http://127.0.0.1:4200/runs/flow-run/ea66fd5c-f10d-415c-a181-0e347a83c217
11:32:09.589 | INFO    | Flow run 'spectral-marmoset' - Finished in state Completed()
```

Adding `@sync_compatible` to `trigger_dbt_cli_command` fixes it:

```py
...
@task
@sync_compatible
async def trigger_dbt_cli_command():
...
```

```
11:32:40.622 | INFO    | prefect.engine - Created flow run 'great-zebra' for flow 'main'
11:32:40.623 | INFO    | prefect.engine - View at http://127.0.0.1:4200/runs/flow-run/2c60829a-57ed-4e80-885b-d82af2fde872
15:32:40  Running with dbt=1.8.7
15:32:40  dbt version: 1.8.7
15:32:40  python version: 3.12.7

...

11:32:41.017 | INFO    | Task run 'trigger_dbt_cli_command-211' - Finished in state Completed()
11:32:41.063 | INFO    | Flow run 'great-zebra' - Finished in state Completed()
```