### PR TITLE
fix pydantic 2.10 compat

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -9049,6 +9049,9 @@
                                     "additionalProperties": {
                                         "type": "integer"
                                     },
+                                    "propertyNames": {
+                                        "format": "uuid"
+                                    },
                                     "title": "Response Count Deployments By Flow Ui Flows Count Deployments Post"
                                 }
                             }
@@ -9113,6 +9116,9 @@
                                                 "type": "null"
                                             }
                                         ]
+                                    },
+                                    "propertyNames": {
+                                        "format": "uuid"
                                     },
                                     "title": "Response Next Runs By Flow Ui Flows Next Runs Post"
                                 }
@@ -9227,6 +9233,9 @@
                                     "type": "object",
                                     "additionalProperties": {
                                         "type": "integer"
+                                    },
+                                    "propertyNames": {
+                                        "format": "uuid"
                                     },
                                     "title": "Response Count Task Runs By Flow Run Ui Flow Runs Count Task Runs Post"
                                 }
@@ -9804,7 +9813,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Metadata ",
+                        "title": "Metadata",
                         "description": "User-defined artifact metadata. Content must be string key and value pairs."
                     },
                     "flow_run_id": {
@@ -9928,7 +9937,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Metadata ",
+                        "title": "Metadata",
                         "description": "User-defined artifact metadata. Content must be string key and value pairs."
                     },
                     "flow_run_id": {
@@ -10048,7 +10057,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of flow run IDs to include"
                     }
                 },
@@ -10071,7 +10080,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of artifact keys to include"
                     },
                     "like_": {
@@ -10083,7 +10092,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Like ",
+                        "title": "Like",
                         "description": "A string to match artifact keys against. This can include SQL wildcard characters like `%` and `_`.",
                         "examples": [
                             "my-artifact-%"
@@ -10098,7 +10107,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Exists ",
+                        "title": "Exists",
                         "description": "If `true`, only include artifacts with a non-null key. If `false`, only include artifacts with a null key. Should return all rows in the ArtifactCollection table if specified."
                     }
                 },
@@ -10122,7 +10131,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of artifact ids to include"
                     }
                 },
@@ -10146,7 +10155,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of task run IDs to include"
                     }
                 },
@@ -10169,7 +10178,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of artifact types to include"
                     },
                     "not_any_": {
@@ -10184,7 +10193,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Not Any ",
+                        "title": "Not Any",
                         "description": "A list of artifact types to exclude"
                     }
                 },
@@ -10268,7 +10277,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Metadata ",
+                        "title": "Metadata",
                         "description": "User-defined artifact metadata. Content must be string key and value pairs."
                     },
                     "flow_run_id": {
@@ -10386,7 +10395,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of flow run IDs to include"
                     }
                 },
@@ -10410,7 +10419,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of artifact ids to include"
                     }
                 },
@@ -10433,7 +10442,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of artifact keys to include"
                     },
                     "like_": {
@@ -10445,7 +10454,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Like ",
+                        "title": "Like",
                         "description": "A string to match artifact keys against. This can include SQL wildcard characters like `%` and `_`.",
                         "examples": [
                             "my-artifact-%"
@@ -10460,7 +10469,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Exists ",
+                        "title": "Exists",
                         "description": "If `true`, only include artifacts with a non-null key. If `false`, only include artifacts with a null key."
                     }
                 },
@@ -10484,7 +10493,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of task run IDs to include"
                     }
                 },
@@ -10507,7 +10516,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of artifact types to include"
                     },
                     "not_any_": {
@@ -10522,7 +10531,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Not Any ",
+                        "title": "Not Any",
                         "description": "A list of artifact types to exclude"
                     }
                 },
@@ -10580,7 +10589,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Metadata "
+                        "title": "Metadata"
                     }
                 },
                 "additionalProperties": false,
@@ -11104,7 +11113,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Before ",
+                        "title": "Before",
                         "description": "Only include automations created before this datetime"
                     }
                 },
