### PR TITLE
Stop running all services in ephemeral app

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -489,6 +489,7 @@ def create_app(
     """
     settings = settings or prefect.settings.get_current_settings()
     cache_key = (settings.hash_key(), ephemeral)
+    ephemeral = ephemeral or bool(os.getenv("PREFECT__SERVER_EPHEMERAL"))
 
     from prefect.logging.configuration import setup_logging
 
@@ -525,50 +526,52 @@ def create_app(
     async def start_services():
         """Start additional services when the Prefect REST API starts up."""
 
-        if ephemeral:
-            app.state.services = None
-            return
-
         service_instances = []
-        if prefect.settings.PREFECT_API_SERVICES_SCHEDULER_ENABLED.value():
-            service_instances.append(services.scheduler.Scheduler())
-            service_instances.append(services.scheduler.RecentDeploymentsScheduler())
 
-        if prefect.settings.PREFECT_API_SERVICES_LATE_RUNS_ENABLED.value():
-            service_instances.append(services.late_runs.MarkLateRuns())
+        if ephemeral:
+            if prefect.settings.PREFECT_SERVER_ANALYTICS_ENABLED.value():
+                service_instances.append(services.telemetry.Telemetry())
 
-        if prefect.settings.PREFECT_API_SERVICES_PAUSE_EXPIRATIONS_ENABLED.value():
-            service_instances.append(services.pause_expirations.FailExpiredPauses())
+        # don't run services in ephemeral mode
+        else:
+            if prefect.settings.PREFECT_API_SERVICES_SCHEDULER_ENABLED.value():
+                service_instances.append(services.scheduler.Scheduler())
+                service_instances.append(
+                    services.scheduler.RecentDeploymentsScheduler()
+                )
 
-        if prefect.settings.PREFECT_API_SERVICES_CANCELLATION_CLEANUP_ENABLED.value():
-            service_instances.append(
-                services.cancellation_cleanup.CancellationCleanup()
-            )
+            if prefect.settings.PREFECT_API_SERVICES_LATE_RUNS_ENABLED.value():
+                service_instances.append(services.late_runs.MarkLateRuns())
 
-        if prefect.settings.PREFECT_SERVER_ANALYTICS_ENABLED.value():
-            service_instances.append(services.telemetry.Telemetry())
+            if prefect.settings.PREFECT_API_SERVICES_PAUSE_EXPIRATIONS_ENABLED.value():
+                service_instances.append(services.pause_expirations.FailExpiredPauses())
 
-        if prefect.settings.PREFECT_API_SERVICES_FLOW_RUN_NOTIFICATIONS_ENABLED.value():
-            service_instances.append(
-                services.flow_run_notifications.FlowRunNotifications()
-            )
+            if prefect.settings.PREFECT_API_SERVICES_CANCELLATION_CLEANUP_ENABLED.value():
+                service_instances.append(
+                    services.cancellation_cleanup.CancellationCleanup()
+                )
 
-        if prefect.settings.PREFECT_API_SERVICES_FOREMAN_ENABLED.value():
-            service_instances.append(services.foreman.Foreman())
+            if prefect.settings.PREFECT_API_SERVICES_FLOW_RUN_NOTIFICATIONS_ENABLED.value():
+                service_instances.append(
+                    services.flow_run_notifications.FlowRunNotifications()
+                )
 
-        if prefect.settings.PREFECT_API_SERVICES_TRIGGERS_ENABLED.value():
-            service_instances.append(ReactiveTriggers())
-            service_instances.append(ProactiveTriggers())
-            service_instances.append(Actions())
+            if prefect.settings.PREFECT_API_SERVICES_FOREMAN_ENABLED.value():
+                service_instances.append(services.foreman.Foreman())
 
-        if prefect.settings.PREFECT_API_SERVICES_TASK_RUN_RECORDER_ENABLED:
-            service_instances.append(TaskRunRecorder())
+            if prefect.settings.PREFECT_API_SERVICES_TRIGGERS_ENABLED.value():
+                service_instances.append(ReactiveTriggers())
+                service_instances.append(ProactiveTriggers())
+                service_instances.append(Actions())
 
-        if prefect.settings.PREFECT_API_SERVICES_EVENT_PERSISTER_ENABLED:
-            service_instances.append(EventPersister())
+            if prefect.settings.PREFECT_API_SERVICES_TASK_RUN_RECORDER_ENABLED:
+                service_instances.append(TaskRunRecorder())
 
-        if prefect.settings.PREFECT_API_EVENTS_STREAM_OUT_ENABLED:
-            service_instances.append(stream.Distributor())
+            if prefect.settings.PREFECT_API_SERVICES_EVENT_PERSISTER_ENABLED:
+                service_instances.append(EventPersister())
+
+            if prefect.settings.PREFECT_API_EVENTS_STREAM_OUT_ENABLED:
+                service_instances.append(stream.Distributor())
 
         loop = asyncio.get_running_loop()
 
@@ -828,6 +831,7 @@ class SubprocessASGIServer:
         # used to turn off serving the UI
         server_env = {
             "PREFECT_UI_ENABLED": "0",
+            "PREFECT__SERVER_EPHEMERAL": "1",
         }
         return subprocess.Popen(
             args=[

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -531,6 +531,15 @@ def create_app(
         if prefect.settings.PREFECT_SERVER_ANALYTICS_ENABLED.value():
             service_instances.append(services.telemetry.Telemetry())
 
+        if prefect.settings.PREFECT_API_SERVICES_TASK_RUN_RECORDER_ENABLED:
+            service_instances.append(TaskRunRecorder())
+
+        if prefect.settings.PREFECT_API_SERVICES_EVENT_PERSISTER_ENABLED:
+            service_instances.append(EventPersister())
+
+        if prefect.settings.PREFECT_API_EVENTS_STREAM_OUT_ENABLED:
+            service_instances.append(stream.Distributor())
+
         # don't run services in ephemeral mode
         if not ephemeral:
             if prefect.settings.PREFECT_API_SERVICES_SCHEDULER_ENABLED.value():
@@ -562,15 +571,6 @@ def create_app(
                 service_instances.append(ReactiveTriggers())
                 service_instances.append(ProactiveTriggers())
                 service_instances.append(Actions())
-
-            if prefect.settings.PREFECT_API_SERVICES_TASK_RUN_RECORDER_ENABLED:
-                service_instances.append(TaskRunRecorder())
-
-            if prefect.settings.PREFECT_API_SERVICES_EVENT_PERSISTER_ENABLED:
-                service_instances.append(EventPersister())
-
-            if prefect.settings.PREFECT_API_EVENTS_STREAM_OUT_ENABLED:
-                service_instances.append(stream.Distributor())
 
         loop = asyncio.get_running_loop()
 

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -528,12 +528,11 @@ def create_app(
 
         service_instances = []
 
-        if ephemeral:
-            if prefect.settings.PREFECT_SERVER_ANALYTICS_ENABLED.value():
-                service_instances.append(services.telemetry.Telemetry())
+        if prefect.settings.PREFECT_SERVER_ANALYTICS_ENABLED.value():
+            service_instances.append(services.telemetry.Telemetry())
 
         # don't run services in ephemeral mode
-        else:
+        if not ephemeral:
             if prefect.settings.PREFECT_API_SERVICES_SCHEDULER_ENABLED.value():
                 service_instances.append(services.scheduler.Scheduler())
                 service_instances.append(

--- a/src/prefect/server/services/telemetry.py
+++ b/src/prefect/server/services/telemetry.py
@@ -94,6 +94,8 @@ class Telemetry(LoopService):
                 "python_version": platform.python_version(),
                 "python_implementation": platform.python_implementation(),
                 "environment": self.telemetry_environment,
+                "ephemeral_server": bool(os.getenv("PREFECT__SERVER_EPHEMERAL"))
+                or False,
                 "api_version": SERVER_API_VERSION,
                 "prefect_version": prefect.__version__,
                 "session_id": self.session_id,

--- a/src/prefect/server/services/telemetry.py
+++ b/src/prefect/server/services/telemetry.py
@@ -94,7 +94,7 @@ class Telemetry(LoopService):
                 "python_version": platform.python_version(),
                 "python_implementation": platform.python_implementation(),
                 "environment": self.telemetry_environment,
-                "ephemeral_server": bool(os.getenv("PREFECT__SERVER_EPHEMERAL", False))
+                "ephemeral_server": bool(os.getenv("PREFECT__SERVER_EPHEMERAL", False)),
                 "api_version": SERVER_API_VERSION,
                 "prefect_version": prefect.__version__,
                 "session_id": self.session_id,

--- a/src/prefect/server/services/telemetry.py
+++ b/src/prefect/server/services/telemetry.py
@@ -94,8 +94,7 @@ class Telemetry(LoopService):
                 "python_version": platform.python_version(),
                 "python_implementation": platform.python_implementation(),
                 "environment": self.telemetry_environment,
-                "ephemeral_server": bool(os.getenv("PREFECT__SERVER_EPHEMERAL"))
-                or False,
+                "ephemeral_server": bool(os.getenv("PREFECT__SERVER_EPHEMERAL", False))
                 "api_version": SERVER_API_VERSION,
                 "prefect_version": prefect.__version__,
                 "session_id": self.session_id,


### PR DESCRIPTION
I noticed that all services, including the scheduler, etc. were running in a background process on a loop anytime an ephemeral server was started. This hogs resources and is not intended behavior - we were not using the `ephemeral` flag on `create_app` as we should have.

This PR uses an env var to signal to the application when it should run in ephemeral mode.