### PR TITLE
migrate `prefect_aws.batch` off `sync_compatible`

### DIFF
--- a/src/integrations/prefect-aws/prefect_aws/batch.py
+++ b/src/integrations/prefect-aws/prefect_aws/batch.py
@@ -3,14 +3,81 @@
 from typing import Any, Dict, Optional
 
 from prefect import task
+from prefect._internal.compatibility.async_dispatch import async_dispatch
 from prefect.logging import get_run_logger
-from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
+from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect_aws.credentials import AwsCredentials
 
 
 @task
-@sync_compatible
-async def batch_submit(
+async def batch_submit_async(
+    job_name: str,
+    job_queue: str,
+    job_definition: str,
+    aws_credentials: AwsCredentials,
+    **batch_kwargs: Optional[Dict[str, Any]],
+) -> str:
+    """
+    Asynchronously submit a job to the AWS Batch job service.
+
+    Args:
+        job_name: The AWS batch job name.
+        job_queue: Name of the AWS batch job queue.
+        job_definition: The AWS batch job definition.
+        aws_credentials: Credentials to use for authentication with AWS.
+        **batch_kwargs: Additional keyword arguments to pass to the boto3
+            `submit_job` function. See the documentation for
+            [submit_job](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html#Batch.Client.submit_job)
+            for more details.
+
+    Returns:
+        The id corresponding to the job.
+
+    Example:
+        Submits a job to batch.
+
+        ```python
+        from prefect import flow
+        from prefect_aws import AwsCredentials
+        from prefect_aws.batch import batch_submit
+
+
+        @flow
+        def example_batch_submit_flow():
+            aws_credentials = AwsCredentials(
+                aws_access_key_id="acccess_key_id",
+                aws_secret_access_key="secret_access_key"
+            )
+            job_id = batch_submit(
+                "job_name",
+                "job_queue",
+                "job_definition",
+                aws_credentials
+            )
+            return job_id
+
+        example_batch_submit_flow()
+        ```
+
+    """  # noqa
+    logger = get_run_logger()
+    logger.info("Preparing to submit %s job to %s job queue", job_name, job_queue)
+
+    batch_client = aws_credentials.get_boto3_session().client("batch")
+
+    response = await run_sync_in_worker_thread(
+        batch_client.submit_job,
+        jobName=job_name,
+        jobQueue=job_queue,
+        jobDefinition=job_definition,
+        **batch_kwargs,
+    )
+    return response["jobId"]
+
+
+@task
+@async_dispatch(batch_submit_async)
+def batch_submit(
     job_name: str,
     job_queue: str,
     job_definition: str,
@@ -65,8 +132,7 @@ async def batch_submit(
 
     batch_client = aws_credentials.get_boto3_session().client("batch")
 
-    response = await run_sync_in_worker_thread(
-        batch_client.submit_job,
+    response = batch_client.submit_job(
         jobName=job_name,
         jobQueue=job_queue,
         jobDefinition=job_definition,

--- a/src/integrations/prefect-aws/prefect_aws/batch.py
+++ b/src/integrations/prefect-aws/prefect_aws/batch.py
@@ -10,7 +10,7 @@ from prefect_aws.credentials import AwsCredentials
 
 
 @task
-async def batch_submit_async(
+async def abatch_submit(
     job_name: str,
     job_queue: str,
     job_definition: str,
@@ -76,7 +76,7 @@ async def batch_submit_async(
 
 
 @task
-@async_dispatch(batch_submit_async)
+@async_dispatch(abatch_submit)
 def batch_submit(
     job_name: str,
     job_queue: str,

--- a/src/integrations/prefect-aws/pyproject.toml
+++ b/src/integrations/prefect-aws/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "botocore>=1.27.53",
   "mypy_boto3_s3>=1.24.94",
   "mypy_boto3_secretsmanager>=1.26.49",
-  "prefect>=3.0.0",
+  "prefect>=3.1.2",
   "pyparsing>=3.1.1",
   "tenacity>=8.0.0",
 ]

--- a/src/integrations/prefect-aws/tests/test_batch.py
+++ b/src/integrations/prefect-aws/tests/test_batch.py
@@ -4,7 +4,7 @@ from uuid import UUID
 import boto3
 import pytest
 from moto import mock_batch, mock_iam
-from prefect_aws.batch import batch_submit, batch_submit_async
+from prefect_aws.batch import abatch_submit, batch_submit
 
 from prefect import flow
 
@@ -72,57 +72,57 @@ def job_definition_arn(batch_client):
     return job_definition_arn
 
 
-def test_batch_submit(job_queue_arn, job_definition_arn, aws_credentials):
-    @flow
-    def test_flow():
-        return batch_submit(
+class TestBatchSubmit:
+    def test_batch_submit(self, job_queue_arn, job_definition_arn, aws_credentials):
+        @flow
+        def test_flow():
+            return batch_submit(
+                "batch_test_job",
+                job_queue_arn,
+                job_definition_arn,
+                aws_credentials,
+            )
+
+        job_id = test_flow()
+
+        assert_valid_job_id(job_id)
+
+    async def test_batch_submit_async_dispatch(
+        self, job_queue_arn, job_definition_arn, aws_credentials
+    ):
+        @flow
+        async def test_flow():
+            return await batch_submit(
+                "batch_test_job",
+                job_queue_arn,
+                job_definition_arn,
+                aws_credentials,
+            )
+
+        job_id = await test_flow()
+        assert_valid_job_id(job_id)
+
+    async def test_batch_submit_force_sync_from_async(
+        self, job_queue_arn, job_definition_arn, aws_credentials
+    ):
+        job_id = batch_submit(
+            "batch_test_job",
+            job_queue_arn,
+            job_definition_arn,
+            aws_credentials,
+            _sync=True,
+        )
+        assert_valid_job_id(job_id)
+
+
+class TestBatchSubmitAsync:
+    async def test_batch_submit_explicit_async(
+        self, job_queue_arn, job_definition_arn, aws_credentials
+    ):
+        job_id = await abatch_submit(
             "batch_test_job",
             job_queue_arn,
             job_definition_arn,
             aws_credentials,
         )
-
-    job_id = test_flow()
-
-    assert_valid_job_id(job_id)
-
-
-async def test_batch_submit_async_dispatch(
-    job_queue_arn, job_definition_arn, aws_credentials
-):
-    @flow
-    async def test_flow():
-        return await batch_submit(
-            "batch_test_job",
-            job_queue_arn,
-            job_definition_arn,
-            aws_credentials,
-        )
-
-    job_id = await test_flow()
-    assert_valid_job_id(job_id)
-
-
-async def test_batch_submit_explicit_async(
-    job_queue_arn, job_definition_arn, aws_credentials
-):
-    job_id = await batch_submit_async(
-        "batch_test_job",
-        job_queue_arn,
-        job_definition_arn,
-        aws_credentials,
-    )
-    assert_valid_job_id(job_id)
-
-
-async def test_batch_submit_force_sync_from_async(
-    job_queue_arn, job_definition_arn, aws_credentials
-):
-    job_id = batch_submit(
-        "batch_test_job",
-        job_queue_arn,
-        job_definition_arn,
-        aws_credentials,
-        _sync=True,
-    )
-    assert_valid_job_id(job_id)
+        assert_valid_job_id(job_id)


### PR DESCRIPTION
related to #15008

migrates `prefect_aws.batch` tasks to explicit sync / async via `async_dispatch`

also updates `async_dispatch` to allow dispatching async task objects

will continue with `prefect_aws` after this PR