@@ -11127,7 +11136,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "Only include automations with names that match any of these strings"
                     }
                 },
@@ -11615,7 +11624,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of block type ids to include"
                     }
                 },
@@ -11639,7 +11648,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of block ids to include"
                     }
                 },
@@ -11659,7 +11668,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Eq ",
+                        "title": "Eq",
                         "description": "Filter block documents for only those that are or are not anonymous."
                     }
                 },
@@ -11682,7 +11691,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of block names to include"
                     },
                     "like_": {
@@ -11694,7 +11703,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Like ",
+                        "title": "Like",
                         "description": "A string to match block names against. This can include SQL wildcard characters like `%` and `_`.",
                         "examples": [
                             "my-block%"
@@ -11943,7 +11952,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of block type ids to include"
                     }
                 },
@@ -11966,7 +11975,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "All ",
+                        "title": "All",
                         "description": "A list of block capabilities. Block entities will be returned only if an associated block schema has a superset of the defined capabilities.",
                         "examples": [
                             [
@@ -11996,7 +12005,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of IDs to include"
                     }
                 },
@@ -12019,7 +12028,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of block schema versions.",
                         "examples": [
                             [
@@ -12251,7 +12260,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Like ",
+                        "title": "Like",
                         "description": "A case-insensitive partial match. For example,  passing 'marvin' will match 'marvin', 'sad-Marvin', and 'marvin-robot'.",
                         "examples": [
                             "marvin"
@@ -12277,7 +12286,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of slugs to match"
                     }
                 },
@@ -14289,9 +14298,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "call-webhook"
-                        ],
                         "const": "call-webhook",
                         "title": "Type",
                         "default": "call-webhook"
@@ -14320,9 +14326,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "cancel-flow-run"
-                        ],
                         "const": "cancel-flow-run",
                         "title": "Type",
                         "default": "cancel-flow-run"
@@ -14336,9 +14339,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "change-flow-run-state"
-                        ],
                         "const": "change-flow-run-state",
                         "title": "Type",
                         "default": "change-flow-run-state"
@@ -14383,9 +14383,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "compound"
-                        ],
                         "const": "compound",
                         "title": "Type",
                         "default": "compound"
@@ -14453,9 +14450,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "compound"
-                        ],
                         "const": "compound",
                         "title": "Type",
                         "default": "compound"
@@ -14837,9 +14831,6 @@
                 "properties": {
                     "input_type": {
                         "type": "string",
-                        "enum": [
-                            "constant"
-                        ],
                         "const": "constant",
                         "title": "Input Type",
                         "default": "constant"
@@ -15476,7 +15467,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Ge ",
+                        "title": "Ge",
                         "description": "Only include deployments with a concurrency limit greater than or equal to this value"
                     },
                     "le_": {
@@ -15488,7 +15479,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Le ",
+                        "title": "Le",
                         "description": "Only include deployments with a concurrency limit less than or equal to this value"
                     },
                     "is_null_": {
@@ -15500,7 +15491,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Is Null ",
+                        "title": "Is Null",
                         "description": "If true, only include deployments without a concurrency limit"
                     }
                 },
@@ -15524,7 +15515,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of deployment ids to include"
                     }
                 },
