### PR TITLE
Move installation notes to bottom of self-host doc

### DIFF
--- a/docs/3.0/manage/self-host.mdx
+++ b/docs/3.0/manage/self-host.mdx
@@ -14,49 +14,6 @@ Prefect Cloud and self-hosted Prefect server share a common set of capabilities.
 Prefect Cloud provides the additional features required by organizations such as RBAC, Audit logs, and SSO. 
 See the [Prefect Cloud overview](/3.0/manage/cloud/) for more information.
 
-## Prefect server installation notes
-
-Your self-hosted server must meet the following requirements and configuration settings.
-
-### SQLite
-
-SQLite is not packaged with the Prefect installation. But most systems already have SQLite installed, and it is typically bundled with Python.
-
-If you self-host a Prefect server instance with a SQLite database, certain Linux versions of SQLite can be problematic.
-Compatible versions include Ubuntu 22.04 LTS and Ubuntu 20.04 LTS.
-
-To confirm SQLite is installed, run:
-
-```bash
-sqlite3 --version
-```
-
-### Use a self-signed SSL certificate
-
-When using a self-signed SSL certificate, you need to configure your environment to trust the certificate.
-Add the certificate to your system bundle and point your tools to use that bundle by configuring the 
-`SSL_CERT_FILE` environment variable.
-
-If the certificate is not part of your system bundle, set the
-`PREFECT_API_TLS_INSECURE_SKIP_VERIFY` to `True` to disable certificate verification altogether.
-
-<Warning>
-Disabling certificate validation is insecure and only suggested as an option for testing.
-</Warning>
-
-### Proxies
-
-Prefect supports communicating with proxies through environment variables.
-Whether you use a Prefect Cloud account or self-host a Prefect server instance, set `HTTPS_PROXY` and 
-`SSL_CERT_FILE` in your environment. 
-Then the underlying network libraries will route Prefect's requests appropriately.
-
-Alternatively, the Prefect library connects to the API through any proxies you have listed in the `HTTP_PROXY` or 
-`ALL_PROXY` environment variables.
-You may also use the `NO_PROXY` environment variable to specify which hosts should not pass through the proxy.
-
-For more information about these environment variables, see the [cURL documentation](https://everything.curl.dev/usingcurl/proxies/env).
-
 ## Self-host a Prefect server
 
 1. Spin up a self-hosted Prefect server instance UI with the `prefect server start` CLI command in the terminal:
@@ -246,3 +203,47 @@ prefect server database downgrade -y -r d20618ce678e
 To downgrade all migrations, use the `base` revision.
 
 See the [contributing docs](/contribute/dev-contribute) to learn how to create a database migration.
+
+
+## Prefect server installation notes
+
+Your self-hosted server must meet the following requirements and configuration settings.
+
+### SQLite
+
+SQLite is not packaged with the Prefect installation. But most systems already have SQLite installed, and it is typically bundled with Python.
+
+If you self-host a Prefect server instance with a SQLite database, certain Linux versions of SQLite can be problematic.
+Compatible versions include Ubuntu 22.04 LTS and Ubuntu 20.04 LTS.
+
+To confirm SQLite is installed, run:
+
+```bash
+sqlite3 --version
+```
+
+### Use a self-signed SSL certificate
+
+When using a self-signed SSL certificate, you need to configure your environment to trust the certificate.
+Add the certificate to your system bundle and point your tools to use that bundle by configuring the 
+`SSL_CERT_FILE` environment variable.
+
+If the certificate is not part of your system bundle, set the
+`PREFECT_API_TLS_INSECURE_SKIP_VERIFY` to `True` to disable certificate verification altogether.
+
+<Warning>
+Disabling certificate validation is insecure and only suggested as an option for testing.
+</Warning>
+
+### Proxies
+
+Prefect supports communicating with proxies through environment variables.
+Whether you use a Prefect Cloud account or self-host a Prefect server instance, set `HTTPS_PROXY` and 
+`SSL_CERT_FILE` in your environment. 
+Then the underlying network libraries will route Prefect's requests appropriately.
+
+Alternatively, the Prefect library connects to the API through any proxies you have listed in the `HTTP_PROXY` or 
+`ALL_PROXY` environment variables.
+You may also use the `NO_PROXY` environment variable to specify which hosts should not pass through the proxy.
+
+For more information about these environment variables, see the [cURL documentation](https://everything.curl.dev/usingcurl/proxies/env).


### PR DESCRIPTION
The [self-hosting page](https://docs.prefect.io/3.0/manage/self-host) opens with a series of advanced installation notes that may not be relevant to most users, but seem like part of the critical path because of their location on the page (e.g. you see a section called "Use a self-signed SSL certificate" before you get to step 1 of "Self-host a Prefect server").

This PR moves them to the end of the page, which is appropriate for their content and likelihood of applicability to all users.