### PR TITLE
Adds a dead-letter queue to memory subscriptions to avoid infinite loops

### DIFF
--- a/src/prefect/server/utilities/messaging/memory.py
+++ b/src/prefect/server/utilities/messaging/memory.py
@@ -1,8 +1,9 @@
 import asyncio
 import copy
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import timedelta
+from pathlib import Path
 from typing import (
     Any,
     AsyncGenerator,
@@ -13,8 +14,11 @@ from typing import (
     TypeVar,
     Union,
 )
+from uuid import uuid4
 
+import anyio
 from cachetools import TTLCache
+from pydantic_core import to_json
 from typing_extensions import Self
 
 from prefect.logging import get_logger
@@ -22,6 +26,7 @@ from prefect.server.utilities.messaging import Cache as _Cache
 from prefect.server.utilities.messaging import Consumer as _Consumer
 from prefect.server.utilities.messaging import Message, MessageHandler, StopConsumer
 from prefect.server.utilities.messaging import Publisher as _Publisher
+from prefect.settings.context import get_current_settings
 
 logger = get_logger(__name__)
 
@@ -34,21 +39,60 @@ class MemoryMessage:
 
 
 class Subscription:
-    topic: "Topic"
-    _queue: asyncio.Queue
-    _retry: asyncio.Queue
+    """
+    A subscription to a topic.
 
-    def __init__(self, topic: "Topic", max_retries: int = 3) -> None:
+    Messages are delivered to the subscription's queue and retried up to a
+    maximum number of times. If a message cannot be delivered after the maximum
+    number of retries it is moved to the dead letter queue.
+
+    The dead letter queue is a directory of JSON files containing the serialized
+    message.
+
+    Messages remain in the dead letter queue until they are removed manually.
+
+    Attributes:
+        topic: The topic that the subscription receives messages from.
+        max_retries: The maximum number of times a message will be retried for
+            this subscription.
+        dead_letter_queue_path: The path to the dead letter queue folder.
+    """
+
+    def __init__(
+        self,
+        topic: "Topic",
+        max_retries: int = 3,
+        dead_letter_queue_path: Union[Path, str, None] = None,
+    ) -> None:
         self.topic = topic
         self.max_retries = max_retries
-        self.dead_letter_queue = list()
+        self.dead_letter_queue_path = (
+            Path(dead_letter_queue_path)
+            if dead_letter_queue_path
+            else get_current_settings().home / "dlq"
+        )
         self._queue = asyncio.Queue()
         self._retry = asyncio.Queue()
 
     async def deliver(self, message: MemoryMessage) -> None:
+        """
+        Deliver a message to the subscription's queue.
+
+        Args:
+            message: The message to deliver.
+        """
         await self._queue.put(message)
 
     async def retry(self, message: MemoryMessage) -> None:
+        """
+        Place a message back on the retry queue.
+
+        If the message has retried more than the maximum number of times it is
+        moved to the dead letter queue.
+
+        Args:
+            message: The message to retry.
+        """
         message.retry_count += 1
         if message.retry_count > self.max_retries:
             logger.warning(
@@ -56,14 +100,35 @@ class Subscription:
                 message.retry_count,
                 extra={"event_message": message},
             )
-            self.dead_letter_queue.append(message)
+            await self.send_to_dead_letter_queue(message)
         else:
             await self._retry.put(message)
 
     async def get(self) -> MemoryMessage:
+        """
+        Get a message from the subscription's queue.
+        """
         if self._retry.qsize() > 0:
             return await self._retry.get()
         return await self._queue.get()
+
+    async def send_to_dead_letter_queue(self, message: MemoryMessage) -> None:
+        """
+        Send a message to the dead letter queue.
+
+        The dead letter queue is a directory of JSON files containing the
+        serialized messages.
+
+        Args:
+            message: The message to send to the dead letter queue.
+        """
+        self.dead_letter_queue_path.mkdir(parents=True, exist_ok=True)
+        try:
+            await anyio.Path(self.dead_letter_queue_path / uuid4().hex).write_bytes(
+                to_json(asdict(message))
+            )
+        except Exception as e:
+            logger.warning("Failed to write message to dead letter queue", exc_info=e)
 
 
 class Topic:

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -786,10 +786,12 @@ async def test_task_run_recorder_sends_repeated_failed_messages_to_dead_letter(
             message(duplicate_pending_event).attributes,
         )
 
-    while not service.consumer.subscription.dead_letter_queue:
+    while not list(service.consumer.subscription.dead_letter_queue_path.glob("*")):
         await asyncio.sleep(0.1)
 
-    assert len(service.consumer.subscription.dead_letter_queue) == 1
+    assert (
+        len(list(service.consumer.subscription.dead_letter_queue_path.glob("*"))) == 1
+    )
 
     service_task.cancel()
     try:

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -18,7 +18,7 @@ from prefect.server.models.task_runs import read_task_run
 from prefect.server.schemas.core import FlowRun, TaskRunPolicy
 from prefect.server.schemas.states import StateDetails, StateType
 from prefect.server.services import task_run_recorder
-from prefect.server.utilities.messaging import MessageHandler
+from prefect.server.utilities.messaging import MessageHandler, create_publisher
 from prefect.server.utilities.messaging.memory import MemoryMessage
 
 
@@ -29,6 +29,7 @@ async def test_start_and_stop_service():
 
     await service.started_event.wait()
     assert service.consumer_task is not None
+    assert service.consumer is not None
 
     await service.stop()
     assert service.consumer_task is None
@@ -753,3 +754,45 @@ async def test_task_run_recorder_handles_all_out_of_order_permutations(
 
     state_types = set(state.type for state in states)
     assert state_types == {StateType.PENDING, StateType.RUNNING, StateType.COMPLETED}
+
+
+async def test_task_run_recorder_sends_repeated_failed_messages_to_dead_letter(
+    session: AsyncSession,
+    pending_event: ReceivedEvent,
+):
+    """
+    Test to ensure situations like the one described in https://github.com/PrefectHQ/prefect/issues/15607
+    don't overwhelm the task run recorder.
+    """
+    pending_transition_time = pendulum.datetime(2024, 1, 1, 0, 0, 0, 0, "UTC")
+    assert pending_event.occurred == pending_transition_time
+
+    service = task_run_recorder.TaskRunRecorder()
+
+    service_task = asyncio.create_task(service.start())
+    await service.started_event.wait()
+
+    async with create_publisher("events") as publisher:
+        await publisher.publish_data(
+            message(pending_event).data, message(pending_event).attributes
+        )
+        # Sending a task run event with the same task run id and timestamp but
+        # a different id will raise an error when trying to insert it into the
+        # database
+        duplicate_pending_event = pending_event.model_copy()
+        duplicate_pending_event.id = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+        await publisher.publish_data(
+            message(duplicate_pending_event).data,
+            message(duplicate_pending_event).attributes,
+        )
+
+    while not service.consumer.subscription.dead_letter_queue:
+        await asyncio.sleep(0.1)
+
+    assert len(service.consumer.subscription.dead_letter_queue) == 1
+
+    service_task.cancel()
+    try:
+        await service_task
+    except asyncio.CancelledError:
+        pass

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -769,10 +769,10 @@ async def test_task_run_recorder_sends_repeated_failed_messages_to_dead_letter(
     assert pending_event.occurred == pending_transition_time
 
     service = task_run_recorder.TaskRunRecorder()
-    service.consumer.subscription.dead_letter_queue_path = tmp_path / "dlq"
 
     service_task = asyncio.create_task(service.start())
     await service.started_event.wait()
+    service.consumer.subscription.dead_letter_queue_path = tmp_path / "dlq"
 
     async with create_publisher("events") as publisher:
         await publisher.publish_data(

--- a/tests/server/services/test_task_run_recorder.py
+++ b/tests/server/services/test_task_run_recorder.py
@@ -1,6 +1,7 @@
 import asyncio
 from datetime import timedelta
 from itertools import permutations
+from pathlib import Path
 from typing import AsyncGenerator
 from uuid import UUID
 
@@ -757,8 +758,8 @@ async def test_task_run_recorder_handles_all_out_of_order_permutations(
 
 
 async def test_task_run_recorder_sends_repeated_failed_messages_to_dead_letter(
-    session: AsyncSession,
     pending_event: ReceivedEvent,
+    tmp_path: Path,
 ):
     """
     Test to ensure situations like the one described in https://github.com/PrefectHQ/prefect/issues/15607
@@ -768,6 +769,7 @@ async def test_task_run_recorder_sends_repeated_failed_messages_to_dead_letter(
     assert pending_event.occurred == pending_transition_time
 
     service = task_run_recorder.TaskRunRecorder()
+    service.consumer.subscription.dead_letter_queue_path = tmp_path / "dlq"
 
     service_task = asyncio.create_task(service.start())
     await service.started_event.wait()

--- a/tests/server/utilities/test_messaging.py
+++ b/tests/server/utilities/test_messaging.py
@@ -24,6 +24,7 @@ from prefect.server.utilities.messaging import (
     create_publisher,
     ephemeral_subscription,
 )
+from prefect.server.utilities.messaging.memory import Consumer as MemoryConsumer
 from prefect.settings import (
     PREFECT_MESSAGING_BROKER,
     PREFECT_MESSAGING_CACHE,
@@ -441,3 +442,44 @@ async def test_ephemeral_subscription(broker: str, publisher: Publisher):
     # TODO: is there a way we can test that ephemeral subscriptions really have cleaned
     # up after themselves after they have exited?  This will differ significantly by
     # each broker implementation, so it's hard to write a generic test.
+
+
+async def test_repeatedly_failed_message_is_moved_to_dead_letter_queue(
+    deduplicating_publisher: Publisher,
+    consumer: MemoryConsumer,
+):
+    captured_messages: List[Message] = []
+
+    async def handler(message: Message):
+        captured_messages.append(message)
+        raise ValueError("Simulated failure")
+
+    consumer_task = asyncio.create_task(consumer.run(handler))
+
+
+    async with deduplicating_publisher as p:
+        await p.publish_data(b"hello, world", {"howdy": "partner"})
+
+    while not consumer.subscription.dead_letter_queue:
+        await asyncio.sleep(0.1)
+    try:
+        consumer_task.cancel()
+        await consumer_task
+    except asyncio.CancelledError:
+        pass
+
+    # Message should have been moved to DLQ after multiple retries
+    assert len(captured_messages) == 4  # Original attempt + 3 retries
+    for message in captured_messages:
+        assert message.data == b"hello, world"
+        assert message.attributes == {"howdy": "partner"}
+
+    # Verify message is in DLQ
+    assert len(consumer.subscription.dead_letter_queue) == 1
+    dlq_message = next(iter(consumer.subscription.dead_letter_queue))
+    assert dlq_message.data == b"hello, world"
+    assert dlq_message.attributes == {"howdy": "partner"}
+    assert dlq_message.retry_count > 3
+
+    remaining_message = await drain_one(consumer)
+    assert not remaining_message

--- a/tests/server/utilities/test_messaging.py
+++ b/tests/server/utilities/test_messaging.py
@@ -456,7 +456,6 @@ async def test_repeatedly_failed_message_is_moved_to_dead_letter_queue(
 
     consumer_task = asyncio.create_task(consumer.run(handler))
 
-
     async with deduplicating_publisher as p:
         await p.publish_data(b"hello, world", {"howdy": "partner"})
 

--- a/tests/server/utilities/test_messaging.py
+++ b/tests/server/utilities/test_messaging.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib
 import json
+from pathlib import Path
 from typing import (
     AsyncContextManager,
     AsyncGenerator,
@@ -453,12 +454,15 @@ async def test_ephemeral_subscription(broker: str, publisher: Publisher):
 async def test_repeatedly_failed_message_is_moved_to_dead_letter_queue(
     deduplicating_publisher: Publisher,
     consumer: MemoryConsumer,
+    tmp_path: Path,
 ):
     captured_messages: List[Message] = []
 
     async def handler(message: Message):
         captured_messages.append(message)
         raise ValueError("Simulated failure")
+
+    consumer.subscription.dead_letter_queue_path = tmp_path / "dlq"
 
     consumer_task = asyncio.create_task(consumer.run(handler))
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
In https://github.com/PrefectHQ/prefect/issues/15607, users are seeing the task run recorder get stuck in an infinite loop when trying to insert a task run state update with the same task run ID and timestamp as another task run state update, but with a different ID. This PR doesn't solve the underlying problem (which appears to be a race condition in the client-side code), but it does add a dead-letter queue to the `Subscription` class to avoid messages being retried ad-infinitum. By default, messages will attempt to be processed 3 times before being removed from the subscription's queue.

Closes https://github.com/PrefectHQ/prefect/issues/15607