@@ -15547,7 +15538,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of deployment names to include",
                         "examples": [
                             [
@@ -15565,7 +15556,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Like ",
+                        "title": "Like",
                         "description": "A case-insensitive partial match. For example,  passing 'marvin' will match 'marvin', 'sad-Marvin', and 'marvin-robot'.",
                         "examples": [
                             "marvin"
@@ -15588,7 +15579,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Eq ",
+                        "title": "Eq",
                         "description": "Only returns where deployment is/is not paused"
                     }
                 },
@@ -15616,7 +15607,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "All ",
+                        "title": "All",
                         "description": "A list of tags. Deployments will be returned only if their tags are a superset of the list",
                         "examples": [
                             [
@@ -15634,7 +15625,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Is Null ",
+                        "title": "Is Null",
                         "description": "If true, only include deployments without tags"
                     }
                 },
@@ -15657,7 +15648,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of work queue names to include",
                         "examples": [
                             [
@@ -15806,7 +15797,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Like ",
+                        "title": "Like",
                         "description": "A case-insensitive partial match on deployment or flow names. For example, passing 'example' might match deployments or flows with 'example' in their names."
                     }
                 },
@@ -16545,9 +16536,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "do-nothing"
-                        ],
                         "const": "do-nothing",
                         "title": "Type",
                         "default": "do-nothing"
@@ -16919,9 +16907,7 @@
                     "next_page": {
                         "anyOf": [
                             {
-                                "type": "string",
-                                "minLength": 1,
-                                "format": "uri"
+                                "type": "string"
                             },
                             {
                                 "type": "null"
@@ -17071,9 +17057,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "event"
-                        ],
                         "const": "event",
                         "title": "Type",
                         "default": "event"
@@ -17317,7 +17300,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Is Null ",
+                        "title": "Is Null",
                         "description": "If true, only include flows without deployments"
                     }
                 },
@@ -17341,7 +17324,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of flow ids to include"
                     }
                 },
@@ -17364,7 +17347,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of flow names to include",
                         "examples": [
                             [
@@ -17382,7 +17365,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Like ",
+                        "title": "Like",
                         "description": "A case-insensitive partial match. For example,  passing 'marvin' will match 'marvin', 'sad-Marvin', and 'marvin-robot'.",
                         "examples": [
                             "marvin"
@@ -17413,7 +17396,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "All ",
+                        "title": "All",
                         "description": "A list of tags. Flows will be returned only if their tags are a superset of the list",
                         "examples": [
                             [
@@ -17431,7 +17414,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Is Null ",
+                        "title": "Is Null",
                         "description": "If true, only include flows without tags"
                     }
                 },
@@ -18143,7 +18126,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of flow run deployment ids to include"
                     },
                     "is_null_": {
@@ -18155,7 +18138,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Is Null ",
+                        "title": "Is Null",
                         "description": "If true, only include flow runs without deployment ids"
                     }
                 },
@@ -18176,7 +18159,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Before ",
+                        "title": "Before",
                         "description": "Only include flow runs ending at or before this time"
                     },
                     "after_": {
@@ -18189,7 +18172,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "After ",
+                        "title": "After",
                         "description": "Only include flow runs ending at or after this time"
                     },
                     "is_null_": {
@@ -18201,7 +18184,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Is Null ",
+                        "title": "Is Null",
                         "description": "If true, only return flow runs without an end time"
                     }
                 },
@@ -18222,7 +18205,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Before ",
+                        "title": "Before",
                         "description": "Only include flow runs scheduled to start at or before this time"
                     },
                     "after_": {
@@ -18235,7 +18218,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "After ",
+                        "title": "After",
                         "description": "Only include flow runs scheduled to start at or after this time"
                     }
                 },
@@ -18258,7 +18241,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of flow run flow_versions to include"
                     }
                 },
@@ -18282,7 +18265,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of flow run ids to include"
                     },
                     "not_any_": {
@@ -18298,7 +18281,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Not Any ",
+                        "title": "Not Any",
                         "description": "A list of flow run ids to exclude"
                     }
                 },
@@ -18321,7 +18304,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of flow run idempotency keys to include"
                     },
                     "not_any_": {
@@ -18336,7 +18319,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Not Any ",
+                        "title": "Not Any",
                         "description": "A list of flow run idempotency keys to exclude"
                     }
                 },
