### PR TITLE
Fix response typing in OpenAPI schema for `GlobalConcurrencyLimitResponse`

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -20034,6 +20034,9 @@
                 },
                 "type": "object",
                 "required": [
+                    "id",
+                    "created",
+                    "updated",
                     "name",
                     "limit",
                     "active_slots"

--- a/src/prefect/server/schemas/responses.py
+++ b/src/prefect/server/schemas/responses.py
@@ -18,7 +18,11 @@ from prefect.server.schemas.core import (
     UpdatedBy,
     WorkQueueStatusDetail,
 )
-from prefect.server.utilities.schemas.bases import ORMBaseModel, PrefectBaseModel
+from prefect.server.utilities.schemas.bases import (
+    ORMBaseModel,
+    PrefectBaseModel,
+    ResponseBaseModel,
+)
 from prefect.types import KeyValueLabelsField
 from prefect.utilities.collections import AutoEnum
 from prefect.utilities.names import generate_slug
@@ -546,7 +550,7 @@ class WorkerResponse(schemas.core.Worker):
         return worker
 
 
-class GlobalConcurrencyLimitResponse(ORMBaseModel):
+class GlobalConcurrencyLimitResponse(ResponseBaseModel):
     """
     A response object for global concurrency limits.
     """

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -212,7 +212,7 @@ class ResponseBaseModel(PrefectBaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    id: UUID = Field(default_factory=uuid4)
+    id: UUID
 
-    created: Optional[DateTime] = Field(default=None, repr=False)
-    updated: Optional[DateTime] = Field(default=None, repr=False)
+    created: Optional[DateTime]
+    updated: Optional[DateTime]

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -12,7 +12,7 @@
 		"format:check": "biome format",
 		"format": "biome format --write",
 		"preview": "vite preview",
-		"service-sync": "uv run ../scripts/generate_oss_openapi_schema.py && npx openapi-typescript oss_schema.json -o src/api/prefect.ts && rm oss_schema.json",
+		"service-sync": "uv run --with-editable ../. ../scripts/generate_oss_openapi_schema.py && npx openapi-typescript oss_schema.json -o src/api/prefect.ts && rm oss_schema.json",
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build"
 	},

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -7177,11 +7177,11 @@ export interface components {
              * Id
              * Format: uuid
              */
-            id?: string;
+            id: string;
             /** Created */
-            created?: string | null;
+            created: string | null;
             /** Updated */
-            updated?: string | null;
+            updated: string | null;
             /**
              * Active
              * @description Whether the global concurrency limit is active.

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -482,26 +482,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/flow_runs/{id}/labels": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * Update Flow Run Labels
-         * @description Update the labels of a flow run.
-         */
-        patch: operations["update_flow_run_labels_flow_runs__id__labels_patch"];
-        trace?: never;
-    };
     "/task_runs/": {
         parameters: {
             query?: never;
@@ -10468,42 +10448,6 @@ export interface operations {
                 content: {
                     "application/json": unknown;
                 };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_flow_run_labels_flow_runs__id__labels_patch: {
-        parameters: {
-            query?: never;
-            header?: {
-                "x-prefect-api-version"?: string;
-            };
-            path: {
-                /** @description The flow run id */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": Record<string, never>;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -482,6 +482,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/flow_runs/{id}/labels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Flow Run Labels
+         * @description Update the labels of a flow run.
+         */
+        patch: operations["update_flow_run_labels_flow_runs__id__labels_patch"];
+        trace?: never;
+    };
     "/task_runs/": {
         parameters: {
             query?: never;
@@ -10448,6 +10468,42 @@ export interface operations {
                 content: {
                     "application/json": unknown;
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_flow_run_labels_flow_runs__id__labels_patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-prefect-api-version"?: string;
+            };
+            path: {
+                /** @description The flow run id */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/ui-v2/src/components/concurrency/global-concurrency-view/dialog/delete-limit-dialog.tsx
+++ b/ui-v2/src/components/concurrency/global-concurrency-view/dialog/delete-limit-dialog.tsx
@@ -9,7 +9,7 @@ import {
 	DialogTrigger,
 } from "@/components/ui/dialog";
 import {
-	GlobalConcurrencyLimit,
+	type GlobalConcurrencyLimit,
 	useDeleteGlobalConcurrencyLimit,
 } from "@/hooks/global-concurrency-limits";
 import { useToast } from "@/hooks/use-toast";
@@ -25,10 +25,7 @@ export const DeleteLimitDialog = ({ limit, onOpenChange, onDelete }: Props) => {
 	const { deleteGlobalConcurrencyLimit, isPending } =
 		useDeleteGlobalConcurrencyLimit();
 
-	const handleOnClick = (id: string | undefined) => {
-		if (!id) {
-			throw new Error("'id' field expected in GlobalConcurrencyLimit");
-		}
+	const handleOnClick = (id: string) => {
 		deleteGlobalConcurrencyLimit(id, {
 			onSuccess: () => {
 				toast({ description: "Concurrency limit deleted" });
@@ -57,7 +54,7 @@ export const DeleteLimitDialog = ({ limit, onOpenChange, onDelete }: Props) => {
 					</DialogTrigger>
 					<Button
 						variant="destructive"
-						onClick={() => handleOnClick(limit?.id)}
+						onClick={() => handleOnClick(limit.id)}
 						loading={isPending}
 					>
 						Delete

--- a/ui-v2/src/hooks/global-concurrency-limits.test.tsx
+++ b/ui-v2/src/hooks/global-concurrency-limits.test.tsx
@@ -204,6 +204,8 @@ describe("global concurrency limits hooks", () => {
 		const UPDATED_LIMIT = {
 			...UPDATED_LIMIT_BODY,
 			id: MOCK_UPDATE_LIMIT_ID,
+			created: "2021-01-01T00:00:00Z",
+			updated: "2021-01-01T00:00:00Z",
 		};
 
 		// ------------ Mock API requests after queries are invalidated


### PR DESCRIPTION
The generated client for the v2 UI has been showing `id`, `created`, `updated` as optional for a response from the API, even though they should always be present. I tracked this down to the response models inheriting from `ORMBaseModel`, which has default factories for these three fields. The default factories will cause these fields to appear optional in the generated OpenAPI schema.

This PR introduces a `ResponseBaseModel` with `id`, `created`, and `updated` as required attributes and uses this new model to update `GlobalConcurrencyLimitResponse` as a test. The generated code now reflects the expected typing.

I started with one model to ensure that we like this pattern. If we do, I can update other response models in followup PRs.