### PR TITLE
Remove `jit="off"` setting for Postgres DBs

### DIFF
--- a/src/prefect/server/database/configurations.py
+++ b/src/prefect/server/database/configurations.py
@@ -204,7 +204,6 @@ class AsyncPostgresConfiguration(BaseDatabaseConfiguration):
                 connect_args["timeout"] = self.connection_timeout
 
             if connect_args:
-                connect_args["server_settings"] = {"jit": "off"}
                 kwargs["connect_args"] = connect_args
 
             if self.sqlalchemy_pool_size is not None:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

The [original issue](https://github.com/MagicStack/asyncpg/issues/530) that led to turning off `jit` when using a Postgres DB has been closed. This PR removes the explicit turning off of the `jit` setting to resolve issues with environments that don't support this setting.

Closes https://github.com/PrefectHQ/prefect/issues/14602
Closes https://github.com/PrefectHQ/prefect/issues/10903