### PR TITLE
Adds in the ability for the client to get a remote_id from the server

### DIFF
--- a/docs/3.0/develop/settings-ref.mdx
+++ b/docs/3.0/develop/settings-ref.mdx
@@ -71,6 +71,13 @@ Settings for for controlling API client behavior
 
 **TOML dotted key path**: `deployments`
 
+### `experiments`
+Settings for controlling experimental features
+
+**Type**: [ExperimentsSettings](#experimentssettings)
+
+**TOML dotted key path**: `experiments`
+
 ### `flows`
 
 **Type**: [FlowsSettings](#flowssettings)
@@ -454,7 +461,18 @@ The default Docker namespace to use when building images.
 `PREFECT_DEPLOYMENTS_DEFAULT_DOCKER_BUILD_NAMESPACE`, `PREFECT_DEFAULT_DOCKER_BUILD_NAMESPACE`
 
 ---
+## ExperimentsSettings
+Settings for configuring experimental features
+### `worker_logging_to_api_enabled`
+Enables the logging of worker logs to Prefect Cloud.
 
+**Type**: `boolean`
+
+**Default**: `False`
+
+**TOML dotted key path**: `experiments.worker_logging_to_api_enabled`
+
+---
 ## FlowsSettings
 Settings for controlling flow behavior
 ### `default_retries`

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -295,7 +295,14 @@
         },
         "ExperimentsSettings": {
             "description": "Settings for configuring experimental features",
-            "properties": {},
+            "properties": {
+                "worker_logging_to_api_enabled": {
+                    "default": false,
+                    "description": "Enables the logging of worker logs to Prefect Cloud.",
+                    "title": "Worker Logging To Api Enabled",
+                    "type": "boolean"
+                }
+            },
             "title": "ExperimentsSettings",
             "type": "object"
         },

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -133,7 +133,8 @@ from prefect.settings import (
     PREFECT_CLIENT_CSRF_SUPPORT_ENABLED,
     PREFECT_CLOUD_API_URL,
     PREFECT_SERVER_ALLOW_EPHEMERAL_MODE,
-    PREFECT_TESTING_UNIT_TEST_MODE, get_current_settings,
+    PREFECT_TESTING_UNIT_TEST_MODE,
+    get_current_settings,
 )
 
 if TYPE_CHECKING:
@@ -2620,8 +2621,10 @@ class PrefectClient:
         )
 
         if (
-                (self.server_type == ServerType.CLOUD
-                or get_current_settings().testing.test_mode)
+            (
+                self.server_type == ServerType.CLOUD
+                or get_current_settings().testing.test_mode
+            )
             and get_worker_id
             and resp.status_code == 200
         ):

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -133,7 +133,7 @@ from prefect.settings import (
     PREFECT_CLIENT_CSRF_SUPPORT_ENABLED,
     PREFECT_CLOUD_API_URL,
     PREFECT_SERVER_ALLOW_EPHEMERAL_MODE,
-    PREFECT_TESTING_UNIT_TEST_MODE,
+    PREFECT_TESTING_UNIT_TEST_MODE, get_current_settings,
 )
 
 if TYPE_CHECKING:
@@ -2620,7 +2620,8 @@ class PrefectClient:
         )
 
         if (
-            self.server_type == ServerType.CLOUD
+                (self.server_type == ServerType.CLOUD
+                or get_current_settings().testing.test_mode)
             and get_worker_id
             and resp.status_code == 200
         ):

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2610,13 +2610,13 @@ class PrefectClient:
         else:
             return_dict = {}
 
-    
         resp = await self._client.post(
             f"/work_pools/{work_pool_name}/workers/heartbeat",
             json={
                 "name": worker_name,
                 "heartbeat_interval_seconds": heartbeat_interval_seconds,
-            } | return_dict,
+            }
+            | return_dict,
         )
 
         if get_worker_id and resp.status_code == 200:

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2619,7 +2619,11 @@ class PrefectClient:
             | return_dict,
         )
 
