### PR TITLE
Add sqlite to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,11 +93,13 @@ WORKDIR /opt/prefect
 # - tini: Used in the entrypoint
 # - build-essential: Required for Python dependencies without wheels
 # - git: Required for retrieving workflows from git sources
+# - sqlite: Required for running an embedded database
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     tini=0.19.* \
     build-essential \
     git=1:2.* \
+    sqlite3=3.40.* \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Pin the pip version


### PR DESCRIPTION
## Summary

Adds sqlite to the Docker image to support running an embedded database: https://docs-3.prefect.io/v3/manage/self-host#sqlite

This comes with a slight image size increase:
- before:   589.19 MiB
- after:    597.74 MiB
- increase: 8.55 MiB

In the context of https://linear.app/prefect/issue/PLA-139/support-sqlite-database, this will make `sqlite` available from the Prefect Server Deployment as part of the Helm Chart (to come in a future PR).

Related to https://linear.app/prefect/issue/PLA-139/support-sqlite-database

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
