### PR TITLE
Bring ORM models and Alembic migrations in sync

### DIFF
--- a/src/prefect/server/database/_migrations/MIGRATION-NOTES.md
+++ b/src/prefect/server/database/_migrations/MIGRATION-NOTES.md
@@ -8,6 +8,10 @@ Each time a database migration is written, an entry is included here with:
 
 This gives us a history of changes and will create merge conflicts if two migrations are made at once, flagging situations where a branch needs to be updated before merging.
 
+# Bring ORM models and migrations back in sync
+SQLite: `a49711513ad4`
+Postgres: `5d03c01be85e`
+
 # Add `labels` column to Flow, FlowRun, TaskRun, and Deployment
 SQLite: `5952a5498b51`
 Postgres: `68a44144428d`

--- a/src/prefect/server/database/_migrations/versions/postgresql/2024_12_04_165333_5d03c01be85e_sync_orm_models_and_migrations.py
+++ b/src/prefect/server/database/_migrations/versions/postgresql/2024_12_04_165333_5d03c01be85e_sync_orm_models_and_migrations.py
@@ -1,0 +1,111 @@
+"""Sync ORM models and migrations
+
+Revision ID: 5d03c01be85e
+Revises: 68a44144428d
+Create Date: 2024-12-04 16:53:33.015870
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "5d03c01be85e"
+down_revision = "68a44144428d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Column is non-null in the ORM and in SQLite.
+    op.execute(
+        "UPDATE artifact_collection SET latest_id=GEN_RANDOM_UUID() WHERE latest_id IS NULL"
+    )
+    op.alter_column(
+        "artifact_collection", "latest_id", existing_type=sa.UUID(), nullable=False
+    )
+
+    # table added in 027c123512befd2bd00a0ef28bd44215e77bece6 but index was
+    # never created in a migration.
+    op.create_index(
+        op.f("ix_artifact_collection__updated"),
+        "artifact_collection",
+        ["updated"],
+        unique=False,
+    )
+
+    # columns removed in c53b00bfa1f6850ab43e168c92c627350c090647
+    op.drop_column("deployment", "schedule")
+    op.drop_column("deployment", "is_schedule_active")
+
+    # column removed in 5784c637e7e11a8e88e2b3146e54e9b6c97d50ef
+    op.drop_column("deployment", "flow_data")
+
+    # Column is no longer a FK since d10c7471a69403bcf88f401091497a2dc8963885
+    op.drop_index("ix_flow_run__deployment_id", table_name="flow_run")
+
+    # column removed in eaa7a5063c73718dff56ce4aeb66e53fcafe60e5
+    op.drop_column("deployment", "manifest_path")
+
+    # columns removed from orm models in 0b62de684447c6955e04c722c276edac4002fd40
+    op.drop_column("deployment_schedule", "catchup")
+    op.drop_column("deployment_schedule", "max_active_runs")
+
+
+def downgrade():
+    op.create_index(
+        "ix_flow_run__deployment_id", "flow_run", ["deployment_id"], unique=False
+    )
+    op.add_column(
+        "deployment_schedule",
+        sa.Column("max_active_runs", sa.INTEGER(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        "deployment_schedule",
+        sa.Column(
+            "catchup",
+            sa.BOOLEAN(),
+            server_default=sa.text("false"),
+            autoincrement=False,
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "deployment",
+        sa.Column(
+            "flow_data",
+            postgresql.JSONB(astext_type=sa.Text()),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "deployment",
+        sa.Column(
+            "is_schedule_active",
+            sa.BOOLEAN(),
+            server_default=sa.text("true"),
+            autoincrement=False,
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "deployment",
+        sa.Column("manifest_path", sa.VARCHAR(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        "deployment",
+        sa.Column(
+            "schedule",
+            postgresql.JSONB(astext_type=sa.Text()),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )
+    op.drop_index(
+        op.f("ix_artifact_collection__updated"), table_name="artifact_collection"
+    )
+    op.alter_column(
+        "artifact_collection", "latest_id", existing_type=sa.UUID(), nullable=True
+    )

--- a/src/prefect/server/database/_migrations/versions/sqlite/2024_12_04_144924_a49711513ad4_sync_orm_models_and_migrations.py
+++ b/src/prefect/server/database/_migrations/versions/sqlite/2024_12_04_144924_a49711513ad4_sync_orm_models_and_migrations.py
@@ -1,0 +1,127 @@
+"""Sync ORM models and migrations
+
+Revision ID: a49711513ad4
+Revises: 5952a5498b51
+Create Date: 2024-12-04 14:49:24.099491
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import sqlite
+
+# revision identifiers, used by Alembic.
+revision = "a49711513ad4"
+down_revision = "5952a5498b51"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("artifact_collection", schema=None) as batch_op:
+        # table added in 027c123512befd2bd00a0ef28bd44215e77bece6 but index was
+        # never created in a migration.
+        batch_op.create_index(
+            batch_op.f("ix_artifact_collection__updated"), ["updated"], unique=False
+        )
+        # index created on the wrong table in ca9f93463a4c38fce8be972d91e808b5935e5d9c
+        batch_op.drop_index("ix_artifact__key_created_desc")
+
+    with op.batch_alter_table("artifact", schema=None) as batch_op:
+        # index created on the wrong table in ca9f93463a4c38fce8be972d91e808b5935e5d9c
+        batch_op.create_index(
+            "ix_artifact__key_created_desc",
+            ["key", sa.text("created DESC")],
+            unique=False,
+            postgresql_include=["id", "updated", "type", "task_run_id", "flow_run_id"],
+        )
+
+    with op.batch_alter_table("block_document", schema=None) as batch_op:
+        # Renamed index to remain consistent with PostgreSQL
+        batch_op.drop_index("ix_block_document__block_type_name_name")
+        batch_op.create_index(
+            "ix_block_document__block_type_name__name",
+            ["block_type_name", "name"],
+            unique=False,
+        )
+
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        # columns removed in c53b00bfa1f6850ab43e168c92c627350c090647
+        batch_op.drop_column("schedule")
+        batch_op.drop_column("is_schedule_active")
+
+        # column removed in 5784c637e7e11a8e88e2b3146e54e9b6c97d50ef
+        batch_op.drop_column("flow_data")
+
+        # column removed in eaa7a5063c73718dff56ce4aeb66e53fcafe60e5
+        batch_op.drop_column("manifest_path")
+
+    with op.batch_alter_table("deployment_schedule", schema=None) as batch_op:
+        # columns removed from orm models in 0b62de684447c6955e04c722c276edac4002fd40
+        batch_op.drop_column("catchup")
+        batch_op.drop_column("max_active_runs")
+
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        # Column is no longer a FK since d10c7471a69403bcf88f401091497a2dc8963885
+        batch_op.drop_index("ix_flow_run__deployment_id")
+        # Index accidentally dropped in 519a2ed6e31e2b60136e1a1a163a9cd0a8d3d5c4
+        batch_op.create_index(
+            "ix_flow_run__scheduler_deployment_id_auto_scheduled_next_schedu",
+            ["deployment_id", "auto_scheduled", "next_scheduled_start_time"],
+            unique=False,
+            postgresql_where=sa.text("state_type = 'SCHEDULED'::state_type"),
+            sqlite_where=sa.text("state_type = 'SCHEDULED'"),
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("flow_run", schema=None) as batch_op:
+        batch_op.drop_index(
+            "ix_flow_run__scheduler_deployment_id_auto_scheduled_next_schedu",
+            postgresql_where=sa.text("state_type = 'SCHEDULED'::state_type"),
+            sqlite_where=sa.text("state_type = 'SCHEDULED'"),
+        )
+        batch_op.create_index(
+            "ix_flow_run__deployment_id", ["deployment_id"], unique=False
+        )
+
+    with op.batch_alter_table("deployment_schedule", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("max_active_runs", sa.INTEGER(), nullable=True))
+        batch_op.add_column(
+            sa.Column(
+                "catchup", sa.BOOLEAN(), server_default=sa.text("'0'"), nullable=False
+            )
+        )
+
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "is_schedule_active",
+                sa.BOOLEAN(),
+                server_default=sa.text("'1'"),
+                nullable=False,
+            )
+        )
+        batch_op.add_column(sa.Column("flow_data", sqlite.JSON(), nullable=True))
+        batch_op.add_column(sa.Column("schedule", sqlite.JSON(), nullable=True))
+        batch_op.add_column(sa.Column("manifest_path", sa.VARCHAR(), nullable=True))
+
+    with op.batch_alter_table("block_document", schema=None) as batch_op:
+        batch_op.drop_index("ix_block_document__block_type_name__name")
+        batch_op.create_index(
+            "ix_block_document__block_type_name_name",
+            ["block_type_name", "name"],
+            unique=False,
+        )
+
+    with op.batch_alter_table("artifact", schema=None) as batch_op:
+        batch_op.drop_index(
+            "ix_artifact__key_created_desc",
+            postgresql_include=["id", "updated", "type", "task_run_id", "flow_run_id"],
+        )
+
+    with op.batch_alter_table("artifact_collection", schema=None) as batch_op:
+        batch_op.create_index(
+            "ix_artifact__key_created_desc", ["key", "created"], unique=False
+        )
+        batch_op.drop_index(batch_op.f("ix_artifact_collection__updated"))

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -2,7 +2,7 @@ import datetime
 import uuid
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Dict, Hashable, List, Tuple, Union, cast
+from typing import Any, Dict, Hashable, Iterable, List, Optional, Tuple, Union, cast
 
 import pendulum
 import sqlalchemy as sa
