### PR TITLE
Fix custom task run name rendering

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -310,7 +310,7 @@ class Task(Generic[P, R]):
             Callable[["TaskRunContext", Dict[str, Any]], Optional[str]]
         ] = None,
         cache_expiration: Optional[datetime.timedelta] = None,
-        task_run_name: Optional[Union[Callable[[], str], str]] = None,
+        task_run_name: Optional[Union[Callable[..., str], str]] = None,
         retries: Optional[int] = None,
         retry_delay_seconds: Optional[
             Union[
@@ -531,7 +531,7 @@ class Task(Generic[P, R]):
         cache_key_fn: Optional[
             Callable[["TaskRunContext", Dict[str, Any]], Optional[str]]
         ] = None,
-        task_run_name: Optional[Union[Callable[[], str], str, Type[NotSet]]] = NotSet,
+        task_run_name: Optional[Union[Callable[..., str], str, Type[NotSet]]] = NotSet,
         cache_expiration: Optional[datetime.timedelta] = None,
         retries: Union[int, Type[NotSet]] = NotSet,
         retry_delay_seconds: Union[
@@ -1583,7 +1583,7 @@ def task(
         Callable[["TaskRunContext", Dict[str, Any]], Optional[str]]
     ] = None,
     cache_expiration: Optional[datetime.timedelta] = None,
-    task_run_name: Optional[Union[Callable[[], str], str]] = None,
+    task_run_name: Optional[Union[Callable[..., str], str]] = None,
     retries: int = 0,
     retry_delay_seconds: Union[
         float,
@@ -1620,7 +1620,7 @@ def task(
         Callable[["TaskRunContext", Dict[str, Any]], Optional[str]], None
     ] = None,
     cache_expiration: Optional[datetime.timedelta] = None,
-    task_run_name: Optional[Union[Callable[[], str], str]] = None,
+    task_run_name: Optional[Union[Callable[..., str], str]] = None,
     retries: Optional[int] = None,
     retry_delay_seconds: Union[
         float, int, List[float], Callable[[int], List[float]], None

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -4,6 +4,7 @@ Module containing the base workflow task class and decorator - for most use case
 # This file requires type-checking with pyright because mypy does not yet support PEP612
 # See https://github.com/python/mypy/issues/8645
 
+import asyncio
 import datetime
 import inspect
 from copy import copy
@@ -309,7 +310,9 @@ class Task(Generic[P, R]):
             Callable[["TaskRunContext", Dict[str, Any]], Optional[str]]
         ] = None,
         cache_expiration: Optional[datetime.timedelta] = None,
-        task_run_name: Optional[Union[Callable[[], str], str]] = None,
+        task_run_name: Optional[
+            Union[Callable[[], str], Callable[[Dict[str, Any]], str], str]
+        ] = None,
         retries: Optional[int] = None,
         retry_delay_seconds: Optional[
             Union[
@@ -370,7 +373,7 @@ class Task(Generic[P, R]):
 
         # the task is considered async if its function is async or an async
         # generator
-        self.isasync = inspect.iscoroutinefunction(
+        self.isasync = asyncio.iscoroutinefunction(
             self.fn
         ) or inspect.isasyncgenfunction(self.fn)
 
@@ -530,7 +533,9 @@ class Task(Generic[P, R]):
         cache_key_fn: Optional[
             Callable[["TaskRunContext", Dict[str, Any]], Optional[str]]
         ] = None,
-        task_run_name: Optional[Union[Callable[[], str], str, Type[NotSet]]] = NotSet,
+        task_run_name: Optional[
+            Union[Callable[[], str], Callable[[Dict[str, Any]], str], str, Type[NotSet]]
+        ] = NotSet,
         cache_expiration: Optional[datetime.timedelta] = None,
         retries: Union[int, Type[NotSet]] = NotSet,
         retry_delay_seconds: Union[
@@ -726,7 +731,6 @@ class Task(Generic[P, R]):
         wait_for: Optional[Iterable[PrefectFuture]] = None,
         extra_task_inputs: Optional[Dict[str, Set[TaskRunInput]]] = None,
         deferred: bool = False,
-        custom_task_run_name: Optional[str] = None,
     ) -> TaskRun:
         from prefect.utilities.engine import (
             _dynamic_key_for_task_run,
@@ -743,14 +747,14 @@ class Task(Generic[P, R]):
             client = get_client()
 
         async with client:
-            task_run_name = custom_task_run_name or self.name
             if not flow_run_context:
                 dynamic_key = f"{self.task_key}-{str(uuid4().hex)}"
+                task_run_name = self.name
             else:
                 dynamic_key = _dynamic_key_for_task_run(
                     context=flow_run_context, task=self
                 )
-                task_run_name += f"-{str(dynamic_key)[:3]}"
+                task_run_name = f"{self.name}-{dynamic_key}"
 
             if deferred:
                 state = Scheduled()
@@ -1060,6 +1064,8 @@ class Task(Generic[P, R]):
         task runner. This call only blocks execution while the task is being submitted,
         once it is submitted, the flow function will continue executing.
 
+        This method is always synchronous, even if the underlying user function is asynchronous.
+
         Args:
             *args: Arguments to run the task with
             return_state: Return the result of the flow run wrapped in a
@@ -1112,7 +1118,7 @@ class Task(Generic[P, R]):
             >>>
             >>> @flow
             >>> async def my_flow():
-            >>>     await my_async_task.submit()
+            >>>     my_async_task.submit()
 
             Run a sync task in an async flow
 
@@ -1170,51 +1176,73 @@ class Task(Generic[P, R]):
 
     @overload
     def map(
-        self: "Task[P, NoReturn]",
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> PrefectFutureList[PrefectFuture[NoReturn]]:
-        ...
-
-    @overload
-    def map(
-        self: "Task[P, Coroutine[Any, Any, T]]",
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> PrefectFutureList[PrefectFuture[T]]:
-        ...
-
-    @overload
-    def map(
-        self: "Task[P, T]",
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> PrefectFutureList[PrefectFuture[T]]:
-        ...
-
-    @overload
-    def map(
-        self: "Task[P, Coroutine[Any, Any, T]]",
-        *args: P.args,
+        self: "Task[P, R]",
+        *args: Any,
         return_state: Literal[True],
-        **kwargs: P.kwargs,
-    ) -> PrefectFutureList[State[T]]:
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = ...,
+        deferred: bool = ...,
+        **kwargs: Any,
+    ) -> List[State[R]]:
         ...
 
     @overload
     def map(
-        self: "Task[P, T]",
-        *args: P.args,
+        self: "Task[P, R]",
+        *args: Any,
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = ...,
+        deferred: bool = ...,
+        **kwargs: Any,
+    ) -> PrefectFutureList[R]:
+        ...
+
+    @overload
+    def map(
+        self: "Task[P, R]",
+        *args: Any,
         return_state: Literal[True],
-        **kwargs: P.kwargs,
-    ) -> PrefectFutureList[State[T]]:
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = ...,
+        deferred: bool = ...,
+        **kwargs: Any,
+    ) -> List[State[R]]:
+        ...
+
+    @overload
+    def map(
+        self: "Task[P, R]",
+        *args: Any,
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = ...,
+        deferred: bool = ...,
+        **kwargs: Any,
+    ) -> PrefectFutureList[R]:
+        ...
+
+    @overload
+    def map(
+        self: "Task[P, Coroutine[Any, Any, R]]",
+        *args: Any,
+        return_state: Literal[True],
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = ...,
+        deferred: bool = ...,
+        **kwargs: Any,
+    ) -> List[State[R]]:
+        ...
+
+    @overload
+    def map(
+        self: "Task[P, Coroutine[Any, Any, R]]",
+        *args: Any,
+        return_state: Literal[False],
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = ...,
+        deferred: bool = ...,
+        **kwargs: Any,
+    ) -> PrefectFutureList[R]:
         ...
 
     def map(
         self,
         *args: Any,
         return_state: bool = False,
-        wait_for: Optional[Iterable[PrefectFuture]] = None,
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = None,
         deferred: bool = False,
         **kwargs: Any,
     ):
@@ -1234,6 +1262,8 @@ class Task(Generic[P, R]):
         call blocks if given a future as input while the future is resolved. It
         also blocks while the tasks are being submitted, once they are
         submitted, the flow function will continue executing.
+
+        This method is always synchronous, even if the underlying user function is asynchronous.
 
         Args:
             *args: Iterable and static arguments to run the tasks with
@@ -1436,7 +1466,6 @@ class Task(Generic[P, R]):
             >>>     y = task_2.apply_async(wait_for=[x])
 
         """
-        from prefect.utilities.engine import _resolve_custom_task_run_name
         from prefect.utilities.visualization import (
             VisualizationUnsupportedError,
             get_task_viz_tracker,
@@ -1459,9 +1488,8 @@ class Task(Generic[P, R]):
                 deferred=True,
                 wait_for=wait_for,
                 extra_task_inputs=dependencies,
-                custom_task_run_name=_resolve_custom_task_run_name(self, parameters),  # type: ignore
             )
-        )
+        )  # type: ignore
 
         from prefect.utilities.engine import emit_task_run_state_change_event
 
@@ -1559,7 +1587,9 @@ def task(
         Callable[["TaskRunContext", Dict[str, Any]], Optional[str]]
     ] = None,
     cache_expiration: Optional[datetime.timedelta] = None,
-    task_run_name: Optional[Union[Callable[[], str], str]] = None,
+    task_run_name: Optional[
+        Union[Callable[[], str], Callable[[Dict[str, Any]], str], str]
+    ] = None,
     retries: int = 0,
     retry_delay_seconds: Union[
         float,
@@ -1596,7 +1626,9 @@ def task(
         Callable[["TaskRunContext", Dict[str, Any]], Optional[str]], None
     ] = None,
     cache_expiration: Optional[datetime.timedelta] = None,
-    task_run_name: Optional[Union[Callable[[], str], str]] = None,
+    task_run_name: Optional[
+        Union[Callable[[], str], Callable[[Dict[str, Any]], str], str]
+    ] = None,
     retries: Optional[int] = None,
     retry_delay_seconds: Union[
         float, int, List[float], Callable[[int], List[float]], None

--- a/tests/public/flows/test_flow_with_mapped_tasks.py
+++ b/tests/public/flows/test_flow_with_mapped_tasks.py
@@ -46,9 +46,9 @@ async def test_flow_with_mapped_tasks():
         {"number": 3, "is_even": False},
         {"number": 4, "is_even": True},
     ]
-    assert names == [
+    assert set(names) == {
         "increment_number - input: 1",
         "increment_number - input: 2",
         "wildcard!",
         "wildcard!",
-    ]
+    }

--- a/tests/public/flows/test_flow_with_mapped_tasks.py
+++ b/tests/public/flows/test_flow_with_mapped_tasks.py
@@ -1,34 +1,40 @@
 """This is a regression test for https://github.com/PrefectHQ/prefect/issues/15747"""
 
-from typing import Tuple
+from typing import Any
 
 from prefect import flow, task
-from prefect.client.schemas.objects import FlowRun
-from prefect.context import get_run_context
 from prefect.runtime import task_run
+
+names = []
 
 
 def generate_task_run_name(parameters: dict) -> str:
-    return f'{task_run.task_name} - input: {parameters["input"]["number"]}'
+    names.append(f'{task_run.task_name} - input: {parameters["input"]["number"]}')
+    return names[-1]
+
+
+def alternate_task_run_name() -> str:
+    names.append("wildcard!")
+    return names[-1]
 
 
 @task(log_prints=True, task_run_name=generate_task_run_name)
 def increment_number(input: dict) -> dict:
     input["number"] += 1
-    input["name"] = get_run_context().task_run.name
-    print(f"increment_number - result: {input['number']}")
     return input
 
 
 @flow
-def double_increment_flow() -> Tuple[list, FlowRun]:
+def double_increment_flow() -> list[dict[str, Any]]:
     inputs = [
         {"number": 1, "is_even": False},
         {"number": 2, "is_even": True},
     ]
 
     first_increment = increment_number.map(input=inputs)
-    second_increment = increment_number.map(input=first_increment)
+    second_increment = increment_number.with_options(
+        task_run_name=alternate_task_run_name
+    ).map(input=first_increment)
     final_results = second_increment.result()
     print(f"Final results: {final_results}")
     return final_results
@@ -37,6 +43,12 @@ def double_increment_flow() -> Tuple[list, FlowRun]:
 async def test_flow_with_mapped_tasks():
     results = double_increment_flow()
     assert results == [
-        {"number": 3, "is_even": False, "name": "increment_number - input: 2"},
-        {"number": 4, "is_even": True, "name": "increment_number - input: 3"},
+        {"number": 3, "is_even": False},
+        {"number": 4, "is_even": True},
+    ]
+    assert names == [
+        "increment_number - input: 1",
+        "increment_number - input: 2",
+        "wildcard!",
+        "wildcard!",
     ]

--- a/tests/public/flows/test_flow_with_mapped_tasks.py
+++ b/tests/public/flows/test_flow_with_mapped_tasks.py
@@ -1,0 +1,42 @@
+"""This is a regression test for https://github.com/PrefectHQ/prefect/issues/15747"""
+
+from typing import Tuple
+
+from prefect import flow, task
+from prefect.client.schemas.objects import FlowRun
+from prefect.context import get_run_context
+from prefect.runtime import task_run
+
+
+def generate_task_run_name() -> str:
+    return f'{task_run.task_name} - input: {task_run.parameters["input"]["number"]}'
+
+
+@task(log_prints=True, task_run_name=generate_task_run_name)
+def increment_number(input: dict) -> dict:
+    input["number"] += 1
+    input["name"] = get_run_context().task_run.name
+    print(f"increment_number - result: {input['number']}")
+    return input
+
+
+@flow
+def double_increment_flow() -> Tuple[list, FlowRun]:
+    inputs = [
+        {"number": 1, "is_even": False},
+        {"number": 2, "is_even": True},
+    ]
+
+    first_increment = increment_number.map(input=inputs)
+    second_increment = increment_number.map(input=first_increment)
+    final_results = second_increment.result()
+    print(f"Final results: {final_results}")
+    return final_results
+
+
+async def test_flow_with_mapped_tasks():
+    results = double_increment_flow()
+    assert results == [
+        {"number": 3, "is_even": False, "name": "increment_number - input: 2"},
+        {"number": 4, "is_even": True, "name": "increment_number - input: 3"},
+    ]

--- a/tests/public/flows/test_flow_with_mapped_tasks.py
+++ b/tests/public/flows/test_flow_with_mapped_tasks.py
@@ -8,8 +8,8 @@ from prefect.context import get_run_context
 from prefect.runtime import task_run
 
 
-def generate_task_run_name() -> str:
-    return f'{task_run.task_name} - input: {task_run.parameters["input"]["number"]}'
+def generate_task_run_name(parameters: dict) -> str:
+    return f'{task_run.task_name} - input: {parameters["input"]["number"]}'
 
 
 @task(log_prints=True, task_run_name=generate_task_run_name)


### PR DESCRIPTION
<details>
<summary>MRE i was using</summary>

```python
from random import uniform
from time import sleep
from typing import Any

from prefect import flow, task
from prefect.runtime import task_run


def generate_task_run_name(parameters: dict[str, Any]) -> str:
    """previously we got parameters here from prefect.runtime.task_run.parameters, but as discussed below the values are not guaranteed to be resolved"""
    return f'{task_run.task_name} - input["val"]:  {parameters["input"]["val"]}'


@task(log_prints=True)
def pre_task() -> bool:
    return True


@task(log_prints=True, task_run_name=generate_task_run_name)
def task_1(input: dict[str, Any]) -> dict[str, Any]:
    input_val = input["val"]
    input["val"] = input_val + 1
    print(f'task_1 - input["val"]:  {input_val}, output:  {input}')

    sleep(uniform(1, 5))
    return input


@task(log_prints=True, task_run_name=generate_task_run_name)
def task_2(input: dict[str, Any]) -> dict[str, Any]:
    input_val = input["val"]
    input["val"] = input_val * 10
    print(f'task_2 - input["val"]:  {input_val}, output:  {input}')

    sleep(uniform(1, 5))
    return input


@task(log_prints=True, task_run_name=generate_task_run_name)
def task_3(input: dict[str, Any]) -> None:
    input_val = input["val"]
    print(f'task_3 - input["val"]: {input_val}')

    sleep(uniform(1, 5))
    return


@flow
def my_flow() -> None:
    pre_task()
    inputs: list[dict[str, Any]] = [
        {"val": 1, "something_else": True},
        {"val": 2, "something_else": True},
        {"val": 3, "something_else": True},
        {"val": 4, "something_else": True},
        {"val": 5, "something_else": True},
        {"val": 6, "something_else": True},
        {"val": 7, "something_else": True},
        {"val": 8, "something_else": True},
    ]

    result_1 = task_1.map(input=inputs)
    result_2 = task_2.map(input=result_1)
    final_result = task_3.map(input=result_2)

    final_result.wait()


if __name__ == "__main__":
    my_flow()

```

</details>

closes #15747

the issue (which https://github.com/PrefectHQ/prefect/pull/15770 does not address) is that the `TaskRunContext` may receive a non-resolved dict of `parameters` when it is created, and the `TaskRunContext` is treated as immutable. this itself feels like an incongruence to address - but this PR is mostly concerned with the custom task run name

with CSTRO I'm not sure that we can move the future resolution before the creation / entrance of the `TaskRunContext` (happy to talk this through sync) while also correctly handling `UpstreamTaskError` exceptions, so in addition to fixing the templating syntax like `task_run_name="using {input[val]}"` by deferring the attempt to render the custom name, this PR proposes a new DX when providing a callable `task_run_name` that needs access to the rendered `parameters`

```python
def generate_task_run_name(parameters: dict) -> str:
    return f'{task_run.task_name} - input: {parameters["input"]["number"]}'
```

if the user provides a function that accepts a `parameters` dict, then we will populate it with the dict of parameters, which at that point is guaranteed to be resolved

if we are okay with this slight pivot, then I think we should deprecate / remove the `get_parameters` from `runtime.task_run`, since it does not currently work for cases where futures need to be resolved
