### PR TITLE
Fix the key for worker metadata: it's is just "metadata"

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2613,9 +2613,11 @@ class PrefectClient:
             "heartbeat_interval_seconds": heartbeat_interval_seconds,
         }
         if worker_metadata:
-            params["worker_metadata"] = worker_metadata.model_dump(mode="json")
+            params["metadata"] = worker_metadata.model_dump(mode="json")
         if get_worker_id:
             params["return_id"] = get_worker_id
+
+        print(f"params: {params}")
 
         resp = await self._client.post(
             f"/work_pools/{work_pool_name}/workers/heartbeat",

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2617,8 +2617,6 @@ class PrefectClient:
         if get_worker_id:
             params["return_id"] = get_worker_id
 
-        print(f"params: {params}")
-
         resp = await self._client.post(
             f"/work_pools/{work_pool_name}/workers/heartbeat",
             json=params,

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -2737,7 +2737,7 @@ class TestPrefectClientWorkerHeartbeat:
             assert mock_post.call_args[1]["json"] == {
                 "name": "test-worker",
                 "heartbeat_interval_seconds": 10,
-                "worker_metadata": {
+                "metadata": {
                     "integrations": [{"name": "prefect-aws", "version": "1.0.0"}]
                 },
             }

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -1914,7 +1914,7 @@ class TestBaseWorkerHeartbeat:
                     json={
                         "name": worker.name,
                         "heartbeat_interval_seconds": worker.heartbeat_interval_seconds,
-                        "worker_metadata": {
+                        "metadata": {
                             "integrations": [
                                 {"name": "prefect-aws", "version": "1.0.0"}
                             ]
@@ -1972,7 +1972,7 @@ class TestBaseWorkerHeartbeat:
                     json={
                         "name": worker.name,
                         "heartbeat_interval_seconds": worker.heartbeat_interval_seconds,
-                        "worker_metadata": {
+                        "metadata": {
                             "integrations": [
                                 {"name": "prefect-aws", "version": "1.0.0"}
                             ],


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

The JSON key for worker metadata is actually just "metadata." 🤦 

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
