### PR TITLE
Moves `experimental_warn` setting to `experiments` model and removes `async_fetch_state_result`

### DIFF
--- a/docs/3.0/develop/settings-ref.mdx
+++ b/docs/3.0/develop/settings-ref.mdx
@@ -164,18 +164,6 @@ The URL of the Prefect UI. If not set, the client will attempt to infer it.
 **Supported environment variables**:
 `PREFECT_SILENCE_API_URL_MISCONFIGURATION`
 
-### `experimental_warn`
-If `True`, warn on usage of experimental features.
-
-**Type**: `boolean`
-
-**Default**: `True`
-
-**TOML dotted key path**: `experimental_warn`
-
-**Supported environment variables**:
-`PREFECT_EXPERIMENTAL_WARN`
-
 ### `async_fetch_state_result`
 
         Determines whether `State.result()` fetches results automatically or not.
@@ -475,6 +463,18 @@ The default Docker namespace to use when building images.
 ---
 ## ExperimentsSettings
 Settings for configuring experimental features
+### `warn`
+If `True`, warn on usage of experimental features.
+
+**Type**: `boolean`
+
+**Default**: `True`
+
+**TOML dotted key path**: `experiments.warn`
+
+**Supported environment variables**:
+`PREFECT_EXPERIMENTS_WARN`, `PREFECT_EXPERIMENTAL_WARN`
+
 ### `worker_logging_to_api_enabled`
 Enables the logging of worker logs to Prefect Cloud.
 

--- a/docs/3.0/develop/settings-ref.mdx
+++ b/docs/3.0/develop/settings-ref.mdx
@@ -164,26 +164,6 @@ The URL of the Prefect UI. If not set, the client will attempt to infer it.
 **Supported environment variables**:
 `PREFECT_SILENCE_API_URL_MISCONFIGURATION`
 
