### PR TITLE
[UI v2] feat: Adding basic table for global concurrency limit

### DIFF
--- a/ui-v2/src/components/concurrency/global-concurrency-view/data-table/data-table.tsx
+++ b/ui-v2/src/components/concurrency/global-concurrency-view/data-table/data-table.tsx
@@ -1,0 +1,37 @@
+import { DataTable } from "@/components/ui/data-table";
+import { type GlobalConcurrencyLimit } from "@/hooks/global-concurrency-limits";
+import {
+	createColumnHelper,
+	getCoreRowModel,
+	useReactTable,
+} from "@tanstack/react-table";
+
+const columnHelper = createColumnHelper<GlobalConcurrencyLimit>();
+const columns = [
+	columnHelper.accessor("name", {
+		header: "Name",
+	}),
+	columnHelper.accessor("limit", {
+		header: "Limit",
+	}),
+	columnHelper.accessor("active_slots", {
+		header: "Active Slots",
+	}),
+	columnHelper.accessor("slot_decay_per_second", {
+		header: "Slots Decay Per Second",
+	}),
+];
+
+type Props = {
+	data: Array<GlobalConcurrencyLimit>;
+};
+
+export const GlobalConcurrencyDataTable = ({ data }: Props) => {
+	const table = useReactTable({
+		data,
+		columns,
+		getCoreRowModel: getCoreRowModel(),
+	});
+
+	return <DataTable table={table} />;
+};

--- a/ui-v2/src/components/concurrency/global-concurrency-view/data-table/index.ts
+++ b/ui-v2/src/components/concurrency/global-concurrency-view/data-table/index.ts
@@ -1,0 +1,1 @@
+export { GlobalConcurrencyDataTable } from "./data-table";

--- a/ui-v2/src/components/concurrency/global-concurrency-view/index.tsx
+++ b/ui-v2/src/components/concurrency/global-concurrency-view/index.tsx
@@ -1,7 +1,7 @@
-import { Flex } from "@/components/ui/flex";
 import { useListGlobalConcurrencyLimits } from "@/hooks/global-concurrency-limits";
 import { useState } from "react";
 import { CreateOrEditLimitDialog } from "./create-or-edit-limit-dialog";
+import { GlobalConcurrencyDataTable } from "./data-table";
 import { GlobalConcurrencyLimitEmptyState } from "./global-concurrency-limit-empty-state";
 import { GlobalConcurrencyLimitsHeader } from "./global-concurrency-limits-header";
 
@@ -18,15 +18,10 @@ export const GlobalConcurrencyView = () => {
 			{data.length === 0 ? (
 				<GlobalConcurrencyLimitEmptyState onAdd={openAddDialog} />
 			) : (
-				<Flex flexDirection="column" gap={2}>
+				<div className="flex flex-col gap-4">
 					<GlobalConcurrencyLimitsHeader onAdd={openAddDialog} />
-					<div>TODO</div>
-					<ul>
-						{data.map((limit) => (
-							<li key={limit.id}>{JSON.stringify(limit)}</li>
-						))}
-					</ul>
-				</Flex>
+					<GlobalConcurrencyDataTable data={data} />
+				</div>
 			)}
 			<CreateOrEditLimitDialog
 				open={openDialog}

--- a/ui-v2/src/routes/concurrency-limits.tsx
+++ b/ui-v2/src/routes/concurrency-limits.tsx
@@ -8,11 +8,9 @@ import { z } from "zod";
  * Schema for validating URL search parameters for the Concurrency Limits page.
  * @property {'global' | 'task-run'} tab used designate which tab view to display
  */
-const searchParams = z
-	.object({
-		tab: z.enum(["global", "task-run"]).default("global"),
-	})
-	.strict();
+const searchParams = z.object({
+	tab: z.enum(["global", "task-run"]).default("global"),
+});
 
 export type TabOptions = z.infer<typeof searchParams>["tab"];
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2cedcde9-4d96-4e16-bbf5-701e73fbb792)

<!-- Include an overview of the proposed changes here -->
1. Adds a `hidePagination` option to `DataTable` for tables that do not support pagination features
2. Adds basic table for global concurrency limit. Will do active toggle in a separate PR, and action list on another one

<img width="1509" alt="Screenshot 2024-12-07 at 12 43 42 PM" src="https://github.com/user-attachments/assets/bcd7e33a-6706-484b-9baa-6a57c0e39952">

<img width="1505" alt="Screenshot 2024-12-07 at 12 48 01 PM" src="https://github.com/user-attachments/assets/4b427982-620d-4aa2-b3e4-fbbd585a8e07">

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