@@ -141,7 +141,7 @@ class Flow(Base):
     tags: Mapped[List[str]] = mapped_column(
         JSON, server_default="[]", default=list, nullable=False
     )
-    labels: Mapped[Union[schemas.core.KeyValueLabels, None]] = mapped_column(
+    labels: Mapped[Optional[schemas.core.KeyValueLabels]] = mapped_column(
         JSON, nullable=True
     )
 
@@ -151,6 +151,9 @@ class Flow(Base):
     __table_args__ = (
         sa.UniqueConstraint("name"),
         sa.Index("ix_flow__created", "created"),
+        sa.Index("trgm_ix_flow_name", "name", postgresql_using="gin").ddl_if(
+            dialect="postgresql"
+        ),
     )
 
 
@@ -178,7 +181,7 @@ class FlowRunState(Base):
         default=schemas.states.StateDetails,
         nullable=False,
     )
-    _data = sa.Column(sa.JSON, nullable=True, name="data")
+    _data: Optional[Any] = sa.Column(JSON, nullable=True, name="data")
 
     result_artifact_id = sa.Column(
         UUID(),
@@ -216,14 +219,17 @@ class FlowRunState(Base):
     def as_state(self) -> schemas.states.State:
         return schemas.states.State.model_validate(self, from_attributes=True)
 
-    __table_args__ = (
-        sa.Index(
-            "uq_flow_run_state__flow_run_id_timestamp_desc",
-            "flow_run_id",
-            sa.desc("timestamp"),
-            unique=True,
-        ),
-    )
+    @declared_attr.directive
+    @classmethod
+    def __table_args__(cls) -> Iterable[sa.Index]:
+        return (
+            sa.Index(
+                "uq_flow_run_state__flow_run_id_timestamp_desc",
+                cls.flow_run_id,
+                cls.timestamp.desc(),
+                unique=True,
+            ),
+        )
 
 
 class TaskRunState(Base):
@@ -252,7 +258,7 @@ class TaskRunState(Base):
         default=schemas.states.StateDetails,
         nullable=False,
     )
