### PR TITLE
Dont reuse exc name in nested exception handling

### DIFF
--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -256,10 +256,10 @@ async def exception_to_failed_state(
         if write_result:
             try:
                 await result_store.apersist_result_record(data)
-            except Exception as exc:
+            except Exception as nested_exc:
                 local_logger.warning(
                     "Failed to write result: %s Execution will continue, but the result has not been written",
-                    exc,
+                    nested_exc,
                 )
     else:
         # Attach the exception for local usage, will not be available when retrieved


### PR DESCRIPTION
I honestly am not sure if this is a fix or not, but I have a suspicion this could be the issue with https://github.com/PrefectHQ/prefect/issues/15893