### PR TITLE
bump required minor versions of core

### DIFF
--- a/src/integrations/prefect-azure/pyproject.toml
+++ b/src/integrations/prefect-azure/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "azure_identity>=1.10",
   "azure_mgmt_containerinstance>=10.0",
   "azure-mgmt-resource>=21.2",
-  "prefect>=3.0.0",
+  "prefect>=3.1.1",
   "setuptools",                         #required in 3.12 to get pkg_resources (used by azureml.core)
 ]
 dynamic = ["version"]

--- a/src/integrations/prefect-docker/pyproject.toml
+++ b/src/integrations/prefect-docker/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["prefect>=3.0.0", "docker>=6.1.1", "exceptiongroup"]
+dependencies = ["prefect>=3.1.1", "docker>=6.1.1", "exceptiongroup"]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/src/integrations/prefect-gcp/pyproject.toml
+++ b/src/integrations/prefect-gcp/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-  "prefect>=3.0.0",
+  "prefect>=3.1.1",
   "google-api-python-client>=2.20.0",
   "google-cloud-storage>=2.0.0",
   "tenacity>=8.0.0",

--- a/src/integrations/prefect-kubernetes/pyproject.toml
+++ b/src/integrations/prefect-kubernetes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 dependencies = [
-    "prefect>=3.1.0",
+    "prefect>=3.1.1",
     "kubernetes-asyncio>=29.0.0",
     "tenacity>=8.2.3",
     "exceptiongroup",


### PR DESCRIPTION
for collections that offer a worker

related to https://github.com/PrefectHQ/prefect/issues/16188

but its still not totally clear how the error in that issue arose. it seems like there might have been some python pathing issue where (somehow) the `3.0.11` version was used instead of the `3.1.1` version (that has the `Integration` schema) that was installed on top, but seems to not be a bug on our side