### PR TITLE
Update release notes for tidiness

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     directory: '/ui/'
     schedule:
       interval: "weekly"
-    labels: ["ui", "development"]
+    labels: ["ui", "ui-dependency"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,9 @@
 # .github/release.yml
 
 changelog:
+  exclude:
+    labels:
+      - ui-dependency # these dont affect user environments
   categories:
     - title: Breaking Changes ⚠️
       labels:
@@ -26,6 +29,8 @@ changelog:
     - title: Development & Tidiness 🧹
       labels:
         - development
+    - title: Documentation 📓
+      labels:
         - docs
     - title: Uncategorized
       labels:


### PR DESCRIPTION
Updates release notes for tidiness that I've been manually doing; for PRs that only touch docs files, let's not add `development` so that they get categorized as Documentation updates.

Also specifically excludes dependabot updates to UI dependencies as these don't affect user environments at all.