### PR TITLE
Exclude UI v2 PRs from the release notes auto-generation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,3 +15,7 @@ upstream dependency:
 
 2.x:
   - base-branch: '2.x'
+
+ui-replatform:
+  - changed-files:
+      - any-glob-to-any-file: ui-v2/**

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,7 @@ changelog:
   exclude:
     labels:
       - ui-dependency # these dont affect user environments
+      - ui-replatform # lots of ongoing work, but not user facing... yet
   categories:
     - title: Breaking Changes ⚠️
       labels:


### PR DESCRIPTION
Small update to make release notes compilation easier.
