### PR TITLE
Fix formatting of `list` and `set` settings values when marshaling to environment variables

### DIFF
--- a/src/prefect/settings/base.py
+++ b/src/prefect/settings/base.py
@@ -90,9 +90,9 @@ class PrefectBaseSettings(BaseSettings):
                 )
                 env_variables.update(child_env)
             elif (value := env.get(key)) is not None:
-                env_variables[f"{self.model_config.get('env_prefix')}{key.upper()}"] = (
-                    _to_environment_variable_value(value)
-                )
+                env_variables[
+                    f"{self.model_config.get('env_prefix')}{key.upper()}"
+                ] = _to_environment_variable_value(value)
         return env_variables
 
     @model_serializer(

--- a/src/prefect/settings/base.py
+++ b/src/prefect/settings/base.py
@@ -90,9 +90,9 @@ class PrefectBaseSettings(BaseSettings):
                 )
                 env_variables.update(child_env)
             elif (value := env.get(key)) is not None:
-                env_variables[
-                    f"{self.model_config.get('env_prefix')}{key.upper()}"
-                ] = str(value)
+                env_variables[f"{self.model_config.get('env_prefix')}{key.upper()}"] = (
+                    _to_environment_variable_value(value)
+                )
         return env_variables
 
     @model_serializer(
@@ -191,3 +191,9 @@ def _build_settings_config(
         pyproject_toml_table_header=("tool", "prefect", *path),
         json_schema_extra=_add_environment_variables,
     )
+
+
+def _to_environment_variable_value(value: Any) -> str:
+    if isinstance(value, (list, set, tuple)):
+        return ",".join(str(v) for v in value)
+    return str(value)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1891,7 +1891,7 @@ class TestSettingValues:
                 assert settings_value == value
                 # get value from legacy setting object
                 assert getattr(prefect.settings, setting).value() == value
-                
+
             # ensure the value gets added to the environment variables, but "legacy" will use
             # their updated name
             if not SUPPORTED_SETTINGS[setting].get("legacy"):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -244,7 +244,7 @@ SUPPORTED_SETTINGS = {
     },
     "PREFECT_LOGGING_COLORS": {"test_value": True},
     "PREFECT_LOGGING_CONFIG_PATH": {"test_value": Path("/path/to/settings.yaml")},
-    "PREFECT_LOGGING_EXTRA_LOGGERS": {"test_value": ["bar", "foo"]},
+    "PREFECT_LOGGING_EXTRA_LOGGERS": {"test_value": ["foo", "bar"]},
     "PREFECT_LOGGING_INTERNAL_LEVEL": {"test_value": "INFO", "legacy": True},
     "PREFECT_LOGGING_LEVEL": {"test_value": "INFO"},
     "PREFECT_LOGGING_LOG_PRINTS": {"test_value": True},
@@ -1882,9 +1882,16 @@ class TestSettingValues:
             if isinstance(settings_value, pydantic.SecretStr):
                 settings_value = settings_value.get_secret_value()
 
-            assert settings_value == value
-            # get value from legacy setting object
-            assert getattr(prefect.settings, setting).value() == value
+            if setting == "PREFECT_LOGGING_EXTRA_LOGGERS":
+                assert sorted(settings_value) == sorted(value)
+                legacy_value = getattr(prefect.settings, setting).value()
+                assert isinstance(legacy_value, list)
+                assert sorted(legacy_value) == sorted(value)
+            else:
+                assert settings_value == value
+                # get value from legacy setting object
+                assert getattr(prefect.settings, setting).value() == value
+                
             # ensure the value gets added to the environment variables, but "legacy" will use
             # their updated name
             if not SUPPORTED_SETTINGS[setting].get("legacy"):


### PR DESCRIPTION
This PR fixes conversion of Settings to environment variables for settings of type set/list. For example `PREFECT_LOGGING_EXTRA_LOGGERS` values can be supplied as string with values separated by delimiter. The conversion back to env. var. value is done by simple `str()`, which returns different value ("foo,bar" != "['foo','bar']"). 

Solution: 
Applied value to environment variable value conversion function in `PrefectBaseSettings.to_environment_variables` to convert list/set/tuple values.

Note:
`PREFECT_LOGGING_EXTRA_LOGGERS` is set to be of type list and if validated by `validate_set_T_from_delim_string` the original order is lost. Currently, there is no need for OrderedSet (i assume) other than in tests for easier value assertion. But there is also no need for `PREFECT_LOGGING_EXTRA_LOGGERS` to be a list. Let me know if i should resolve this in this PR or in following one.

Affected settings:
1) `PREFECT_LOGGING_EXTRA_LOGGERS`
2) `PREFECT_CLIENT_RETRY_EXTRA_CODES`

Settings tests modified:
1) Changed test values for affected settings in SUPPORTED_SETTINGS to their actual types set by `validate_set_T_from_delim_string`
2) added additional test for environment casts to strings for affected settings
3) applied value to environment variable value conversion function for env var tests.

### Checklist

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
