### PR TITLE
[UI v2] feat: Have UX related mutation callbacks be handled in the UX layer

### DIFF
--- a/ui-v2/src/components/variables/data-table/cells.tsx
+++ b/ui-v2/src/components/variables/data-table/cells.tsx
@@ -52,9 +52,12 @@ export const ActionsCell = ({ row, onVariableEdit }: ActionsCellProps) => {
 	if (!id) return null;
 
 	const onVariableDelete = () => {
-		deleteVariable(id);
-		toast({
-			title: "Variable deleted",
+		deleteVariable(id, {
+			onSuccess: () => {
+				toast({
+					title: "Variable deleted",
+				});
+			},
 		});
 	};
 

--- a/ui-v2/src/hooks/variables.ts
+++ b/ui-v2/src/hooks/variables.ts
@@ -1,6 +1,5 @@
 import type { components } from "@/api/prefect";
 import { getQueryService } from "@/api/service";
-import { useToast } from "@/hooks/use-toast";
 import { startsWith } from "@/lib/utils";
 import {
 	queryOptions,
@@ -185,11 +184,6 @@ useVariables.loader = ({
 		context.queryClient.ensureQueryData(buildCountQuery()),
 	]);
 
-type UseCreateVariableOptions = {
-	onSuccess: () => void;
-	onError: (error: Error) => void;
-};
-
 /**
  * Hook for creating a new variable
  *
@@ -219,12 +213,8 @@ type UseCreateVariableOptions = {
  * });
  * ```
  */
-export const useCreateVariable = ({
-	onSuccess,
-	onError,
-}: UseCreateVariableOptions) => {
+export const useCreateVariable = () => {
 	const queryClient = useQueryClient();
-	const { toast } = useToast();
 
 	const { mutate: createVariable, ...rest } = useMutation({
 		mutationFn: (variable: components["schemas"]["VariableCreate"]) => {
@@ -237,21 +227,9 @@ export const useCreateVariable = ({
 				predicate: (query) => startsWith(query.queryKey, variableKeys.all),
 			});
 		},
-		onSuccess: () => {
-			toast({
-				title: "Variable created",
-			});
-			onSuccess();
-		},
-		onError,
 	});
 
 	return { createVariable, ...rest };
-};
-
-type UseUpdateVariableProps = {
-	onSuccess: () => void;
-	onError: (error: Error) => void;
 };
 
 type VariableUpdateWithId = components["schemas"]["VariableUpdate"] & {
@@ -286,12 +264,8 @@ type VariableUpdateWithId = components["schemas"]["VariableUpdate"] & {
  * });
  * ```
  */
-export const useUpdateVariable = ({
-	onSuccess,
-	onError,
-}: UseUpdateVariableProps) => {
+export const useUpdateVariable = () => {
 	const queryClient = useQueryClient();
-	const { toast } = useToast();
 
 	const { mutate: updateVariable, ...rest } = useMutation({
 		mutationFn: (variable: VariableUpdateWithId) => {
@@ -306,13 +280,6 @@ export const useUpdateVariable = ({
 				predicate: (query) => startsWith(query.queryKey, variableKeys.all),
 			});
 		},
-		onSuccess: () => {
-			toast({
-				title: "Variable updated",
-			});
-			onSuccess();
-		},
-		onError,
 	});
 
 	return { updateVariable, ...rest };

--- a/ui-v2/tests/mocks/handlers.ts
+++ b/ui-v2/tests/mocks/handlers.ts
@@ -16,6 +16,9 @@ const variablesHandlers = [
 	http.patch("http://localhost:4200/api/variables/:id", () => {
 		return new HttpResponse(null, { status: 204 });
 	}),
+	http.delete("http://localhost:4200/api/variables/:id", () => {
+		return HttpResponse.json({ status: 204 });
+	}),
 ];
 
 export const handlers = [


### PR DESCRIPTION
What does this PR do and why?
------------------------
This PR handles all UX related mutation callbacks to be handled on the UX layer.

`useMutation` is divided into 2 separate  concerns: 1️⃣ Data, 2️⃣ UX.
Upon success on the data layer, **it is not guaranteed that the UX related callbacks will be invoked**.

This is why after calling a defined `useMutation`, there are callback options to pass, in which all UX related callbacks should be handled there.

Here is a good article of how `useMutation` is architected with seperation of concerns: 
https://tkdodo.eu/blog/mastering-mutations-in-react-query#some-callbacks-might-not-fire
![Screenshot 2024-11-27 at 10 24 04 AM](https://github.com/user-attachments/assets/5dde1335-a27b-483e-a46e-bb73d384139d)


Overall, `useMutation` _should_ be designed with 2 considerations:
1️⃣ When initially creating a `mutation`,  handle all data / cache related callbacks here
2️⃣ When calling the `mutation` in a UX component, handle the UX updates (eg: re-routing, toasts) there


<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Related to https://github.com/PrefectHQ/prefect/issues/15512

