### PR TITLE
Workaround `respx` incompatibility with `httpx==0.28.0`

### DIFF
--- a/flows/client_context_lifespan.py
+++ b/flows/client_context_lifespan.py
@@ -115,11 +115,8 @@ async def client_context_lifespan_is_robust_to_mixed_concurrency():
 
 
 async def concurrency_tests():
-    print("Testing threaded concurrency")
     client_context_lifespan_is_robust_to_threaded_concurrency()
-    print("Testing high async concurrency")
     await client_context_lifespan_is_robust_to_high_async_concurrency()
-    print("Testing mixed concurrency")
     await client_context_lifespan_is_robust_to_mixed_concurrency()
 
 

--- a/flows/client_context_lifespan.py
+++ b/flows/client_context_lifespan.py
@@ -102,7 +102,7 @@ async def client_context_lifespan_is_robust_to_mixed_concurrency():
                 prefect.context.SettingsContext.get().model_copy(),
             ),
         )
-        for _ in range(100)
+        for _ in range(10)
     ]
     for thread in threads:
         thread.start()

--- a/flows/client_context_lifespan.py
+++ b/flows/client_context_lifespan.py
@@ -102,7 +102,7 @@ async def client_context_lifespan_is_robust_to_mixed_concurrency():
                 prefect.context.SettingsContext.get().model_copy(),
             ),
         )
-        for _ in range(10)
+        for _ in range(100)
     ]
     for thread in threads:
         thread.start()

--- a/flows/client_context_lifespan.py
+++ b/flows/client_context_lifespan.py
@@ -98,7 +98,7 @@ async def client_context_lifespan_is_robust_to_mixed_concurrency():
                 prefect.context.SettingsContext.get().model_copy(),
             ),
         )
-        for _ in range(100)
+        for _ in range(10)
     ]
     for thread in threads:
         thread.start()

--- a/flows/client_context_lifespan.py
+++ b/flows/client_context_lifespan.py
@@ -85,10 +85,14 @@ async def client_context_lifespan_is_robust_to_mixed_concurrency():
 
     async def enter_client_many_times(context):
         # We must re-enter the profile context in the new thread
-        with context:
-            async with anyio.create_task_group() as tg:
-                for _ in range(10):
-                    tg.start_soon(enter_client)
+        try:
+            with context:
+                async with anyio.create_task_group() as tg:
+                    for _ in range(100):
+                        tg.start_soon(enter_client)
+        except Exception as e:
+            print(f"Error entering client many times {e}")
+            raise e
 
     threads = [
         threading.Thread(

--- a/flows/worker.py
+++ b/flows/worker.py
@@ -3,10 +3,8 @@ import subprocess
 import sys
 from threading import Thread
 from typing import List
-from uuid import uuid4
 
 from pydantic_extra_types.pendulum_dt import DateTime
-from uv import find_uv_bin
 
 from prefect.events import Event
 from prefect.events.clients import get_events_subscriber
@@ -37,11 +35,7 @@ def main():
     listener_thread.start()
 
     subprocess.check_call(
-        [find_uv_bin(), "venv", str(uuid4())], stdout=sys.stdout, stderr=sys.stderr
-    )
-
-    subprocess.check_call(
-        [find_uv_bin(), "pip", "install", "prefect-kubernetes>=0.5.0"],
+        ["python", "-m", "pip", "install", "prefect-kubernetes>=0.5.0"],
         stdout=sys.stdout,
         stderr=sys.stderr,
     )
@@ -83,7 +77,7 @@ def main():
         stderr=sys.stderr,
     )
     subprocess.check_call(
-        [find_uv_bin(), "pip", "uninstall", "prefect-kubernetes"],
+        ["python", "-m", "pip", "uninstall", "prefect-kubernetes", "-y"],
         stdout=sys.stdout,
         stderr=sys.stderr,
     )

--- a/flows/worker.py
+++ b/flows/worker.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 from threading import Thread
 from typing import List
+from uuid import uuid4
 
 from pydantic_extra_types.pendulum_dt import DateTime
 from uv import find_uv_bin
@@ -34,6 +35,10 @@ def main():
 
     listener_thread = Thread(target=run_event_listener, args=(events,), daemon=True)
     listener_thread.start()
+
+    subprocess.check_call(
+        [find_uv_bin(), "venv", str(uuid4())], stdout=sys.stdout, stderr=sys.stderr
+    )
 
     subprocess.check_call(
         [find_uv_bin(), "pip", "install", "prefect-kubernetes>=0.5.0"],

--- a/flows/worker.py
+++ b/flows/worker.py
@@ -5,6 +5,7 @@ from threading import Thread
 from typing import List
 
 from pydantic_extra_types.pendulum_dt import DateTime
+from uv import find_uv_bin
 
 from prefect.events import Event
 from prefect.events.clients import get_events_subscriber
@@ -35,7 +36,7 @@ def main():
     listener_thread.start()
 
     subprocess.check_call(
-        ["python", "-m", "pip", "install", "prefect-kubernetes>=0.5.0"],
+        [find_uv_bin(), "pip", "install", "prefect-kubernetes>=0.5.0"],
         stdout=sys.stdout,
         stderr=sys.stderr,
     )
@@ -77,7 +78,7 @@ def main():
         stderr=sys.stderr,
     )
     subprocess.check_call(
-        ["python", "-m", "pip", "uninstall", "prefect-kubernetes", "-y"],
+        [find_uv_bin(), "pip", "uninstall", "prefect-kubernetes", "-y"],
         stdout=sys.stdout,
         stderr=sys.stderr,
     )

--- a/flows/worker.py
+++ b/flows/worker.py
@@ -78,7 +78,7 @@ def main():
         stderr=sys.stderr,
     )
     subprocess.check_call(
-        [find_uv_bin(), "pip", "uninstall", "prefect-kubernetes", "-y"],
+        [find_uv_bin(), "pip", "uninstall", "prefect-kubernetes"],
         stdout=sys.stdout,
         stderr=sys.stderr,
     )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,8 +25,7 @@ vale
 vermin
 virtualenv
 watchfiles
