### PR TITLE
[UI v2] feat: Adds @tests alias for easier access when writing tests

### DIFF
--- a/ui-v2/src/hooks/deployments/deployments.test.tsx
+++ b/ui-v2/src/hooks/deployments/deployments.test.tsx
@@ -5,11 +5,11 @@ import { describe, expect, it } from "vitest";
 
 import {
 	type Deployment,
-	usePaginateDeployments,
 	useCountDeployments,
+	usePaginateDeployments,
 } from "./index";
 
-import { server } from "../../../tests/mocks/node";
+import { server } from "@tests/mocks";
 
 describe("deployments hooks", () => {
 	const seedDeployments = (): Deployment[] => [

--- a/ui-v2/src/hooks/global-concurrency-limits.test.tsx
+++ b/ui-v2/src/hooks/global-concurrency-limits.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { server } from "@tests/mocks";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
@@ -11,8 +12,6 @@ import {
 	useListGlobalConcurrencyLimits,
 	useUpdateGlobalConcurrencyLimit,
 } from "./global-concurrency-limits";
-
-import { server } from "../../tests/mocks/node";
 
 describe("global concurrency limits hooks", () => {
 	const seedGlobalConcurrencyLimits = () => [

--- a/ui-v2/src/hooks/variables.test.tsx
+++ b/ui-v2/src/hooks/variables.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
 import { components } from "@/api/prefect";
+import { server } from "@tests/mocks";
 
 import {
 	buildCountQuery,
@@ -13,8 +14,6 @@ import {
 	useUpdateVariable,
 	useVariables,
 } from "./variables";
-
-import { server } from "../../tests/mocks/node";
 
 describe("variable hooks", () => {
 	const seedVariables = () => [

--- a/ui-v2/tests/mocks/index.ts
+++ b/ui-v2/tests/mocks/index.ts
@@ -1,0 +1,1 @@
+export { server } from "./node";

--- a/ui-v2/tests/setup.ts
+++ b/ui-v2/tests/setup.ts
@@ -1,9 +1,9 @@
 /// <reference lib="dom" />
-import { expect, afterEach, vi, beforeAll, afterAll } from "vitest";
-import { cleanup } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
+import { cleanup } from "@testing-library/react";
+import { afterAll, afterEach, beforeAll, expect, vi } from "vitest";
 import "@testing-library/jest-dom";
-import { server } from "./mocks/node";
+import { server } from "./mocks";
 
 beforeAll(() => {
 	server.listen({

--- a/ui-v2/tests/variables/variables.test.tsx
+++ b/ui-v2/tests/variables/variables.test.tsx
@@ -1,4 +1,9 @@
 import "./mocks";
+import { Toaster } from "@/components/ui/toaster";
+import { VariablesDataTable } from "@/components/variables/data-table";
+import { router } from "@/router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { RouterProvider } from "@tanstack/react-router";
 import {
 	getByLabelText,
 	getByTestId,
@@ -6,24 +11,18 @@ import {
 	render,
 	screen,
 } from "@testing-library/react";
-import { VariablesDataTable } from "@/components/variables/data-table";
 import userEvent from "@testing-library/user-event";
+import { server } from "@tests/mocks";
+import { http, HttpResponse } from "msw";
 import {
-	describe,
-	it,
-	expect,
-	vi,
 	afterEach,
-	beforeEach,
 	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
 } from "vitest";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Toaster } from "@/components/ui/toaster";
-import { server } from "../mocks/node";
-import { HttpResponse } from "msw";
-import { http } from "msw";
-import { router } from "@/router";
-import { RouterProvider } from "@tanstack/react-router";
 
 const renderVariablesPage = async () => {
 	const user = userEvent.setup();

--- a/ui-v2/tsconfig.app.json
+++ b/ui-v2/tsconfig.app.json
@@ -7,7 +7,8 @@
 		"skipLibCheck": true,
 		"baseUrl": ".",
 		"paths": {
-			"@/*": ["./src/*"]
+			"@/*": ["./src/*"],
+			"@tests/*": ["./tests/*"]
 		},
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,

--- a/ui-v2/tsconfig.json
+++ b/ui-v2/tsconfig.json
@@ -11,7 +11,8 @@
 	"compilerOptions": {
 		"baseUrl": ".",
 		"paths": {
-			"@/*": ["./src/*"]
+			"@/*": ["./src/*"],
+			"@tests/*": ["./tests/*"]
 		}
 	}
 }

--- a/ui-v2/vite.config.ts
+++ b/ui-v2/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "./src"),
+			"@tests": path.resolve(__dirname, "./tests"),
 		},
 	},
 });


### PR DESCRIPTION
Importing re-usable testing mocks can be confusing by using relative pathing. This PR adds an alias to make it straightforward in importing re-usable mocks in our tests

### Checklist
1. Creates a path alias `@tests`.
2. Updates tests to use ` import { server } from '@tests/mocks`

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
