### PR TITLE
[UI v2] feat: Adding mutations for global concurrency limit

### DIFF
--- a/ui-v2/src/hooks/global-concurrency-limits.test.tsx
+++ b/ui-v2/src/hooks/global-concurrency-limits.test.tsx
@@ -8,7 +8,6 @@ import {
 	queryKeyFactory,
 	useCreateGlobalConcurrencyLimit,
 	useDeleteGlobalConcurrencyLimit,
-	useGetGlobalConcurrencyLimit,
 	useListGlobalConcurrencyLimits,
 	useUpdateGlobalConcurrencyLimit,
 } from "./global-concurrency-limits";
@@ -29,17 +28,6 @@ describe("global concurrency limits hooks", () => {
 		},
 	];
 
-	const seedGlobalConcurrencyLimitDetails = () => ({
-		id: "0",
-		created: "2021-01-01T00:00:00Z",
-		updated: "2021-01-01T00:00:00Z",
-		active: false,
-		name: "global concurrency limit 0",
-		limit: 0,
-		active_slots: 0,
-		slot_decay_per_second: 0,
-	});
-
 	const mockFetchGlobalConcurrencyLimitsAPI = (
 		globalConcurrencyLimits: Array<GlobalConcurrencyLimit>,
 	) => {
@@ -48,19 +36,6 @@ describe("global concurrency limits hooks", () => {
 				"http://localhost:4200/api/v2/concurrency_limits/filter",
 				() => {
 					return HttpResponse.json(globalConcurrencyLimits);
-				},
-			),
-		);
-	};
-
-	const mockFetchGlobalConcurrencyLimitDetailsAPI = (
-		globalConcurrencyLimit: GlobalConcurrencyLimit,
-	) => {
-		server.use(
-			http.get(
-				"http://localhost:4200/api/v2/concurrency_limits/:id_or_name",
-				() => {
-					return HttpResponse.json(globalConcurrencyLimit);
 				},
 			),
 		);
@@ -95,26 +70,6 @@ describe("global concurrency limits hooks", () => {
 		// ------------ Assert
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 		expect(result.current.data).toEqual(mockList);
-	});
-
-	/**
-	 * Data Management:
-	 * - Asserts global concurrency limit details data is fetched based on the APIs invoked for the hook
-	 */
-	it("is stores details data into the appropriate details query when using useQuery()", async () => {
-		// ------------ Mock API requests when cache is empty
-		const mockDetails = seedGlobalConcurrencyLimitDetails();
-		mockFetchGlobalConcurrencyLimitDetailsAPI(mockDetails);
-
-		// ------------ Initialize hooks to test
-		const { result } = renderHook(
-			() => useGetGlobalConcurrencyLimit(mockDetails.id),
-			{ wrapper: createQueryWrapper({}) },
-		);
-
-		// ------------ Assert
-		await waitFor(() => expect(result.current.isSuccess).toBe(true));
-		expect(result.current.data).toEqual(mockDetails);
 	});
 
 	/**
@@ -256,13 +211,8 @@ describe("global concurrency limits hooks", () => {
 			limit.id === MOCK_UPDATE_LIMIT_ID ? UPDATED_LIMIT : limit,
 		);
 		mockFetchGlobalConcurrencyLimitsAPI(mockData);
-		mockFetchGlobalConcurrencyLimitDetailsAPI(UPDATED_LIMIT);
 
 		// ------------ Initialize cache
-		queryClient.setQueryData(
-			queryKeyFactory.detail(MOCK_UPDATE_LIMIT_ID),
-			seedGlobalConcurrencyLimitDetails(),
-		);
 
 		queryClient.setQueryData(
 			queryKeyFactory.list(filter),
@@ -275,10 +225,6 @@ describe("global concurrency limits hooks", () => {
 			{ wrapper: createQueryWrapper({ queryClient }) },
 		);
 
-		const { result: useGetGlobalConcurrencyLimitResult } = renderHook(
-			() => useGetGlobalConcurrencyLimit(MOCK_UPDATE_LIMIT_ID),
-			{ wrapper: createQueryWrapper({ queryClient }) },
-		);
 		const { result: useUpdateGlobalConcurrencyLimitResult } = renderHook(
 			useUpdateGlobalConcurrencyLimit,
 			{ wrapper: createQueryWrapper({ queryClient }) },
@@ -300,9 +246,7 @@ describe("global concurrency limits hooks", () => {
 				true,
 			),
 		);
-		expect(useGetGlobalConcurrencyLimitResult.current.data).toMatchObject(
-			UPDATED_LIMIT,
-		);
+
 		const limit = useListGlobalConcurrencyLimitsResult.current.data?.find(
 			(limit) => limit.id === MOCK_UPDATE_LIMIT_ID,
 		);

--- a/ui-v2/src/hooks/global-concurrency-limits.test.tsx
+++ b/ui-v2/src/hooks/global-concurrency-limits.test.tsx
@@ -1,12 +1,16 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
 import {
 	type GlobalConcurrencyLimit,
+	queryKeyFactory,
+	useCreateGlobalConcurrencyLimit,
+	useDeleteGlobalConcurrencyLimit,
 	useGetGlobalConcurrencyLimit,
 	useListGlobalConcurrencyLimits,
+	useUpdateGlobalConcurrencyLimit,
 } from "./global-concurrency-limits";
 
 import { server } from "../../tests/mocks/node";
@@ -111,5 +115,197 @@ describe("global concurrency limits hooks", () => {
 		// ------------ Assert
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 		expect(result.current.data).toEqual(mockDetails);
+	});
+
+	/**
+	 * Data Management:
+	 * - Asserts global concurrency limit calls delete API and refetches updated list
+	 */
+	it("useDeleteGlobalConcurrencyLimit() invalidates cache and fetches updated value", async () => {
+		const ID_TO_DELETE = "0";
+		const queryClient = new QueryClient();
+
+		// ------------ Mock API requests after queries are invalidated
+		const mockData = seedGlobalConcurrencyLimits().filter(
+			(limit) => limit.id !== ID_TO_DELETE,
+		);
+		mockFetchGlobalConcurrencyLimitsAPI(mockData);
+
+		// ------------ Initialize cache
+		queryClient.setQueryData(
+			queryKeyFactory.list(filter),
+			seedGlobalConcurrencyLimits(),
+		);
+
+		// ------------ Initialize hooks to test
+		const { result: useListGlobalConcurrencyLimitsResult } = renderHook(
+			() => useListGlobalConcurrencyLimits(filter),
+			{ wrapper: createQueryWrapper({ queryClient }) },
+		);
+
+		const { result: useDeleteGlobalConcurrencyLimitResult } = renderHook(
+			useDeleteGlobalConcurrencyLimit,
+			{ wrapper: createQueryWrapper({ queryClient }) },
+		);
+
+		// ------------ Invoke mutation
+		act(() =>
+			useDeleteGlobalConcurrencyLimitResult.current.deleteGlobalConcurrencyLimit(
+				ID_TO_DELETE,
+			),
+		);
+
+		// ------------ Assert
+		await waitFor(() =>
+			expect(useDeleteGlobalConcurrencyLimitResult.current.isSuccess).toBe(
+				true,
+			),
+		);
+		expect(useListGlobalConcurrencyLimitsResult.current.data).toHaveLength(0);
+	});
+
+	/**
+	 * Data Management:
+	 * - Asserts create mutation API is called.
+	 * - Upon create mutation API being called, cache is invalidated and asserts cache invalidation APIS are called
+	 */
+	it("useCreateGlobalConcurrencyLimit() invalidates cache and fetches updated value", async () => {
+		const queryClient = new QueryClient();
+		const MOCK_NEW_LIMIT_ID = "1";
+		const MOCK_NEW_LIMIT = {
+			active: true,
+			active_slots: 0,
+			denied_slots: 0,
+			limit: 0,
+			name: "global concurrency limit 1",
+			slot_decay_per_second: 0,
+		};
+
+		// ------------ Mock API requests after queries are invalidated
+		const NEW_LIMIT_DATA = {
+			...MOCK_NEW_LIMIT,
+			id: MOCK_NEW_LIMIT_ID,
+			created: "2021-01-01T00:00:00Z",
+			updated: "2021-01-01T00:00:00Z",
+			active_slots: 0,
+			slot_decay_per_second: 0,
+		};
+
+		const mockData = [...seedGlobalConcurrencyLimits(), NEW_LIMIT_DATA];
+		mockFetchGlobalConcurrencyLimitsAPI(mockData);
+
+		// ------------ Initialize cache
+		queryClient.setQueryData(
+			queryKeyFactory.list(filter),
+			seedGlobalConcurrencyLimits(),
+		);
+
+		// ------------ Initialize hooks to test
+		const { result: useListGlobalConcurrencyLimitsResult } = renderHook(
+			() => useListGlobalConcurrencyLimits(filter),
+			{ wrapper: createQueryWrapper({ queryClient }) },
+		);
+		const { result: useCreateGlobalConcurrencyLimitResult } = renderHook(
+			useCreateGlobalConcurrencyLimit,
+			{ wrapper: createQueryWrapper({ queryClient }) },
+		);
+
+		// ------------ Invoke mutation
+		act(() =>
+			useCreateGlobalConcurrencyLimitResult.current.createGlobalConcurrencyLimit(
+				MOCK_NEW_LIMIT,
+			),
+		);
+
+		// ------------ Assert
+		await waitFor(() =>
+			expect(useCreateGlobalConcurrencyLimitResult.current.isSuccess).toBe(
+				true,
+			),
+		);
+		expect(useListGlobalConcurrencyLimitsResult.current.data).toHaveLength(2);
+		const newLimit = useListGlobalConcurrencyLimitsResult.current.data?.find(
+			(limit) => limit.id === MOCK_NEW_LIMIT_ID,
+		);
+		expect(newLimit).toMatchObject(NEW_LIMIT_DATA);
+	});
+
+	/**
+	 * Data Management:
+	 * - Asserts update mutation API is called.
+	 * - Upon update mutation API being called, cache invalidates global concurrency limit details cache
+	 */
+	it("useUpdateGlobalConcurrencyLimit() invalidates cache and fetches updated value", async () => {
+		const queryClient = new QueryClient();
+		const MOCK_UPDATE_LIMIT_ID = "0";
+		const UPDATED_LIMIT_BODY = {
+			active: true,
+			active_slots: 0,
+			denied_slots: 0,
+			limit: 0,
+			name: "global concurrency limit updated",
+			slot_decay_per_second: 0,
+		};
+		const UPDATED_LIMIT = {
+			...UPDATED_LIMIT_BODY,
+			id: MOCK_UPDATE_LIMIT_ID,
+		};
+
+		// ------------ Mock API requests after queries are invalidated
+		const mockData = seedGlobalConcurrencyLimits().map((limit) =>
+			limit.id === MOCK_UPDATE_LIMIT_ID ? UPDATED_LIMIT : limit,
+		);
+		mockFetchGlobalConcurrencyLimitsAPI(mockData);
+		mockFetchGlobalConcurrencyLimitDetailsAPI(UPDATED_LIMIT);
+
+		// ------------ Initialize cache
+		queryClient.setQueryData(
+			queryKeyFactory.detail(MOCK_UPDATE_LIMIT_ID),
+			seedGlobalConcurrencyLimitDetails(),
+		);
+
+		queryClient.setQueryData(
+			queryKeyFactory.list(filter),
+			seedGlobalConcurrencyLimits(),
+		);
+
+		// ------------ Initialize hooks to test
+		const { result: useListGlobalConcurrencyLimitsResult } = renderHook(
+			() => useListGlobalConcurrencyLimits(filter),
+			{ wrapper: createQueryWrapper({ queryClient }) },
+		);
+
+		const { result: useGetGlobalConcurrencyLimitResult } = renderHook(
+			() => useGetGlobalConcurrencyLimit(MOCK_UPDATE_LIMIT_ID),
+			{ wrapper: createQueryWrapper({ queryClient }) },
+		);
+		const { result: useUpdateGlobalConcurrencyLimitResult } = renderHook(
+			useUpdateGlobalConcurrencyLimit,
+			{ wrapper: createQueryWrapper({ queryClient }) },
+		);
+
+		// ------------ Invoke mutation
+		act(() =>
+			useUpdateGlobalConcurrencyLimitResult.current.updateGlobalConcurrencyLimit(
+				{
+					id_or_name: MOCK_UPDATE_LIMIT_ID,
+					...UPDATED_LIMIT_BODY,
+				},
+			),
+		);
+
+		// ------------ Assert
+		await waitFor(() =>
+			expect(useUpdateGlobalConcurrencyLimitResult.current.isSuccess).toBe(
+				true,
+			),
+		);
+		expect(useGetGlobalConcurrencyLimitResult.current.data).toMatchObject(
+			UPDATED_LIMIT,
+		);
+		const limit = useListGlobalConcurrencyLimitsResult.current.data?.find(
+			(limit) => limit.id === MOCK_UPDATE_LIMIT_ID,
+		);
+		expect(limit).toMatchObject(UPDATED_LIMIT);
 	});
 });

