### PR TITLE
Add type completeness check to CI

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -84,6 +84,6 @@ jobs:
 
       - name: Generate type completeness score
         run: |
-          output=$(uv tool run --with . pyright --verifytypes prefect --ignoreexternal --outputjson)
-          score=$(echo "$output" | jq -r '.typeCompleteness.completenessScore')
+          uv tool run --with . pyright --verifytypes prefect --ignoreexternal --outputjson > prefect-analysis.json
+          score=$(jq -r '.typeCompleteness.completenessScore' prefect-analysis.json)
           echo "Type completeness score: $score"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -84,4 +84,6 @@ jobs:
 
       - name: Generate type completeness score
         run: |
-          uv tool run --with . pyright --verifytypes prefect --ignoreexternal --outputjson
+          uv tool run --with . pyright --verifytypes prefect --ignoreexternal --outputjson > prefect-analysis.json || true
+          score=$(jq -r '.typeCompleteness.completenessScore' prefect-analysis.json)
+          echo "Type completeness score: $score"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -84,6 +84,6 @@ jobs:
 
       - name: Generate type completeness score
         run: |
-          output=$(uv tool run --with= . pyright --verifytypes prefect --ignoreexternal --outputjson)
+          output=$(uv tool run --with . pyright --verifytypes prefect --ignoreexternal --outputjson)
           score=$(echo "$output" | jq -r '.typeCompleteness.completenessScore')
           echo "Type completeness score: $score"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -80,13 +80,8 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
         with:
-          enable-cache: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        id: setup_python
-        with:
           python-version: "3.12"
+          enable-cache: true
 
       - name: Install packages
         run: |

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -83,7 +83,10 @@ jobs:
           python-version: "3.12"
 
       - name: Calculate type completeness score
+        id: calculate_current_score
         run: |
+          # `pyright` will exit with a non-zero status code if it finds any issues,
+          # so we need to explicitly ignore the exit code with `|| true`.
           uv tool run --with . pyright --verifytypes prefect --ignoreexternal --outputjson > prefect-analysis.json || true
           SCORE=$(jq -r '.typeCompleteness.completenessScore' prefect-analysis.json)
           echo "current_score=$SCORE" >> $GITHUB_OUTPUT
@@ -93,6 +96,7 @@ jobs:
           git checkout ${{ github.base_ref }}
 
       - name: Calculate base branch score
+        id: calculate_base_score
         run: |
           uv tool run --with . pyright --verifytypes prefect --ignoreexternal --outputjson > prefect-analysis-base.json || true
           BASE_SCORE=$(jq -r '.typeCompleteness.completenessScore' prefect-analysis-base.json)
@@ -100,11 +104,14 @@ jobs:
 
       - name: Compare scores
         run: |
-          if (( $(awk 'BEGIN {print ('$BASE_SCORE' > '$CURRENT_SCORE')}') )); then
+          CURRENT_SCORE=$(echo ${{ steps.calculate_current_score.outputs.current_score }})
+          BASE_SCORE=$(echo ${{ steps.calculate_base_score.outputs.base_score }})
+
+          if (( $(echo "$BASE_SCORE > $CURRENT_SCORE" | bc -l) )); then
             echo "❌ Type completeness score has decreased from $BASE_SCORE to $CURRENT_SCORE" >> $GITHUB_STEP_SUMMARY
             exit 1
-          elif (( $(awk 'BEGIN {print ('$BASE_SCORE' < '$CURRENT_SCORE')}') )); then
+          elif (( $(echo "$BASE_SCORE < $CURRENT_SCORE" | bc -l) )); then
             echo "✅ Type completeness score has increased from $BASE_SCORE to $CURRENT_SCORE" >> $GITHUB_STEP_SUMMARY
           else
-            echo "✅ Type completeness score has not changed from $BASE_SCORE to $CURRENT_SCORE" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Type completeness score remained unchanged at $BASE_SCORE" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -103,7 +103,7 @@ jobs:
           if (( $(echo "$BASE_SCORE > $CURRENT_SCORE" | bc -l) )); then
             echo "❌ Type completeness score has decreased from $BASE_SCORE to $CURRENT_SCORE" >> $GITHUB_STEP_SUMMARY
             exit 1
-          else if (( $(echo "$BASE_SCORE < $CURRENT_SCORE" | bc -l) )); then
+          elif (( $(echo "$BASE_SCORE < $CURRENT_SCORE" | bc -l) )); then
             echo "✅ Type completeness score has increased from $BASE_SCORE to $CURRENT_SCORE" >> $GITHUB_STEP_SUMMARY
           else
             echo "✅ Type completeness score has not changed from $BASE_SCORE to $CURRENT_SCORE" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -100,10 +100,10 @@ jobs:
 
       - name: Compare scores
         run: |
