### PR TITLE
Include info about registering built-in blocks

### DIFF
--- a/docs/v3/develop/blocks.mdx
+++ b/docs/v3/develop/blocks.mdx
@@ -406,7 +406,9 @@ You can create and use these block types through the UI without installing any a
 | Twilio SMS                  | `twilio-sms`             | Send notifications through Twilio SMS.                                       |
 
 <Note>
-If you're using a self-hosted prefect server, you need to register the built-in blocks, for example using `prefect block register -m prefect.blocks.notifications`.
+Built-in blocks should be registered the first time you start a Prefect server. If the auto-registration fails, you can manually register the blocks using `prefect blocks register`. 
+
+For example, to register all built-in notification blocks, run `prefect block register -m prefect.blocks.notifications`.
 </Note>
 
 <Warning>

--- a/docs/v3/develop/blocks.mdx
+++ b/docs/v3/develop/blocks.mdx
@@ -405,6 +405,9 @@ You can create and use these block types through the UI without installing any a
 | SMB                         | `smb`                    | Store data as a file on a SMB share.                                         |
 | Twilio SMS                  | `twilio-sms`             | Send notifications through Twilio SMS.                                       |
 
+<Note>
+If you're using a self-hosted prefect server, you need to register the built-in blocks, for example using `prefect block register -m prefect.blocks.notifications`.
+</Note>
 
 <Warning>
 The `S3`, `Azure`, `GCS`, and `GitHub` blocks are deprecated in favor of the corresponding `S3Bucket`, 


### PR DESCRIPTION
The docs were unclear to me on why the built-in blocks didn't show up in the UI. See this [slack thread](https://prefect-community.slack.com/archives/C04DZJC94DC/p1733490977608259).