-    _data = sa.Column(sa.JSON, nullable=True, name="data")
+    _data: Optional[Any] = sa.Column(JSON, nullable=True, name="data")
 
     result_artifact_id = sa.Column(
         UUID(),
@@ -290,14 +296,17 @@ class TaskRunState(Base):
     def as_state(self) -> schemas.states.State:
         return schemas.states.State.model_validate(self, from_attributes=True)
 
-    __table_args__ = (
-        sa.Index(
-            "uq_task_run_state__task_run_id_timestamp_desc",
-            "task_run_id",
-            sa.desc("timestamp"),
-            unique=True,
-        ),
-    )
+    @declared_attr.directive
+    @classmethod
+    def __table_args__(cls) -> Iterable[sa.Index]:
+        return (
+            sa.Index(
+                "uq_task_run_state__task_run_id_timestamp_desc",
+                cls.task_run_id,
+                cls.timestamp.desc(),
+                unique=True,
+            ),
+        )
 
 
 class Artifact(Base):
@@ -330,12 +339,27 @@ class Artifact(Base):
     # Suffixed with underscore as attribute name 'metadata' is reserved for the MetaData instance when using a declarative base class.
     metadata_ = sa.Column(sa.JSON, nullable=True)
 
-    __table_args__ = (
-        sa.Index(
-            "ix_artifact__key",
-            "key",
-        ),
-    )
+    @declared_attr.directive
+    @classmethod
+    def __table_args__(cls) -> Iterable[sa.Index]:
+        return (
+            sa.Index(
+                "ix_artifact__key",
+                cls.key,
+            ),
+            sa.Index(
+                "ix_artifact__key_created_desc",
+                cls.key,
+                cls.created.desc(),
+                postgresql_include=[
+                    "id",
+                    "updated",
+                    "type",
+                    "task_run_id",
+                    "flow_run_id",
+                ],
+            ),
+        )
 
 
 class ArtifactCollection(Base):
@@ -383,13 +407,16 @@ class TaskRunStateCache(Base):
     )
     task_run_state_id = sa.Column(UUID(), nullable=False)
 
-    __table_args__ = (
-        sa.Index(
-            "ix_task_run_state_cache__cache_key_created_desc",
-            "cache_key",
-            sa.desc("created"),
-        ),
-    )
+    @declared_attr.directive
+    @classmethod
+    def __table_args__(cls) -> Iterable[sa.Index]:
+        return (
+            sa.Index(
+                "ix_task_run_state_cache__cache_key_created_desc",
+                cls.cache_key,
+                cls.created.desc(),
+            ),
+        )
 
 
 class Run(Base):
@@ -407,14 +434,16 @@ class Run(Base):
     )
     state_type = sa.Column(sa.Enum(schemas.states.StateType, name="state_type"))
     state_name = sa.Column(sa.String, nullable=True)
