### PR TITLE
Create worker, tasks, testing, and UI settings models

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,8 @@ markers =
 
 env =
     # NOTE: Additional Prefect setting values are set dynamically in conftest.py
-    PREFECT_TEST_MODE = 1
-    PREFECT_UNIT_TEST_MODE = 1
+    PREFECT_TESTING_TEST_MODE = 1
+    PREFECT_TESTING_UNIT_TEST_MODE = 1
     PREFECT_SERVER_LOGGING_LEVEL = DEBUG
 
 asyncio_mode = auto

--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -39,6 +39,7 @@ class PrefectBaseModel(BaseModel):
         extra=(
             "ignore"
             if os.getenv("PREFECT_TEST_MODE", "0").lower() not in ["true", "1"]
+            and os.getenv("PREFECT_TESTING_TEST_MODE", "0").lower() not in ["true", "1"]
             else "forbid"
         ),
     )

--- a/src/prefect/client/cloud.py
+++ b/src/prefect/client/cloud.py
@@ -19,7 +19,7 @@ from prefect.settings import (
     PREFECT_API_KEY,
     PREFECT_API_URL,
     PREFECT_CLOUD_API_URL,
-    PREFECT_UNIT_TEST_MODE,
+    PREFECT_TESTING_UNIT_TEST_MODE,
 )
 
 PARSE_API_URL_REGEX = re.compile(r"accounts/(.{36})/workspaces/(.{36})")
@@ -68,7 +68,7 @@ class CloudClient:
         httpx_settings["headers"].setdefault("Authorization", f"Bearer {api_key}")
 
         httpx_settings.setdefault("base_url", host)
-        if not PREFECT_UNIT_TEST_MODE.value():
+        if not PREFECT_TESTING_UNIT_TEST_MODE.value():
             httpx_settings.setdefault("follow_redirects", True)
         self._client = PrefectHttpxAsyncClient(
             **httpx_settings, enable_csrf_support=False

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -133,7 +133,7 @@ from prefect.settings import (
     PREFECT_CLIENT_CSRF_SUPPORT_ENABLED,
     PREFECT_CLOUD_API_URL,
     PREFECT_SERVER_ALLOW_EPHEMERAL_MODE,
-    PREFECT_UNIT_TEST_MODE,
+    PREFECT_TESTING_UNIT_TEST_MODE,
 )
 
 if TYPE_CHECKING:
@@ -385,7 +385,7 @@ class PrefectClient:
             ),
         )
 
-        if not PREFECT_UNIT_TEST_MODE:
+        if not PREFECT_TESTING_UNIT_TEST_MODE:
             httpx_settings.setdefault("follow_redirects", True)
 
         enable_csrf_support = (
@@ -3594,7 +3594,7 @@ class SyncPrefectClient:
             ),
         )
 
-        if not PREFECT_UNIT_TEST_MODE:
+        if not PREFECT_TESTING_UNIT_TEST_MODE:
             httpx_settings.setdefault("follow_redirects", True)
 
         enable_csrf_support = (

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -73,8 +73,8 @@ from prefect.settings import (
     PREFECT_DEFAULT_WORK_POOL_NAME,
     PREFECT_FLOW_DEFAULT_RETRIES,
     PREFECT_FLOW_DEFAULT_RETRY_DELAY_SECONDS,
+    PREFECT_TESTING_UNIT_TEST_MODE,
     PREFECT_UI_URL,
-    PREFECT_UNIT_TEST_MODE,
 )
 from prefect.states import State
 from prefect.task_runners import TaskRunner, ThreadPoolTaskRunner
@@ -1371,7 +1371,7 @@ class Flow(Generic[P, R]):
             visualize_task_dependencies,
         )
 
-        if not PREFECT_UNIT_TEST_MODE:
+        if not PREFECT_TESTING_UNIT_TEST_MODE:
             warnings.warn(
                 "`flow.visualize()` will execute code inside of your flow that is not"
                 " decorated with `@task` or `@flow`."

--- a/src/prefect/logging/logging.yml
+++ b/src/prefect/logging/logging.yml
@@ -97,7 +97,7 @@ loggers:
         level: "${PREFECT_LOGGING_LEVEL}"
 
     prefect._internal:
-        level: "${PREFECT_LOGGING_INTERNAL_LEVEL}"
+        level: "${PREFECT_INTERNAL_LOGGING_LEVEL}"
         propagate: false
         handlers: [debug]
 

--- a/src/prefect/server/database/configurations.py
+++ b/src/prefect/server/database/configurations.py
@@ -26,7 +26,7 @@ from prefect.settings import (
     PREFECT_API_DATABASE_TIMEOUT,
     PREFECT_SQLALCHEMY_MAX_OVERFLOW,
     PREFECT_SQLALCHEMY_POOL_SIZE,
-    PREFECT_UNIT_TEST_MODE,
+    PREFECT_TESTING_UNIT_TEST_MODE,
 )
 from prefect.utilities.asyncutils import add_event_loop_shutdown_callback
 
@@ -421,7 +421,7 @@ class AioSqliteConfiguration(BaseDatabaseConfiguration):
         # before returning and raising an error
         # setting the value very high allows for more 'concurrency'
         # without running into errors, but may result in slow api calls
-        if PREFECT_UNIT_TEST_MODE.value() is True:
+        if PREFECT_TESTING_UNIT_TEST_MODE.value() is True:
             cursor.execute("PRAGMA busy_timeout = 5000;")  # 5s
         else:
             cursor.execute("PRAGMA busy_timeout = 60000;")  # 60s

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -64,6 +64,7 @@ class PrefectBaseModel(BaseModel):
         extra=(
             "ignore"
             if os.getenv("PREFECT_TEST_MODE", "0").lower() not in ["true", "1"]
+            and os.getenv("PREFECT_TESTING_TEST_MODE", "0").lower() not in ["true", "1"]
             else "forbid"
         ),
     )