@@ -18359,7 +18342,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of flow run names to include",
                         "examples": [
                             [
@@ -18377,7 +18360,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Like ",
+                        "title": "Like",
                         "description": "A case-insensitive partial match. For example,  passing 'marvin' will match 'marvin', 'sad-Marvin', and 'marvin-robot'.",
                         "examples": [
                             "marvin"
@@ -18401,7 +18384,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Before ",
+                        "title": "Before",
                         "description": "Only include flow runs with a next_scheduled_start_time or before this time"
                     },
                     "after_": {
@@ -18414,7 +18397,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "After ",
+                        "title": "After",
                         "description": "Only include flow runs with a next_scheduled_start_time at or after this time"
                     }
                 },
@@ -18443,7 +18426,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of parent flow run ids to include"
                     }
                 },
@@ -18472,7 +18455,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of flow run parent_task_run_ids to include"
                     },
                     "is_null_": {
@@ -18484,7 +18467,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Is Null ",
+                        "title": "Is Null",
                         "description": "If true, only include flow runs without parent_task_run_id"
                     }
                 },
@@ -18505,7 +18488,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Before ",
+                        "title": "Before",
                         "description": "Only include flow runs starting at or before this time"
                     },
                     "after_": {
@@ -18518,7 +18501,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "After ",
+                        "title": "After",
                         "description": "Only include flow runs starting at or after this time"
                     },
                     "is_null_": {
@@ -18530,7 +18513,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Is Null ",
+                        "title": "Is Null",
                         "description": "If true, only return flow runs without a start time"
                     }
                 },
@@ -18588,7 +18571,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of flow run state names to include"
                     },
                     "not_any_": {
@@ -18603,7 +18586,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Not Any ",
+                        "title": "Not Any",
                         "description": "A list of flow run state names to exclude"
                     }
                 },
@@ -18626,7 +18609,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of flow run state types to include"
                     },
                     "not_any_": {
@@ -18641,7 +18624,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Not Any ",
+                        "title": "Not Any",
                         "description": "A list of flow run state types to exclude"
                     }
                 },
@@ -18669,7 +18652,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "All ",
+                        "title": "All",
                         "description": "A list of tags. Flow runs will be returned only if their tags are a superset of the list",
                         "examples": [
                             [
@@ -18687,7 +18670,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Is Null ",
+                        "title": "Is Null",
                         "description": "If true, only include flow runs without tags"
                     }
                 },
@@ -18715,7 +18698,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of work queue names to include",
                         "examples": [
                             [
@@ -18733,7 +18716,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Is Null ",
+                        "title": "Is Null",
                         "description": "If true, only include flow runs without work queue names"
                     }
                 },
@@ -18983,7 +18966,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Eq ",
+                        "title": "Eq",
                         "description": "Filter notification policies for only those that are or are not active."
                     }
                 },
@@ -20243,7 +20226,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of flow run IDs to include"
                     }
                 },
@@ -20263,7 +20246,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Ge ",
+                        "title": "Ge",
                         "description": "Include logs with a level greater than or equal to this level",
                         "examples": [
                             20
@@ -20278,7 +20261,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Le ",
+                        "title": "Le",
                         "description": "Include logs with a level less than or equal to this level",
                         "examples": [
                             50
@@ -20305,7 +20288,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of task run IDs to include"
                     },
                     "is_null_": {
@@ -20317,7 +20300,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Is Null ",
+                        "title": "Is Null",
                         "description": "If true, only include logs without a task run id"
                     }
                 },
@@ -20338,7 +20321,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Before ",
+                        "title": "Before",
                         "description": "Only include logs with a timestamp at or before this time"
                     },
                     "after_": {
@@ -20351,7 +20334,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "After ",
+                        "title": "After",
                         "description": "Only include logs with a timestamp at or after this time"
                     }
                 },
