### PR TITLE
Update syntax in integrations-cards.md to avoid parsing errors

### DIFF
--- a/docs/integrations/integration-cards.md
+++ b/docs/integrations/integration-cards.md
@@ -1,13 +1,12 @@
+{/* The code below is a jinja2 template that will be rendered by create_integrations_cards.py */}
 
-<!-- The code below is a jinja2 template that will be rendered by create_integrations_cards.py -->
-<CardGroup cols={4}  className="text-center">
-
-{% for integration in integrations %}
-    <Card title="{{ integration['tag'] }}">
-        <a href="/integration/{{ integration['documentation'] }}"> <img src="{{ integration['iconUrl'] }}" alt="{{ integration['integrationName'] }}"/>
-        </a>
-        Maintained by <a href="{{ integration['authorUrl'] }}"> {{ integration['author'] }} </a>
-    </Card>
-{% endfor %}
-
+<CardGroup cols={4} className="text-center">
+{integrations.map(integration => (
+  <Card title={integration.tag}>
+    <a href={`/integration/${integration.documentation}`}>
+      <img src={integration.iconUrl} alt={integration.integrationName}/>
+    </a>
+    Maintained by <a href={integration.authorUrl}>{integration.author}</a>
+  </Card>
+))}
 </CardGroup>


### PR DESCRIPTION
Related to https://linear.app/prefect/issue/OSS-6053/migrate-away-from-mkdocs-for-generating-integrations-cards

I noticed the following error when building the docs locally:

```
% mintlify dev
⠹ Preparing local Mintlify instance...
 ⚠️  Parsing error: ./integrations/integration-cards.md:2:2 - Unexpected character `!` (U+0021) before name, expected a character that can start a name, such as a letter, `$`, or `_` (note: to create a comment in MDX, use `{/* text */}`)
 ```

We should probably use something other than mkdocs to generate the integrations page, as referenced in the Linear issue above.

### Checklist

- [ ] ~This pull request references any related issue by including "closes `<link to issue>`"~
- [ ] ~If this pull request adds new functionality, it includes unit tests that cover the changes~
- [ ] ~If this pull request removes docs files, it includes redirect settings in `mint.json`.~
- [ ] ~If this pull request adds functions or classes, it includes helpful docstrings.~
