### PR TITLE
Fix documentation link to task settings

### DIFF
--- a/docs/3.0/develop/write-tasks.mdx
+++ b/docs/3.0/develop/write-tasks.mdx
@@ -20,7 +20,7 @@ and final state
 Flows and tasks share some common features:
 
 - They can be defined using their respective decorator, which accepts configuration settings 
-(see all [task settings](/3.0/develop/write-tasks/#task-arguments) and 
+(see all [task settings](/3.0/develop/write-tasks/#task-configuration) and 
 [flow settings](/3.0/develop/write-flows/#flow-settings))
 - They can have a name, description, and tags for organization and bookkeeping
 - They provide retries, timeouts, and other hooks to handle failure and completion events


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

I noticed the link to task settings was broken because the section title was different than the link. This PR fixes it by updating the link.  

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
