### PR TITLE
Add support for defining settings via `pyproject.toml`

### DIFF
--- a/docs/3.0/develop/settings-and-profiles.mdx
+++ b/docs/3.0/develop/settings-and-profiles.mdx
@@ -43,6 +43,8 @@ You can configure settings via the following sources (highest to lowest preceden
 
 - **`prefect.toml` file**: A `prefect.toml` file is useful when you want to declare settings for an entire project. You can keep this file in your project directory and it will be automatically applied regardless of where you run your project.
 
+- **`pyproject.toml` file**: If you already have a `pyproject.toml` file in your project or like to consolidate settings for all your tools in one place, you can declare settings in the `[tool.prefect]` table of your `pyproject.toml` file.
+
 - **Profiles**: Prefect profiles are useful for switching between different environments. For example, you might use one profile for a local Prefect server and another for your production environment.
 
 When multiple settings sources define the same setting, Prefect follows this precedence order (highest to lowest):
@@ -51,6 +53,7 @@ When multiple settings sources define the same setting, Prefect follows this pre
   <Step title="Environment variables"/>
   <Step title=".env file in the current working directory"/>
   <Step title="prefect.toml file in the current working directory"/>
+  <Step title="pyproject.toml file in the current working directory"/>
   <Step title="Active profile settings"/>
   <Step title="Default values"/>
 </Steps>
@@ -110,6 +113,19 @@ level = "DEBUG"
 If you commit your `prefect.toml` file to a code repository, creating deployments from flows in that repository will use the settings declared in the `prefect.toml` file.
 
 You can see the `prefect.toml` path for each setting in the [settings reference documentation](/3.0/develop/settings-ref).
+
+### `pyproject.toml` file
+
+Declaring settings in a `pyproject.toml` file is very similar to declaring settings in a `prefect.toml` file. The main difference is that settings are declared in the `[tool.prefect]` table instead of at the root of the file.
+
+For example, the following `pyproject.toml` file declares a setting for the logging level:
+
+```toml pyproject.toml
+[tool.prefect]
+logging.level = "DEBUG"
+```
+
+The advantage of declaring settings in a `pyproject.toml` file is that it allows you to keep all your dependencies and settings for all your tools in one place. You can learn more about `pyproject.toml` files in the [Python Packaging User Guide](https://packaging.python.org/en/latest/specifications/pyproject-toml/#arbitrary-tool-configuration-the-tool-table).
 
 ### Profiles
 

--- a/docs/3.0/develop/settings-ref.mdx
+++ b/docs/3.0/develop/settings-ref.mdx
@@ -357,6 +357,9 @@ Settings for controlling API client behavior
 
 **TOML dotted key path**: `client.max_retries`
 
+**Supported environment variables**:
+`PREFECT_CLIENT_MAX_RETRIES`
+
 ### `retry_jitter_factor`
 
         A value greater than or equal to zero to control the amount of jitter added to retried
@@ -374,6 +377,9 @@ Settings for controlling API client behavior
 
 **TOML dotted key path**: `client.retry_jitter_factor`
 
+**Supported environment variables**:
+`PREFECT_CLIENT_RETRY_JITTER_FACTOR`
+
 ### `retry_extra_codes`
 
         A list of extra HTTP status codes to retry on. Defaults to an empty list.
@@ -384,6 +390,9 @@ Settings for controlling API client behavior
 **Type**: `string | integer | array | None`
 
 **TOML dotted key path**: `client.retry_extra_codes`
+
+**Supported environment variables**:
+`PREFECT_CLIENT_RETRY_EXTRA_CODES`
 
 ### `csrf_support_enabled`
 
@@ -399,6 +408,9 @@ Settings for controlling API client behavior
 **Default**: `True`
 
 **TOML dotted key path**: `client.csrf_support_enabled`
+
+**Supported environment variables**:
+`PREFECT_CLIENT_CSRF_SUPPORT_ENABLED`
 
 ### `metrics`
 
@@ -471,6 +483,9 @@ Enables the logging of worker logs to Prefect Cloud.
 **Default**: `False`
 
 **TOML dotted key path**: `experiments.worker_logging_to_api_enabled`
+
+**Supported environment variables**:
+`PREFECT_EXPERIMENTS_WORKER_LOGGING_TO_API_ENABLED`
 
 ---
 ## FlowsSettings
@@ -2069,6 +2084,9 @@ The number of seconds to wait before retrying when a task run cannot secure a co
 
 **TOML dotted key path**: `server.tasks.tag_concurrency_slot_wait_seconds`
 
+**Supported environment variables**:
+`PREFECT_SERVER_TASKS_TAG_CONCURRENCY_SLOT_WAIT_SECONDS`, `PREFECT_TASK_RUN_TAG_CONCURRENCY_SLOT_WAIT_SECONDS`
+
 ### `max_cache_key_length`
 The maximum number of characters allowed for a task run cache key.
 
@@ -2077,6 +2095,9 @@ The maximum number of characters allowed for a task run cache key.
 **Default**: `2000`
 
 **TOML dotted key path**: `server.tasks.max_cache_key_length`
+
+**Supported environment variables**:
+`PREFECT_SERVER_TASKS_MAX_CACHE_KEY_LENGTH`, `PREFECT_API_TASK_CACHE_KEY_MAX_LENGTH`
 
 ### `scheduling`
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -767,8 +767,8 @@
       "source": "/latest/concepts/tasks"
     },
     {
-      "destination": "/3.0/manage/settings-and-profiles",
-      "source": "/3.0/develop/settings-and-profiles"
+      "destination": "/3.0/develop/settings-and-profiles",
+      "source": "/3.0/manage/settings-and-profiles"
     },
     {
       "destination": "/latest",

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -158,6 +158,9 @@
                     "default": 5,
                     "description": "\n        The maximum number of retries to perform on failed HTTP requests.\n        Defaults to 5. Set to 0 to disable retries.\n        See `PREFECT_CLIENT_RETRY_EXTRA_CODES` for details on which HTTP status codes are\n        retried.\n        ",
                     "minimum": 0,
+                    "supported_environment_variables": [
+                        "PREFECT_CLIENT_MAX_RETRIES"
+                    ],
                     "title": "Max Retries",
                     "type": "integer"
                 },
@@ -165,6 +168,9 @@
                     "default": 0.2,
                     "description": "\n        A value greater than or equal to zero to control the amount of jitter added to retried\n        client requests. Higher values introduce larger amounts of jitter.\n        Set to 0 to disable jitter. See `clamped_poisson_interval` for details on the how jitter\n        can affect retry lengths.\n        ",
                     "minimum": 0.0,
+                    "supported_environment_variables": [
+                        "PREFECT_CLIENT_RETRY_JITTER_FACTOR"
+                    ],
                     "title": "Retry Jitter Factor",
                     "type": "number"
                 },
