### PR TITLE
Pick up trace context from run labels

### DIFF
--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -664,15 +664,10 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
             self._telemetry.start_span(
                 name=self.flow.name,
                 run=self.flow_run,
+                client=self.client,
                 parameters=self.parameters,
                 parent_labels=parent_labels,
             )
-            carrier = self._telemetry.propagate_traceparent()
-            if carrier:
-                self.client.update_flow_run_labels(
-                    flow_run_id=self.flow_run.id,
-                    labels={LABELS_TRACEPARENT_KEY: carrier[TRACEPARENT_KEY]},
-                )
 
             try:
                 yield self
@@ -1233,18 +1228,13 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
             if parent_flow_run and parent_flow_run.flow_run:
                 parent_labels = parent_flow_run.flow_run.labels
 
-            self._telemetry.start_span(
+            await self._telemetry.async_start_span(
                 name=self.flow.name,
                 run=self.flow_run,
+                client=self.client,
                 parameters=self.parameters,
                 parent_labels=parent_labels,
             )
-            carrier = self._telemetry.propagate_traceparent()
-            if carrier:
-                await self.client.update_flow_run_labels(
-                    flow_run_id=self.flow_run.id,
-                    labels={LABELS_TRACEPARENT_KEY: carrier[TRACEPARENT_KEY]},
-                )
 
             try:
                 yield self

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -705,6 +705,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                         self._telemetry.start_span(
                             run=self.task_run,
                             name=self.task.name,
+                            client=self.client,
                             parameters=self.parameters,
                             parent_labels=parent_labels,
                         )
@@ -1243,9 +1244,10 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
                         if parent_flow_run_context and parent_flow_run_context.flow_run:
                             parent_labels = parent_flow_run_context.flow_run.labels
 
-                        self._telemetry.start_span(
+                        await self._telemetry.async_start_span(
                             run=self.task_run,
                             name=self.task.name,
+                            client=self.client,
                             parameters=self.parameters,
                             parent_labels=parent_labels,
                         )

--- a/src/prefect/telemetry/instrumentation.py
+++ b/src/prefect/telemetry/instrumentation.py
@@ -55,7 +55,7 @@ def _url_join(base_url: str, path: str) -> str:
 
 def setup_exporters(
     api_url: str, api_key: str
-) -> tuple[TracerProvider, MeterProvider, "LoggerProvider"]:
+) -> "tuple[TracerProvider, MeterProvider, LoggerProvider]":
     account_id, workspace_id = extract_account_and_workspace_id(api_url)
     telemetry_url = _url_join(api_url, "telemetry/")
 

--- a/src/prefect/telemetry/run_telemetry.py
+++ b/src/prefect/telemetry/run_telemetry.py
@@ -1,6 +1,6 @@
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from opentelemetry import propagate, trace
 from opentelemetry.context import Context
@@ -51,8 +51,8 @@ class RunTelemetry:
         run: Union[TaskRun, FlowRun],
         client: PrefectClient,
         name: Optional[str] = None,
-        parameters: Optional[Dict[str, Any]] = None,
-        parent_labels: Optional[Dict[str, Any]] = None,
+        parameters: Optional[dict[str, Any]] = None,
+        parent_labels: Optional[dict[str, Any]] = None,
     ):
         should_set_traceparent = self._should_set_traceparent(run)
         traceparent, span = self._start_span(run, name, parameters, parent_labels)
@@ -139,7 +139,7 @@ class RunTelemetry:
 
     def _traceparent_and_context_from_labels(
         self, labels: Optional[KeyValueLabels]
-    ) -> Tuple[Optional[str], Union[Context, None]]:
+    ) -> tuple[Optional[str], Union[Context, None]]:
         """Get trace context from run labels if it exists."""
         if not labels or LABELS_TRACEPARENT_KEY not in labels:
             return None, None

--- a/src/prefect/telemetry/run_telemetry.py
+++ b/src/prefect/telemetry/run_telemetry.py
@@ -69,8 +69,8 @@ class RunTelemetry:
         run: Union[TaskRun, FlowRun],
         client: SyncPrefectClient,
         name: Optional[str] = None,
-        parameters: Optional[Dict[str, Any]] = None,
-        parent_labels: Optional[Dict[str, Any]] = None,
+        parameters: Optional[dict[str, Any]] = None,
+        parent_labels: Optional[dict[str, Any]] = None,
     ):
         should_set_traceparent = self._should_set_traceparent(run)
         traceparent, span = self._start_span(run, name, parameters, parent_labels)
@@ -84,9 +84,9 @@ class RunTelemetry:
         self,
         run: Union[TaskRun, FlowRun],
         name: Optional[str] = None,
-        parameters: Optional[Dict[str, Any]] = None,
-        parent_labels: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[Optional[str], Span]:
+        parameters: Optional[dict[str, Any]] = None,
+        parent_labels: Optional[dict[str, Any]] = None,
+    ) -> tuple[Optional[str], Span]:
         """
         Start a span for a task run.
         """

