### PR TITLE
Add in WorkerAPILogger and related functionality

### DIFF
--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -19,7 +19,6 @@ from prefect._internal.concurrency.api import create_call, from_sync
 from prefect._internal.concurrency.event_loop import get_running_loop
 from prefect._internal.concurrency.services import BatchedQueueService
 from prefect._internal.concurrency.threads import in_global_loop
-from prefect.client.base import ServerType, determine_server_type
 from prefect.client.orchestration import get_client
 from prefect.client.schemas.actions import LogCreate
 from prefect.exceptions import MissingContextError
@@ -32,7 +31,8 @@ from prefect.settings import (
     PREFECT_LOGGING_TO_API_BATCH_INTERVAL,
     PREFECT_LOGGING_TO_API_BATCH_SIZE,
     PREFECT_LOGGING_TO_API_MAX_LOG_SIZE,
-    PREFECT_LOGGING_TO_API_WHEN_MISSING_FLOW, get_current_settings,
+    PREFECT_LOGGING_TO_API_WHEN_MISSING_FLOW,
+    get_current_settings,
 )
 
 
@@ -238,7 +238,6 @@ class APILogHandler(logging.Handler):
 
 
 class WorkerAPILogHandler(APILogHandler):
-
     def emit(self, record: logging.LogRecord):
         if get_current_settings().experiments.worker_logging_to_api_enabled:
             super().emit(record)

--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -206,7 +206,7 @@ def task_run_logger(
     )
 
 
-def get_worker_logger(worker: "BaseWorker"):
+def get_worker_logger(worker: "BaseWorker",name: Optional[str] = None):
     """
     Create a worker logger with the worker's metadata attached.
 
@@ -214,11 +214,13 @@ def get_worker_logger(worker: "BaseWorker"):
     If the worker does not have a backend_id a basic logger will be returned.
     If the worker does not have a backend_id attribute, a basic logger will be returned.
     """
+
+    worker_log_name = name or f"workers.{worker.__class__.type}.{worker.name.lower()}"
     try:
         if worker.backend_id:
             return PrefectLogAdapter(
                 get_logger(
-                    "prefect.workers",
+                    worker_log_name
                 ),
                 extra={
                     "worker_id": str(worker.backend_id),
@@ -226,12 +228,12 @@ def get_worker_logger(worker: "BaseWorker"):
             )
         else:
             return get_logger(
-                "prefect.workers",
+                worker_log_name
             )
     except AttributeError:
         # Going to throw this in there in case if we have a user defined worker w/o a backend_id
         return get_logger(
-            "prefect.workers",
+            worker_log_name
         )
 
 

--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -206,7 +206,7 @@ def task_run_logger(
     )
 
 
-def get_worker_logger(worker: "BaseWorker",name: Optional[str] = None):
+def get_worker_logger(worker: "BaseWorker", name: Optional[str] = None):
     """
     Create a worker logger with the worker's metadata attached.
 
@@ -219,22 +219,16 @@ def get_worker_logger(worker: "BaseWorker",name: Optional[str] = None):
     try:
         if worker.backend_id:
             return PrefectLogAdapter(
-                get_logger(
-                    worker_log_name
-                ),
+                get_logger(worker_log_name),
                 extra={
                     "worker_id": str(worker.backend_id),
                 },
             )
         else:
-            return get_logger(
-                worker_log_name
-            )
+            return get_logger(worker_log_name)
     except AttributeError:
         # Going to throw this in there in case if we have a user defined worker w/o a backend_id
-        return get_logger(
-            worker_log_name
-        )
+        return get_logger(worker_log_name)
 
 
 @contextmanager

--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -216,18 +216,16 @@ def get_worker_logger(worker: "BaseWorker", name: Optional[str] = None):
     """
 
     worker_log_name = name or f"workers.{worker.__class__.type}.{worker.name.lower()}"
-    try:
-        if worker.worker_id:
-            return PrefectLogAdapter(
-                get_logger(worker_log_name),
-                extra={
-                    "worker_id": str(worker.worker_id),
-                },
-            )
-        else:
-            return get_logger(worker_log_name)
-    except AttributeError:
-        # Going to throw this in there in case if we have a user defined worker w/o a backend_id
+
+    worker_id = getattr(worker, "backend_id", None)
+    if worker_id:
+        return PrefectLogAdapter(
+            get_logger(worker_log_name),
+            extra={
+                "worker_id": str(worker.backend_id),
+            },
+        )
+    else:
         return get_logger(worker_log_name)
 
 

--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from prefect.context import RunContext
     from prefect.flows import Flow
     from prefect.tasks import Task
+    from prefect.workers.base import BaseWorker
 
 
 class PrefectLogAdapter(logging.LoggerAdapter):
@@ -203,6 +204,35 @@ def task_run_logger(
             **kwargs,
         },
     )
