### PR TITLE
fix ssl verify and update tests

### DIFF
--- a/.github/workflows/markdown-tests.yaml
+++ b/.github/workflows/markdown-tests.yaml
@@ -4,6 +4,7 @@ env:
   # enable colored output
   # https://github.com/pytest-dev/pytest/issues/7443
   PY_COLORS: 1
+  UV_SYSTEM_PYTHON: 1
 
 on:
   workflow_dispatch:
@@ -93,9 +94,9 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install -U uv
-          uv pip install --upgrade --system -e '.[dev]'
-          uv pip install --upgrade --system -r requirements-markdown-tests.txt
-          uv pip uninstall --system pytest-benchmark
+          uv pip install --upgrade -r requirements-markdown-tests.txt
+          uv pip install --upgrade -e '.[dev]'
+          uv pip uninstall pytest-benchmark
 
       - name: Start server
         run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,7 +25,7 @@ vale
 vermin
 virtualenv
 watchfiles
-respx
+respx@git+https://github.com/ndhansen/respx.git
 
 # type stubs
 types-cachetools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,8 +25,7 @@ vale
 vermin
 virtualenv
 watchfiles
-# TODO: go back to `respx` once fix is released
-respx@git+https://github.com/ndhansen/respx.git
+respx
 
 # type stubs
 types-cachetools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,6 +25,7 @@ vale
 vermin
 virtualenv
 watchfiles
+# TODO: go back to `respx` once fix is released
 respx@git+https://github.com/ndhansen/respx.git
 
 # type stubs

--- a/scripts/run-integration-flows.py
+++ b/scripts/run-integration-flows.py
@@ -15,7 +15,6 @@ Example:
 
 import subprocess
 import sys
-from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 from typing import Union
 
@@ -38,20 +37,18 @@ def run_script(script_path: str):
 
 
 def run_flows(search_path: Union[str, Path]):
-    count = 0
     print(f"Running integration tests with client version: {__version__}")
     scripts = sorted(Path(search_path).glob("**/*.py"))
-    with ProcessPoolExecutor(max_workers=4) as executor:
-        results = list(executor.map(run_script, scripts))
+    errors = []
+    for script in scripts:
+        print(f"Running {script}")
+        try:
+            run_script(str(script))
+        except Exception as e:
+            print(f"Error running {script}: {e}")
+            errors.append(e)
 