-# TODO: go back to `respx` once fix is released
-respx@git+https://github.com/ndhansen/respx.git
+respx
 
 # type stubs
 types-cachetools

--- a/scripts/run-integration-flows.py
+++ b/scripts/run-integration-flows.py
@@ -30,7 +30,7 @@ def run_script(script_path: str):
     print(f" {script_path} ".center(90, "-"), flush=True)
     try:
         result = subprocess.run(
-            ["uv", "run", script_path], capture_output=True, text=True, check=True
+            ["uv", "run", script_path], stdout=sys.stdout, stderr=sys.stderr, check=True
         )
         return result.stdout, result.stderr, None
     except subprocess.CalledProcessError as e:

--- a/scripts/run-integration-flows.py
+++ b/scripts/run-integration-flows.py
@@ -32,8 +32,10 @@ def run_script(script_path: str):
         result = subprocess.run(
             ["uv", "run", script_path], capture_output=True, text=True, check=True
         )
+        print(f"Finished {script_path}", flush=True)
         return result.stdout, result.stderr, None
     except subprocess.CalledProcessError as e:
+        print(f"Failed {script_path}", flush=True)
         return e.stdout, e.stderr, e
 
 

--- a/scripts/run-integration-flows.py
+++ b/scripts/run-integration-flows.py
@@ -30,7 +30,7 @@ def run_script(script_path: str):
     print(f" {script_path} ".center(90, "-"), flush=True)
     try:
         result = subprocess.run(
-            ["uv", "run", script_path], stdout=sys.stdout, stderr=sys.stderr, check=True
+            ["uv", "run", script_path], capture_output=True, text=True, check=True
         )
         return result.stdout, result.stderr, None
     except subprocess.CalledProcessError as e:

--- a/scripts/run-integration-flows.py
+++ b/scripts/run-integration-flows.py
@@ -31,10 +31,8 @@ def run_script(script_path: str):
         result = subprocess.run(
             ["uv", "run", script_path], capture_output=True, text=True, check=True
         )
-        print(f"Finished {script_path}", flush=True)
         return result.stdout, result.stderr, None
     except subprocess.CalledProcessError as e:
-        print(f"Failed {script_path}", flush=True)
         return e.stdout, e.stderr, e
 
 

--- a/scripts/run-integration-flows.py
+++ b/scripts/run-integration-flows.py
@@ -15,7 +15,6 @@ Example:
 
 import subprocess
 import sys
-from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 from typing import Union
 
@@ -40,20 +39,18 @@ def run_script(script_path: str):
 
 
 def run_flows(search_path: Union[str, Path]):
-    count = 0
     print(f"Running integration tests with client version: {__version__}")
     scripts = sorted(Path(search_path).glob("**/*.py"))
