### PR TITLE
improve `Dockerfile` build time and add CI to catch future slow downs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,12 +30,13 @@ env/
 venv/
 
 # Documentation artifacts
-docs/api-ref/schema.json
+docs/
 site/
 
 # UI artifacts
 src/prefect/server/ui/*
 ui/node_modules
+ui-v2/
 
 # Databases
 *.db
@@ -49,3 +50,9 @@ dask-worker-space/
 # Editors
 .idea/
 .vscode/
+
+# Other
+tests/
+compat-tests/
+benches/
+build/

--- a/.github/workflows/time-docker-build.yaml
+++ b/.github/workflows/time-docker-build.yaml
@@ -2,6 +2,8 @@ name: Docker Build Time Benchmark
 
 on:
   push:
+    branches:
+      - main
     paths:
       - "Dockerfile"
       - ".dockerignore"

--- a/.github/workflows/time-docker-build.yaml
+++ b/.github/workflows/time-docker-build.yaml
@@ -21,11 +21,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Build base branch first
+      # For PRs, checkout the base branch to compare against
       - name: Checkout base branch
         if: github.base_ref
-        run: |
-          git checkout ${{ github.base_ref }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          clean: true
 
       - name: Clean Docker system
         run: |
@@ -42,10 +44,13 @@ jobs:
           base_time=$((end_time - start_time))
           echo "base_time=$base_time" >> $GITHUB_OUTPUT
 
-      # Now build current branch with fresh cache
-      - name: Checkout current branch
-        run: |
-          git checkout ${{ github.head_ref || github.ref_name }}
+      # For PRs, checkout back to the PR's HEAD
+      - name: Checkout PR branch
+        if: github.base_ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          clean: true
 
       - name: Clean Docker system again
         run: |

--- a/.github/workflows/time-docker-build.yaml
+++ b/.github/workflows/time-docker-build.yaml
@@ -2,8 +2,6 @@ name: Docker Build Time Benchmark
 
 on:
   push:
-    branches:
-      - main
     paths:
       - "Dockerfile"
       - ".dockerignore"
@@ -23,37 +21,51 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and time Docker image
-        id: build_time
-        run: |
-          start_time=$(date +%s)
-          DOCKER_BUILDKIT=1 docker build . --progress=plain
-          end_time=$(date +%s)
-          build_time=$((end_time - start_time))
-          echo "BUILD_TIME=$build_time" >> $GITHUB_ENV
-          echo "build_time=$build_time" >> $GITHUB_OUTPUT
-
+      # Build base branch first
       - name: Checkout base branch
         if: github.base_ref
         run: |
           git checkout ${{ github.base_ref }}
+
+      - name: Clean Docker system
+        run: |
+          docker system prune -af
+          docker builder prune -af
 
       - name: Build base branch image
         if: github.base_ref
         id: base_build_time
         run: |
           start_time=$(date +%s)
-          DOCKER_BUILDKIT=1 docker build . --progress=plain
+          DOCKER_BUILDKIT=1 docker build . --no-cache --progress=plain
           end_time=$(date +%s)
           base_time=$((end_time - start_time))
           echo "base_time=$base_time" >> $GITHUB_OUTPUT
+
+      # Now build current branch with fresh cache
+      - name: Checkout current branch
+        run: |
+          git checkout ${{ github.head_ref || github.ref_name }}
+
+      - name: Clean Docker system again
+        run: |
+          docker system prune -af
+          docker builder prune -af
+
+      - name: Build and time Docker image
+        id: build_time
+        run: |
+          start_time=$(date +%s)
+          DOCKER_BUILDKIT=1 docker build . --no-cache --progress=plain
+          end_time=$(date +%s)
+          build_time=$((end_time - start_time))
+          echo "build_time=$build_time" >> $GITHUB_OUTPUT
 
       - name: Compare build times
         run: |
           CURRENT_TIME=${{ steps.build_time.outputs.build_time }}
 
           if [ "${{ github.base_ref }}" != "" ]; then
-            # PR comparison mode
             BASE_TIME=${{ steps.base_build_time.outputs.base_time }}
             
             echo "### 🏗️ Docker Build Time Comparison" >> $GITHUB_STEP_SUMMARY
@@ -87,15 +99,7 @@ jobs:
               echo "Great job optimizing the build!" >> $GITHUB_STEP_SUMMARY
             fi
           else
-            # Push comparison mode (compare with previous runs)
             echo "### 🏗️ Docker Build Time" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "Build completed in ${CURRENT_TIME} seconds" >> $GITHUB_STEP_SUMMARY
           fi
-
-      - name: Upload build time data
-        uses: actions/upload-artifact@v3
-        with:
-          name: build-time-results
-          path: |
-            ${{ github.workspace }}/*-analysis.json

--- a/.github/workflows/time-docker-build.yaml
+++ b/.github/workflows/time-docker-build.yaml
@@ -1,0 +1,99 @@
+name: Docker Build Time Benchmark
+
+on:
+  push:
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and time Docker image
+        id: build_time
+        run: |
+          start_time=$(date +%s)
+          DOCKER_BUILDKIT=1 docker build . --progress=plain
+          end_time=$(date +%s)
+          build_time=$((end_time - start_time))
+          echo "BUILD_TIME=$build_time" >> $GITHUB_ENV
+          echo "build_time=$build_time" >> $GITHUB_OUTPUT
+
+      - name: Checkout base branch
+        if: github.base_ref
+        run: |
+          git checkout ${{ github.base_ref }}
+
+      - name: Build base branch image
+        if: github.base_ref
+        id: base_build_time
+        run: |
+          start_time=$(date +%s)
+          DOCKER_BUILDKIT=1 docker build . --progress=plain
+          end_time=$(date +%s)
+          base_time=$((end_time - start_time))
+          echo "base_time=$base_time" >> $GITHUB_OUTPUT
+
+      - name: Compare build times
+        run: |
+          CURRENT_TIME=${{ steps.build_time.outputs.build_time }}
+
+          if [ "${{ github.base_ref }}" != "" ]; then
+            # PR comparison mode
+            BASE_TIME=${{ steps.base_build_time.outputs.base_time }}
+            
+            echo "### 🏗️ Docker Build Time Comparison" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Branch | Build Time | Difference |" >> $GITHUB_STEP_SUMMARY
+            echo "|--------|------------|------------|" >> $GITHUB_STEP_SUMMARY
+            echo "| base (${{ github.base_ref }}) | ${BASE_TIME}s | - |" >> $GITHUB_STEP_SUMMARY
+            
+            DIFF=$((CURRENT_TIME - BASE_TIME))
+            PERCENT=$(echo "scale=2; ($CURRENT_TIME - $BASE_TIME) * 100 / $BASE_TIME" | bc)
+            
+            if [ $DIFF -gt 0 ]; then
+              DIFF_TEXT="⬆️ +${DIFF}s (+${PERCENT}%)"
+            elif [ $DIFF -lt 0 ]; then
+              DIFF_TEXT="⬇️ ${DIFF}s (${PERCENT}%)"
+            else
+              DIFF_TEXT="✨ No change"
+            fi
+            
+            echo "| current (${{ github.head_ref }}) | ${CURRENT_TIME}s | $DIFF_TEXT |" >> $GITHUB_STEP_SUMMARY
+            
+            # Fail if build time increased by more than 5%
+            if (( $(echo "$PERCENT > 5" | bc -l) )); then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "❌ **Build time increased by more than 5%!**" >> $GITHUB_STEP_SUMMARY
+              echo "This change significantly increases the build time. Please review the Dockerfile changes." >> $GITHUB_STEP_SUMMARY
+              exit 1
+            elif (( $(echo "$PERCENT < 0" | bc -l) )); then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "✅ **Build time decreased!**" >> $GITHUB_STEP_SUMMARY
+              echo "Great job optimizing the build!" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            # Push comparison mode (compare with previous runs)
+            echo "### 🏗️ Docker Build Time" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Build completed in ${CURRENT_TIME} seconds" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload build time data
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-time-results
+          path: |
+            ${{ github.workspace }}/*-analysis.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,8 +100,8 @@ RUN apt-get update && \
     git=1:2.* \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install UV from official image
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+# Install UV from official image - pin to specific version for build caching
+COPY --from=ghcr.io/astral-sh/uv:0.5.8 /uv /uvx /bin/
 
 # Install dependencies using a temporary mount for requirements files
 RUN --mount=type=bind,source=requirements-client.txt,target=/tmp/requirements-client.txt \


### PR DESCRIPTION
there's still work to be done here, since i'm not sure what caused the dramatically inflated runtime of the `Docker images` job, but now at least we can relatively quantify all changes to the `Dockerfile`

inspired by https://github.com/PrefectHQ/prefect/pull/16327 (see https://github.com/PrefectHQ/prefect/actions/runs/12284945352?pr=16348)

![image](https://github.com/user-attachments/assets/af850056-3725-4a0f-a429-4bc084e23e57)

