### PR TITLE
[UI v2] feat: Introducing declarative useSet custom hook and replacing selected tags state for this hook

### DIFF
--- a/ui-v2/src/components/flows/data-table.tsx
+++ b/ui-v2/src/components/flows/data-table.tsx
@@ -17,6 +17,7 @@ import {
 import { ChevronDownIcon, SearchIcon } from "lucide-react";
 import { useState } from "react";
 import { columns } from "./columns";
+import { useSet } from "@/hooks/use-set";
 
 const SearchComponent = () => {
 	const navigate = useNavigate();
@@ -41,19 +42,13 @@ const SearchComponent = () => {
 	);
 };
 const FilterComponent = () => {
-	const [selectedTags, setSelectedTags] = useState<string[]>([]);
+	const [selectedTags, selectedTagsUtils] = useSet<string>();
 	const [open, setOpen] = useState(false);
 
-	const toggleTag = (tag: string) => {
-		setSelectedTags((prev) =>
-			prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
-		);
-	};
-
 	const renderSelectedTags = () => {
-		if (selectedTags.length === 0) return "All tags";
-		if (selectedTags.length === 1) return selectedTags[0];
-		return `${selectedTags[0]}, ${selectedTags[1]}${selectedTags.length > 2 ? "..." : ""}`;
+		if (selectedTags.size === 0) return "All tags";
+		if (selectedTags.size === 1) return Array.from(selectedTags)[0];
+		return `${Array.from(selectedTags)[0]}, ${Array.from(selectedTags)[1]}${selectedTags.size > 2 ? "..." : ""}`;
 	};
 
 	return (
@@ -68,12 +63,12 @@ const FilterComponent = () => {
 				<DropdownMenuItem
 					onSelect={(e) => {
 						e.preventDefault();
-						toggleTag("Tag 1");
+						selectedTagsUtils.toggle("Tag 1");
 					}}
 				>
 					<input
 						type="checkbox"
-						checked={selectedTags.includes("Tag 1")}
+						checked={selectedTags.has("Tag 1")}
 						readOnly
 						className="mr-2"
 					/>
@@ -82,12 +77,12 @@ const FilterComponent = () => {
 				<DropdownMenuItem
 					onSelect={(e) => {
 						e.preventDefault();
-						toggleTag("Tag 2");
+						selectedTagsUtils.toggle("Tag 2");
 					}}
 				>
 					<input
 						type="checkbox"
-						checked={selectedTags.includes("Tag 2")}
+						checked={selectedTags.has("Tag 2")}
 						readOnly
 						className="mr-2"
 					/>
@@ -96,12 +91,12 @@ const FilterComponent = () => {
 				<DropdownMenuItem
 					onSelect={(e) => {
 						e.preventDefault();
-						toggleTag("Tag 3");
+						selectedTagsUtils.toggle("Tag 3");
 					}}
 				>
 					<input
 						type="checkbox"
-						checked={selectedTags.includes("Tag 3")}
+						checked={selectedTags.has("Tag 3")}
 						readOnly
 						className="mr-2"
 					/>

--- a/ui-v2/src/hooks/use-set.test.ts
+++ b/ui-v2/src/hooks/use-set.test.ts
@@ -1,0 +1,101 @@
+import { act, renderHook } from "@testing-library/react";
+import { useSet } from "./use-set";
+
+import { describe, it, expect } from "vitest";
+
+describe("useSet", () => {
+	it("add() to set", () => {
+		// Setup
+		const { result } = renderHook(useSet<string>);
+
+		// Update State
+		const [, util] = result.current;
+		act(() => util.add("a"));
+
+		// Get Updated State
+		const [set] = result.current;
+
+		// Asserts
+		expect(set.has("a")).toEqual(true);
+		expect(Array.from(set)).toEqual(["a"]);
+	});
+
+	it("remove() from set", () => {
+		// Setup
+		const { result } = renderHook(() => useSet(new Set(["a"])));
+
+		// Update State
+		const [, util] = result.current;
+		act(() => util.remove("a"));
+
+		// Get Updated State
+		const [set] = result.current;
+
+		// Asserts
+		expect(set.has("a")).toEqual(false);
+		expect(Array.from(set)).toEqual([]);
+	});
+
+	it("toggle() value from set -- value exists", () => {
+		// Setup
+		const { result } = renderHook(() => useSet(new Set(["a"])));
+
+		// Update State
+		const [, util] = result.current;
+		act(() => util.toggle("a"));
+
+		// Get Updated State
+		const [set] = result.current;
+
+		// Asserts
+		expect(set.has("a")).toEqual(false);
+		expect(Array.from(set)).toEqual([]);
+	});
+
+	it("toggle() value from set -- value does not exist", () => {
+		// Setup
+		const { result } = renderHook(useSet<string>);
+
+		// Update State
+		const [, util] = result.current;
+		act(() => util.toggle("a"));
+
+		// Get Updated State
+		const [set] = result.current;
+
+		// Asserts
+		expect(set.has("a")).toEqual(true);
+		expect(Array.from(set)).toEqual(["a"]);
+	});
+
+	it("clear() values from set ", () => {
+		// Setup
+		const { result } = renderHook(() => useSet(new Set(["a", "b", "c"])));
+
+		// Update State
+		const [, util] = result.current;
+		act(() => util.clear());
+
+		// Get Updated State
+		const [set] = result.current;
+
+		// Asserts
+		expect(Array.from(set)).toEqual([]);
+	});
+
+	it("reset() values to set", () => {
+		// Setup
+		const { result } = renderHook(() => useSet(new Set(["a", "b", "c"])));
+
+		// Update State
+		const [, util] = result.current;
+		act(() => util.clear());
+		act(() => util.reset());
+
+		// Get Updated State
+		const [set] = result.current;
+
+		// Asserts
+		expect(Array.from(set)).toEqual(["a", "b", "c"]);
+	});
+});

--- a/ui-v2/src/hooks/use-set.ts
+++ b/ui-v2/src/hooks/use-set.ts
@@ -1,0 +1,65 @@
+import { useCallback, useMemo, useState } from "react";
+
+type StableActions<K> = {
+	add: (key: K) => void;
+	remove: (key: K) => void;
+	toggle: (key: K) => void;
+	reset: () => void;
+	clear: () => void;
+};
+
+type Actions<K> = StableActions<K> & {
+	has: (key: K) => boolean;
+};
+
+/**
+ * A hook that is used to declarative to keep state of a 'Set' type of data structure.
+ * This is useful in cases where the UX needs to keep track of selected rows by id
+ *
+ * @param initialSet Initial state of a Set
+ * @returns a Set object and utils as a tuple
+ *
+ * @example
+ * ```tsx
+ * function FlowCheckboxList() {
+ *   const [selectedIDs, { has, toggle }] = useSet<string>();
+ *
+ *   return flows.map((flow) =>
+ * 		<Checkbox
+ * 			key={flow.id}
+ * 			checked={has(flow.id)}
+ * 			onCheck={() => toggle(flow.id)}
+ * 			label={flow.name} />
+ *
+ * }
+ * ```
+ */
+export const useSet = <K>(initialSet = new Set<K>()): [Set<K>, Actions<K>] => {
+	const [set, setSet] = useState(initialSet);
+
+	const stableActions = useMemo(() => {
+		const add = (item: K) =>
+			setSet((curr) => new Set([...Array.from(curr), item]));
+		const remove = (item: K) =>
+			setSet(
+				(curr) => new Set([...Array.from(curr).filter((i) => i !== item)]),
+			);
+		const toggle = (item: K) =>
+			setSet((curr) =>
+				curr.has(item)
+					? new Set(Array.from(curr).filter((i) => i !== item))
+					: new Set([...Array.from(curr), item]),
+			);
+		const reset = () => setSet(initialSet);
+		const clear = () => setSet(new Set());
+
+		return { add, remove, toggle, clear, reset };
+	}, [initialSet]);
+
+	const utils = {
+		has: useCallback((item) => set.has(item), [set]),
+		...stableActions,
+	} as Actions<K>;
+
+	return [set, utils];
+};


### PR DESCRIPTION
What does this PR do and why?
------------------------
1. Adds a custom hook `useSet`. This custom hook is a declarative way of keeping state for "selected" types. Most likely in the app we will need to keep state of selected IDs for a list. This hook can be used for convenience and uniqueness for the selected items in a declarative way.
2. Adds an example test on how to test hooks only using `renderHook`. I haven't seen an example of this in the codebase yet
3. Attempts to replace the imperative way of keeping track of selected tags from `useState` to `useSet` as en example.
⚠️ I haven't been able to run this locally, and cannot validate if this replacement works. I can revert this change if needed


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.

Related to https://github.com/PrefectHQ/prefect/issues/15512

