### PR TITLE
refactor `async_dispatch` to enable forcing behavior for instance methods

### DIFF
--- a/src/integrations/prefect-slack/prefect_slack/credentials.py
+++ b/src/integrations/prefect-slack/prefect_slack/credentials.py
@@ -50,14 +50,6 @@ class SlackCredentials(Block):
         return AsyncWebClient(token=self.token.get_secret_value())
 
 
-async def _notify_async(obj: Any, body: str, subject: Optional[str] = None):
-    client = obj.get_client()
-
-    response = await client.send(text=body)
-
-    obj._raise_on_failure(response)
-
-
 class SlackWebhook(NotificationBlock):
     """
     Block holding a Slack webhook for use in tasks and flows.
@@ -127,9 +119,13 @@ class SlackWebhook(NotificationBlock):
         """
         Sends a message to the Slack channel.
         """
-        await _notify_async(self, body, subject)
+        client = self.get_client()
 
-    @async_dispatch(_notify_async)  # type: ignore
+        response = await client.send(text=body)
+
+        self._raise_on_failure(response)
+
+    @async_dispatch(notify_async)
     def notify(self, body: str, subject: Optional[str] = None):
         """
         Sends a message to the Slack channel.

--- a/src/integrations/prefect-slack/prefect_slack/credentials.py
+++ b/src/integrations/prefect-slack/prefect_slack/credentials.py
@@ -117,12 +117,10 @@ class SlackWebhook(NotificationBlock):
 
     async def notify_async(self, body: str, subject: Optional[str] = None):
         """
-        Sends a message to the Slack channel.
+        Sends a message to the Slack channel asynchronously.
         """
         client = self.get_client()
-
         response = await client.send(text=body)
-
         self._raise_on_failure(response)
 
     @async_dispatch(notify_async)
@@ -131,7 +129,5 @@ class SlackWebhook(NotificationBlock):
         Sends a message to the Slack channel.
         """
         client = self.get_client(sync_client=True)
-
         response = client.send(text=body)
-
         self._raise_on_failure(response)

--- a/src/prefect/_internal/compatibility/async_dispatch.py
+++ b/src/prefect/_internal/compatibility/async_dispatch.py
@@ -1,7 +1,6 @@
 import asyncio
-import inspect
 from functools import wraps
-from typing import Any, Callable, Coroutine, Protocol, TypeVar, Union
+from typing import Any, Callable, Coroutine, Optional, TypeVar, Union
 
 from typing_extensions import ParamSpec
 
@@ -9,65 +8,45 @@ R = TypeVar("R")
 P = ParamSpec("P")
 
 
-class AsyncDispatchable(Protocol[P, R]):
-    """Protocol for functions decorated with async_dispatch."""
-
-    def __call__(
-        self, *args: P.args, **kwargs: P.kwargs
-    ) -> Union[R, Coroutine[Any, Any, R]]:
-        ...
-
-    aio: Callable[P, Coroutine[Any, Any, R]]
-    sync: Callable[P, R]
-
-
 def is_in_async_context() -> bool:
-    """Check if we're in an async context."""
+    """
+    Returns True if called from within an async context (coroutine or running event loop)
+    """
     try:
-        # First check if we're in a coroutine
-        if asyncio.current_task() is not None:
-            return True
-
-        # Check if we have a loop and it's running
-        loop = asyncio.get_event_loop()
-        return loop.is_running()
+        asyncio.get_running_loop()
+        return True
     except RuntimeError:
         return False
 
 
 def async_dispatch(
     async_impl: Callable[P, Coroutine[Any, Any, R]],
-) -> Callable[[Callable[P, R]], AsyncDispatchable[P, R]]:
+) -> Callable[[Callable[P, R]], Callable[P, Union[R, Coroutine[Any, Any, R]]]]:
     """
-    Decorator that adds async compatibility to a sync function.
-
-    The decorated function will:
-    - Return a coroutine when in an async context (detected via running event loop)
-    - Run synchronously when in a sync context
-    - Provide .aio for explicit async access
-    - Provide .sync for explicit sync access
+    Decorator that dispatches to either sync or async implementation based on context.
 
     Args:
-        async_impl: The async implementation to dispatch to when async execution
-                   is needed
+        async_impl: The async implementation to dispatch to when in async context
     """
