### PR TITLE
[UI v2] Use cva() on StateBadge

### DIFF
--- a/ui-v2/src/components/ui/state-badge/index.tsx
+++ b/ui-v2/src/components/ui/state-badge/index.tsx
@@ -1,14 +1,15 @@
-import { Badge } from "../badge";
 import type { components } from "@/api/prefect";
+import { cva } from "class-variance-authority";
 import {
+	BanIcon,
+	CheckIcon,
 	ClockIcon,
 	PauseIcon,
-	XIcon,
-	CheckIcon,
-	ServerCrashIcon,
-	BanIcon,
 	PlayIcon,
+	ServerCrashIcon,
+	XIcon,
 } from "lucide-react";
+import { Badge } from "../badge";
 
 const ICONS = {
 	COMPLETED: CheckIcon,
@@ -25,29 +26,31 @@ const ICONS = {
 	React.ElementType
 >;
 
-const CLASSES = {
-	COMPLETED: "bg-green-50 text-green-600 hover:bg-green-50",
-	FAILED: "bg-red-50 text-red-600 hover:bg-red-50",
-	RUNNING: "bg-blue-100 text-blue-700 hover:bg-blue-100",
-	CANCELLED: "bg-gray-300 text-gray-800 hover:bg-gray-300",
-	CANCELLING: "bg-gray-300 text-gray-800 hover:bg-gray-300",
-	CRASHED: "bg-orange-50 text-orange-600 hover:bg-orange-50",
-	PAUSED: "bg-gray-300 text-gray-800 hover:bg-gray-300",
-	PENDING: "bg-gray-300 text-gray-800 hover:bg-gray-300",
-	SCHEDULED: "bg-yellow-100 text-yellow-700 hover:bg-yellow-100",
-} as const satisfies Record<components["schemas"]["StateType"], string>;
+const stateBadgeVariants = cva("gap-1", {
+	variants: {
+		state: {
+			COMPLETED: "bg-green-50 text-green-600 hover:bg-green-50",
+			FAILED: "bg-red-50 text-red-600 hover:bg-red-50",
+			RUNNING: "bg-blue-100 text-blue-700 hover:bg-blue-100",
+			CANCELLED: "bg-gray-300 text-gray-800 hover:bg-gray-300",
+			CANCELLING: "bg-gray-300 text-gray-800 hover:bg-gray-300",
+			CRASHED: "bg-orange-50 text-orange-600 hover:bg-orange-50",
+			PAUSED: "bg-gray-300 text-gray-800 hover:bg-gray-300",
+			PENDING: "bg-gray-300 text-gray-800 hover:bg-gray-300",
+			SCHEDULED: "bg-yellow-100 text-yellow-700 hover:bg-yellow-100",
+		} satisfies Record<components["schemas"]["StateType"], string>,
+	},
+});
 
 export const StateBadge = ({
 	state,
 }: { state: components["schemas"]["State"] }) => {
 	const Icon = ICONS[state.type];
 	return (
-		<Badge className={CLASSES[state.type]}>
-			<div className="flex items-center gap-1">
-				<Icon size={16} />
+		<Badge className={stateBadgeVariants({ state: state.type })}>
+			<Icon size={16} />
 
-				{state.name}
-			</div>
+			{state.name}
 		</Badge>
 	);
 };

--- a/ui-v2/src/components/ui/state-badge/state-badge.stories.tsx
+++ b/ui-v2/src/components/ui/state-badge/state-badge.stories.tsx
@@ -1,47 +1,38 @@
+import type { components } from "@/api/prefect.ts";
 import type { Meta, StoryObj } from "@storybook/react";
 import { StateBadge } from ".";
 
+const badgesByState: Record<components["schemas"]["StateType"], string[]> = {
+	COMPLETED: ["Completed"],
+	FAILED: ["Failed"],
+	RUNNING: ["Running"],
+	PENDING: ["Pending"],
+	PAUSED: ["Paused"],
+	CANCELLED: ["Cancelled"],
+	CANCELLING: ["Cancelling"],
+	CRASHED: ["Crashed"],
+	SCHEDULED: ["Scheduled", "Late"],
+};
+
 const meta = {
 	title: "UI/StateBadge",
-	component: StateBadge,
-	argTypes: {
-		state: {
-			options: [
-				"COMPLETED",
-				"FAILED",
-				"RUNNING",
-				"PENDING",
-				"PAUSED",
-				"CANCELLED",
-				"CANCELLING",
-				"CRASHED",
-				"SCHEDULED",
-				"LATE",
-			],
-			mapping: {
-				COMPLETED: { type: "COMPLETED", name: "Completed" },
-				FAILED: { type: "FAILED", name: "Failed" },
-				RUNNING: { type: "RUNNING", name: "Running" },
-				PENDING: { type: "PENDING", name: "Pending" },
-				PAUSED: { type: "PAUSED", name: "Paused" },
-				CANCELLED: { type: "CANCELLED", name: "Cancelled" },
-				CANCELLING: { type: "CANCELLING", name: "Cancelling" },
-				CRASHED: { type: "CRASHED", name: "Crashed" },
-				SCHEDULED: { type: "SCHEDULED", name: "Scheduled" },
-				LATE: { type: "SCHEDULED", name: "Late" },
-			},
-		},
+	component: function StateBadgeStories() {
+		return (
+			<div className="flex flex-col gap-4 items-start">
+				{Object.entries(badgesByState).map(([type, names]) =>
+					names.map((name) => (
+						<StateBadge
+							key={name}
+							state={{ type, name } as components["schemas"]["State"]}
+						/>
+					)),
+				)}
+			</div>
+		);
 	},
 } satisfies Meta<typeof StateBadge>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const States: Story = {
-	args: {
-		state: {
-			type: "COMPLETED",
-			name: "Completed",
-		},
-	},
-};
+export const States: Story = {};

--- a/ui-v2/src/components/ui/state-badge/state-badge.stories.tsx
+++ b/ui-v2/src/components/ui/state-badge/state-badge.stories.tsx
@@ -14,7 +14,9 @@ const badgesByState: Record<components["schemas"]["StateType"], string[]> = {
 	SCHEDULED: ["Scheduled", "Late"],
 };
 
-const meta = {
+export const story: StoryObj = { name: "StateBadge" };
+
+export default {
 	title: "UI/StateBadge",
 	component: function StateBadgeStories() {
 		return (
@@ -30,9 +32,4 @@ const meta = {
 			</div>
 		);
 	},
-} satisfies Meta<typeof StateBadge>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const States: Story = {};
+} satisfies Meta;

--- a/ui-v2/src/components/ui/state-badge/state-badge.test.tsx
+++ b/ui-v2/src/components/ui/state-badge/state-badge.test.tsx
@@ -1,15 +1,15 @@
 import { render, screen } from "@testing-library/react";
-import { StateBadge } from "./index";
 import {
+	BanIcon,
+	CheckIcon,
 	ClockIcon,
 	PauseIcon,
-	XIcon,
-	CheckIcon,
-	ServerCrashIcon,
-	BanIcon,
 	PlayIcon,
+	ServerCrashIcon,
+	XIcon,
 } from "lucide-react";
 import { describe, expect, test } from "vitest";
+import { StateBadge } from "./index";
 
 describe("StateBadge", () => {
 	const states = [
@@ -87,7 +87,7 @@ describe("StateBadge", () => {
 				SCHEDULED: "bg-yellow-100 text-yellow-700 hover:bg-yellow-100",
 			}[type];
 
-			expect(badge?.parentElement).toHaveClass(...expectedClasses.split(" "));
+			expect(badge).toHaveClass(...expectedClasses.split(" "));
 		},
 	);
 });


### PR DESCRIPTION
This PR includes three small improvements: 

1. Use `cva()` on state-based styles for `StateBadge` to get Tailwind [IntelliSense](https://cva.style/docs/getting-started/installation#intellisense). 
2. Make the Storybook story a "Catalog" of all states. 
3. Simplify the Storybook hierarchy via [single-story hoisting](https://storybook.js.org/docs/writing-stories/naming-components-and-hierarchy#single-story-hoisting). 

![image](https://github.com/user-attachments/assets/cbf098bc-299f-4654-8de8-827449390705)

Please let me know if only some of the above are interested, and I will revert the other changes. 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
