### PR TITLE
Fix env var deep merge order on worker

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -163,7 +163,7 @@ class BaseJobConfiguration(BaseModel):
         if isinstance(job_config.get("env"), dict) and (
             hardcoded_env := variables.get("env")
         ):
-            job_config["env"] = hardcoded_env | job_config.get("env")
+            job_config["env"] = job_config.get("env") | hardcoded_env
 
         populated_configuration = apply_values(template=job_config, values=variables)
         populated_configuration = await resolve_block_document_references(

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -146,26 +146,26 @@ class BaseJobConfiguration(BaseModel):
         Important: this method expects that the base_job_template was already
         validated server-side.
         """
-        job_config: Dict[str, Any] = base_job_template["job_configuration"]
+        base_config: Dict[str, Any] = base_job_template["job_configuration"]
         variables_schema = base_job_template["variables"]
         variables = cls._get_base_config_defaults(
             variables_schema.get("properties", {})
         )
 
-        # copy variable defaults for `env` to job config before they're replaced by
+        # copy variable defaults for `env` to base config before they're replaced by
         # deployment overrides
         if variables.get("env"):
-            job_config["env"] = variables.get("env")
+            base_config["env"] = variables.get("env")
 
         variables.update(values)
 
         # deep merge `env`
-        if isinstance(job_config.get("env"), dict) and (
-            hardcoded_env := variables.get("env")
+        if isinstance(base_config.get("env"), dict) and (
+            deployment_env := variables.get("env")
         ):
-            job_config["env"] = job_config.get("env") | hardcoded_env
+            base_config["env"] = base_config.get("env") | deployment_env
 
-        populated_configuration = apply_values(template=job_config, values=variables)
+        populated_configuration = apply_values(template=base_config, values=variables)
         populated_configuration = await resolve_block_document_references(
             template=populated_configuration, client=client
         )

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -1817,7 +1817,7 @@ class TestBaseWorkerStart:
         ),
         (
             {"A": "1", "B": "2"},
-            {"B": ""},  # empty strings will still override
+            {"B": ""},  # empty strings are considered values and will still override
             {},
             {"A": "1", "B": ""},
         ),

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -1799,6 +1799,12 @@ class TestBaseWorkerStart:
         ),
         (
             {"A": "1", "B": "2"},
+            {"A": "1", "B": "3"},
+            {},
+            {"A": "1", "B": "3"},
+        ),
+        (
+            {"A": "1", "B": "2"},
             {"C": "3", "D": "4"},
             {},
             {"A": "1", "B": "2", "C": "3", "D": "4"},
@@ -1811,14 +1817,15 @@ class TestBaseWorkerStart:
         ),
         (
             {"A": "1", "B": "2"},
-            {"B": ""},  # will be treated as unset and not apply
+            {"B": ""},  # empty strings will still override
             {},
-            {"A": "1", "B": "2"},
+            {"A": "1", "B": ""},
         ),
     ],
     ids=[
         "flow_run_into_deployment",
-        "deployment_into_work_pool",
+        "deployment_into_work_pool_overlap",
+        "deployment_into_work_pool_no_overlap",
         "flow_run_into_work_pool",
         "try_overwrite_with_empty_str",
     ],


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
Changes merge order so overlapping keys select deployment env vars over work pool env vars.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
