### PR TITLE
Set `COVERAGE_CORE=sysmon` to speed up test on 3.12

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -159,6 +159,11 @@ jobs:
           echo "COVERAGE_FILE=${COVERAGE_FILE}" >> $GITHUB_ENV
           echo "artifact_name=coverage-data-${sanitized_test_type}-${{ matrix.python-version }}-${sanitized_database}" >> $GITHUB_OUTPUT
 
+      - name: Set coverage core
+        if: ${{ matrix.python-version == '3.12' }}
+        run: |
+          echo "COVERAGE_CORE=sysmon" >> $GITHUB_ENV
+
       - name: Run tests
         run: |
           echo "Using COVERAGE_FILE=$COVERAGE_FILE"
@@ -343,6 +348,11 @@ jobs:
           export COVERAGE_FILE=".coverage.${sanitized_python_version}.${sanitized_database}"
           echo "COVERAGE_FILE=${COVERAGE_FILE}" >> $GITHUB_ENV
           echo "artifact_name=coverage-data-docker-${{ matrix.python-version }}-${sanitized_database}" >> $GITHUB_OUTPUT
+
+      - name: Set coverage core
+        if: ${{ matrix.python-version == '3.12' }}
+        run: |
+          echo "COVERAGE_CORE=sysmon" >> $GITHUB_ENV
 
       - name: Run tests
         run: |


### PR DESCRIPTION
The 3.12 tests were running slow, so this PR sets `COVERAGE_CORE` for Python 3.12 tests. I learned about this setting in https://github.com/nedbat/coveragepy/issues/1665. The 3.12 test run significantly faster now and have gone from the slowest to the fastest:

![Screenshot 2024-11-01 at 10 17 29 AM](https://github.com/user-attachments/assets/818e1b5e-a69b-47a0-9d21-02769b56cc98)
