### PR TITLE
update `asyncio_default_fixture_loop_scope` in all collections

### DIFF
--- a/src/integrations/prefect-aws/pyproject.toml
+++ b/src/integrations/prefect-aws/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
   "mypy",
   "pillow",
   "pre-commit",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-asyncio >= 0.18.2, != 0.22.0, < 0.23.0", # Cannot override event loop in 0.23.0. See https://github.com/pytest-dev/pytest-asyncio/issues/706 for more details.
   "pytest-cov",
   "pytest-env",

--- a/src/integrations/prefect-aws/pyproject.toml
+++ b/src/integrations/prefect-aws/pyproject.toml
@@ -86,7 +86,6 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
-env = [
-  "PREFECT_TEST_MODE=1",
-]
+env = ["PREFECT_TEST_MODE=1"]

--- a/src/integrations/prefect-azure/pyproject.toml
+++ b/src/integrations/prefect-azure/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
   "pillow",
   "pre-commit",
   "pytest-asyncio",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-env",
   "pytest-xdist",
 ]

--- a/src/integrations/prefect-azure/pyproject.toml
+++ b/src/integrations/prefect-azure/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "azure_mgmt_containerinstance>=10.0",
   "azure-mgmt-resource>=21.2",
   "prefect>=3.0.0rc1",
-  "setuptools",                                           #required in 3.12 to get pkg_resources (used by azureml.core)
+  "setuptools",                         #required in 3.12 to get pkg_resources (used by azureml.core)
 ]
 dynamic = ["version"]
 
@@ -85,7 +85,6 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
-env = [
-  "PREFECT_TEST_MODE=1",
-]
+env = ["PREFECT_TEST_MODE=1"]

--- a/src/integrations/prefect-bitbucket/pyproject.toml
+++ b/src/integrations/prefect-bitbucket/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
   "pillow",
   "pre-commit",
   "pytest-asyncio",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-env",
   "pytest-xdist",
 ]

--- a/src/integrations/prefect-bitbucket/pyproject.toml
+++ b/src/integrations/prefect-bitbucket/pyproject.toml
@@ -75,7 +75,6 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
-env = [
-  "PREFECT_TEST_MODE=1",
-]
+env = ["PREFECT_TEST_MODE=1"]

--- a/src/integrations/prefect-dask/pyproject.toml
+++ b/src/integrations/prefect-dask/pyproject.toml
@@ -80,7 +80,6 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
-env = [
-  "PREFECT_TEST_MODE=1",
-]
+env = ["PREFECT_TEST_MODE=1"]

--- a/src/integrations/prefect-dask/pyproject.toml
+++ b/src/integrations/prefect-dask/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
   "pillow",
   "pre-commit",
   "pytest-asyncio >= 0.18.2, != 0.22.0, < 0.23.0",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-env",
   "pytest-xdist",
 ]

--- a/src/integrations/prefect-databricks/pyproject.toml
+++ b/src/integrations/prefect-databricks/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
   "pillow",
   "pre-commit",
   "pytest-asyncio",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-env",
   "pytest-xdist",
   "respx",

--- a/src/integrations/prefect-databricks/pyproject.toml
+++ b/src/integrations/prefect-databricks/pyproject.toml
@@ -71,7 +71,6 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
-env = [
-  "PREFECT_TEST_MODE=1",
-]
+env = ["PREFECT_TEST_MODE=1"]

--- a/src/integrations/prefect-dbt/pyproject.toml
+++ b/src/integrations/prefect-dbt/pyproject.toml
@@ -93,7 +93,6 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
-env = [
-  "PREFECT_TEST_MODE=1",
-]
+env = ["PREFECT_TEST_MODE=1"]

--- a/src/integrations/prefect-dbt/pyproject.toml
+++ b/src/integrations/prefect-dbt/pyproject.toml
@@ -58,7 +58,7 @@ dev = [
   "prefect-gcp[bigquery]>=0.6.0rc1",
   "prefect-snowflake>=0.28.0rc1",
   "prefect-sqlalchemy>=0.5.1",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-asyncio",
   "pytest-env",
   "pytest-xdist",

--- a/src/integrations/prefect-docker/pyproject.toml
+++ b/src/integrations/prefect-docker/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
   "pillow",
   "pre-commit",
   "pytest-asyncio",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-env",
   "pytest-xdist",
 ]