-    if not inspect.iscoroutinefunction(async_impl):
-        raise TypeError(
-            "async_impl must be an async function to dispatch in async contexts"
-        )
 
-    def decorator(sync_fn: Callable[P, R]) -> AsyncDispatchable[P, R]:
+    def decorator(
+        sync_fn: Callable[P, R],
+    ) -> Callable[P, Union[R, Coroutine[Any, Any, R]]]:
+        if not asyncio.iscoroutinefunction(async_impl):
+            raise TypeError("async_impl must be an async function")
+
         @wraps(sync_fn)
         def wrapper(
-            *args: P.args, **kwargs: P.kwargs
+            *args: P.args,
+            _sync: Optional[bool] = None,  # type: ignore
+            **kwargs: P.kwargs,
         ) -> Union[R, Coroutine[Any, Any, R]]:
-            if is_in_async_context():
-                return async_impl(*args, **kwargs)
-            return sync_fn(*args, **kwargs)
+            should_run_sync = _sync if _sync is not None else not is_in_async_context()
 
-        # Attach both async and sync implementations directly
-        wrapper.aio = async_impl
-        wrapper.sync = sync_fn
+            if should_run_sync:
+                return sync_fn(*args, **kwargs)
+            return async_impl(*args, **kwargs)
+
         return wrapper  # type: ignore
 
     return decorator

--- a/tests/_internal/compatibility/test_async_dispatch.py
+++ b/tests/_internal/compatibility/test_async_dispatch.py
@@ -202,7 +202,9 @@ class TestIsInAsyncContext:
 
 
 class TestMethodBinding:
-    @pytest.mark.xfail(reason="Method binding not yet implemented")
+    # @pytest.mark.skip(
+    #     reason="TODO: Allow forcing sync call of instance method from async context (without passing the instance)"
+    # )
     async def test_can_force_sync_dispatch_from_async_context(self):
         """Verify that we can force sync dispatch from an async context"""
 
@@ -221,5 +223,5 @@ class TestMethodBinding:
 
         assert counter.count == 0
         await counter.increment_async()
-        counter.increment()
+        counter.increment.sync(counter)
         assert counter.count == 2

--- a/tests/_internal/compatibility/test_async_dispatch.py
+++ b/tests/_internal/compatibility/test_async_dispatch.py
@@ -199,3 +199,42 @@ class TestIsInAsyncContext:
             assert (
                 is_in_async_context() is False
             ), "the loop should be closed and not considered an async context"
+
+
+class TestMethodBinding:
+    @pytest.mark.xfail(reason="Method binding not yet implemented")
+    async def test_can_force_sync_dispatch_from_async_context(self):
+        """Verify that we can force sync dispatch from an async context"""
+
+        class Counter:
+            def __init__(self):
+                self.count = 0
+
+            async def increment_async(self):
+                self.count += 1
+
+            @async_dispatch(increment_async)
+            def increment(self):
+                self.count += 1
+
+        counter = Counter()
+
+        assert counter.count == 0
+        await counter.increment_async()
+        counter.increment()
+        assert counter.count == 2
+
+    @pytest.mark.xfail(reason="Method binding not yet implemented")
+    async def test_async_dispatch_debug(self):
+        data = []
+
+        async def async_fn(self):
+            data.append("async")
+
+        @async_dispatch(async_fn)
+        def sync_fn(self):
+            data.append("sync")
+
+        obj = type("Test", (), {})()
+        sync_fn(obj)
+        assert data == ["sync"]

--- a/tests/_internal/compatibility/test_async_dispatch.py
+++ b/tests/_internal/compatibility/test_async_dispatch.py
@@ -223,18 +223,3 @@ class TestMethodBinding:
         await counter.increment_async()
         counter.increment()
         assert counter.count == 2
-
-    @pytest.mark.xfail(reason="Method binding not yet implemented")
-    async def test_async_dispatch_debug(self):
-        data = []
-
-        async def async_fn(self):
-            data.append("async")
-
-        @async_dispatch(async_fn)
-        def sync_fn(self):
-            data.append("sync")
-
-        obj = type("Test", (), {})()
-        sync_fn(obj)
-        assert data == ["sync"]