--- a/src/prefect/settings/legacy.py
+++ b/src/prefect/settings/legacy.py
@@ -44,9 +44,15 @@ class Setting:
         return self._default
 
     def value(self: Self) -> Any:
-        if self.name == "PREFECT_TEST_SETTING":
-            if "PREFECT_TEST_MODE" in os.environ:
-                return get_current_settings().test_setting
+        if (
+            self.name == "PREFECT_TEST_SETTING"
+            or self.name == "PREFECT_TESTING_TEST_SETTING"
+        ):
+            if (
+                "PREFECT_TEST_MODE" in os.environ
+                or "PREFECT_TESTING_TEST_MODE" in os.environ
+            ):
+                return get_current_settings().testing.test_setting
             else:
                 return None
 

--- a/src/prefect/settings/models/api.py
+++ b/src/prefect/settings/models/api.py
@@ -39,7 +39,3 @@ class APISettings(PrefectBaseSettings):
         default=60.0,
         description="The default timeout for requests to the API",
     )
-    default_limit: int = Field(
-        default=200,
-        description="The default limit applied to queries that can return multiple objects, such as `POST /flow_runs/filter`.",
-    )

--- a/src/prefect/settings/models/internal.py
+++ b/src/prefect/settings/models/internal.py
@@ -1,0 +1,21 @@
+from pydantic import AliasChoices, AliasPath, Field
+from pydantic_settings import SettingsConfigDict
+
+from prefect.settings.base import PrefectBaseSettings
+from prefect.types import LogLevel
+
+
+class InternalSettings(PrefectBaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="PREFECT_INTERNAL_", env_file=".env", extra="ignore"
+    )
+
+    logging_level: LogLevel = Field(
+        default="ERROR",
+        description="The default logging level for Prefect's internal machinery loggers.",
+        validation_alias=AliasChoices(
+            AliasPath("logging_level"),
+            "prefect_internal_logging_level",
+            "prefect_logging_internal_level",
+        ),
+    )

--- a/src/prefect/settings/models/server/api.py
+++ b/src/prefect/settings/models/server/api.py
@@ -25,6 +25,16 @@ class ServerAPISettings(PrefectBaseSettings):
         description="The API's port address (defaults to `4200`).",
     )
 
