### PR TITLE
Remove missing page from the nav

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -196,8 +196,7 @@
         "v3/automate/events/events",
         "v3/automate/events/automations-triggers",
         "v3/automate/events/custom-triggers",
-        "v3/automate/events/webhook-triggers",
-        "v3/automate/incidents"
+        "v3/automate/events/webhook-triggers"
       ],
       "version": "v3"
     },


### PR DESCRIPTION
I noticed an error when building the docs locally:

```
% mintlify dev
⠹ Preparing local Mintlify instance...
...
⠧ Preparing local Mintlify instance...⚠️   "v3/automate/incidents" is defined in the mint.json navigation but the file does not exist.
```

This seems to be because the incidents page was removed from the docs but left in the nav.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] ~This pull request references any related issue by including "closes `<link to issue>`"~
- [ ] ~If this pull request adds new functionality, it includes unit tests that cover the changes~
- [ ] ~If this pull request removes docs files, it includes redirect settings in `mint.json`.~
- [ ] ~If this pull request adds functions or classes, it includes helpful docstrings.~
