### PR TITLE
Fix `prefect config view` not showing .env file settings

### DIFF
--- a/src/prefect/cli/config.py
+++ b/src/prefect/cli/config.py
@@ -251,7 +251,7 @@ def view(
         _process_setting(setting, env_value, "env")
 
     # Process settings from .env file
-    for key, value in dotenv_values().items():
+    for key, value in dotenv_values(".env").items():
         if key in VALID_SETTING_NAMES:
             setting = _get_settings_fields(prefect.settings.Settings)[key]
             if setting.name in processed_settings or value is None:


### PR DESCRIPTION
This PR fixes `prefect config view` for .env file settings with added tests.

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