-    state_timestamp: Mapped[Union[pendulum.DateTime, None]] = mapped_column(
+    state_timestamp: Mapped[Optional[pendulum.DateTime]] = mapped_column(
         Timestamp(), nullable=True
     )
     run_count = sa.Column(sa.Integer, server_default="0", default=0, nullable=False)
-    expected_start_time: Mapped[pendulum.DateTime] = mapped_column(Timestamp())
+    expected_start_time: Mapped[Optional[pendulum.DateTime]] = mapped_column(
+        Timestamp()
+    )
     next_scheduled_start_time = sa.Column(Timestamp())
-    start_time: Mapped[pendulum.DateTime] = mapped_column(Timestamp())
-    end_time: Mapped[pendulum.DateTime] = mapped_column(Timestamp())
+    start_time: Mapped[Optional[pendulum.DateTime]] = mapped_column(Timestamp())
+    end_time: Mapped[Optional[pendulum.DateTime]] = mapped_column(Timestamp())
     total_run_time: Mapped[datetime.timedelta] = mapped_column(
         sa.Interval(),
         server_default="0",
@@ -501,7 +530,7 @@ class FlowRun(Run):
         index=True,
     )
 
-    deployment_id: Mapped[Union[uuid.UUID, None]] = mapped_column(UUID(), nullable=True)
+    deployment_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(), nullable=True)
     work_queue_name = sa.Column(sa.String, index=True)
     flow_version = sa.Column(sa.String, index=True)
     deployment_version = sa.Column(sa.String, index=True)
@@ -517,11 +546,11 @@ class FlowRun(Run):
     tags: Mapped[List[str]] = mapped_column(
         JSON, server_default="[]", default=list, nullable=False
     )
