### PR TITLE
Fix setting task states with duplicate timestamps

### DIFF
--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -427,6 +427,11 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
 
         self.task_run.state = new_state = state
 
+        if last_state.timestamp == new_state.timestamp:
+            # Ensure that the state timestamp is unique, or at least not equal to the last state.
+            # This might occur especially on Windows where the timestamp resolution is limited.
+            new_state.timestamp += pendulum.duration(microseconds=1)
+
         # Ensure that the state_details are populated with the current run IDs
         new_state.state_details.task_run_id = self.task_run.id
         new_state.state_details.flow_run_id = self.task_run.flow_run_id
@@ -941,6 +946,11 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
             raise ValueError("Task run is not set")
 
         self.task_run.state = new_state = state
+
+        if last_state.timestamp == new_state.timestamp:
+            # Ensure that the state timestamp is unique, or at least not equal to the last state.
+            # This might occur especially on Windows where the timestamp resolution is limited.
+            new_state.timestamp += pendulum.duration(microseconds=1)
 
         # Ensure that the state_details are populated with the current run IDs
         new_state.state_details.task_run_id = self.task_run.id

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from pathlib import Path
 from typing import List, Optional
 from unittest import mock
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, MagicMock, call, patch
 from uuid import UUID, uuid4
 
 import anyio
@@ -38,7 +38,7 @@ from prefect.settings import (
     PREFECT_TASK_DEFAULT_RETRIES,
     temporary_settings,
 )
