### PR TITLE
migrate `prefect_aws.s3` async tasks to `async_dispatch`

### DIFF
--- a/src/integrations/prefect-aws/prefect_aws/s3.py
+++ b/src/integrations/prefect-aws/prefect_aws/s3.py
@@ -1681,6 +1681,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
         """
         Downloads objects *within* a folder (excluding the folder itself)
         from the S3 bucket to a folder.
+        Changed in version 0.6.0.
 
         Args:
             from_folder: The path to the folder to download from.

--- a/src/integrations/prefect-aws/prefect_aws/s3.py
+++ b/src/integrations/prefect-aws/prefect_aws/s3.py
@@ -1746,6 +1746,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
         """Asynchronously streams an object from another bucket to this bucket. Requires the
         object to be downloaded and uploaded in chunks. If `self`'s credentials
         allow for writes to the other bucket, try using `S3Bucket.copy_object`.
+        Added in version 0.5.3.
 
         Args:
             bucket: The bucket to stream from.

--- a/src/integrations/prefect-aws/prefect_aws/s3.py
+++ b/src/integrations/prefect-aws/prefect_aws/s3.py
@@ -51,8 +51,7 @@ async def adownload_from_bucket(
         ```python
         from prefect import flow
         from prefect_aws import AwsCredentials
-        from prefect_aws.s3 import download_from_bucket
-
+        from prefect_aws.s3 import adownload_from_bucket
 
         @flow
         async def example_download_from_bucket_flow():
@@ -60,13 +59,13 @@ async def adownload_from_bucket(
                 aws_access_key_id="acccess_key_id",
                 aws_secret_access_key="secret_access_key"
             )
-            data = await download_from_bucket(
+            data = await adownload_from_bucket(
                 bucket="bucket",
                 key="key",
                 aws_credentials=aws_credentials,
             )
 
-        example_download_from_bucket_flow()
+        await example_download_from_bucket_flow()
         ```
     """
     logger = get_run_logger()
@@ -123,7 +122,7 @@ def download_from_bucket(
                 aws_access_key_id="acccess_key_id",
                 aws_secret_access_key="secret_access_key"
             )
-            data = await download_from_bucket(
+            data = download_from_bucket(
                 bucket="bucket",
                 key="key",
                 aws_credentials=aws_credentials,
@@ -177,7 +176,7 @@ async def aupload_to_bucket(
         ```python
         from prefect import flow
         from prefect_aws import AwsCredentials
-        from prefect_aws.s3 import s3_upload
+        from prefect_aws.s3 import aupload_to_bucket
 
 
         @flow
@@ -187,14 +186,14 @@ async def aupload_to_bucket(
                 aws_secret_access_key="secret_access_key"
             )
             with open("data.csv", "rb") as file:
-                key = await s3_upload(
+                key = await aupload_to_bucket(
                     bucket="bucket",
                     key="data.csv",
                     data=file.read(),
                     aws_credentials=aws_credentials,
                 )
 
-        example_s3_upload_flow()
+        await example_s3_upload_flow()
         ```
     """
     logger = get_run_logger()
@@ -243,7 +242,7 @@ def upload_to_bucket(
         ```python
         from prefect import flow
         from prefect_aws import AwsCredentials
-        from prefect_aws.s3 import s3_upload
+        from prefect_aws.s3 import upload_to_bucket
 
 
         @flow
@@ -253,7 +252,7 @@ def upload_to_bucket(
                 aws_secret_access_key="secret_access_key"
             )
             with open("data.csv", "rb") as file:
-                key = await s3_upload(
+                key = upload_to_bucket(
                     bucket="bucket",
                     key="data.csv",
                     data=file.read(),
@@ -329,7 +328,7 @@ async def acopy_objects(
                 aws_credentials=aws_credentials,
             )
 
-        example_copy_flow()
+        await example_copy_flow()
         ```
 
         Copy notes.txt from s3://my-bucket/my_folder/notes.txt to
@@ -352,7 +351,7 @@ async def acopy_objects(
                 target_bucket_name="other-bucket",
             )
 
-        example_copy_flow()
+        await example_copy_flow()
         ```
 
     """
@@ -418,13 +417,13 @@ def copy_objects(
         ```python
         from prefect import flow
         from prefect_aws import AwsCredentials
-        from prefect_aws.s3 import s3_copy
+        from prefect_aws.s3 import copy_objects
 
         aws_credentials = AwsCredentials.load("my-creds")
 
         @flow
-        async def example_copy_flow():
-            await s3_copy(
+        def example_copy_flow():
+            copy_objects(
                 source_path="my_folder/notes.txt",
                 target_path="my_folder/notes_copy.txt",
                 source_bucket_name="my-bucket",
@@ -440,13 +439,13 @@ def copy_objects(
         ```python
         from prefect import flow
         from prefect_aws import AwsCredentials
-        from prefect_aws.s3 import s3_copy
+        from prefect_aws.s3 import copy_objects
 
         aws_credentials = AwsCredentials.load("shared-creds")
 
         @flow
-        async def example_copy_flow():
-            await s3_copy(
+        def example_copy_flow():
+            copy_objects(
                 source_path="my_folder/notes.txt",
                 target_path="notes_copy.txt",
                 source_bucket_name="my-bucket",
@@ -664,7 +663,7 @@ async def alist_objects(
                 aws_credentials=aws_credentials
             )
 
-        example_s3_list_objects_flow()
+        await example_s3_list_objects_flow()
         ```
     """  # noqa E501
     logger = get_run_logger()
@@ -728,12 +727,12 @@ def list_objects(
 
 
         @flow
-        async def example_s3_list_objects_flow():
+        def example_s3_list_objects_flow():
             aws_credentials = AwsCredentials(
                 aws_access_key_id="acccess_key_id",
                 aws_secret_access_key="secret_access_key"
             )
-            objects = await list_objects(
+            objects = list_objects(
                 bucket="data_bucket",
                 aws_credentials=aws_credentials
             )

--- a/src/integrations/prefect-aws/prefect_aws/s3.py
+++ b/src/integrations/prefect-aws/prefect_aws/s3.py
@@ -24,7 +24,7 @@ from prefect_aws.client_parameters import AwsClientParameters
 
 
 @task
-async def s3_adownload(
+async def adownload_from_bucket(
     bucket: str,
     key: str,
     aws_credentials: AwsCredentials,
@@ -51,22 +51,22 @@ async def s3_adownload(
         ```python
         from prefect import flow
         from prefect_aws import AwsCredentials
-        from prefect_aws.s3 import s3_download
+        from prefect_aws.s3 import download_from_bucket
 
 
         @flow
-        async def example_s3_download_flow():
+        async def example_download_from_bucket_flow():
             aws_credentials = AwsCredentials(
                 aws_access_key_id="acccess_key_id",
                 aws_secret_access_key="secret_access_key"
             )
-            data = await s3_download(
+            data = await download_from_bucket(
                 bucket="bucket",
                 key="key",
                 aws_credentials=aws_credentials,
             )
 
-        example_s3_download_flow()
+        example_download_from_bucket_flow()
         ```
     """
     logger = get_run_logger()
@@ -86,8 +86,8 @@ async def s3_adownload(
 
 
 @task
-@async_dispatch(s3_adownload)
-def s3_download(
+@async_dispatch(adownload_from_bucket)
+def download_from_bucket(
     bucket: str,
     key: str,
     aws_credentials: AwsCredentials,
@@ -114,22 +114,22 @@ def s3_download(
         ```python
         from prefect import flow
         from prefect_aws import AwsCredentials
-        from prefect_aws.s3 import s3_download
+        from prefect_aws.s3 import download_from_bucket
 
 
         @flow
-        async def example_s3_download_flow():
+        async def example_download_from_bucket_flow():
             aws_credentials = AwsCredentials(
                 aws_access_key_id="acccess_key_id",
                 aws_secret_access_key="secret_access_key"
             )
-            data = await s3_download(
+            data = await download_from_bucket(
                 bucket="bucket",
                 key="key",
                 aws_credentials=aws_credentials,
             )
 
-        example_s3_download_flow()
+        example_download_from_bucket_flow()
         ```
     """
     logger = get_run_logger()
@@ -146,8 +146,11 @@ def s3_download(
     return output
 
 
+s3_download = download_from_bucket  # backward compatibility
+
+
 @task
-async def s3_aupload(
+async def aupload_to_bucket(
     data: bytes,
     bucket: str,
     aws_credentials: AwsCredentials,
@@ -212,8 +215,8 @@ async def s3_aupload(
 
 
 @task
-@async_dispatch(s3_aupload)
-def s3_upload(
+@async_dispatch(aupload_to_bucket)
+def upload_to_bucket(
     data: bytes,
     bucket: str,
     aws_credentials: AwsCredentials,
@@ -274,8 +277,11 @@ def s3_upload(
     return key
 
 
+s3_upload = upload_to_bucket  # backward compatibility
+
+
 @task
-async def s3_acopy(
+async def acopy_objects(
     source_path: str,
     target_path: str,
     source_bucket_name: str,
@@ -310,13 +316,13 @@ async def s3_acopy(
         ```python
         from prefect import flow
         from prefect_aws import AwsCredentials
-        from prefect_aws.s3 import s3_copy
+        from prefect_aws.s3 import acopy_objects
 
         aws_credentials = AwsCredentials.load("my-creds")
 
         @flow
         async def example_copy_flow():
-            await s3_copy(
+            await acopy_objects(
                 source_path="my_folder/notes.txt",
                 target_path="my_folder/notes_copy.txt",
                 source_bucket_name="my-bucket",
@@ -332,13 +338,13 @@ async def s3_acopy(
         ```python
         from prefect import flow
         from prefect_aws import AwsCredentials
-        from prefect_aws.s3 import s3_copy
+        from prefect_aws.s3 import acopy_objects
 
         aws_credentials = AwsCredentials.load("shared-creds")
 
         @flow
         async def example_copy_flow():
-            await s3_copy(
+            await acopy_objects(
                 source_path="my_folder/notes.txt",
                 target_path="notes_copy.txt",
                 source_bucket_name="my-bucket",
@@ -376,8 +382,8 @@ async def s3_acopy(
 
 
 @task
-@async_dispatch(s3_acopy)
-def s3_copy(
+@async_dispatch(acopy_objects)
+def copy_objects(
     source_path: str,
     target_path: str,
     source_bucket_name: str,
@@ -476,8 +482,11 @@ def s3_copy(
     return target_path
 
 
+s3_copy = copy_objects  # backward compatibility
+
+
 @task
-async def s3_amove(
+async def amove_objects(
     source_path: str,
     target_path: str,
     source_bucket_name: str,
@@ -534,8 +543,8 @@ async def s3_amove(
 
 
 @task
-@async_dispatch(s3_amove)
-def s3_move(
+@async_dispatch(amove_objects)
+def move_objects(
     source_path: str,
     target_path: str,
     source_bucket_name: str,
@@ -588,6 +597,9 @@ def s3_move(
     return target_path
 
 
+s3_move = move_objects  # backward compatibility
+
+
 def _list_objects_sync(page_iterator: PageIterator):
     """
     Synchronous method to collect S3 objects into a list
@@ -602,7 +614,7 @@ def _list_objects_sync(page_iterator: PageIterator):
 
 
 @task
-async def s3_alist_objects(
+async def alist_objects(
     bucket: str,
     aws_credentials: AwsCredentials,
     aws_client_parameters: AwsClientParameters = AwsClientParameters(),
@@ -638,7 +650,7 @@ async def s3_alist_objects(
         ```python
         from prefect import flow
         from prefect_aws import AwsCredentials
-        from prefect_aws.s3 import s3_list_objects
+        from prefect_aws.s3 import alist_objects
 
 
         @flow
@@ -647,7 +659,7 @@ async def s3_alist_objects(
                 aws_access_key_id="acccess_key_id",
                 aws_secret_access_key="secret_access_key"
             )
-            objects = await s3_list_objects(
+            objects = await alist_objects(
                 bucket="data_bucket",
                 aws_credentials=aws_credentials
             )
@@ -675,8 +687,8 @@ async def s3_alist_objects(
 
 
 @task
-@async_dispatch(s3_alist_objects)
-def s3_list_objects(
+@async_dispatch(alist_objects)
+def list_objects(
     bucket: str,
     aws_credentials: AwsCredentials,
     aws_client_parameters: AwsClientParameters = AwsClientParameters(),
@@ -712,7 +724,7 @@ def s3_list_objects(
         ```python
         from prefect import flow
         from prefect_aws import AwsCredentials
-        from prefect_aws.s3 import s3_list_objects
+        from prefect_aws.s3 import list_objects
 
 
         @flow
@@ -721,7 +733,7 @@ def s3_list_objects(
                 aws_access_key_id="acccess_key_id",
                 aws_secret_access_key="secret_access_key"
             )
-            objects = await s3_list_objects(
+            objects = await list_objects(
                 bucket="data_bucket",
                 aws_credentials=aws_credentials
             )
@@ -746,6 +758,9 @@ def s3_list_objects(
         page_iterator = page_iterator.search(f"{jmespath_query} | {{Contents: @}}")
 
     return _list_objects_sync(page_iterator)  # type: ignore
+
+
+s3_list_objects = list_objects  # backward compatibility
 
 
 class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock):

--- a/src/integrations/prefect-aws/prefect_aws/s3.py
+++ b/src/integrations/prefect-aws/prefect_aws/s3.py
@@ -1872,6 +1872,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
     ) -> str:
         """
         Asynchronously uploads an object from a path to the S3 bucket.
+        Added in version 0.5.3.
 
         Args:
             from_path: The path to the file to upload from.

--- a/src/integrations/prefect-aws/prefect_aws/s3.py
+++ b/src/integrations/prefect-aws/prefect_aws/s3.py
@@ -2144,6 +2144,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
         """
         Uploads files *within* a folder (excluding the folder itself)
         to the object storage service folder.
+        Added in version 0.5.3.
 
         Args:
             from_folder: The path to the folder to upload from.

--- a/src/integrations/prefect-aws/prefect_aws/s3.py
+++ b/src/integrations/prefect-aws/prefect_aws/s3.py
@@ -699,6 +699,7 @@ def list_objects(
 ) -> List[Dict[str, Any]]:
     """
     Lists details of objects in a given S3 bucket.
+    Added in version 0.5.3.
 
     Args:
         bucket: Name of bucket to list items from. Required if a default value was not

--- a/src/integrations/prefect-aws/prefect_aws/s3.py
+++ b/src/integrations/prefect-aws/prefect_aws/s3.py
@@ -33,6 +33,8 @@ async def adownload_from_bucket(
     """
     Downloads an object with a given key from a given S3 bucket.
 
+    Added in prefect-aws==0.5.3.
+
     Args:
         bucket: Name of bucket to download object from. Required if a default value was
             not supplied when creating the task.
@@ -158,6 +160,8 @@ async def aupload_to_bucket(
 ) -> str:
     """
     Asynchronously uploads data to an S3 bucket.
+
+    Added in prefect-aws==0.5.3.
 
     Args:
         data: Bytes representation of data to upload to S3.
@@ -294,6 +298,8 @@ async def acopy_objects(
     credentials must have permission to read the source object and write to the target
     object. If the credentials do not have those permissions, try using
     `S3Bucket.stream_from`.
+
+    Added in prefect-aws==0.5.3.
 
     Args:
         source_path: The path to the object to copy. Can be a string or `Path`.
@@ -499,6 +505,8 @@ async def amove_objects(
     permissions, this method will raise an error. If the credentials have permission to
     read the source object but not delete it, the object will be copied but not deleted.
 
+    Added in prefect-aws==0.5.3.
+
     Args:
         source_path: The path of the object to move
         target_path: The path to move the object to
@@ -626,6 +634,8 @@ async def alist_objects(
     """
     Asynchronously lists details of objects in a given S3 bucket.
 
+    Added in prefect-aws==0.5.3.
+
     Args:
         bucket: Name of bucket to list items from. Required if a default value was not
             supplied when creating the task.
@@ -699,7 +709,6 @@ def list_objects(
 ) -> List[Dict[str, Any]]:
     """
     Lists details of objects in a given S3 bucket.
-    Added in version 0.5.3.
 
     Args:
         bucket: Name of bucket to list items from. Required if a default value was not
@@ -2076,7 +2085,7 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
     ) -> Union[str, None]:
         """
         Asynchronously uploads files *within* a folder (excluding the folder itself)
-        to the object storage service folder.
+        to the object storage service folder. Added in version prefect-aws==0.5.3.
 
         Args:
             from_folder: The path to the folder to upload from.
@@ -2148,7 +2157,6 @@ class S3Bucket(WritableFileSystem, WritableDeploymentStorage, ObjectStorageBlock
         """
         Uploads files *within* a folder (excluding the folder itself)
         to the object storage service folder.
-        Added in version 0.5.3.
 
         Args:
             from_folder: The path to the folder to upload from.

--- a/src/integrations/prefect-aws/tests/test_s3.py
+++ b/src/integrations/prefect-aws/tests/test_s3.py
@@ -10,6 +10,10 @@ from prefect_aws import AwsCredentials, MinIOCredentials
 from prefect_aws.client_parameters import AwsClientParameters
 from prefect_aws.s3 import (
     S3Bucket,
+    acopy_objects,
+    adownload_from_bucket,
+    alist_objects,
+    amove_objects,
     s3_copy,
     s3_download,
     s3_list_objects,
@@ -1137,3 +1141,111 @@ class TestS3Bucket:
         assert hasattr(
             loaded.credentials, "aws_access_key_id"
         ), "`credentials` were not properly initialized"
+
+    @pytest.mark.parametrize(
+        "client_parameters",
+        [
+            pytest.param(
+                "aws_client_parameters_custom_endpoint",
+                marks=pytest.mark.is_public(False),
+            ),
+            pytest.param(
+                "aws_client_parameters_custom_endpoint",
+                marks=pytest.mark.is_public(True),
+            ),
+            pytest.param(
+                "aws_client_parameters_empty",
+                marks=pytest.mark.is_public(False),
+            ),
+            pytest.param(
+                "aws_client_parameters_empty",
+                marks=pytest.mark.is_public(True),
+            ),
+            pytest.param(
+                "aws_client_parameters_public_bucket",
+                marks=[
+                    pytest.mark.is_public(False),
+                    pytest.mark.xfail(reason="Bucket is not a public one"),
+                ],
+            ),
+            pytest.param(
+                "aws_client_parameters_public_bucket",
+                marks=pytest.mark.is_public(True),
+            ),
+        ],
+        indirect=True,
+    )
+    async def test_async_download_from_bucket(
+        self, object, client_parameters, aws_credentials
+    ):
+        @flow(validate_parameters=False)
+        async def test_flow():
+            return await adownload_from_bucket(
+                bucket="bucket",
+                key="object",
+                aws_credentials=aws_credentials,
+                aws_client_parameters=client_parameters,
+            )
+
+        result = await test_flow()
+        assert result == b"TEST"
+
+    @pytest.mark.parametrize("client_parameters", aws_clients, indirect=True)
+    async def test_async_list_objects(
+        self, object, object_in_folder, client_parameters, aws_credentials
+    ):
+        @flow(validate_parameters=False)
+        async def test_flow():
+            return await alist_objects(
+                bucket="bucket",
+                aws_credentials=aws_credentials,
+                aws_client_parameters=client_parameters,
+            )
+
+        objects = await test_flow()
+        assert len(objects) == 2
+        assert [object["Key"] for object in objects] == ["folder/object", "object"]
+
+    @pytest.mark.parametrize("client_parameters", aws_clients, indirect=True)
+    async def test_async_copy_objects(self, object, bucket, bucket_2, aws_credentials):
+        def read(bucket, key):
+            stream = io.BytesIO()
+            bucket.download_fileobj(key, stream)
+            stream.seek(0)
+            return stream.read()
+
+        @flow(validate_parameters=False)
+        async def test_flow():
+            await acopy_objects(
+                source_path="object",
+                target_path="subfolder/new_object",
+                source_bucket_name="bucket",
+                aws_credentials=aws_credentials,
+                target_bucket_name="bucket_2",
+            )
+
+        await test_flow()
+        assert read(bucket_2, "subfolder/new_object") == b"TEST"
+
+    @pytest.mark.parametrize("client_parameters", aws_clients, indirect=True)
+    async def test_async_move_objects(self, object, bucket, bucket_2, aws_credentials):
+        def read(bucket, key):
+            stream = io.BytesIO()
+            bucket.download_fileobj(key, stream)
+            stream.seek(0)
+            return stream.read()
+
+        @flow(validate_parameters=False)
+        async def test_flow():
+            await amove_objects(
+                source_path="object",
+                target_path="moved_object",
+                source_bucket_name="bucket",
+                target_bucket_name="bucket_2",
+                aws_credentials=aws_credentials,
+            )
+
+        await test_flow()
+        assert read(bucket_2, "moved_object") == b"TEST"
+        with pytest.raises(ClientError):
+            read(bucket, "object")

--- a/src/integrations/prefect-aws/tests/test_s3.py
+++ b/src/integrations/prefect-aws/tests/test_s3.py
@@ -1178,7 +1178,7 @@ class TestS3Bucket:
     async def test_async_download_from_bucket(
         self, object, client_parameters, aws_credentials
     ):
-        @flow(validate_parameters=False)
+        @flow
         async def test_flow():
             return await adownload_from_bucket(
                 bucket="bucket",
@@ -1194,7 +1194,7 @@ class TestS3Bucket:
     async def test_async_list_objects(
         self, object, object_in_folder, client_parameters, aws_credentials
     ):
-        @flow(validate_parameters=False)
+        @flow
         async def test_flow():
             return await alist_objects(
                 bucket="bucket",
@@ -1214,7 +1214,7 @@ class TestS3Bucket:
             stream.seek(0)
             return stream.read()
 
-        @flow(validate_parameters=False)
+        @flow
         async def test_flow():
             await acopy_objects(
                 source_path="object",
@@ -1235,7 +1235,7 @@ class TestS3Bucket:
             stream.seek(0)
             return stream.read()
 
-        @flow(validate_parameters=False)
+        @flow
         async def test_flow():
             await amove_objects(
                 source_path="object",


### PR DESCRIPTION
related to #15008 

adds explicit async methods to all public tasks and methods in `prefect_aws.s3` and removes use of `sync_compatable`

<details>

<summary>old notes</summary>

i intentionally did not do the `S3Bucket` methods here, since there's an open question I want to discuss with @desertaxle

## question
on S3Bucket
```python
async def get_directory()
```
is not actually async at all, not even a sending sync stuff to a worker thread

the established pattern would say we do
```python
async def aget_directory(self):
   # send to worker threads

@async_dispatch(aget_directory)
def get_directory(self):
   # original impl
```
that seems like it was duplicate a lot for not a very compelling reason

but because stopped supporting async in sync we might need to do this

</details>

also renamed tasks in backword compat fashion per [this comment](https://github.com/PrefectHQ/prefect/pull/16096#discussion_r1856739686)