@@ -201,16 +207,23 @@
                             503
                         ]
                     ],
+                    "supported_environment_variables": [
+                        "PREFECT_CLIENT_RETRY_EXTRA_CODES"
+                    ],
                     "title": "Retry Extra Codes"
                 },
                 "csrf_support_enabled": {
                     "default": true,
                     "description": "\n        Determines if CSRF token handling is active in the Prefect client for API\n        requests.\n\n        When enabled (`True`), the client automatically manages CSRF tokens by\n        retrieving, storing, and including them in applicable state-changing requests\n        ",
+                    "supported_environment_variables": [
+                        "PREFECT_CLIENT_CSRF_SUPPORT_ENABLED"
+                    ],
                     "title": "Csrf Support Enabled",
                     "type": "boolean"
                 },
                 "metrics": {
-                    "$ref": "#/$defs/ClientMetricsSettings"
+                    "$ref": "#/$defs/ClientMetricsSettings",
+                    "supported_environment_variables": []
                 }
             },
             "title": "ClientSettings",
@@ -299,6 +312,9 @@
                 "worker_logging_to_api_enabled": {
                     "default": false,
                     "description": "Enables the logging of worker logs to Prefect Cloud.",
+                    "supported_environment_variables": [
+                        "PREFECT_EXPERIMENTS_WORKER_LOGGING_TO_API_ENABLED"
+                    ],
                     "title": "Worker Logging To Api Enabled",
                     "type": "boolean"
                 }
@@ -1758,17 +1774,26 @@
                     "default": 30,
                     "description": "The number of seconds to wait before retrying when a task run cannot secure a concurrency slot from the server.",
                     "minimum": 0.0,