-          if (( $(echo "$BASE_SCORE > $CURRENT_SCORE" | bc -l) )); then
+          if (( $(awk 'BEGIN {print ('$BASE_SCORE' > '$CURRENT_SCORE')}') )); then
             echo "❌ Type completeness score has decreased from $BASE_SCORE to $CURRENT_SCORE" >> $GITHUB_STEP_SUMMARY
             exit 1
-          elif (( $(echo "$BASE_SCORE < $CURRENT_SCORE" | bc -l) )); then
+          elif (( $(awk 'BEGIN {print ('$BASE_SCORE' < '$CURRENT_SCORE')}') )); then
             echo "✅ Type completeness score has increased from $BASE_SCORE to $CURRENT_SCORE" >> $GITHUB_STEP_SUMMARY
           else
             echo "✅ Type completeness score has not changed from $BASE_SCORE to $CURRENT_SCORE" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -109,6 +109,7 @@ jobs:
 
           if (( $(echo "$BASE_SCORE > $CURRENT_SCORE" | bc -l) )); then
             echo "❌ Type completeness score has decreased from $BASE_SCORE to $CURRENT_SCORE" >> $GITHUB_STEP_SUMMARY
+            echo "Please add type annotations to your code to increase the type completeness score." >> $GITHUB_STEP_SUMMARY
             exit 1
           elif (( $(echo "$BASE_SCORE < $CURRENT_SCORE" | bc -l) )); then
             echo "✅ Type completeness score has increased from $BASE_SCORE to $CURRENT_SCORE" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -67,3 +67,29 @@ jobs:
       - name: Run pre-commit
         run: |
           pre-commit run --show-diff-on-failure --color=always --all-files
+
+  type-completeness-check:
+    name: Type completeness check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        id: setup_python
+        with:
+          python-version: "3.12"
+
+      - name: Install packages
+        run: |
+          output=$(uv tool run pyright --verifytypes prefect --ignoreexternal --outputjson)
+          score=$(echo "$output" | jq -r '.typeCompleteness.completenessScore')
+          echo "Type completeness score: $score"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -81,7 +81,6 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.12"
-          enable-cache: true
 
       - name: Install packages
         run: |

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -84,6 +84,4 @@ jobs:
 
       - name: Generate type completeness score
         run: |
-          uv tool run --with . pyright --verifytypes prefect --ignoreexternal --outputjson > prefect-analysis.json
-          score=$(jq -r '.typeCompleteness.completenessScore' prefect-analysis.json)
-          echo "Type completeness score: $score"
+          uv tool run --with . pyright --verifytypes prefect --ignoreexternal --outputjson

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -82,8 +82,8 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install packages
+      - name: Generate type completeness score
         run: |
-          output=$(uv tool run pyright --verifytypes prefect --ignoreexternal --outputjson)
+          output=$(uv tool run --with= . pyright --verifytypes prefect --ignoreexternal --outputjson)
           score=$(echo "$output" | jq -r '.typeCompleteness.completenessScore')
           echo "Type completeness score: $score"

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -82,8 +82,29 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Generate type completeness score
+      - name: Calculate type completeness score
         run: |
           uv tool run --with . pyright --verifytypes prefect --ignoreexternal --outputjson > prefect-analysis.json || true
-          score=$(jq -r '.typeCompleteness.completenessScore' prefect-analysis.json)
-          echo "Type completeness score: $score"
+          SCORE=$(jq -r '.typeCompleteness.completenessScore' prefect-analysis.json)
+          echo "current_score=$SCORE" >> $GITHUB_OUTPUT
+
+      - name: Checkout base branch
+        run: |
+          git checkout ${{ github.base_ref }}
+
+      - name: Calculate base branch score
+        run: |
+          uv tool run --with . pyright --verifytypes prefect --ignoreexternal --outputjson > prefect-analysis-base.json || true
+          BASE_SCORE=$(jq -r '.typeCompleteness.completenessScore' prefect-analysis-base.json)
+          echo "base_score=$BASE_SCORE" >> $GITHUB_OUTPUT
+
+      - name: Compare scores
+        run: |
+          if (( $(echo "$BASE_SCORE > $CURRENT_SCORE" | bc -l) )); then
+            echo "❌ Type completeness score has decreased from $BASE_SCORE to $CURRENT_SCORE" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          else if (( $(echo "$BASE_SCORE < $CURRENT_SCORE" | bc -l) )); then
+            echo "✅ Type completeness score has increased from $BASE_SCORE to $CURRENT_SCORE" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "✅ Type completeness score has not changed from $BASE_SCORE to $CURRENT_SCORE" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->
This PR adds a type completeness check to the Static Analysis workflow. The check uses `pyright` to calculate a type completeness score and ensures that a PR will not decrease the type completeness score by comparing the generated score to the score generated on the base branch. 

Contributors will be able to see the output in the summary of the Static Analysis workflow:
![Screenshot 2024-12-04 at 9 33 58 AM](https://github.com/user-attachments/assets/e0beb441-483c-4b16-9d3d-a713ed01acb3)

Inspired by discussion in https://github.com/PrefectHQ/prefect/discussions/16167
