### PR TITLE
Add `_request_timeout` to Kubernetes watches

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/events.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/events.py
@@ -1,6 +1,7 @@
 import asyncio
 from typing import Dict, List, Optional
 
+import aiohttp
 import kubernetes_asyncio
 import kubernetes_asyncio.watch
 from kubernetes_asyncio.client import ApiClient, V1Pod
@@ -81,6 +82,7 @@ class KubernetesEventsReplicator:
                 namespace=self._namespace,
                 label_selector=f"job-name={self._job_name}",
                 timeout_seconds=self._timeout_seconds,
+                _request_timeout=aiohttp.ClientTimeout(),
             ):
                 phase = event["object"].status.phase
 

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -907,6 +907,7 @@ class KubernetesWorker(BaseWorker):
                         func=batch_client.list_namespaced_job,
                         namespace=namespace,
                         field_selector=f"metadata.name={job_name}",
+                        _request_timeout=aiohttp.ClientTimeout(),
                         **watch_kwargs,
                     ):
                         yield event
@@ -915,6 +916,7 @@ class KubernetesWorker(BaseWorker):
                         job_list = await batch_client.list_namespaced_job(
                             namespace=namespace,
                             field_selector=f"metadata.name={job_name}",
+                            _request_timeout=aiohttp.ClientTimeout(),
                         )
 
                         resource_version = job_list.metadata.resource_version
@@ -1118,6 +1120,7 @@ class KubernetesWorker(BaseWorker):
                 namespace=configuration.namespace,
                 label_selector=f"job-name={job_name}",
                 timeout_seconds=configuration.pod_watch_timeout_seconds,
+                _request_timeout=aiohttp.ClientTimeout(),
             ):
                 pod: V1Pod = event["object"]
                 last_pod_name = pod.metadata.name

--- a/src/integrations/prefect-kubernetes/tests/test_worker.py
+++ b/src/integrations/prefect-kubernetes/tests/test_worker.py
@@ -2301,6 +2301,7 @@ class TestKubernetesWorker:
                 func=mock_batch_client.return_value.list_namespaced_job,
                 namespace=mock.ANY,
                 field_selector=mock.ANY,
+                _request_timeout=mock.ANY,
             )
 
             if job_timeout is not None:
@@ -2322,6 +2323,7 @@ class TestKubernetesWorker:
                         namespace=mock.ANY,
                         label_selector=mock.ANY,
                         timeout_seconds=42,
+                        _request_timeout=mock.ANY,
                     ),
                     mock.call(**expected_job_call_kwargs),
                 ]
@@ -2365,11 +2367,13 @@ class TestKubernetesWorker:
                         namespace=mock.ANY,
                         label_selector=mock.ANY,
                         timeout_seconds=mock.ANY,
+                        _request_timeout=mock.ANY,
                     ),
                     mock.call(
                         func=mock_batch_client.return_value.list_namespaced_job,
                         namespace=mock.ANY,
                         field_selector=mock.ANY,
+                        _request_timeout=mock.ANY,
                         # Note: timeout_seconds is excluded here
                     ),
                 ]
@@ -2410,11 +2414,13 @@ class TestKubernetesWorker:
                         namespace="my-awesome-flows",
                         label_selector=mock.ANY,
                         timeout_seconds=60,
+                        _request_timeout=mock.ANY,
                     ),
                     mock.call(
                         func=mock_batch_client.return_value.list_namespaced_job,
                         namespace="my-awesome-flows",
                         field_selector=mock.ANY,
+                        _request_timeout=mock.ANY,
                     ),
                 ]
             )
@@ -2551,6 +2557,7 @@ class TestKubernetesWorker:
                         namespace=mock.ANY,
                         label_selector=mock.ANY,
                         timeout_seconds=mock.ANY,
+                        _request_timeout=mock.ANY,
                     ),
                     # Starts with the full timeout minus the amount we slept streaming logs
                     mock.call(
@@ -2558,6 +2565,7 @@ class TestKubernetesWorker:
                         field_selector=mock.ANY,
                         namespace=mock.ANY,
                         timeout_seconds=pytest.approx(50, 1),
+                        _request_timeout=mock.ANY,
                     ),
                 ]
             )
@@ -2776,12 +2784,14 @@ class TestKubernetesWorker:
                         func=mock_batch_client.return_value.list_namespaced_job,
                         namespace=mock.ANY,
                         field_selector="metadata.name=mock-job",
+                        _request_timeout=mock.ANY,
                     ),
                     mock.call(
                         func=mock_batch_client.return_value.list_namespaced_job,
                         namespace=mock.ANY,
                         field_selector="metadata.name=mock-job",
                         resource_version="1",
+                        _request_timeout=mock.ANY,
                     ),
                 ]
             )


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
Closes #15622

This is a workaround for an issue in `kubernetes_asyncio` in which a 5 minute request timeout is the default behavior. There is an [open PR](https://github.com/tomplus/kubernetes_asyncio/pull/337) to resolve there that seems like it'll be released in December at the earliest. In the meantime, we can override the 5 minute timeout by passing a `ClientTimeout` into `_request_timeout` on our watches.

This enables `timeout_seconds` to once again do its job of enforcing timeouts on watches.

After starting a flow run with a CPU request that was impossible to schedule on my cluster and a 20 minute timeout `pod_watch_timeout_seconds`:

```
23:44:49.737 | INFO    | prefect.flow_runs.worker - Completed submission of flow run 'd957920d-ef3d-4c26-a148-a287d037e0d8'
00:04:49.626 | ERROR   | prefect.flow_runs.worker - Job 'proud-coati-jh4qw': Pod never started.
00:04:49.657 | INFO    | prefect.flow_runs.worker - Job event 'SuccessfulCreate' at 2024-10-16 23:44:49+00:00: Created pod: proud-coati-jh4qw-dsmxl
00:04:49.661 | INFO    | prefect.flow_runs.worker - Pod event 'NotTriggerScaleUp' (92 times) at 2024-10-16 23:59:59+00:00: pod didn't trigger scale-up: 1 max node group size reached
00:04:49.666 | INFO    | prefect.flow_runs.worker - Pod event 'FailedScheduling' (5 times) at 2024-10-17 00:00:18+00:00: 0/3 nodes are available: 3 Insufficient cpu, 3 Insufficient memory. preemption: 0/3 nodes are available: 3 No preemption victims found for incoming pod.
00:04:49.830 | INFO    | prefect.flow_runs.worker - Reported flow run 'd957920d-ef3d-4c26-a148-a287d037e0d8' as crashed: Flow run infrastructure exited with non-zero status code -1.
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
