### PR TITLE
[UI v2] Move delete variable mutation to variable hooks module

### DIFF
--- a/ui-v2/src/components/variables/data-table/cells.tsx
+++ b/ui-v2/src/components/variables/data-table/cells.tsx
@@ -7,8 +7,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { MoreVerticalIcon } from "lucide-react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { getQueryService } from "@/api/service";
 import type { CellContext } from "@tanstack/react-table";
 import type { components } from "@/api/prefect";
 import { useToast } from "@/hooks/use-toast";
@@ -20,6 +18,7 @@ import {
 } from "@/components/ui/hover-card";
 import { useRef } from "react";
 import { useIsOverflowing } from "@/hooks/use-is-overflowing";
+import { useDeleteVariable } from "@/hooks/variables";
 
 type ActionsCellProps = CellContext<
 	components["schemas"]["Variable"],
@@ -30,25 +29,8 @@ type ActionsCellProps = CellContext<
 
 export const ActionsCell = ({ row, onVariableEdit }: ActionsCellProps) => {
 	const id = row.original.id;
-	const queryClient = useQueryClient();
-	const { mutate: deleteVariable } = useMutation({
-		mutationKey: ["delete-variable"],
-		mutationFn: async (id: string) =>
-			await getQueryService().DELETE("/variables/{id}", {
-				params: { path: { id } },
-			}),
-		onSettled: async () => {
-			return await Promise.all([
-				queryClient.invalidateQueries({
-					predicate: (query) => query.queryKey[0] === "variables",
-				}),
-				queryClient.invalidateQueries({
-					queryKey: ["total-variable-count"],
-				}),
-			]);
-		},
-	});
 	const { toast } = useToast();
+	const { deleteVariable } = useDeleteVariable();
 	if (!id) return null;
 
 	const onVariableDelete = () => {

--- a/ui-v2/src/hooks/variables.ts
+++ b/ui-v2/src/hooks/variables.ts
@@ -287,9 +287,9 @@ export const useUpdateVariable = () => {
 
 /**
  * Hook for deleting a variable
- * 
+ *
  * @returns Mutation object for deleting a variable with loading/error states and trigger function
- * 
+ *
  * @example
  * ```ts
  * const { deleteVariable } = useDeleteVariable({
@@ -300,7 +300,7 @@ export const useUpdateVariable = () => {
  *     console.error('Failed to delete variable:', error);
  *   }
  * });
- * 
+ *
  * // Delete a variable by ID
  * deleteVariable('variable-id-to-delete');
  * ```

--- a/ui-v2/src/hooks/variables.ts
+++ b/ui-v2/src/hooks/variables.ts
@@ -314,11 +314,9 @@ export const useDeleteVariable = () => {
 				params: { path: { id } },
 			}),
 		onSettled: async () => {
-			return await Promise.all([
-				queryClient.invalidateQueries({
-					queryKey: variableKeys.all,
-				}),
-			]);
+			return await queryClient.invalidateQueries({
+				queryKey: variableKeys.all,
+			});
 		},
 	});
 

--- a/ui-v2/src/hooks/variables.ts
+++ b/ui-v2/src/hooks/variables.ts
@@ -284,3 +284,43 @@ export const useUpdateVariable = () => {
 
 	return { updateVariable, ...rest };
 };
+
+/**
+ * Hook for deleting a variable
+ * 
+ * @returns Mutation object for deleting a variable with loading/error states and trigger function
+ * 
+ * @example
+ * ```ts
+ * const { deleteVariable } = useDeleteVariable({
+ *   onSuccess: () => {
+ *     // Handle successful deletion
+ *   },
+ *   onError: (error) => {
+ *     console.error('Failed to delete variable:', error);
+ *   }
+ * });
+ * 
+ * // Delete a variable by ID
+ * deleteVariable('variable-id-to-delete');
+ * ```
+ */
+export const useDeleteVariable = () => {
+	const queryClient = useQueryClient();
+
+	const { mutate: deleteVariable, ...rest } = useMutation({
+		mutationFn: async (id: string) =>
+			await getQueryService().DELETE("/variables/{id}", {
+				params: { path: { id } },
+			}),
+		onSettled: async () => {
+			return await Promise.all([
+				queryClient.invalidateQueries({
+					queryKey: variableKeys.all,
+				}),
+			]);
+		},
+	});
+
+	return { deleteVariable, ...rest };
+};


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
As noted by @devinvillarosa  in https://github.com/PrefectHQ/prefect/pull/16140, the delete variable mutation should be located in the variables hooks module to take advantage of the centralized query key factory and increase reusability. This PR does that.

Related to #15512 
