### PR TITLE
update typing in `blocks.abstract` and `concurrency`

### DIFF
--- a/src/prefect/blocks/abstract.py
+++ b/src/prefect/blocks/abstract.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from logging import Logger
+from logging import Logger, LoggerAdapter
 from pathlib import Path
 from typing import (
     Any,
@@ -15,13 +15,15 @@ from typing import (
     Union,
 )
 
-from typing_extensions import Self
+from typing_extensions import Self, TypeAlias
 
 from prefect.blocks.core import Block
 from prefect.exceptions import MissingContextError
 from prefect.logging.loggers import get_logger, get_run_logger
 
 T = TypeVar("T")
+
+LoggerOrAdapter: TypeAlias = Union[Logger, LoggerAdapter]
 
 
 class CredentialsBlock(Block, ABC):
@@ -34,7 +36,7 @@ class CredentialsBlock(Block, ABC):
     """
 
     @property
-    def logger(self) -> Logger:
+    def logger(self) -> LoggerOrAdapter:
         """
         Returns a logger based on whether the CredentialsBlock
         is called from within a flow or task run context.
@@ -73,10 +75,10 @@ class NotificationBlock(Block, ABC):
     """
 
     _block_schema_capabilities = ["notify"]
-    _events_excluded_methods = Block._events_excluded_methods.default + ["notify"]
+    _events_excluded_methods = Block._events_excluded_methods + ["notify"]
 
     @property
-    def logger(self) -> Logger:
+    def logger(self) -> LoggerOrAdapter:
         """
         Returns a logger based on whether the NotificationBlock
         is called from within a flow or task run context.
@@ -123,7 +125,7 @@ class JobRun(ABC, Generic[T]):  # not a block
     """
 
     @property
-    def logger(self) -> Logger:
+    def logger(self) -> LoggerOrAdapter:
         """
         Returns a logger based on whether the JobRun
         is called from within a flow or task run context.
@@ -158,7 +160,7 @@ class JobBlock(Block, ABC):
     """
 
     @property
-    def logger(self) -> Logger:
+    def logger(self) -> LoggerOrAdapter:
         """
         Returns a logger based on whether the JobBlock
         is called from within a flow or task run context.
@@ -202,7 +204,7 @@ class DatabaseBlock(Block, ABC):
     """
 
     @property
-    def logger(self) -> Logger:
+    def logger(self) -> LoggerOrAdapter:
         """
         Returns a logger based on whether the DatabaseBlock
         is called from within a flow or task run context.
@@ -337,7 +339,7 @@ class ObjectStorageBlock(Block, ABC):
     """
 
     @property
-    def logger(self) -> Logger:
+    def logger(self) -> LoggerOrAdapter:
         """
         Returns a logger based on whether the ObjectStorageBlock
         is called from within a flow or task run context.
@@ -469,7 +471,7 @@ class SecretBlock(Block, ABC):
     """
 
     @property
-    def logger(self) -> Logger:
+    def logger(self) -> LoggerOrAdapter:
         """
         Returns a logger based on whether the SecretBlock
         is called from within a flow or task run context.

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -326,7 +326,9 @@ class Block(BaseModel, ABC):
 
     # Exclude `save` as it uses the `sync_compatible` decorator and needs to be
     # decorated directly.
-    _events_excluded_methods = ["block_initialization", "save", "dict"]
+    _events_excluded_methods: ClassVar[List[str]] = PrivateAttr(
+        default=["block_initialization", "save", "dict"]
+    )
 
     @classmethod
     def __dispatch_key__(cls):

--- a/src/prefect/concurrency/asyncio.py
+++ b/src/prefect/concurrency/asyncio.py
@@ -7,7 +7,6 @@ import httpx
 import pendulum
 
 from prefect._internal.compatibility.deprecated import deprecated_parameter
-from prefect.utilities.asyncutils import run_coro_as_sync
 
 try:
     from pendulum import Interval
@@ -198,25 +197,6 @@ async def _aacquire_concurrency_slots(
     return retval
 
 
-def _acquire_concurrency_slots(
-    names: List[str],
-    slots: int,
-    mode: Literal["concurrency", "rate_limit"] = "concurrency",
-    timeout_seconds: Optional[float] = None,
-    create_if_missing: Optional[bool] = None,
-    max_retries: Optional[int] = None,
-    strict: bool = False,
-) -> List[MinimalConcurrencyLimitResponse]:
-    result = run_coro_as_sync(
-        _aacquire_concurrency_slots(
-            names, slots, mode, timeout_seconds, create_if_missing, max_retries, strict
-        )
-    )
-    if result is None:
-        raise RuntimeError("Failed to acquire concurrency slots")
-    return result
-
-
 async def _arelease_concurrency_slots(
     names: List[str], slots: int, occupancy_seconds: float
 ) -> List[MinimalConcurrencyLimitResponse]:
@@ -225,17 +205,6 @@ async def _arelease_concurrency_slots(
             names=names, slots=slots, occupancy_seconds=occupancy_seconds
         )
         return _response_to_minimal_concurrency_limit_response(response)
-
-
-def _release_concurrency_slots(
-    names: List[str], slots: int, occupancy_seconds: float
-) -> List[MinimalConcurrencyLimitResponse]:
-    result = run_coro_as_sync(
-        _arelease_concurrency_slots(names, slots, occupancy_seconds)
-    )
-    if result is None:
-        raise RuntimeError("Failed to release concurrency slots")
-    return result
 
 
 def _response_to_minimal_concurrency_limit_response(

--- a/src/prefect/concurrency/sync.py
+++ b/src/prefect/concurrency/sync.py
@@ -81,7 +81,6 @@ def concurrency(
         create_if_missing=create_if_missing,
         strict=strict,
         max_retries=max_retries,
-        _sync=True,
     )
     acquisition_time = pendulum.now("UTC")
     emitted_events = _emit_concurrency_acquisition_events(limits, occupy)
@@ -94,7 +93,6 @@ def concurrency(
             names,
             occupy,
             occupancy_period.total_seconds(),
-            _sync=True,
         )
         _emit_concurrency_release_events(limits, occupy, emitted_events)
 
@@ -134,6 +132,5 @@ def rate_limit(
         timeout_seconds=timeout_seconds,
         create_if_missing=create_if_missing,
         strict=strict,
-        _sync=True,
     )
     _emit_concurrency_acquisition_events(limits, occupy)

--- a/src/prefect/concurrency/sync.py
+++ b/src/prefect/concurrency/sync.py
@@ -9,6 +9,9 @@ from typing import (
 )
 
 import pendulum
+from typing_extensions import Literal
+
+from prefect.utilities.asyncutils import run_coro_as_sync
 
 try:
     from pendulum import Interval
@@ -19,8 +22,8 @@ except ImportError:
 from prefect.client.schemas.responses import MinimalConcurrencyLimitResponse
 
 from .asyncio import (
-    _acquire_concurrency_slots,
-    _release_concurrency_slots,
+    _aacquire_concurrency_slots,
+    _arelease_concurrency_slots,
 )
 from .events import (
     _emit_concurrency_acquisition_events,
@@ -28,6 +31,36 @@ from .events import (
 )
 
 T = TypeVar("T")
+
+
+def _release_concurrency_slots(
+    names: List[str], slots: int, occupancy_seconds: float
+) -> List[MinimalConcurrencyLimitResponse]:
+    result = run_coro_as_sync(
+        _arelease_concurrency_slots(names, slots, occupancy_seconds)
+    )
+    if result is None:
+        raise RuntimeError("Failed to release concurrency slots")
+    return result
+
+
+def _acquire_concurrency_slots(
+    names: List[str],
+    slots: int,
+    mode: Literal["concurrency", "rate_limit"] = "concurrency",
+    timeout_seconds: Optional[float] = None,
+    create_if_missing: Optional[bool] = None,
+    max_retries: Optional[int] = None,
+    strict: bool = False,
+) -> List[MinimalConcurrencyLimitResponse]:
+    result = run_coro_as_sync(
+        _aacquire_concurrency_slots(
+            names, slots, mode, timeout_seconds, create_if_missing, max_retries, strict
+        )
+    )
+    if result is None:
+        raise RuntimeError("Failed to acquire concurrency slots")
+    return result
 
 
 @contextmanager

--- a/tests/concurrency/test_acquire_concurrency_slots.py
+++ b/tests/concurrency/test_acquire_concurrency_slots.py
@@ -4,7 +4,9 @@ from unittest import mock
 from httpx import Response
 
 from prefect.client.schemas.responses import MinimalConcurrencyLimitResponse
-from prefect.concurrency.asyncio import _acquire_concurrency_slots
+from prefect.concurrency.asyncio import (
+    _aacquire_concurrency_slots,
+)
 
 
 async def test_calls_increment_client_method():
@@ -21,7 +23,7 @@ async def test_calls_increment_client_method():
         )
         increment_concurrency_slots.return_value = response
 
-        await _acquire_concurrency_slots(
+        await _aacquire_concurrency_slots(
             names=["test-1", "test-2"], slots=1, mode="concurrency"
         )
         increment_concurrency_slots.assert_called_once_with(
@@ -46,5 +48,5 @@ async def test_returns_minimal_concurrency_limit():
         )
         increment_concurrency_slots.return_value = response
 
-        result = await _acquire_concurrency_slots(["test-1", "test-2"], 1)
+        result = await _aacquire_concurrency_slots(["test-1", "test-2"], 1)
         assert result == limits

--- a/tests/concurrency/test_concurrency_asyncio.py
+++ b/tests/concurrency/test_concurrency_asyncio.py
@@ -93,7 +93,7 @@ async def test_concurrency_can_be_used_within_a_flow_strictly():
     state = await my_flow(return_state=True)
     assert state.is_failed()
     with pytest.raises(ConcurrencySlotAcquisitionError):
-        await state.result()
+        await state.result()  # type: ignore[reportGeneralTypeIssues]
 
 
 async def test_concurrency_emits_events(
@@ -112,7 +112,7 @@ async def test_concurrency_emits_events(
 
     await resource_heavy()
 
-    await asserting_events_worker.drain()
+    await asserting_events_worker.drain()  # type: ignore[reportGeneralTypeIssues]
     assert isinstance(asserting_events_worker._client, AssertingEventsClient)
     assert len(asserting_events_worker._client.events) == 4  # 2 acquire, 2 release
 
@@ -281,7 +281,7 @@ async def test_rate_limit_can_be_used_within_a_flow_with_strict():
     state = await my_flow(return_state=True)
     assert state.is_failed()
     with pytest.raises(ConcurrencySlotAcquisitionError):
-        await state.result()
+        await state.result()  # type: ignore[reportGeneralTypeIssues]
 
 
 async def test_rate_limit_emits_events(
@@ -296,7 +296,7 @@ async def test_rate_limit_emits_events(
 
     await resource_heavy()
 
-    await asserting_events_worker.drain()
+    await asserting_events_worker.drain()  # type: ignore[reportGeneralTypeIssues]
     assert isinstance(asserting_events_worker._client, AssertingEventsClient)
     assert len(asserting_events_worker._client.events) == 2
 
@@ -373,11 +373,11 @@ async def test_rate_limit_without_limit_names(names):
     assert not executed
 
     with mock.patch(
-        "prefect.concurrency.asyncio._acquire_concurrency_slots",
+        "prefect.concurrency.sync._acquire_concurrency_slots",
         wraps=lambda *args, **kwargs: None,
     ) as acquire_spy:
         with mock.patch(
-            "prefect.concurrency.asyncio._arelease_concurrency_slots",
+            "prefect.concurrency.sync._arelease_concurrency_slots",
             wraps=lambda *args, **kwargs: None,
         ) as release_spy:
             await resource_heavy()
@@ -443,11 +443,11 @@ async def test_concurrency_without_limit_names(names):
     assert not executed
 
     with mock.patch(
-        "prefect.concurrency.asyncio._acquire_concurrency_slots",
+        "prefect.concurrency.sync._acquire_concurrency_slots",
         wraps=lambda *args, **kwargs: None,
     ) as acquire_spy:
         with mock.patch(
-            "prefect.concurrency.asyncio._release_concurrency_slots",
+            "prefect.concurrency.sync._arelease_concurrency_slots",
             wraps=lambda *args, **kwargs: None,
         ) as release_spy:
             await resource_heavy()

--- a/tests/concurrency/test_concurrency_asyncio.py
+++ b/tests/concurrency/test_concurrency_asyncio.py
@@ -7,8 +7,8 @@ from starlette import status
 from prefect import flow, task
 from prefect.concurrency.asyncio import (
     ConcurrencySlotAcquisitionError,
-    _acquire_concurrency_slots,
-    _release_concurrency_slots,
+    _aacquire_concurrency_slots,
+    _arelease_concurrency_slots,
     concurrency,
     rate_limit,
 )
@@ -28,12 +28,12 @@ async def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV
     assert not executed
 
     with mock.patch(
-        "prefect.concurrency.asyncio._acquire_concurrency_slots",
-        wraps=_acquire_concurrency_slots,
+        "prefect.concurrency.asyncio._aacquire_concurrency_slots",
+        wraps=_aacquire_concurrency_slots,
     ) as acquire_spy:
         with mock.patch(
-            "prefect.concurrency.asyncio._release_concurrency_slots",
-            wraps=_release_concurrency_slots,
+            "prefect.concurrency.asyncio._arelease_concurrency_slots",
+            wraps=_arelease_concurrency_slots,
         ) as release_spy:
             await resource_heavy()
 
@@ -221,12 +221,12 @@ async def test_rate_limit_orchestrates_api(
     assert not executed
 
     with mock.patch(
-        "prefect.concurrency.asyncio._acquire_concurrency_slots",
-        wraps=_acquire_concurrency_slots,
+        "prefect.concurrency.asyncio._aacquire_concurrency_slots",
+        wraps=_aacquire_concurrency_slots,
     ) as acquire_spy:
         with mock.patch(
-            "prefect.concurrency.asyncio._release_concurrency_slots",
-            wraps=_release_concurrency_slots,
+            "prefect.concurrency.asyncio._arelease_concurrency_slots",
+            wraps=_arelease_concurrency_slots,
         ) as release_spy:
             await resource_heavy()
 
@@ -377,7 +377,7 @@ async def test_rate_limit_without_limit_names(names):
         wraps=lambda *args, **kwargs: None,
     ) as acquire_spy:
         with mock.patch(
-            "prefect.concurrency.asyncio._release_concurrency_slots",
+            "prefect.concurrency.asyncio._arelease_concurrency_slots",
             wraps=lambda *args, **kwargs: None,
         ) as release_spy:
             await resource_heavy()
@@ -401,12 +401,12 @@ async def test_concurrency_creates_new_limits_if_requested(
     assert not executed
 
     with mock.patch(
-        "prefect.concurrency.asyncio._acquire_concurrency_slots",
-        wraps=_acquire_concurrency_slots,
+        "prefect.concurrency.asyncio._aacquire_concurrency_slots",
+        wraps=_aacquire_concurrency_slots,
     ) as acquire_spy:
         with mock.patch(
-            "prefect.concurrency.asyncio._release_concurrency_slots",
-            wraps=_release_concurrency_slots,
+            "prefect.concurrency.asyncio._arelease_concurrency_slots",
+            wraps=_arelease_concurrency_slots,
         ) as release_spy:
             await resource_heavy()
 

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -43,7 +43,6 @@ def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV2):
                 create_if_missing=None,
                 max_retries=None,
                 strict=False,
-                _sync=True,
             )
 
             # On release we calculate how many seconds the slots were occupied
@@ -275,7 +274,6 @@ def test_rate_limit_orchestrates_api(concurrency_limit_with_decay: ConcurrencyLi
                 timeout_seconds=None,
                 create_if_missing=None,
                 strict=False,
-                _sync=True,
             )
 
             # When used as a rate limit concurrency slots are not explicitly

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -5,12 +5,13 @@ from httpx import HTTPStatusError, Request, Response
 from starlette import status
 
 from prefect import flow, task
-from prefect.concurrency.asyncio import (
-    ConcurrencySlotAcquisitionError,
+from prefect.concurrency.asyncio import ConcurrencySlotAcquisitionError
+from prefect.concurrency.sync import (
     _acquire_concurrency_slots,
     _release_concurrency_slots,
+    concurrency,
+    rate_limit,
 )
-from prefect.concurrency.sync import concurrency, rate_limit
 from prefect.events.clients import AssertingEventsClient
 from prefect.events.worker import EventsWorker
 from prefect.server.schemas.core import ConcurrencyLimitV2

--- a/tests/concurrency/test_release_concurrency_slots.py
+++ b/tests/concurrency/test_release_concurrency_slots.py
@@ -4,7 +4,9 @@ from unittest import mock
 from httpx import Response
 
 from prefect.client.schemas.responses import MinimalConcurrencyLimitResponse
-from prefect.concurrency.asyncio import _release_concurrency_slots
+from prefect.concurrency.asyncio import (
+    _arelease_concurrency_slots,
+)
 
 
 async def test_calls_release_client_method():
@@ -21,7 +23,7 @@ async def test_calls_release_client_method():
         )
         client_release_concurrency_slots.return_value = response
 
-        await _release_concurrency_slots(
+        await _arelease_concurrency_slots(
             names=["test-1", "test-2"], slots=1, occupancy_seconds=1.0
         )
         client_release_concurrency_slots.assert_called_once_with(
@@ -45,5 +47,5 @@ async def test_returns_minimal_concurrency_limit():
         )
         client_release_concurrency_slots.return_value = response
 
-        result = await _release_concurrency_slots(["test-1", "test-2"], 1, 1.0)
+        result = await _arelease_concurrency_slots(["test-1", "test-2"], 1, 1.0)
         assert result == limits

--- a/tests/concurrency/v1/test_increment_concurrency_limits.py
+++ b/tests/concurrency/v1/test_increment_concurrency_limits.py
@@ -4,7 +4,9 @@ from unittest import mock
 from httpx import Response
 
 from prefect.client.schemas.responses import MinimalConcurrencyLimitResponse
-from prefect.concurrency.asyncio import _acquire_concurrency_slots
+from prefect.concurrency.asyncio import (
+    _aacquire_concurrency_slots,
+)
 
 
 async def test_calls_increment_client_method():
@@ -25,7 +27,7 @@ async def test_calls_increment_client_method():
         )
         increment_concurrency_slots.return_value = response
 
-        await _acquire_concurrency_slots(
+        await _aacquire_concurrency_slots(
             names=["test-1", "test-2"], slots=1, mode="concurrency"
         )
         increment_concurrency_slots.assert_called_once_with(
@@ -54,5 +56,5 @@ async def test_returns_minimal_concurrency_limit():
         )
         increment_concurrency_slots.return_value = response
 
-        result = await _acquire_concurrency_slots(["test-1", "test-2"], 1)
+        result = await _aacquire_concurrency_slots(["test-1", "test-2"], 1)
         assert result == limits


### PR DESCRIPTION
and migrates private concurrency context managers' helpers off `sync_compatible` 

cc @aaazzam 