### PR TITLE
[UI v2] poc: Re-organize variable queries and mutations using queryOptions factory pattern

### DIFF
--- a/ui-v2/eslint.config.js
+++ b/ui-v2/eslint.config.js
@@ -7,6 +7,7 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 import testingLibrary from "eslint-plugin-testing-library";
 import jestDom from "eslint-plugin-jest-dom";
+import pluginQuery from "@tanstack/eslint-plugin-query";
 
 export default tseslint.config(
 	{ ignores: ["dist", "src/api/prefect.ts"] },
@@ -14,6 +15,7 @@ export default tseslint.config(
 		extends: [
 			js.configs.recommended,
 			...tseslint.configs.recommendedTypeChecked,
+			...pluginQuery.configs["flat/recommended"],
 		],
 		files: ["**/*.{ts,tsx}"],
 		languageOptions: {

--- a/ui-v2/eslint.config.js
+++ b/ui-v2/eslint.config.js
@@ -15,7 +15,6 @@ export default tseslint.config(
 		extends: [
 			js.configs.recommended,
 			...tseslint.configs.recommendedTypeChecked,
-			...pluginQuery.configs["flat/recommended"],
 		],
 		files: ["**/*.{ts,tsx}"],
 		languageOptions: {
@@ -46,6 +45,7 @@ export default tseslint.config(
 			...react.configs["jsx-runtime"].rules,
 		},
 	},
+	...pluginQuery.configs["flat/recommended"],
 	...pluginRouter.configs["flat/recommended"],
 	{
 		files: ["tests/**/*.{ts,tsx}"],

--- a/ui-v2/package-lock.json
+++ b/ui-v2/package-lock.json
@@ -54,6 +54,7 @@
 				"@storybook/react": "^8.4.2",
 				"@storybook/react-vite": "^8.4.2",
 				"@storybook/test": "^8.4.2",
+				"@tanstack/eslint-plugin-query": "^5.61.6",
 				"@tanstack/eslint-plugin-router": "^1.77.7",
 				"@tanstack/router-devtools": "^1.58.15",
 				"@tanstack/router-plugin": "^1.58.12",
@@ -3765,6 +3766,169 @@
 			"dev": true,
 			"dependencies": {
 				"@swc/counter": "^0.1.3"
+			}
+		},
+		"node_modules/@tanstack/eslint-plugin-query": {
+			"version": "5.61.6",
+			"resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.61.6.tgz",
+			"integrity": "sha512-39DEve67KRcUOv4WI3svSyKzFGEhPTH4gzy99UBh2PmrDOUvAjfG59zSheNJFLHHokpSOQYJhFRNuMlC00CBMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/utils": "^8.15.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0"
+			}
+		},
+		"node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.16.0.tgz",
+			"integrity": "sha512-mwsZWubQvBki2t5565uxF0EYvG+FwdFb8bMtDuGQLdCCnGPrDEDvm1gtfynuKlnpzeBRqdFCkMf9jg1fnAK8sg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.16.0",
+				"@typescript-eslint/visitor-keys": "8.16.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/types": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.16.0.tgz",
+			"integrity": "sha512-NzrHj6thBAOSE4d9bsuRNMvk+BvaQvmY4dDglgkgGC0EW/tB3Kelnp3tAKH87GEwzoxgeQn9fNGRyFJM/xd+GQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.16.0.tgz",
+			"integrity": "sha512-E2+9IzzXMc1iaBy9zmo+UYvluE3TW7bCGWSF41hVWUE01o8nzr1rvOQYSxelxr6StUvRcTMe633eY8mXASMaNw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@typescript-eslint/types": "8.16.0",
+				"@typescript-eslint/visitor-keys": "8.16.0",
+				"debug": "^4.3.4",
+				"fast-glob": "^3.3.2",
+				"is-glob": "^4.0.3",
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"ts-api-utils": "^1.3.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/utils": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.16.0.tgz",
+			"integrity": "sha512-C1zRy/mOL8Pj157GiX4kaw7iyRLKfJXBR3L82hk5kS/GyHcOFmy4YUq/zfZti72I9wnuQtA/+xzft4wCC8PJdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@typescript-eslint/scope-manager": "8.16.0",
+				"@typescript-eslint/types": "8.16.0",
+				"@typescript-eslint/typescript-estree": "8.16.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@tanstack/eslint-plugin-query/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.16.0.tgz",
+			"integrity": "sha512-pq19gbaMOmFE3CbL0ZB8J8BFCo2ckfHBfaIsaOZgBIF4EoISJIdLX5xRhd0FGB0LlHReNRuzoJoMGpTjq8F2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.16.0",
+				"eslint-visitor-keys": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@tanstack/eslint-plugin-query/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@tanstack/eslint-plugin-query/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@tanstack/eslint-plugin-query/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/@tanstack/eslint-plugin-router": {

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -64,6 +64,7 @@
 		"@storybook/react": "^8.4.2",
 		"@storybook/react-vite": "^8.4.2",
 		"@storybook/test": "^8.4.2",
+		"@tanstack/eslint-plugin-query": "^5.61.6",
 		"@tanstack/eslint-plugin-router": "^1.77.7",
 		"@tanstack/router-devtools": "^1.58.15",
 		"@tanstack/router-plugin": "^1.58.12",


### PR DESCRIPTION
What does this PR do and why?
------------------------
⚠️ Proof of concept ⚠️ 
This PR expands on the current variables query key factory pattern, but moves it using `queryOptions`. Additionally, while using `queryOptions`, this moves `queryKeys` to be associated with `queryFn`.

> Separating QueryKey from QueryFunction was a mistake


[Blog for a good read on _why_ we should associate the two together](https://tkdodo.eu/blog/the-query-options-api#query-factories)

Notable changes:
1. Adds `@tanstack/eslint-plugin-query` as a [dev dependency](https://tanstack.com/query/v5/docs/eslint/eslint-plugin-query). This eslint rule checks if variables passed in the `queryFn` is also passed as a `queryKey`
2.  Abstract `queryFn` and `mutationFn` into its own function wrapper. Purpose is to separate concerns from APIs and queries 🧅. Additionally most @tanstack docs [follow a similar pattern](https://tanstack.com/router/latest/docs/framework/react/examples/basic-react-query-file-based)
3. 🏗️ Re-organize the query key structure (similar to how the blog post ☝️ suggests)
**Before**
![Screenshot 2024-11-29 at 8 53 50 AM](https://github.com/user-attachments/assets/2ce75dd1-e46b-4dc5-a5f5-cf39489e88f6)
**After**
![Screenshot 2024-11-28 at 2 55 08 PM](https://github.com/user-attachments/assets/dfd6daf4-f773-47cf-9fee-09d37924b006)
4. Update mutation docs now that UX callbacks has been updated from a previous PR https://github.com/PrefectHQ/prefect/pull/16141

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Related to #15512 