--- a/src/prefect/telemetry/run_telemetry.py
+++ b/src/prefect/telemetry/run_telemetry.py
@@ -1,8 +1,9 @@
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 from opentelemetry import propagate, trace
+from opentelemetry.context import Context
 from opentelemetry.propagators.textmap import Setter
 from opentelemetry.trace import (
     Span,
@@ -12,6 +13,7 @@ from opentelemetry.trace import (
 )
 
 import prefect
+from prefect.client.orchestration import PrefectClient, SyncPrefectClient
 from prefect.client.schemas import FlowRun, TaskRun
 from prefect.client.schemas.objects import State
 from prefect.context import FlowRunContext
@@ -44,13 +46,59 @@ class RunTelemetry:
     )
     span: Optional[Span] = None
 
+    async def async_start_span(
+        self,
+        run: Union[TaskRun, FlowRun],
+        client: PrefectClient,
+        name: Optional[str] = None,
+        parameters: Optional[Dict[str, Any]] = None,
+        parent_labels: Optional[Dict[str, Any]] = None,
+    ):
+        traceparent, span = self._start_span(run, name, parameters, parent_labels)
+
+        if (
+            traceparent
+            and LABELS_TRACEPARENT_KEY not in run.labels
+            and self._run_type(run) == "flow"
+        ):
+            # If the run is a flow run we need to update the flow run labels
+            # with the traceparent so that the traceparent is propagated to
+            # child runs.
+            await client.update_flow_run_labels(
+                run.id, {LABELS_TRACEPARENT_KEY: traceparent}
+            )
+
+        return span
+
     def start_span(
+        self,
+        run: Union[TaskRun, FlowRun],
+        client: SyncPrefectClient,
+        name: Optional[str] = None,
+        parameters: Optional[Dict[str, Any]] = None,
+        parent_labels: Optional[Dict[str, Any]] = None,
+    ):
+        traceparent, span = self._start_span(run, name, parameters, parent_labels)
+
+        if (
+            traceparent
+            and LABELS_TRACEPARENT_KEY not in run.labels
+            and self._run_type(run) == "flow"
+        ):
+            # If the run is a flow run we need to update the flow run labels
+            # with the traceparent so that the traceparent is propagated to
+            # child runs.
+            client.update_flow_run_labels(run.id, {LABELS_TRACEPARENT_KEY: traceparent})
+
+        return span
+
+    def _start_span(
         self,
         run: Union[TaskRun, FlowRun],
         name: Optional[str] = None,
         parameters: Optional[Dict[str, Any]] = None,
         parent_labels: Optional[Dict[str, Any]] = None,
-    ):
+    ) -> Tuple[Optional[str], Span]:
         """
         Start a span for a task run.
         """
@@ -62,10 +110,15 @@ class RunTelemetry:
             f"prefect.run.parameter.{k}": type(v).__name__
             for k, v in parameters.items()
         }
-        run_type = "task" if isinstance(run, TaskRun) else "flow"
+
+        traceparent, context = self._traceparent_and_context_from_labels(
+            {**parent_labels, **run.labels}
+        )
+        run_type = self._run_type(run)
 
         self.span = self._tracer.start_span(
             name=name or run.name,
+            context=context,
             attributes={
                 f"prefect.{run_type}.name": name or run.name,
                 "prefect.run.type": run_type,
@@ -75,7 +128,29 @@ class RunTelemetry:
                 **parent_labels,
             },
         )
-        return self.span
+
+        if not traceparent:
+            traceparent = self._traceparent_from_span(self.span)
+
+        return traceparent, self.span
+
+    def _run_type(self, run: Union[TaskRun, FlowRun]) -> str:
+        return "task" if isinstance(run, TaskRun) else "flow"
+
+    def _traceparent_and_context_from_labels(
+        self, labels: Optional[KeyValueLabels]
+    ) -> Tuple[Optional[str], Union[Context, None]]:
+        """Get trace context from run labels if it exists."""
+        if not labels or LABELS_TRACEPARENT_KEY not in labels:
+            return None, None
+        traceparent = labels[LABELS_TRACEPARENT_KEY]
+        carrier = {TRACEPARENT_KEY: traceparent}
+        return str(traceparent), propagate.extract(carrier)
+
+    def _traceparent_from_span(self, span: Span) -> Optional[str]:
+        carrier = {}
+        propagate.inject(carrier, context=trace.set_span_in_context(span))
+        return carrier.get(TRACEPARENT_KEY)
 
     def end_span_on_success(self) -> None:
         """

--- a/tests/telemetry/test_instrumentation.py
+++ b/tests/telemetry/test_instrumentation.py
@@ -225,9 +225,17 @@ class TestFlowRunInstrumentation:
         else:
             run_flow_sync(the_flow, flow_run=flow_run)  # type: ignore
 
+        assert flow_run.labels[LABELS_TRACEPARENT_KEY] == (
+            "00-ec8af70b445d54387035c27eb182dd22-4a593d8fa95f1902-01"
+        )
+
         spans = instrumentation.get_finished_spans()
         assert len(spans) == 1
         span = spans[0]
+
+        span_context = span.get_span_context()
+        assert span_context is not None
+        assert span_context.trace_id == 314419354619557650326501540139523824930
 
         assert span.parent is not None
         assert span.parent.trace_id == 314419354619557650326501540139523824930


### PR DESCRIPTION
This updates the RunTelemetry class to pull the traceparent from the runs labels. A traceparent can be added to these labels by server-side code. For instance if a run is Late when we transition to Late the server will start a span and store the traceparent in the flow run's labels. This way when the flow run is later picked up by a worker this "Late" span becomes the root span for the trace.

Related to CLOUD-732