### PR TITLE
[UI v2] Add hooks for paginating and counting deployments

### DIFF
--- a/ui-v2/src/hooks/deployments/deployments.test.tsx
+++ b/ui-v2/src/hooks/deployments/deployments.test.tsx
@@ -1,0 +1,113 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import {
+	type Deployment,
+	usePaginateDeployments,
+	useCountDeployments,
+} from "./index";
+
+import { server } from "../../../tests/mocks/node";
+
+describe("deployments hooks", () => {
+	const seedDeployments = (): Deployment[] => [
+		{
+			id: "deployment-1",
+			created: "2021-01-01T00:00:00Z",
+			updated: "2021-01-01T00:00:00Z",
+			name: "Test Deployment 1",
+			version: "1.0",
+			tags: ["test"],
+			schedules: [],
+			work_queue_name: "default",
+			work_pool_name: "default",
+			parameter_openapi_schema: {},
+			status: "READY",
+			description: null,
+			storage_document_id: null,
+			infrastructure_document_id: null,
+			path: null,
+			entrypoint: null,
+			flow_id: "test-flow-id",
+			paused: false,
+			enforce_parameter_schema: false,
+		},
+	];
+
+	const mockFetchDeploymentsAPI = (deployments: Array<Deployment>) => {
+		server.use(
+			http.post("http://localhost:4200/api/deployments/paginate", () => {
+				return HttpResponse.json(deployments);
+			}),
+		);
+	};
+
+	const mockFetchDeploymentsCountAPI = (count: number) => {
+		server.use(
+			http.post("http://localhost:4200/api/deployments/count", () => {
+				return HttpResponse.json(count);
+			}),
+		);
+	};
+
+	const createQueryWrapper = ({ queryClient = new QueryClient() }) => {
+		const QueryWrapper = ({ children }: { children: React.ReactNode }) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+		return QueryWrapper;
+	};
+
+	const paginationFilter = {
+		page: 1,
+		limit: 10,
+		sort: "NAME_ASC" as const,
+	};
+
+	const countFilter = {
+		offset: 0,
+		sort: "NAME_ASC" as const,
+	};
+
+	/**
+	 * Data Management:
+	 * - Asserts deployment list data is fetched and stored correctly
+	 */
+	it("stores paginated deployments data into the appropriate query", async () => {
+		// Mock API response
+		const mockList = seedDeployments();
+		mockFetchDeploymentsAPI(mockList);
+
+		// Initialize hook
+		const { result } = renderHook(
+			() => usePaginateDeployments(paginationFilter),
+			{
+				wrapper: createQueryWrapper({}),
+			},
+		);
+
+		// Assert
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual(mockList);
+	});
+
+	/**
+	 * Data Management:
+	 * - Asserts deployment count data is fetched and stored correctly
+	 */
+	it("stores deployment count data into the appropriate query", async () => {
+		// Mock API response
+		const mockCount = 1;
+		mockFetchDeploymentsCountAPI(mockCount);
+
+		// Initialize hook
+		const { result } = renderHook(() => useCountDeployments(countFilter), {
+			wrapper: createQueryWrapper({}),
+		});
+
+		// Assert
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toEqual(mockCount);
+	});
+});

