### PR TITLE
require `pydantic-settings>2.2.1`

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -22,7 +22,7 @@ prometheus-client >= 0.20.0
 pydantic >= 2.7, < 3.0.0
 pydantic_core >= 2.12.0, < 3.0.0
 pydantic_extra_types >= 2.8.2, < 3.0.0
-pydantic_settings
+pydantic_settings > 2.2.1
 python_dateutil >= 2.8.2, < 3.0.0
 python-slugify >= 5.0, < 9.0
 pyyaml >= 5.4.1, < 7.0.0


### PR DESCRIPTION
with new settings sources, we need `pydantic-settings > 2.2.1`

<details>

## test

```bash
find_err() {
  local package=$1
  local command=$2
  local start_version=$3
  local reverse=$4

  # Get and sort versions, using sort -u to remove duplicates
  versions=($(pip index versions "$package" | rg -o '\d+\.\d+\.\d+' | sort -V -u))
  if [[ "$reverse" == "reverse" ]]; then
    versions=($(echo "${versions[@]}" | tr ' ' '\n' | sort -rV -u))
  fi

  # Print header
  echo "📦 Testing $package versions starting from $start_version"
  echo "🔍 Command: $command"
  echo "-------------------------------------------"

  local start=false
  local last_working_version=""

  for version in "${versions[@]}"; do
    if [[ "$version" == "$start_version" || "$start" == true ]]; then
      start=true
      printf "Testing v%-10s" "$version"

      # Run the command silently
      if output=$(uv run --with "$package==$version" python -c "$command" 2>&1); then
        echo " ✅"
        last_working_version=$version
      else
        echo " ❌"
        echo -e "\nFirst failing version: $version"
        echo "Last working version: $last_working_version"
        echo -e "\nError:"
        echo "$output" | tail -n 3
        break
      fi
    fi
  done
}

find_err "pydantic-settings" "from prefect.settings import Settings; Settings()" 2.6.0 'reverse'
```

</details>