### PR TITLE
revert `pydantic==2.10.0` workaround given upstream fix

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -20,7 +20,7 @@ packaging >= 21.3, < 24.3
 pathspec >= 0.8.0
 pendulum >= 3.0.0, <4
 prometheus-client >= 0.20.0
-pydantic >= 2.7, < 3.0.0
+pydantic >= 2.7, < 3.0.0, != 2.10.0
 pydantic_core >= 2.12.0, < 3.0.0
 pydantic_extra_types >= 2.8.2, < 3.0.0
 pydantic_settings > 2.2.1

--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -84,12 +84,9 @@ class PrefectBaseModel(BaseModel):
         Returns:
             PrefectBaseModel: A new instance of the model with the reset fields.
         """
-        data = self.model_dump()
         return self.model_copy(
             update={
-                field: self.model_fields[field].get_default(
-                    call_default_factory=True, validated_data=data
-                )
+                field: self.model_fields[field].get_default(call_default_factory=True)
                 for field in self._reset_fields
             }
         )

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -109,12 +109,9 @@ class PrefectBaseModel(BaseModel):
         Returns:
             PrefectBaseModel: A new instance of the model with the reset fields.
         """
-        data = self.model_dump()
         return self.model_copy(
             update={
-                field: self.model_fields[field].get_default(
-                    call_default_factory=True, validated_data=data
-                )
+                field: self.model_fields[field].get_default(call_default_factory=True)
                 for field in self._reset_fields
             }
         )


### PR DESCRIPTION
revert changes to `reset_fields` from https://github.com/PrefectHQ/prefect/pull/16076 given fix in https://github.com/pydantic/pydantic/pull/10909 and disallows `2.10.0` (open to leaving the workaround in and closing this PR for more permissive resolutions but if we can avoid an extra `model_dump()` why not)