### PR TITLE
[UI v2] feat: Use queryOptions API to define queries

### DIFF
--- a/ui-v2/src/hooks/variables.ts
+++ b/ui-v2/src/hooks/variables.ts
@@ -3,6 +3,7 @@ import { getQueryService } from "@/api/service";
 import { useToast } from "@/hooks/use-toast";
 import { startsWith } from "@/lib/utils";
 import {
+	queryOptions,
 	useMutation,
 	useQueryClient,
 	useQueries,
@@ -53,17 +54,18 @@ const variableKeys: VariableKeys = {
  *  - staleTime: How long the data should be considered fresh (1 second)
  *  - placeholderData: Uses previous data while loading new data
  */
-const buildVariablesQuery = (options: UseVariablesOptions) => ({
-	queryKey: variableKeys.filtered(options),
-	queryFn: async () => {
-		const response = await getQueryService().POST("/variables/filter", {
-			body: options,
-		});
-		return response.data;
-	},
-	staleTime: 1000,
-	placeholderData: keepPreviousData,
-});
+const buildVariablesQuery = (options: UseVariablesOptions) =>
+	queryOptions({
+		queryKey: variableKeys.filtered(options),
+		queryFn: async () => {
+			const response = await getQueryService().POST("/variables/filter", {
+				body: options,
+			});
+			return response.data;
+		},
+		staleTime: 1000,
+		placeholderData: keepPreviousData,
+	});
 
 /**
  * Builds a query configuration for counting variables with optional filters
@@ -74,18 +76,19 @@ const buildVariablesQuery = (options: UseVariablesOptions) => ({
  *  - staleTime: How long the data should be considered fresh (1 second)
  *  - placeholderData: Uses previous data while loading new data
  */
-const buildCountQuery = (options?: UseVariablesOptions) => ({
-	queryKey: variableKeys.filteredCount(options),
-	queryFn: async () => {
-		const body = options?.variables ? { variables: options.variables } : {};
-		const response = await getQueryService().POST("/variables/count", {
-			body,
-		});
-		return response.data;
-	},
-	staleTime: 1000,
-	placeholderData: keepPreviousData,
-});
+const buildCountQuery = (options?: UseVariablesOptions) =>
+	queryOptions({
+		queryKey: variableKeys.filteredCount(options),
+		queryFn: async () => {
+			const body = options?.variables ? { variables: options.variables } : {};
+			const response = await getQueryService().POST("/variables/count", {
+				body,
+			});
+			return response.data;
+		},
+		staleTime: 1000,
+		placeholderData: keepPreviousData,
+	});
 
 /**
  * Hook for fetching and managing variables data with filtering, pagination, and counts


### PR DESCRIPTION
What does this PR do and why?
------------------------
This PR wraps `queryKey` and `queryFn` objects using the `queryOptions` API.
Opting to use the `queryOptions` wrapper due to its Typescript benefits (see attachment).
Additionally, all tanstack router + query uses `queryOptions` in their latest documentation examples

Overall, by using the `queryOptions` wrapper, our codebase knows what the expected return type is based on the `query keys` provided in the `queryClient`

And a good blog read: https://tkdodo.eu/blog/the-query-options-api

(Without the wrapper, TS assumes `any` type that is associated with the provided `queryKey`. With the wrapper, TS magically 🧙 knows what the expected type is for this cache)

https://github.com/user-attachments/assets/5fae4841-19c9-4765-b974-dc5b22c9ce6f



### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Related to https://github.com/PrefectHQ/prefect/issues/15512
