### PR TITLE
added noZoom tag to integration images

### DIFF
--- a/docs/integrations/integrations.mdx
+++ b/docs/integrations/integrations.mdx
@@ -8,205 +8,205 @@ mode: "wide"
 <CardGroup cols={4}  className="text-center">
 
     <Card title="Alert">
-        <a href="https://khuyentran1401.github.io/prefect-alert/"> <img src="/images/integrations/alert.png" alt="prefect-alert"/>
+        <a href="https://khuyentran1401.github.io/prefect-alert/"> <img src="/images/integrations/alert.png" noZoom alt="prefect-alert"/>
         </a>
         Maintained by <a href="https://github.com/khuyentran1401"> Khuyen Tran </a>
     </Card>
 
     <Card title="AWS">
-        <a href="/integrations/prefect-aws"> <img src="/images/integrations/aws.png" alt="prefect-aws"/>
+        <a href="/integrations/prefect-aws"> <img src="/images/integrations/aws.png" noZoom alt="prefect-aws"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="Azure">
-        <a href="/integrations/prefect-azure"> <img src="/images/integrations/azure.png" alt="prefect-azure"/>
+        <a href="/integrations/prefect-azure"> <img src="/images/integrations/azure.png" noZoom alt="prefect-azure"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="Bitbucket">
-        <a href="/integrations/prefect-bitbucket"> <img src="/images/integrations/bitbucket.png" alt="prefect-bitbucket"/>
+        <a href="/integrations/prefect-bitbucket"> <img src="/images/integrations/bitbucket.png" noZoom alt="prefect-bitbucket"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="Coiled">
-        <a href="https://docs.coiled.io/user_guide/labs/prefect.html?utm_source=prefect-docs&utm_medium=integrations"> <img src="/images/integrations/coiled.png" alt="coiled"/>
+        <a href="https://docs.coiled.io/user_guide/labs/prefect.html?utm_source=prefect-docs&utm_medium=integrations"> <img src="/images/integrations/coiled.png" noZoom alt="coiled"/>
         </a>
         Maintained by <a href="https://www.coiled.io/"> Coiled </a>
     </Card>
 
     <Card title="CubeJS">
-        <a href="https://alessandrolollo.github.io/prefect-cubejs/"> <img src="/images/integrations/cubejs.png" alt="prefect-cubejs"/>
+        <a href="https://alessandrolollo.github.io/prefect-cubejs/"> <img src="/images/integrations/cubejs.png" noZoom alt="prefect-cubejs"/>
         </a>
         Maintained by <a href="https://github.com/AlessandroLollo"> Alessandro Lollo </a>
     </Card>
 
     <Card title="Dask">
-        <a href="/integrations/prefect-dask"> <img src="/images/integrations/dask.png" alt="prefect-dask"/>
+        <a href="/integrations/prefect-dask"> <img src="/images/integrations/dask.png" noZoom alt="prefect-dask"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="Databricks">
-        <a href="/integrations/prefect-databricks"> <img src="/images/integrations/databricks.png" alt="prefect-databricks"/>
+        <a href="/integrations/prefect-databricks"> <img src="/images/integrations/databricks.png" noZoom alt="prefect-databricks"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="dbt">
-        <a href="/integrations/prefect-dbt"> <img src="/images/integrations/dbt.png" alt="prefect-dbt"/>
+        <a href="/integrations/prefect-dbt"> <img src="/images/integrations/dbt.png" noZoom alt="prefect-dbt"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="Docker">
-        <a href="/integrations/prefect-docker"> <img src="/images/integrations/docker.png" alt="prefect-docker"/>
+        <a href="/integrations/prefect-docker"> <img src="/images/integrations/docker.png" noZoom alt="prefect-docker"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="Earthdata">
-        <a href="https://giorgiobasile.github.io/prefect-earthdata/"> <img src="/images/integrations/nasa.png" alt="prefect-earthdata"/>
+        <a href="https://giorgiobasile.github.io/prefect-earthdata/"> <img src="/images/integrations/nasa.png" noZoom alt="prefect-earthdata"/>
         </a>
         Maintained by <a href="https://github.com/giorgiobasile"> Giorgio Basile </a>
     </Card>
 
     <Card title="Email">
-        <a href="/integrations/prefect-email"> <img src="/images/integrations/email.png" alt="prefect-email"/>
+        <a href="/integrations/prefect-email"> <img src="/images/integrations/email.png" noZoom alt="prefect-email"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="Fivetran">
-        <a href="https://fivetran.github.io/prefect-fivetran/"> <img src="/images/integrations/fivetran.png" alt="prefect-fivetran"/>
+        <a href="https://fivetran.github.io/prefect-fivetran/"> <img src="/images/integrations/fivetran.png" noZoom alt="prefect-fivetran"/>
         </a>
         Maintained by <a href="https://www.fivetran.com/"> Fivetran </a>
     </Card>
 
     <Card title="Fugue">
