### PR TITLE
Add caching doc section on unserializable inputs

### DIFF
--- a/docs/v3/develop/big-data.mdx
+++ b/docs/v3/develop/big-data.mdx
@@ -111,7 +111,7 @@ from cloud object storage.
 
 Caching saves you time and compute by allowing you to avoid re-running tasks unnecessarily.
 Note that caching requires task result persistence.
-Learn more about [caching](/v3/develop/write-tasks/).
+Learn more about [caching](/v3/develop/task-caching/).
 
 ### Compress results written to disk
 

--- a/docs/v3/develop/task-caching.mdx
+++ b/docs/v3/develop/task-caching.mdx
@@ -360,6 +360,89 @@ def my_cached_task(x: int):
 ```
 </Note>
 
+
+### Handling Non-Serializable Objects
+
+You may have task inputs that can't (or shouldn't) be serialized as part of the cache key. There are two direct approaches to handle this:
+
+
+1. Using a custom cache key function:
+```python
+from prefect import flow, task
+from prefect.cache_policies import CacheKeyFnPolicy, RUN_ID
+from prefect.context import TaskRunContext
+from pydantic import BaseModel, ConfigDict
+
+class NotSerializable:
+    def __getstate__(self):
+        raise TypeError("NooOoOOo! I will not be serialized!")
+
+class ContainsNonSerializableObject(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    name: str
+    bad_object: NotSerializable
+
+def custom_cache_key_fn(context: TaskRunContext, parameters: dict) -> str:
+    return parameters["some_object"].name
+
+@task(cache_policy=CacheKeyFnPolicy(cache_key_fn=custom_cache_key_fn) + RUN_ID)
+def use_object(some_object: ContainsNonSerializableObject) -> str:
+    return f"Used {some_object.name}"
+
+
+@flow
+def demo_flow():
+    obj = ContainsNonSerializableObject(name="test", bad_object=NotSerializable())
+    state = use_object(obj, return_state=True) # Not cached!
+    assert state.name == "Completed"
+    other_state = use_object(obj, return_state=True) # Cached!
+    assert other_state.name == "Cached"
+    assert state.result() == other_state.result()
+```
+
+2. Using Pydantic's [custom serialization](https://docs.pydantic.dev/latest/concepts/serialization/#custom-serializers) on your input types:
+```python
+from pydantic import BaseModel, ConfigDict, model_serializer
+from prefect import flow, task
+from prefect.cache_policies import INPUTS, RUN_ID
+
+class NotSerializable:
+    def __getstate__(self):
+        raise TypeError("NooOoOOo! I will not be serialized!")
+
+class ContainsNonSerializableObject(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    name: str
+    bad_object: NotSerializable
+
+    @model_serializer
+    def ser_model(self) -> dict:
+        """Only serialize the name, not the problematic object"""
+        return {"name": self.name}
+
+@task(cache_policy=INPUTS + RUN_ID)
+def use_object(some_object: ContainsNonSerializableObject) -> str:
+    return f"Used {some_object.name}"
+
+@flow
+def demo_flow():
+    some_object = ContainsNonSerializableObject(
+        name="test",
+        bad_object=NotSerializable()
+    )
+    state = use_object(some_object, return_state=True) # Not cached!
+    assert state.name == "Completed"
+    other_state = use_object(some_object, return_state=True) # Cached!
+    assert other_state.name == "Cached"
+    assert state.result() == other_state.result()
+```
+
+Choose the approach that best fits your needs:
+- Use Pydantic models when you want consistent serialization across your application
+- Use custom cache key functions when you need different caching logic for different tasks
+
 ## Multi-task caching
 
 There are many situations in which multiple tasks need to always run together or not at all.

--- a/docs/v3/develop/task-caching.mdx
+++ b/docs/v3/develop/task-caching.mdx
@@ -363,7 +363,11 @@ def my_cached_task(x: int):
 
 ### Handling Non-Serializable Objects
 
-You may have task inputs that can't (or shouldn't) be serialized as part of the cache key. There are two direct approaches to handle this:
+You may have task inputs that can't (or shouldn't) be serialized as part of the cache key. There are two direct approaches to handle this, both of which based on the same idea.
+
+
+You can **adjust the serialization logic** to only serialize certain properties of an input:
+
 
 
 1. Using a custom cache key function:

--- a/docs/v3/develop/write-tasks.mdx
+++ b/docs/v3/develop/write-tasks.mdx
@@ -350,6 +350,7 @@ Tasks allow for customization through optional arguments that can be provided to
 | `tags`                | An optional set of tags associated with runs of this task. These tags are combined with any tags defined by a `prefect.tags` context at task runtime.                                                             |
 | `timeout_seconds`     | An optional number of seconds indicating a maximum runtime for the task. If the task exceeds this runtime, it will be marked as failed. |
 | `cache_key_fn`        | An optional callable that, given the task run context and call parameters, generates a string key. If the key matches a previous completed state, that state result is restored instead of running the task again. |
+| `cache_policy`        | An optional policy that determines what information is used to generate cache keys. Available policies include `INPUTS`, `TASK_SOURCE`, `RUN_ID`, `FLOW_PARAMETERS`, and `NONE`. Can be combined using the + operator. |
 | `cache_expiration`    | An optional amount of time indicating how long cached states for this task are restorable; if not provided, cached states will never expire. |
 | `retries`             | An optional number of times to retry on task run failure. |
 | `retry_delay_seconds` | An optional number of seconds to wait before retrying the task after failure. This is only applicable if `retries` is nonzero.                                                                                          |


### PR DESCRIPTION
this has come up a lot, adds two examples of how to handle unserializable task inputs that you still want to compute a cache key for