### PR TITLE
Update worker to give worker labels to flow runs during submittal

### DIFF
--- a/src/prefect/client/cloud.py
+++ b/src/prefect/client/cloud.py
@@ -1,5 +1,6 @@
 import re
 from typing import Any, Dict, List, Optional, cast
+from uuid import UUID
 
 import anyio
 import httpx
@@ -12,6 +13,7 @@ from prefect.client.base import PrefectHttpxAsyncClient
 from prefect.client.schemas.objects import (
     IPAllowlist,
     IPAllowlistMyAccessResponse,
+    KeyValueLabels,
     Workspace,
 )
 from prefect.exceptions import ObjectNotFound, PrefectException
@@ -150,6 +152,25 @@ class CloudClient:
     async def check_ip_allowlist_access(self) -> IPAllowlistMyAccessResponse:
         response = await self.get(f"{self.account_base_url}/ip_allowlist/my_access")
         return IPAllowlistMyAccessResponse.model_validate(response)
+
+    async def update_flow_run_labels(
+        self, flow_run_id: UUID, labels: KeyValueLabels
+    ) -> httpx.Response:
+        """
+        Update the labels for a flow run.
+
+        Args:
+            flow_run_id: The identifier for the flow run to update.
+            labels: A dictionary of labels to update for the flow run.
+
+        Returns:
+            an `httpx.Response` object from the PATCH request
+        """
+
+        return await self._client.patch(
+            f"{self.workspace_base_url}/flow_runs/{flow_run_id}/labels",
+            json=labels,
+        )
 
     async def __aenter__(self):
         await self._client.__aenter__()

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -93,7 +93,6 @@ from prefect.client.schemas.objects import (
     FlowRunInput,
     FlowRunNotificationPolicy,
     FlowRunPolicy,
-    KeyValueLabels,
     Log,
     Parameter,
     TaskRunPolicy,
@@ -764,23 +763,6 @@ class PrefectClient:
         return await self._client.patch(
             f"/flow_runs/{flow_run_id}",
             json=flow_run_data.model_dump(mode="json", exclude_unset=True),
-        )
-
-    async def update_flow_run_labels(self, flow_run_id: UUID, labels: KeyValueLabels):
-        """
-        Update the labels for a flow run.
-
-        Args:
-            flow_run_id: The identifier for the flow run to update.
-            labels: A dictionary of labels to update for the flow run.
-
-        Returns:
-            an `httpx.Response` object from the PATCH request
-        """
-
-        return await self._client.patch(
-            f"/flow_runs/{flow_run_id}/labels",
-            json=labels,
         )
 
     async def delete_flow_run(
@@ -3919,23 +3901,6 @@ class SyncPrefectClient:
         return self._client.patch(
             f"/flow_runs/{flow_run_id}",
             json=flow_run_data.model_dump(mode="json", exclude_unset=True),
-        )
-
-    def update_flow_run_labels(self, flow_run_id: UUID, labels: KeyValueLabels):
-        """
-        Update the labels for a flow run.
-
-        Args:
-            flow_run_id: The identifier for the flow run to update.
-            labels: A dictionary of labels to update for the flow run.
-
-        Returns:
-            an `httpx.Response` object from the PATCH request
-        """
-
-        return self._client.patch(
-            f"/flow_runs/{flow_run_id}/labels",
-            json=labels,
         )
 
     def read_flow_run(self, flow_run_id: UUID) -> FlowRun:

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -93,6 +93,7 @@ from prefect.client.schemas.objects import (
     FlowRunInput,
     FlowRunNotificationPolicy,
     FlowRunPolicy,
+    KeyValueLabels,
     Log,
     Parameter,
     TaskRunPolicy,
@@ -763,6 +764,23 @@ class PrefectClient:
         return await self._client.patch(
             f"/flow_runs/{flow_run_id}",
             json=flow_run_data.model_dump(mode="json", exclude_unset=True),
+        )
+
+    async def update_flow_run_labels(self, flow_run_id: UUID, labels: KeyValueLabels):
+        """
+        Update the labels for a flow run.
+
+        Args:
+            flow_run_id: The identifier for the flow run to update.
+            labels: A dictionary of labels to update for the flow run.
+
+        Returns:
+            an `httpx.Response` object from the PATCH request
+        """
+
+        return await self._client.patch(
+            f"/flow_runs/{flow_run_id}/labels",
+            json=labels,
         )
 
     async def delete_flow_run(
@@ -3901,6 +3919,23 @@ class SyncPrefectClient:
         return self._client.patch(
             f"/flow_runs/{flow_run_id}",
             json=flow_run_data.model_dump(mode="json", exclude_unset=True),
+        )
+
+    def update_flow_run_labels(self, flow_run_id: UUID, labels: KeyValueLabels):
+        """
+        Update the labels for a flow run.
+
+        Args:
+            flow_run_id: The identifier for the flow run to update.
+            labels: A dictionary of labels to update for the flow run.
+
+        Returns:
+            an `httpx.Response` object from the PATCH request
+        """
+
+        return self._client.patch(
+            f"/flow_runs/{flow_run_id}/labels",
+            json=labels,
         )
 
     def read_flow_run(self, flow_run_id: UUID) -> FlowRun:

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -23,6 +23,9 @@ from pydantic import (
     HttpUrl,
     IPvAnyNetwork,
     SerializationInfo,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
     Tag,
     field_validator,
     model_serializer,
@@ -67,6 +70,8 @@ if TYPE_CHECKING:
 
 
 R = TypeVar("R", default=Any)
+
+KeyValueLabels = dict[str, Union[StrictBool, StrictInt, StrictFloat, str]]
 
 
 DEFAULT_BLOCK_SCHEMA_VERSION = "non-versioned"

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -18,6 +18,7 @@ from typing_extensions import Literal
 import prefect
 from prefect._internal.schemas.validators import return_v_or_none
 from prefect.client.base import ServerType
+from prefect.client.cloud import CloudClient, get_cloud_client
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas.actions import WorkPoolCreate, WorkPoolUpdate
 from prefect.client.schemas.objects import (
@@ -439,6 +440,7 @@ class BaseWorker(abc.ABC):
         self._exit_stack: AsyncExitStack = AsyncExitStack()
         self._runs_task_group: Optional[anyio.abc.TaskGroup] = None
         self._client: Optional[PrefectClient] = None
+        self._cloud_client: Optional[CloudClient] = None
         self._last_polled_time: pendulum.DateTime = pendulum.now("utc")
         self._limit = limit
         self._limiter: Optional[anyio.CapacityLimiter] = None
@@ -630,8 +632,13 @@ class BaseWorker(abc.ABC):
             raise ValueError("`PREFECT_API_URL` must be set to start a Worker.")
 
         self._client = get_client()
+
         await self._exit_stack.enter_async_context(self._client)
         await self._exit_stack.enter_async_context(self._runs_task_group)
+
+        if self._client.server_type == ServerType.CLOUD:
+            self._cloud_client = get_cloud_client()
+            await self._exit_stack.enter_async_context(self._cloud_client)
 
         self.is_setup = True
 
@@ -1197,8 +1204,8 @@ class BaseWorker(abc.ABC):
         """
         Give this worker's identifying labels to the specified flow run.
         """
-        if self._client and self._client.server_type == ServerType.CLOUD:
-            await self._client.update_flow_run_labels(
+        if self._cloud_client:
+            await self._cloud_client.update_flow_run_labels(
                 flow_run_id,
                 {
                     "prefect.worker.name": self.name,

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -1983,3 +1983,60 @@ class TestBaseWorkerHeartbeat:
                 )
 
             assert worker._worker_metadata_sent
+
+
+async def test_worker_gives_labels_to_flow_runs_when_using_cloud_api(
+    prefect_client: PrefectClient, worker_deployment_wq1, work_pool
+):
+    update_labels_mock = AsyncMock()
+
+    def create_run_with_deployment(state):
+        return prefect_client.create_flow_run_from_deployment(
+            worker_deployment_wq1.id, state=state
+        )
+
+    flow_run = await create_run_with_deployment(
+        Scheduled(scheduled_time=pendulum.now("utc").subtract(days=1))
+    )
+
+    async with WorkerTestImpl(work_pool_name=work_pool.name) as worker:
+        assert worker._client is not None
+        worker._client.server_type = ServerType.CLOUD
+        worker._client.update_flow_run_labels = update_labels_mock
+
+        worker._work_pool = work_pool
+        worker.run = AsyncMock()
+
+        await worker.get_and_submit_flow_runs()
+
+    update_labels_mock.assert_awaited_once_with(
+        flow_run.id,
+        {"prefect.worker.name": worker.name, "prefect.worker.type": worker.type},
+    )
+
+
+async def test_worker_does_not_give_labels_to_flow_runs_when_not_using_cloud_api(
+    prefect_client: PrefectClient, worker_deployment_wq1, work_pool
+):
+    update_labels_mock = AsyncMock()
+
+    def create_run_with_deployment(state):
+        return prefect_client.create_flow_run_from_deployment(
+            worker_deployment_wq1.id, state=state
+        )
+
+    await create_run_with_deployment(
+        Scheduled(scheduled_time=pendulum.now("utc").subtract(days=1))
+    )
+
+    async with WorkerTestImpl(work_pool_name=work_pool.name) as worker:
+        assert worker._client is not None
+        worker._client.server_type = ServerType.SERVER  # Not cloud
+        worker._client.update_flow_run_labels = update_labels_mock
+
+        worker._work_pool = work_pool
+        worker.run = AsyncMock()
+
+        await worker.get_and_submit_flow_runs()
+
+    update_labels_mock.assert_not_awaited()

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -1988,7 +1988,7 @@ class TestBaseWorkerHeartbeat:
 async def test_worker_gives_labels_to_flow_runs_when_using_cloud_api(
     prefect_client: PrefectClient, worker_deployment_wq1, work_pool
 ):
-    update_labels_mock = AsyncMock()
+    CloudClientMock = AsyncMock()
 
     def create_run_with_deployment(state):
         return prefect_client.create_flow_run_from_deployment(
@@ -2002,14 +2002,14 @@ async def test_worker_gives_labels_to_flow_runs_when_using_cloud_api(
     async with WorkerTestImpl(work_pool_name=work_pool.name) as worker:
         assert worker._client is not None
         worker._client.server_type = ServerType.CLOUD
-        worker._client.update_flow_run_labels = update_labels_mock
+        worker._cloud_client = CloudClientMock
 
         worker._work_pool = work_pool
         worker.run = AsyncMock()
 
         await worker.get_and_submit_flow_runs()
 
-    update_labels_mock.assert_awaited_once_with(
+    CloudClientMock.update_flow_run_labels.assert_awaited_once_with(
         flow_run.id,
         {"prefect.worker.name": worker.name, "prefect.worker.type": worker.type},
     )


### PR DESCRIPTION
This updates the base worker to update the labels of each flow run with information about the worker that submitted the run. This information will be captured in the OpenTelemetry spans when the flow run is executed.

Related to CLOUD-569