### PR TITLE
Fixes the worker url slug

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -878,7 +878,7 @@ class BaseWorker(abc.ABC):
                     and self.backend_id
                 ):
                     worker_path = f"worker/{self.backend_id}"
-                    base_url = url_for("work-pool", self._work_pool.id)
+                    base_url = url_for("work-pool", self._work_pool.name)
 
                     run_logger.info(
                         f"Running on worker id: {self.backend_id}. See worker logs here: {base_url}/{worker_path}"


### PR DESCRIPTION
We used the `workpool.id` rather then `workpool.name` in generating the link to the workpool which isn't the proper routing used in the url.
<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