@@ -20531,9 +20514,6 @@
                 "properties": {
                     "input_type": {
                         "type": "string",
-                        "enum": [
-                            "parameter"
-                        ],
                         "const": "parameter",
                         "title": "Input Type",
                         "default": "parameter"
@@ -20554,9 +20534,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "pause-automation"
-                        ],
                         "const": "pause-automation",
                         "title": "Type",
                         "default": "pause-automation"
@@ -20593,9 +20570,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "pause-deployment"
-                        ],
                         "const": "pause-deployment",
                         "title": "Type",
                         "default": "pause-deployment"
@@ -20632,9 +20606,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "pause-work-pool"
-                        ],
                         "const": "pause-work-pool",
                         "title": "Type",
                         "default": "pause-work-pool"
@@ -20671,9 +20642,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "pause-work-queue"
-                        ],
                         "const": "pause-work-queue",
                         "title": "Type",
                         "default": "pause-work-queue"
@@ -20879,9 +20847,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "resume-automation"
-                        ],
                         "const": "resume-automation",
                         "title": "Type",
                         "default": "resume-automation"
@@ -20918,9 +20883,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "resume-deployment"
-                        ],
                         "const": "resume-deployment",
                         "title": "Type",
                         "default": "resume-deployment"
@@ -20957,9 +20919,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "resume-flow-run"
-                        ],
                         "const": "resume-flow-run",
                         "title": "Type",
                         "default": "resume-flow-run"
@@ -20973,9 +20932,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "resume-work-pool"
-                        ],
                         "const": "resume-work-pool",
                         "title": "Type",
                         "default": "resume-work-pool"
@@ -21012,9 +20968,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "resume-work-queue"
-                        ],
                         "const": "resume-work-queue",
                         "title": "Type",
                         "default": "resume-work-queue"
@@ -21051,9 +21004,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "run-deployment"
-                        ],
                         "const": "run-deployment",
                         "title": "Type",
                         "default": "run-deployment"
@@ -21228,9 +21178,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "send-notification"
-                        ],
                         "const": "send-notification",
                         "title": "Type",
                         "default": "send-notification"
@@ -21264,9 +21211,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "sequence"
-                        ],
                         "const": "sequence",
                         "title": "Type",
                         "default": "sequence"
@@ -21318,9 +21262,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "sequence"
-                        ],
                         "const": "sequence",
                         "title": "Type",
                         "default": "sequence"
@@ -21379,10 +21320,7 @@
                 "title": "SetStateStatus",
                 "description": "Enumerates return statuses for setting run states."
             },
-            "Settings": {
-                "title": "Settings",
-                "description": "Settings for Prefect using Pydantic settings.\n\nSee https://docs.pydantic.dev/latest/concepts/pydantic_settings"
-            },
+            "Settings": {},
             "SimpleFlowRun": {
                 "properties": {
                     "id": {
@@ -21533,9 +21471,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "abort_details"
-                        ],
                         "const": "abort_details",
                         "title": "Type",
                         "description": "The type of state transition detail. Used to ensure pydantic does not coerce into a different type.",
@@ -21562,9 +21497,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "accept_details"
-                        ],
                         "const": "accept_details",
                         "title": "Type",
                         "description": "The type of state transition detail. Used to ensure pydantic does not coerce into a different type.",
@@ -21814,9 +21746,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "reject_details"
-                        ],
                         "const": "reject_details",
                         "title": "Type",
                         "description": "The type of state transition detail. Used to ensure pydantic does not coerce into a different type.",
@@ -21859,9 +21788,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "wait_details"
-                        ],
                         "const": "wait_details",
                         "title": "Type",
                         "description": "The type of state transition detail. Used to ensure pydantic does not coerce into a different type.",
@@ -21896,9 +21822,6 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": [
-                            "suspend-flow-run"
-                        ],
                         "const": "suspend-flow-run",
                         "title": "Type",
                         "default": "suspend-flow-run"