-        if get_worker_id and resp.status_code == 200:
+        if (
+            self.server_type == ServerType.CLOUD
+            and get_worker_id
+            and resp.status_code == 200
+        ):
             return UUID(resp.text)
         else:
             return None

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2604,13 +2604,19 @@ class PrefectClient:
             worker_name: The name of the worker sending the heartbeat.
             return_id: Whether to return the worker ID.
         """
+
+        if get_worker_id:
+            return_dict = {"return_id": get_worker_id}
+        else:
+            return_dict = {}
+
+    
         resp = await self._client.post(
             f"/work_pools/{work_pool_name}/workers/heartbeat",
             json={
                 "name": worker_name,
                 "heartbeat_interval_seconds": heartbeat_interval_seconds,
-                "return_id": get_worker_id,
-            },
+            } | return_dict,
         )
 
         if get_worker_id and resp.status_code == 200:

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2603,7 +2603,7 @@ class PrefectClient:
         Args:
             work_pool_name: The name of the work pool to heartbeat against.
             worker_name: The name of the worker sending the heartbeat.
-            return_id: Whether to return the worker ID.
+            return_id: Whether to return the worker ID. Note: will return `None` if the connected server does not support returning worker IDs, even if `return_id` is `True`.
         """
 
         if get_worker_id:

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2594,21 +2594,29 @@ class PrefectClient:
         work_pool_name: str,
         worker_name: str,
         heartbeat_interval_seconds: Optional[float] = None,
-    ):
+        get_worker_id: bool = False,
+    ) -> Optional[UUID]:
         """
         Sends a worker heartbeat for a given work pool.
 
         Args:
             work_pool_name: The name of the work pool to heartbeat against.
             worker_name: The name of the worker sending the heartbeat.
+            return_id: Whether to return the worker ID.
         """
-        await self._client.post(
+        resp = await self._client.post(
             f"/work_pools/{work_pool_name}/workers/heartbeat",
             json={
                 "name": worker_name,
                 "heartbeat_interval_seconds": heartbeat_interval_seconds,
+                "return_id": get_worker_id,
             },
         )
+
+        if get_worker_id and resp.status_code == 200:
+            return UUID(resp.text)
+        else:
+            return None
 
     async def read_workers_for_work_pool(
         self,

--- a/src/prefect/settings/models/experiments.py
+++ b/src/prefect/settings/models/experiments.py
@@ -1,3 +1,5 @@
+from pydantic import Field
+
 from prefect.settings.base import PrefectBaseSettings, PrefectSettingsConfigDict
 
 
@@ -12,4 +14,9 @@ class ExperimentsSettings(PrefectBaseSettings):
         extra="ignore",
         toml_file="prefect.toml",
         prefect_toml_table_header=("experiments",),
+    )
+
+    worker_logging_to_api_enabled: bool = Field(
+        default=False,
+        description="Enables the logging of worker logs to Prefect Cloud.",
     )

--- a/src/prefect/settings/models/worker.py
+++ b/src/prefect/settings/models/worker.py
@@ -54,3 +54,8 @@ class WorkerSettings(PrefectBaseSettings):
         default_factory=WorkerWebserverSettings,
         description="Settings for a worker's webserver",
     )
+
+    experiment_logging_to_api_enabled: bool = Field(
+        default=False,
+        description="If True, enables the experiment to log worker logs to the API.",
+    )

--- a/src/prefect/settings/models/worker.py
+++ b/src/prefect/settings/models/worker.py
@@ -54,8 +54,3 @@ class WorkerSettings(PrefectBaseSettings):
         default_factory=WorkerWebserverSettings,
         description="Settings for a worker's webserver",
     )
-
-    experiment_logging_to_api_enabled: bool = Field(
-        default=False,
-        description="If True, enables the experiment to log worker logs to the API.",
-    )

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -15,6 +15,7 @@ from typing_extensions import Literal
 
 import prefect
 from prefect._internal.schemas.validators import return_v_or_none
+from prefect.client.base import ServerType
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas.actions import WorkPoolCreate, WorkPoolUpdate
 from prefect.client.schemas.objects import StateType, WorkPool
