### PR TITLE
[UI v2] declarative spacing for variables

### DIFF
--- a/ui-v2/src/components/ui/block.tsx
+++ b/ui-v2/src/components/ui/block.tsx
@@ -4,7 +4,14 @@ import { UtilityProps, spacingUtiltiesClasses } from "./utils/spacing-utils";
 
 type Props = Omit<
 	UtilityProps,
-	"alignItems" | "alignSelf" | "display" | "flexDirection" | "gap"
+	| "alignItems"
+	| "alignSelf"
+	| "display"
+	| "flexDirection"
+	| "gap"
+	| "justifyContent"
+	| "justifyItems"
+	| "justifySelf"
 > & {
 	className?: string;
 	children: React.ReactNode;

--- a/ui-v2/src/components/ui/utils/spacing-utils.ts
+++ b/ui-v2/src/components/ui/utils/spacing-utils.ts
@@ -27,6 +27,18 @@ type AlignItems = "center" | "start" | "end" | "stretch" | "baseline";
 
 type AlignSelf = "auto" | "center" | "start" | "end" | "stretch" | "baseline";
 
+type JustifyContent =
+	| "center"
+	| "start"
+	| "end"
+	| "space-between"
+	| "space-around"
+	| "space-evenly";
+
+type JustifyItems = "center" | "start" | "end" | "stretch";
+
+type JustifySelf = "auto" | "center" | "start" | "end" | "stretch";
+
 type Spaces =
 	| 0
 	| 0.5
@@ -56,6 +68,9 @@ export type UtilityProps = Partial<{
 	display: Displays;
 	flexDirection: FlexDirection;
 	gap: Spaces;
+	justifyContent: JustifyContent;
+	justifyItems: JustifyItems;
+	justifySelf: JustifySelf;
 	m: Spaces;
 	mb: Spaces;
 	ml: Spaces;
@@ -139,6 +154,28 @@ export const spacingUtiltiesClasses = cva("", {
 			48: "gap-48",
 			64: "gap-64",
 		},
+		justifyContent: {
+			center: "justify-center",
+			start: "justify-start",
+			end: "justify-end",
+			"space-between": "justify-between",
+			"space-around": "justify-around",
+			"space-evenly": "justify-evenly",
+		},
+		justifyItems: {
+			center: "justify-items-center",
+			start: "justify-items-start",
+			end: "justify-items-end",
+			stretch: "justify-items-stretch",
+		},
+		justifySelf: {
+			auto: "justify-self-auto",
+			center: "justify-self-center",
+			start: "start",
+			end: "end",
+			stretch: "stretch",
+		},
+
 		m: {
 			0: "m-0",
 			0.5: "m-0.5",

--- a/ui-v2/src/components/variables/data-table/cells.tsx
+++ b/ui-v2/src/components/variables/data-table/cells.tsx
@@ -7,6 +7,7 @@ import {
 	DropdownMenuLabel,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Flex } from "@/components/ui/flex";
 import {
 	HoverCard,
 	HoverCardContent,
@@ -44,7 +45,7 @@ export const ActionsCell = ({ row, onVariableEdit }: ActionsCellProps) => {
 	};
 
 	return (
-		<div className="flex flex-row justify-end">
+		<Flex flexDirection="row" justifyContent="end">
 			<DropdownMenu>
 				<DropdownMenuTrigger asChild>
 					<Button variant="outline" className="h-8 w-8 p-0">
@@ -96,7 +97,7 @@ export const ActionsCell = ({ row, onVariableEdit }: ActionsCellProps) => {
 					<DropdownMenuItem onClick={onVariableDelete}>Delete</DropdownMenuItem>
 				</DropdownMenuContent>
 			</DropdownMenu>
-		</div>
+		</Flex>
 	);
 };
 

--- a/ui-v2/src/components/variables/layout.tsx
+++ b/ui-v2/src/components/variables/layout.tsx
@@ -4,6 +4,7 @@ import {
 	BreadcrumbList,
 } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
+import { Flex } from "@/components/ui/flex";
 import { Icon } from "@/components/ui/icons";
 
 export const VariablesLayout = ({
@@ -14,8 +15,8 @@ export const VariablesLayout = ({
 	children: React.ReactNode;
 }) => {
 	return (
-		<div className="flex flex-col gap-4">
-			<div className="flex items-center gap-2">
+		<Flex flexDirection="column" gap={4}>
+			<Flex alignItems="center" gap={2}>
 				<Breadcrumb>
 					<BreadcrumbList>
 						<BreadcrumbItem className="text-xl font-semibold">
@@ -31,8 +32,8 @@ export const VariablesLayout = ({
 				>
 					<Icon id="Plus" className="h-4 w-4" />
 				</Button>
-			</div>
+			</Flex>
 			{children}
-		</div>
+		</Flex>
 	);
 };


### PR DESCRIPTION
<!-- Include an overview of the proposed changes here -->
This exercise made me realize that I forgot the `justify*` properties

1. Adds `justify` props for spacing utility
2. Replaces basic spacing divs in `variables` in favor for `<Flex />`


### Checklist
<img width="1509" alt="Screenshot 2024-12-06 at 1 40 19 PM" src="https://github.com/user-attachments/assets/c8c78b38-3404-4b85-9bb0-30ee1c522664">
<img width="1504" alt="Screenshot 2024-12-06 at 1 40 27 PM" src="https://github.com/user-attachments/assets/1046f782-2b54-4482-91d8-3730e7b63d23">

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.

Follows up https://github.com/PrefectHQ/prefect/pull/16249
Relates to https://github.com/PrefectHQ/prefect/issues/15512 