--- a/ui-v2/src/hooks/deployments/index.ts
+++ b/ui-v2/src/hooks/deployments/index.ts
@@ -1,0 +1,193 @@
+import type { components } from "@/api/prefect";
+import { getQueryService } from "@/api/service";
+import {
+	type QueryClient,
+	queryOptions,
+	useSuspenseQuery,
+} from "@tanstack/react-query";
+
+export type Deployment = components["schemas"]["DeploymentResponse"];
+export type DeploymentsFilter =
+	components["schemas"]["Body_read_deployments_deployments_filter_post"];
+export type DeploymentsPaginationFilter =
+	components["schemas"]["Body_paginate_deployments_deployments_paginate_post"];
+
+/**
+ * Query key factory for deployments-related queries
+ *
+ * @property {function} all - Returns base key for all deployment queries
+ * @property {function} lists - Returns key for all list-type deployment queries
+ * @property {function} list - Generates key for specific filtered deployment queries
+ * @property {function} counts - Returns key for all count-type deployment queries
+ * @property {function} count - Generates key for specific filtered count queries
+ *
+ * ```
+ * all    =>   ['deployments']
+ * lists  =>   ['deployments', 'list']
+ * list   =>   ['deployments', 'list', { ...filter }]
+ * counts =>   ['deployments', 'counts']
+ * count  =>   ['deployments', 'counts', { ...filter }]
+ * ```
+ */
+export const queryKeyFactory = {
+	all: () => ["deployments"] as const,
+	lists: () => [...queryKeyFactory.all(), "list"] as const,
+	list: (filter: DeploymentsFilter | DeploymentsPaginationFilter) =>
+		[...queryKeyFactory.lists(), filter] as const,
+	counts: () => [...queryKeyFactory.all(), "counts"] as const,
+	count: (filter: DeploymentsFilter) =>
+		[...queryKeyFactory.counts(), filter] as const,
+};
+
+// ----------------------------
+//  Query Options Factories
+// ----------------------------
+
+/**
+ * Builds a query configuration for fetching paginated deployments
+ *
+ * @param filter - Pagination and filter options including:
+ *   - page: Page number to fetch (default: 1)
+ *   - limit: Number of items per page (default: 10)
+ *   - sort: Sort order for results (default: "NAME_ASC")
+ *   - deployments: Optional deployment-specific filters
+ * @returns Query configuration object for use with TanStack Query
+ *
+ * @example
+ * ```ts
+ * const query = buildPaginateDeploymentsQuery({
+ *   page: 2,
+ *   limit: 25,
+ *   sort: "CREATED_DESC"
+ * });
+ * ```
+ */
+export const buildPaginateDeploymentsQuery = (
+	filter: DeploymentsPaginationFilter = {
+		page: 1,
+		limit: 10,
+		sort: "NAME_ASC",
+	},
+) =>
+	queryOptions({
+		queryKey: queryKeyFactory.list(filter),
+		queryFn: async () => {
+			const res = await getQueryService().POST("/deployments/paginate", {
+				body: filter,
+			});
+			return res.data ?? [];
+		},
+	});
+
+/**
+ * Builds a query configuration for counting deployments based on filter criteria
+ *
+ * @param filter - Filter options for the deployments count query including:
+ *   - offset: Number of items to skip (default: 0)
+ *   - sort: Sort order for results (default: "NAME_ASC")
+ *   - deployments: Optional deployment-specific filters
+ * @returns Query configuration object for use with TanStack Query
+ *
+ * @example
+ * ```ts
+ * const query = buildCountDeploymentsQuery({
+ *   offset: 0,
+ *   limit: 10,
+ *   sort: "NAME_ASC",
+ *   deployments: {
+ *     name: { like_: "my-deployment" }
+ *   }
+ * });
+ * ```
+ */
+export const buildCountDeploymentsQuery = (
+	filter: DeploymentsFilter = { offset: 0, sort: "NAME_ASC" },
+) =>
+	queryOptions({
+		queryKey: queryKeyFactory.list(filter),
+		queryFn: async () => {
+			const res = await getQueryService().POST("/deployments/count", {
+				body: filter,
+			});
+			return res.data ?? [];
+		},
+	});
+
+// ----------------------------
+//  Queries
+// ----------------------------
+
+/**
+ * Hook for fetching paginated deployments with suspense
+ *
+ * @param filter - Pagination and filter options for the deployments query
+ * @returns SuspenseQueryResult containing the paginated deployments data
+ *
+ * @example
+ * ```ts
+ * const { data: deployments } = usePaginateDeployments({
+ *   page: 1,
+ *   limit: 25,
+ *   sort: "NAME_ASC",
+ *   deployments: {
+ *     name: { like_: "my-deployment" }
+ *   }
+ * });
+ * ```
+ */
+export const usePaginateDeployments = (
+	filter: DeploymentsPaginationFilter = {
+		page: 1,
+		limit: 10,
+		sort: "NAME_ASC",
+	},
+) => useSuspenseQuery(buildPaginateDeploymentsQuery(filter));
+
+/**
+ * Data loader for the usePaginateDeployments hook, used by TanStack Router
+ * Prefetches paginated deployments data
+ *
+ * @param deps - Filter options to use for prefetching deployments
+ * @param context - Router context containing queryClient
+ * @returns Promise that resolves when deployments data is prefetched
+ */
+usePaginateDeployments.loader = ({
+	context,
+	deps,
+}: {
+	deps: DeploymentsPaginationFilter;
+	context: { queryClient: QueryClient };
+}) => context.queryClient.ensureQueryData(buildPaginateDeploymentsQuery(deps));
+
+/**
+ * Hook for fetching the count of deployments based on filter criteria with suspense
+ *
+ * @param filter - Filter options for the deployments count query
+ * @returns SuspenseQueryResult containing the count of deployments
+ *
+ * @example
+ * ```ts
+ * const { data: count } = useCountDeployments({
+ *   deployments: { name: { like_: "my-deployment" } }
+ * });
+ * ```
+ */
+export const useCountDeployments = (
+	filter: DeploymentsFilter = { offset: 0, sort: "NAME_ASC" },
+) => useSuspenseQuery(buildCountDeploymentsQuery(filter));
+
+/**
+ * Data loader for the useCountDeployments hook, used by TanStack Router
+ * Prefetches count of deployments
+ *
+ * @param deps - Filter options to use for prefetching deployments
+ * @param context - Router context containing queryClient
+ * @returns Promise that resolves when deployments data is prefetched
+ */
+useCountDeployments.loader = ({
+	context,
+	deps,
+}: {
+	deps: DeploymentsFilter;
+	context: { queryClient: QueryClient };
+}) => context.queryClient.ensureQueryData(buildCountDeploymentsQuery(deps));


### PR DESCRIPTION
This PR adds a `usePaginateDeployments` hook and a `useCountDeployments` hook. Both will be use to provide data to the deployments table view.