@@ -737,7 +738,7 @@ class BaseWorker(abc.ABC):
         if (
             get_current_settings().experiments.worker_logging_to_api_enabled
             and (
-                "api.prefect.cloud" in get_current_settings().api.url
+                self._client.server_type == ServerType.CLOUD
                 or get_current_settings().testing.test_mode
             )
             and self.backend_id is None

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -733,11 +733,10 @@ class BaseWorker(abc.ABC):
         queues. Sends a worker heartbeat to the API.
         """
         await self._update_local_work_pool_info()
-
         # Only do this logic if we've enabled the experiment, are connected to cloud and we don't have an ID.
         if (
             get_current_settings().worker.experiment_logging_to_api_enabled
-            and "api.prefect.cloud" in get_current_settings().api.url
+            and ("api.prefect.cloud" in get_current_settings().api.url or get_current_settings().testing.test_mode)
             and self.backend_id is None
         ):
             get_worker_id = True

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -4,7 +4,7 @@ import threading
 from contextlib import AsyncExitStack
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Type, Union
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import anyio
 import anyio.abc
@@ -29,6 +29,7 @@ from prefect.logging.loggers import PrefectLogAdapter, flow_run_logger, get_logg
 from prefect.plugins import load_prefect_collections
 from prefect.settings import (
     PREFECT_API_URL,
+    PREFECT_EXPERIMENT_WORKER_LOGGING_TO_API_ENABLED,
     PREFECT_TEST_MODE,
     PREFECT_WORKER_HEARTBEAT_SECONDS,
     PREFECT_WORKER_PREFETCH_SECONDS,
@@ -421,6 +422,7 @@ class BaseWorker(abc.ABC):
             heartbeat_interval_seconds or PREFECT_WORKER_HEARTBEAT_SECONDS.value()
         )
 
+        self._remote_id: Optional[UUID] = None
         self._work_pool: Optional[WorkPool] = None
         self._exit_stack: AsyncExitStack = AsyncExitStack()
         self._runs_task_group: Optional[anyio.abc.TaskGroup] = None
@@ -710,12 +712,20 @@ class BaseWorker(abc.ABC):
 
         self._work_pool = work_pool
 
-    async def _send_worker_heartbeat(self):
+    async def _send_worker_heartbeat(
+        self, get_worker_id: bool = False
+    ) -> Optional[UUID]:
+        """
+        Sends a heartbeat to the API.
+
+        If `get_worker_id` is True, the worker ID will be retrieved from the API.
+        """
         if self._work_pool:
-            await self._client.send_worker_heartbeat(
+            return await self._client.send_worker_heartbeat(
                 work_pool_name=self._work_pool_name,
                 worker_name=self.name,
                 heartbeat_interval_seconds=self.heartbeat_interval_seconds,
+                get_worker_id=get_worker_id,
             )
 
     async def sync_with_backend(self):
@@ -725,9 +735,23 @@ class BaseWorker(abc.ABC):
         """
         await self._update_local_work_pool_info()
 
-        await self._send_worker_heartbeat()
+        if PREFECT_EXPERIMENT_WORKER_LOGGING_TO_API_ENABLED and self._remote_id is None:
+            get_worker_id = True
+        else:
+            get_worker_id = False
 
-        self._logger.debug("Worker synchronized with the Prefect API server.")
+        remote_id = await self._send_worker_heartbeat(get_worker_id=get_worker_id)
+
+        if get_worker_id and remote_id is None:
+            self._logger.warning(
+                "Failed to retrieve worker ID from the Prefect API server."
+            )
+        else:
+            self._remote_id = remote_id
+
+        self._logger.debug(
+            f"Worker synchronized with the Prefect API server. Remote ID: {self._remote_id}"
+        )
 
     async def _get_scheduled_flow_runs(
         self,

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -29,11 +29,11 @@ from prefect.logging.loggers import PrefectLogAdapter, flow_run_logger, get_logg
 from prefect.plugins import load_prefect_collections
 from prefect.settings import (
     PREFECT_API_URL,
-    PREFECT_EXPERIMENT_WORKER_LOGGING_TO_API_ENABLED,
     PREFECT_TEST_MODE,
     PREFECT_WORKER_HEARTBEAT_SECONDS,
     PREFECT_WORKER_PREFETCH_SECONDS,
     PREFECT_WORKER_QUERY_SECONDS,
+PREFECT_WORKER_EXPERIMENT_LOGGING_TO_API_ENABLED,
     get_current_settings,
 )
 from prefect.states import (
@@ -735,7 +735,7 @@ class BaseWorker(abc.ABC):
         """
         await self._update_local_work_pool_info()
 
-        if PREFECT_EXPERIMENT_WORKER_LOGGING_TO_API_ENABLED and self._remote_id is None:
+        if PREFECT_WORKER_EXPERIMENT_LOGGING_TO_API_ENABLED and self._remote_id is None:
             get_worker_id = True
         else:
             get_worker_id = False

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -735,8 +735,11 @@ class BaseWorker(abc.ABC):
         await self._update_local_work_pool_info()
         # Only do this logic if we've enabled the experiment, are connected to cloud and we don't have an ID.
         if (
-            get_current_settings().worker.experiment_logging_to_api_enabled
-            and ("api.prefect.cloud" in get_current_settings().api.url or get_current_settings().testing.test_mode)
+            get_current_settings().experiments.worker_logging_to_api_enabled
+            and (
+                "api.prefect.cloud" in get_current_settings().api.url
+                or get_current_settings().testing.test_mode
+            )
             and self.backend_id is None
         ):
             get_worker_id = True

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -30,10 +30,10 @@ from prefect.plugins import load_prefect_collections
 from prefect.settings import (
     PREFECT_API_URL,
     PREFECT_TEST_MODE,
+    PREFECT_WORKER_EXPERIMENT_LOGGING_TO_API_ENABLED,
     PREFECT_WORKER_HEARTBEAT_SECONDS,
     PREFECT_WORKER_PREFETCH_SECONDS,
     PREFECT_WORKER_QUERY_SECONDS,
-PREFECT_WORKER_EXPERIMENT_LOGGING_TO_API_ENABLED,
     get_current_settings,
 )
 from prefect.states import (

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -422,7 +422,7 @@ class BaseWorker(abc.ABC):
             heartbeat_interval_seconds or PREFECT_WORKER_HEARTBEAT_SECONDS.value()
         )
 
-        self._remote_id: Optional[UUID] = None
+        self.backend_id: Optional[UUID] = None
         self._work_pool: Optional[WorkPool] = None
         self._exit_stack: AsyncExitStack = AsyncExitStack()
         self._runs_task_group: Optional[anyio.abc.TaskGroup] = None
@@ -735,7 +735,7 @@ class BaseWorker(abc.ABC):
         """
         await self._update_local_work_pool_info()
 
-        if PREFECT_WORKER_EXPERIMENT_LOGGING_TO_API_ENABLED and self._remote_id is None:
+        if PREFECT_WORKER_EXPERIMENT_LOGGING_TO_API_ENABLED and self.backend_id is None:
             get_worker_id = True
         else:
             get_worker_id = False
@@ -747,10 +747,10 @@ class BaseWorker(abc.ABC):
                 "Failed to retrieve worker ID from the Prefect API server."
             )
         else:
-            self._remote_id = remote_id
+            self.backend_id = remote_id
 
         self._logger.debug(
-            f"Worker synchronized with the Prefect API server. Remote ID: {self._remote_id}"
+            f"Worker synchronized with the Prefect API server. Remote ID: {self.backend_id}"
         )
 
     async def _get_scheduled_flow_runs(

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -30,7 +30,6 @@ from prefect.plugins import load_prefect_collections
 from prefect.settings import (
     PREFECT_API_URL,
     PREFECT_TEST_MODE,
-    PREFECT_WORKER_EXPERIMENT_LOGGING_TO_API_ENABLED,
     PREFECT_WORKER_HEARTBEAT_SECONDS,
     PREFECT_WORKER_PREFETCH_SECONDS,
     PREFECT_WORKER_QUERY_SECONDS,
@@ -735,7 +734,12 @@ class BaseWorker(abc.ABC):
         """
         await self._update_local_work_pool_info()
 
-        if PREFECT_WORKER_EXPERIMENT_LOGGING_TO_API_ENABLED and self.backend_id is None:
+        # Only do this logic if we've enabled the experiment, are connected to cloud and we don't have an ID.
+        if (
+            get_current_settings().worker.experiment_logging_to_api_enabled
+            and "api.prefect.cloud" in get_current_settings().api.url
+            and self.backend_id is None
+        ):
             get_worker_id = True
         else:
             get_worker_id = False

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -228,6 +228,7 @@ SUPPORTED_SETTINGS = {
     },
     "PREFECT_EVENTS_WEBSOCKET_BACKFILL_PAGE_SIZE": {"test_value": 10, "legacy": True},
     "PREFECT_EXPERIMENTAL_WARN": {"test_value": True},
+    "PREFECT_EXPERIMENTS_WORKER_LOGGING_TO_API_ENABLED": {"test_value": False},
     "PREFECT_FLOW_DEFAULT_RETRIES": {"test_value": 10, "legacy": True},
     "PREFECT_FLOWS_DEFAULT_RETRIES": {"test_value": 10},
     "PREFECT_FLOW_DEFAULT_RETRY_DELAY_SECONDS": {"test_value": 10, "legacy": True},

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -23,6 +23,7 @@ from prefect.server.schemas.core import Deployment, Flow, WorkPool
 from prefect.server.schemas.responses import DeploymentResponse
 from prefect.settings import (
     PREFECT_API_URL,
+    PREFECT_EXPERIMENT_WORKER_LOGGING_TO_API_ENABLED,
     PREFECT_TEST_MODE,
     PREFECT_WORKER_PREFETCH_SECONDS,
     get_current_settings,
@@ -77,6 +78,14 @@ async def variables(prefect_client: PrefectClient):
 @pytest.fixture
 def no_api_url():
     with temporary_settings(updates={PREFECT_TEST_MODE: False, PREFECT_API_URL: None}):
+        yield
+
+
+@pytest.fixture
+def experimental_logging_enabled():
+    with temporary_settings(
+        updates={PREFECT_EXPERIMENT_WORKER_LOGGING_TO_API_ENABLED: True}
+    ):
         yield
 
 
@@ -159,6 +168,43 @@ async def test_worker_sends_heartbeat_messages(
         )
         second_heartbeat = workers[0].last_heartbeat_time
         assert second_heartbeat > first_heartbeat
+
+
+async def test_worker_sends_heartbeat_gets_id(
+    experimental_logging_enabled,
+):
+
+    async with WorkerTestImpl(name="test", work_pool_name="test-work-pool") as worker:
+        mock = AsyncMock(return_value="test")
+        setattr(
+            worker._client,"send_worker_heartbeat",mock
+        )
+        await worker.sync_with_backend()
+
+        send_worker_heartbeat_kwargs = mock.await_args_list[0].kwargs
+
+        assert worker._remote_id == 'test'
+        mock.assert_called()
+        assert send_worker_heartbeat_kwargs['get_worker_id'] == True
+
+async def test_worker_sends_heartbeat_only_gets_id_once(
+    experimental_logging_enabled,
+):
+
+    async with WorkerTestImpl(name="test", work_pool_name="test-work-pool") as worker:
+        mock = AsyncMock(return_value="test")
+        setattr(
+            worker._client,"send_worker_heartbeat",mock
+        )
+        await worker.sync_with_backend()
+        await worker.sync_with_backend()
+
+        second_call = mock.await_args_list[1]
+
+        assert worker._remote_id == 'test'
+        assert second_call.kwargs['get_worker_id'] == False
+
+
 
 
 async def test_worker_with_work_pool(

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -23,9 +23,9 @@ from prefect.server.schemas.core import Deployment, Flow, WorkPool
 from prefect.server.schemas.responses import DeploymentResponse
 from prefect.settings import (
     PREFECT_API_URL,
-    PREFECT_EXPERIMENT_WORKER_LOGGING_TO_API_ENABLED,
     PREFECT_TEST_MODE,
     PREFECT_WORKER_PREFETCH_SECONDS,
+PREFECT_WORKER_EXPERIMENT_LOGGING_TO_API_ENABLED,
     get_current_settings,
     temporary_settings,
 )
@@ -84,7 +84,7 @@ def no_api_url():
 @pytest.fixture
 def experimental_logging_enabled():
     with temporary_settings(
-        updates={PREFECT_EXPERIMENT_WORKER_LOGGING_TO_API_ENABLED: True}
+        updates={   PREFECT_WORKER_EXPERIMENT_LOGGING_TO_API_ENABLED: True}
     ):
         yield
 

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -195,7 +195,7 @@ respx_mock
 
         await worker.sync_with_backend()
 
-        assert worker._remote_id == test_worker_id
+        assert worker.backend_id == test_worker_id
 
 
 async def test_worker_sends_heartbeat_only_gets_id_once(
@@ -209,7 +209,7 @@ async def test_worker_sends_heartbeat_only_gets_id_once(
 
         second_call = mock.await_args_list[1]
 
-        assert worker._remote_id == "test"
+        assert worker.backend_id == "test"
         assert not second_call.kwargs["get_worker_id"]
 
 

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -25,8 +25,8 @@ from prefect.server.schemas.core import Deployment, Flow, WorkPool
 from prefect.server.schemas.responses import DeploymentResponse
 from prefect.settings import (
     PREFECT_API_URL,
-    PREFECT_TEST_MODE,
     PREFECT_EXPERIMENTS_WORKER_LOGGING_TO_API_ENABLED,
+    PREFECT_TEST_MODE,
     PREFECT_WORKER_PREFETCH_SECONDS,
     get_current_settings,
     temporary_settings,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

Add in the optional ability for a worker to get it's ID from the server using the heartbeat mechanism. This should only be enabled if `PREFECT_EXPERIMENTAL_WORKER_LOGGING_API_ENABLED` is set. This PR doesn't do any logging atm, just set the ground work for future PRs. 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
