### PR TITLE
Fix sorting of tags to determine nightly release version

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -19,7 +19,15 @@ jobs:
       - name: Get latest tag
         id: get_latest_tag
         run: |
-          latest_tag=$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9]+)?$' | grep -Ev 'rc|alpha|beta|post' | sort -V | tail -n1)
+          # Retrieve the latest tag by:
+          # 1. Listing all tags
+          # 2. Filtering for tags matching the pattern `[0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9]+)?$`
+          # 3. Filtering out tags containing `rc`, `alpha`, `beta`, or `post`
+          # 4. Replacing `.dev` with `~dev` for sorting purposes
+          # 5. Sorting the tags in version order
+          # 6. Replacing `~dev` with `.dev`
+          # 7. Taking the last tag
+          latest_tag=$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9]+)?$' | grep -Ev 'rc|alpha|beta|post' | sed 's/\.dev/~dev/' | sort --version-sort | sed 's/~dev/.dev/' | tail -n1)
           if [ -z "$latest_tag" ]; then
             echo "No matching tags found."
             exit 1


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

The nightly release workflow has continued to released dev versions for `3.0.11` even though `3.0.11` has been released. It should be releasing `3.0.12` dev version now. The sorting for the latest version was considering dev versions newer than release versions, so this PR updates the `latest_tag` one-liner to modify the tags to sort correctly and then revert the change after sorting.
