### PR TITLE
fix extra loggers parsing

### DIFF
--- a/src/prefect/settings/models/logging.py
+++ b/src/prefect/settings/models/logging.py
@@ -1,11 +1,18 @@
+from functools import partial
 from pathlib import Path
 from typing import Annotated, Literal, Optional, Union
 
-from pydantic import AfterValidator, AliasChoices, AliasPath, Field, model_validator
+from pydantic import (
+    AliasChoices,
+    AliasPath,
+    BeforeValidator,
+    Field,
+    model_validator,
+)
 from typing_extensions import Self
 
 from prefect.settings.base import PrefectBaseSettings, _build_settings_config
-from prefect.types import LogLevel
+from prefect.types import LogLevel, validate_set_T_from_delim_string
 
 
 def max_log_size_smaller_than_batch_size(values):
@@ -97,7 +104,7 @@ class LoggingSettings(PrefectBaseSettings):
 
     extra_loggers: Annotated[
         Union[str, list[str], None],
-        AfterValidator(lambda v: [n.strip() for n in v.split(",")] if v else []),
+        BeforeValidator(partial(validate_set_T_from_delim_string, type_=str)),
     ] = Field(
         default=None,
         description="Additional loggers to attach to Prefect logging at runtime.",

--- a/src/prefect/types/__init__.py
+++ b/src/prefect/types/__init__.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Annotated, Any, Dict, List, Sequence, Set, TypeVar, Union
+from typing import Annotated, Any, Dict, List, Set, TypeVar, Union
 from typing_extensions import Literal
 import orjson
 import pydantic
@@ -7,7 +7,6 @@ import pydantic
 from pydantic import (
     BeforeValidator,
     Field,
-    SecretStr,
     StrictBool,
     StrictFloat,
     StrictInt,

--- a/src/prefect/types/__init__.py
+++ b/src/prefect/types/__init__.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Annotated, Any, Dict, List, Set, TypeVar, Union
+from typing import Annotated, Any, Dict, List, Sequence, Set, TypeVar, Union
 from typing_extensions import Literal
 import orjson
 import pydantic
@@ -110,7 +110,7 @@ def validate_set_T_from_delim_string(
     T_adapter = TypeAdapter(type_)
     delim = delim or ","
     if isinstance(value, str):
-        return {T_adapter.validate_strings(s) for s in value.split(delim)}
+        return {T_adapter.validate_strings(s.strip()) for s in value.split(delim)}
     errors = []
     try:
         return {T_adapter.validate_python(value)}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -597,8 +597,8 @@ class TestSettingsClass:
         assert settings.model_dump() == new_settings.model_dump()
 
     def test_settings_hash_key(self):
-        settings = Settings(testing=dict(test_mode=True))
-        diff_settings = Settings(testing=dict(test_mode=False))
+        settings = Settings(testing=dict(test_mode=True))  # type: ignore
+        diff_settings = Settings(testing=dict(test_mode=False))  # type: ignore
 
         assert settings.hash_key() == settings.hash_key()
 
@@ -729,17 +729,26 @@ class TestSettingAccess:
     @pytest.mark.parametrize(
         "value,expected",
         [
+            (None, []),
             ("foo", ["foo"]),
             ("foo,bar", ["foo", "bar"]),
             ("foo, bar, foobar ", ["foo", "bar", "foobar"]),
+            (["foo", "bar"], ["foo", "bar"]),
+        ],
+        ids=[
+            "none",
+            "string",
+            "comma_separated",
+            "comma_separated_with_spaces",
+            "python_list",
         ],
     )
     def test_extra_loggers(self, value, expected):
         settings = Settings(logging=LoggingSettings(extra_loggers=value))
-        assert PREFECT_LOGGING_EXTRA_LOGGERS.value_from(settings) == expected
+        assert set(PREFECT_LOGGING_EXTRA_LOGGERS.value_from(settings)) == set(expected)
 
     def test_prefect_home_expands_tilde_in_path(self):
-        settings = Settings(home="~/test")
+        settings = Settings(home=Path("~/test"))  # type: ignore
         assert PREFECT_HOME.value_from(settings) == Path("~/test").expanduser()
 
     @pytest.mark.parametrize(
@@ -1371,7 +1380,7 @@ class TestSaveProfiles:
 
 class TestProfile:
     def test_init_casts_names_to_setting_types(self):
-        profile = Profile(name="test", settings={"PREFECT_DEBUG_MODE": 1})
+        profile = Profile(name="test", settings={"PREFECT_DEBUG_MODE": 1})  # type: ignore
         assert profile.settings == {PREFECT_DEBUG_MODE: 1}
 
     def test_validate_settings(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -748,7 +748,7 @@ class TestSettingAccess:
         assert set(PREFECT_LOGGING_EXTRA_LOGGERS.value_from(settings)) == set(expected)
 
     def test_prefect_home_expands_tilde_in_path(self):
-        settings = Settings(home=Path("~/test"))  # type: ignore
+        settings = Settings(home="~/test")  # type: ignore
         assert PREFECT_HOME.value_from(settings) == Path("~/test").expanduser()
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
setting `extra_loggers` to a normal python list failed, since we tried to `split()` in an `AfterValidator`, this switches us to use the same handling as we do for client extra retry codes i.e. either `list,of,things` or `['list', 'of', 'things']` to support `.env` as well as native types (found this when using controlflow)