### PR TITLE
[UI v2] Fix tab order in variable create dialog

### DIFF
--- a/ui-v2/src/components/ui/json-input.tsx
+++ b/ui-v2/src/components/ui/json-input.tsx
@@ -1,0 +1,59 @@
+import React, { useRef, useEffect } from "react";
+
+import { json } from "@codemirror/lang-json";
+import { cn } from "@/lib/utils";
+import { useCodeMirror } from "@uiw/react-codemirror";
+
+const extensions = [json()];
+
+type JsonInputProps = React.ComponentProps<"div"> & {
+	value?: string;
+	onChange?: (value: string) => void;
+	onBlur?: () => void;
+	disabled?: boolean;
+	className?: string;
+};
+
+export const JsonInput = React.forwardRef<HTMLDivElement, JsonInputProps>(
+	(
+		{ className, value, onChange, onBlur, disabled, ...props },
+		forwardedRef,
+	) => {
+		const editor = useRef<HTMLDivElement | null>(null);
+		const { setContainer } = useCodeMirror({
+			container: editor.current,
+			extensions,
+			value,
+			onChange,
+			onBlur,
+			indentWithTab: false,
+			editable: !disabled,
+		});
+
+		useEffect(() => {
+			if (editor.current) {
+				setContainer(editor.current);
+			}
+		}, [setContainer]);
+
+		return (
+			<div
+				className={cn(
+					"rounded-md border shadow-sm overflow-hidden focus-within:outline-none focus-within:ring-1 focus-within:ring-ring",
+					className,
+				)}
+				ref={(node) => {
+					editor.current = node;
+					if (typeof forwardedRef === "function") {
+						forwardedRef(node);
+					} else if (forwardedRef) {
+						forwardedRef.current = node;
+					}
+				}}
+				{...props}
+			/>
+		);
+	},
+);
+
+JsonInput.displayName = "JsonInput";

--- a/ui-v2/src/components/variables/add-variable-dialog.tsx
+++ b/ui-v2/src/components/variables/add-variable-dialog.tsx
@@ -9,8 +9,6 @@ import {
 	DialogTrigger,
 } from "@/components/ui/dialog";
 import { zodResolver } from "@hookform/resolvers/zod";
-import CodeMirror, { EditorView } from "@uiw/react-codemirror";
-import { json } from "@codemirror/lang-json";
 import { useMutation } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -30,6 +28,7 @@ import { Loader2 } from "lucide-react";
 import { TagsInput } from "../ui/tags-input";
 import { useToast } from "@/hooks/use-toast";
 import { queryClient } from "@/router";