--- a/src/integrations/prefect-docker/pyproject.toml
+++ b/src/integrations/prefect-docker/pyproject.toml
@@ -22,11 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = [
-  "prefect>=3.0.0rc1",
-  "docker>=6.1.1",
-  "exceptiongroup",
-]
+dependencies = ["prefect>=3.0.0rc1", "docker>=6.1.1", "exceptiongroup"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
@@ -74,6 +70,7 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
 env = ["PREFECT_TEST_MODE=1"]
 filterwarnings = [

--- a/src/integrations/prefect-email/pyproject.toml
+++ b/src/integrations/prefect-email/pyproject.toml
@@ -71,7 +71,6 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
-env = [
-  "PREFECT_TEST_MODE=1",
-]
+env = ["PREFECT_TEST_MODE=1"]

--- a/src/integrations/prefect-email/pyproject.toml
+++ b/src/integrations/prefect-email/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
   "pillow",
   "pre-commit",
   "pytest-asyncio",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-env",
   "pytest-xdist",
 ]

--- a/src/integrations/prefect-gcp/pyproject.toml
+++ b/src/integrations/prefect-gcp/pyproject.toml
@@ -95,10 +95,9 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
-env = [
-  "PREFECT_TEST_MODE=1",
-]
+env = ["PREFECT_TEST_MODE=1"]
 filterwarnings = [
   "ignore:Type google._upb._message.* uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14:DeprecationWarning",
 ]

--- a/src/integrations/prefect-gcp/pyproject.toml
+++ b/src/integrations/prefect-gcp/pyproject.toml
@@ -61,7 +61,7 @@ dev = [
   "pillow",
   "pre-commit",
   "pyarrow",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-asyncio",
   "pytest-env",
   "pytest-xdist",

--- a/src/integrations/prefect-github/pyproject.toml
+++ b/src/integrations/prefect-github/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
   "pillow",
   "pre-commit",
   "pytest-asyncio",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-env",
   "pytest-xdist",
 ]

--- a/src/integrations/prefect-github/pyproject.toml
+++ b/src/integrations/prefect-github/pyproject.toml
@@ -4,10 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prefect-github"
-dependencies = [
-  "sgqlc>=15.0",
-  "prefect>=3.0.0rc1",
-]
+dependencies = ["sgqlc>=15.0", "prefect>=3.0.0rc1"]
 dynamic = ["version"]
 description = "Prefect integrations interacting with GitHub"
 readme = "README.md"
@@ -73,7 +70,6 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
-env = [
-  "PREFECT_TEST_MODE=1",
-]
+env = ["PREFECT_TEST_MODE=1"]

--- a/src/integrations/prefect-gitlab/pyproject.toml
+++ b/src/integrations/prefect-gitlab/pyproject.toml
@@ -22,11 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = [
-  "prefect>=3.0.0rc1",
-  "python-gitlab>=3.12.0",
-  "tenacity>=8.2.3",
-]
+dependencies = ["prefect>=3.0.0rc1", "python-gitlab>=3.12.0", "tenacity>=8.2.3"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
@@ -75,7 +71,6 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
-env = [
-  "PREFECT_TEST_MODE=1",
-]
+env = ["PREFECT_TEST_MODE=1"]

--- a/src/integrations/prefect-gitlab/pyproject.toml
+++ b/src/integrations/prefect-gitlab/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
   "pillow",
   "pre-commit",
   "pytest-asyncio",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-env",
   "pytest-xdist",
 ]

--- a/src/integrations/prefect-kubernetes/pyproject.toml
+++ b/src/integrations/prefect-kubernetes/pyproject.toml
@@ -79,6 +79,7 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
 env = ["PREFECT_TEST_MODE=1"]
 timeout = 30

--- a/src/integrations/prefect-kubernetes/pyproject.toml
+++ b/src/integrations/prefect-kubernetes/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
     "pillow",
     "pre-commit",
     "pytest-asyncio",
-    "pytest",
+    "pytest >= 8.3",
     "pytest-env",
     "pytest-timeout",
     "pytest-xdist",

--- a/src/integrations/prefect-ray/pyproject.toml
+++ b/src/integrations/prefect-ray/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
   "pillow",
   "pre-commit",
   "pytest-asyncio",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-asyncio>=0.18.2,!=0.22.0,<0.23.0",
   "pytest-env",
   "pytest-xdist",

--- a/src/integrations/prefect-ray/pyproject.toml
+++ b/src/integrations/prefect-ray/pyproject.toml
@@ -22,10 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = [
-  "prefect>=3.0.0rc1",
-  "ray[default]>=2.0.0",
-]
+dependencies = ["prefect>=3.0.0rc1", "ray[default]>=2.0.0"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
@@ -75,7 +72,6 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
-env = [
-  "PREFECT_TEST_MODE=1",
-]
+env = ["PREFECT_TEST_MODE=1"]

--- a/src/integrations/prefect-redis/pyproject.toml
+++ b/src/integrations/prefect-redis/pyproject.toml
@@ -71,8 +71,7 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
 timeout = "30"
-env = [
-  "PREFECT_TEST_MODE=1",
-]
+env = ["PREFECT_TEST_MODE=1"]

--- a/src/integrations/prefect-redis/pyproject.toml
+++ b/src/integrations/prefect-redis/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
   "pillow",
   "pre-commit",
   "pytest-asyncio",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-env",
   "pytest-timeout",
   "pytest-xdist",

--- a/src/integrations/prefect-shell/pyproject.toml
+++ b/src/integrations/prefect-shell/pyproject.toml
@@ -71,7 +71,6 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
-env = [
-  "PREFECT_TEST_MODE=1",
-]
+env = ["PREFECT_TEST_MODE=1"]

--- a/src/integrations/prefect-shell/pyproject.toml
+++ b/src/integrations/prefect-shell/pyproject.toml
@@ -79,6 +79,5 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
-asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
 env = ["PREFECT_TEST_MODE=1"]

--- a/src/integrations/prefect-shell/pyproject.toml
+++ b/src/integrations/prefect-shell/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
   "pillow",
   "pre-commit",
   "pytest-asyncio",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-env",
   "pytest-xdist",
 ]

--- a/src/integrations/prefect-shell/pyproject.toml
+++ b/src/integrations/prefect-shell/pyproject.toml
@@ -54,7 +54,15 @@ version_file = "prefect_shell/_version.py"
 root = "../../.."
 tag_regex = "^prefect-shell-(?P<version>\\d+\\.\\d+\\.\\d+(?:[a-zA-Z0-9]+(?:\\.[a-zA-Z0-9]+)*)?)$"
 fallback_version = "0.2.0"
-git_describe_command = 'git describe --dirty --tags --long --match "prefect-shell-*[0-9]*"'
+git_describe_command = [
+  "git",
+  "describe",
+  "--dirty",
+  "--tags",
+  "--long",
+  "--match",
+  "prefect-shell-*[0-9]*",
+]
 
 [tool.interrogate]
 ignore-init-module = true

--- a/src/integrations/prefect-slack/pyproject.toml
+++ b/src/integrations/prefect-slack/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
   "pillow",
   "pre-commit",
   "pytest-asyncio",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-env",
   "pytest-xdist",
 ]