--- a/ui-v2/src/hooks/global-concurrency-limits.ts
+++ b/ui-v2/src/hooks/global-concurrency-limits.ts
@@ -1,6 +1,11 @@
 import type { components } from "@/api/prefect";
 import { getQueryService } from "@/api/service";
-import { queryOptions, useQuery } from "@tanstack/react-query";
+import {
+	queryOptions,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
 
 export type GlobalConcurrencyLimit =
 	components["schemas"]["GlobalConcurrencyLimitResponse"];
@@ -9,7 +14,7 @@ export type GlobalConcurrencyLimitsFilter =
 
 /**
  * ```
- *  🏗️ Variable queries construction 👷
+ *  🏗️ Global concurrency limits queries construction 👷
  *  all   =>   ['global-concurrency-limits'] // key to match ['global-concurrency-limits', ...
  *  list  =>   ['global-concurrency-limits', 'list'] // key to match ['global-concurrency-limits', 'list', ...
  *             ['global-concurrency-limits', 'list', { ...filter1 }]
@@ -19,7 +24,7 @@ export type GlobalConcurrencyLimitsFilter =
  *             ['global-concurrency-limits', 'details', { ...globalConcurrencyLimit2 }]
  * ```
  * */
-const queryKeyFactory = {
+export const queryKeyFactory = {
 	all: () => ["global-concurrency-limits"] as const,
 	lists: () => [...queryKeyFactory.all(), "list"] as const,
 	list: (filter: GlobalConcurrencyLimitsFilter) =>
@@ -77,4 +82,148 @@ export const useGetGlobalConcurrencyLimit = (id_or_name: string) =>
 // ----- ✍🏼 Mutations 🗄️
 // ----------------------------
 
-// TODO:
+/**
+ * Hook for deleting a global concurrency limit
+ *
+ * @returns Mutation object for deleting a global concurrency limit with loading/error states and trigger function
+ *
+ * @example
+ * ```ts
+ * const { deleteGlobalConcurrencyLimit } = useDeleteGlobalConcurrencyLimit();
+ *
+ * // Delete a  global concurrency limit by id or name
+ * deleteGlobalConcurrencyLimit('id-to-delete', {
+ *   onSuccess: () => {
+ *     // Handle successful deletion
+ *   },
+ *   onError: (error) => {
+ *     console.error('Failed to delete global concurrency limit:', error);
+ *   }
+ * });
+ * ```
+ */
+export const useDeleteGlobalConcurrencyLimit = () => {
+	const queryClient = useQueryClient();
+	const { mutate: deleteGlobalConcurrencyLimit, ...rest } = useMutation({
+		mutationFn: (id_or_name: string) =>
+			getQueryService().DELETE("/v2/concurrency_limits/{id_or_name}", {
+				params: { path: { id_or_name } },
+			}),
+		onSuccess: () => {
+			// After a successful deletion, invalidate the listing queries only to refetch
+			return queryClient.invalidateQueries({
+				queryKey: queryKeyFactory.lists(),
+			});
+		},
+	});
+	return {
+		deleteGlobalConcurrencyLimit,
+		...rest,
+	};
+};
+
+/**
+ * Hook for creating a new global concurrency limit
+ *
+ * @returns Mutation object for creating a global concurrency limit with loading/error states and trigger function
+ *
+ * @example
+ * ```ts
+ * const { createGlobalConcurrencyLimit, isLoading } = useCreateGlobalConcurrencyLimit();
+ *
+ * // Create a new  global concurrency limit
+ * createGlobalConcurrencyLimit({
+ * 	active: true
+ * 	limit: 0
+ * 	name: "my limit"
+ * 	slot_decay_per_second: 0
+ * }, {
+ *   onSuccess: () => {
+ *     // Handle successful creation
+ *     console.log('Global concurrency limit created successfully');
+ *   },
+ *   onError: (error) => {
+ *     // Handle error
+ *     console.error('Failed to global concurrency limit:', error);
+ *   }
+ * });
+ * ```
+ */
+export const useCreateGlobalConcurrencyLimit = () => {
+	const queryClient = useQueryClient();
+	const { mutate: createGlobalConcurrencyLimit, ...rest } = useMutation({
+		mutationFn: (body: components["schemas"]["ConcurrencyLimitV2Create"]) =>
+			getQueryService().POST("/v2/concurrency_limits/", {
+				body,
+			}),
+		onSuccess: () => {
+			// After a successful creation, invalidate the listing queries only to refetch
+			return queryClient.invalidateQueries({
+				queryKey: queryKeyFactory.lists(),
+			});
+		},
+	});
+	return {
+		createGlobalConcurrencyLimit,
+		...rest,
+	};
+};
+
+type GlobalConcurrencyLimitUpdateWithId =
+	components["schemas"]["ConcurrencyLimitV2Update"] & {
+		id_or_name: string;
+	};
+
+/**
+ * Hook for updating an existing global concurrency limit
+ *
+ * @returns Mutation object for updating a global concurrency limit with loading/error states and trigger function
+ *
+ * @example
+ * ```ts
+ * const { udateGlobalConcurrencyLimit } = useUpdateGlobalConcurrencyLimit();
+ *
+ * // Update an existing  global concurrency limit
+ * updateGlobalConcurrencyLimit({
+ *  id_or_name: "1",
+ * 	active: true
+ * 	limit: 0
+ * 	name: "my limit"
+ * 	slot_decay_per_second: 0
+ * }, {
+ *   onSuccess: () => {
+ *     // Handle successful update
+ *   },
+ *   onError: (error) => {
+ *     console.error('Failed to update  global concurrency limit:', error);
+ *   }
+ * });
+ * ```
+ */
+export const useUpdateGlobalConcurrencyLimit = () => {
+	const queryClient = useQueryClient();
+	const { mutate: updateGlobalConcurrencyLimit, ...rest } = useMutation({
+		mutationFn: ({ id_or_name, ...body }: GlobalConcurrencyLimitUpdateWithId) =>
+			getQueryService().PATCH("/v2/concurrency_limits/{id_or_name}", {
+				body,
+				params: { path: { id_or_name } },
+			}),
+		onSuccess: (_, { id_or_name }) => {
+			// After a successful creation, invalidate lists and sepecfic details queries
+			return Promise.all([
+				// list queries
+				queryClient.invalidateQueries({
+					queryKey: queryKeyFactory.lists(),
+				}),
+				// Specific limit details
+				queryClient.invalidateQueries({
+					queryKey: queryKeyFactory.detail(id_or_name),
+				}),
+			]);
+		},
+	});
+	return {
+		updateGlobalConcurrencyLimit,
+		...rest,
+	};
+};

--- a/ui-v2/tests/mocks/handlers.ts
+++ b/ui-v2/tests/mocks/handlers.ts
@@ -4,12 +4,6 @@ const globalConcurrencyLimitsHandlers = [
 	http.post("http://localhost:4200/api/v2/concurrency_limits/filter", () => {
 		return HttpResponse.json([]);
 	}),
-	http.get(
-		"http://localhost:4200/api/v2/concurrency_limits/:id_or_name",
-		() => {
-			return HttpResponse.json([]);
-		},
-	),
 	http.post("http://localhost:4200/api/v2/concurrency_limits/", () => {
 		return HttpResponse.json({ status: "success" }, { status: 201 });
 	}),

--- a/ui-v2/tests/mocks/handlers.ts
+++ b/ui-v2/tests/mocks/handlers.ts
@@ -1,5 +1,32 @@
 import { http, HttpResponse } from "msw";
 
+const globalConcurrencyLimitsHandlers = [
+	http.post("http://localhost:4200/api/v2/concurrency_limits/filter", () => {
+		return HttpResponse.json([]);
+	}),
+	http.get(
+		"http://localhost:4200/api/v2/concurrency_limits/:id_or_name",
+		() => {
+			return HttpResponse.json([]);
+		},
+	),
+	http.post("http://localhost:4200/api/v2/concurrency_limits/", () => {
+		return HttpResponse.json({ status: "success" }, { status: 201 });
+	}),
+	http.patch(
+		"http://localhost:4200/api/v2/concurrency_limits/:id_or_name",
+		() => {
+			return new HttpResponse(null, { status: 204 });
+		},
+	),
+	http.delete(
+		"http://localhost:4200/api/v2/concurrency_limits/:id_or_name",
+		() => {
+			return HttpResponse.json({ status: 204 });
+		},
+	),
+];
+
 const variablesHandlers = [
 	http.post("http://localhost:4200/api/variables/", () => {
 		return HttpResponse.json({ status: "success" }, { status: 201 });
@@ -40,5 +67,6 @@ export const handlers = [
 	http.post("http://localhost:4200/api/deployments/count", () => {
 		return HttpResponse.json(1);
 	}),
+	...globalConcurrencyLimitsHandlers,
 	...variablesHandlers,
 ];


### PR DESCRIPTION
Building the  mutations `global concurrency limits`queries

This PR just focuses on the mutations for `global concurrency limits` queries.
![Screenshot 2024-12-04 at 12 07 10 PM](https://github.com/user-attachments/assets/680c5f08-7c2b-479b-ac1d-f48d33b893b2)

1. Defines Mutations for `global concurrency limits`
2. Updates `msw` handlers for generic `global concurrency limits`  API mocks


### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Follow up to https://github.com/PrefectHQ/prefect/pull/16220
Related to https://github.com/PrefectHQ/prefect/issues/15512
