### PR TITLE
Fix worker filter param

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2630,7 +2630,7 @@ class PrefectClient:
         response = await self._client.post(
             f"/work_pools/{work_pool_name}/workers/filter",
             json={
-                "worker_filter": (
+                "workers": (
                     worker_filter.model_dump(mode="json", exclude_unset=True)
                     if worker_filter
                     else None


### PR DESCRIPTION
This PR fixes a misnamed filter parameter for the `/workers/filter` client call.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
