### PR TITLE
fix map typing

### DIFF
--- a/flows/deploy.py
+++ b/flows/deploy.py
@@ -1,5 +1,7 @@
+import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 import anyio
 
@@ -49,10 +51,12 @@ def main():
 
     finally:
         subprocess.check_call(
-            ["prefect", "work-pool", "delete", "test-pool"],
+            ["prefect", "--no-prompt", "work-pool", "delete", "test-pool"],
             stdout=sys.stdout,
             stderr=sys.stderr,
         )
+
+        shutil.rmtree(Path(__file__).parent.parent / "prefect-recipes")
 
 
 if __name__ == "__main__":

--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -298,10 +298,10 @@ class PrefectFutureList(list, Iterator, Generic[F]):
         wait(self, timeout=timeout)
 
     def result(
-        self,
+        self: "PrefectFutureList[R]",
         timeout: Optional[float] = None,
         raise_on_failure: bool = True,
-    ) -> List:
+    ) -> List[R]:
         """
         Get the results of all task runs associated with the futures in the list.
 

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1060,6 +1060,8 @@ class Task(Generic[P, R]):
         task runner. This call only blocks execution while the task is being submitted,
         once it is submitted, the flow function will continue executing.
 
+        This method is always used synchronously, even if the underlying user function is asynchronous.
+
         Args:
             *args: Arguments to run the task with
             return_state: Return the result of the flow run wrapped in a
@@ -1112,7 +1114,7 @@ class Task(Generic[P, R]):
             >>>
             >>> @flow
             >>> async def my_flow():
-            >>>     await my_async_task.submit()
+            >>>     my_async_task.submit()
 
             Run a sync task in an async flow
 
@@ -1217,7 +1219,7 @@ class Task(Generic[P, R]):
         wait_for: Optional[Iterable[PrefectFuture[T]]] = None,
         deferred: bool = False,
         **kwargs: Any,
-    ):
+    ) -> Union[PrefectFutureList[R], List[State[R]]]:
         """
         Submit a mapped run of the task to a worker.
 
@@ -1234,6 +1236,8 @@ class Task(Generic[P, R]):
         call blocks if given a future as input while the future is resolved. It
         also blocks while the tasks are being submitted, once they are
         submitted, the flow function will continue executing.
+
+        This method is always used synchronously, even if the underlying user function is asynchronous.
 
         Args:
             *args: Iterable and static arguments to run the tasks with

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -85,6 +85,9 @@ T = TypeVar("T")  # Generic type var for capturing the inner return type of asyn
 R = TypeVar("R")  # The return type of the user's function
 P = ParamSpec("P")  # The parameters of the task
 
+A1 = TypeVar("A1")
+A2 = TypeVar("A2")
+
 NUM_CHARS_DYNAMIC_KEY = 8
 
 logger = get_logger("tasks")
