### PR TITLE
Fix error when listing workspaces without an active workspace

### DIFF
--- a/src/prefect/cli/cloud/__init__.py
+++ b/src/prefect/cli/cloud/__init__.py
@@ -613,7 +613,7 @@ async def ls():
     )
 
     for workspace_handle in sorted(workspace.handle for workspace in workspaces):
-        if workspace_handle == current_workspace.handle:
+        if current_workspace and workspace_handle == current_workspace.handle:
             table.add_row(f"[green]* {workspace_handle}[/green]")
         else:
             table.add_row(f"  {workspace_handle}")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR adds a check to avoid raising an error when listing workspaces without a current workspace. It also adds some test coverage to the `prefect cloud workspace ls` command that was missing.

Closes https://github.com/PrefectHQ/prefect/issues/16098
