### PR TITLE
Include worker ID with worker-originated flow run logs

### DIFF
--- a/src/prefect/logging/handlers.py
+++ b/src/prefect/logging/handlers.py
@@ -181,6 +181,7 @@ class APILogHandler(logging.Handler):
         """
         flow_run_id = getattr(record, "flow_run_id", None)
         task_run_id = getattr(record, "task_run_id", None)
+        worker_id = getattr(record, "worker_id", None)
 
         if not flow_run_id:
             try:
@@ -216,6 +217,7 @@ class APILogHandler(logging.Handler):
         log = LogCreate(
             flow_run_id=flow_run_id if is_uuid_like else None,
             task_run_id=task_run_id,
+            worker_id=worker_id,
             name=record.name,
             level=record.levelno,
             timestamp=pendulum.from_timestamp(

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -502,15 +502,19 @@ class BaseWorker(abc.ABC):
         return slugify(self.name)
 
     def get_flow_run_logger(self, flow_run: "FlowRun") -> PrefectLogAdapter:
+        extra = {
+            "worker_name": self.name,
+            "work_pool_name": (
+                self._work_pool_name if self._work_pool else "<unknown>"
+            ),
+            "work_pool_id": str(getattr(self._work_pool, "id", "unknown")),
+        }
+        if self.backend_id:
+            extra["worker_id"] = str(self.backend_id)
+
         return flow_run_logger(flow_run=flow_run).getChild(
             "worker",
-            extra={
-                "worker_name": self.name,
-                "work_pool_name": (
-                    self._work_pool_name if self._work_pool else "<unknown>"
-                ),
-                "work_pool_id": str(getattr(self._work_pool, "id", "unknown")),
-            },
+            extra=extra,
         )
 
     async def start(

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -1585,7 +1585,7 @@ async def test_get_flow_run_logger_with_worker_id_set(
             "flow_name": "<unknown>",
             "worker_name": "test",
             "work_pool_name": work_pool.name,
-            "work_pool_id": str(work_pool.id),
+            "work_pool_id": work_pool.id,
             "worker_id": worker_id,
         }
 

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -1538,7 +1538,7 @@ class TestPrepareForFlowRun:
         assert job_config.command == "prefect flow-run execute"
 
 
-async def test_get_flow_run_logger(
+async def test_get_flow_run_logger_without_worker_id_set(
     prefect_client: PrefectClient, worker_deployment_wq1, work_pool
 ):
     flow_run = await prefect_client.create_flow_run_from_deployment(
@@ -1549,6 +1549,7 @@ async def test_get_flow_run_logger(
         name="test", work_pool_name=work_pool.name, create_pool_if_not_found=False
     ) as worker:
         await worker.sync_with_backend()
+        assert worker.backend_id is None
         logger = worker.get_flow_run_logger(flow_run)
 
         assert logger.name == "prefect.flow_runs.worker"
@@ -1559,6 +1560,33 @@ async def test_get_flow_run_logger(
             "worker_name": "test",
             "work_pool_name": work_pool.name,
             "work_pool_id": str(work_pool.id),
+        }
+
+
+async def test_get_flow_run_logger_with_worker_id_set(
+    prefect_client: PrefectClient, worker_deployment_wq1, work_pool
+):
+    flow_run = await prefect_client.create_flow_run_from_deployment(
+        worker_deployment_wq1.id
+    )
+
+    async with WorkerTestImpl(
+        name="test", work_pool_name=work_pool.name, create_pool_if_not_found=False
+    ) as worker:
+        await worker.sync_with_backend()
+        worker_id = uuid.uuid4()
+        worker.backend_id = worker_id
+        logger = worker.get_flow_run_logger(flow_run)
+
+        assert logger.name == "prefect.flow_runs.worker"
+        assert logger.extra == {
+            "flow_run_name": flow_run.name,
+            "flow_run_id": str(flow_run.id),
+            "flow_name": "<unknown>",
+            "worker_name": "test",
+            "work_pool_name": work_pool.name,
+            "work_pool_id": str(work_pool.id),
+            "worker_id": worker_id,
         }
 
 

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -1564,7 +1564,10 @@ async def test_get_flow_run_logger_without_worker_id_set(
 
 
 async def test_get_flow_run_logger_with_worker_id_set(
-    prefect_client: PrefectClient, worker_deployment_wq1, work_pool
+    prefect_client: PrefectClient,
+    worker_deployment_wq1,
+    work_pool,
+    experimental_logging_enabled,
 ):
     flow_run = await prefect_client.create_flow_run_from_deployment(
         worker_deployment_wq1.id
@@ -1585,8 +1588,8 @@ async def test_get_flow_run_logger_with_worker_id_set(
             "flow_name": "<unknown>",
             "worker_name": "test",
             "work_pool_name": work_pool.name,
-            "work_pool_id": work_pool.id,
-            "worker_id": worker_id,
+            "work_pool_id": str(work_pool.id),
+            "worker_id": str(worker_id),
         }
 
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

Expanding on our work to emit worker logs, this PR includes the worker ID when a worker emits logs on behalf of a flow run. We do this so that we can show these logs, which are very often about infrastructure, alongside other infra-related worker logs on the new worker page.

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
