### PR TITLE
Add `new` action to `OpsGenieWebhook` for `apprise==1.9.0` compatibility

### DIFF
--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -494,6 +494,7 @@ class OpsgenieWebhook(AbstractAppriseNotificationBlock):
                 entity=self.entity,
                 batch=self.batch,
                 tags=self.tags,
+                action="new",
             ).url()
         )
         self._start_apprise_client(url)

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -292,7 +292,7 @@ class TestOpsgenieWebhook:
 
             AppriseMock.assert_called_once()
             apprise_instance_mock.add.assert_called_once_with(
-                f"opsgenie://{self.API_KEY}//?action=map&region=us&priority=normal&"
+                f"opsgenie://{self.API_KEY}//?action=new&region=us&priority=normal&"
                 "batch=no&%3Ainfo=note&%3Asuccess=close&%3Awarning=new&%3Afailure="
                 "new&format=text&overflow=upstream"
             )
@@ -304,7 +304,7 @@ class TestOpsgenieWebhook:
     def _test_notify_sync(self, targets="", params=None, **kwargs):
         with patch("apprise.Apprise", autospec=True) as AppriseMock:
             if params is None:
-                params = "action=map&region=us&priority=normal&batch=no"
+                params = "action=new&region=us&priority=normal&batch=no"
 
             apprise_instance_mock = AppriseMock.return_value
             apprise_instance_mock.async_notify = AsyncMock()
@@ -331,7 +331,7 @@ class TestOpsgenieWebhook:
         self._test_notify_sync()
 
     def test_notify_sync_params(self):
-        params = "action=map&region=eu&priority=low&batch=yes"
+        params = "action=new&region=eu&priority=low&batch=yes"
         self._test_notify_sync(params=params, region_name="eu", priority=1, batch=True)
 
     def test_notify_sync_targets(self):
@@ -349,7 +349,7 @@ class TestOpsgenieWebhook:
         self._test_notify_sync(targets=targets, target_user=["user1", "user2"])
 
     def test_notify_sync_details(self):
-        params = "action=map&region=us&priority=normal&batch=no&%2Bkey1=value1&%2Bkey2=value2"
+        params = "action=new&region=us&priority=normal&batch=no&%2Bkey1=value1&%2Bkey2=value2"
         self._test_notify_sync(
             params=params,
             details={


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
`apprise`'s new default `MAP` action for OpsGenie is a no-op (no notification is sent). To create an OpsGenie alert we need to include the `new` action type. As is, this is backwards compatible with older `apprise` versions, but if we bumped the minimum requirement for `apprise` to `1.9.0` we could either import and use `OpsgenieAlertAction.NEW` or maybe even support `action` as a block field instead of just sending a string.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