-        <a href="https://fugue-project.github.io/prefect-fugue/"> <img src="https://avatars.githubusercontent.com/u/65140352?s=200&v=4" alt="prefect-fugue"/>
+        <a href="https://fugue-project.github.io/prefect-fugue/"> <img src="https://avatars.githubusercontent.com/u/65140352?s=200&v=4" noZoom alt="prefect-fugue"/>
         </a>
         Maintained by <a href="https://github.com/fugue-project/fugue"> The Fugue Development Team </a>
     </Card>
 
     <Card title="GCP">
-        <a href="/integrations/prefect-gcp"> <img src="/images/integrations/gcp.png" alt="prefect-gcp"/>
+        <a href="/integrations/prefect-gcp"> <img src="/images/integrations/gcp.png" noZoom alt="prefect-gcp"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="GitHub">
-        <a href="/integrations/prefect-github"> <img src="/images/integrations/github.png" alt="prefect-github"/>
+        <a href="/integrations/prefect-github"> <img src="/images/integrations/github.png" noZoom alt="prefect-github"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="GitLab">
-        <a href="/integrations/prefect-gitlab"> <img src="/images/integrations/gitlab.png" alt="prefect-gitlab"/>
+        <a href="/integrations/prefect-gitlab"> <img src="/images/integrations/gitlab.png" noZoom alt="prefect-gitlab"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="Google Sheets">
-        <a href="https://stefanocascavilla.github.io/prefect-google-sheets/"> <img src="/images/integrations/gsheets.png" alt="prefect-google-sheets"/>
+        <a href="https://stefanocascavilla.github.io/prefect-google-sheets/"> <img src="/images/integrations/gsheets.png" noZoom alt="prefect-google-sheets"/>
         </a>
         Maintained by <a href="https://github.com/stefanocascavilla"> Stefano Cascavilla </a>
     </Card>
 
     <Card title="HashiCorp Vault">
-        <a href="https://github.com/pbchekin/prefect-vault"> <img src="/images/integrations/vault.png" alt="prefect-vault"/>
+        <a href="https://github.com/pbchekin/prefect-vault"> <img src="/images/integrations/vault.png" noZoom alt="prefect-vault"/>
         </a>
         Maintained by <a href="https://github.com/pbchekin"> Pavel Chekin </a>
     </Card>
 
     <Card title="Kubernetes">
-        <a href="/integrations/prefect-kubernetes"> <img src="/images/integrations/kubernetes.png" alt="prefect-kubernetes"/>
+        <a href="/integrations/prefect-kubernetes"> <img src="/images/integrations/kubernetes.png" noZoom alt="prefect-kubernetes"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="KV">
-        <a href="https://github.com/zanieb/prefect-kv"> <img src="/images/integrations/prefect-kv.svg" alt="prefect-kv"/>
+        <a href="https://github.com/zanieb/prefect-kv"> <img src="/images/integrations/prefect-kv.svg" noZoom alt="prefect-kv"/>
         </a>
         Maintained by <a href="https://github.com/zanieb"> Zanie Blue </a>
     </Card>
 
     <Card title="MetricFlow">
-        <a href="https://alessandrolollo.github.io/prefect-metricflow/"> <img src="/images/integrations/metricflow.png" alt="prefect-metricflow"/>
+        <a href="https://alessandrolollo.github.io/prefect-metricflow/"> <img src="/images/integrations/metricflow.png" noZoom alt="prefect-metricflow"/>
         </a>
         Maintained by <a href="https://github.com/AlessandroLollo"> Alessandro Lollo </a>
     </Card>
 
     <Card title="Planetary Computer">
-        <a href="https://giorgiobasile.github.io/prefect-planetary-computer/"> <img src="/images/integrations/microsoft.png" alt="prefect-planetary-computer"/>
+        <a href="https://giorgiobasile.github.io/prefect-planetary-computer/"> <img src="/images/integrations/microsoft.png" noZoom alt="prefect-planetary-computer"/>
         </a>
         Maintained by <a href="https://github.com/giorgiobasile"> Giorgio Basile </a>
     </Card>
 
     <Card title="Ray">
