### PR TITLE
expose `job_variables` in `runtime.flow_run`

### DIFF
--- a/src/prefect/runtime/flow_run.py
+++ b/src/prefect/runtime/flow_run.py
@@ -44,6 +44,7 @@ __all__ = [
     "run_count",
     "api_url",
     "ui_url",
+    "job_variables",
 ]
 
 
@@ -317,6 +318,11 @@ def get_flow_run_ui_url() -> Optional[str]:
     return f"{PREFECT_UI_URL.value()}/flow-runs/flow-run/{flow_run_id}"
 
 
+def get_job_variables() -> Optional[Dict[str, Any]]:
+    flow_run_ctx = FlowRunContext.get()
+    return flow_run_ctx.flow_run.job_variables if flow_run_ctx else None
+
+
 FIELDS = {
     "id": get_id,
     "tags": get_tags,
@@ -331,4 +337,5 @@ FIELDS = {
     "api_url": get_flow_run_api_url,
     "ui_url": get_flow_run_ui_url,
     "flow_version": get_flow_version,
+    "job_variables": get_job_variables,
 }

--- a/tests/runtime/test_flow_run.py
+++ b/tests/runtime/test_flow_run.py
@@ -645,3 +645,21 @@ class TestURL:
         monkeypatch.setenv(name="PREFECT__FLOW_RUN_ID", value=str(run.id))
 
         assert getattr(flow_run, url_type) == expected_url
+
+
+class TestJobVariables:
+    async def test_job_variables_is_attribute(self):
+        assert "job_variables" in dir(flow_run)
+
+    async def test_job_variables_is_none_when_not_set(self):
+        assert flow_run.job_variables is None
+
+    async def test_job_variables_returns_variables_when_present_dynamically(self):
+        assert flow_run.job_variables is None
+
+        with FlowRunContext.model_construct(
+            flow_run=FlowRun.model_construct(job_variables={"foo": "bar"})
+        ):
+            assert flow_run.job_variables == {"foo": "bar"}
+
+        assert flow_run.job_variables is None


### PR DESCRIPTION
```python
In [1]: from prefect import flow

In [2]: import prefect.runtime

In [3]: @flow(log_prints=True)
   ...: def f(): print(prefect.runtime.flow_run.job_variables)

In [4]: f()
17:55:23.174 | INFO    | prefect.engine - Created flow run 'true-panda' for flow 'f'
17:55:23.423 | INFO    | Flow run 'true-panda' - {}
17:55:23.548 | INFO    | Flow run 'true-panda' - Finished in state Completed()
```