### PR TITLE
fix `__getattr__` conflict in `prefect.docker.__init__`

### DIFF
--- a/src/prefect/docker/__init__.py
+++ b/src/prefect/docker/__init__.py
@@ -13,6 +13,10 @@ _public_api: dict[str, tuple[str, str]] = {
 def __getattr__(name: str) -> object:
     from importlib import import_module
 
+    # Let Python handle its own special attributes
+    if name.startswith("__") and name.endswith("__"):
+        return object.__getattribute__(object(), name)
+
     if name in _public_api:
         module, attr = _public_api[name]
         return getattr(import_module(module), attr)

--- a/src/prefect/docker/__init__.py
+++ b/src/prefect/docker/__init__.py
@@ -13,12 +13,8 @@ _public_api: dict[str, tuple[str, str]] = {
 def __getattr__(name: str) -> object:
     from importlib import import_module
 
-    # Let Python handle its own special attributes
-    if name.startswith("__") and name.endswith("__"):
-        return object.__getattribute__(object(), name)
-
     if name in _public_api:
         module, attr = _public_api[name]
         return getattr(import_module(module), attr)
 
-    raise ImportError(f"module {__name__!r} has no attribute {name!r}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/docker/test_public_api.py
+++ b/tests/docker/test_public_api.py
@@ -1,0 +1,19 @@
+from unittest import TestCase
+from warnings import warn
+
+from prefect import flow
+
+
+def function_that_warns():
+    warn("Test warning!")
+
+
+@flow
+def my_flow():
+    function_that_warns()
+
+
+class TestWarnings(TestCase):
+    def test_warning(self):
+        with self.assertWarns(UserWarning):
+            function_that_warns()

--- a/tests/docker/test_public_api.py
+++ b/tests/docker/test_public_api.py
@@ -14,6 +14,8 @@ def my_flow():
 
 
 class TestWarnings(TestCase):
+    """this is a regression test for https://github.com/PrefectHQ/prefect/issues/16171"""
+
     def test_warning(self):
         with self.assertWarns(UserWarning):
             function_that_warns()


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/16171

---

Fix `unittest.assertWarns()` compatibility with module `__getattr__` handling in `prefect.docker.__init__`

issue arises bc unittest's `assertWarns` uses `getattr()` with a default value to safely check for `__warningregistry__` on modules

https://github.com/python/cpython/blob/e546876d83e1cc3f761e1eeca57f8a4533d06d00/Lib/unittest/case.py#L290-L294

Our `__getattr__` implementation was raising `ImportError`, preventing Python from handling the default value case, so this PR changes it to raise `AttributeError` to follow attribute lookup protocol (like the other dynamic imports we have)