### PR TITLE
fix worker not releasing limit slot on failed propose pending state

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1015,8 +1015,7 @@ class BaseWorker(abc.ABC):
                 )
             return exc
         finally:
-            if self._limiter:
-                self._limiter.release_on_behalf_of(flow_run.id)
+            self._release_limit_slot(flow_run.id)
 
         if not task_status._future.done():
             run_logger.error(


### PR DESCRIPTION
Fixes a bug where workers aborting a flow run submission doesn't release the concurrency slot that was claimed. I've based this on what has been done in the runner as this issue doesn't seem to exist over there https://github.com/PrefectHQ/prefect/blob/8758666101ce96d4f7ce098563a41ea81db8d5ef/src/prefect/runner/runner.py#L963. I've had a quick look at putting together a test case for this but I might need a hand here. Cheers.

Closes https://github.com/PrefectHQ/prefect/issues/15952