+
+
+def get_worker_logger(worker: "BaseWorker"):
+    """
+    Create a worker logger with the worker's metadata attached.
+
+    If the worker has a backend_id, it will be attached to the log records.
+    If the worker does not have a backend_id a basic logger will be returned.
+    If the worker does not have a backend_id attribute, a basic logger will be returned.
+    """
+    try:
+        if worker.backend_id:
+            return PrefectLogAdapter(
+                get_logger(
+                    "prefect.workers",
+                ),
+                extra={
+                    "worker_id": str(worker.backend_id),
+                },
+            )
+        else:
+            return get_logger(
+                "prefect.workers",
+            )
+    except AttributeError:
+        # Going to throw this in there in case if we have a user defined worker w/o a backend_id
+        return get_logger(
+            "prefect.workers",
+        )
 
 
 @contextmanager

--- a/src/prefect/logging/loggers.py
+++ b/src/prefect/logging/loggers.py
@@ -217,11 +217,11 @@ def get_worker_logger(worker: "BaseWorker", name: Optional[str] = None):
 
     worker_log_name = name or f"workers.{worker.__class__.type}.{worker.name.lower()}"
     try:
-        if worker.backend_id:
+        if worker.worker_id:
             return PrefectLogAdapter(
                 get_logger(worker_log_name),
                 extra={
-                    "worker_id": str(worker.backend_id),
+                    "worker_id": str(worker.worker_id),
                 },
             )
         else:

--- a/src/prefect/logging/logging.yml
+++ b/src/prefect/logging/logging.yml
@@ -69,6 +69,10 @@ handlers:
     class: logging.StreamHandler
     formatter: debug
 
+  worker_api:
+    level: 0
+    class: prefect.logging.handlers.WorkerAPILogHandler
+
 loggers:
   prefect:
     level: "${PREFECT_LOGGING_LEVEL}"
@@ -85,6 +89,10 @@ loggers:
   prefect.task_runs:
     level: NOTSET
     handlers: [api]
+
+  prefect.workers:
+    level: NOTSET
+    handlers: [worker_api]
 
   prefect.server:
     level: "${PREFECT_SERVER_LOGGING_LEVEL}"

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -755,8 +755,6 @@ class LogCreate(ActionBaseModel):
     worker_id: Optional[UUID] = Field(None)
 
 
-
-
 def validate_base_job_template(v):
     if v == dict():
         return v

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -752,7 +752,6 @@ class LogCreate(ActionBaseModel):
     timestamp: DateTime = Field(default=..., description="The log timestamp.")
     flow_run_id: Optional[UUID] = Field(None)
     task_run_id: Optional[UUID] = Field(None)
-    worker_id: Optional[UUID] = Field(None)
 
 
 def validate_base_job_template(v):

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -752,6 +752,9 @@ class LogCreate(ActionBaseModel):
     timestamp: DateTime = Field(default=..., description="The log timestamp.")
     flow_run_id: Optional[UUID] = Field(None)
     task_run_id: Optional[UUID] = Field(None)
+    worker_id: Optional[UUID] = Field(None)
+
+
 
 
 def validate_base_job_template(v):

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -412,7 +412,7 @@ class BaseWorker(abc.ABC):
             raise ValueError("Worker name cannot contain '/' or '%'")
         self.name = name or f"{self.__class__.__name__} {uuid4()}"
         self._started_event: Optional[Event] = None
-        self.worker_id: Optional[UUID] = None
+        self.backend_id: Optional[UUID] = None
         self._logger = get_worker_logger(self)
 
         self.is_setup = False
@@ -757,21 +757,20 @@ class BaseWorker(abc.ABC):
             self._logger.warning(
                 "Failed to retrieve worker ID from the Prefect API server."
             )
