### PR TITLE
Fix documentation link to deployment concept

### DIFF
--- a/docs/3.0/deploy/index.mdx
+++ b/docs/3.0/deploy/index.mdx
@@ -6,7 +6,7 @@ description: Learn how to use deployments to trigger flow runs remotely.
 
 Deployments allow you to run flows on a [schedule](/3.0/automate/add-schedules/) and trigger runs based on [events](/3.0/automate/events/automations-triggers/).
 
-[Deployments](/3.0/deploy/infrastructure-examples/docker/) are server-side representations of flows.
+Deployments are server-side representations of flows.
 They store the crucial metadata for remote orchestration including when, where, and how a workflow should run.
 
 In addition to manually triggering and managing flow runs, deploying a flow exposes an API and UI that allow you to:

--- a/docs/3.0/get-started/quickstart.mdx
+++ b/docs/3.0/get-started/quickstart.mdx
@@ -171,7 +171,7 @@ You can also choose from other [work pool types](https://docs.prefect.io/concept
 
 ## Deploy and schedule your flow
 
-A [deployment](/3.0/deploy/infrastructure-examples/docker/) is used to determine when, where, and how a flow should run.
+A [deployment](/3.0/deploy/) is used to determine when, where, and how a flow should run.
 Deployments elevate flows to remotely configurable entities that have their own API.
 
 1. Create a deployment in code:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
* On Quickstart-page, to explain the concept of deployment in Prefect, link to the general Deployment-page  instead of a specific page about Deployment in Docker.
* On the general Deployment-page, remove an unexpected link to a Docker deployment section. Linking to the Docker deployment section is done in a later section on the same page already, where it is more appropriate.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
