### PR TITLE
[UI v2] feat: Adds react-compiler eslint rule as a warning

### DIFF
--- a/ui-v2/eslint.config.js
+++ b/ui-v2/eslint.config.js
@@ -3,6 +3,7 @@ import pluginQuery from "@tanstack/eslint-plugin-query";
 import pluginRouter from "@tanstack/eslint-plugin-router";
 import jestDom from "eslint-plugin-jest-dom";
 import react from "eslint-plugin-react";
+import reactCompilerPlugin from "eslint-plugin-react-compiler";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 import testingLibrary from "eslint-plugin-testing-library";
@@ -34,6 +35,7 @@ export default tseslint.config(
 			react,
 			"react-hooks": reactHooks,
 			"react-refresh": reactRefresh,
+			"react-compiler": reactCompilerPlugin,
 		},
 		rules: {
 			...reactHooks.configs.recommended.rules,
@@ -43,10 +45,12 @@ export default tseslint.config(
 			],
 			...react.configs.recommended.rules,
 			...react.configs["jsx-runtime"].rules,
+			"react-compiler/react-compiler": "warn", // Move to "error" once all warnings have been resolved
 		},
 	},
 	...pluginQuery.configs["flat/recommended"],
 	...pluginRouter.configs["flat/recommended"],
+
 	{
 		files: ["tests/**/*.{ts,tsx}"],
 		...testingLibrary.configs["flat/react"],

--- a/ui-v2/package-lock.json
+++ b/ui-v2/package-lock.json
@@ -71,6 +71,7 @@
 				"eslint": "^9.12.0",
 				"eslint-plugin-jest-dom": "^5.4.0",
 				"eslint-plugin-react": "^7.37.1",
+				"eslint-plugin-react-compiler": "^19.0.0-beta-df7b47d-20241124",
 				"eslint-plugin-react-hooks": "^5.1.0-rc.0",
 				"eslint-plugin-react-refresh": "^0.4.9",
 				"eslint-plugin-storybook": "^0.11.0",
@@ -187,6 +188,19 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@babel/helper-annotate-as-pure": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
+			"integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/helper-compilation-targets": {
 			"version": "7.25.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
@@ -198,6 +212,42 @@
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-create-class-features-plugin": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
+			"integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^7.25.9",
+				"@babel/helper-member-expression-to-functions": "^7.25.9",
+				"@babel/helper-optimise-call-expression": "^7.25.9",
+				"@babel/helper-replace-supers": "^7.25.9",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+				"@babel/traverse": "^7.25.9",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/helper-member-expression-to-functions": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
+			"integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^7.25.9",
+				"@babel/types": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -233,11 +283,56 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
+		"node_modules/@babel/helper-optimise-call-expression": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
+			"integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/helper-plugin-utils": {
 			"version": "7.25.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
 			"integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
 			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-replace-supers": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
+			"integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-member-expression-to-functions": "^7.25.9",
+				"@babel/helper-optimise-call-expression": "^7.25.9",
+				"@babel/traverse": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
+			"integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^7.25.9",
+				"@babel/types": "^7.25.9"
+			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -318,6 +413,23 @@
 			"integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
 			"dev": true,
 			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-private-methods": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz",
+			"integrity": "sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-class-features-plugin": "^7.25.9",
 				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
@@ -6530,6 +6642,27 @@
 				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
 			}
 		},
+		"node_modules/eslint-plugin-react-compiler": {
+			"version": "19.0.0-beta-df7b47d-20241124",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.0.0-beta-df7b47d-20241124.tgz",
+			"integrity": "sha512-82PfnllC8jP/68KdLAbpWuYTcfmtGLzkqy2IW85WopKMTr+4rdQpp+lfliQ/QE79wWrv/dRoADrk3Pdhq25nTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.24.4",
+				"@babel/parser": "^7.24.4",
+				"@babel/plugin-transform-private-methods": "^7.25.9",
+				"hermes-parser": "^0.25.1",
+				"zod": "^3.22.4",
+				"zod-validation-error": "^3.0.3"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=7"
+			}
+		},
 		"node_modules/eslint-plugin-react-hooks": {
 			"version": "5.1.0-rc-fb9a90fa48-20240614",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0-rc-fb9a90fa48-20240614.tgz",
@@ -7390,6 +7523,23 @@
 			"resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
 			"integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
 			"dev": true
+		},
+		"node_modules/hermes-estree": {
+			"version": "0.25.1",
+			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+			"integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/hermes-parser": {
+			"version": "0.25.1",
+			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+			"integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hermes-estree": "0.25.1"
+			}
 		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "4.0.0",
@@ -11729,6 +11879,19 @@
 			"integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-validation-error": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.4.0.tgz",
+			"integrity": "sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"zod": "^3.18.0"
 			}
 		}
 	}

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -80,6 +80,7 @@
 		"eslint": "^9.12.0",
 		"eslint-plugin-jest-dom": "^5.4.0",
 		"eslint-plugin-react": "^7.37.1",
+		"eslint-plugin-react-compiler": "^19.0.0-beta-df7b47d-20241124",
 		"eslint-plugin-react-hooks": "^5.1.0-rc.0",
 		"eslint-plugin-react-refresh": "^0.4.9",
 		"eslint-plugin-storybook": "^0.11.0",


### PR DESCRIPTION
https://www.npmjs.com/package/eslint-plugin-react-compiler

1. Adds react-compiler eslint rule. Currently sets it as "warn". but should be moved to "error" until all 3 violations have been resolved. (Should re-visit these violations soon).

As this codebase is still green, should warn developers on the future react compiler violations

```
prefect/ui-v2/src/components/ui/json-input.tsx
  24:15  warning  Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef)  react-compiler/react-compiler
  24:15  warning  Ref values (the `current` property) may not be accessed during render. (https://react.dev/reference/react/useRef)  react-compiler/react-compiler

/prefect/ui-v2/src/components/ui/sidebar/sidebar.tsx
  66:5  warning  Writing to a variable defined outside a component or hook is not allowed. Consider using an effect  react-compiler/react-compiler
```  

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
