### PR TITLE
check for active workers when deploying

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -41,6 +41,7 @@ from prefect.cli._utilities import (
 )
 from prefect.cli.root import app, is_interactive
 from prefect.client.schemas.actions import DeploymentScheduleCreate
+from prefect.client.schemas.filters import WorkerFilter
 from prefect.client.schemas.objects import ConcurrencyLimitConfig
 from prefect.client.schemas.schedules import (
     CronSchedule,
@@ -802,14 +803,24 @@ async def _run_single_deploy(
                         " YAML file."
                     ),
                 )
-    if not work_pool.is_push_pool and not work_pool.is_managed_pool:
+    active_workers = []
+    if work_pool_name:
+        active_workers = await client.read_workers_for_work_pool(
+            work_pool_name, worker_filter=WorkerFilter(status={"any_": ["ONLINE"]})
+        )
+
+    if (
+        not work_pool.is_push_pool
+        and not work_pool.is_managed_pool
+        and not active_workers
+    ):
         app.console.print(
-            "\nTo execute flow runs from this deployment, start a worker in a"
+            "\nTo execute flow runs from these deployments, start a worker in a"
             " separate terminal that pulls work from the"
-            f" {deploy_config['work_pool']['name']!r} work pool:"
+            f" {work_pool_name!r} work pool:"
         )
         app.console.print(
-            f"\n\t$ prefect worker start --pool {deploy_config['work_pool']['name']!r}",
+            f"\n\t$ prefect worker start --pool {work_pool_name!r}",
             style="blue",
         )
     app.console.print(

--- a/src/prefect/client/schemas/filters.py
+++ b/src/prefect/client/schemas/filters.py
@@ -912,6 +912,17 @@ class WorkerFilterLastHeartbeatTime(PrefectBaseModel):
     )
 
 
+class WorkerFilterStatus(PrefectBaseModel):
+    """Filter by `Worker.status`."""
+
+    any_: Optional[List[str]] = Field(
+        default=None, description="A list of worker statuses to include"
+    )
+    not_any_: Optional[List[str]] = Field(
+        default=None, description="A list of worker statuses to exclude"
+    )
+
+
 class WorkerFilter(PrefectBaseModel, OperatorMixin):
     # worker_config_id: Optional[WorkerFilterWorkPoolId] = Field(
     #     default=None, description="Filter criteria for `Worker.worker_config_id`"
@@ -920,6 +931,9 @@ class WorkerFilter(PrefectBaseModel, OperatorMixin):
     last_heartbeat_time: Optional[WorkerFilterLastHeartbeatTime] = Field(
         default=None,
         description="Filter criteria for `Worker.last_heartbeat_time`",
+    )
+    status: Optional[WorkerFilterStatus] = Field(
+        default=None, description="Filter criteria for `Worker.status`"
     )
 
 

--- a/src/prefect/server/api/workers.py
+++ b/src/prefect/server/api/workers.py
@@ -607,7 +607,7 @@ async def worker_heartbeat(
 @router.post("/{work_pool_name}/workers/filter")
 async def read_workers(
     work_pool_name: str = Path(..., description="The work pool name"),
-    workers: schemas.filters.WorkerFilter = None,
+    workers: Optional[schemas.filters.WorkerFilter] = None,
     limit: int = dependencies.LimitBody(),
     offset: int = Body(0, ge=0),
     worker_lookups: WorkerLookups = Depends(WorkerLookups),

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -1824,6 +1824,9 @@ class WorkerFilter(PrefectOperatorFilterBaseModel):
         if self.last_heartbeat_time is not None:
             filters.append(self.last_heartbeat_time.as_sql_filter())
 
+        if self.status is not None:
+            filters.append(self.status.as_sql_filter())
+
         return filters
 
 


### PR DESCRIPTION
This PR adds code to check if a work pool has active workers when deploying a flow in order to not display irrelevant informantion to users with an existing setup. This check is added to the various methods for deploying a flow.
closes https://github.com/PrefectHQ/prefect/issues/15513

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
