### PR TITLE
fix metadata storage path for `RayTaskRunner`

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -103,6 +103,8 @@ jobs:
           PREFECT_API_URL: http://127.0.0.1:4200/api
           SERVER_VERSION: ${{ matrix.server-version.version }}
         run: >
+          uv pip install src/integrations/prefect-ray &&
+          uv pip install . &&
           ./scripts/run-integration-flows.py flows/
 
       - name: Show server logs

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -27,6 +27,9 @@ on:
       - .nvmrc
       - Dockerfile
 
+env:
+  UV_SYSTEM_PYTHON: true
+
 jobs:
   compatibility-tests:
     name: Integration tests @${{ matrix.server-version.version }}
@@ -68,7 +71,7 @@ jobs:
       - name: Install python packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system .
+          uv pip install --upgrade .
 
       - name: Start server@${{ matrix.server-version.version }}
         if: ${{ matrix.server-version.version != 'main' }}

--- a/flows/ray_result_storage_location.py
+++ b/flows/ray_result_storage_location.py
@@ -1,0 +1,73 @@
+# /// script
+# dependencies = ["prefect-ray@git+https://github.com/PrefectHQ/prefect-ray.git"]
+# ///
+
+"""This is a regression test for https://github.com/PrefectHQ/prefect/issues/16009"""
+
+from pathlib import Path
+
+from prefect_ray import RayTaskRunner
+
+from prefect import flow, get_run_logger, task
+from prefect.serializers import PickleSerializer
+from prefect.settings import (
+    PREFECT_LOCAL_STORAGE_PATH,
+    PREFECT_RESULTS_PERSIST_BY_DEFAULT,
+    temporary_settings,
+)
+
+
+@task(result_storage_key="test-key")
+def task_a():
+    logger = get_run_logger()
+    current_storage_path = PREFECT_LOCAL_STORAGE_PATH.value()
+    logger.info(f"Task running with storage path: {current_storage_path}")
+    return 42
+
+
+@flow(task_runner=RayTaskRunner)
+def my_flow():
+    state = task_a.submit(return_state=True)
+    return state.result()
+
+
+if __name__ == "__main__":
+    # Create a temporary directory for test results
+    tmp_path = Path("test_results")
+    tmp_path.mkdir(exist_ok=True)
+
+    try:
+        with temporary_settings(
+            {
+                PREFECT_RESULTS_PERSIST_BY_DEFAULT: True,
+                PREFECT_LOCAL_STORAGE_PATH: str(tmp_path),
+            },
+        ):
+            my_flow()
+
+            # Check result file exists in correct location
+            result_file = tmp_path / "test-key"
+            assert result_file.exists(), f"Result file not found at {result_file}"
+
+            # Verify file contents - use pickle serializer since that's what was used to write
+            serializer = PickleSerializer()
+            result = serializer.loads(result_file.read_bytes())
+            assert result == 42
+
+            # Verify no files exist in CWD
+            cwd_result = Path.cwd() / "test-key"
+            assert not cwd_result.exists(), f"Found unexpected result file in current working directory: {cwd_result}"
+
+            # List all files in tmp_path for debugging
+            found_files = list(tmp_path.glob("**/*"))
+            assert len(found_files) == 2, (
+                f"Expected exactly two files in {tmp_path}, "
+                f"found {len(found_files)}: {found_files!r}"
+            )
+
+        print("Result storage location test passed!")
+    finally:
+        # Clean up test directory
+        import shutil
+
+        shutil.rmtree(tmp_path)

--- a/flows/ray_result_storage_location.py
+++ b/flows/ray_result_storage_location.py
@@ -1,7 +1,3 @@
-# /// script
-# dependencies = ["prefect-ray@git+https://github.com/PrefectHQ/prefect-ray.git"]
-# ///
-
 """This is a regression test for https://github.com/PrefectHQ/prefect/issues/16009"""
 
 from pathlib import Path

--- a/flows/ray_result_storage_location.py
+++ b/flows/ray_result_storage_location.py
@@ -61,6 +61,9 @@ if __name__ == "__main__":
                 f"Expected exactly two files in {tmp_path}, "
                 f"found {len(found_files)}: {found_files!r}"
             )
+            assert any(
+                f.name == "test-key" for f in found_files
+            ), f"Expected to find 'test-key' in {found_files!r}"
 
         print("Result storage location test passed!")
     finally:

--- a/src/integrations/prefect-ray/prefect_ray/task_runners.py
+++ b/src/integrations/prefect-ray/prefect_ray/task_runners.py
@@ -362,9 +362,6 @@ class RayTaskRunner(TaskRunner[PrefectRayFuture]):
         This variable is otherwise unused as the ray object refs are also
         contained in parameters.
         """
-        from prefect.filesystems import LocalFileSystem
-        from prefect.results import ResultStore
-        from prefect.settings import get_current_settings
 
         # Resolve Ray futures to ensure that the task function receives the actual values
         def resolve_ray_future(expr):
@@ -376,15 +373,6 @@ class RayTaskRunner(TaskRunner[PrefectRayFuture]):
         parameters = visit_collection(
             parameters, visit_fn=resolve_ray_future, return_data=True
         )
-
-        # Create a fresh result store rather than modifying the existing one
-        settings = get_current_settings()
-        storage_path = settings.results.local_storage_path
-        if storage_path:
-            result_store = ResultStore(
-                result_storage=LocalFileSystem(basepath=str(storage_path))
-            )
-            context["result_store"] = result_store
 
         run_task_kwargs = {
             "task": task,

--- a/src/integrations/prefect-ray/prefect_ray/task_runners.py
+++ b/src/integrations/prefect-ray/prefect_ray/task_runners.py
@@ -362,6 +362,9 @@ class RayTaskRunner(TaskRunner[PrefectRayFuture]):
         This variable is otherwise unused as the ray object refs are also
         contained in parameters.
         """
+        from prefect.filesystems import LocalFileSystem
+        from prefect.results import ResultStore
+        from prefect.settings import get_current_settings
 
         # Resolve Ray futures to ensure that the task function receives the actual values
         def resolve_ray_future(expr):
@@ -373,6 +376,15 @@ class RayTaskRunner(TaskRunner[PrefectRayFuture]):
         parameters = visit_collection(
             parameters, visit_fn=resolve_ray_future, return_data=True
         )
+
+        # Create a fresh result store rather than modifying the existing one
+        settings = get_current_settings()
+        storage_path = settings.results.local_storage_path
+        if storage_path:
+            result_store = ResultStore(
+                result_storage=LocalFileSystem(basepath=str(storage_path))
+            )
+            context["result_store"] = result_store
 
         run_task_kwargs = {
             "task": task,

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -88,7 +88,6 @@ async def get_default_result_storage() -> WritableFileSystem:
     """
     Generate a default file system for result storage.
     """
-    print("\n\n\n\n\ngetting default result storage\n\n\n\n\n")
     settings = get_current_settings()
     default_block = settings.results.default_storage_block
     basepath = settings.results.local_storage_path
@@ -106,7 +105,7 @@ async def get_default_result_storage() -> WritableFileSystem:
 
     _default_storages[cache_key] = storage
 
-    print(f"returning storage: {storage}")
+    logger.debug(f"Using default result storage: {storage}")
     return storage
 
 
@@ -317,7 +316,6 @@ class ResultStore(BaseModel):
         if flow.cache_result_in_memory is not None:
             update["cache_result_in_memory"] = flow.cache_result_in_memory
         if self.result_storage is None and update.get("result_storage") is None:
-            print("\n\n\nFOR FLOW\n\n\n")
             update["result_storage"] = await get_default_result_storage()
         update["metadata_storage"] = NullFileSystem()
         return self.model_copy(update=update)
@@ -326,6 +324,11 @@ class ResultStore(BaseModel):
     async def update_for_task(self: Self, task: "Task") -> Self:
         """
         Create a new result store for a task.
+
+        Args:
+            task: The task to update the result store for.
+        Returns:
+            An updated result store.
         """
         from prefect.settings import get_current_settings
 

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -332,7 +332,6 @@ class ResultStore(BaseModel):
         """
         from prefect.settings import get_current_settings
 
-        logger = get_logger("results")
         logger.debug(f"Updating result store for task {task.name}")
         logger.debug(f"Current result store: {self}")
         logger.debug(f"Task result_storage: {task.result_storage}")
@@ -540,7 +539,6 @@ class ResultStore(BaseModel):
         """
         Create a result record.
         """
-        logger = get_logger("results")
         logger.debug(f"Creating result record with key: {key}")
         logger.debug(f"Current storage_key_fn: {self.storage_key_fn}")
         logger.debug(f"Current result_storage: {self.result_storage}")

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -365,7 +365,7 @@ class ResultStore(BaseModel):
             and update.get("result_storage") is None
             or (self.result_storage and self.result_storage.basepath is None)
         ):
-            update["result_storage"] = await get_default_result_storage()
+            update["result_storage"] = await get_default_result_storage(_sync=False)
         if (
             isinstance(self.metadata_storage, NullFileSystem)
             and update.get("metadata_storage", NotSet) is NotSet

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -1157,7 +1157,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
         """
         Enters a client context and creates a task run if needed.
         """
-
+        # Use hydrated_context to ensure settings and context are properly propagated
         with hydrated_context(self.context):
             async with AsyncClientContext.get_or_create():
                 self._client = get_client()


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/16009

as described in the linked issue, we were writing result metadata files to the `cwd` when using a ray task runner because child processes would get a `None` storage `basepath` - this PR checks for this case and makes sure we also respect the `result_storage_key`