### PR TITLE
Adds in the worker_id to the LogCreate schema

### DIFF
--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -562,6 +562,7 @@ class LogCreate(ActionBaseModel):
     timestamp: DateTime = Field(default=..., description="The log timestamp.")
     flow_run_id: Optional[UUID] = Field(None)
     task_run_id: Optional[UUID] = Field(None)
+    worker_id: Optional[UUID] = Field(None)
 
 
 class WorkPoolCreate(ActionBaseModel):

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -564,6 +564,16 @@ class LogCreate(ActionBaseModel):
     task_run_id: Optional[UUID] = Field(None)
     worker_id: Optional[UUID] = Field(None)
 
+    def model_dump(self, *args, **kwargs):
+        """
+        The worker_id field is only included in logs sent to Prefect Cloud.
+        If it's unset, we should not include it in the log payload.
+        """
+        data = super().model_dump(*args, **kwargs)
+        if self.worker_id is None:
+            data.pop("worker_id")
+        return data
+
 
 class WorkPoolCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a work pool."""


### PR DESCRIPTION
This PR adds in `worker_id` to the LogCreate schema. Ended up being a lot smaller then i thought it would be.

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
