### PR TITLE
Allow for unpersisted 2.x result payloads in states

### DIFF
--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -186,7 +186,7 @@ class StateDetails(PrefectBaseModel):
 
 
 def data_discriminator(x: Any) -> str:
-    if isinstance(x, dict) and "type" in x:
+    if isinstance(x, dict) and "type" in x and x["type"] != "unpersisted":
         return "BaseResult"
     elif isinstance(x, dict) and "storage_key" in x:
         return "ResultRecordMetadata"
@@ -363,6 +363,12 @@ class State(ObjectBaseModel, Generic[R]):
         if self.type == StateType.SCHEDULED:
             if not self.state_details.scheduled_time:
                 self.state_details.scheduled_time = DateTime.now("utc")
+        return self
+
+    @model_validator(mode="after")
+    def set_unpersisted_results_to_none(self) -> Self:
+        if isinstance(self.data, dict) and self.data.get("type") == "unpersisted":
+            self.data = None
         return self
 
     def is_scheduled(self) -> bool:


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/15694

This may be controversial, but this PR explicitly patches the ability to load states from a 2.x API that have "unpersisted" results associated with them. This arises primarily when mixing Prefect versions across clients, specifically when triggering 2.x deployments from 3.x flows (see issue).  

As users upgrade, I think this is a reasonable thing to support that doesn't lose any information (since the result is unpersisted), and I believe the logic for checking that we're in the situation is specific enough so as to avoid other failure modes (if you actually have a real result you care about, it will be persisted somewhere else using one of our classes/types).