-    for script, (stdout, stderr, error) in zip(scripts, results):
-        print(f" {script.relative_to(search_path)} ".center(90, "-"), flush=True)
-        print(stdout)
-        print(stderr)
-        if error:
-            raise error
-        print("".center(90, "-") + "\n", flush=True)
-        count += 1
+    assert not errors, "Errors occurred while running flows"
 
 
 if __name__ == "__main__":

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+import ssl
 import warnings
 from contextlib import AsyncExitStack
 from typing import (
@@ -283,12 +284,18 @@ class PrefectClient:
         httpx_settings.setdefault("headers", {})
 
         if PREFECT_API_TLS_INSECURE_SKIP_VERIFY:
-            httpx_settings.setdefault("verify", False)
+            # Create an unverified context for insecure connections
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            httpx_settings.setdefault("verify", ctx)
         else:
             cert_file = PREFECT_API_SSL_CERT_FILE.value()
             if not cert_file:
                 cert_file = certifi.where()
-            httpx_settings.setdefault("verify", cert_file)
+            # Create a verified context with the certificate file
+            ctx = ssl.create_default_context(cafile=cert_file)
+            httpx_settings.setdefault("verify", ctx)
 
         if api_version is None:
             api_version = SERVER_API_VERSION
@@ -3541,12 +3548,18 @@ class SyncPrefectClient:
         httpx_settings.setdefault("headers", {})
 
         if PREFECT_API_TLS_INSECURE_SKIP_VERIFY:
-            httpx_settings.setdefault("verify", False)
+            # Create an unverified context for insecure connections
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            httpx_settings.setdefault("verify", ctx)
         else:
             cert_file = PREFECT_API_SSL_CERT_FILE.value()
             if not cert_file:
                 cert_file = certifi.where()
-            httpx_settings.setdefault("verify", cert_file)
+            # Create a verified context with the certificate file
+            ctx = ssl.create_default_context(cafile=cert_file)
+            httpx_settings.setdefault("verify", ctx)
 
         if api_version is None:
             api_version = SERVER_API_VERSION

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -702,23 +702,23 @@ class FlowRunNotificationPolicyCreate(ActionBaseModel):
 class FlowRunNotificationPolicyUpdate(ActionBaseModel):
     """Data used by the Prefect REST API to update a flow run notification policy."""
 
-    is_active: Optional[bool] = Field(None)
-    state_names: Optional[List[str]] = Field(None)
-    tags: Optional[List[str]] = Field(None)
-    block_document_id: Optional[UUID] = Field(None)
-    message_template: Optional[str] = Field(None)
+    is_active: Optional[bool] = Field(default=None)
+    state_names: Optional[List[str]] = Field(default=None)
+    tags: Optional[List[str]] = Field(default=None)
+    block_document_id: Optional[UUID] = Field(default=None)
+    message_template: Optional[str] = Field(default=None)
 
 
 class ArtifactCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create an artifact."""
 
-    key: Optional[str] = Field(None)
-    type: Optional[str] = Field(None)
-    description: Optional[str] = Field(None)
-    data: Optional[Union[Dict[str, Any], Any]] = Field(None)
-    metadata_: Optional[Dict[str, str]] = Field(None)
-    flow_run_id: Optional[UUID] = Field(None)
-    task_run_id: Optional[UUID] = Field(None)
+    key: Optional[str] = Field(default=None)
+    type: Optional[str] = Field(default=None)
+    description: Optional[str] = Field(default=None)
+    data: Optional[Union[Dict[str, Any], Any]] = Field(default=None)
+    metadata_: Optional[Dict[str, str]] = Field(default=None)
+    flow_run_id: Optional[UUID] = Field(default=None)
+    task_run_id: Optional[UUID] = Field(default=None)
 
     _validate_artifact_format = field_validator("key")(validate_artifact_key)
 

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -637,8 +637,9 @@ class BaseWorker(abc.ABC):
         await self._exit_stack.enter_async_context(self._runs_task_group)
 
         if self._client.server_type == ServerType.CLOUD:
-            self._cloud_client = get_cloud_client()
-            await self._exit_stack.enter_async_context(self._cloud_client)
+            self._cloud_client = await self._exit_stack.enter_async_context(
+                get_cloud_client()
+            )
 
         self.is_setup = True
 

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -546,9 +546,8 @@ class TestTwilioSMS:
 
 class TestCustomWebhook:
     async def test_notify_async(self):
-        with respx.mock as xmock:
+        with respx.mock(using="httpx") as xmock:
             xmock.post("https://example.com/")
-            xmock.route(host="localhost").pass_through()
 
             custom_block = CustomWebhookNotificationBlock(
                 name="test name",
@@ -562,16 +561,15 @@ class TestCustomWebhook:
             assert last_req.headers["user-agent"] == "Prefect Notifications"
             assert (
                 last_req.content
-                == b'{"msg": "subject\\ntest", "token": "someSecretToken"}'
+                == b'{"msg":"subject\\ntest","token":"someSecretToken"}'
             )
             assert last_req.extensions == {
                 "timeout": {"connect": 10, "pool": 10, "read": 10, "write": 10}
             }
 
     def test_notify_sync(self):
-        with respx.mock as xmock:
+        with respx.mock(using="httpx") as xmock:
             xmock.post("https://example.com/")
-            xmock.route(host="localhost").pass_through()
 
             custom_block = CustomWebhookNotificationBlock(
                 name="test name",
@@ -586,14 +584,14 @@ class TestCustomWebhook:
             assert last_req.headers["user-agent"] == "Prefect Notifications"
             assert (
                 last_req.content
-                == b'{"msg": "subject\\ntest", "token": "someSecretToken"}'
+                == b'{"msg":"subject\\ntest","token":"someSecretToken"}'
             )
             assert last_req.extensions == {
                 "timeout": {"connect": 10, "pool": 10, "read": 10, "write": 10}
             }
 
     async def test_user_agent_override(self):
-        with respx.mock as xmock:
+        with respx.mock(using="httpx") as xmock:
             xmock.post("https://example.com/")
 
             custom_block = CustomWebhookNotificationBlock(
@@ -609,14 +607,14 @@ class TestCustomWebhook:
             assert last_req.headers["user-agent"] == "CustomUA"
             assert (
                 last_req.content
-                == b'{"msg": "subject\\ntest", "token": "someSecretToken"}'
+                == b'{"msg":"subject\\ntest","token":"someSecretToken"}'
             )
             assert last_req.extensions == {
                 "timeout": {"connect": 10, "pool": 10, "read": 10, "write": 10}
             }
 
     async def test_timeout_override(self):
-        with respx.mock as xmock:
+        with respx.mock(using="httpx") as xmock:
             xmock.post("https://example.com/")
 
             custom_block = CustomWebhookNotificationBlock(
@@ -631,14 +629,14 @@ class TestCustomWebhook:
             last_req = xmock.calls.last.request
             assert (
                 last_req.content
-                == b'{"msg": "subject\\ntest", "token": "someSecretToken"}'
+                == b'{"msg":"subject\\ntest","token":"someSecretToken"}'
             )
             assert last_req.extensions == {
                 "timeout": {"connect": 30, "pool": 30, "read": 30, "write": 30}
             }
 
     async def test_request_cookie(self):
-        with respx.mock as xmock:
+        with respx.mock(using="httpx") as xmock:
             xmock.post("https://example.com/")
 
             custom_block = CustomWebhookNotificationBlock(
@@ -655,14 +653,14 @@ class TestCustomWebhook:
             assert last_req.headers["cookie"] == "key=secretCookieValue"
             assert (
                 last_req.content
-                == b'{"msg": "subject\\ntest", "token": "someSecretToken"}'
+                == b'{"msg":"subject\\ntest","token":"someSecretToken"}'
             )
             assert last_req.extensions == {
                 "timeout": {"connect": 30, "pool": 30, "read": 30, "write": 30}
             }
 
     async def test_subst_nested_list(self):
-        with respx.mock as xmock:
+        with respx.mock(using="httpx")(using="httpx") as xmock:
             xmock.post("https://example.com/")
 
             custom_block = CustomWebhookNotificationBlock(
@@ -679,14 +677,14 @@ class TestCustomWebhook:
             assert last_req.headers["user-agent"] == "Prefect Notifications"
             assert (
                 last_req.content
-                == b'{"data": {"sub1": [{"in-list": "test", "name": "test name"}]}}'
+                == b'{"data":{"sub1":[{"in-list":"test","name":"test name"}]}}'
             )
             assert last_req.extensions == {
                 "timeout": {"connect": 10, "pool": 10, "read": 10, "write": 10}
             }
 
     async def test_subst_none(self):
-        with respx.mock as xmock:
+        with respx.mock(using="httpx") as xmock:
             xmock.post("https://example.com/")
 
             custom_block = CustomWebhookNotificationBlock(
@@ -701,8 +699,7 @@ class TestCustomWebhook:
             last_req = xmock.calls.last.request
             assert last_req.headers["user-agent"] == "Prefect Notifications"
             assert (
-                last_req.content
-                == b'{"msg": "null\\ntest", "token": "someSecretToken"}'
+                last_req.content == b'{"msg":"null\\ntest","token":"someSecretToken"}'
             )
             assert last_req.extensions == {
                 "timeout": {"connect": 10, "pool": 10, "read": 10, "write": 10}

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -81,8 +81,8 @@ class TestChangingProfileAndCheckingServerConnection:
     def authorized_cloud(self):
         # attempts to reach the Cloud 2 workspaces endpoint implies a good connection
         # to Prefect Cloud as opposed to a hosted Prefect server instance
-        with respx.mock:
-            authorized = respx.get(
+        with respx.mock(using="httpx") as respx_mock:
+            authorized = respx_mock.get(
                 "https://mock-cloud.prefect.io/api/me/workspaces",
             ).mock(return_value=Response(200, json=[]))
 
@@ -91,8 +91,8 @@ class TestChangingProfileAndCheckingServerConnection:
     @pytest.fixture
     def unauthorized_cloud(self):
         # requests to cloud with an invalid key will result in a 401 response
-        with respx.mock:
-            unauthorized = respx.get(
+        with respx.mock(using="httpx") as respx_mock:
+            unauthorized = respx_mock.get(
                 "https://mock-cloud.prefect.io/api/me/workspaces",
             ).mock(return_value=Response(401, json={}))
 
@@ -101,8 +101,8 @@ class TestChangingProfileAndCheckingServerConnection:
     @pytest.fixture
     def unhealthy_cloud(self):
         # Cloud may respond with a 500 error when having connection issues
-        with respx.mock:
-            unhealthy_cloud = respx.get(
+        with respx.mock(using="httpx") as respx_mock:
+            unhealthy_cloud = respx_mock.get(
                 "https://mock-cloud.prefect.io/api/me/workspaces",
             ).mock(return_value=Response(500, json={}))
 
@@ -111,8 +111,8 @@ class TestChangingProfileAndCheckingServerConnection:
     @pytest.fixture
     def hosted_server_has_no_cloud_api(self):
         # if the API URL points to a hosted Prefect server instance, no Cloud API will be found
-        with respx.mock:
-            hosted = respx.get(
+        with respx.mock(using="httpx") as respx_mock:
+            hosted = respx_mock.get(
                 "https://hosted-server.prefect.io/api/me/workspaces",
             ).mock(return_value=Response(404, json={}))
 
@@ -120,8 +120,8 @@ class TestChangingProfileAndCheckingServerConnection:
 
     @pytest.fixture
     def healthy_hosted_server(self):
-        with respx.mock:
-            hosted = respx.get(
+        with respx.mock(using="httpx") as respx_mock:
+            hosted = respx_mock.get(
                 "https://hosted-server.prefect.io/api/health",
             ).mock(return_value=Response(200, json={}))
 
@@ -132,8 +132,8 @@ class TestChangingProfileAndCheckingServerConnection:
 
     @pytest.fixture
     def unhealthy_hosted_server(self):
-        with respx.mock:
-            badly_hosted = respx.get(
+        with respx.mock(using="httpx") as respx_mock:
+            badly_hosted = respx_mock.get(
                 "https://hosted-server.prefect.io/api/health",
             ).mock(side_effect=self.connection_error)
 

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -62,7 +62,7 @@ async def kubernetes_work_pool(prefect_client: PrefectClient):
     )
 
     with respx.mock(
-        assert_all_mocked=False, base_url=PREFECT_API_URL.value()
+        assert_all_mocked=False, base_url=PREFECT_API_URL.value(), using="httpx"
     ) as respx_mock:
         respx_mock.get("/csrf-token", params={"client": ANY}).pass_through()
         respx_mock.route(path__startswith="/work_pools/").pass_through()

--- a/tests/client/test_cloud_client.py
+++ b/tests/client/test_cloud_client.py
@@ -83,7 +83,7 @@ async def test_get_cloud_work_pool_types():
         }
     ):
         with respx.mock(
-            assert_all_mocked=False, base_url=PREFECT_API_URL.value()
+            assert_all_mocked=False, base_url=PREFECT_API_URL.value(), using="httpx"
         ) as respx_mock:
             respx_mock.route(
                 M(
@@ -111,7 +111,7 @@ async def test_read_current_workspace():
 
     with temporary_settings(updates={PREFECT_API_URL: api_url}):
         with respx.mock(
-            assert_all_mocked=False, base_url=PREFECT_API_URL.value()
+            assert_all_mocked=False, base_url=PREFECT_API_URL.value(), using="httpx"
         ) as respx_mock:
             respx_mock.get("https://api.prefect.cloud/api/me/workspaces").mock(
                 return_value=httpx.Response(

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -2216,7 +2216,9 @@ class TestAutomations:
         )
 
     async def test_create_automation(self, cloud_client, automation: AutomationCore):
-        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+        with respx.mock(
+            base_url=PREFECT_CLOUD_API_URL.value(), using="httpx"
+        ) as router:
             created_automation = automation.model_dump(mode="json")
             created_automation["id"] = str(uuid4())
             create_route = router.post("/automations/").mock(
@@ -2232,7 +2234,9 @@ class TestAutomations:
             assert automation_id == UUID(created_automation["id"])
 
     async def test_read_automation(self, cloud_client, automation: AutomationCore):
-        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+        with respx.mock(
+            base_url=PREFECT_CLOUD_API_URL.value(), using="httpx"
+        ) as router:
             created_automation = automation.model_dump(mode="json")
             created_automation["id"] = str(uuid4())
 
@@ -2250,7 +2254,9 @@ class TestAutomations:
     async def test_read_automation_not_found(
         self, cloud_client, automation: AutomationCore
     ):
-        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+        with respx.mock(
+            base_url=PREFECT_CLOUD_API_URL.value(), using="httpx"
+        ) as router:
             created_automation = automation.model_dump(mode="json")
             created_automation["id"] = str(uuid4())
 
@@ -2268,7 +2274,9 @@ class TestAutomations:
     async def test_read_automations_by_name(
         self, cloud_client, automation: AutomationCore
     ):
-        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+        with respx.mock(
+            base_url=PREFECT_CLOUD_API_URL.value(), using="httpx"
+        ) as router:
             created_automation = automation.model_dump(mode="json")
             created_automation["id"] = str(uuid4())
             read_route = router.post("/automations/filter").mock(
@@ -2301,7 +2309,9 @@ class TestAutomations:
     async def test_read_automations_by_name_multiple_same_name(
         self, cloud_client, automation: AutomationCore, automation2: AutomationCore
     ):
-        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+        with respx.mock(
+            base_url=PREFECT_CLOUD_API_URL.value(), using="httpx"
+        ) as router:
             created_automation = automation.model_dump(mode="json")
             created_automation["id"] = str(uuid4())
 
@@ -2331,7 +2341,9 @@ class TestAutomations:
     async def test_read_automations_by_name_not_found(
         self, cloud_client, automation: AutomationCore
     ):
-        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+        with respx.mock(
+            base_url=PREFECT_CLOUD_API_URL.value(), using="httpx"
+        ) as router:
             created_automation = automation.model_dump(mode="json")
             created_automation["id"] = str(uuid4())
             created_automation["name"] = "nonexistent"
@@ -2348,7 +2360,9 @@ class TestAutomations:
             assert nonexistent_automation == []
 
     async def test_delete_owned_automations(self, cloud_client):
-        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+        with respx.mock(
+            base_url=PREFECT_CLOUD_API_URL.value(), using="httpx"
+        ) as router:
             resource_id = f"prefect.deployment.{uuid4()}"
             delete_route = router.delete(f"/automations/owned-by/{resource_id}").mock(
                 return_value=httpx.Response(204)

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -1,10 +1,11 @@
 import json
 import os
+import ssl
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import Generator, List
 from unittest import mock
-from unittest.mock import ANY, MagicMock, Mock
+from unittest.mock import MagicMock, Mock
 from uuid import UUID, uuid4
 
 import anyio
@@ -1446,15 +1447,14 @@ async def test_prefect_api_tls_insecure_skip_verify_setting_set_to_true(monkeypa
         )
         get_client()
 
-    mock.assert_called_once_with(
-        headers=ANY,
-        verify=False,
-        base_url=ANY,
-        limits=ANY,
-        http2=ANY,
-        timeout=ANY,
-        enable_csrf_support=ANY,
-    )
+    # Get the verify argument from the mock call
+    call_kwargs = mock.call_args[1]
+    verify_ctx = call_kwargs["verify"]
+
+    # Verify it's an SSL context with the correct insecure settings
+    assert isinstance(verify_ctx, ssl.SSLContext)
+    assert verify_ctx.verify_mode == ssl.CERT_NONE
+    assert verify_ctx.check_hostname is False
 
 
 async def test_prefect_api_tls_insecure_skip_verify_setting_set_to_false(monkeypatch):
@@ -1465,102 +1465,118 @@ async def test_prefect_api_tls_insecure_skip_verify_setting_set_to_false(monkeyp
         )
         get_client()
 
-    mock.assert_called_once_with(
-        headers=ANY,
-        verify=ANY,
-        base_url=ANY,
-        limits=ANY,
-        http2=ANY,
-        timeout=ANY,
-        enable_csrf_support=ANY,
-    )
+    # Get the verify argument from the mock call
+    call_kwargs = mock.call_args[1]
+    verify_ctx = call_kwargs["verify"]
+
+    # Verify it's an SSL context with secure settings
+    assert isinstance(verify_ctx, ssl.SSLContext)
+    assert verify_ctx.verify_mode == ssl.CERT_REQUIRED
+    assert verify_ctx.check_hostname is True
 
 
 async def test_prefect_api_tls_insecure_skip_verify_default_setting(monkeypatch):
     mock = Mock()
     monkeypatch.setattr("prefect.client.orchestration.PrefectHttpxAsyncClient", mock)
     get_client()
-    mock.assert_called_once_with(
-        headers=ANY,
-        verify=ANY,
-        base_url=ANY,
-        limits=ANY,
-        http2=ANY,
-        timeout=ANY,
-        enable_csrf_support=ANY,
-    )
+
+    # Get the verify argument from the mock call
+    call_kwargs = mock.call_args[1]
+    verify_ctx = call_kwargs["verify"]
+
+    # Verify it's an SSL context with secure settings (default)
+    assert isinstance(verify_ctx, ssl.SSLContext)
+    assert verify_ctx.verify_mode == ssl.CERT_REQUIRED
+    assert verify_ctx.check_hostname is True
 
 
 async def test_prefect_api_ssl_cert_file_setting_explicitly_set(monkeypatch):
+    cert_path = "my_cert.pem"
+
+    # Mock the SSL context creation
+    mock_context = Mock()
+    mock_create_default_context = Mock(return_value=mock_context)
+    monkeypatch.setattr("ssl.create_default_context", mock_create_default_context)
+
     with temporary_settings(
         updates={
             PREFECT_API_TLS_INSECURE_SKIP_VERIFY: False,
-            PREFECT_API_SSL_CERT_FILE: "my_cert.pem",
+            PREFECT_API_SSL_CERT_FILE: cert_path,
         }
     ):
-        mock = Mock()
+        mock_client = Mock()
         monkeypatch.setattr(
-            "prefect.client.orchestration.PrefectHttpxAsyncClient", mock
+            "prefect.client.orchestration.PrefectHttpxAsyncClient", mock_client
         )
         get_client()
 
-    mock.assert_called_once_with(
-        headers=ANY,
-        verify="my_cert.pem",
-        base_url=ANY,
-        limits=ANY,
-        http2=ANY,
-        timeout=ANY,
-        enable_csrf_support=ANY,
-    )
+    # Verify SSL context was created with correct cert file
+    mock_create_default_context.assert_called_once_with(cafile=cert_path)
+
+    # Get the verify argument from the mock call
+    call_kwargs = mock_client.call_args[1]
+    verify_ctx = call_kwargs["verify"]
+
+    # Verify the context was passed to the client
+    assert verify_ctx == mock_context
 
 
 async def test_prefect_api_ssl_cert_file_default_setting(monkeypatch):
     os.environ["SSL_CERT_FILE"] = "my_cert.pem"
 
+    # Mock the SSL context creation
+    mock_context = Mock()
+    mock_create_default_context = Mock(return_value=mock_context)
+    monkeypatch.setattr("ssl.create_default_context", mock_create_default_context)
+
     with temporary_settings(
         updates={PREFECT_API_TLS_INSECURE_SKIP_VERIFY: False},
         set_defaults={PREFECT_API_SSL_CERT_FILE: os.environ.get("SSL_CERT_FILE")},
     ):
-        mock = Mock()
+        mock_client = Mock()
         monkeypatch.setattr(
-            "prefect.client.orchestration.PrefectHttpxAsyncClient", mock
+            "prefect.client.orchestration.PrefectHttpxAsyncClient", mock_client
         )
         get_client()
 
-    mock.assert_called_once_with(
-        headers=ANY,
-        verify="my_cert.pem",
-        base_url=ANY,
-        limits=ANY,
-        http2=ANY,
-        timeout=ANY,
-        enable_csrf_support=ANY,
-    )
+    # Verify SSL context was created with correct cert file
+    mock_create_default_context.assert_called_once_with(cafile="my_cert.pem")
+
+    # Get the verify argument from the mock call
+    call_kwargs = mock_client.call_args[1]
+    verify_ctx = call_kwargs["verify"]
+
+    # Verify the context was passed to the client
+    assert verify_ctx == mock_context
 
 
 async def test_prefect_api_ssl_cert_file_default_setting_fallback(monkeypatch):
     os.environ["SSL_CERT_FILE"] = ""
 
+    # Mock the SSL context creation
+    mock_context = Mock()
+    mock_create_default_context = Mock(return_value=mock_context)
+    monkeypatch.setattr("ssl.create_default_context", mock_create_default_context)
+
     with temporary_settings(
         updates={PREFECT_API_TLS_INSECURE_SKIP_VERIFY: False},
         set_defaults={PREFECT_API_SSL_CERT_FILE: os.environ.get("SSL_CERT_FILE")},
     ):
-        mock = Mock()
+        mock_client = Mock()
         monkeypatch.setattr(
-            "prefect.client.orchestration.PrefectHttpxAsyncClient", mock
+            "prefect.client.orchestration.PrefectHttpxAsyncClient", mock_client
         )
         get_client()
 
-    mock.assert_called_once_with(
-        headers=ANY,
-        verify=certifi.where(),
-        base_url=ANY,
-        limits=ANY,
-        http2=ANY,
-        timeout=ANY,
-        enable_csrf_support=ANY,
-    )
+    # Verify SSL context was created with certifi's default cert
+    mock_create_default_context.assert_called_once_with(cafile=certifi.where())
+
+    # Get the verify argument from the mock call
+    call_kwargs = mock_client.call_args[1]
+    verify_ctx = call_kwargs["verify"]
+
+    # Verify the context was passed to the client
+    assert verify_ctx == mock_context
 
 
 class TestClientAPIVersionRequests:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -583,3 +583,13 @@ def leaves_no_extraneous_files():
             "One of the tests in this module left new files in the "
             f"working directory: {new_files}"
         )
+
+
+@pytest.fixture
+def respx_mock():
+    """
+    Temporary override of respx to mock httpx instead of httpcore until respx supports
+    httpx>=0.28.0
+    """
+    with respx.mock(using="httpx") as xmock:
+        yield xmock

--- a/tests/deployment/test_flow_runs.py
+++ b/tests/deployment/test_flow_runs.py
@@ -111,7 +111,7 @@ class TestRunDeployment:
         }
 
         with respx.mock(
-            base_url=PREFECT_API_URL.value(), assert_all_mocked=True
+            base_url=PREFECT_API_URL.value(), assert_all_mocked=True, using="httpx"
         ) as router:
             router.get("/csrf-token", params={"client": mock.ANY}).pass_through()
             router.get(f"/deployments/name/foo/{deployment.name}").pass_through()
@@ -146,6 +146,7 @@ class TestRunDeployment:
             base_url=PREFECT_API_URL.value(),
             assert_all_mocked=True,
             assert_all_called=False,
+            using="httpx",
         ) as router:
             router.get("/csrf-token", params={"client": mock.ANY}).pass_through()
             router.get(f"/deployments/name/foo/{deployment.name}").pass_through()
@@ -198,6 +199,7 @@ class TestRunDeployment:
             base_url=PREFECT_API_URL.value(),
             assert_all_mocked=True,
             assert_all_called=False,
+            using="httpx",
         ) as router:
             router.get("/csrf-token", params={"client": mock.ANY}).pass_through()
             router.get(f"/deployments/name/foo/{deployment.name}").pass_through()
@@ -239,6 +241,7 @@ class TestRunDeployment:
             base_url=PREFECT_API_URL.value(),
             assert_all_mocked=True,
             assert_all_called=False,
+            using="httpx",
         ) as router:
             router.get("/csrf-token", params={"client": mock.ANY}).pass_through()
             router.get(f"/deployments/name/foo/{deployment.name}").pass_through()

--- a/tests/fixtures/collections_registry.py
+++ b/tests/fixtures/collections_registry.py
@@ -428,6 +428,7 @@ def mock_collection_registry(
     }
 
     with respx.mock(
+        using="httpx",
         assert_all_mocked=False,
         assert_all_called=False,
         base_url=PREFECT_API_URL.value(),

--- a/tests/server/services/test_telemetry.py
+++ b/tests/server/services/test_telemetry.py
@@ -11,8 +11,8 @@ from prefect.server.services.telemetry import Telemetry
 
 @pytest.fixture
 def sens_o_matic_mock():
-    with respx.mock:
-        sens_o_matic = respx.post(
+    with respx.mock(using="httpx") as respx_mock:
+        sens_o_matic = respx_mock.post(
             "https://sens-o-matic.prefect.io/",
         ).mock(return_value=Response(200, json={}))
 
@@ -21,8 +21,8 @@ def sens_o_matic_mock():
 
 @pytest.fixture
 def error_sens_o_matic_mock():
-    with respx.mock:
-        sens_o_matic = respx.post(
+    with respx.mock(using="httpx") as respx_mock:
+        sens_o_matic = respx_mock.post(
             "https://sens-o-matic.prefect.io/",
         ).mock(return_value=Response(500, json={}))
 


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/16148

- uses the fork of `respx` with the [fix](https://github.com/lundberg/respx/pull/278) until the main version is released
- also updates the markdown tests setup to actually use the working version of `prefect` instead overwriting it

---
relatedly, https://github.com/PrefectHQ/prefect/pull/16168 fixes httpx issues with tests and an issue with the worker's cloud client context when adding flow run labels