-    labels: Mapped[Union[schemas.core.KeyValueLabels, None]] = mapped_column(
+    labels: Mapped[Optional[schemas.core.KeyValueLabels]] = mapped_column(
         JSON, nullable=True
     )
 
-    created_by: Mapped[Union[schemas.core.CreatedBy, None]] = mapped_column(
+    created_by: Mapped[Optional[schemas.core.CreatedBy]] = mapped_column(
         Pydantic(schemas.core.CreatedBy),
         server_default=None,
         default=None,
@@ -538,7 +567,7 @@ class FlowRun(Run):
         index=True,
     )
 
-    parent_task_run_id: Mapped[uuid.UUID] = mapped_column(
+    parent_task_run_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         UUID(),
         sa.ForeignKey(
             "task_run.id",
@@ -563,7 +592,7 @@ class FlowRun(Run):
         index=True,
     )
 
-    work_queue_id: Mapped[Union[uuid.UUID, None]] = mapped_column(
+    work_queue_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         UUID,
         sa.ForeignKey("work_queue.id", ondelete="SET NULL"),
         nullable=True,
@@ -629,50 +658,65 @@ class FlowRun(Run):
         foreign_keys=[work_queue_id],
     )
 
-    __table_args__ = (
-        sa.Index(
-            "uq_flow_run__flow_id_idempotency_key",
-            "flow_id",
-            "idempotency_key",
-            unique=True,
-        ),
-        sa.Index(
-            "ix_flow_run__coalesce_start_time_expected_start_time_desc",
-            sa.desc(coalesce("start_time", "expected_start_time")),
-        ),
-        sa.Index(
-            "ix_flow_run__coalesce_start_time_expected_start_time_asc",
-            sa.asc(coalesce("start_time", "expected_start_time")),
-        ),
-        sa.Index(
-            "ix_flow_run__expected_start_time_desc",
-            sa.desc("expected_start_time"),
-        ),
-        sa.Index(
-            "ix_flow_run__next_scheduled_start_time_asc",
-            sa.asc("next_scheduled_start_time"),
-        ),
-        sa.Index(
-            "ix_flow_run__end_time_desc",
-            sa.desc("end_time"),
-        ),
-        sa.Index(
-            "ix_flow_run__start_time",
-            "start_time",
-        ),
-        sa.Index(
-            "ix_flow_run__state_type",
-            "state_type",
-        ),
-        sa.Index(
-            "ix_flow_run__state_name",
-            "state_name",
-        ),
-        sa.Index(
-            "ix_flow_run__state_timestamp",
-            "state_timestamp",
-        ),
-    )
+    @declared_attr.directive
+    @classmethod
+    def __table_args__(cls) -> Iterable[sa.Index]:
+        return (
+            sa.Index(
+                "uq_flow_run__flow_id_idempotency_key",
+                cls.flow_id,
+                cls.idempotency_key,
+                unique=True,
+            ),
+            sa.Index(
+                "ix_flow_run__coalesce_start_time_expected_start_time_desc",
+                coalesce(cls.start_time, cls.expected_start_time).desc(),
+            ),
+            sa.Index(
+                "ix_flow_run__coalesce_start_time_expected_start_time_asc",
+                coalesce(cls.start_time, cls.expected_start_time).asc(),
+            ),
+            sa.Index(
+                "ix_flow_run__expected_start_time_desc",
+                cls.expected_start_time.desc(),
+            ),
+            sa.Index(
+                "ix_flow_run__next_scheduled_start_time_asc",
+                cls.next_scheduled_start_time.asc(),
+            ),
+            sa.Index(
+                "ix_flow_run__end_time_desc",
+                cls.end_time.desc(),
+            ),
+            sa.Index(
+                "ix_flow_run__start_time",
+                cls.start_time,
+            ),
+            sa.Index(
+                "ix_flow_run__state_type",
+                cls.state_type,
+            ),
+            sa.Index(
+                "ix_flow_run__state_name",
+                cls.state_name,
+            ),
+            sa.Index(
+                "ix_flow_run__state_timestamp",
+                cls.state_timestamp,
+            ),
+            sa.Index("trgm_ix_flow_run_name", cls.name, postgresql_using="gin").ddl_if(
+                dialect="postgresql"
+            ),
+            sa.Index(
+                # index names are at most 63 characters long.
+                "ix_flow_run__scheduler_deployment_id_auto_scheduled_next_schedu",
+                cls.deployment_id,
+                cls.auto_scheduled,
+                cls.next_scheduled_start_time,
+                postgresql_where=cls.state_type == schemas.states.StateType.SCHEDULED,
+                sqlite_where=cls.state_type == schemas.states.StateType.SCHEDULED,
+            ),
+        )
 
 
 class TaskRun(Run):
@@ -719,7 +763,7 @@ class TaskRun(Run):
     tags: Mapped[List[str]] = mapped_column(
         JSON, server_default="[]", default=list, nullable=False
     )
-    labels: Mapped[Union[schemas.core.KeyValueLabels, None]] = mapped_column(
+    labels: Mapped[Optional[schemas.core.KeyValueLabels]] = mapped_column(
         JSON, nullable=True
     )
 
@@ -786,43 +830,49 @@ class TaskRun(Run):
         uselist=False,
     )
 
-    __table_args__ = (
-        sa.Index(
-            "uq_task_run__flow_run_id_task_key_dynamic_key",
-            "flow_run_id",
-            "task_key",
-            "dynamic_key",
-            unique=True,
-        ),
-        sa.Index(
-            "ix_task_run__expected_start_time_desc",
-            sa.desc("expected_start_time"),
-        ),
-        sa.Index(
-            "ix_task_run__next_scheduled_start_time_asc",
-            sa.asc("next_scheduled_start_time"),
-        ),
-        sa.Index(
-            "ix_task_run__end_time_desc",
-            sa.desc("end_time"),
-        ),
-        sa.Index(
-            "ix_task_run__start_time",
-            "start_time",
-        ),
-        sa.Index(
-            "ix_task_run__state_type",
-            "state_type",
-        ),
-        sa.Index(
-            "ix_task_run__state_name",
-            "state_name",
-        ),
-        sa.Index(
-            "ix_task_run__state_timestamp",
-            "state_timestamp",
-        ),
-    )
+    @declared_attr.directive
+    @classmethod
+    def __table_args__(cls) -> Iterable[sa.Index]:
+        return (
+            sa.Index(
+                "uq_task_run__flow_run_id_task_key_dynamic_key",
+                cls.flow_run_id,
+                cls.task_key,
+                cls.dynamic_key,
+                unique=True,
+            ),
+            sa.Index(
+                "ix_task_run__expected_start_time_desc",
+                cls.expected_start_time.desc(),
+            ),
+            sa.Index(
+                "ix_task_run__next_scheduled_start_time_asc",
+                cls.next_scheduled_start_time.asc(),
+            ),
+            sa.Index(
+                "ix_task_run__end_time_desc",
+                cls.end_time.desc(),
+            ),
+            sa.Index(
+                "ix_task_run__start_time",
+                cls.start_time,
+            ),
+            sa.Index(
+                "ix_task_run__state_type",
+                cls.state_type,
+            ),
+            sa.Index(
+                "ix_task_run__state_name",
+                cls.state_name,
+            ),
+            sa.Index(
+                "ix_task_run__state_timestamp",
+                cls.state_timestamp,
+            ),
+            sa.Index("trgm_ix_task_run_name", cls.name, postgresql_using="gin").ddl_if(
+                dialect="postgresql"
+            ),
+        )
 
 
 class DeploymentSchedule(Base):
@@ -868,7 +918,7 @@ class Deployment(Base):
         index=True,
     )
 
-    work_queue_id: Mapped[uuid.UUID] = mapped_column(
+    work_queue_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         UUID,
         sa.ForeignKey("work_queue.id", ondelete="SET NULL"),
         nullable=True,
@@ -885,21 +935,21 @@ class Deployment(Base):
     )
 
     # deprecated in favor of `concurrency_limit_id` FK
-    _concurrency_limit: Mapped[Union[int, None]] = mapped_column(
+    _concurrency_limit: Mapped[Optional[int]] = mapped_column(
         sa.Integer, default=None, nullable=True, name="concurrency_limit"
     )
-    concurrency_limit_id: Mapped[Union[uuid.UUID, None]] = mapped_column(
+    concurrency_limit_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         UUID,
         sa.ForeignKey("concurrency_limit_v2.id", ondelete="SET NULL"),
         nullable=True,
     )
     global_concurrency_limit: Mapped[
-        Union["ConcurrencyLimitV2", None]
+        Optional["ConcurrencyLimitV2"]
     ] = sa.orm.relationship(
         lazy="selectin",
     )
     concurrency_options: Mapped[
-        Union[schemas.core.ConcurrencyOptions, None]
+        Optional[schemas.core.ConcurrencyOptions]
     ] = mapped_column(
         Pydantic(schemas.core.ConcurrencyOptions),
         server_default=None,
@@ -910,7 +960,7 @@ class Deployment(Base):
     tags: Mapped[List[str]] = mapped_column(
         JSON, server_default="[]", default=list, nullable=False
     )
-    labels: Mapped[Union[schemas.core.KeyValueLabels, None]] = mapped_column(
+    labels: Mapped[Optional[schemas.core.KeyValueLabels]] = mapped_column(
         JSON, nullable=True
     )
     parameters = sa.Column(JSON, server_default="{}", default=dict, nullable=False)
@@ -962,6 +1012,9 @@ class Deployment(Base):
         sa.Index(
             "ix_deployment__created",
             "created",
+        ),
+        sa.Index("trgm_ix_deployment_name", "name", postgresql_using="gin").ddl_if(
+            dialect="postgresql"
         ),
     )
 
@@ -1029,6 +1082,9 @@ class BlockType(Base):
             "slug",
             unique=True,
         ),
+        sa.Index("trgm_ix_block_type_name", "name", postgresql_using="gin").ddl_if(
+            dialect="postgresql"
+        ),
     )
 
 
@@ -1059,6 +1115,9 @@ class BlockSchema(Base):
             unique=True,
         ),
         sa.Index("ix_block_schema__created", "created"),
+        sa.Index(
+            "ix_block_schema__capabilities", "capabilities", postgresql_using="gin"
+        ).ddl_if(dialect="postgresql"),
     )
 
 
