### PR TITLE
fix phantom missing fields for triggers schemas

### DIFF
--- a/src/prefect/events/schemas/automations.py
+++ b/src/prefect/events/schemas/automations.py
@@ -147,7 +147,7 @@ class EventTrigger(ResourceTrigger):
         ),
     )
     posture: Literal[Posture.Reactive, Posture.Proactive] = Field(  # type: ignore[valid-type]
-        Posture.Reactive,
+        default=Posture.Reactive,
         description=(
             "The posture of this trigger, either Reactive or Proactive.  Reactive "
             "triggers respond to the _presence_ of the expected events, while "
@@ -155,7 +155,7 @@ class EventTrigger(ResourceTrigger):
         ),
     )
     threshold: int = Field(
-        1,
+        default=1,
         description=(
             "The number of events required for this trigger to fire (for "
             "Reactive triggers), or the number of events expected (for Proactive "
@@ -163,7 +163,7 @@ class EventTrigger(ResourceTrigger):
         ),
     )
     within: timedelta = Field(
-        timedelta(seconds=0),
+        default=timedelta(seconds=0),
         ge=timedelta(seconds=0),
         description=(
             "The time period over which the events must occur.  For Reactive triggers, "

--- a/src/prefect/events/schemas/deployment_triggers.py
+++ b/src/prefect/events/schemas/deployment_triggers.py
@@ -42,22 +42,27 @@ class BaseDeploymentTrigger(PrefectBaseModel, abc.ABC, extra="ignore"):  # type:
     # Fields from Automation
 
     name: Optional[str] = Field(
-        None, description="The name to give to the automation created for this trigger."
+        default=None,
+        description="The name to give to the automation created for this trigger.",
     )
-    description: str = Field("", description="A longer description of this automation")
-    enabled: bool = Field(True, description="Whether this automation will be evaluated")
+    description: str = Field(
+        default="", description="A longer description of this automation"
+    )
+    enabled: bool = Field(
+        default=True, description="Whether this automation will be evaluated"
+    )
 
     # Fields from the RunDeployment action
 
     parameters: Optional[Dict[str, Any]] = Field(
-        None,
+        default=None,
         description=(
             "The parameters to pass to the deployment, or None to use the "
             "deployment's default parameters"
         ),
     )
     job_variables: Optional[Dict[str, Any]] = Field(
-        None,
+        default=None,
         description=(
             "Job variables to pass to the deployment, or None to use the "
             "deployment's default job variables"


### PR DESCRIPTION
on `main`, an example like this will complain about missing fields even though the schema has defaults the user doesn't need to pass

```python
from prefect.events import DeploymentEventTrigger

if __name__ == "__main__":
    DeploymentEventTrigger(expect={"weeeeeee"})
```

it seems to be because pydantic needs `default=` in the `Field` definitions to recognize the default value as "not required" by the constructor of the instance

---
this might be a bug related to multiple-inheritance to report to pydantic but for now, this is a QoL improvement