### PR TITLE
Temporarily disable passing worker labels to flow run

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -989,7 +989,6 @@ class BaseWorker(abc.ABC):
         try:
             configuration = await self._get_configuration(flow_run)
             submitted_event = self._emit_flow_run_submitted_event(configuration)
-            await self._give_worker_labels_to_flow_run(flow_run.id)
             result = await self.run(
                 flow_run=flow_run,
                 task_status=task_status,

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -2083,6 +2083,7 @@ class TestBaseWorkerHeartbeat:
             assert worker._worker_metadata_sent
 
 
+@pytest.mark.skip(reason="Passing worker labels to flow run is temporarily disabled")
 async def test_worker_gives_labels_to_flow_runs_when_using_cloud_api(
     prefect_client: PrefectClient, worker_deployment_wq1, work_pool
 ):
@@ -2118,6 +2119,7 @@ async def test_worker_gives_labels_to_flow_runs_when_using_cloud_api(
     )
 
 
+@pytest.mark.skip(reason="Passing worker labels to flow run is temporarily disabled")
 async def test_worker_does_not_give_labels_to_flow_runs_when_not_using_cloud_api(
     prefect_client: PrefectClient, worker_deployment_wq1, work_pool
 ):


### PR DESCRIPTION
This PR temporarily removes `_give_worker_labels_to_flow_run` from the worker's submission loop. 

This method uses the `CloudClient.update_flow_run_labels`. The `CloudClient` does not have all the special `httpx_settings` and custom transport setup that we instantiate in the constructor of `PrefectClient`. This can potentially lead to instability and can lead to `httpx.ConnectTimeout` errors (and others) when the `CloudClient` is used in something like the `Worker` that will need to make a lot of requests. Previously the `CloudClient` was only for things like 1 of CLI commands.

The `_give_worker_labels_to_flow_run` method can be added back to the worker's submission loop when `update_flow_run_labels` is moved over to `PrefectClient` (which is blocked by https://github.com/PrefectHQ/prefect/pull/16233/files, but to my understanding is going to happen soon). For now it is non critical to have this in place and will lead to less errors.

Long term we might need consolidate creating our `httpx_settings` if the `CloudClient` is going to be used in higher request volume scenarios like orchestration.