### PR TITLE
sanitize decorators and callable parameters on entrypoint load

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -2148,6 +2148,9 @@ def _sanitize_and_load_flow(
 
         # Exclude callable type keyword arguments from flow decorator
         for func_decorator in func_def.decorator_list:
+            if not hasattr(func_decorator, "keywords"):
+                continue
+
             func_decorator.keywords = list(
                 filter(
                     lambda keyword_arg: keyword_arg.arg not in exclude_keyword_args,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
During `prefect deploy` command execution, if python environment is not setup prefect load entrypoint using code parsing by ast module.
Now this is done by `_sanitize_and_load_flow` function which tries to sanitize code definition and try to load the flow.
Now in flow decorator, if it used any other decorator or uses callback hooks `on_completion`, `on_running` etc. then it will throw ScriptError.
So in this PR, try to sanitize the decorators and keywords used in flow decorator to try to load flow.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - Closes https://github.com/PrefectHQ/prefect/issues/15942
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
