### PR TITLE
Fix logging for FastAPI and Uvicorn

### DIFF
--- a/src/prefect/logging/logging.yml
+++ b/src/prefect/logging/logging.yml
@@ -102,9 +102,13 @@ loggers:
 
   uvicorn:
     level: "${PREFECT_SERVER_LOGGING_LEVEL}"
+    handlers: [console]
+    propagate: false
 
   fastapi:
     level: "${PREFECT_SERVER_LOGGING_LEVEL}"
+    handlers: [console]
+    propagate: false
 
 # The root logger: any logger without propagation disabled sends to here as well
 root:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
The default `logging.yml` was missing handlers for the `fastapi` and `uvicorn` loggers. This PR adds a `console` handler for each, so logs are printed to the console as expected. These loggers also have `propagate` set to `false` to prevent duplicate logging.

Closes https://github.com/PrefectHQ/prefect/issues/15775