+import { JsonInput } from "@/components/ui/json-input";
 
 const formSchema = z.object({
 	name: z.string().min(2, { message: "Name must be at least 2 characters" }),
@@ -133,7 +132,7 @@ export const AddVariableDialog = ({
 								<FormItem>
 									<FormLabel>Name</FormLabel>
 									<FormControl>
-										<Input {...field} />
+										<Input autoComplete="off" {...field} />
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -144,23 +143,9 @@ export const AddVariableDialog = ({
 							name="value"
 							render={({ field }) => (
 								<FormItem>
-									<FormLabel id="value-label">Value</FormLabel>
+									<FormLabel>Value</FormLabel>
 									<FormControl>
-										<CodeMirror
-											aria-labelledby="value-label"
-											extensions={[json()]}
-											basicSetup={{
-												foldGutter: false,
-												history: false,
-											}}
-											theme={EditorView.theme({
-												"&.cm-editor.cm-focused": {
-													outline: "none",
-												},
-											})}
-											className="rounded-md border shadow-sm overflow-hidden"
-											{...field}
-										/>
+										<JsonInput {...field} />
 									</FormControl>
 									<FormMessage />
 								</FormItem>

--- a/ui-v2/tests/variables/mocks.tsx
+++ b/ui-v2/tests/variables/mocks.tsx
@@ -1,7 +1,10 @@
 import { vi } from "vitest";
 import React from "react";
 
-export const MockCodeMirror = React.forwardRef<
+//  Mock out JsonInput because the underlying CodeMirror editor
+//  relies on browser APIs that are not available in JSDOM.
+// TODO: Ensure input into JsonInput is covered by Playwright tests.
+export const MockJsonInput = React.forwardRef<
 	HTMLTextAreaElement,
 	{
 		value: string;
@@ -15,17 +18,13 @@ export const MockCodeMirror = React.forwardRef<
 			onChange={(e) => {
 				props.onChange?.(e.target.value);
 			}}
-			data-testid="mock-codemirror"
+			data-testid="mock-json-input"
 		/>
 	);
 });
 
-MockCodeMirror.displayName = "MockCodemirror";
+MockJsonInput.displayName = "MockJsonInput";
 
-vi.mock("@uiw/react-codemirror", () => ({
-	default: MockCodeMirror,
-	json: () => ({}),
-	EditorView: {
-		theme: () => ({}),
-	},
+vi.mock("@/components/ui/json-input", () => ({
+	JsonInput: MockJsonInput,
 }));

--- a/ui-v2/tests/variables/variables.test.tsx
+++ b/ui-v2/tests/variables/variables.test.tsx
@@ -70,14 +70,14 @@ describe("Variables page", () => {
 
 			await user.click(screen.getByRole("button", { name: "Add Variable" }));
 			await user.type(screen.getByLabelText("Name"), "my-variable");
-			await userEvent.type(screen.getByTestId("mock-codemirror"), "123");
+			await userEvent.type(screen.getByTestId("mock-json-input"), "123");
 			await user.click(
 				screen.getByRole("button", { name: "Close", expanded: true }),
 			);
 			await user.click(screen.getByRole("button", { name: "Add Variable" }));
 
 			expect(screen.getByLabelText("Name")).toHaveValue("");
-			expect(screen.getByTestId("mock-codemirror")).toHaveValue("");
+			expect(screen.getByTestId("mock-json-input")).toHaveValue("");
 		});
 
 		it("should allow adding a variable", async () => {
@@ -98,7 +98,7 @@ describe("Variables page", () => {
 			await user.click(screen.getByRole("button", { name: "Add Variable" }));
 			expect(screen.getByText("New Variable")).toBeVisible();
 			await user.type(screen.getByLabelText("Name"), "my-variable");
-			await userEvent.type(screen.getByTestId("mock-codemirror"), "123");
+			await userEvent.type(screen.getByTestId("mock-json-input"), "123");
 			await userEvent.type(screen.getByLabelText("Tags"), "tag1");
 			await user.click(screen.getByRole("button", { name: "Create" }));
 
@@ -129,7 +129,7 @@ describe("Variables page", () => {
 			// Value validation error
 			await user.type(screen.getByLabelText("Name"), "my-variable");
 			await userEvent.type(
-				screen.getByTestId("mock-codemirror"),
+				screen.getByTestId("mock-json-input"),
 				"{{Invalid JSON",
 			);
 			await user.click(screen.getByRole("button", { name: "Create" }));
@@ -160,7 +160,7 @@ describe("Variables page", () => {
 
 			await user.click(screen.getByRole("button", { name: "Add Variable" }));
 			await user.type(screen.getByLabelText("Name"), "my-variable");
-			await userEvent.type(screen.getByTestId("mock-codemirror"), "123");
+			await userEvent.type(screen.getByTestId("mock-json-input"), "123");
 			await user.click(screen.getByRole("button", { name: "Create" }));
 			expect(screen.getByText("Failed to create variable")).toBeVisible();
 		});
@@ -189,7 +189,7 @@ describe("Variables page", () => {
 
 			await user.click(screen.getByRole("button", { name: "Add Variable" }));
 			await user.type(screen.getByLabelText("Name"), "my-variable");
-			await userEvent.type(screen.getByTestId("mock-codemirror"), "123");
+			await userEvent.type(screen.getByTestId("mock-json-input"), "123");
 			await user.click(screen.getByRole("button", { name: "Create" }));
 
 			expect(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
@aaazzam discovered that the tab order was messed up on the `AddVariableDialog` component. I tracked the issue down to the `CodeMirror` component, but I don't know why it messed it up. 

Fortunately, `@uiw/react-codemirror` has a `useCodeMirror` hook that gives us more control over component creation. I used `useCodeMirror` to create a `JsonInput` component that doesn't have the same tab order foibles.

`AddVarialbeDialog` is now an upstanding citizen:
![add-variable-dialog-tab-order](https://github.com/user-attachments/assets/371fedbe-762f-4c22-b623-b5e92404c081)

Related to https://github.com/PrefectHQ/prefect/issues/15512