+                    "supported_environment_variables": [
+                        "PREFECT_SERVER_TASKS_TAG_CONCURRENCY_SLOT_WAIT_SECONDS",
+                        "PREFECT_TASK_RUN_TAG_CONCURRENCY_SLOT_WAIT_SECONDS"
+                    ],
                     "title": "Tag Concurrency Slot Wait Seconds",
                     "type": "number"
                 },
                 "max_cache_key_length": {
                     "default": 2000,
                     "description": "The maximum number of characters allowed for a task run cache key.",
+                    "supported_environment_variables": [
+                        "PREFECT_SERVER_TASKS_MAX_CACHE_KEY_LENGTH",
+                        "PREFECT_API_TASK_CACHE_KEY_MAX_LENGTH"
+                    ],
                     "title": "Max Cache Key Length",
                     "type": "integer"
                 },
                 "scheduling": {
-                    "$ref": "#/$defs/ServerTasksSchedulingSettings"
+                    "$ref": "#/$defs/ServerTasksSchedulingSettings",
+                    "supported_environment_variables": []
                 }
             },
             "title": "ServerTasksSettings",

--- a/src/prefect/settings/models/api.py
+++ b/src/prefect/settings/models/api.py
@@ -4,9 +4,8 @@ from typing import Optional
 from pydantic import Field, SecretStr
 
 from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
     PrefectBaseSettings,
-    PrefectSettingsConfigDict,
+    _build_settings_config,
 )
 
 
@@ -15,11 +14,7 @@ class APISettings(PrefectBaseSettings):
     Settings for interacting with the Prefect API
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_API_",
-        prefect_toml_table_header=("api",),
-    )
+    model_config = _build_settings_config(("api",))
     url: Optional[str] = Field(
         default=None,
         description="The URL of the Prefect API. If not set, the client will attempt to infer it.",

--- a/src/prefect/settings/models/cli.py
+++ b/src/prefect/settings/models/cli.py
@@ -3,9 +3,8 @@ from typing import Optional
 from pydantic import Field
 
 from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
     PrefectBaseSettings,
-    PrefectSettingsConfigDict,
+    _build_settings_config,
 )
 
 
@@ -14,11 +13,7 @@ class CLISettings(PrefectBaseSettings):
     Settings for controlling CLI behavior
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_CLI_",
-        prefect_toml_table_header=("cli",),
-    )
+    model_config = _build_settings_config(("cli",))
 
     colors: bool = Field(
         default=True,

--- a/src/prefect/settings/models/client.py
+++ b/src/prefect/settings/models/client.py
@@ -1,9 +1,8 @@
 from pydantic import AliasChoices, AliasPath, Field
 
 from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
     PrefectBaseSettings,
-    PrefectSettingsConfigDict,
+    _build_settings_config,
 )
 from prefect.types import ClientRetryExtraCodes
 