-        <a href="/integrations/prefect-ray"> <img src="/images/integrations/ray.png" alt="prefect-ray"/>
+        <a href="/integrations/prefect-ray"> <img src="/images/integrations/ray.png" noZoom alt="prefect-ray"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="Shell">
-        <a href="/integrations/prefect-shell"> <img src="/images/integrations/shell.png" alt="prefect-shell"/>
+        <a href="/integrations/prefect-shell"> <img src="/images/integrations/shell.png" noZoom alt="prefect-shell"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="Sifflet">
-        <a href="https://siffletapp.github.io/prefect-sifflet/"> <img src="/images/integrations/sifflet.png" alt="prefect-sifflet"/>
+        <a href="https://siffletapp.github.io/prefect-sifflet/"> <img src="/images/integrations/sifflet.png" noZoom alt="prefect-sifflet"/>
         </a>
         Maintained by <a href="https://www.siffletdata.com/"> Sifflet and Alessandro Lollo </a>
     </Card>
 
     <Card title="Slack">
-        <a href="/integrations/prefect-slack"> <img src="/images/integrations/slack.png" alt="prefect-slack"/>
+        <a href="/integrations/prefect-slack"> <img src="/images/integrations/slack.png" noZoom alt="prefect-slack"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="Snowflake">
-        <a href="/integrations/prefect-snowflake"> <img src="/images/integrations/snowflake.png" alt="prefect-snowflake"/>
+        <a href="/integrations/prefect-snowflake"> <img src="/images/integrations/snowflake.png" noZoom alt="prefect-snowflake"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="Soda Cloud">
-        <a href="https://alessandrolollo.github.io/prefect-soda-cloud/"> <img src="/images/integrations/soda.png" alt="prefect-soda-cloud"/>
+        <a href="https://alessandrolollo.github.io/prefect-soda-cloud/"> <img src="/images/integrations/soda.png" noZoom alt="prefect-soda-cloud"/>
         </a>
         Maintained by <a href="https://github.com/AlessandroLollo"> Alessandro Lollo </a>
     </Card>
 
     <Card title="Soda Core">
-        <a href="https://sodadata.github.io/prefect-soda-core/"> <img src="/images/integrations/soda.png" alt="prefect-soda-core"/>
+        <a href="https://sodadata.github.io/prefect-soda-core/"> <img src="/images/integrations/soda.png" noZoom alt="prefect-soda-core"/>
         </a>
         Maintained by <a href="https://github.com/sodadata"> Soda and Alessandro Lollo </a>
     </Card>
 
     <Card title="Spark on Kubernetes">
-        <a href="https://tardunge.github.io/prefect-spark-on-k8s-operator/"> <img src="/images/integrations/spark-on-kubernetes.png" alt="prefect-spark-on-k8s-operator"/>
+        <a href="https://tardunge.github.io/prefect-spark-on-k8s-operator/"> <img src="/images/integrations/spark-on-kubernetes.png" noZoom alt="prefect-spark-on-k8s-operator"/>
         </a>
         Maintained by <a href="https://github.com/tardunge"> Manoj Babu Katragadda </a>
     </Card>
 
     <Card title="SQLAlchemy">
-        <a href="/integrations/prefect-sqlalchemy"> <img src="/images/integrations/sqlalchemy.png" alt="prefect-sqlalchemy"/>
+        <a href="/integrations/prefect-sqlalchemy"> <img src="/images/integrations/sqlalchemy.png" noZoom alt="prefect-sqlalchemy"/>
         </a>
         Maintained by <a href="https://prefect.io"> Prefect </a>
     </Card>
 
     <Card title="Stitch">
-        <a href="https://alessandrolollo.github.io/prefect-stitch/"> <img src="/images/integrations/stitch.png" alt="prefect-stitch"/>
+        <a href="https://alessandrolollo.github.io/prefect-stitch/"> <img src="/images/integrations/stitch.png" noZoom alt="prefect-stitch"/>
         </a>
         Maintained by <a href="https://github.com/AlessandroLollo"> Alessandro Lollo </a>
     </Card>
 
     <Card title="Transform">
-        <a href="https://alessandrolollo.github.io/prefect-transform/"> <img src="/images/integrations/transform.png" alt="prefect-transform"/>
+        <a href="https://alessandrolollo.github.io/prefect-transform/"> <img src="/images/integrations/transform.png" noZoom alt="prefect-transform"/>
         </a>
         Maintained by <a href="https://github.com/AlessandroLollo"> Alessandro Lollo </a>
     </Card>


### PR DESCRIPTION
Our docs provider, Mintlify, automatically binds a click event to images to enable a modal zoom. The noZoom attribute prevents this click handler from being bound.

More info here - https://mintlify.com/docs/image-embeds\#disable-image-zoom


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