@@ -1107,6 +1166,10 @@ class BlockDocument(Base):
             "block_type_id",
             "name",
             unique=True,
+        ),
+        sa.Index("ix_block_document__block_type_name__name", "block_type_name", "name"),
+        sa.Index("trgm_ix_block_document_name", "name", postgresql_using="gin").ddl_if(
+            dialect="postgresql"
         ),
     )
 
@@ -1181,9 +1244,9 @@ class WorkQueue(Base):
         sa.Integer,
         nullable=True,
     )
-    priority: Mapped[int] = mapped_column(sa.Integer, index=True, nullable=False)
+    priority: Mapped[int] = mapped_column(sa.Integer, nullable=False)
 
-    last_polled: Mapped[Union[pendulum.DateTime, None]] = mapped_column(
+    last_polled: Mapped[Optional[pendulum.DateTime]] = mapped_column(
         Timestamp(),
         nullable=True,
     )
@@ -1193,8 +1256,6 @@ class WorkQueue(Base):
         default=WorkQueueStatus.NOT_READY,
         server_default=WorkQueueStatus.NOT_READY.value,
     )
-
-    __table_args__ = (sa.UniqueConstraint("work_pool_id", "name"),)
 
     work_pool_id: Mapped[uuid.UUID] = mapped_column(
         UUID,
@@ -1209,18 +1270,30 @@ class WorkQueue(Base):
         foreign_keys=[work_pool_id],
     )
 
+    __table_args__ = (
+        sa.UniqueConstraint("work_pool_id", "name"),
+        sa.Index("ix_work_queue__work_pool_id_priority", "work_pool_id", "priority"),
+        sa.Index("trgm_ix_work_queue_name", "name", postgresql_using="gin").ddl_if(
+            dialect="postgresql"
+        ),
+    )
+
 
 class WorkPool(Base):
     """SQLAlchemy model of an worker"""
 
     name = sa.Column(sa.String, nullable=False)
     description = sa.Column(sa.String)
-    type: Mapped[str] = mapped_column(sa.String)
+    type: Mapped[str] = mapped_column(sa.String, index=True)
     base_job_template = sa.Column(JSON, nullable=False, server_default="{}", default={})
     is_paused: Mapped[bool] = mapped_column(
         sa.Boolean, nullable=False, server_default="0", default=False
     )
