### PR TITLE
[UI v2] feat: Adding generic empty-state component, and replaced variables empty-state for it

### DIFF
--- a/ui-v2/.gitignore
+++ b/ui-v2/.gitignore
@@ -28,3 +28,4 @@ dist-ssr
 oss_schema.json
 *.tsbuildinfo
 *storybook.log
+*.orig

--- a/ui-v2/src/components/ui/empty-state.stories.tsx
+++ b/ui-v2/src/components/ui/empty-state.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { PlusIcon } from "lucide-react";
+import { Button } from "./button";
+import { DocsLink } from "./docs-link";
+import {
+	EmptyState,
+	EmptyStateActions,
+	EmptyStateDescription,
+	EmptyStateIcon,
+	EmptyStateTitle,
+} from "./empty-state";
+
+const meta: Meta<typeof EmptyState> = {
+	title: "UI/EmptyState",
+	component: EmptyState,
+	parameters: {
+		docs: {
+			description: {
+				component:
+					"EmptyState is used to prompt to user to create a resource when there is none",
+			},
+		},
+	},
+};
+export default meta;
+
+type Story = StoryObj<typeof EmptyState>;
+export const Usage: Story = {
+	render: () => <EmptyStateExample />,
+};
+
+function EmptyStateExample(): JSX.Element {
+	return (
+		<EmptyState>
+			<EmptyStateIcon id="Variable" />
+			<EmptyStateTitle>Add a variable to get started</EmptyStateTitle>
+			<EmptyStateDescription>
+				Variables store non-sensitive pieces of JSON.
+			</EmptyStateDescription>
+			<EmptyStateActions>
+				<Button onClick={console.log}>
+					Add Variable <PlusIcon className="h-4 w-4 ml-2" />
+				</Button>
+				<DocsLink id="variables-guide" />
+			</EmptyStateActions>
+		</EmptyState>
+	);
+}

--- a/ui-v2/src/components/ui/empty-state.tsx
+++ b/ui-v2/src/components/ui/empty-state.tsx
@@ -1,0 +1,43 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { icons } from "lucide-react";
+
+const EmptyStateIcon = ({ id }: { id: keyof typeof icons }): JSX.Element => {
+	const LucideIcon = icons[id];
+	return <LucideIcon className="h-12 w-12 text-muted-foreground mb-8" />;
+};
+const EmptyStateTitle = ({
+	children,
+}: { children: React.ReactNode }): JSX.Element => (
+	<h3 className="text-2xl font-bold">{children}</h3>
+);
+
+const EmptyStateDescription = ({
+	children,
+}: { children: React.ReactNode }): JSX.Element => (
+	<p className="text-md text-muted-foreground">{children}</p>
+);
+
+const EmptyStateActions = ({
+	children,
+}: { children: React.ReactNode }): JSX.Element => (
+	<div className="flex gap-2 mt-4">{children}</div>
+);
+
+type Props = {
+	children: React.ReactNode;
+};
+const EmptyState = ({ children }: Props): JSX.Element => (
+	<Card>
+		<CardContent className="flex flex-col gap-2 items-center justify-center py-16">
+			{children}
+		</CardContent>
+	</Card>
+);
+
+export {
+	EmptyState,
+	EmptyStateIcon,
+	EmptyStateTitle,
+	EmptyStateDescription,
+	EmptyStateActions,
+};

--- a/ui-v2/src/components/variables/empty-state.tsx
+++ b/ui-v2/src/components/variables/empty-state.tsx
@@ -1,7 +1,13 @@
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import { DocsLink } from "@/components/ui/docs-link";
-import { PlusIcon, VariableIcon } from "lucide-react";
+import {
+	EmptyState,
+	EmptyStateActions,
+	EmptyStateDescription,
+	EmptyStateIcon,
+	EmptyStateTitle,
+} from "@/components/ui/empty-state";
+import { PlusIcon } from "lucide-react";
 
 type VariablesEmptyStateProps = {
 	onAddVariableClick: () => void;
@@ -9,19 +15,17 @@ type VariablesEmptyStateProps = {
 export const VariablesEmptyState = ({
 	onAddVariableClick,
 }: VariablesEmptyStateProps) => (
-	<Card>
-		<CardContent className="flex flex-col gap-2 items-center justify-center py-16">
-			<VariableIcon className="h-12 w-12 text-muted-foreground mb-8" />
-			<h3 className="text-2xl font-bold">Add a variable to get started</h3>
-			<p className="text-md text-muted-foreground">
-				Variables store non-sensitive pieces of JSON.
-			</p>
-			<div className="flex gap-2 mt-4">
-				<Button onClick={() => onAddVariableClick()}>
-					Add Variable <PlusIcon className="h-4 w-4 ml-2" />
-				</Button>
-				<DocsLink id="variables-guide" />
-			</div>
-		</CardContent>
-	</Card>
+	<EmptyState>
+		<EmptyStateIcon id="Variable" />
+		<EmptyStateTitle>Add a variable to get started</EmptyStateTitle>
+		<EmptyStateDescription>
+			Variables store non-sensitive pieces of JSON.
+		</EmptyStateDescription>
+		<EmptyStateActions>
+			<Button onClick={() => onAddVariableClick()}>
+				Add Variable <PlusIcon className="h-4 w-4 ml-2" />
+			</Button>
+			<DocsLink id="variables-guide" />
+		</EmptyStateActions>
+	</EmptyState>
 );


### PR DESCRIPTION
<!-- Include an overview of the proposed changes here -->
Looking at the upcoming concurrency page, there can be some generic components that can be re-used. One of them being `EmptyState`. This PR:
1. Adds a generic `EmptyState` composite component. This components manages the styling and pieces needed to create an Empty State
2. Replaces variables EmptyState to use this generic `EmptyState`

<img width="1502" alt="Screenshot 2024-12-03 at 10 29 25 AM" src="https://github.com/user-attachments/assets/e1af95bd-a994-4ea1-8846-aa41d380113f">
<img width="1507" alt="Screenshot 2024-12-03 at 11 47 27 AM" src="https://github.com/user-attachments/assets/e9ce0c8c-221d-45b3-934e-16fe7ca0dd15">



### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
