### PR TITLE
fix wrong exception in lazy import __getattr__

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -117,3 +117,23 @@ class TestSignatureMismatchError:
         unpickled = cloudpickle.loads(pickled)
         assert str(sme) == str(unpickled)
         assert sme.args == unpickled.args
+
+
+class TestPrefectModuleImportExceptions:
+    def test_attribute_error_on_getattr(self):
+        import prefect
+
+        with pytest.raises(
+            AttributeError, match=r"module prefect has no attribute foo"
+        ):
+            prefect.foo
+
+    def test_import_error_on_from_import(self):
+        with pytest.raises(
+            ImportError, match=r"cannot import name 'foo' from 'prefect' \(.*\)"
+        ):
+            from prefect import foo  # noqa
+
+    def test_module_not_found_erorr_on_import(self):
+        with pytest.raises(ModuleNotFoundError, match=r"No module named 'prefect.foo'"):
+            import prefect.foo  # noqa


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
raise AttributeError instead of ModuleNotFoundError in `__getattr__` in `prefect/__init__.py` (issue https://github.com/PrefectHQ/prefect/issues/15739) 
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
