### PR TITLE
fix flow run graph endpoint for nested task runs

### DIFF
--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -947,8 +947,15 @@ class AsyncPostgresQueryComponents(BaseQueryComponents):
                         end_time=row.end_time,
                         parents=[Edge(id=id) for id in row.parent_ids or []],
                         children=[Edge(id=id) for id in row.child_ids or []],
+                        # ensure encapsulating_ids is deduplicated
+                        # so parents only show up once
                         encapsulating=[
-                            Edge(id=id) for id in row.encapsulating_ids or []
+                            Edge(id=id)
+                            for id in (
+                                list(set(row.encapsulating_ids))
+                                if row.encapsulating_ids
+                                else []
+                            )
                         ],
                         artifacts=graph_artifacts.get(row.id, []),
                     ),
@@ -1427,7 +1434,13 @@ class AioSqliteQueryComponents(BaseQueryComponents):
                         end_time=time(row.end_time),
                         parents=edges(row.parent_ids),
                         children=edges(row.child_ids),
-                        encapsulating=edges(row.encapsulating_ids),
+                        # ensure encapsulating_ids is deduplicated
+                        # so parents only show up once
+                        encapsulating=edges(
+                            list(set(row.encapsulating_ids.split(",")))
+                            if row.encapsulating_ids
+                            else None
+                        ),
                         artifacts=graph_artifacts.get(UUID(row.id), []),
                     ),
                 )


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/15933

When checking if task runs are nested task runs, if the parent function contains multiple arguments, we'll end up with multiple edges (because there are two parents). 

Normally when constructing edges this is the behavior we want. However when generating our list of encapsulating ids (parents that have a nested task run), this shows up as two of the same parent, which is unexpected for that field. This PR ensures we deduplicates the encapsulating_ids field.