--- a/src/integrations/prefect-snowflake/pyproject.toml
+++ b/src/integrations/prefect-snowflake/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
   "pillow",
   "pre-commit",
   "pytest-asyncio",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-env",
   "pytest-xdist",
 ]

--- a/src/integrations/prefect-snowflake/pyproject.toml
+++ b/src/integrations/prefect-snowflake/pyproject.toml
@@ -4,10 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prefect-snowflake"
-dependencies = [
-  "snowflake-connector-python>=2.7.6",
-  "prefect>=3.0.0rc1",
-]
+dependencies = ["snowflake-connector-python>=2.7.6", "prefect>=3.0.0rc1"]
 dynamic = ["version"]
 description = "Prefect integrations for interacting with Snowflake"
 readme = "README.md"
@@ -73,7 +70,6 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
-env = [
-  "PREFECT_TEST_MODE=1",
-]
+env = ["PREFECT_TEST_MODE=1"]

--- a/src/integrations/prefect-sqlalchemy/pyproject.toml
+++ b/src/integrations/prefect-sqlalchemy/pyproject.toml
@@ -4,10 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prefect-sqlalchemy"
-dependencies = [
-  "sqlalchemy>=1.4.31,<3",
-  "prefect>=3.0.0rc1",
-]
+dependencies = ["sqlalchemy>=1.4.31,<3", "prefect>=3.0.0rc1"]
 dynamic = ["version"]
 description = "Prefect integrations for working with databases"
 readme = "README.md"
@@ -76,7 +73,6 @@ fail_under = 80
 show_missing = true
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "session"
 asyncio_mode = "auto"
-env = [
-  "PREFECT_TEST_MODE=1",
-]
+env = ["PREFECT_TEST_MODE=1"]

--- a/src/integrations/prefect-sqlalchemy/pyproject.toml
+++ b/src/integrations/prefect-sqlalchemy/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
   "pillow",
   "pre-commit",
   "psycopg2",
-  "pytest",
+  "pytest >= 8.3",
   "pytest-asyncio",
   "pytest-env",
   "pytest-xdist",


### PR DESCRIPTION
newer versions of `pytest` require us to set this, this avoids the warning that tells us this