### PR TITLE
fix: `prefect_redis` use of `async`

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/blocks.py
+++ b/src/integrations/prefect-redis/prefect_redis/blocks.py
@@ -77,7 +77,7 @@ class RedisDatabase(WritableFileSystem):
         Returns:
             Contents at key as bytes
         """
-        client = self.get_client()
+        client = self.get_async_client()
         ret = await client.get(path)
 
         await client.close()
@@ -90,7 +90,7 @@ class RedisDatabase(WritableFileSystem):
             path: Redis key to write to
             content: Binary object to write
         """
-        client = self.get_client()
+        client = self.get_async_client()
         ret = await client.set(path, content)
 
         await client.close()

--- a/src/integrations/prefect-redis/prefect_redis/locking.py
+++ b/src/integrations/prefect-redis/prefect_redis/locking.py
@@ -148,7 +148,7 @@ class RedisLockManager(LockManager):
         lock = AsyncLock(self.async_client, lock_name)
         lock_freed = await lock.acquire(blocking_timeout=timeout)
         if lock_freed:
-            lock.release()
+            await lock.release()
         return lock_freed
 
     def is_locked(self, key: str) -> bool:


### PR DESCRIPTION
It seems async wasn't being correctly used and pretty obvious errors were being thrown within async tasks

```python
redis_block = RedisDatabase.load("mein")
s3_block = S3Bucket.load("stuff")

task_cached = partial(
    task,
    cache_policy=(INPUTS).configure(
        isolation_level=IsolationLevel.READ_COMMITTED,
        lock_manager=RedisLockManager(
            **{
                k: v
                for k, v in redis_block.as_connection_params().items()
                if not k.startswith("_")
            }
        ),
        key_storage=redis_block,  # Keys are stored in Redis for fast access
    ),
    log_prints=True,  # print() statements will be logged
    persist_result=True,
    result_storage=s3_block,  # S3 as data sink
    cache_result_in_memory=False,  # Do not cache results in memory (they can also be huge)
    result_serializer="json",
    cache_expiration=timedelta(
        minutes=1
    ),  # Default cache expiration, should override per-task
)

@task_cached
async def mein_task():
... Will fail
```

> also note how  `as_connection_params` is broken too as  underscore attributes need to be manually filtered out 🤔 PR?   