### PR TITLE
Correct Flow import in schedule tutorial

### DIFF
--- a/docs/v3/tutorials/schedule.mdx
+++ b/docs/v3/tutorials/schedule.mdx
@@ -72,13 +72,13 @@ To set a flow to run on a schedule, you need to create a deployment.
 1. Create a deployment in code:
 
    ```python create_deployment.py
-   from prefect import flow
+   from prefect import Flow
 
    # Source for the code to deploy (here, a GitHub repo)
    SOURCE_REPO="https://github.com/prefecthq/demos.git"
 
    if __name__ == "__main__":
-       flow.from_source(
+       Flow.from_source(
            source=SOURCE_REPO,
            entrypoint="my_gh_workflow.py:repo_info", # Specific flow to run
        ).deploy(


### PR DESCRIPTION
`prefect.flow()` is a function, `prefect.Flow` is a class with a `from_source` class method. The tutorial uses the latter, not the former.

