### PR TITLE
Soft wrap deployment link

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -744,10 +744,11 @@ async def _run_single_deploy(
     )
 
     if PREFECT_UI_URL:
-        app.console.print(
+        message = (
             "\nView Deployment in UI:"
             f" {PREFECT_UI_URL.value()}/deployments/deployment/{deployment_id}\n"
         )
+        app.console.print(message, soft_wrap=True)
 
     identical_deployment_exists_in_prefect_file = (
         _check_if_identical_deployment_in_prefect_file(


### PR DESCRIPTION
another example of where we should use `soft_wrap` to avoid line breaks from making invalid links