+    default_limit: int = Field(
+        default=200,
+        description="The default limit applied to queries that can return multiple objects, such as `POST /flow_runs/filter`.",
+        validation_alias=AliasChoices(
+            AliasPath("default_limit"),
+            "prefect_server_api_default_limit",
+            "prefect_api_default_limit",
+        ),
+    )
+
     keepalive_timeout: int = Field(
         default=5,
         description="""

--- a/src/prefect/settings/models/server/database.py
+++ b/src/prefect/settings/models/server/database.py
@@ -144,6 +144,26 @@ class ServerDatabaseSettings(PrefectBaseSettings):
         ),
     )
 
+    sqlalchemy_pool_size: Optional[int] = Field(
+        default=None,
+        description="Controls connection pool size when using a PostgreSQL database with the Prefect API. If not set, the default SQLAlchemy pool size will be used.",
+        validation_alias=AliasChoices(
+            AliasPath("sqlalchemy_pool_size"),
+            "prefect_server_database_sqlalchemy_pool_size",
+            "prefect_sqlalchemy_pool_size",
+        ),
+    )
+
+    sqlalchemy_max_overflow: Optional[int] = Field(
+        default=None,
+        description="Controls maximum overflow of the connection pool when using a PostgreSQL database with the Prefect API. If not set, the default SQLAlchemy maximum overflow value will be used.",
+        validation_alias=AliasChoices(
+            AliasPath("sqlalchemy_max_overflow"),
+            "prefect_server_database_sqlalchemy_max_overflow",
+            "prefect_sqlalchemy_max_overflow",
+        ),
+    )
+
     @model_validator(mode="after")
     def emit_warnings(self) -> Self:  # noqa: F821
         """More post-hoc validation of settings, including warnings for misconfigurations."""

--- a/src/prefect/settings/models/server/deployments.py
+++ b/src/prefect/settings/models/server/deployments.py
@@ -1,0 +1,24 @@
+from pydantic import AliasChoices, AliasPath, Field
+from pydantic_settings import SettingsConfigDict
+
+from prefect.settings.base import PrefectBaseSettings
+
+
+class ServerDeploymentsSettings(PrefectBaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="PREFECT_SERVER_DEPLOYMENTS_", env_file=".env", extra="ignore"
+    )
+
+    concurrency_slot_wait_seconds: float = Field(
+        default=30.0,
+        ge=0.0,
+        description=(
+            "The number of seconds to wait before retrying when a deployment flow run"
+            " cannot secure a concurrency slot from the server."
+        ),
+        validation_alias=AliasChoices(
+            AliasPath("concurrency_slot_wait_seconds"),
+            "prefect_server_deployments_concurrency_slot_wait_seconds",
+            "prefect_deployment_concurrency_slot_wait_seconds",
+        ),
+    )

--- a/src/prefect/settings/models/server/root.py
+++ b/src/prefect/settings/models/server/root.py
@@ -9,11 +9,13 @@ from prefect.types import LogLevel
 
 from .api import ServerAPISettings
 from .database import ServerDatabaseSettings
+from .deployments import ServerDeploymentsSettings
 from .ephemeral import ServerEphemeralSettings
 from .events import ServerEventsSettings
 from .flow_run_graph import ServerFlowRunGraphSettings
 from .services import ServerServicesSettings
 from .tasks import ServerTasksSettings
+from .ui import ServerUISettings
 
 
 class ServerSettings(PrefectBaseSettings):
@@ -107,10 +109,13 @@ class ServerSettings(PrefectBaseSettings):
         default_factory=ServerAPISettings,
         description="Settings for controlling API server behavior",
     )
-
     database: ServerDatabaseSettings = Field(
         default_factory=ServerDatabaseSettings,
         description="Settings for controlling server database behavior",
+    )
+    deployments: ServerDeploymentsSettings = Field(
+        default_factory=ServerDeploymentsSettings,
+        description="Settings for controlling server deployments behavior",
     )
     ephemeral: ServerEphemeralSettings = Field(
         default_factory=ServerEphemeralSettings,
@@ -131,4 +136,8 @@ class ServerSettings(PrefectBaseSettings):
     tasks: ServerTasksSettings = Field(
         default_factory=ServerTasksSettings,
         description="Settings for controlling server tasks behavior",
+    )
+    ui: ServerUISettings = Field(
+        default_factory=ServerUISettings,
+        description="Settings for controlling server UI behavior",
     )

--- a/src/prefect/settings/models/server/ui.py
+++ b/src/prefect/settings/models/server/ui.py
@@ -1,0 +1,52 @@
+from typing import Optional
+
+from pydantic import AliasChoices, AliasPath, Field
+from pydantic_settings import SettingsConfigDict
+
+from prefect.settings.base import PrefectBaseSettings
+
+
+class ServerUISettings(PrefectBaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="PREFECT_SERVER_UI_", env_file=".env", extra="ignore"
+    )
+
+    enabled: bool = Field(
+        default=True,
+        description="Whether or not to serve the Prefect UI.",
+        validation_alias=AliasChoices(
+            AliasPath("enabled"),
+            "prefect_server_ui_enabled",
+            "prefect_ui_enabled",
+        ),
+    )
+
+    api_url: Optional[str] = Field(
+        default=None,
+        description="The connection url for communication from the UI to the API. Defaults to `PREFECT_API_URL` if set. Otherwise, the default URL is generated from `PREFECT_SERVER_API_HOST` and `PREFECT_SERVER_API_PORT`.",
+        validation_alias=AliasChoices(
+            AliasPath("api_url"),
+            "prefect_server_ui_api_url",
+            "prefect_ui_api_url",
+        ),
+    )
+
+    serve_base: str = Field(
+        default="/",
+        description="The base URL path to serve the Prefect UI from.",
+        validation_alias=AliasChoices(
+            AliasPath("serve_base"),
+            "prefect_server_ui_serve_base",
+            "prefect_ui_serve_base",
+        ),
+    )
+
+    static_directory: Optional[str] = Field(
+        default=None,
+        description="The directory to serve static files from. This should be used when running into permissions issues when attempting to serve the UI from the default directory (for example when running in a Docker container).",
+        validation_alias=AliasChoices(
+            AliasPath("static_directory"),
+            "prefect_server_ui_static_directory",
+            "prefect_ui_static_directory",
+        ),
+    )

--- a/src/prefect/settings/models/tasks.py
+++ b/src/prefect/settings/models/tasks.py
@@ -1,0 +1,91 @@
+from typing import Optional, Union
+
+from pydantic import AliasChoices, AliasPath, Field
+from pydantic_settings import SettingsConfigDict
+
+from prefect.settings.base import PrefectBaseSettings
+
+
+class TasksRunnerSettings(PrefectBaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="PREFECT_TASKS_RUNNER_", env_file=".env", extra="ignore"
+    )
+
+    thread_pool_max_workers: Optional[int] = Field(
+        default=None,
+        gt=0,
+        description="The maximum number of workers for ThreadPoolTaskRunner.",
+        validation_alias=AliasChoices(
+            AliasPath("thread_pool_max_workers"),
+            "prefect_tasks_runner_thread_pool_max_workers",
+            "prefect_task_runner_thread_pool_max_workers",
+        ),
+    )
+
+
+class TasksSchedulingSettings(PrefectBaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="PREFECT_TASKS_SCHEDULING_", env_file=".env", extra="ignore"
+    )
+
+    default_storage_block: Optional[str] = Field(
+        default=None,
+        description="The `block-type/block-document` slug of a block to use as the default storage for autonomous tasks.",
+        validation_alias=AliasChoices(
+            AliasPath("default_storage_block"),
+            "prefect_tasks_scheduling_default_storage_block",
+            "prefect_task_scheduling_default_storage_block",
+        ),
+    )
+
+    delete_failed_submissions: bool = Field(
+        default=True,
+        description="Whether or not to delete failed task submissions from the database.",
+        validation_alias=AliasChoices(
+            AliasPath("delete_failed_submissions"),
+            "prefect_tasks_scheduling_delete_failed_submissions",
+            "prefect_task_scheduling_delete_failed_submissions",
+        ),
+    )
+
+
+class TasksSettings(PrefectBaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="PREFECT_TASKS_", env_file=".env", extra="ignore"
+    )
+
+    refresh_cache: bool = Field(
+        default=False,
+        description="If `True`, enables a refresh of cached results: re-executing the task will refresh the cached results.",
+    )
+
+    default_retries: int = Field(
+        default=0,
+        ge=0,
+        description="This value sets the default number of retries for all tasks.",
+        validation_alias=AliasChoices(
+            AliasPath("default_retries"),
+            "prefect_tasks_default_retries",
+            "prefect_task_default_retries",
+        ),
+    )
+
+    default_retry_delay_seconds: Union[int, float, list[float]] = Field(
+        default=0,
+        description="This value sets the default retry delay seconds for all tasks.",
+        validation_alias=AliasChoices(
+            AliasPath("default_retry_delay_seconds"),
+            "prefect_tasks_default_retry_delay_seconds",
+            "prefect_task_default_retry_delay_seconds",
+        ),
+    )
+
+    runner: TasksRunnerSettings = Field(
+        default_factory=TasksRunnerSettings,
+        description="Settings for controlling task runner behavior",
+    )
+
+    scheduling: TasksSchedulingSettings = Field(
+        default_factory=TasksSchedulingSettings,
+        description="Settings for controlling client-side task scheduling behavior",
+    )

--- a/src/prefect/settings/models/testing.py
+++ b/src/prefect/settings/models/testing.py
@@ -1,0 +1,52 @@
+from typing import Any, Optional
+
+from pydantic import AliasChoices, AliasPath, Field
+from pydantic_settings import SettingsConfigDict
+
+from prefect.settings.base import PrefectBaseSettings
+
+
+class TestingSettings(PrefectBaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="PREFECT_TESTING_", env_file=".env", extra="ignore"
+    )
+
+    test_mode: bool = Field(
+        default=False,
+        description="If `True`, places the API in test mode. This may modify behavior to facilitate testing.",
+        validation_alias=AliasChoices(
+            AliasPath("test_mode"),
+            "prefect_testing_test_mode",
+            "prefect_test_mode",
+        ),
+    )
+
+    unit_test_mode: bool = Field(
+        default=False,
+        description="This setting only exists to facilitate unit testing. If `True`, code is executing in a unit test context. Defaults to `False`.",
+        validation_alias=AliasChoices(
+            AliasPath("unit_test_mode"),
+            "prefect_testing_unit_test_mode",
+            "prefect_unit_test_mode",
+        ),
+    )
+
+    unit_test_loop_debug: bool = Field(
+        default=True,
+        description="If `True` turns on debug mode for the unit testing event loop.",
+        validation_alias=AliasChoices(
+            AliasPath("unit_test_loop_debug"),
+            "prefect_testing_unit_test_loop_debug",
+            "prefect_unit_test_loop_debug",
+        ),
+    )
+
+    test_setting: Optional[Any] = Field(
+        default="FOO",
+        description="This setting only exists to facilitate unit testing. If in test mode, this setting will return its value. Otherwise, it returns `None`.",
+        validation_alias=AliasChoices(
+            AliasPath("test_setting"),
+            "prefect_testing_test_setting",
+            "prefect_test_setting",
+        ),
+    )

--- a/src/prefect/settings/models/worker.py
+++ b/src/prefect/settings/models/worker.py
@@ -1,0 +1,46 @@
+from pydantic import Field
+from pydantic_settings import SettingsConfigDict
+
+from prefect.settings.base import PrefectBaseSettings
+
+
+class WorkerWebserverSettings(PrefectBaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="PREFECT_WORKER_WEBSERVER_", env_file=".env", extra="ignore"
+    )
+
+    host: str = Field(
+        default="0.0.0.0",
+        description="The host address the worker's webserver should bind to.",
+    )
+
+    port: int = Field(
+        default=8080,
+        description="The port the worker's webserver should bind to.",
+    )
+
+
+class WorkerSettings(PrefectBaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="PREFECT_WORKER_", env_file=".env", extra="ignore"
+    )
+
+    heartbeat_seconds: float = Field(
+        default=30,
+        description="Number of seconds a worker should wait between sending a heartbeat.",
+    )
+
+    query_seconds: float = Field(
+        default=10,
+        description="Number of seconds a worker should wait between queries for scheduled work.",
+    )
+
+    prefetch_seconds: float = Field(
+        default=10,
+        description="The number of seconds into the future a worker should query for scheduled work.",
+    )
+
+    webserver: WorkerWebserverSettings = Field(
+        default_factory=WorkerWebserverSettings,
+        description="Settings for a worker's webserver",
+    )

--- a/src/prefect/settings/sources.py
+++ b/src/prefect/settings/sources.py
@@ -142,7 +142,12 @@ class ProfileSettingsTomlLoader(PydanticBaseSettingsSource):
 
 def _is_test_mode() -> bool:
     """Check if the current process is in test mode."""
-    return bool(os.getenv("PREFECT_TEST_MODE") or os.getenv("PREFECT_UNIT_TEST_MODE"))
+    return bool(
+        os.getenv("PREFECT_TEST_MODE")
+        or os.getenv("PREFECT_UNIT_TEST_MODE")
+        or os.getenv("PREFECT_TESTING_UNIT_TEST_MODE")
+        or os.getenv("PREFECT_TESTING_TEST_MODE")
+    )
 
 
 def _get_profiles_path() -> Path:

--- a/tests/client/test_cloud_client.py
+++ b/tests/client/test_cloud_client.py
@@ -6,7 +6,11 @@ import respx
 from respx.patterns import M
 
 from prefect.client.cloud import get_cloud_client
-from prefect.settings import PREFECT_API_URL, PREFECT_UNIT_TEST_MODE, temporary_settings
+from prefect.settings import (
+    PREFECT_API_URL,
+    PREFECT_TESTING_UNIT_TEST_MODE,
+    temporary_settings,
+)
 
 mock_work_pool_types_response = {
     "prefect": {
@@ -61,7 +65,7 @@ async def test_cloud_client_follow_redirects():
         assert client._client.follow_redirects is False
 
     # follow redirects by default
-    with temporary_settings({PREFECT_UNIT_TEST_MODE: False}):
+    with temporary_settings({PREFECT_TESTING_UNIT_TEST_MODE: False}):
         async with get_cloud_client() as client:
             assert client._client.follow_redirects is True
 

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -77,7 +77,7 @@ from prefect.settings import (
     PREFECT_API_URL,
     PREFECT_CLIENT_CSRF_SUPPORT_ENABLED,
     PREFECT_CLOUD_API_URL,
-    PREFECT_UNIT_TEST_MODE,
+    PREFECT_TESTING_UNIT_TEST_MODE,
     temporary_settings,
 )
 from prefect.states import Completed, Pending, Running, Scheduled, State
@@ -2312,7 +2312,7 @@ async def test_prefect_client_follow_redirects():
         assert client._client.follow_redirects is False
 
     # follow redirects by default
-    with temporary_settings({PREFECT_UNIT_TEST_MODE: False}):
+    with temporary_settings({PREFECT_TESTING_UNIT_TEST_MODE: False}):
         async with PrefectClient(api=app) as client:
             assert client._client.follow_redirects is True
 

--- a/tests/server/utilities/test_schemas.py
+++ b/tests/server/utilities/test_schemas.py
@@ -22,11 +22,11 @@ def reload_prefect_base_model(
     import prefect.server.utilities.schemas.bases
 
     original_base_model = prefect.server.utilities.schemas.bases.PrefectBaseModel
-    original_environment = os.environ.get("PREFECT_TEST_MODE")
+    original_environment = os.environ.get("PREFECT_TESTING_TEST_MODE")
     if test_mode_value is not None:
-        os.environ["PREFECT_TEST_MODE"] = test_mode_value
+        os.environ["PREFECT_TESTING_TEST_MODE"] = test_mode_value
     else:
-        os.environ.pop("PREFECT_TEST_MODE")
+        os.environ.pop("PREFECT_TESTING_TEST_MODE")
 
     try:
         # We must re-execute the module since the setting is configured at base model
@@ -38,9 +38,9 @@ def reload_prefect_base_model(
         yield PrefectBaseModel
     finally:
         if original_environment is None:
-            os.environ.pop("PREFECT_TEST_MODE")
+            os.environ.pop("PREFECT_TESTING_TEST_MODE")
         else:
-            os.environ["PREFECT_TEST_MODE"] = original_environment
+            os.environ["PREFECT_TESTING_TEST_MODE"] = original_environment
 
         # We must restore this type or `isinstance` checks will fail later
         prefect.server.utilities.schemas.bases.PrefectBaseModel = original_base_model

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -77,7 +77,7 @@ SUPPORTED_SETTINGS = {
     "PREFECT_API_DATABASE_PORT": {"test_value": 5432, "legacy": True},
     "PREFECT_API_DATABASE_TIMEOUT": {"test_value": 10.0, "legacy": True},
     "PREFECT_API_DATABASE_USER": {"test_value": "user", "legacy": True},
-    "PREFECT_API_DEFAULT_LIMIT": {"test_value": 100},
+    "PREFECT_API_DEFAULT_LIMIT": {"test_value": 100, "legacy": True},
     "PREFECT_API_ENABLE_HTTP2": {"test_value": True},
     "PREFECT_API_ENABLE_METRICS": {"test_value": True, "legacy": True},
     "PREFECT_API_EVENTS_RELATED_RESOURCE_CACHE_TTL": {
@@ -197,7 +197,10 @@ SUPPORTED_SETTINGS = {
     "PREFECT_DEFAULT_DOCKER_BUILD_NAMESPACE": {"test_value": "prefect", "legacy": True},
     "PREFECT_DEFAULT_RESULT_STORAGE_BLOCK": {"test_value": "block", "legacy": True},
     "PREFECT_DEFAULT_WORK_POOL_NAME": {"test_value": "default", "legacy": True},
-    "PREFECT_DEPLOYMENT_CONCURRENCY_SLOT_WAIT_SECONDS": {"test_value": 10.0},
+    "PREFECT_DEPLOYMENT_CONCURRENCY_SLOT_WAIT_SECONDS": {
+        "test_value": 10.0,
+        "legacy": True,
+    },
     "PREFECT_DEPLOYMENT_SCHEDULE_MAX_SCHEDULED_RUNS": {
         "test_value": 10,
         "legacy": True,
@@ -231,6 +234,7 @@ SUPPORTED_SETTINGS = {
     "PREFECT_FLOW_DEFAULT_RETRY_DELAY_SECONDS": {"test_value": 10, "legacy": True},
     "PREFECT_FLOWS_DEFAULT_RETRY_DELAY_SECONDS": {"test_value": 10},
     "PREFECT_HOME": {"test_value": Path.home() / ".prefect" / "test"},
+    "PREFECT_INTERNAL_LOGGING_LEVEL": {"test_value": "INFO"},
     "PREFECT_LOCAL_STORAGE_PATH": {
         "test_value": Path("/path/to/storage"),
         "legacy": True,
@@ -238,7 +242,7 @@ SUPPORTED_SETTINGS = {
     "PREFECT_LOGGING_COLORS": {"test_value": True},
     "PREFECT_LOGGING_CONFIG_PATH": {"test_value": Path("/path/to/settings.yaml")},
     "PREFECT_LOGGING_EXTRA_LOGGERS": {"test_value": "foo"},
-    "PREFECT_LOGGING_INTERNAL_LEVEL": {"test_value": "INFO"},
+    "PREFECT_LOGGING_INTERNAL_LEVEL": {"test_value": "INFO", "legacy": True},
     "PREFECT_LOGGING_LEVEL": {"test_value": "INFO"},
     "PREFECT_LOGGING_LOG_PRINTS": {"test_value": True},
     "PREFECT_LOGGING_MARKUP": {"test_value": True},
@@ -275,6 +279,7 @@ SUPPORTED_SETTINGS = {
     "PREFECT_SERVER_API_CORS_ALLOWED_ORIGINS": {"test_value": "foo"},
     "PREFECT_SERVER_API_CSRF_TOKEN_EXPIRATION": {"test_value": timedelta(seconds=10)},
     "PREFECT_SERVER_API_CSRF_PROTECTION_ENABLED": {"test_value": True},
+    "PREFECT_SERVER_API_DEFAULT_LIMIT": {"test_value": 10},
     "PREFECT_SERVER_API_HOST": {"test_value": "host"},
     "PREFECT_SERVER_API_KEEPALIVE_TIMEOUT": {"test_value": 10},
     "PREFECT_SERVER_API_PORT": {"test_value": 4200},
@@ -295,8 +300,11 @@ SUPPORTED_SETTINGS = {
     "PREFECT_SERVER_DATABASE_NAME": {"test_value": "prefect"},
     "PREFECT_SERVER_DATABASE_PASSWORD": {"test_value": "password"},
     "PREFECT_SERVER_DATABASE_PORT": {"test_value": 5432},
+    "PREFECT_SERVER_DATABASE_SQLALCHEMY_MAX_OVERFLOW": {"test_value": 10},
+    "PREFECT_SERVER_DATABASE_SQLALCHEMY_POOL_SIZE": {"test_value": 10},
     "PREFECT_SERVER_DATABASE_TIMEOUT": {"test_value": 10.0},
     "PREFECT_SERVER_DATABASE_USER": {"test_value": "user"},
+    "PREFECT_SERVER_DEPLOYMENTS_CONCURRENCY_SLOT_WAIT_SECONDS": {"test_value": 10.0},
     "PREFECT_SERVER_DEPLOYMENT_SCHEDULE_MAX_SCHEDULED_RUNS": {"test_value": 10},
     "PREFECT_SERVER_EPHEMERAL_ENABLED": {"test_value": True},
     "PREFECT_SERVER_EPHEMERAL_STARTUP_TIMEOUT_SECONDS": {"test_value": 10},
@@ -374,18 +382,33 @@ SUPPORTED_SETTINGS = {
     "PREFECT_SERVER_TASKS_TAG_CONCURRENCY_SLOT_WAIT_SECONDS": {
         "test_value": 10.0,
     },
+    "PREFECT_SERVER_UI_API_URL": {"test_value": "https://api.prefect.io"},
+    "PREFECT_SERVER_UI_ENABLED": {"test_value": True},
+    "PREFECT_SERVER_UI_SERVE_BASE": {"test_value": "/base"},
+    "PREFECT_SERVER_UI_STATIC_DIRECTORY": {"test_value": "/path/to/static"},
     "PREFECT_SILENCE_API_URL_MISCONFIGURATION": {"test_value": True},
-    "PREFECT_SQLALCHEMY_MAX_OVERFLOW": {"test_value": 10},
-    "PREFECT_SQLALCHEMY_POOL_SIZE": {"test_value": 10},
+    "PREFECT_SQLALCHEMY_MAX_OVERFLOW": {"test_value": 10, "legacy": True},
+    "PREFECT_SQLALCHEMY_POOL_SIZE": {"test_value": 10, "legacy": True},
+    "PREFECT_TASKS_DEFAULT_RETRIES": {"test_value": 10},
+    "PREFECT_TASKS_DEFAULT_RETRY_DELAY_SECONDS": {"test_value": 10},
     "PREFECT_TASKS_REFRESH_CACHE": {"test_value": True},
-    "PREFECT_TASK_DEFAULT_RETRIES": {"test_value": 10},
-    "PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS": {"test_value": 10},
+    "PREFECT_TASKS_RUNNER_THREAD_POOL_MAX_WORKERS": {"test_value": 5},
+    "PREFECT_TASKS_SCHEDULING_DEFAULT_STORAGE_BLOCK": {"test_value": "block"},
+    "PREFECT_TASKS_SCHEDULING_DELETE_FAILED_SUBMISSIONS": {"test_value": True},
+    "PREFECT_TASK_DEFAULT_RETRIES": {"test_value": 10, "legacy": True},
+    "PREFECT_TASK_DEFAULT_RETRY_DELAY_SECONDS": {"test_value": 10, "legacy": True},
     "PREFECT_TASK_RUN_TAG_CONCURRENCY_SLOT_WAIT_SECONDS": {
         "test_value": 10,
         "legacy": True,
     },
-    "PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK": {"test_value": "block"},
-    "PREFECT_TASK_SCHEDULING_DELETE_FAILED_SUBMISSIONS": {"test_value": True},
+    "PREFECT_TASK_SCHEDULING_DEFAULT_STORAGE_BLOCK": {
+        "test_value": "block",
+        "legacy": True,
+    },
+    "PREFECT_TASK_SCHEDULING_DELETE_FAILED_SUBMISSIONS": {
+        "test_value": True,
+        "legacy": True,
+    },
     "PREFECT_TASK_SCHEDULING_MAX_RETRY_QUEUE_SIZE": {"test_value": 10, "legacy": True},
     "PREFECT_TASK_SCHEDULING_MAX_SCHEDULED_QUEUE_SIZE": {
         "test_value": 10,
@@ -395,21 +418,25 @@ SUPPORTED_SETTINGS = {
         "test_value": timedelta(seconds=10),
         "legacy": True,
     },
-    "PREFECT_TEST_MODE": {"test_value": True},
-    "PREFECT_TEST_SETTING": {"test_value": "bar"},
-    "PREFECT_UI_API_URL": {"test_value": "https://api.prefect.io"},
-    "PREFECT_UI_ENABLED": {"test_value": True},
-    "PREFECT_UI_SERVE_BASE": {"test_value": "/base"},
-    "PREFECT_UI_STATIC_DIRECTORY": {"test_value": "/path/to/static"},
+    "PREFECT_TESTING_TEST_MODE": {"test_value": True},
+    "PREFECT_TESTING_TEST_SETTING": {"test_value": "bar"},
+    "PREFECT_TESTING_UNIT_TEST_LOOP_DEBUG": {"test_value": True},
+    "PREFECT_TESTING_UNIT_TEST_MODE": {"test_value": True},
+    "PREFECT_TEST_MODE": {"test_value": True, "legacy": True},
+    "PREFECT_TEST_SETTING": {"test_value": "bar", "legacy": True},
+    "PREFECT_UI_API_URL": {"test_value": "https://api.prefect.io", "legacy": True},
+    "PREFECT_UI_ENABLED": {"test_value": True, "legacy": True},
+    "PREFECT_UI_SERVE_BASE": {"test_value": "/base", "legacy": True},
+    "PREFECT_UI_STATIC_DIRECTORY": {"test_value": "/path/to/static", "legacy": True},
     "PREFECT_UI_URL": {"test_value": "https://ui.prefect.io"},
-    "PREFECT_UNIT_TEST_LOOP_DEBUG": {"test_value": True},
-    "PREFECT_UNIT_TEST_MODE": {"test_value": True},
+    "PREFECT_UNIT_TEST_LOOP_DEBUG": {"test_value": True, "legacy": True},
+    "PREFECT_UNIT_TEST_MODE": {"test_value": True, "legacy": True},
     "PREFECT_WORKER_HEARTBEAT_SECONDS": {"test_value": 10.0},
     "PREFECT_WORKER_PREFETCH_SECONDS": {"test_value": 10.0},
     "PREFECT_WORKER_QUERY_SECONDS": {"test_value": 10.0},
     "PREFECT_WORKER_WEBSERVER_HOST": {"test_value": "host"},
     "PREFECT_WORKER_WEBSERVER_PORT": {"test_value": 8080},
-    "PREFECT_TASK_RUNNER_THREAD_POOL_MAX_WORKERS": {"test_value": 5},
+    "PREFECT_TASK_RUNNER_THREAD_POOL_MAX_WORKERS": {"test_value": 5, "legacy": True},
 }
 
 
@@ -464,12 +491,17 @@ class TestSettingsClass:
 
         new_settings = settings.copy_with_update(updates={PREFECT_TEST_SETTING: "TEST"})
         new_set_keys = set(new_settings.model_dump(exclude_unset=True).keys())
-        # Only the API key setting should be set
-        assert new_set_keys - set_keys == {"test_setting"}
+        assert new_set_keys == set_keys
+
+        set_testing_keys = set(settings.testing.model_dump(exclude_unset=True).keys())
+        new_set_testing_keys = set(
+            new_settings.testing.model_dump(exclude_unset=True).keys()
+        )
+        assert new_set_testing_keys - set_testing_keys == {"test_setting"}
 
     def test_settings_copy_with_update(self):
         settings = get_current_settings()
-        assert settings.unit_test_mode is True
+        assert settings.testing.unit_test_mode is True
 
         with temporary_settings(restore_defaults={PREFECT_API_KEY}):
             new_settings = settings.copy_with_update(
@@ -477,7 +509,7 @@ class TestSettingsClass:
                 set_defaults={PREFECT_UNIT_TEST_MODE: False, PREFECT_API_KEY: "TEST"},
             )
             assert (
-                new_settings.unit_test_mode is True
+                new_settings.testing.unit_test_mode is True
             ), "Not changed, existing value was not default"
             assert (
                 new_settings.api.key is not None
@@ -488,7 +520,7 @@ class TestSettingsClass:
     def test_settings_loads_environment_variables_at_instantiation(self, monkeypatch):
         assert PREFECT_TEST_MODE.value() is True
 
-        monkeypatch.setenv("PREFECT_TEST_MODE", "0")
+        monkeypatch.setenv("PREFECT_TESTING_TEST_MODE", "0")
         new_settings = Settings()
         assert PREFECT_TEST_MODE.value_from(new_settings) is False
 
@@ -516,8 +548,8 @@ class TestSettingsClass:
             },
             # From test settings
             "PREFECT_SERVER_LOGGING_LEVEL": "DEBUG",
-            "PREFECT_TEST_MODE": "True",
-            "PREFECT_UNIT_TEST_MODE": "True",
+            "PREFECT_TESTING_TEST_MODE": "True",
+            "PREFECT_TESTING_UNIT_TEST_MODE": "True",
             # From init
             "PREFECT_SERVER_API_PORT": "3000",
         }
@@ -540,8 +572,8 @@ class TestSettingsClass:
         assert settings.model_dump() == new_settings.model_dump()
 
     def test_settings_hash_key(self):
-        settings = Settings(test_mode=True)
-        diff_settings = Settings(test_mode=False)
+        settings = Settings(testing=dict(test_mode=True))
+        diff_settings = Settings(testing=dict(test_mode=False))
 
         assert settings.hash_key() == settings.hash_key()
 
@@ -606,20 +638,20 @@ class TestSettingsClass:
 
     def test_loads_when_profile_path_does_not_exist(self, monkeypatch):
         monkeypatch.setenv("PREFECT_PROFILES_PATH", str(Path.home() / "nonexistent"))
-        monkeypatch.delenv("PREFECT_TEST_MODE", raising=False)
-        monkeypatch.delenv("PREFECT_UNIT_TEST_MODE", raising=False)
-        assert Settings().test_setting == "FOO"
+        monkeypatch.delenv("PREFECT_TESTING_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_UNIT_TEST_MODE", raising=False)
+        assert Settings().testing.test_setting == "FOO"
 
     def test_loads_when_profile_path_is_not_a_toml_file(self, monkeypatch, tmp_path):
         monkeypatch.setenv("PREFECT_PROFILES_PATH", str(tmp_path / "profiles.toml"))
-        monkeypatch.delenv("PREFECT_TEST_MODE", raising=False)
-        monkeypatch.delenv("PREFECT_UNIT_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_UNIT_TEST_MODE", raising=False)
 
         with open(tmp_path / "profiles.toml", "w") as f:
             f.write("Ceci n'est pas un fichier toml")
 
         with pytest.warns(UserWarning, match="Failed to load profiles from"):
-            assert Settings().test_setting == "FOO"
+            assert Settings().testing.test_setting == "FOO"
 
     def test_valid_setting_names_matches_supported_settings(self):
         assert (
@@ -801,11 +833,11 @@ class TestSettingAccess:
             assert len(w) == 1
             assert issubclass(w[-1].category, DeprecationWarning)
             assert (
-                "Accessing `Settings().PREFECT_TEST_MODE` is deprecated. Use `Settings().test_mode` instead."
+                "Accessing `Settings().PREFECT_TEST_MODE` is deprecated. Use `Settings().testing.test_mode` instead."
                 in str(w[-1].message)
             )
 
-        assert value == settings.test_mode
+        assert value == settings.testing.test_mode
 
     def test_settings_with_serialization_alias(self, monkeypatch):
         assert not Settings().client.metrics.enabled
@@ -1024,7 +1056,9 @@ class TestTemporarySettings:
             with temporary_settings(updates={PREFECT_TEST_MODE: False}):
                 raise ValueError()
 
-        assert os.environ["PREFECT_TEST_MODE"] == "1", "Does not alter os environ."
+        assert (
+            os.environ["PREFECT_TESTING_TEST_MODE"] == "1"
+        ), "Does not alter os environ."
         assert PREFECT_TEST_MODE.value() is True
 
 
@@ -1041,8 +1075,8 @@ class TestSettingsSources:
     def test_resolution_order(self, temporary_env_file, monkeypatch, tmp_path):
         profiles_path = tmp_path / "profiles.toml"
 
-        monkeypatch.delenv("PREFECT_TEST_MODE", raising=False)
-        monkeypatch.delenv("PREFECT_UNIT_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_UNIT_TEST_MODE", raising=False)
         monkeypatch.setenv("PREFECT_PROFILES_PATH", str(profiles_path))
 
         profiles_path.write_text(
@@ -1067,7 +1101,7 @@ class TestSettingsSources:
         assert Settings().client.retry_extra_codes == {420, 500}
 
         monkeypatch.setenv("PREFECT_TEST_MODE", "1")
-        monkeypatch.setenv("PREFECT_UNIT_TEST_MODE", "1")
+        monkeypatch.setenv("PREFECT_TESTING_UNIT_TEST_MODE", "1")
         monkeypatch.delenv("PREFECT_PROFILES_PATH", raising=True)
 
         assert Settings().client.retry_extra_codes == set()
@@ -1076,8 +1110,8 @@ class TestSettingsSources:
         Settings().client.metrics.enabled = False
         profiles_path = tmp_path / "profiles.toml"
 
-        monkeypatch.delenv("PREFECT_TEST_MODE", raising=False)
-        monkeypatch.delenv("PREFECT_UNIT_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_UNIT_TEST_MODE", raising=False)
         monkeypatch.setenv("PREFECT_PROFILES_PATH", str(profiles_path))
 
         profiles_path.write_text(
@@ -1098,8 +1132,8 @@ class TestSettingsSources:
     ):
         profiles_path = tmp_path / "profiles.toml"
 
-        monkeypatch.delenv("PREFECT_TEST_MODE", raising=False)
-        monkeypatch.delenv("PREFECT_UNIT_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_TEST_MODE", raising=False)
+        monkeypatch.delenv("PREFECT_TESTING_UNIT_TEST_MODE", raising=False)
         monkeypatch.setenv("PREFECT_PROFILES_PATH", str(profiles_path))
 
         profiles_path.write_text(
@@ -1615,7 +1649,10 @@ class TestSettingValues:
     def test_set_via_env_var(self, setting_and_value, monkeypatch):
         setting, value = setting_and_value
 
-        if setting == "PREFECT_TEST_SETTING":
+        if (
+            setting == "PREFECT_TEST_SETTING"
+            or setting == "PREFECT_TESTING_TEST_SETTING"
+        ):
             monkeypatch.setenv("PREFECT_TEST_MODE", "True")
 
         # mock set the env var
@@ -1629,10 +1666,13 @@ class TestSettingValues:
         setting, value = setting_and_value
         if setting == "PREFECT_PROFILES_PATH":
             pytest.skip("Profiles path cannot be set via a profile")
-        if setting == "PREFECT_TEST_SETTING":
+        if (
+            setting == "PREFECT_TEST_SETTING"
+            or setting == "PREFECT_TESTING_TEST_SETTING"
+        ):
             # PREFECT_TEST_MODE is used to set PREFECT_TEST_SETTING which messes
             # with profile loading
-            pytest.skip("Can only set PREFECT_TEST_SETTING when in test mode")
+            pytest.skip("Can only set PREFECT_TESTING_TEST_SETTING when in test mode")
 
         with open(temporary_profiles_path, "w") as f:
             toml.dump(
@@ -1651,7 +1691,10 @@ class TestSettingValues:
         setting, value = setting_and_value
         if setting == "PREFECT_PROFILES_PATH":
             monkeypatch.delenv("PREFECT_PROFILES_PATH", raising=False)
-        if setting == "PREFECT_TEST_SETTING":
+        if (
+            setting == "PREFECT_TEST_SETTING"
+            or setting == "PREFECT_TESTING_TEST_SETTING"
+        ):
             monkeypatch.setenv("PREFECT_TEST_MODE", "True")
 
         temporary_env_file(f"{setting}={value}")


### PR DESCRIPTION
Creates final settings models for workers, tasks, testing, internal, and UI settings.

This PR updates the serializer for `PrefectBaseSettings` to ensure that fields that have been set on child models after object creation are included when dumping the model with `exclude_unset=True`.