### PR TITLE
[UI v2] feat: Adding DocsLink reusable component

### DIFF
--- a/ui-v2/src/components/ui/docs-link.stories.tsx
+++ b/ui-v2/src/components/ui/docs-link.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { DocsLink } from "./docs-link";
+
+const meta: Meta<typeof DocsLink> = {
+	title: "UI/DocsLink",
+	component: DocsLink,
+	parameters: {
+		docs: {
+			description: {
+				component:
+					"DocsLink is used to open the docs page for a specific feature",
+			},
+		},
+	},
+};
+export default meta;
+
+type Story = StoryObj<typeof DocsLink>;
+export const Usage: Story = {
+	args: {
+		id: "global-concurrency-guide",
+	},
+};

--- a/ui-v2/src/components/ui/docs-link.tsx
+++ b/ui-v2/src/components/ui/docs-link.tsx
@@ -1,0 +1,25 @@
+import { ExternalLinkIcon } from "lucide-react";
+
+import { Button } from "./button";
+
+const DOCS_LINKS = {
+	"global-concurrency-guide":
+		"https://docs.prefect.io/v3/develop/global-concurrency-limits",
+	"variables-guide": "https://docs.prefect.io/latest/guides/variables/",
+} as const;
+
+type DocsID = keyof typeof DOCS_LINKS;
+
+type Props = {
+	id: DocsID;
+};
+
+export const DocsLink = ({ id }: Props): JSX.Element => {
+	return (
+		<a href={DOCS_LINKS[id]} target="_blank" rel="noreferrer">
+			<Button variant="outline">
+				View Docs <ExternalLinkIcon className="h-4 w-4 ml-2" />
+			</Button>
+		</a>
+	);
+};

--- a/ui-v2/src/components/variables/empty-state.tsx
+++ b/ui-v2/src/components/variables/empty-state.tsx
@@ -1,6 +1,7 @@
-import { ExternalLinkIcon, PlusIcon, VariableIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { DocsLink } from "@/components/ui/docs-link";
+import { PlusIcon, VariableIcon } from "lucide-react";
 
 type VariablesEmptyStateProps = {
 	onAddVariableClick: () => void;
@@ -19,15 +20,7 @@ export const VariablesEmptyState = ({
 				<Button onClick={() => onAddVariableClick()}>
 					Add Variable <PlusIcon className="h-4 w-4 ml-2" />
 				</Button>
-				<a
-					href="https://docs.prefect.io/latest/guides/variables/"
-					target="_blank"
-					rel="noreferrer"
-				>
-					<Button variant="outline">
-						View Docs <ExternalLinkIcon className="h-4 w-4 ml-2" />
-					</Button>
-				</a>
+				<DocsLink id="variables-guide" />
 			</div>
 		</CardContent>
 	</Card>


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
1. Create a re-usable `DocsLink` component that can be re-used throughout the app.
2. Replace Docs link in variables page in favor for new `DocsLink` component

<img width="1502" alt="Screenshot 2024-12-03 at 10 29 25 AM" src="https://github.com/user-attachments/assets/8712bdc2-3a4d-462b-b729-228039c6a25f">

https://github.com/user-attachments/assets/59553b4c-37c9-48de-a224-8802bd270c59

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