--- a/tests/_internal/compatibility/test_async_dispatch.py
+++ b/tests/_internal/compatibility/test_async_dispatch.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import List, Optional
 
 import pytest
 
@@ -11,154 +12,136 @@ from prefect.utilities.asyncutils import run_sync_in_worker_thread
 
 class TestAsyncDispatchBasicUsage:
     def test_async_compatible_fn_in_sync_context(self):
-        data = []
+        data: List[str] = []
 
-        async def my_function_async():
+        async def my_function_async() -> None:
             data.append("async")
 
         @async_dispatch(my_function_async)
-        def my_function():
+        def my_function() -> None:
             data.append("sync")
 
         my_function()
         assert data == ["sync"]
 
     async def test_async_compatible_fn_in_async_context(self):
-        data = []
+        data: List[str] = []
 
-        async def my_function_async():
+        async def my_function_async() -> None:
             data.append("async")
 
         @async_dispatch(my_function_async)
-        def my_function():
+        def my_function() -> None:
             data.append("sync")
 
         await my_function()
         assert data == ["async"]
 
+    async def test_can_force_sync_or_async_dispatch(self):
+        """Verify that we can force sync or async dispatch regardless of context"""
+        data: List[str] = []
 
-class TestAsyncDispatchExplicitUsage:
-    async def test_async_compatible_fn_explicit_async_usage(self):
-        """Verify .aio property works as expected"""
-        data = []
-
-        async def my_function_async():
+        async def my_function_async() -> None:
             data.append("async")
 
         @async_dispatch(my_function_async)
-        def my_function():
+        def my_function() -> None:
             data.append("sync")
 
-        await my_function.aio()
-        assert data == ["async"]
-
-    def test_async_compatible_fn_explicit_async_usage_with_asyncio_run(self):
-        """Verify .aio property works as expected with asyncio.run"""
-        data = []
-
-        async def my_function_async():
-            data.append("async")
-
-        @async_dispatch(my_function_async)
-        def my_function():
-            data.append("sync")
-
-        asyncio.run(my_function.aio())
-        assert data == ["async"]
-
-    async def test_async_compatible_fn_explicit_sync_usage(self):
-        """Verify .sync property works as expected in async context"""
-        data = []
-
-        async def my_function_async():
-            data.append("async")
-
-        @async_dispatch(my_function_async)
-        def my_function():
-            data.append("sync")
-
-        # Even though we're in async context, .sync should force sync execution
-        my_function.sync()
+        # Force sync even in async context
+        my_function(_sync=True)
         assert data == ["sync"]
 
-    def test_async_compatible_fn_explicit_sync_usage_in_sync_context(self):
-        """Verify .sync property works as expected in sync context"""
-        data = []
+        data.clear()
 
-        async def my_function_async():
-            data.append("async")
-
-        @async_dispatch(my_function_async)
-        def my_function():
-            data.append("sync")
-
-        my_function.sync()
-        assert data == ["sync"]
+        # Force async
+        await my_function(_sync=False)
+        assert data == ["async"]
 
 
 class TestAsyncDispatchValidation:
     def test_async_compatible_requires_async_implementation(self):
         """Verify we properly reject non-async implementations"""
 
-        def not_async():
+        def not_async() -> None:
             pass
 
         with pytest.raises(TypeError, match="async_impl must be an async function"):
 
             @async_dispatch(not_async)
-            def my_function():
+            def my_function() -> None:
                 pass
 
