### PR TITLE
Ensure `.env` files load only Prefect environment variables

### DIFF
--- a/src/prefect/settings/base.py
+++ b/src/prefect/settings/base.py
@@ -11,12 +11,14 @@ from pydantic import (
 )
 from pydantic_settings import (
     BaseSettings,
+    DotEnvSettingsSource,
     PydanticBaseSettingsSource,
     SettingsConfigDict,
 )
 
 from prefect.settings.sources import (
     EnvFilterSettingsSource,
+    FilteredDotEnvSettingsSource,
     PrefectTomlConfigSettingsSource,
     ProfileSettingsTomlLoader,
     PyprojectTomlConfigSettingsSource,
@@ -62,7 +64,18 @@ class PrefectBaseSettings(BaseSettings):
                 env_parse_enums=cls.model_config.get("env_parse_enums"),
                 env_filter=list(env_filter),
             ),
-            dotenv_settings,
+            FilteredDotEnvSettingsSource(
+                settings_cls,
+                env_file=cls.model_config.get("env_file"),
+                env_file_encoding=cls.model_config.get("env_file_encoding"),
+                case_sensitive=cls.model_config.get("case_sensitive"),
+                env_prefix=cls.model_config.get("env_prefix"),
+                env_nested_delimiter=cls.model_config.get("env_nested_delimiter"),
+                env_ignore_empty=cls.model_config.get("env_ignore_empty"),
+                env_parse_none_str=cls.model_config.get("env_parse_none_str"),
+                env_parse_enums=cls.model_config.get("env_parse_enums"),
+                env_blacklist=list(env_filter),
+            ),
             file_secret_settings,
             PrefectTomlConfigSettingsSource(settings_cls),
             PyprojectTomlConfigSettingsSource(settings_cls),
@@ -90,9 +103,9 @@ class PrefectBaseSettings(BaseSettings):
                 )
                 env_variables.update(child_env)
             elif (value := env.get(key)) is not None:
