### PR TITLE
Add `Block.aload` method and remove `@sync_compatible` from `Block.load`

### DIFF
--- a/src/prefect/cli/_prompts.py
+++ b/src/prefect/cli/_prompts.py
@@ -503,7 +503,7 @@ async def prompt_push_custom_docker_image(
             docker_registry_creds_name = f"deployment-{slugify(deployment_config['name'])}-{slugify(deployment_config['work_pool']['name'])}-registry-creds"
             create_new_block = False
             try:
-                await credentials_block.load(docker_registry_creds_name)
+                await credentials_block.aload(docker_registry_creds_name)
                 if not confirm(
                     (
                         "Would you like to use the existing Docker registry credentials"

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -1028,7 +1028,7 @@ async def _generate_git_clone_pull_step(
         )
 
         try:
-            await Secret.load(token_secret_block_name)
+            await Secret.aload(token_secret_block_name)
             if not confirm(
                 (
                     "We found an existing token saved for this deployment. Would"

--- a/src/prefect/client/utilities.py
+++ b/src/prefect/client/utilities.py
@@ -7,7 +7,7 @@ Utilities for working with clients.
 
 from collections.abc import Awaitable, Coroutine
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, overload
 
 from typing_extensions import Concatenate, ParamSpec, TypeGuard, TypeVar
 
@@ -71,9 +71,23 @@ def client_injector(
     return wrapper
 
 
+@overload
 def inject_client(
     fn: Callable[P, Coroutine[Any, Any, R]],
 ) -> Callable[P, Coroutine[Any, Any, R]]:
+    ...
+
+
+@overload
+def inject_client(
+    fn: Callable[P, R],
+) -> Callable[P, R]:
+    ...
+
+
+def inject_client(
+    fn: Callable[P, Union[Coroutine[Any, Any, R], R]],
+) -> Callable[P, Union[Coroutine[Any, Any, R], R]]:
     """
     Simple helper to provide a context managed client to an asynchronous function.
 

--- a/src/prefect/deployments/steps/pull.py
+++ b/src/prefect/deployments/steps/pull.py
@@ -190,7 +190,7 @@ async def pull_with_block(block_document_name: str, block_type_slug: str):
 
     full_slug = f"{block_type_slug}/{block_document_name}"
     try:
-        block = await Block.load(full_slug)
+        block = await Block.aload(full_slug)
     except Exception:
         deployment_logger.exception("Unable to load block '%s'", full_slug)
         raise

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -129,7 +129,7 @@ async def resolve_result_storage(
     elif isinstance(result_storage, Path):
         storage_block = LocalFileSystem(basepath=str(result_storage))
     elif isinstance(result_storage, str):
-        storage_block = await Block.load(result_storage, client=client)
+        storage_block = await Block.aload(result_storage, client=client)
         storage_block_id = storage_block._block_document_id
         assert storage_block_id is not None, "Loaded storage blocks must have ids"
     elif isinstance(result_storage, UUID):
@@ -168,7 +168,7 @@ async def get_or_create_default_task_scheduling_storage() -> ResultStorage:
     default_block = settings.tasks.scheduling.default_storage_block
 
     if default_block is not None:
-        return await Block.load(default_block)
+        return await Block.aload(default_block)
 
     # otherwise, use the local file system
     basepath = settings.results.local_storage_path

--- a/src/prefect/testing/utilities.py
+++ b/src/prefect/testing/utilities.py
@@ -249,7 +249,7 @@ async def assert_uses_result_storage(
             (
                 storage
                 if isinstance(storage, Block)
-                else await Block.load(storage, client=client)
+                else await Block.aload(storage, client=client)
             ),
         )
     else:
@@ -260,7 +260,7 @@ async def assert_uses_result_storage(
             (
                 storage
                 if isinstance(storage, Block)
-                else await Block.load(storage, client=client)
+                else await Block.aload(storage, client=client)
             ),
         )
 


### PR DESCRIPTION
This PR improves type hinting on `Block.load` by removing the `@sync_compatible` decorator and using `@async_dispatch` instead.

I had to update `@async_dispatch` to handle class methods and update the dispatch behavior in tasks and flows to match the behavior provided by `@sync_compatible`.

Also, `@inject_client` might be a thorn in our side because it makes wrapped functions async. To handle that in this PR, I removed `@inject_client` from `Block.load` and moved the client retrieval inside the method. There's a weird split where sometimes we can use the sync client, and other times we have to use the async client, but we can clean that up once we remove `@async_dispatch`.

Related to https://github.com/PrefectHQ/prefect/issues/16292