-        elif self.worker_id is None and remote_id is not None:
-            self.worker_id = remote_id
+        elif self.backend_id is None and remote_id is not None:
+            self.backend_id = remote_id
             self._logger = get_worker_logger(self)
-            self._logger.info(f"id {self.worker_id}")
 
         self._logger.debug(
-            f"Worker synchronized with the Prefect API server. Remote ID: {self.worker_id}"
+            f"Worker synchronized with the Prefect API server. Remote ID: {self.backend_id}"
         )
 
     def _should_get_worker_id(self):
         """Determines if the worker should request an ID from the API server."""
         return (
-            get_current_settings().experiments.worker_logging_to_api_enabled
-            and self._client.server_type == ServerType.CLOUD
-            and self.worker_id is None
+                get_current_settings().experiments.worker_logging_to_api_enabled
+                and self._client.server_type == ServerType.CLOUD
+                and self.backend_id is None
         )
 
     async def _get_scheduled_flow_runs(

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -754,10 +754,7 @@ class BaseWorker(abc.ABC):
             else:
                 raise e
 
-        if (
-            self._should_get_worker_id()
-            and remote_id is None
-        ):
+        if self._should_get_worker_id() and remote_id is None:
             self._logger.warning(
                 "Failed to retrieve worker ID from the Prefect API server."
             )

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -768,9 +768,9 @@ class BaseWorker(abc.ABC):
     def _should_get_worker_id(self):
         """Determines if the worker should request an ID from the API server."""
         return (
-                get_current_settings().experiments.worker_logging_to_api_enabled
-                and self._client.server_type == ServerType.CLOUD
-                and self.backend_id is None
+            get_current_settings().experiments.worker_logging_to_api_enabled
+            and self._client.server_type == ServerType.CLOUD
+            and self.backend_id is None
         )
 
     async def _get_scheduled_flow_runs(

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -757,7 +757,7 @@ class BaseWorker(abc.ABC):
         try:
             remote_id = await self._send_worker_heartbeat(get_worker_id=get_worker_id)
         except httpx.HTTPStatusError as e:
-            if e.response.status_code == 422:
+            if e.response.status_code == 422 and get_worker_id:
                 self._logger.warning(
                     "Failed to retrieve worker ID from the Prefect API server."
                 )

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -640,7 +640,7 @@ class TestAPILogHandler:
 
 class TestWorkerLogging:
     class WorkerTestImpl(BaseWorker):
-        type: str = "test"
+        type: str = "logging_test"
         job_configuration: Type[BaseJobConfiguration] = BaseJobConfiguration
 
         async def _send_worker_heartbeat(self, *_, **__):
@@ -659,18 +659,18 @@ class TestWorkerLogging:
     async def test_get_worker_logger_works_with_no_backend_id(self,experiment_enabled):
         async with self.WorkerTestImpl(name="test", work_pool_name="test-work-pool") as worker:
             logger = get_worker_logger(worker)
-            assert logger.name == "prefect.workers.test.test"
+            assert logger.name == "prefect.workers.logging_test.test"
 
     async def test_get_worker_logger_works_with_backend_id(self,experiment_enabled):
 
        async with self.WorkerTestImpl(name="test", work_pool_name="test-work-pool") as worker:
             await worker.sync_with_backend()
             logger = get_worker_logger(worker)
-            assert logger.name ==  "prefect.workers.test.test"
+            assert logger.name ==  "prefect.workers.logging_test.test"
             assert logger.extra['worker_id'] == "test_backend_id"
 
     async def test_worker_emits_logs_with_worker_id(self, caplog,experiment_enabled):
-        
+
         async with self.WorkerTestImpl(
             name="test", work_pool_name="test-work-pool"
         ) as worker:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -670,6 +670,7 @@ class TestWorkerLogging:
             assert logger.extra['worker_id'] == "test_backend_id"
 
     async def test_worker_emits_logs_with_worker_id(self, caplog,experiment_enabled):
+        
         async with self.WorkerTestImpl(
             name="test", work_pool_name="test-work-pool"
         ) as worker:
@@ -680,12 +681,6 @@ class TestWorkerLogging:
                 r for r in caplog.records if "testing_with_extras" in r.message
             ]
 
-            assert any(
-                [
-                    isinstance(h, WorkerAPILogHandler)
-                    for h in worker._logger.logger.handlers
-                ]
-            )
             assert "testing_with_extras" in caplog.text
             assert record_with_extras[0].worker_id == worker.backend_id
             assert worker._logger.extra["worker_id"] == worker.backend_id

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -681,8 +681,8 @@ class TestWorkerLogging:
             ]
 
             assert "testing_with_extras" in caplog.text