-                env_variables[
-                    f"{self.model_config.get('env_prefix')}{key.upper()}"
-                ] = str(value)
+                env_variables[f"{self.model_config.get('env_prefix')}{key.upper()}"] = (
+                    str(value)
+                )
         return env_variables
 
     @model_serializer(

--- a/src/prefect/settings/base.py
+++ b/src/prefect/settings/base.py
@@ -44,13 +44,14 @@ class PrefectBaseSettings(BaseSettings):
         See https://docs.pydantic.dev/latest/concepts/pydantic_settings/#customise-settings-sources
         """
         env_filter = set()
-        for field in settings_cls.model_fields.values():
+        for field_name, field in settings_cls.model_fields.items():
             if field.validation_alias is not None and isinstance(
                 field.validation_alias, AliasChoices
             ):
                 for alias in field.validation_alias.choices:
                     if isinstance(alias, AliasPath) and len(alias.path) > 0:
                         env_filter.add(alias.path[0])
+            env_filter.add(field_name)
         return (
             init_settings,
             EnvFilterSettingsSource(

--- a/src/prefect/settings/base.py
+++ b/src/prefect/settings/base.py
@@ -11,7 +11,6 @@ from pydantic import (
 )
 from pydantic_settings import (
     BaseSettings,
-    DotEnvSettingsSource,
     PydanticBaseSettingsSource,
     SettingsConfigDict,
 )
@@ -103,9 +102,9 @@ class PrefectBaseSettings(BaseSettings):
                 )
                 env_variables.update(child_env)
             elif (value := env.get(key)) is not None:
-                env_variables[f"{self.model_config.get('env_prefix')}{key.upper()}"] = (
-                    str(value)
-                )
+                env_variables[
+                    f"{self.model_config.get('env_prefix')}{key.upper()}"
+                ] = str(value)
         return env_variables
 
     @model_serializer(

--- a/src/prefect/settings/sources.py
+++ b/src/prefect/settings/sources.py
@@ -2,7 +2,7 @@ import os
 import sys
 import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 import dotenv
 import toml

--- a/src/prefect/settings/sources.py
+++ b/src/prefect/settings/sources.py
@@ -92,14 +92,6 @@ class FilteredDotEnvSettingsSource(DotEnvSettingsSource):
             env_parse_enums,
         )
         self.env_blacklist = env_blacklist
-
-        # Filter out environment variables that don't start with the env prefix
-        self.env_vars = {
-            key: value
-            for key, value in self.env_vars.items()  # type: ignore
-            if (env_prefix := settings_cls.model_config.get("env_prefix"))
-            and key.lower().startswith(env_prefix.lower())
-        }
         if self.env_blacklist:
             if isinstance(self.env_vars, dict):
                 for key in self.env_blacklist:

--- a/src/prefect/settings/sources.py
+++ b/src/prefect/settings/sources.py
@@ -2,7 +2,7 @@ import os
 import sys
 import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
 
 import dotenv
 import toml
@@ -10,10 +10,15 @@ from pydantic import AliasChoices
 from pydantic.fields import FieldInfo
 from pydantic_settings import (
     BaseSettings,
+    DotEnvSettingsSource,
     EnvSettingsSource,
     PydanticBaseSettingsSource,
 )
-from pydantic_settings.sources import ConfigFileSourceMixin
+from pydantic_settings.sources import (
+    ENV_FILE_SENTINEL,
+    ConfigFileSourceMixin,
+    DotenvType,
+)
 
 from prefect.settings.constants import DEFAULT_PREFECT_HOME, DEFAULT_PROFILES_PATH
 from prefect.utilities.collections import get_from_dict
@@ -58,6 +63,52 @@ class EnvFilterSettingsSource(EnvSettingsSource):
                     key: value
                     for key, value in self.env_vars.items()  # type: ignore
                     if key.lower() not in env_filter
+                }
+
+
+class FilteredDotEnvSettingsSource(DotEnvSettingsSource):
+    def __init__(
+        self,
+        settings_cls: type[BaseSettings],
+        env_file: Optional[DotenvType] = ENV_FILE_SENTINEL,
+        env_file_encoding: Optional[str] = None,
+        case_sensitive: Optional[bool] = None,
+        env_prefix: Optional[str] = None,
+        env_nested_delimiter: Optional[str] = None,
+        env_ignore_empty: Optional[bool] = None,
+        env_parse_none_str: Optional[str] = None,
+        env_parse_enums: Optional[bool] = None,
+        env_blacklist: Optional[List[str]] = None,
+    ) -> None:
+        super().__init__(
+            settings_cls,
+            env_file,
+            env_file_encoding,
+            case_sensitive,
+            env_prefix,
+            env_nested_delimiter,
+            env_ignore_empty,
+            env_parse_none_str,
+            env_parse_enums,
+        )
+        self.env_blacklist = env_blacklist
+
+        # Filter out environment variables that don't start with the env prefix
+        self.env_vars = {
+            key: value
+            for key, value in self.env_vars.items()  # type: ignore
+            if (env_prefix := settings_cls.model_config.get("env_prefix"))
+            and key.lower().startswith(env_prefix.lower())
+        }
+        if self.env_blacklist:
+            if isinstance(self.env_vars, dict):
+                for key in self.env_blacklist:
+                    self.env_vars.pop(key, None)
+            else:
+                self.env_vars = {
+                    key: value
+                    for key, value in self.env_vars.items()  # type: ignore
+                    if key.lower() not in env_blacklist
                 }
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1390,6 +1390,13 @@ class TestSettingsSources:
 
         assert Settings().client.retry_extra_codes == set()
 
+    def test_dot_env_filters_as_expected(self, temporary_env_file):
+        expected_home = Settings().home
+        expected_db_name = Settings().server.database.name
+        temporary_env_file("HOME=foo\nNAME=bar")
+        assert Settings().home == expected_home
+        assert Settings().server.database.name == expected_db_name
+
 
 class TestLoadProfiles:
     @pytest.fixture(autouse=True)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1395,7 +1395,9 @@ class TestSettingsSources:
         expected_db_name = Settings().server.database.name
         temporary_env_file("HOME=foo\nNAME=bar")
         assert Settings().home == expected_home
+        assert Settings().home != "foo"
         assert Settings().server.database.name == expected_db_name
+        assert Settings().server.database.name != "bar"
 
 
 class TestLoadProfiles:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR subclasses `DotEnvSettingsSource` to ensure environment variables in `.env` files not prefixed with `PREFECT_` are not loaded when retrieving the configured settings. 

Closes https://github.com/PrefectHQ/prefect/issues/15943