-    async def test_async_compatible_fn_attributes_exist(self):
-        """Verify both .sync and .aio attributes are present"""
-
-        async def my_function_async():
-            pass
-
-        @async_dispatch(my_function_async)
-        def my_function():
-            pass
-
-        assert hasattr(my_function, "sync"), "Should have .sync attribute"
-        assert hasattr(my_function, "aio"), "Should have .aio attribute"
-        assert (
-            my_function.sync is my_function.__wrapped__
-        ), "Should reference original sync function"
-        assert (
-            my_function.aio is my_function_async
-        ), "Should reference original async function"
-
-
-class TestAsyncCompatibleFnCannotBeUsedWithAsyncioRun:
-    def test_async_compatible_fn_in_sync_context_errors_with_asyncio_run(self):
-        """this is here to illustrate the expected behavior"""
-        data = []
-
-        async def my_function_async():
-            data.append("async")
-
-        @async_dispatch(my_function_async)
-        def my_function():
-            data.append("sync")
-
-        with pytest.raises(ValueError, match="coroutine was expected, got None"):
-            asyncio.run(my_function())
-
-    async def test_async_compatible_fn_in_async_context_fails_with_asyncio_run(self):
-        """this is here to illustrate the expected behavior"""
-        data = []
-
-        async def my_function_async():
-            data.append("async")
-
-        @async_dispatch(my_function_async)
-        def my_function():
-            data.append("sync")
+    def test_async_compatible_requires_implementation(self):
+        """Verify we properly reject missing implementations"""
 
         with pytest.raises(
-            RuntimeError, match="cannot be called from a running event loop"
+            TypeError,
+            match=r"async_dispatch\(\) missing 1 required positional argument: 'async_impl'",
         ):
-            asyncio.run(my_function())
+
+            @async_dispatch()
+            def my_function() -> None:
+                pass
+
+
+class TestMethodBinding:
+    async def test_method_binding_works_correctly(self):
+        """Verify that self is properly bound for instance methods"""
+
+        class Counter:
+            def __init__(self) -> None:
+                self.count = 0
+
+            async def increment_async(self) -> None:
+                self.count += 1
+
+            @async_dispatch(increment_async)
+            def increment(self) -> None:
+                self.count += 1
+
+        counter = Counter()
+        assert counter.count == 0
+
+        # Test sync
+        counter.increment(_sync=True)
+        assert counter.count == 1
+
+        # Test async
+        await counter.increment(_sync=False)
+        assert counter.count == 2
+
+    async def test_method_binding_respects_context(self):
+        """Verify that methods automatically dispatch based on context"""
+
+        class Counter:
+            def __init__(self) -> None:
+                self.count = 0
+                self.calls: List[str] = []
+
+            async def increment_async(self) -> None:
+                self.calls.append("async")
+                self.count += 1
+
+            @async_dispatch(increment_async)
+            def increment(self) -> None:
+                self.calls.append("sync")
+                self.count += 1
+
+        counter = Counter()
+
+        # In sync context
+        def sync_caller() -> None:
+            counter.increment(_sync=True)
+
+        sync_caller()
+        assert counter.calls == ["sync"]
+        assert counter.count == 1
+
+        # In async context
+        await counter.increment()
+        assert counter.calls == ["sync", "async"]
+        assert counter.count == 2
 
 
 class TestIsInAsyncContext:
@@ -171,7 +154,7 @@ class TestIsInAsyncContext:
         assert is_in_async_context() is False
 
     async def test_is_in_async_context_with_nested_sync_in_worker_thread(self):
-        def sync_func():
+        def sync_func() -> bool:
             return is_in_async_context()
 
         assert await run_sync_in_worker_thread(sync_func) is False
@@ -180,9 +163,9 @@ class TestIsInAsyncContext:
         """Verify detection with just a running event loop"""
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-        result = None
+        result: Optional[bool] = None
 
-        def check_context():
+        def check_context() -> None:
             nonlocal result
             result = is_in_async_context()
             loop.stop()
@@ -199,29 +182,3 @@ class TestIsInAsyncContext:
             assert (
                 is_in_async_context() is False
             ), "the loop should be closed and not considered an async context"
-
-
-class TestMethodBinding:
-    # @pytest.mark.skip(
-    #     reason="TODO: Allow forcing sync call of instance method from async context (without passing the instance)"
-    # )
-    async def test_can_force_sync_dispatch_from_async_context(self):
-        """Verify that we can force sync dispatch from an async context"""
-
-        class Counter:
-            def __init__(self):
-                self.count = 0
-
-            async def increment_async(self):
-                self.count += 1
-
-            @async_dispatch(increment_async)
-            def increment(self):
-                self.count += 1
-
-        counter = Counter()
-
-        assert counter.count == 0
-        await counter.increment_async()
-        counter.increment.sync(counter)
-        assert counter.count == 2


### PR DESCRIPTION
because of binding issues with the property-based method of "forcing" sync or async, here we concede and switch to `_sync` even though this means [we can't get perfect typing](https://peps.python.org/pep-0612/#concatenating-keyword-parameters)