@@ -22183,8 +22106,7 @@
                 "description": "An ORM representation of task run data."
             },
             "TaskRunCount": {
-                "type": "object",
-                "title": "TaskRunCount"
+                "type": "object"
             },
             "TaskRunCreate": {
                 "properties": {
@@ -22440,7 +22362,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Before ",
+                        "title": "Before",
                         "description": "Only include task runs expected to start at or before this time"
                     },
                     "after_": {
@@ -22453,7 +22375,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "After ",
+                        "title": "After",
                         "description": "Only include task runs expected to start at or after this time"
                     }
                 },
@@ -22482,7 +22404,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of task run flow run ids to include"
                     },
                     "is_null_": {
@@ -22494,7 +22416,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Is Null ",
+                        "title": "Is Null",
                         "description": "Filter for task runs with None as their flow run id",
                         "default": false
                     }
@@ -22519,7 +22441,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of task run ids to include"
                     }
                 },
@@ -22542,7 +22464,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of task run names to include",
                         "examples": [
                             [
@@ -22560,7 +22482,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Like ",
+                        "title": "Like",
                         "description": "A case-insensitive partial match. For example,  passing 'marvin' will match 'marvin', 'sad-Marvin', and 'marvin-robot'.",
                         "examples": [
                             "marvin"
@@ -22584,7 +22506,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Before ",
+                        "title": "Before",
                         "description": "Only include task runs starting at or before this time"
                     },
                     "after_": {
@@ -22597,7 +22519,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "After ",
+                        "title": "After",
                         "description": "Only include task runs starting at or after this time"
                     },
                     "is_null_": {
@@ -22609,7 +22531,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Is Null ",
+                        "title": "Is Null",
                         "description": "If true, only return task runs without a start time"
                     }
                 },
@@ -22667,7 +22589,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of task run state names to include"
                     }
                 },
@@ -22690,7 +22612,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of task run state types to include"
                     }
                 },
@@ -22710,7 +22632,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Exists ",
+                        "title": "Exists",
                         "description": "If true, only include task runs that are subflow run parents; if false, exclude parent task runs"
                     }
                 },
@@ -22738,7 +22660,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "All ",
+                        "title": "All",
                         "description": "A list of tags. Task runs will be returned only if their tags are a superset of the list",
                         "examples": [
                             [
@@ -22756,7 +22678,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Is Null ",
+                        "title": "Is Null",
                         "description": "If true, only include task runs without tags"
                     }
                 },
@@ -22832,9 +22754,6 @@
                 "properties": {
                     "input_type": {
                         "type": "string",
-                        "enum": [
-                            "task_run"
-                        ],
                         "const": "task_run",
                         "title": "Input Type",
                         "default": "task_run"
@@ -23231,7 +23150,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of variable ids to include"
                     }
                 },
@@ -23254,7 +23173,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of variables names to include"
                     },
                     "like_": {
@@ -23266,7 +23185,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Like ",
+                        "title": "Like",
                         "description": "A string to match variable names against. This can include SQL wildcard characters like `%` and `_`.",
                         "examples": [
                             "my_variable_%"
@@ -23297,7 +23216,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "All ",
+                        "title": "All",
                         "description": "A list of tags. Variables will be returned only if their tags are a superset of the list",
                         "examples": [
                             [
@@ -23315,7 +23234,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Is Null ",
+                        "title": "Is Null",
                         "description": "If true, only include Variables without tags"
                     }
                 },
@@ -23642,7 +23561,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of work pool ids to include"
                     }
                 },
@@ -23665,7 +23584,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of work pool names to include"
                     }
                 },
@@ -23688,7 +23607,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of work pool types to include"
                     }
                 },
@@ -24006,7 +23925,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of work queue ids to include"
                     }
                 },