-    with ProcessPoolExecutor(max_workers=4) as executor:
-        results = list(executor.map(run_script, scripts))
+    errors = []
+    for script in scripts:
+        print(f"Running {script}")
+        try:
+            run_script(str(script))
+        except Exception as e:
+            print(f"Error running {script}: {e}")
+            errors.append(e)
 
-    for script, (stdout, stderr, error) in zip(scripts, results):
-        print(f" {script.relative_to(search_path)} ".center(90, "-"), flush=True)
-        print(stdout)
-        print(stderr)
-        if error:
-            raise error
-        print("".center(90, "-") + "\n", flush=True)
-        count += 1
+    assert not errors, "Errors occurred while running flows"
 
 
 if __name__ == "__main__":

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -637,8 +637,9 @@ class BaseWorker(abc.ABC):
         await self._exit_stack.enter_async_context(self._runs_task_group)
 
         if self._client.server_type == ServerType.CLOUD:
-            self._cloud_client = get_cloud_client()
-            await self._exit_stack.enter_async_context(self._cloud_client)
+            self._cloud_client = await self._exit_stack.enter_async_context(
+                get_cloud_client()
+            )
 
         self.is_setup = True
 

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -546,9 +546,8 @@ class TestTwilioSMS:
 
 class TestCustomWebhook:
     async def test_notify_async(self):
-        with respx.mock as xmock:
+        with respx.mock(using="httpx") as xmock:
             xmock.post("https://example.com/")