-### `async_fetch_state_result`
-
-        Determines whether `State.result()` fetches results automatically or not.
-        In Prefect 2.6.0, the `State.result()` method was updated to be async
-        to facilitate automatic retrieval of results from storage which means when
-        writing async code you must `await` the call. For backwards compatibility,
-        the result is not retrieved by default for async users. You may opt into this
-        per call by passing  `fetch=True` or toggle this setting to change the behavior
-        globally.
-        
-
-**Type**: `boolean`
-
-**Default**: `False`
-
-**TOML dotted key path**: `async_fetch_state_result`
-
-**Supported environment variables**:
-`PREFECT_ASYNC_FETCH_STATE_RESULT`
-
 ---
 ## APISettings
 Settings for interacting with the Prefect API

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -309,6 +309,16 @@
         "ExperimentsSettings": {
             "description": "Settings for configuring experimental features",
             "properties": {
+                "warn": {
+                    "default": true,
+                    "description": "If `True`, warn on usage of experimental features.",
+                    "supported_environment_variables": [
+                        "PREFECT_EXPERIMENTS_WARN",
+                        "PREFECT_EXPERIMENTAL_WARN"
+                    ],
+                    "title": "Warn",
+                    "type": "boolean"
+                },
                 "worker_logging_to_api_enabled": {
                     "default": false,
                     "description": "Enables the logging of worker logs to Prefect Cloud.",
@@ -2218,17 +2228,9 @@
             "title": "Silence Api Url Misconfiguration",
             "type": "boolean"
         },
-        "experimental_warn": {
-            "default": true,
-            "description": "If `True`, warn on usage of experimental features.",
-            "supported_environment_variables": [
-                "PREFECT_EXPERIMENTAL_WARN"
-            ],
-            "title": "Experimental Warn",
-            "type": "boolean"
-        },
         "async_fetch_state_result": {
             "default": false,
+            "deprecated": true,
             "description": "\n        Determines whether `State.result()` fetches results automatically or not.\n        In Prefect 2.6.0, the `State.result()` method was updated to be async\n        to facilitate automatic retrieval of results from storage which means when\n        writing async code you must `await` the call. For backwards compatibility,\n        the result is not retrieved by default for async users. You may opt into this\n        per call by passing  `fetch=True` or toggle this setting to change the behavior\n        globally.\n        ",
             "supported_environment_variables": [
                 "PREFECT_ASYNC_FETCH_STATE_RESULT"

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -2227,16 +2227,6 @@
             ],
             "title": "Silence Api Url Misconfiguration",
             "type": "boolean"
-        },
-        "async_fetch_state_result": {
-            "default": false,
-            "deprecated": true,
-            "description": "\n        Determines whether `State.result()` fetches results automatically or not.\n        In Prefect 2.6.0, the `State.result()` method was updated to be async\n        to facilitate automatic retrieval of results from storage which means when\n        writing async code you must `await` the call. For backwards compatibility,\n        the result is not retrieved by default for async users. You may opt into this\n        per call by passing  `fetch=True` or toggle this setting to change the behavior\n        globally.\n        ",
-            "supported_environment_variables": [
-                "PREFECT_ASYNC_FETCH_STATE_RESULT"
-            ],
-            "title": "Async Fetch State Result",
-            "type": "boolean"
         }
     },
     "title": "Prefect Settings",

--- a/src/integrations/prefect-dask/tests/conftest.py
+++ b/src/integrations/prefect-dask/tests/conftest.py
@@ -4,7 +4,6 @@ import sys
 
 import pytest
 
-from prefect.settings import PREFECT_ASYNC_FETCH_STATE_RESULT, temporary_settings
 from prefect.testing.utilities import prefect_test_harness
 
 
@@ -46,9 +45,3 @@ def event_loop(request):
     # Workaround for failures in pytest_asyncio 0.17;
     # see https://github.com/pytest-dev/pytest-asyncio/issues/257
     policy.set_event_loop(loop)
-
-
-@pytest.fixture(autouse=True)
-def fetch_state_result():
-    with temporary_settings(updates={PREFECT_ASYNC_FETCH_STATE_RESULT: True}):
-        yield

--- a/src/integrations/prefect-ray/tests/conftest.py
+++ b/src/integrations/prefect-ray/tests/conftest.py
@@ -1,16 +1,9 @@
 import pytest
 
-from prefect.settings import PREFECT_ASYNC_FETCH_STATE_RESULT, temporary_settings
 from prefect.testing.utilities import prefect_test_harness
 
 
 @pytest.fixture(scope="session", autouse=True)
 def prefect_db():
     with prefect_test_harness():
-        yield
-
-
-@pytest.fixture(autouse=True)
-def fetch_state_result():
-    with temporary_settings(updates={PREFECT_ASYNC_FETCH_STATE_RESULT: True}):
         yield

--- a/src/integrations/prefect-sqlalchemy/tests/conftest.py
+++ b/src/integrations/prefect-sqlalchemy/tests/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 
-from prefect.settings import PREFECT_ASYNC_FETCH_STATE_RESULT, temporary_settings
 from prefect.testing.utilities import prefect_test_harness
 
 
@@ -10,10 +9,4 @@ def prefect_db():
     Sets up test harness for temporary DB during test runs.
     """
     with prefect_test_harness():
-        yield
-
-
-@pytest.fixture(autouse=True)
-def fetch_state_result():
-    with temporary_settings(updates={PREFECT_ASYNC_FETCH_STATE_RESULT: True}):
         yield

--- a/src/prefect/settings/models/experiments.py
+++ b/src/prefect/settings/models/experiments.py
@@ -1,4 +1,4 @@
-from pydantic import Field
+from pydantic import AliasChoices, AliasPath, Field
 
 from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
@@ -9,6 +9,14 @@ class ExperimentsSettings(PrefectBaseSettings):
     """
 
     model_config = _build_settings_config(("experiments",))
+
+    warn: bool = Field(
+        default=True,
+        description="If `True`, warn on usage of experimental features.",
+        validation_alias=AliasChoices(
+            AliasPath("warn"), "prefect_experiments_warn", "prefect_experimental_warn"
+        ),
+    )
 
     worker_logging_to_api_enabled: bool = Field(
         default=False,

--- a/src/prefect/settings/models/root.py
+++ b/src/prefect/settings/models/root.py
@@ -13,9 +13,6 @@ from urllib.parse import urlparse
 from pydantic import BeforeValidator, Field, SecretStr, model_validator
 from typing_extensions import Self
 
-from prefect._internal.compatibility.deprecated import (
-    generate_deprecation_message,
-)
 from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 from prefect.settings.models.tasks import TasksSettings
 from prefect.settings.models.testing import TestingSettings
@@ -150,26 +147,6 @@ class Settings(PrefectBaseSettings):
         Sometimes when a user manually set `PREFECT_API_URL` to a custom url,reverse-proxy for example,
         we would like to silence this warning so we will set it to `FALSE`.
         """,
-    )
-
-    # this setting needs to be removed
-    async_fetch_state_result: bool = Field(
-        default=False,
-        description="""
-        Determines whether `State.result()` fetches results automatically or not.
-        In Prefect 2.6.0, the `State.result()` method was updated to be async
-        to facilitate automatic retrieval of results from storage which means when
-        writing async code you must `await` the call. For backwards compatibility,
-        the result is not retrieved by default for async users. You may opt into this
-        per call by passing  `fetch=True` or toggle this setting to change the behavior
-        globally.
-        """,
-        deprecated=generate_deprecation_message(
-            "The `async_fetch_state_result` setting",
-            start_date="Oct 2024",
-            end_date="Jan 2025",
-            help="Please ensure you are awaiting calls to `result()` when calling in an async context.",
-        ),
     )
 
     ###########################################################################

--- a/src/prefect/settings/models/root.py
+++ b/src/prefect/settings/models/root.py
@@ -13,6 +13,9 @@ from urllib.parse import urlparse
 from pydantic import BeforeValidator, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from prefect._internal.compatibility.deprecated import (
+    generate_deprecation_message,
+)
 from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 from prefect.settings.models.tasks import TasksSettings
 from prefect.settings.models.testing import TestingSettings
@@ -149,11 +152,6 @@ class Settings(PrefectBaseSettings):
         """,
     )
 
-    experimental_warn: bool = Field(
-        default=True,
-        description="If `True`, warn on usage of experimental features.",
-    )
-
     # this setting needs to be removed
     async_fetch_state_result: bool = Field(
         default=False,
@@ -166,6 +164,12 @@ class Settings(PrefectBaseSettings):
         per call by passing  `fetch=True` or toggle this setting to change the behavior
         globally.
         """,
+        deprecated=generate_deprecation_message(
+            "The `async_fetch_state_result` setting",
+            start_date="Oct 2024",
+            end_date="Jan 2025",
+            help="Please ensure you are awaiting calls to `result()` when calling in an async context.",
+        ),
     )
 
     ###########################################################################

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -33,7 +33,6 @@ from prefect.results import (
     ResultRecordMetadata,
     ResultStore,
 )
-from prefect.settings import PREFECT_ASYNC_FETCH_STATE_RESULT
 from prefect.utilities.annotations import BaseAnnotation
 from prefect.utilities.asyncutils import in_async_main_thread, sync_compatible
 from prefect.utilities.collections import ensure_iterable
@@ -60,23 +59,17 @@ def get_state_result(
     See `State.result()`
     """
 
-    if fetch is None and (
-        PREFECT_ASYNC_FETCH_STATE_RESULT or not in_async_main_thread()
-    ):
-        # Fetch defaults to `True` for sync users or async users who have opted in
-        fetch = True
-    if not fetch:
-        if fetch is None and in_async_main_thread():
-            warnings.warn(
-                (
-                    "State.result() was called from an async context but not awaited. "
-                    "This method will be updated to return a coroutine by default in "
-                    "the future. Pass `fetch=True` and `await` the call to get rid of "
-                    "this warning."
-                ),
-                DeprecationWarning,
-                stacklevel=2,
-            )
+    if not fetch and in_async_main_thread():
+        warnings.warn(
+            (
+                "State.result() was called from an async context but not awaited. "
+                "This method will be updated to return a coroutine by default in "
+                "the future. Pass `fetch=True` and `await` the call to get rid of "
+                "this warning."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         return state.data
     else:

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -12,6 +12,7 @@ import httpx
 import pendulum
 from typing_extensions import TypeGuard
 
+from prefect._internal.compatibility import deprecated
 from prefect.client.schemas import State as State
 from prefect.client.schemas import StateDetails, StateType
 from prefect.exceptions import (
@@ -40,10 +41,17 @@ from prefect.utilities.collections import ensure_iterable
 logger = get_logger("states")
 
 
+@deprecated.deprecated_parameter(
+    "fetch",
+    when=lambda fetch: fetch is not True,
+    start_date="Oct 2024",
+    end_date="Jan 2025",
+    help="Please ensure you are awaiting the call to `result()` when calling in an async context.",
+)
 def get_state_result(
     state: State[R],
     raise_on_failure: bool = True,
-    fetch: Optional[bool] = None,
+    fetch: bool = True,
     retry_result_failure: bool = True,
 ) -> R:
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,6 @@ from prefect.settings import (
     PREFECT_API_SERVICES_TASK_RUN_RECORDER_ENABLED,
     PREFECT_API_SERVICES_TRIGGERS_ENABLED,
     PREFECT_API_URL,
-    PREFECT_ASYNC_FETCH_STATE_RESULT,
     PREFECT_CLI_COLORS,
     PREFECT_CLI_WRAP_LINES,
     PREFECT_HOME,
@@ -323,7 +322,6 @@ def pytest_sessionstart(session):
             PREFECT_CLI_COLORS: False,
             PREFECT_CLI_WRAP_LINES: False,
             # Enable future change
-            PREFECT_ASYNC_FETCH_STATE_RESULT: True,
             # Enable debug logging
             PREFECT_LOGGING_LEVEL: "DEBUG",
             PREFECT_LOGGING_INTERNAL_LEVEL: "DEBUG",

--- a/tests/results/test_result_fetch.py
+++ b/tests/results/test_result_fetch.py
@@ -1,21 +1,6 @@
-import pytest
-
 from prefect import flow, task
-from prefect.settings import PREFECT_ASYNC_FETCH_STATE_RESULT, temporary_settings
 
 
-@pytest.fixture(autouse=True)
-def disable_fetch_by_default():
-    """
-    The test suite defaults to the future behavior.
-
-    For these tests, we enable the default user behavior.
-    """
-    with temporary_settings({PREFECT_ASYNC_FETCH_STATE_RESULT: False}):
-        yield
-
-
-@pytest.mark.skip(reason="This test is flaky and needs to be fixed")
 async def test_async_result_warnings_are_not_raised_by_engine():
     # Since most of our tests are run with the opt-in globally enabled, this test
     # covers a bunch of features to cover remaining cases where we may internally
@@ -92,8 +77,7 @@ async def test_async_result_returns_coroutine_with_setting():
         return 1
 
     state = await foo(return_state=True)
-    with temporary_settings({PREFECT_ASYNC_FETCH_STATE_RESULT: True}):
-        coro = state.result(fetch=True)
+    coro = state.result()
 
     assert await coro == 1
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -228,6 +228,7 @@ SUPPORTED_SETTINGS = {
     },
     "PREFECT_EVENTS_WEBSOCKET_BACKFILL_PAGE_SIZE": {"test_value": 10, "legacy": True},
     "PREFECT_EXPERIMENTAL_WARN": {"test_value": True},
+    "PREFECT_EXPERIMENTS_WARN": {"test_value": True},
     "PREFECT_EXPERIMENTS_WORKER_LOGGING_TO_API_ENABLED": {"test_value": False},
     "PREFECT_FLOW_DEFAULT_RETRIES": {"test_value": 10, "legacy": True},
     "PREFECT_FLOWS_DEFAULT_RETRIES": {"test_value": 10},

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -226,7 +226,7 @@ SUPPORTED_SETTINGS = {
         "legacy": True,
     },
     "PREFECT_EVENTS_WEBSOCKET_BACKFILL_PAGE_SIZE": {"test_value": 10, "legacy": True},
-    "PREFECT_EXPERIMENTAL_WARN": {"test_value": True},
+    "PREFECT_EXPERIMENTAL_WARN": {"test_value": True, "legacy": True},
     "PREFECT_EXPERIMENTS_WARN": {"test_value": True},
     "PREFECT_EXPERIMENTS_WORKER_LOGGING_TO_API_ENABLED": {"test_value": False},
     "PREFECT_FLOW_DEFAULT_RETRIES": {"test_value": 10, "legacy": True},

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -178,7 +178,6 @@ SUPPORTED_SETTINGS = {
     "PREFECT_API_TASK_CACHE_KEY_MAX_LENGTH": {"test_value": 10, "legacy": True},
     "PREFECT_API_TLS_INSECURE_SKIP_VERIFY": {"test_value": True},
     "PREFECT_API_URL": {"test_value": "https://api.prefect.io"},
-    "PREFECT_ASYNC_FETCH_STATE_RESULT": {"test_value": True},
     "PREFECT_CLIENT_CSRF_SUPPORT_ENABLED": {"test_value": True},
     "PREFECT_CLIENT_ENABLE_METRICS": {"test_value": True, "legacy": True},
     "PREFECT_CLIENT_MAX_RETRIES": {"test_value": 3},


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

This PR takes care of two settings on the root model that shouldn't be there long term:
- `experimental_warn` is moved to `experiments.warn`
- `async_fetch_state_result` is removed and the default behavior for fetching results is updated to match this setting being enabled. The corresponding `fetch` kwargs are also deprecated so we can eventually clean all that up.
