### PR TITLE
Fix bad workspace commands in the tutorials

### DIFF
--- a/docs/v3/tutorials/debug.mdx
+++ b/docs/v3/tutorials/debug.mdx
@@ -93,8 +93,8 @@ def process_data(run: int, fail_at_run: Optional[int] = None) -> bool:
 Now, all flow runs succeed in spite of the `--fail-at-run` flag.
 Deploy the fix to the staging workspace to confirm this new behavior.
 
-```bash
-prefect cloud workspace --set "<account>/staging"
+```
+prefect cloud workspace set --workspace "<account>/staging"
 python simulate_failures.py --fail-at-run 3
 ```
 
@@ -102,8 +102,8 @@ After the script finishes, open the **Home** page in Prefect Cloud to verify tha
 
 You can now switch workspaces to update the code used in the production workspace as well.
 
-```bash
-prefect cloud workspace --set "<account>/production"
+```
+prefect cloud workspace set --workspace "<account>/production"
 python simulate_failures.py
 ```
 

--- a/docs/v3/tutorials/debug.mdx
+++ b/docs/v3/tutorials/debug.mdx
@@ -93,7 +93,7 @@ def process_data(run: int, fail_at_run: Optional[int] = None) -> bool:
 Now, all flow runs succeed in spite of the `--fail-at-run` flag.
 Deploy the fix to the staging workspace to confirm this new behavior.
 
-```
+```bash
 prefect cloud workspace set --workspace "<account>/staging"
 python simulate_failures.py --fail-at-run 3
 ```
@@ -102,7 +102,7 @@ After the script finishes, open the **Home** page in Prefect Cloud to verify tha
 
 You can now switch workspaces to update the code used in the production workspace as well.
 
-```
+```bash
 prefect cloud workspace set --workspace "<account>/production"
 python simulate_failures.py
 ```

--- a/docs/v3/tutorials/platform.mdx
+++ b/docs/v3/tutorials/platform.mdx
@@ -101,13 +101,13 @@ Run the following script from the demo repository to create flow runs in each wo
 
 ```bash
 # Run flows in the production workspace
-prefect cloud workspace --set "<account>/production"
+prefect cloud workspace set --workspace "<account>/production"
 python simulate_failures.py
 ```
 
 ```bash
 # Run flows in the staging workspace 
-prefect cloud workspace --set "<account>/staging"
+prefect cloud workspace set --workspace "<account>/staging"
 python simulate_failures.py --fail-at-run 3
 ```
 


### PR DESCRIPTION
A few CLI commands in the tutorials use incorrect syntax.

### Checklist

- [ ] ~This pull request references any related issue by including "closes `<link to issue>`"~
- [ ] ~If this pull request adds new functionality, it includes unit tests that cover the changes~
- [ ] ~If this pull request removes docs files, it includes redirect settings in `mint.json`.~
- [ ] ~If this pull request adds functions or classes, it includes helpful docstrings.~
