### PR TITLE
[UI v2] Create empty state for deployments page

### DIFF
--- a/ui-v2/src/components/deployments/empty-state/empty-state.stories.tsx
+++ b/ui-v2/src/components/deployments/empty-state/empty-state.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { DeploymentsEmptyState } from ".";
+
+export const story: StoryObj = { name: "EmptyState" };
+
+export default {
+	component: DeploymentsEmptyState,
+	title: "Components/Deployments/EmptyState",
+} satisfies Meta;

--- a/ui-v2/src/components/deployments/empty-state/index.tsx
+++ b/ui-v2/src/components/deployments/empty-state/index.tsx
@@ -1,0 +1,26 @@
+import { DocsLink } from "@/components/ui/docs-link";
+import {
+	EmptyState,
+	EmptyStateActions,
+	EmptyStateDescription,
+	EmptyStateIcon,
+	EmptyStateTitle,
+} from "@/components/ui/empty-state";
+
+export const DeploymentsEmptyState = () => (
+	<EmptyState>
+		<div className="flex items-center gap-3">
+			<EmptyStateIcon id="Workflow" />
+			<EmptyStateIcon id="MoreHorizontal" />
+			<EmptyStateIcon id="Rocket" />
+		</div>
+		<EmptyStateTitle>Create a deployment to get started</EmptyStateTitle>
+		<EmptyStateDescription>
+			Deployments elevate workflows from functions you call manually to API
+			objects that can be remotely triggered.
+		</EmptyStateDescription>
+		<EmptyStateActions>
+			<DocsLink id="deployments-guide" />
+		</EmptyStateActions>
+	</EmptyState>
+);

--- a/ui-v2/src/components/deployments/header.tsx
+++ b/ui-v2/src/components/deployments/header.tsx
@@ -1,0 +1,19 @@
+import {
+	Breadcrumb,
+	BreadcrumbItem,
+	BreadcrumbList,
+} from "@/components/ui/breadcrumb";
+
+export const DeploymentsPageHeader = () => {
+	return (
+		<div className="flex items-center gap-2">
+			<Breadcrumb>
+				<BreadcrumbList>
+					<BreadcrumbItem className="text-xl font-semibold">
+						Deployments
+					</BreadcrumbItem>
+				</BreadcrumbList>
+			</Breadcrumb>
+		</div>
+	);
+};

--- a/ui-v2/src/components/ui/docs-link.tsx
+++ b/ui-v2/src/components/ui/docs-link.tsx
@@ -10,6 +10,7 @@ const DOCS_LINKS = {
 	"task-concurrency-guide":
 		"https://docs.prefect.io/v3/develop/task-run-limits",
 	"variables-guide": "https://docs.prefect.io/latest/guides/variables/",
+	"deployments-guide": "https://docs.prefect.io/v3/deploy/index",
 } as const;
 
 type DocsID = keyof typeof DOCS_LINKS;

--- a/ui-v2/src/components/ui/icons/constants.ts
+++ b/ui-v2/src/components/ui/icons/constants.ts
@@ -17,8 +17,10 @@ import {
 	Pause,
 	Play,
 	Plus,
+	Rocket,
 	Search,
 	ServerCrash,
+	Workflow,
 	Variable,
 	X,
 } from "lucide-react";
@@ -42,8 +44,10 @@ export const ICONS = {
 	Pause,
 	Play,
 	Plus,
+	Rocket,
 	Search,
 	ServerCrash,
+	Workflow,
 	Variable,
 	X,
 } as const;

--- a/ui-v2/src/routes/deployments.tsx
+++ b/ui-v2/src/routes/deployments.tsx
@@ -1,3 +1,5 @@
+import { DeploymentsEmptyState } from "@/components/deployments/empty-state";
+import { DeploymentsPageHeader } from "@/components/deployments/header";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/deployments")({
@@ -5,5 +7,10 @@ export const Route = createFileRoute("/deployments")({
 });
 
 function RouteComponent() {
-	return "🚧🚧 Pardon our dust! 🚧🚧";
+	return (
+		<div className="flex flex-col gap-4">
+			<DeploymentsPageHeader />
+			<DeploymentsEmptyState />
+		</div>
+	);
 }


### PR DESCRIPTION
This PR adds an empty state for the deployments page, matching the existing empty state as closely as possible while using `react-lucide` icons.

Here's what it looks like:
![Screenshot 2024-12-10 at 11 57 37 AM](https://github.com/user-attachments/assets/44f082f1-d77e-41b8-ad60-97e51cadf761)