-            assert record_with_extras[0].worker_id == worker.backend_id
-            assert worker._logger.extra["worker_id"] == worker.backend_id
+            assert record_with_extras[0].worker_id == worker.worker_id
+            assert worker._logger.extra["worker_id"] == worker.worker_id
 
 
 class TestAPILogWorker:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -11,9 +11,6 @@ from unittest.mock import ANY, MagicMock
 
 import pendulum
 import pytest
-from unittest import mock
-from unittest.mock import patch
-
 from rich.color import Color, ColorType
 from rich.console import Console
 from rich.highlighter import NullHighlighter, ReprHighlighter
@@ -37,7 +34,8 @@ from prefect.logging.formatters import JsonFormatter
 from prefect.logging.handlers import (
     APILogHandler,
     APILogWorker,
-    PrefectConsoleHandler, WorkerAPILogHandler,
+    PrefectConsoleHandler,
+    WorkerAPILogHandler,
 )
 from prefect.logging.highlighters import PrefectConsoleHighlighter
 from prefect.logging.loggers import (
@@ -658,9 +656,7 @@ class TestWorkerLogging:
 
     @pytest.fixture
     def logging_to_api_enabled(self):
-        with temporary_settings(
-            updates={PREFECT_LOGGING_TO_API_ENABLED: True}
-        ):
+        with temporary_settings(updates={PREFECT_LOGGING_TO_API_ENABLED: True}):
             yield
 
     @pytest.fixture
@@ -674,7 +670,6 @@ class TestWorkerLogging:
         logger.addHandler(worker_handler)
         yield logger
         logger.removeHandler(worker_handler)
-
 
     async def test_get_worker_logger_works_with_no_backend_id(self, experiment_enabled):
         async with self.WorkerTestImpl(
@@ -707,19 +702,18 @@ class TestWorkerLogging:
             assert record_with_extras[0].backend_id == worker.backend_id
             assert worker._logger.extra["worker_id"] == worker.backend_id
 
-
-    def test_worker_logger_sends_log_to_api_worker(self, logger, mock_log_worker,experiment_enabled,logging_to_api_enabled):
+    def test_worker_logger_sends_log_to_api_worker(
+        self, logger, mock_log_worker, experiment_enabled, logging_to_api_enabled
+    ):
         logger.info("test-worker-log")
 
         mock_log_worker.instance().send.assert_called_once()
         assert len(mock_log_worker.instance().send.call_args_list) == 1
 
-        log_statement =mock_log_worker.instance().send.call_args.args[0]
-        assert log_statement['name'] == logger.name
-        assert log_statement['level'] == 20
-        assert log_statement['message'] == 'test-worker-log'
-
-
+        log_statement = mock_log_worker.instance().send.call_args.args[0]
+        assert log_statement["name"] == logger.name
+        assert log_statement["level"] == 20
+        assert log_statement["message"] == "test-worker-log"
 
 
 class TestAPILogWorker:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -699,7 +699,7 @@ class TestWorkerLogging:
             ]
 
             assert "testing_with_extras" in caplog.text
-            assert record_with_extras[0].backend_id == worker.backend_id
+            assert record_with_extras[0].worker_id == worker.backend_id
             assert worker._logger.extra["worker_id"] == worker.backend_id
 
     def test_worker_logger_sends_log_to_api_worker(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -681,8 +681,8 @@ class TestWorkerLogging:
             ]
 
             assert "testing_with_extras" in caplog.text
-            assert record_with_extras[0].worker_id == worker.worker_id
-            assert worker._logger.extra["worker_id"] == worker.worker_id
+            assert record_with_extras[0].backend_id == worker.backend_id
+            assert worker._logger.extra["worker_id"] == worker.backend_id
 
 
 class TestAPILogWorker:

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -172,10 +172,11 @@ async def test_worker_sends_heartbeat_messages(
         assert second_heartbeat > first_heartbeat
 
 
-async def test_worker_sends_heartbeat_gets_id(experimental_logging_enabled, respx_mock):
+async def test_worker_sends_heartbeat_gets_id( respx_mock):
     work_pool_name = "test-work-pool"
     test_worker_id = uuid.UUID("028EC481-5899-49D7-B8C5-37A2726E9840")
     async with WorkerTestImpl(name="test", work_pool_name=work_pool_name) as worker:
+        setattr(worker, "_should_get_worker_id", lambda: True)
         # Pass through the non-relevant paths
         respx_mock.get(f"api/work_pools/{work_pool_name}").pass_through()
         respx_mock.get("api/csrf-token?").pass_through()
@@ -193,10 +194,9 @@ async def test_worker_sends_heartbeat_gets_id(experimental_logging_enabled, resp
         assert worker.backend_id == test_worker_id
 
 
-async def test_worker_sends_heartbeat_only_gets_id_once(
-    experimental_logging_enabled,
-):
+async def test_worker_sends_heartbeat_only_gets_id_once():
     async with WorkerTestImpl(name="test", work_pool_name="test-work-pool") as worker:
+        setattr(worker, "_should_get_worker_id", lambda: True)
         mock = AsyncMock(return_value="test")
         setattr(worker._client, "send_worker_heartbeat", mock)
         await worker.sync_with_backend()

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -192,7 +192,7 @@ async def test_worker_sends_heartbeat_gets_id(respx_mock):
 
         await worker.sync_with_backend()
 
-        assert worker.backend_id == test_worker_id
+        assert worker.worker_id == test_worker_id
 
 
 async def test_worker_sends_heartbeat_only_gets_id_once(experimental_logging_enabled):
@@ -205,7 +205,7 @@ async def test_worker_sends_heartbeat_only_gets_id_once(experimental_logging_ena
 
         second_call = mock.await_args_list[1]
 
-        assert worker.backend_id == "test"
+        assert worker.worker_id == "test"
         assert not second_call.kwargs["get_worker_id"]
 
 

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -172,7 +172,7 @@ async def test_worker_sends_heartbeat_messages(
         assert second_heartbeat > first_heartbeat
 
 
-async def test_worker_sends_heartbeat_gets_id( respx_mock):
+async def test_worker_sends_heartbeat_gets_id(respx_mock):
     work_pool_name = "test-work-pool"
     test_worker_id = uuid.UUID("028EC481-5899-49D7-B8C5-37A2726E9840")
     async with WorkerTestImpl(name="test", work_pool_name=work_pool_name) as worker:

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -12,6 +12,7 @@ from starlette import status
 import prefect
 import prefect.client.schemas as schemas
 from prefect.blocks.core import Block
+from prefect.client.base import ServerType
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas import FlowRun
 from prefect.exceptions import (
@@ -194,9 +195,9 @@ async def test_worker_sends_heartbeat_gets_id(respx_mock):
         assert worker.backend_id == test_worker_id
 
 
-async def test_worker_sends_heartbeat_only_gets_id_once():
+async def test_worker_sends_heartbeat_only_gets_id_once(experimental_logging_enabled):
     async with WorkerTestImpl(name="test", work_pool_name="test-work-pool") as worker:
-        setattr(worker, "_should_get_worker_id", lambda: True)
+        worker._client.server_type = ServerType.CLOUD
         mock = AsyncMock(return_value="test")
         setattr(worker._client, "send_worker_heartbeat", mock)
         await worker.sync_with_backend()

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -192,7 +192,7 @@ async def test_worker_sends_heartbeat_gets_id(respx_mock):
 
         await worker.sync_with_backend()
 
-        assert worker.worker_id == test_worker_id
+        assert worker.backend_id == test_worker_id
 
 
 async def test_worker_sends_heartbeat_only_gets_id_once(experimental_logging_enabled):
@@ -205,7 +205,7 @@ async def test_worker_sends_heartbeat_only_gets_id_once(experimental_logging_ena
 
         second_call = mock.await_args_list[1]
 
-        assert worker.worker_id == "test"
+        assert worker.backend_id == "test"
         assert not second_call.kwargs["get_worker_id"]
 
 


### PR DESCRIPTION
Adds the ability for a worker to send logs to the Prefect Cloud endpoint with the relevant attributes set for Cloud to ingest the worker logs into clickhouse. 

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