-    default_queue_id: Mapped[UUID] = mapped_column(UUID, nullable=True)
+    default_queue_id: Mapped[UUID] = mapped_column(
+        UUID,
+        sa.ForeignKey("work_queue.id", ondelete="RESTRICT", use_alter=True),
+        nullable=True,
+    )
     concurrency_limit = sa.Column(
         sa.Integer,
         nullable=True,
@@ -1232,10 +1305,12 @@ class WorkPool(Base):
         default=WorkPoolStatus.NOT_READY,
         server_default=WorkPoolStatus.NOT_READY.value,
     )
-    last_transitioned_status_at: Mapped[Union[pendulum.DateTime, None]] = mapped_column(
+    last_transitioned_status_at: Mapped[Optional[pendulum.DateTime]] = mapped_column(
         Timestamp(), nullable=True
     )
-    last_status_event_id: Mapped[uuid.UUID] = mapped_column(UUID, nullable=True)
+    last_status_event_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID, nullable=True
+    )
 
     __table_args__ = (sa.UniqueConstraint("name"),)
 
@@ -1258,7 +1333,6 @@ class Worker(Base):
         nullable=False,
         server_default=now(),
         default=lambda: pendulum.now("UTC"),
-        index=True,
     )
     heartbeat_interval_seconds = sa.Column(sa.Integer, nullable=True)
 
@@ -1269,7 +1343,14 @@ class Worker(Base):
         server_default=WorkerStatus.OFFLINE.value,
     )
 
-    __table_args__ = (sa.UniqueConstraint("work_pool_id", "name"),)
+    __table_args__ = (
+        sa.UniqueConstraint("work_pool_id", "name"),
+        sa.Index(
+            "ix_worker__work_pool_id_last_heartbeat_time",
+            "work_pool_id",
+            "last_heartbeat_time",
+        ),
+    )
 
 
 class Agent(Base):
@@ -1325,7 +1406,7 @@ class FlowRunNotificationQueue(Base):
 
 class Variable(Base):
     name = sa.Column(sa.String, nullable=False)
-    value = sa.Column(sa.JSON, nullable=False)
+    value: Optional[Any] = sa.Column(JSON)
     tags = sa.Column(JSON, server_default="[]", default=list, nullable=False)
 
     __table_args__ = (sa.UniqueConstraint("name"),)


### PR DESCRIPTION
As I was looking into low-hanging fruit to improve prefect's type completeness, I ran into several issues with the ORM model definitions. Over time the migrations and the models have diverged somewhat, for various reasons, and this commit brings them back together again.

With this commit, you can run `prefect server database revision --autogenerate` in a clean checkout and alembic will generate empty migration steps. At the same time, the ORM models accurately reflect what is in the database.

## Changes summary

- Update the alembic `include_object` hook to support per-dialect filtering for indexes, and to avoid enum-to-varchar conversions for existing columns in SQLite.
- Add indexes added by manual migrations into their respective ORM models, with dialect-specific information where needed.
- Keep index names consistent across PostgreSQL and SQLite.
- Drop an index that was accidentally applied to the wrong table in the SQLite migrations.
- Drop an index that was created for a foreign key column now that no longer is a foreign key.
- Correct ORM annotations for columns accidentally marked as nullable when they were converted to `Mapped[...]` / `mapped_column()`
- Mark `WorkPool.default_queue_id` as a foreign key in the ORM model; it already is one in the database.
- Drop columns that were removed from the ORM models.
- Use `Optional[...]` instead of `Union[..., None]` in annotations.
- Mark the Variable.value column as nullable; NULL represents None.
- Annotate the JSONB columns to keep type completeness score lower

## Changes per ORM model

### PostgreSQL-only trigram indexes, defined solely in migration scripts

Each of these indexes is now attached to the ORM and alembic will only consider exporting these for the PostgreSQL migrations.
- `BlockDocument.name`: trgm_ix_block_document_name
- `BlockSchema.capablities`: ix_block_schema__capabilities
- `BlockType.name`: trgm_ix_block_type_name
- `Deployment.name`: trgm_ix_deployment_name
- `Flow.name`: trgm_ix_flow_name
- `FlowRun.name`: trgm_ix_flow_run_name
- `TaskRun.name`: trgm_ix_task_run_name
- `WorkQueue.name`: trgm_ix_work_queue_name
	
### `Artifact`
- Indexes created in migration, but against the wrong table in SQLite
	- 2023-03-24, ca9f93463a4c38fce8be972d91e808b5935e5d9c
		- `ix_artifact__key_created_desc`
		- for SQLite, it is incorrectly created against the `artifact_collection` table.
	
### `ArtifactCollection`
- Column nullable in PostgreSQL but not in SQLite, nor in the ORM model.
	- 2023-03-24, 027c123512befd2bd00a0ef28bd44215e77bece6
		- `latest_id`, made NOT NULL in PostgreSQL.
- Indexes created in migration, but against the wrong table in SQLite
	- 2023-03-24, ca9f93463a4c38fce8be972d91e808b5935e5d9c
		- `ix_artifact__key_created_desc`
		- for PG, it is correctly created against the `artifact` table.
