### PR TITLE
Backport: deleting flows in python client prefect 2.0

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -9,8 +9,8 @@ on:
   pull_request:
     paths:
       - .github/workflows/python-tests.yaml
-      - src/prefect/**/*.py
-      - tests/**/*.py
+      - "src/prefect/**/*.py"
+      - "tests/**/*.py"
       - requirements.txt
       - requirements-client.txt
       - requirements-dev.txt
@@ -21,8 +21,8 @@ on:
       - 2.x
     paths:
       - .github/workflows/python-tests.yaml
-      - src/prefect/**/*.py
-      - tests/**/*.py
+      - "src/prefect/**/*.py"
+      - "tests/**/*.py"
       - requirements.txt
       - requirements-client.txt
       - requirements-dev.txt

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -9,8 +9,8 @@ on:
   pull_request:
     paths:
       - .github/workflows/python-tests.yaml
-      - "src/prefect/**/*.py"
-      - "tests/**/*.py"
+      - src/prefect/**/*.py
+      - tests/**/*.py
       - requirements.txt
       - requirements-client.txt
       - requirements-dev.txt
@@ -21,8 +21,8 @@ on:
       - 2.x
     paths:
       - .github/workflows/python-tests.yaml
-      - "src/prefect/**/*.py"
-      - "tests/**/*.py"
+      - src/prefect/**/*.py
+      - tests/**/*.py
       - requirements.txt
       - requirements-client.txt
       - requirements-dev.txt

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -491,6 +491,23 @@ class PrefectClient:
         """
         response = await self._client.get(f"/flows/{flow_id}")
         return Flow.parse_obj(response.json())
+    
+    async def delete_flow(self, flow_id: UUID) -> None:
+        """
+        Delete a flow by UUID.
+        Args:
+            flow_id: ID of the flow to be deleted
+        Raises:
+            prefect.exceptions.ObjectNotFound: If request returns 404
+            httpx.RequestError: If requests fails
+        """
+        try:
+            await self._client.delete(f"/flows/{flow_id}")
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == status.HTTP_404_NOT_FOUND:
+                raise prefect.exceptions.ObjectNotFound(http_exc=e) from e
+            else:
+                raise
 
     async def read_flows(
         self,

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -491,7 +491,7 @@ class PrefectClient:
         """
         response = await self._client.get(f"/flows/{flow_id}")
         return Flow.parse_obj(response.json())
-    
+
     async def delete_flow(self, flow_id: UUID) -> None:
         """
         Delete a flow by UUID.

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -567,6 +567,19 @@ async def test_create_then_read_flow(prefect_client):
     assert lookup.name == foo.name
 
 
+async def test_create_then_delete_flow(prefect_client):
+    @flow
+    def foo():
+        pass
+
+    flow_id = await prefect_client.create_flow(foo)
+    assert isinstance(flow_id, UUID)
+
+    await prefect_client.delete_flow(flow_id)
+    with pytest.raises(prefect.exceptions.PrefectHTTPStatusError, match="404"):
+        await prefect_client.read_flow(flow_id)
+
+
 async def test_create_then_read_deployment(
     prefect_client, infrastructure_document_id, storage_document_id
 ):


### PR DESCRIPTION
Closes #16307 in Prefect 2.x. Original PR: #16308 
