### PR TITLE
Dont cache on any key computation errors and log for visibility

### DIFF
--- a/src/prefect/cache_policies.py
+++ b/src/prefect/cache_policies.py
@@ -175,7 +175,7 @@ class CompoundCachePolicy(CachePolicy):
                 keys.append(policy_key)
         if not keys:
             return None
-        return hash_objects(*keys)
+        return hash_objects(*keys, raise_on_failure=True)
 
 
 @dataclass
@@ -224,7 +224,7 @@ class TaskSource(CachePolicy):
             else:
                 raise
 
-        return hash_objects(lines)
+        return hash_objects(lines, raise_on_failure=True)
 
 
 @dataclass
@@ -242,7 +242,7 @@ class FlowParameters(CachePolicy):
     ) -> Optional[str]:
         if not flow_parameters:
             return None
-        return hash_objects(flow_parameters)
+        return hash_objects(flow_parameters, raise_on_failure=True)
 
 
 @dataclass
@@ -293,7 +293,7 @@ class Inputs(CachePolicy):
             if key not in exclude:
                 hashed_inputs[key] = val
 
-        return hash_objects(hashed_inputs)
+        return hash_objects(hashed_inputs, raise_on_failure=True)
 
     def __sub__(self, other: str) -> "CachePolicy":
         if not isinstance(other, str):

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -150,11 +150,17 @@ class BaseTaskRunEngine(Generic[P, R]):
             else:
                 parameters = None
 
-            key = self.task.cache_policy.compute_key(
-                task_ctx=task_run_context,
-                inputs=self.parameters,
-                flow_parameters=parameters,
-            )
+            try:
+                key = self.task.cache_policy.compute_key(
+                    task_ctx=task_run_context,
+                    inputs=self.parameters,
+                    flow_parameters=parameters,
+                )
+            except Exception:
+                self.logger.exception(
+                    "Error encountered when computing cache key - result will not be persisted.",
+                )
+                key = None
         elif self.task.result_storage_key is not None:
             key = _format_user_supplied_storage_key(self.task.result_storage_key)
         return key

--- a/src/prefect/utilities/hashing.py
+++ b/src/prefect/utilities/hashing.py
@@ -48,10 +48,13 @@ def file_hash(path: str, hash_algo=_md5) -> str:
     return stable_hash(contents, hash_algo=hash_algo)
 
 
-def hash_objects(*args, hash_algo=_md5, **kwargs) -> Optional[str]:
+def hash_objects(
+    *args, hash_algo=_md5, raise_on_failure: bool = False, **kwargs
+) -> Optional[str]:
     """
     Attempt to hash objects by dumping to JSON or serializing with cloudpickle.
-    On failure of both, `None` will be returned
+    On failure of both, `None` will be returned; to raise on failure, set
+    `raise_on_failure=True`.
     """
     try:
         serializer = JSONSerializer(dumps_kwargs={"sort_keys": True})
@@ -62,6 +65,7 @@ def hash_objects(*args, hash_algo=_md5, **kwargs) -> Optional[str]:
     try:
         return stable_hash(cloudpickle.dumps((args, kwargs)), hash_algo=hash_algo)
     except Exception:
-        pass
+        if raise_on_failure:
+            raise
 
     return None


### PR DESCRIPTION
Closes #15861 

This PR encourages `CachePolicy.compute_key` to raise exceptions on failure that can be handled by the engine; specifically, if any inputs are not serializable, instead of silently ignoring that policy by returning `None` we log the error and explicitly state that caching will not be performed. This is most important when using compound cache key policies and now ensures universal behavior across various policy configurations.