@@ -24029,7 +23948,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of work queue names to include",
                         "examples": [
                             [
@@ -24050,7 +23969,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Startswith ",
+                        "title": "Startswith",
                         "description": "A list of case-insensitive starts-with matches. For example,  passing 'marvin' will match 'marvin', and 'Marvin-robot', but not 'sad-marvin'.",
                         "examples": [
                             [
@@ -24420,7 +24339,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Before ",
+                        "title": "Before",
                         "description": "Only include processes whose last heartbeat was at or before this time"
                     },
                     "after_": {
@@ -24433,7 +24352,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "After ",
+                        "title": "After",
                         "description": "Only include processes whose last heartbeat was at or after this time"
                     }
                 },
@@ -24456,7 +24375,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Any ",
+                        "title": "Any",
                         "description": "A list of worker statuses to include"
                     },
                     "not_any_": {
@@ -24471,7 +24390,7 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Not Any ",
+                        "title": "Not Any",
                         "description": "A list of worker statuses to exclude"
                     }
                 },

--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -86,7 +86,9 @@ class PrefectBaseModel(BaseModel):
         """
         return self.model_copy(
             update={
-                field: self.model_fields[field].get_default(call_default_factory=True)
+                field: self.model_fields[field].get_default(
+                    call_default_factory=True, validated_data=self.model_dump()
+                )
                 for field in self._reset_fields
             }
         )

--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -84,10 +84,11 @@ class PrefectBaseModel(BaseModel):
         Returns:
             PrefectBaseModel: A new instance of the model with the reset fields.
         """
+        data = self.model_dump()
         return self.model_copy(
             update={
                 field: self.model_fields[field].get_default(
-                    call_default_factory=True, validated_data=self.model_dump()
+                    call_default_factory=True, validated_data=data
                 )
                 for field in self._reset_fields
             }

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -109,10 +109,11 @@ class PrefectBaseModel(BaseModel):
         Returns:
             PrefectBaseModel: A new instance of the model with the reset fields.
         """
+        data = self.model_dump()
         return self.model_copy(
             update={
                 field: self.model_fields[field].get_default(
-                    call_default_factory=True, validated_data=self.model_dump()
+                    call_default_factory=True, validated_data=data
                 )
                 for field in self._reset_fields
             }

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -111,7 +111,9 @@ class PrefectBaseModel(BaseModel):
         """
         return self.model_copy(
             update={
-                field: self.model_fields[field].get_default(call_default_factory=True)
+                field: self.model_fields[field].get_default(
+                    call_default_factory=True, validated_data=self.model_dump()
+                )
                 for field in self._reset_fields
             }
         )

--- a/tests/events/server/test_events_api.py
+++ b/tests/events/server/test_events_api.py
@@ -8,7 +8,7 @@ import pendulum
 import pytest
 from httpx import AsyncClient
 from pendulum.datetime import DateTime
-from pydantic_core import Url
+from pydantic.networks import AnyHttpUrl
 
 from prefect.server.events.counting import Countable, TimeUnit
 from prefect.server.events.filters import (
@@ -135,7 +135,8 @@ async def test_querying_for_events_returns_first_page(
 
     assert first_page.events == events_page_one
     assert first_page.total == 123
-    assert first_page.next_page == Url(
+    assert isinstance(first_page.next_page, AnyHttpUrl)
+    assert str(first_page.next_page) == (
         f"http://test/api/events/filter/next?page-token={ENCODED_MOCK_PAGE_TOKEN}"
     )
 
@@ -213,7 +214,8 @@ async def test_querying_for_subsequent_page_returns_it(
 
     assert second_page.events == events_page_two
     assert second_page.total == 123
-    assert second_page.next_page == Url(
+    assert isinstance(second_page.next_page, AnyHttpUrl)
+    assert str(second_page.next_page) == (
         f"http://test/api/events/filter/next?page-token={expected_token}"
     )
 


### PR DESCRIPTION
related to https://github.com/pydantic/pydantic/issues/10912

---

pydantic 2.10 broke us because of
- `get_default` (as used in `PrefectBaseModel.reset_fields`) now conditionally requires a new kwarg
- something about comparing instances of `AnyHttpUrl` i haven't grokked yet (only broke a couple events tests)