@@ -13,11 +12,7 @@ class ClientMetricsSettings(PrefectBaseSettings):
     Settings for controlling metrics reporting from the client
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_CLIENT_METRICS_",
-        prefect_toml_table_header=("client", "metrics"),
-    )
+    model_config = _build_settings_config(("client", "metrics"))
 
     enabled: bool = Field(
         default=False,
@@ -42,13 +37,7 @@ class ClientSettings(PrefectBaseSettings):
     Settings for controlling API client behavior
     """
 
-    model_config = PrefectSettingsConfigDict(
-        env_prefix="PREFECT_CLIENT_",
-        env_file=".env",
-        extra="ignore",
-        toml_file="prefect.toml",
-        prefect_toml_table_header=("client",),
-    )
+    model_config = _build_settings_config(("client",))
 
     max_retries: int = Field(
         default=5,

--- a/src/prefect/settings/models/cloud.py
+++ b/src/prefect/settings/models/cloud.py
@@ -5,9 +5,8 @@ from pydantic import Field, model_validator
 from typing_extensions import Self
 
 from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
     PrefectBaseSettings,
-    PrefectSettingsConfigDict,
+    _build_settings_config,
 )
 
 
@@ -33,11 +32,7 @@ class CloudSettings(PrefectBaseSettings):
     Settings for interacting with Prefect Cloud
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_CLOUD_",
-        prefect_toml_table_header=("cloud",),
-    )
+    model_config = _build_settings_config(("cloud",))
 
     api_url: str = Field(
         default="https://api.prefect.cloud/api",

--- a/src/prefect/settings/models/deployments.py
+++ b/src/prefect/settings/models/deployments.py
@@ -2,11 +2,7 @@ from typing import Optional
 
 from pydantic import AliasChoices, AliasPath, Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class DeploymentsSettings(PrefectBaseSettings):
@@ -14,11 +10,7 @@ class DeploymentsSettings(PrefectBaseSettings):
     Settings for configuring deployments defaults
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_DEPLOYMENTS_",
-        prefect_toml_table_header=("deployments",),
-    )
+    model_config = _build_settings_config(("deployments",))
 
     default_work_pool_name: Optional[str] = Field(
         default=None,

--- a/src/prefect/settings/models/experiments.py
+++ b/src/prefect/settings/models/experiments.py
@@ -1,6 +1,6 @@
 from pydantic import Field
 
-from prefect.settings.base import PrefectBaseSettings, PrefectSettingsConfigDict
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class ExperimentsSettings(PrefectBaseSettings):
@@ -8,13 +8,7 @@ class ExperimentsSettings(PrefectBaseSettings):
     Settings for configuring experimental features
     """
 
-    model_config = PrefectSettingsConfigDict(
-        env_prefix="PREFECT_EXPERIMENTS_",
-        env_file=".env",
-        extra="ignore",
-        toml_file="prefect.toml",
-        prefect_toml_table_header=("experiments",),
-    )
+    model_config = _build_settings_config(("experiments",))
 
     worker_logging_to_api_enabled: bool = Field(
         default=False,

--- a/src/prefect/settings/models/flows.py
+++ b/src/prefect/settings/models/flows.py
@@ -2,11 +2,7 @@ from typing import Union
 
 from pydantic import AliasChoices, AliasPath, Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class FlowsSettings(PrefectBaseSettings):
@@ -14,11 +10,7 @@ class FlowsSettings(PrefectBaseSettings):
     Settings for controlling flow behavior
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_FLOWS_",
-        prefect_toml_table_header=("flows",),
-    )
+    model_config = _build_settings_config(("flows",))
 
     default_retries: int = Field(
         default=0,

--- a/src/prefect/settings/models/internal.py
+++ b/src/prefect/settings/models/internal.py
@@ -1,19 +1,11 @@
 from pydantic import AliasChoices, AliasPath, Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 from prefect.types import LogLevel
 
 
 class InternalSettings(PrefectBaseSettings):
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_INTERNAL_",
-        prefect_toml_table_header=("internal",),
-    )
+    model_config = _build_settings_config(("internal",))
 
     logging_level: LogLevel = Field(
         default="ERROR",

--- a/src/prefect/settings/models/logging.py
+++ b/src/prefect/settings/models/logging.py
@@ -4,11 +4,7 @@ from typing import Annotated, Literal, Optional, Union
 from pydantic import AfterValidator, AliasChoices, AliasPath, Field, model_validator
 from typing_extensions import Self
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 from prefect.types import LogLevel
 
 
@@ -29,11 +25,7 @@ class LoggingToAPISettings(PrefectBaseSettings):
     Settings for controlling logging to the API
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_LOGGING_TO_API_",
-        prefect_toml_table_header=("logging", "to_api"),
-    )
+    model_config = _build_settings_config(("logging", "to_api"))
 
     enabled: bool = Field(
         default=True,
@@ -86,11 +78,7 @@ class LoggingSettings(PrefectBaseSettings):
     Settings for controlling logging behavior
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_LOGGING_",
-        prefect_toml_table_header=("logging",),
-    )
+    model_config = _build_settings_config(("logging",))
 
     level: LogLevel = Field(
         default="INFO",

--- a/src/prefect/settings/models/results.py
+++ b/src/prefect/settings/models/results.py
@@ -3,11 +3,7 @@ from typing import Optional
 
 from pydantic import AliasChoices, AliasPath, Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class ResultsSettings(PrefectBaseSettings):
@@ -15,11 +11,7 @@ class ResultsSettings(PrefectBaseSettings):
     Settings for controlling result storage behavior
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_RESULTS_",
-        prefect_toml_table_header=("results",),
-    )
+    model_config = _build_settings_config(("results",))
 
     default_serializer: str = Field(
         default="pickle",

--- a/src/prefect/settings/models/root.py
+++ b/src/prefect/settings/models/root.py
@@ -13,11 +13,7 @@ from urllib.parse import urlparse
 from pydantic import BeforeValidator, Field, SecretStr, model_validator
 from typing_extensions import Self
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 from prefect.settings.models.tasks import TasksSettings
 from prefect.settings.models.testing import TestingSettings
 from prefect.settings.models.worker import WorkerSettings
@@ -47,10 +43,7 @@ class Settings(PrefectBaseSettings):
     See https://docs.pydantic.dev/latest/concepts/pydantic_settings
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_",
-    )
+    model_config = _build_settings_config()
 
     home: Annotated[Path, BeforeValidator(lambda x: Path(x).expanduser())] = Field(
         default=Path("~") / ".prefect",

--- a/src/prefect/settings/models/runner.py
+++ b/src/prefect/settings/models/runner.py
@@ -1,10 +1,6 @@
 from pydantic import Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 from prefect.types import LogLevel
 
 
@@ -13,11 +9,7 @@ class RunnerServerSettings(PrefectBaseSettings):
     Settings for controlling runner server behavior
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_RUNNER_SERVER_",
-        prefect_toml_table_header=("runner", "server"),
-    )
+    model_config = _build_settings_config(("runner", "server"))
 
     enable: bool = Field(
         default=False,
@@ -50,11 +42,7 @@ class RunnerSettings(PrefectBaseSettings):
     Settings for controlling runner behavior
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_RUNNER_",
-        prefect_toml_table_header=("runner",),
-    )
+    model_config = _build_settings_config(("runner",))
 
     process_limit: int = Field(
         default=5,

--- a/src/prefect/settings/models/server/api.py
+++ b/src/prefect/settings/models/server/api.py
@@ -2,11 +2,7 @@ from datetime import timedelta
 
 from pydantic import AliasChoices, AliasPath, Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class ServerAPISettings(PrefectBaseSettings):
@@ -14,11 +10,7 @@ class ServerAPISettings(PrefectBaseSettings):
     Settings for controlling API server behavior
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_API_",
-        prefect_toml_table_header=("server", "api"),
-    )
+    model_config = _build_settings_config(("server", "api"))
 
     host: str = Field(
         default="127.0.0.1",

--- a/src/prefect/settings/models/server/database.py
+++ b/src/prefect/settings/models/server/database.py
@@ -5,11 +5,7 @@ from urllib.parse import quote_plus
 from pydantic import AliasChoices, AliasPath, Field, SecretStr, model_validator
 from typing_extensions import Literal, Self
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class ServerDatabaseSettings(PrefectBaseSettings):
@@ -17,11 +13,7 @@ class ServerDatabaseSettings(PrefectBaseSettings):
     Settings for controlling server database behavior
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_DATABASE_",
-        prefect_toml_table_header=("server", "database"),
-    )
+    model_config = _build_settings_config(("server", "database"))
 
     connection_url: Optional[SecretStr] = Field(
         default=None,

--- a/src/prefect/settings/models/server/deployments.py
+++ b/src/prefect/settings/models/server/deployments.py
@@ -1,18 +1,10 @@
 from pydantic import AliasChoices, AliasPath, Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class ServerDeploymentsSettings(PrefectBaseSettings):
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_DEPLOYMENTS_",
-        prefect_toml_table_header=("server", "deployments"),
-    )
+    model_config = _build_settings_config(("server", "deployments"))
 
     concurrency_slot_wait_seconds: float = Field(
         default=30.0,

--- a/src/prefect/settings/models/server/ephemeral.py
+++ b/src/prefect/settings/models/server/ephemeral.py
@@ -1,10 +1,6 @@
 from pydantic import AliasChoices, AliasPath, Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class ServerEphemeralSettings(PrefectBaseSettings):
@@ -12,11 +8,7 @@ class ServerEphemeralSettings(PrefectBaseSettings):
     Settings for controlling ephemeral server behavior
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_EPHEMERAL_",
-        prefect_toml_table_header=("server", "ephemeral"),
-    )
+    model_config = _build_settings_config(("server", "ephemeral"))
 
     enabled: bool = Field(
         default=False,

--- a/src/prefect/settings/models/server/events.py
+++ b/src/prefect/settings/models/server/events.py
@@ -2,11 +2,7 @@ from datetime import timedelta
 
 from pydantic import AliasChoices, AliasPath, Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class ServerEventsSettings(PrefectBaseSettings):
@@ -14,11 +10,7 @@ class ServerEventsSettings(PrefectBaseSettings):
     Settings for controlling behavior of the events subsystem
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_EVENTS_",
-        prefect_toml_table_header=("server", "events"),
-    )
+    model_config = _build_settings_config(("server", "events"))
 
     ###########################################################################
     # Events settings

--- a/src/prefect/settings/models/server/flow_run_graph.py
+++ b/src/prefect/settings/models/server/flow_run_graph.py
@@ -1,10 +1,6 @@
 from pydantic import AliasChoices, AliasPath, Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class ServerFlowRunGraphSettings(PrefectBaseSettings):
@@ -12,11 +8,7 @@ class ServerFlowRunGraphSettings(PrefectBaseSettings):
     Settings for controlling behavior of the flow run graph
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_FLOW_RUN_GRAPH_",
-        prefect_toml_table_header=("server", "flow_run_graph"),
-    )
+    model_config = _build_settings_config(("server", "flow_run_graph"))
 
     max_nodes: int = Field(
         default=10000,

--- a/src/prefect/settings/models/server/root.py
+++ b/src/prefect/settings/models/server/root.py
@@ -3,11 +3,7 @@ from typing import Optional
 
 from pydantic import AliasChoices, AliasPath, Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 from prefect.types import LogLevel
 
 from .api import ServerAPISettings
@@ -26,11 +22,7 @@ class ServerSettings(PrefectBaseSettings):
     Settings for controlling server behavior
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_",
-        prefect_toml_table_header=("server",),
-    )
+    model_config = _build_settings_config(("server",))
 
     logging_level: LogLevel = Field(
         default="WARNING",

--- a/src/prefect/settings/models/server/services.py
+++ b/src/prefect/settings/models/server/services.py
@@ -2,11 +2,7 @@ from datetime import timedelta
 
 from pydantic import AliasChoices, AliasPath, Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class ServerServicesCancellationCleanupSettings(PrefectBaseSettings):
@@ -14,10 +10,8 @@ class ServerServicesCancellationCleanupSettings(PrefectBaseSettings):
     Settings for controlling the cancellation cleanup service
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_SERVICES_CANCELLATION_CLEANUP_",
-        prefect_toml_table_header=("server", "services", "cancellation_cleanup"),
+    model_config = _build_settings_config(
+        ("server", "services", "cancellation_cleanup")
     )
 
     enabled: bool = Field(
@@ -46,11 +40,7 @@ class ServerServicesEventPersisterSettings(PrefectBaseSettings):
     Settings for controlling the event persister service
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_SERVICES_EVENT_PERSISTER_",
-        prefect_toml_table_header=("server", "services", "event_persister"),
-    )
+    model_config = _build_settings_config(("server", "services", "event_persister"))
 
     enabled: bool = Field(
         default=True,
@@ -90,10 +80,8 @@ class ServerServicesFlowRunNotificationsSettings(PrefectBaseSettings):
     Settings for controlling the flow run notifications service
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_SERVICES_FLOW_RUN_NOTIFICATIONS_",
-        prefect_toml_table_header=("server", "services", "flow_run_notifications"),
+    model_config = _build_settings_config(
+        ("server", "services", "flow_run_notifications")
     )
 
     enabled: bool = Field(
@@ -112,11 +100,7 @@ class ServerServicesForemanSettings(PrefectBaseSettings):
     Settings for controlling the foreman service
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_SERVICES_FOREMAN_",
-        prefect_toml_table_header=("server", "services", "foreman"),
-    )
+    model_config = _build_settings_config(("server", "services", "foreman"))
 
     enabled: bool = Field(
         default=True,
@@ -195,11 +179,7 @@ class ServerServicesLateRunsSettings(PrefectBaseSettings):
     Settings for controlling the late runs service
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_SERVICES_LATE_RUNS_",
-        prefect_toml_table_header=("server", "services", "late_runs"),
-    )
+    model_config = _build_settings_config(("server", "services", "late_runs"))
 
     enabled: bool = Field(
         default=True,
@@ -241,11 +221,7 @@ class ServerServicesSchedulerSettings(PrefectBaseSettings):
     Settings for controlling the scheduler service
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_SERVICES_SCHEDULER_",
-        prefect_toml_table_header=("server", "services", "scheduler"),
-    )
+    model_config = _build_settings_config(("server", "services", "scheduler"))
 
     enabled: bool = Field(
         default=True,
@@ -368,11 +344,7 @@ class ServerServicesPauseExpirationsSettings(PrefectBaseSettings):
     Settings for controlling the pause expiration service
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_SERVICES_PAUSE_EXPIRATIONS_",
-        prefect_toml_table_header=("server", "services", "pause_expirations"),
-    )
+    model_config = _build_settings_config(("server", "services", "pause_expirations"))
 
     enabled: bool = Field(
         default=True,
@@ -406,11 +378,7 @@ class ServerServicesTaskRunRecorderSettings(PrefectBaseSettings):
     Settings for controlling the task run recorder service
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_SERVICES_TASK_RUN_RECORDER_",
-        prefect_toml_table_header=("server", "services", "task_run_recorder"),
-    )
+    model_config = _build_settings_config(("server", "services", "task_run_recorder"))
 
     enabled: bool = Field(
         default=True,
@@ -428,11 +396,7 @@ class ServerServicesTriggersSettings(PrefectBaseSettings):
     Settings for controlling the triggers service
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_SERVICES_TRIGGERS_",
-        prefect_toml_table_header=("server", "services", "triggers"),
-    )
+    model_config = _build_settings_config(("server", "services", "triggers"))
 
     enabled: bool = Field(
         default=True,
@@ -450,11 +414,7 @@ class ServerServicesSettings(PrefectBaseSettings):
     Settings for controlling server services
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_SERVICES_",
-        prefect_toml_table_header=("server", "services"),
-    )
+    model_config = _build_settings_config(("server", "services"))
 
     cancellation_cleanup: ServerServicesCancellationCleanupSettings = Field(
         default_factory=ServerServicesCancellationCleanupSettings,

--- a/src/prefect/settings/models/server/tasks.py
+++ b/src/prefect/settings/models/server/tasks.py
@@ -2,11 +2,7 @@ from datetime import timedelta
 
 from pydantic import AliasChoices, AliasPath, Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class ServerTasksSchedulingSettings(PrefectBaseSettings):
@@ -14,11 +10,7 @@ class ServerTasksSchedulingSettings(PrefectBaseSettings):
     Settings for controlling server-side behavior related to task scheduling
     """
 
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_TASKS_SCHEDULING_",
-        prefect_toml_table_header=("server", "tasks", "scheduling"),
-    )
+    model_config = _build_settings_config(("server", "tasks", "scheduling"))
 
     max_scheduled_queue_size: int = Field(
         default=1000,
@@ -56,13 +48,7 @@ class ServerTasksSettings(PrefectBaseSettings):
     Settings for controlling server-side behavior related to tasks
     """
 
-    model_config = PrefectSettingsConfigDict(
-        env_file=".env",
-        env_prefix="PREFECT_SERVER_TASKS_",
-        extra="ignore",
-        toml_file="prefect.toml",
-        prefect_toml_table_header=("server", "tasks"),
-    )
+    model_config = _build_settings_config(("server", "tasks"))
 
     tag_concurrency_slot_wait_seconds: float = Field(
         default=30,

--- a/src/prefect/settings/models/server/ui.py
+++ b/src/prefect/settings/models/server/ui.py
@@ -2,19 +2,11 @@ from typing import Optional
 
 from pydantic import AliasChoices, AliasPath, Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class ServerUISettings(PrefectBaseSettings):
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_SERVER_UI_",
-        prefect_toml_table_header=("server", "ui"),
-    )
+    model_config = _build_settings_config(("server", "ui"))
 
     enabled: bool = Field(
         default=True,

--- a/src/prefect/settings/models/tasks.py
+++ b/src/prefect/settings/models/tasks.py
@@ -2,19 +2,11 @@ from typing import Optional, Union
 
 from pydantic import AliasChoices, AliasPath, Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class TasksRunnerSettings(PrefectBaseSettings):
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_TASKS_RUNNER_",
-        prefect_toml_table_header=("tasks", "runner"),
-    )
+    model_config = _build_settings_config(("tasks", "runner"))
 
     thread_pool_max_workers: Optional[int] = Field(
         default=None,
@@ -29,14 +21,7 @@ class TasksRunnerSettings(PrefectBaseSettings):
 
 
 class TasksSchedulingSettings(PrefectBaseSettings):
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_TASKS_SCHEDULING_",
-        prefect_toml_table_header=(
-            "tasks",
-            "scheduling",
-        ),
-    )
+    model_config = _build_settings_config(("tasks", "scheduling"))
 
     default_storage_block: Optional[str] = Field(
         default=None,
@@ -60,11 +45,7 @@ class TasksSchedulingSettings(PrefectBaseSettings):
 
 
 class TasksSettings(PrefectBaseSettings):
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_TASKS_",
-        prefect_toml_table_header=("tasks",),
-    )
+    model_config = _build_settings_config(("tasks",))
 
     refresh_cache: bool = Field(
         default=False,

--- a/src/prefect/settings/models/testing.py
+++ b/src/prefect/settings/models/testing.py
@@ -2,19 +2,11 @@ from typing import Any, Optional
 
 from pydantic import AliasChoices, AliasPath, Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class TestingSettings(PrefectBaseSettings):
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_TESTING_",
-        prefect_toml_table_header=("testing",),
-    )
+    model_config = _build_settings_config(("testing",))
 
     test_mode: bool = Field(
         default=False,

--- a/src/prefect/settings/models/worker.py
+++ b/src/prefect/settings/models/worker.py
@@ -1,21 +1,10 @@
 from pydantic import Field
 
-from prefect.settings.base import (
-    COMMON_CONFIG_DICT,
-    PrefectBaseSettings,
-    PrefectSettingsConfigDict,
-)
+from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
 
 class WorkerWebserverSettings(PrefectBaseSettings):
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_WORKER_WEBSERVER_",
-        prefect_toml_table_header=(
-            "worker",
-            "webserver",
-        ),
-    )
+    model_config = _build_settings_config(("worker", "webserver"))
 
     host: str = Field(
         default="0.0.0.0",
@@ -29,11 +18,7 @@ class WorkerWebserverSettings(PrefectBaseSettings):
 
 
 class WorkerSettings(PrefectBaseSettings):
-    model_config = PrefectSettingsConfigDict(
-        **COMMON_CONFIG_DICT,
-        env_prefix="PREFECT_WORKER_",
-        prefect_toml_table_header=("worker",),
-    )
+    model_config = _build_settings_config(("worker",))
 
     heartbeat_seconds: float = Field(
         default=30,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1107,9 +1107,17 @@ class TestSettingsSources:
 
         assert Settings().client.retry_extra_codes == {420, 500}
 
-        toml_data = {"client": {"retry_extra_codes": "300"}}
+        pyproject_toml_data = {
+            "tool": {"prefect": {"client": {"retry_extra_codes": "200"}}}
+        }
+        with open("pyproject.toml", "w") as f:
+            toml.dump(pyproject_toml_data, f)
+
+        assert Settings().client.retry_extra_codes == {200}
+
+        prefect_toml_data = {"client": {"retry_extra_codes": "300"}}
         with open("prefect.toml", "w") as f:
-            toml.dump(toml_data, f)
+            toml.dump(prefect_toml_data, f)
 
         assert Settings().client.retry_extra_codes == {300}
 
@@ -1122,6 +1130,10 @@ class TestSettingsSources:
         assert Settings().client.retry_extra_codes == {300}
 
         os.unlink("prefect.toml")
+
+        assert Settings().client.retry_extra_codes == {200}
+
+        os.unlink("pyproject.toml")
 
         assert Settings().client.retry_extra_codes == {420, 500}
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR adds support for configuring Prefect settings in a `pyproject.toml` file. This configuration method is useful for users who already use a `pyproject.toml` file to manage their dependencies and configuration for other tools.

Users can declare Prefect settings in their `pyproject.toml` like so:
```toml
[tool.prefect]
cli.colors = false
```

Here's a [preview link](https://prefect-bd373955-add-pyproject-toml-support.mintlify.app/3.0/develop/settings-and-profiles) for the updated documentation.

Closes https://github.com/PrefectHQ/prefect/issues/15043