@@ -1170,44 +1173,44 @@ class Task(Generic[P, R]):
 
     @overload
     def map(
-        self: "Task[P, NoReturn]",
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> PrefectFutureList[PrefectFuture[NoReturn]]:
-        ...
-
-    @overload
-    def map(
-        self: "Task[P, Coroutine[Any, Any, T]]",
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> PrefectFutureList[PrefectFuture[T]]:
-        ...
-
-    @overload
-    def map(
-        self: "Task[P, T]",
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> PrefectFutureList[PrefectFuture[T]]:
-        ...
-
-    @overload
-    def map(
-        self: "Task[P, Coroutine[Any, Any, T]]",
-        *args: P.args,
+        self: "Task[P, Coroutine[Any, Any, R]]",
+        *args: Any,
         return_state: Literal[True],
-        **kwargs: P.kwargs,
-    ) -> PrefectFutureList[State[T]]:
+        wait_for: Optional[Iterable[PrefectFuture[T]]] = ...,
+        deferred: bool = ...,
+        **kwargs: Any,
+    ) -> List[State[R]]:
         ...
 
     @overload
     def map(
-        self: "Task[P, T]",
-        *args: P.args,
+        self: "Task[P, Coroutine[Any, Any, R]]",
+        *args: Any,
+        wait_for: Optional[Iterable[PrefectFuture]] = ...,
+        deferred: bool = ...,
+        **kwargs: Any,
+    ) -> PrefectFutureList[R]:
+        ...
+
+    @overload
+    def map(
+        self: "Task[P, R]",
+        *args: Any,
         return_state: Literal[True],
-        **kwargs: P.kwargs,
-    ) -> PrefectFutureList[State[T]]:
+        wait_for: Optional[Iterable[PrefectFuture]] = ...,
+        deferred: bool = ...,
+        **kwargs: Any,
+    ) -> List[State[R]]:
+        ...
+
+    @overload
+    def map(
+        self: "Task[P, R]",
+        *args: Any,
+        wait_for: Optional[Iterable[PrefectFuture]] = ...,
+        deferred: bool = ...,
+        **kwargs: Any,
+    ) -> PrefectFutureList[R]:
         ...
 
     def map(

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1172,7 +1172,7 @@ class Task(Generic[P, R]):
 
     @overload
     def map(
-        self: "Task[P, Coroutine[Any, Any, R]]",
+        self: "Task[P, R]",
         *args: Any,
         return_state: Literal[True],
         wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = ...,
@@ -1183,7 +1183,7 @@ class Task(Generic[P, R]):
 
     @overload
     def map(
-        self: "Task[P, Coroutine[Any, Any, R]]",
+        self: "Task[P, R]",
         *args: Any,
         wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = ...,
         deferred: bool = ...,
@@ -1213,13 +1213,13 @@ class Task(Generic[P, R]):
         ...
 
     def map(
-        self,
+        self: "Task[P, R]",
         *args: Any,
         return_state: bool = False,
         wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = None,
         deferred: bool = False,
         **kwargs: Any,
-    ) -> Union[PrefectFutureList[R], List[State[R]]]:
+    ):
         """
         Submit a mapped run of the task to a worker.
 

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -85,9 +85,6 @@ T = TypeVar("T")  # Generic type var for capturing the inner return type of asyn
 R = TypeVar("R")  # The return type of the user's function
 P = ParamSpec("P")  # The parameters of the task
 
-A1 = TypeVar("A1")
-A2 = TypeVar("A2")
-
 NUM_CHARS_DYNAMIC_KEY = 8
 
 logger = get_logger("tasks")
@@ -1186,7 +1183,7 @@ class Task(Generic[P, R]):
     def map(
         self: "Task[P, Coroutine[Any, Any, R]]",
         *args: Any,
-        wait_for: Optional[Iterable[PrefectFuture]] = ...,
+        wait_for: Optional[Iterable[PrefectFuture[T]]] = ...,
         deferred: bool = ...,
         **kwargs: Any,
     ) -> PrefectFutureList[R]:
@@ -1197,7 +1194,7 @@ class Task(Generic[P, R]):
         self: "Task[P, R]",
         *args: Any,
         return_state: Literal[True],
-        wait_for: Optional[Iterable[PrefectFuture]] = ...,
+        wait_for: Optional[Iterable[PrefectFuture[T]]] = ...,
         deferred: bool = ...,
         **kwargs: Any,
     ) -> List[State[R]]:
@@ -1207,7 +1204,7 @@ class Task(Generic[P, R]):
     def map(
         self: "Task[P, R]",
         *args: Any,
-        wait_for: Optional[Iterable[PrefectFuture]] = ...,
+        wait_for: Optional[Iterable[PrefectFuture[T]]] = ...,
         deferred: bool = ...,
         **kwargs: Any,
     ) -> PrefectFutureList[R]:
@@ -1217,7 +1214,7 @@ class Task(Generic[P, R]):
         self,
         *args: Any,
         return_state: bool = False,
-        wait_for: Optional[Iterable[PrefectFuture]] = None,
+        wait_for: Optional[Iterable[PrefectFuture[T]]] = None,
         deferred: bool = False,
         **kwargs: Any,
     ):

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1175,7 +1175,7 @@ class Task(Generic[P, R]):
         self: "Task[P, Coroutine[Any, Any, R]]",
         *args: Any,
         return_state: Literal[True],
-        wait_for: Optional[Iterable[PrefectFuture[T]]] = ...,
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = ...,
         deferred: bool = ...,
         **kwargs: Any,
     ) -> List[State[R]]:
@@ -1185,7 +1185,7 @@ class Task(Generic[P, R]):
     def map(
         self: "Task[P, Coroutine[Any, Any, R]]",
         *args: Any,
-        wait_for: Optional[Iterable[PrefectFuture[T]]] = ...,
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = ...,
         deferred: bool = ...,
         **kwargs: Any,
     ) -> PrefectFutureList[R]:
@@ -1196,7 +1196,7 @@ class Task(Generic[P, R]):
         self: "Task[P, R]",
         *args: Any,
         return_state: Literal[True],
-        wait_for: Optional[Iterable[PrefectFuture[T]]] = ...,
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = ...,
         deferred: bool = ...,
         **kwargs: Any,
     ) -> List[State[R]]:
@@ -1206,7 +1206,7 @@ class Task(Generic[P, R]):
     def map(
         self: "Task[P, R]",
         *args: Any,
-        wait_for: Optional[Iterable[PrefectFuture[T]]] = ...,
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = ...,
         deferred: bool = ...,
         **kwargs: Any,
     ) -> PrefectFutureList[R]:
@@ -1216,7 +1216,7 @@ class Task(Generic[P, R]):
         self,
         *args: Any,
         return_state: bool = False,
-        wait_for: Optional[Iterable[PrefectFuture[T]]] = None,
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = None,
         deferred: bool = False,
         **kwargs: Any,
     ) -> Union[PrefectFutureList[R], List[State[R]]]:

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1060,7 +1060,7 @@ class Task(Generic[P, R]):
         task runner. This call only blocks execution while the task is being submitted,
         once it is submitted, the flow function will continue executing.
 
-        This method is always used synchronously, even if the underlying user function is asynchronous.
+        This method is always synchronous, even if the underlying user function is asynchronous.
 
         Args:
             *args: Arguments to run the task with
@@ -1212,8 +1212,30 @@ class Task(Generic[P, R]):
     ) -> PrefectFutureList[R]:
         ...
 
+    @overload
     def map(
-        self: "Task[P, R]",
+        self: "Task[P, Coroutine[Any, Any, R]]",
+        *args: Any,
+        return_state: Literal[True],
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = ...,
+        deferred: bool = ...,
+        **kwargs: Any,
+    ) -> List[State[R]]:
+        ...
+
+    @overload
+    def map(
+        self: "Task[P, Coroutine[Any, Any, R]]",
+        *args: Any,
+        return_state: Literal[False],
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = ...,
+        deferred: bool = ...,
+        **kwargs: Any,
+    ) -> PrefectFutureList[R]:
+        ...
+
+    def map(
+        self,
         *args: Any,
         return_state: bool = False,
         wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = None,
@@ -1237,7 +1259,7 @@ class Task(Generic[P, R]):
         also blocks while the tasks are being submitted, once they are
         submitted, the flow function will continue executing.
 
-        This method is always used synchronously, even if the underlying user function is asynchronous.
+        This method is always synchronous, even if the underlying user function is asynchronous.
 
         Args:
             *args: Iterable and static arguments to run the tasks with


### PR DESCRIPTION
this PR fixes the type errors that arise during normal usage of `Task.map` by forgoing the using the `ParamSpec`, since it seems generally not possible to fully capture the user function signature and also see the correct downstream types

![image](https://github.com/user-attachments/assets/12310f07-530b-4318-bcd3-f1d569e7029f)

also conveys that `wait_for` must be an `Iterable[T | PrefectFuture[T]] | None`

the concession is that we say `*args: Any`, so we lose the user defined arguments
![image](https://github.com/user-attachments/assets/7aec4eea-6cb4-432f-9653-3fa930691333)


but I would argue that not being forced to `type ignore` or `cast` downstream everywhere is actually better than the IDE telling you the arguments of the function you already wrote


<details>
<summary>example</summary>

```python
from prefect import flow, task, unmapped


# Task that returns a regular value
@task
def my_task(x: int) -> int:
    return x * 2


# Task that returns a coroutine (asynchronous task)
@task
async def my_async_task(x: int) -> int:
    return x * 3


# Case 6: Task with multiple arguments
@task
def my_task_multi_args(x: int, y: int) -> int:
    return x * y


@flow
def my_flow():
    # Case 1: Synchronous task, return_state=False (default)
    numbers = my_task.map(range(5)).result()
    print("Synchronous task results:", numbers)

    # Case 2: Synchronous task, return_state=True
    states = my_task.map(range(5), return_state=True)
    print("Synchronous task states:", states)

    # Case 3: Asynchronous task, return_state=False (default)
    async_numbers = my_async_task.map(range(5)).result()
    print("Asynchronous task results:", async_numbers)

    # Case 4: Asynchronous task, return_state=True
    async_states = my_async_task.map(range(5), return_state=True)
    print("Asynchronous task states:", async_states)

    # Case 5: Task with unmapped argument
    @task
    def my_task_with_unmapped(x: int, y: int) -> int:
        return x + y

    numbers_with_unmapped = my_task_with_unmapped.map(range(5), unmapped(10)).result()
    print("Task with unmapped argument results:", numbers_with_unmapped)

    numbers_multi_args = my_task_multi_args.map(range(5), range(5, 10)).result()
    print("Task with multiple arguments results:", numbers_multi_args)


if __name__ == "__main__":
    my_flow()

```
</details>

the only one that remains actually "wrong" is when you map an async task, the type checker ends up thinking you have
```
(variable) async_numbers: List[Coroutine[Any, Any, int]]
```
even though its just `List[int]` but thats because async functions do return `Coroutine[Any, Any, T]`