-            xmock.route(host="localhost").pass_through()
 
             custom_block = CustomWebhookNotificationBlock(
                 name="test name",
@@ -562,16 +561,15 @@ class TestCustomWebhook:
             assert last_req.headers["user-agent"] == "Prefect Notifications"
             assert (
                 last_req.content
-                == b'{"msg": "subject\\ntest", "token": "someSecretToken"}'
+                == b'{"msg":"subject\\ntest","token":"someSecretToken"}'
             )
             assert last_req.extensions == {
                 "timeout": {"connect": 10, "pool": 10, "read": 10, "write": 10}
             }
 
     def test_notify_sync(self):
-        with respx.mock as xmock:
+        with respx.mock(using="httpx") as xmock:
             xmock.post("https://example.com/")
-            xmock.route(host="localhost").pass_through()
 
             custom_block = CustomWebhookNotificationBlock(
                 name="test name",
@@ -586,14 +584,14 @@ class TestCustomWebhook:
             assert last_req.headers["user-agent"] == "Prefect Notifications"
             assert (
                 last_req.content
-                == b'{"msg": "subject\\ntest", "token": "someSecretToken"}'
+                == b'{"msg":"subject\\ntest","token":"someSecretToken"}'
             )
             assert last_req.extensions == {
                 "timeout": {"connect": 10, "pool": 10, "read": 10, "write": 10}
             }
 
     async def test_user_agent_override(self):
-        with respx.mock as xmock:
+        with respx.mock(using="httpx") as xmock:
             xmock.post("https://example.com/")
 
             custom_block = CustomWebhookNotificationBlock(
@@ -609,14 +607,14 @@ class TestCustomWebhook:
             assert last_req.headers["user-agent"] == "CustomUA"
             assert (
                 last_req.content
-                == b'{"msg": "subject\\ntest", "token": "someSecretToken"}'
+                == b'{"msg":"subject\\ntest","token":"someSecretToken"}'
             )
             assert last_req.extensions == {
                 "timeout": {"connect": 10, "pool": 10, "read": 10, "write": 10}
             }
 
     async def test_timeout_override(self):
-        with respx.mock as xmock:
+        with respx.mock(using="httpx") as xmock:
             xmock.post("https://example.com/")
 
             custom_block = CustomWebhookNotificationBlock(
@@ -631,14 +629,14 @@ class TestCustomWebhook:
             last_req = xmock.calls.last.request
             assert (
                 last_req.content
-                == b'{"msg": "subject\\ntest", "token": "someSecretToken"}'
+                == b'{"msg":"subject\\ntest","token":"someSecretToken"}'
             )
             assert last_req.extensions == {
                 "timeout": {"connect": 30, "pool": 30, "read": 30, "write": 30}
             }
 
     async def test_request_cookie(self):
-        with respx.mock as xmock:
+        with respx.mock(using="httpx") as xmock:
             xmock.post("https://example.com/")
 
             custom_block = CustomWebhookNotificationBlock(
@@ -655,14 +653,14 @@ class TestCustomWebhook:
             assert last_req.headers["cookie"] == "key=secretCookieValue"
             assert (
                 last_req.content
-                == b'{"msg": "subject\\ntest", "token": "someSecretToken"}'
+                == b'{"msg":"subject\\ntest","token":"someSecretToken"}'
             )
             assert last_req.extensions == {
                 "timeout": {"connect": 30, "pool": 30, "read": 30, "write": 30}
             }
 
     async def test_subst_nested_list(self):
-        with respx.mock as xmock:
+        with respx.mock(using="httpx")(using="httpx") as xmock:
             xmock.post("https://example.com/")
 
             custom_block = CustomWebhookNotificationBlock(
@@ -679,14 +677,14 @@ class TestCustomWebhook:
             assert last_req.headers["user-agent"] == "Prefect Notifications"
             assert (
                 last_req.content
-                == b'{"data": {"sub1": [{"in-list": "test", "name": "test name"}]}}'
+                == b'{"data":{"sub1":[{"in-list":"test","name":"test name"}]}}'
             )
             assert last_req.extensions == {
                 "timeout": {"connect": 10, "pool": 10, "read": 10, "write": 10}
             }
 
     async def test_subst_none(self):
-        with respx.mock as xmock:
+        with respx.mock(using="httpx") as xmock:
             xmock.post("https://example.com/")
 
             custom_block = CustomWebhookNotificationBlock(
@@ -701,8 +699,7 @@ class TestCustomWebhook:
             last_req = xmock.calls.last.request
             assert last_req.headers["user-agent"] == "Prefect Notifications"
             assert (
-                last_req.content
-                == b'{"msg": "null\\ntest", "token": "someSecretToken"}'
+                last_req.content == b'{"msg":"null\\ntest","token":"someSecretToken"}'
             )
             assert last_req.extensions == {
                 "timeout": {"connect": 10, "pool": 10, "read": 10, "write": 10}

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -81,8 +81,8 @@ class TestChangingProfileAndCheckingServerConnection:
     def authorized_cloud(self):
         # attempts to reach the Cloud 2 workspaces endpoint implies a good connection
         # to Prefect Cloud as opposed to a hosted Prefect server instance
-        with respx.mock:
-            authorized = respx.get(
+        with respx.mock(using="httpx") as respx_mock:
+            authorized = respx_mock.get(
                 "https://mock-cloud.prefect.io/api/me/workspaces",
             ).mock(return_value=Response(200, json=[]))
 
@@ -91,8 +91,8 @@ class TestChangingProfileAndCheckingServerConnection:
     @pytest.fixture
     def unauthorized_cloud(self):
         # requests to cloud with an invalid key will result in a 401 response
-        with respx.mock:
-            unauthorized = respx.get(
+        with respx.mock(using="httpx") as respx_mock:
+            unauthorized = respx_mock.get(
                 "https://mock-cloud.prefect.io/api/me/workspaces",
             ).mock(return_value=Response(401, json={}))
 
@@ -101,8 +101,8 @@ class TestChangingProfileAndCheckingServerConnection:
     @pytest.fixture
     def unhealthy_cloud(self):
         # Cloud may respond with a 500 error when having connection issues
-        with respx.mock:
-            unhealthy_cloud = respx.get(
+        with respx.mock(using="httpx") as respx_mock:
+            unhealthy_cloud = respx_mock.get(
                 "https://mock-cloud.prefect.io/api/me/workspaces",
             ).mock(return_value=Response(500, json={}))
 
@@ -111,8 +111,8 @@ class TestChangingProfileAndCheckingServerConnection:
     @pytest.fixture
     def hosted_server_has_no_cloud_api(self):
         # if the API URL points to a hosted Prefect server instance, no Cloud API will be found
-        with respx.mock:
-            hosted = respx.get(
+        with respx.mock(using="httpx") as respx_mock:
+            hosted = respx_mock.get(
                 "https://hosted-server.prefect.io/api/me/workspaces",
             ).mock(return_value=Response(404, json={}))
 
@@ -120,8 +120,8 @@ class TestChangingProfileAndCheckingServerConnection:
 
     @pytest.fixture
     def healthy_hosted_server(self):
-        with respx.mock:
-            hosted = respx.get(
+        with respx.mock(using="httpx") as respx_mock:
+            hosted = respx_mock.get(
                 "https://hosted-server.prefect.io/api/health",
             ).mock(return_value=Response(200, json={}))
 
@@ -132,8 +132,8 @@ class TestChangingProfileAndCheckingServerConnection:
 
     @pytest.fixture
     def unhealthy_hosted_server(self):
-        with respx.mock:
-            badly_hosted = respx.get(
+        with respx.mock(using="httpx") as respx_mock:
+            badly_hosted = respx_mock.get(
                 "https://hosted-server.prefect.io/api/health",
             ).mock(side_effect=self.connection_error)
 

--- a/tests/cli/test_worker.py
+++ b/tests/cli/test_worker.py
@@ -62,7 +62,7 @@ async def kubernetes_work_pool(prefect_client: PrefectClient):
     )
 
     with respx.mock(
-        assert_all_mocked=False, base_url=PREFECT_API_URL.value()
+        assert_all_mocked=False, base_url=PREFECT_API_URL.value(), using="httpx"
     ) as respx_mock:
         respx_mock.get("/csrf-token", params={"client": ANY}).pass_through()
         respx_mock.route(path__startswith="/work_pools/").pass_through()

--- a/tests/client/test_cloud_client.py
+++ b/tests/client/test_cloud_client.py
@@ -83,7 +83,7 @@ async def test_get_cloud_work_pool_types():
         }
     ):
         with respx.mock(
-            assert_all_mocked=False, base_url=PREFECT_API_URL.value()
+            assert_all_mocked=False, base_url=PREFECT_API_URL.value(), using="httpx"
         ) as respx_mock:
             respx_mock.route(
                 M(
@@ -111,7 +111,7 @@ async def test_read_current_workspace():
 
     with temporary_settings(updates={PREFECT_API_URL: api_url}):
         with respx.mock(
-            assert_all_mocked=False, base_url=PREFECT_API_URL.value()
+            assert_all_mocked=False, base_url=PREFECT_API_URL.value(), using="httpx"
         ) as respx_mock:
             respx_mock.get("https://api.prefect.cloud/api/me/workspaces").mock(
                 return_value=httpx.Response(

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -2216,7 +2216,9 @@ class TestAutomations:
         )
 
     async def test_create_automation(self, cloud_client, automation: AutomationCore):
-        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+        with respx.mock(
+            base_url=PREFECT_CLOUD_API_URL.value(), using="httpx"
+        ) as router:
             created_automation = automation.model_dump(mode="json")
             created_automation["id"] = str(uuid4())
             create_route = router.post("/automations/").mock(
@@ -2232,7 +2234,9 @@ class TestAutomations:
             assert automation_id == UUID(created_automation["id"])
 
     async def test_read_automation(self, cloud_client, automation: AutomationCore):
-        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+        with respx.mock(
+            base_url=PREFECT_CLOUD_API_URL.value(), using="httpx"
+        ) as router:
             created_automation = automation.model_dump(mode="json")
             created_automation["id"] = str(uuid4())
 
@@ -2250,7 +2254,9 @@ class TestAutomations:
     async def test_read_automation_not_found(
         self, cloud_client, automation: AutomationCore
     ):
-        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+        with respx.mock(
+            base_url=PREFECT_CLOUD_API_URL.value(), using="httpx"
+        ) as router:
             created_automation = automation.model_dump(mode="json")
             created_automation["id"] = str(uuid4())
 
@@ -2268,7 +2274,9 @@ class TestAutomations:
     async def test_read_automations_by_name(
         self, cloud_client, automation: AutomationCore
     ):
-        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+        with respx.mock(
+            base_url=PREFECT_CLOUD_API_URL.value(), using="httpx"
+        ) as router:
             created_automation = automation.model_dump(mode="json")
             created_automation["id"] = str(uuid4())
             read_route = router.post("/automations/filter").mock(
@@ -2301,7 +2309,9 @@ class TestAutomations:
     async def test_read_automations_by_name_multiple_same_name(
         self, cloud_client, automation: AutomationCore, automation2: AutomationCore
     ):
-        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+        with respx.mock(
+            base_url=PREFECT_CLOUD_API_URL.value(), using="httpx"
+        ) as router:
             created_automation = automation.model_dump(mode="json")
             created_automation["id"] = str(uuid4())
 
@@ -2331,7 +2341,9 @@ class TestAutomations:
     async def test_read_automations_by_name_not_found(
         self, cloud_client, automation: AutomationCore
     ):
-        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+        with respx.mock(
+            base_url=PREFECT_CLOUD_API_URL.value(), using="httpx"
+        ) as router:
             created_automation = automation.model_dump(mode="json")
             created_automation["id"] = str(uuid4())
             created_automation["name"] = "nonexistent"
@@ -2348,7 +2360,9 @@ class TestAutomations:
             assert nonexistent_automation == []
 
     async def test_delete_owned_automations(self, cloud_client):
-        with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
+        with respx.mock(
+            base_url=PREFECT_CLOUD_API_URL.value(), using="httpx"
+        ) as router:
             resource_id = f"prefect.deployment.{uuid4()}"
             delete_route = router.delete(f"/automations/owned-by/{resource_id}").mock(
                 return_value=httpx.Response(204)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -583,3 +583,13 @@ def leaves_no_extraneous_files():
             "One of the tests in this module left new files in the "
             f"working directory: {new_files}"
         )
+
+
+@pytest.fixture
+def respx_mock():
+    """
+    Temporary override of respx to mock httpx instead of httpcore until respx supports
+    httpx>=0.28.0
+    """
+    with respx.mock(using="httpx") as xmock:
+        yield xmock

--- a/tests/deployment/test_flow_runs.py
+++ b/tests/deployment/test_flow_runs.py
@@ -111,7 +111,7 @@ class TestRunDeployment:
         }
 
         with respx.mock(
-            base_url=PREFECT_API_URL.value(), assert_all_mocked=True
+            base_url=PREFECT_API_URL.value(), assert_all_mocked=True, using="httpx"
         ) as router:
             router.get("/csrf-token", params={"client": mock.ANY}).pass_through()
             router.get(f"/deployments/name/foo/{deployment.name}").pass_through()
@@ -146,6 +146,7 @@ class TestRunDeployment:
             base_url=PREFECT_API_URL.value(),
             assert_all_mocked=True,
             assert_all_called=False,
+            using="httpx",
         ) as router:
             router.get("/csrf-token", params={"client": mock.ANY}).pass_through()
             router.get(f"/deployments/name/foo/{deployment.name}").pass_through()
@@ -198,6 +199,7 @@ class TestRunDeployment:
             base_url=PREFECT_API_URL.value(),
             assert_all_mocked=True,
             assert_all_called=False,
+            using="httpx",
         ) as router:
             router.get("/csrf-token", params={"client": mock.ANY}).pass_through()
             router.get(f"/deployments/name/foo/{deployment.name}").pass_through()
@@ -239,6 +241,7 @@ class TestRunDeployment:
             base_url=PREFECT_API_URL.value(),
             assert_all_mocked=True,
             assert_all_called=False,
+            using="httpx",
         ) as router:
             router.get("/csrf-token", params={"client": mock.ANY}).pass_through()
             router.get(f"/deployments/name/foo/{deployment.name}").pass_through()

--- a/tests/fixtures/collections_registry.py
+++ b/tests/fixtures/collections_registry.py
@@ -428,6 +428,7 @@ def mock_collection_registry(
     }
 
     with respx.mock(
+        using="httpx",
         assert_all_mocked=False,
         assert_all_called=False,
         base_url=PREFECT_API_URL.value(),

--- a/tests/server/services/test_telemetry.py
+++ b/tests/server/services/test_telemetry.py
@@ -11,8 +11,8 @@ from prefect.server.services.telemetry import Telemetry
 
 @pytest.fixture
 def sens_o_matic_mock():
-    with respx.mock:
-        sens_o_matic = respx.post(
+    with respx.mock(using="httpx") as respx_mock:
+        sens_o_matic = respx_mock.post(
             "https://sens-o-matic.prefect.io/",
         ).mock(return_value=Response(200, json={}))
 
@@ -21,8 +21,8 @@ def sens_o_matic_mock():
 
 @pytest.fixture
 def error_sens_o_matic_mock():
-    with respx.mock:
-        sens_o_matic = respx.post(
+    with respx.mock(using="httpx") as respx_mock:
+        sens_o_matic = respx_mock.post(
             "https://sens-o-matic.prefect.io/",
         ).mock(return_value=Response(500, json={}))
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

This PR updates `respx.mock` calls to include `using="httpx"` to mock at the `httpx` level instead of the `httpcore` level. This mitigates `respx` not being compatible with `httpx==0.28.0`.