-from prefect.states import Running, State
+from prefect.states import Completed, Running, State
 from prefect.task_engine import (
     AsyncTaskRunEngine,
     SyncTaskRunEngine,
@@ -78,6 +78,32 @@ class TestSyncTaskRunEngine:
         with pytest.raises(RuntimeError, match="not started"):
             engine.client
 
+    async def test_set_task_run_state(self):
+        engine = SyncTaskRunEngine(task=foo)
+        with engine.initialize_run():
+            running_state = Running()
+
+            new_state = engine.set_state(running_state)
+            assert new_state == running_state
+
+            completed_state = Completed()
+            new_state = engine.set_state(completed_state)
+            assert new_state == completed_state
+
+    async def test_set_task_run_state_duplicated_timestamp(self):
+        engine = SyncTaskRunEngine(task=foo)
+        with engine.initialize_run():
+            running_state = Running()
+            completed_state = Completed()
+            completed_state.timestamp = running_state.timestamp
+
+            new_state = engine.set_state(running_state)
+            assert new_state == running_state
+
+            new_state = engine.set_state(completed_state)
+            assert new_state == completed_state
+            assert new_state.timestamp > running_state.timestamp
+
 
 class TestAsyncTaskRunEngine:
     async def test_basic_init(self):
@@ -99,6 +125,32 @@ class TestAsyncTaskRunEngine:
 
         with pytest.raises(RuntimeError, match="not started"):
             engine.client
+
+    async def test_set_task_run_state(self):
+        engine = AsyncTaskRunEngine(task=foo)
+        async with engine.initialize_run():
+            running_state = Running()
+
+            new_state = await engine.set_state(running_state)
+            assert new_state == running_state
+
+            completed_state = Completed()
+            new_state = await engine.set_state(completed_state)
+            assert new_state == completed_state
+
+    async def test_set_task_run_state_duplicated_timestamp(self):
+        engine = AsyncTaskRunEngine(task=foo)
+        async with engine.initialize_run():
+            running_state = Running()
+            completed_state = Completed()
+            completed_state.timestamp = running_state.timestamp
+
+            new_state = await engine.set_state(running_state)
+            assert new_state == running_state
+
+            new_state = await engine.set_state(completed_state)
+            assert new_state == completed_state
+            assert new_state.timestamp > running_state.timestamp
 
 
 class TestRunTask:
@@ -519,6 +571,56 @@ class TestTaskRunsAsync:
         assert one == 42
         assert two == 42
 
+    async def test_task_run_states(
+        self,
+        prefect_client,
+        events_pipeline,
+    ):
+        @task
+        async def foo():
+            return TaskRunContext.get().task_run.id
+
+        task_run_id = await run_task_async(foo)
+        await events_pipeline.process_events()
+        states = await prefect_client.read_task_run_states(task_run_id)
+
+        state_names = [state.name for state in states]
+        assert state_names == [
+            "Pending",
+            "Running",
+            "Completed",
+        ]
+
+    async def test_task_run_states_with_equal_timestamps(
+        self,
+        prefect_client,
+        events_pipeline,
+    ):
+        @task
+        async def foo():
+            return TaskRunContext.get().task_run.id
+
+        original_set_state = AsyncTaskRunEngine.set_state
+
+        async def alter_new_state_timestamp(engine, state, force=False):
+            """Give the new state the same timestamp as the current state."""
+            state.timestamp = engine.task_run.state.timestamp
+            return await original_set_state(engine, state, force=force)
+
+        with patch.object(AsyncTaskRunEngine, "set_state", alter_new_state_timestamp):
+            task_run_id = await run_task_async(foo)
+
+            await events_pipeline.process_events()
+            states = await prefect_client.read_task_run_states(task_run_id)
+
+            state_names = [state.name for state in states]
+            assert state_names == [
+                "Pending",
+                "Running",
+                "Completed",
+            ]
+            assert states[0].timestamp < states[1].timestamp < states[2].timestamp
+
 
 class TestTaskRunsSync:
     def test_basic(self):
@@ -728,6 +830,56 @@ class TestTaskRunsSync:
 
         assert one == 42
         assert two == 42
+
+    async def test_task_run_states(
+        self,
+        prefect_client,
+        events_pipeline,
+    ):
+        @task
+        def foo():
+            return TaskRunContext.get().task_run.id
+
+        task_run_id = run_task_sync(foo)
+        await events_pipeline.process_events()
+        states = await prefect_client.read_task_run_states(task_run_id)
+
+        state_names = [state.name for state in states]
+        assert state_names == [
+            "Pending",
+            "Running",
+            "Completed",
+        ]
+
+    async def test_task_run_states_with_equal_timestamps(
+        self,
+        prefect_client,
+        events_pipeline,
+    ):
+        @task
+        def foo():
+            return TaskRunContext.get().task_run.id
+
+        original_set_state = SyncTaskRunEngine.set_state
+
+        def alter_new_state_timestamp(engine, state, force=False):
+            """Give the new state the same timestamp as the current state."""
+            state.timestamp = engine.task_run.state.timestamp
+            return original_set_state(engine, state, force=force)
+
+        with patch.object(SyncTaskRunEngine, "set_state", alter_new_state_timestamp):
+            task_run_id = run_task_sync(foo)
+
+            await events_pipeline.process_events()
+            states = await prefect_client.read_task_run_states(task_run_id)
+
+            state_names = [state.name for state in states]
+            assert state_names == [
+                "Pending",
+                "Running",
+                "Completed",
+            ]
+            assert states[0].timestamp < states[1].timestamp < states[2].timestamp
 
 
 class TestReturnState:


### PR DESCRIPTION
closes #16100 , related to #15607 and for some users in #15153.

This PR tries to fix an issue on Windows machines where setting task state from Pending to Running by TaskEngine causes the Running state to be ignored due to the same timestamp. This issue also created infinite loop on Prefect Server resulted from "duplicate key constrain violation" prior to v3.1.4. For the latest version it only causes the task to remain in Pending state until new state is set.

More information is in #16100, but the main issue i see in Windows having resolution of ~15ms for timestamps.

Solution:
Adding check to TaskEngine.set_status for the duplicit timestamp and adding 1us if is equal. I do not like that solution but it should not affect Linux clients, and for Windows clients there is probably no easy way to determine the precise time (easy as this one)