- Indexes declared in the ORM models but never migrated
	- 2023-03-24, 027c123512befd2bd00a0ef28bd44215e77bece6
		- `ix_artifact_collection__updated`

### `BlockDocument`
- Indexes created in a migration but not added to the ORM models
	- 2023-10-30, d445671adda2090ce51612a01f5ffdf7fedc44a5
		- Inconsistently named between PostgreSQL and SQLite:
			- PG: `ix_block_document__block_type_name__name`
			 - SQLite: `ix_block_document__block_type_name_name`
	
### `Deployment`
- columns removed from ORM but never migrated
	- 2024-08-12, c53b00bfa1f6850ab43e168c92c627350c090647
		- `schedule`
		- `is_schedule_active`
	- 2024-06-21, eaa7a5063c73718dff56ce4aeb66e53fcafe60e5
		- `manifest_path`
	- 2022-07-25, 5784c637e7e11a8e88e2b3146e54e9b6c97d50ef
		- `flow_data`
- not marked as nullable in the type annotations
	- 2024-09-13, 926f7a40a296ca8b14fc1c76f774dd719953a8b7
		- `work_queue_id`


### `DeploymentSchedule`
- columns removed from ORM but never migrated
	- 2024-10-25, 0b62de684447c6955e04c722c276edac4002fd40
		- `max_active_runs`
		- `catchup`

### `FlowRun`
- columns accidentally made nullable in the ORM, by switching to `Mapped[...]` and `mapped_column()` without realising that this changes the nullable setting in many cases.
	- 2024-09-13, 926f7a40a296ca8b14fc1c76f774dd719953a8b7
		- `parent_task_run_id`
- no-longer-used FK index
	- 2023-03-24, d10c7471a69403bcf88f401091497a2dc8963885
		- `ix_flow_run__deployment_id`
- index was erroneously dropped from the SQLite schema
	- 2022-11-10, 519a2ed6e31e2b60136e1a1a163a9cd0a8d3d5c4
		- `ix_flow_run__scheduler_deployment_id_auto_scheduled_next_schedu`
			- Index names are limited to 63 characters
### `FlowRunState`
- Column definition in ORM changed from JSONB to JSON
	- 2022-09-21, d742d79076570143c744f319c05b542e53aba539
		- `data`
### `Run`
- columns accidentally made nullable in the ORM, by switching to `Mapped[...]` and `mapped_column()` without realising that this changes the nullable setting in many cases.
	- 2024-09-13, 926f7a40a296ca8b14fc1c76f774dd719953a8b7
		- `expected_start_time`
		- `start_time`
		- `end_time`

### `TaskRunState`
- Column definition in ORM changed from JSONB to JSON
	- 2022-09-21, d742d79076570143c744f319c05b542e53aba539
		- `data`
### `Variable`
- columns set to not nullable in ORM but database has these as nullable
	- 2024-05-22, 7c37407543c17b62756d46501f00fdeb9469951a
		- `value`
		- The JSONB column definition uses `none_as_null=True`, and tests expect `None` to be a valid variable value, so the ORM column was made nullable. Migrations had already made the column nullable in the database.
- Migrated to JSONB column but ORM model uses plain JSON
	- 2024-05-22, 7c37407543c17b62756d46501f00fdeb9469951a
		- `value`

### `Worker`
- Index created in migration but not in ORM model
	- 2023-01-09, 4a5c11e8e49809294ff063d79b95fc115a3e2693
		- `ix_worker__work_pool_id_last_heartbeat_time`
			- Renamed in this commit, originally created in c660a3f13c07cc4c3c2a0b341c32ef4e49a1a667
* Column marked as indexed but index was never created in a migration, almost certainly because the `ix_worker__work_pool_id_last_heartbeat_time` already covers this column.
	- 2022-12-10, c660a3f13c07cc4c3c2a0b341c32ef4e49a1a667 
		- `ix_worker__last_heartbeat_time`

### `WorkQueue`
- Index created in migration but not in ORM model
	- 2023-02-01, 839cc3e1d386a864ccaa8d1c60382533a8a84b65
		- `ix_work_queue__work_pool_id_priority`
* Column marked as indexed but index was never created in a migration, almost certainly because the `ix_work_queue__work_pool_id_priority` already covers this column.
	- 2023-02-01, 839cc3e1d386a864ccaa8d1c60382533a8a84b65 
		- `priority`
	
### `WorkPool`
- Index created in migration but not in ORM model
	- 2023-01-09, 4a5c11e8e49809294ff063d79b95fc115a3e2693
		- `ix_work_pool__type`
			- originally named `ix_worker_pool__type` but it was not present in the ORM model before this point either.
- FK declared in the migration bun not in the ORM model
	- 2023-02-01, 839cc3e1d386a864ccaa8d1c60382533a8a84b65
		- FK from `default_queue_id`  to `work_queue.id`
		


