### PR TITLE
Use released version of `pytest-markdown-docs`

### DIFF
--- a/.github/workflows/markdown-tests.yaml
+++ b/.github/workflows/markdown-tests.yaml
@@ -8,30 +8,30 @@ env:
 on:
   workflow_dispatch:
 
-  # pull_request:
-  #   paths:
-  #     - .github/workflows/markdown-tests.yaml
-  #     - "docs/**"
-  #     - requirements-client.txt
-  #     - requirements-dev.txt
-  #     - requirements-markdown-tests.txt
-  #     - requirements.txt
-  #     - setup.cfg
-  #     - Dockerfile
+  pull_request:
+    paths:
+      - .github/workflows/markdown-tests.yaml
+      - "docs/**"
+      - requirements-client.txt
+      - requirements-dev.txt
+      - requirements-markdown-tests.txt
+      - requirements.txt
+      - setup.cfg
+      - Dockerfile
 
-  # push:
-  #   branches:
-  #     - main
-  # paths:
-  #   - .github/workflows/markdown-tests.yaml
-  #   - "src/prefect/**/*.py"
-  #   - "tests/**/*.py"
-  #   - requirements-client.txt
-  #   - requirements-dev.txt
-  #   - requirements-markdown-tests.txt
-  #   - requirements.txt
-  #   - setup.cfg
-  #   - Dockerfile
+  push:
+    branches:
+      - main
+  paths:
+    - .github/workflows/markdown-tests.yaml
+    - "src/prefect/**/*.py"
+    - "tests/**/*.py"
+    - requirements-client.txt
+    - requirements-dev.txt
+    - requirements-markdown-tests.txt
+    - requirements.txt
+    - setup.cfg
+    - Dockerfile
 
 permissions:
   contents: read

--- a/.github/workflows/markdown-tests.yaml
+++ b/.github/workflows/markdown-tests.yaml
@@ -22,16 +22,16 @@ on:
   push:
     branches:
       - main
-  paths:
-    - .github/workflows/markdown-tests.yaml
-    - "src/prefect/**/*.py"
-    - "tests/**/*.py"
-    - requirements-client.txt
-    - requirements-dev.txt
-    - requirements-markdown-tests.txt
-    - requirements.txt
-    - setup.cfg
-    - Dockerfile
+    paths:
+      - .github/workflows/markdown-tests.yaml
+      - "src/prefect/**/*.py"
+      - "tests/**/*.py"
+      - requirements-client.txt
+      - requirements-dev.txt
+      - requirements-markdown-tests.txt
+      - requirements.txt
+      - setup.cfg
+      - Dockerfile
 
 permissions:
   contents: read

--- a/requirements-markdown-tests.txt
+++ b/requirements-markdown-tests.txt
@@ -1,4 +1,4 @@
-pytest-markdown-docs @ git+https://github.com/PrefectHQ/pytest-markdown-docs@mdx-comment-support
+pytest-markdown-docs >= 0.6.0
 
 pandas
 prefect-aws


### PR DESCRIPTION
This updates `requirements-markdown-tests.txt` to use the newly released version of `pytest-markdown-docs` that supports MDX comments, which we need for our tests to be compatible with Mintlify. It also renables the markdown tests action.

Closes https://github.com/PrefectHQ/prefect/issues/15781