### PR TITLE
update tutorial for clarity

### DIFF
--- a/.github/workflows/time-docker-build.yaml
+++ b/.github/workflows/time-docker-build.yaml
@@ -2,6 +2,8 @@ name: Docker Build Time Benchmark
 
 on:
   push:
+    branches:
+      - main
     paths:
       - "Dockerfile"
       - ".dockerignore"

--- a/.github/workflows/time-docker-build.yaml
+++ b/.github/workflows/time-docker-build.yaml
@@ -2,8 +2,6 @@ name: Docker Build Time Benchmark
 
 on:
   push:
-    branches:
-      - main
     paths:
       - "Dockerfile"
       - ".dockerignore"

--- a/docs/v3/tutorials/pipelines.mdx
+++ b/docs/v3/tutorials/pipelines.mdx
@@ -22,14 +22,18 @@ The first improvement you can make is to add retries to your flow.
 Whenever an HTTP request fails, you can retry it a few times before giving up.
 
 ```python
+from typing import Any
+
+import httpx
 from prefect import task
 
+
 @task(retries=3)
-def fetch_stats(github_repo: str):
+def fetch_stats(github_repo: str) -> dict[str, Any]:
     """Task 1: Fetch the statistics for a GitHub repo"""
 
     api_response = httpx.get(f"https://api.github.com/repos/{github_repo}")
-    api_response.raise_for_status() # Force a retry if you don't get a 2xx status code
+    api_response.raise_for_status() # Force a retry if not a 2xx status code
     return api_response.json()
 ```
 
@@ -37,9 +41,25 @@ def fetch_stats(github_repo: str):
 Run the following code to see retries in action:
 
 ```python
-import httpx
+from typing import Any
 
+import httpx
 from prefect import flow, task # Prefect flow and task decorators
+
+@task(retries=3)
+def fetch_stats(github_repo: str) -> dict[str, Any]:
+    """Task 1: Fetch the statistics for a GitHub repo"""
+
+    api_response = httpx.get(f"https://api.github.com/repos/{github_repo}")
+    api_response.raise_for_status() # Force a retry if not a 2xx status code
+    return api_response.json()
+
+
+@task
+def get_stars(repo_stats: dict[str, Any]) -> int:
+    """Task 2: Get the number of stars from GitHub repo statistics"""
+
+    return repo_stats['stargazers_count']
 
 
 @flow(log_prints=True)
@@ -57,21 +77,6 @@ def show_stars(github_repos: list[str]):
         print(f"{repo}: {stars} stars")
 
 
-@task(retries=3)
-def fetch_stats(github_repo: str):
-    """Task 1: Fetch the statistics for a GitHub repo"""
-
-    api_response = httpx.get(f"https://api.github.com/repos/{github_repo}")
-    api_response.raise_for_status() # Force a retry if you don't get a 2xx status code
-    return api_response.json()
-
-
-@task
-def get_stars(repo_stats: dict):
-    """Task 2: Get the number of stars from GitHub repo statistics"""
-
-    return repo_stats['stargazers_count']
-
 
 # Run the flow
 if __name__ == "__main__":
@@ -86,81 +91,82 @@ if __name__ == "__main__":
 ## Concurrent execution of slow tasks
 
 If individual API requests are slow, you can speed them up in aggregate by making multiple requests concurrently.
-When you call the `submit` method on a task, the task is submitted to a task runner for execution.
+When you call the `map` method on a task, you submit a list of arguments to the task runner to run concurrently (if you want, you could also [`.submit()` each argument individually.](/v3/develop/task-runners#access-results-from-submitted-tasks)).
 
 ```python
 from prefect import flow
 
 @flow(log_prints=True)
-def show_stars(github_repos: list[str]):
+def show_stars(github_repos: list[str]) -> None:
     """Flow: Show the number of stars that GitHub repos have"""
 
     # Task 1: Make HTTP requests concurrently
-    repo_stats = []
-    for repo in github_repos:
-        repo_stats.append({
-            'repo': repo,
-            'task': fetch_stats.submit(repo) # Submit each task to a task runner
-        })
+    stats_futures = fetch_stats.map(github_repos)
 
-    # Task 2: Once each concurrent task completes, show the results
-    for repo in repo_stats:
-        repo_name = repo['repo']
-        stars = get_stars(repo['task'].result()) # Block until the task has completed
-        print(f"{repo_name}: {stars} stars")
+    # Task 2: Once each concurrent task completes, get the star counts
+    stars = get_stars.map(stats_futures).result()
+
+    # Show the results
+    for repo, star_count in zip(github_repos, stars):
+        print(f"{repo}: {star_count} stars")
 ```
 
 <Expandable title="full example">
 Run the following code to see concurrent tasks in action:
 
 ```python
+from typing import Any
+
 import httpx
-
-from prefect import flow, task # Prefect flow and task decorators
-
-
-@flow(log_prints=True)
-def show_stars(github_repos: list[str]):
-    """Flow: Show the number of stars that GitHub repos have"""
-
-    # Task 1: Make HTTP requests concurrently
-    repo_stats = []
-    for repo in github_repos:
-        repo_stats.append({
-            'repo': repo,
-            'task': fetch_stats.submit(repo) # Submit each task to a task runner
-        })
-
-    # Task 2: Once each concurrent task completes, show the results
-    for repo in repo_stats:
-        repo_name = repo['repo']
-        stars = get_stars(repo['task'].result()) # Block until the task has completed
-        print(f"{repo_name}: {stars} stars")
+from prefect import flow, task
 
 
-@task
-def fetch_stats(github_repo: str):
+@task(retries=3)
+def fetch_stats(github_repo: str) -> dict[str, Any]:
     """Task 1: Fetch the statistics for a GitHub repo"""
-
     return httpx.get(f"https://api.github.com/repos/{github_repo}").json()
 
 
 @task
-def get_stars(repo_stats: dict):
+def get_stars(repo_stats: dict[str, Any]) -> int:
     """Task 2: Get the number of stars from GitHub repo statistics"""
+    return repo_stats["stargazers_count"]
 
-    return repo_stats['stargazers_count']
+
+@flow(log_prints=True)
+def show_stars(github_repos: list[str]) -> None:
+    """Flow: Show the number of stars that GitHub repos have"""
+
+    # Task 1: Make HTTP requests concurrently
+    stats_futures = fetch_stats.map(github_repos)
+
+    # Task 2: Once each concurrent task completes, get the star counts
+    stars = get_stars.map(stats_futures).result()
+
+    # Show the results
+    for repo, star_count in zip(github_repos, stars):
+        print(f"{repo}: {star_count} stars")
 
 
-# Run the flow
 if __name__ == "__main__":
-    show_stars([
-        "PrefectHQ/prefect",
-        "pydantic/pydantic",
-        "huggingface/transformers"
-    ])
+    # Run the flow
+    show_stars(
+        [
+            "PrefectHQ/prefect",
+            "pydantic/pydantic",
+            "huggingface/transformers"
+        ]
+    )
+
 ```
 </Expandable>
+
+<Tip>
+Calling `.result()` of the list of futures returned by `.map()` will block until all tasks are complete.
+
+You can read more about this in the [`.map()` documentation](/v3/develop/task-runners#mapping-over-iterables).
+</Tip>
+
 
 ## Avoid getting rate limited
 
@@ -172,74 +178,56 @@ To avoid this, use Prefect to set a global concurrency limit.
 prefect gcl create github-api --limit 60 --slot-decay-per-second 0.016
 ```
 
-Now, you can use this global concurrency limit in your code:
+Now, you can use this global concurrency limit in your code to rate limit your API requests.
 
 ```python
-from prefect import flow
+from typing import Any
+from prefect import task
 from prefect.concurrency.sync import rate_limit
 
-@flow(log_prints=True)
-def show_stars(github_repos: list[str]):
-    """Flow: Show the number of stars that GitHub repos have"""
-
-    repo_stats = []
-    for repo in github_repos:
-        # Apply the concurrency limit to this loop
-        rate_limit("github-api")
-
-        # Call Task 1
-        repo_stats.append({
-            'repo': repo,
-            'task': fetch_stats.submit(repo)
-        })
-
-        # ...
+@task
+def fetch_stats(github_repo: str) -> dict[str, Any]:
+    """Task 1: Fetch the statistics for a GitHub repo"""
+    rate_limit("github-api")
+    return httpx.get(f"https://api.github.com/repos/{github_repo}").json()
 ```
 
 <Expandable title="full example">
 Run the following code to see concurrency limits in action:
 
 ```python
-import httpx
+from typing import Any
 
-from prefect import flow, task # Prefect flow and task decorators
+import httpx
+from prefect import flow, task
 from prefect.concurrency.sync import rate_limit
 
-
-@flow(log_prints=True)
-def show_stars(github_repos: list[str]):
-    """Flow: Show the number of stars that GitHub repos have"""
-
-    repo_stats = []
-    for repo in github_repos:
-        # Apply the concurrency limit to this loop
-        rate_limit("github-api")
-
-        # Call Task 1
-        repo_stats.append({
-            'repo': repo,
-            'task': fetch_stats.submit(repo)
-        })
-
-        # Call Task 2
-        stars = get_stars(repo_stats)
-
-        # Print the result
-        print(f"{repo}: {stars} stars")
-
-
-@task
-def fetch_stats(github_repo: str):
+@task(retries=3)
+def fetch_stats(github_repo: str) -> dict[str, Any]:
     """Task 1: Fetch the statistics for a GitHub repo"""
-
+    rate_limit("github-api")
     return httpx.get(f"https://api.github.com/repos/{github_repo}").json()
 
 
 @task
-def get_stars(repo_stats: dict):
+def get_stars(repo_stats: dict[str, Any]) -> int:
     """Task 2: Get the number of stars from GitHub repo statistics"""
+    return repo_stats["stargazers_count"]
 
-    return repo_stats['stargazers_count']
+
+@flow(log_prints=True)
+def show_stars(github_repos: list[str]) -> None:
+    """Flow: Show the number of stars that GitHub repos have"""
+
+    # Task 1: Make HTTP requests concurrently
+    stats_futures = fetch_stats.map(github_repos)
+
+    # Task 2: Once each concurrent task completes, get the star counts
+    stars = get_stars.map(stats_futures).result()
+
+    # Show the results
+    for repo, star_count in zip(github_repos, stars):
+        print(f"{repo}: {star_count} stars")
 
 
 # Run the flow
@@ -258,13 +246,14 @@ For efficiency, you can skip tasks that have already run.
 For example, if you don't want to fetch the number of stars for a given repository more than once per day, you can cache those results for a day.
 
 ```python
+from typing import Any
 from datetime import timedelta
 
 from prefect import task
 from prefect.cache_policies import INPUTS
 
 @task(cache_policy=INPUTS, cache_expiration=timedelta(days=1))
-def fetch_stats(github_repo: str):
+def fetch_stats(github_repo: str) -> dict[str, Any]:
     """Task 1: Fetch the statistics for a GitHub repo"""
     # ...
 ```
@@ -273,40 +262,44 @@ def fetch_stats(github_repo: str):
 Run the following code to see caching in action:
 
 ```python
+from typing import Any
 from datetime import timedelta
+
 import httpx
-
-from prefect import flow, task # Prefect flow and task decorators
+from prefect import flow, task
 from prefect.cache_policies import INPUTS
+from prefect.concurrency.sync import rate_limit
 
-
-@flow(log_prints=True)
-def show_stars(github_repos: list[str]):
-    """Flow: Show the number of stars that GitHub repos have"""
-
-    for repo in github_repos:
-        # Call Task 1
-        repo_stats = fetch_stats(repo)
-
-        # Call Task 2
-        stars = get_stars(repo_stats)
-
-        # Print the result
-        print(f"{repo}: {stars} stars")
-
-
-@task(cache_policy=INPUTS, cache_expiration=timedelta(days=1))
-def fetch_stats(github_repo: str):
+@task(
+    retries=3,
+    cache_policy=INPUTS,
+    cache_expiration=timedelta(days=1)
+)
+def fetch_stats(github_repo: str) -> dict[str, Any]:
     """Task 1: Fetch the statistics for a GitHub repo"""
-
+    rate_limit("github-api")
     return httpx.get(f"https://api.github.com/repos/{github_repo}").json()
 
 
 @task
-def get_stars(repo_stats: dict):
+def get_stars(repo_stats: dict[str, Any]) -> int:
     """Task 2: Get the number of stars from GitHub repo statistics"""
+    return repo_stats["stargazers_count"]
 
-    return repo_stats['stargazers_count']
+
+@flow(log_prints=True)
+def show_stars(github_repos: list[str]) -> None:
+    """Flow: Show the number of stars that GitHub repos have"""
+
+    # Task 1: Make HTTP requests concurrently
+    stats_futures = fetch_stats.map(github_repos)
+
+    # Task 2: Once each concurrent task completes, get the star counts
+    stars = get_stars.map(stats_futures).result()
+
+    # Show the results
+    for repo, star_count in zip(github_repos, stars):
+        print(f"{repo}: {star_count} stars")
 
 
 # Run the flow
@@ -324,48 +317,44 @@ if __name__ == "__main__":
 This is what your flow looks like after applying all of these improvements:
 
 ```python my_data_pipeline.py
+from typing import Any
 from datetime import timedelta
-import httpx
 
+import httpx
 from prefect import flow, task
 from prefect.cache_policies import INPUTS
 from prefect.concurrency.sync import rate_limit
 
-
-@flow(log_prints=True)
-def show_stars(github_repos: list[str]):
-    """Flow: Show the number of stars that GitHub repos have"""
-
-    # Task 1: Make HTTP requests concurrently while respecting concurrency limits
-    repo_stats = []
-    for repo in github_repos:
-        rate_limit("github-api")
-        repo_stats.append({
-            'repo': repo,
-            'task': fetch_stats.submit(repo) # Submit each task to a task runner
-        })
-
-    # Task 2: Once each concurrent task completes, show the results
-    for repo in repo_stats:
-        repo_name = repo['repo']
-        stars = get_stars(repo['task'].result()) # Block until the task has completed
-        print(f"{repo_name}: {stars} stars")
-
-
-@task(retries=3, cache_policy=INPUTS, cache_expiration=timedelta(days=1))
-def fetch_stats(github_repo: str):
+@task(
+    retries=3,
+    cache_policy=INPUTS,
+    cache_expiration=timedelta(days=1)
+)
+def fetch_stats(github_repo: str) -> dict[str, Any]:
     """Task 1: Fetch the statistics for a GitHub repo"""
-
-    api_response = httpx.get(f"https://api.github.com/repos/{github_repo}")
-    api_response.raise_for_status() # Force a retry if you don't get a 2xx status code
-    return api_response.json()
+    rate_limit("github-api")
+    return httpx.get(f"https://api.github.com/repos/{github_repo}").json()
 
 
 @task
-def get_stars(repo_stats: dict):
+def get_stars(repo_stats: dict[str, Any]) -> int:
     """Task 2: Get the number of stars from GitHub repo statistics"""
+    return repo_stats["stargazers_count"]
 
-    return repo_stats['stargazers_count']
+
+@flow(log_prints=True)
+def show_stars(github_repos: list[str]) -> None:
+    """Flow: Show the number of stars that GitHub repos have"""
+
+    # Task 1: Make HTTP requests concurrently
+    stats_futures = fetch_stats.map(github_repos)
+
+    # Task 2: Once each concurrent task completes, get the star counts
+    stars = get_stars.map(stats_futures).result()
+
+    # Show the results
+    for repo, star_count in zip(github_repos, stars):
+        print(f"{repo}: {star_count} stars")
 
 
 # Run the flow
@@ -383,25 +372,24 @@ Run your flow twice: once to run the tasks and cache the result, again to retrie
 # Run the tasks and cache the results
 python my_data_pipeline.py
 
-# Retrieve the cached results
+# Run again (notice the cached results)
 python my_data_pipeline.py
 ```
 
 The terminal output from the second flow run should look like this:
 
 ```bash
-09:08:12.265 | INFO    | prefect.engine - Created flow run 'laughing-nightingale' for flow 'show-stars'
-09:08:12.266 | INFO    | prefect.engine - View at http://127.0.0.1:4200/runs/flow-run/541864e8-12f7-4890-9397-b2ed361f6b20
-09:08:12.322 | INFO    | Task run 'fetch_stats-0c9' - Finished in state Cached(type=COMPLETED)
-09:08:12.359 | INFO    | Task run 'fetch_stats-e89' - Finished in state Cached(type=COMPLETED)
-09:08:12.360 | INFO    | Task run 'get_stars-b51' - Finished in state Completed()
-09:08:12.361 | INFO    | Flow run 'laughing-nightingale' - PrefectHQ/prefect: 17320 stars
-09:08:12.372 | INFO    | Task run 'fetch_stats-8ef' - Finished in state Cached(type=COMPLETED)
-09:08:12.374 | INFO    | Task run 'get_stars-08d' - Finished in state Completed()
-09:08:12.374 | INFO    | Flow run 'laughing-nightingale' - pydantic/pydantic: 186319 stars
-09:08:12.387 | INFO    | Task run 'get_stars-2af' - Finished in state Completed()
-09:08:12.387 | INFO    | Flow run 'laughing-nightingale' - huggingface/transformers: 134849 stars
-09:08:12.404 | INFO    | Flow run 'laughing-nightingale' - Finished in state Completed()
+20:03:04.398 | INFO | prefect.engine - Created flow run 'laughing-nightingale' for flow 'show-stars'
+20:03:05.146 | INFO | Task run 'fetch_stats-90f' - Finished in state Cached(type=COMPLETED)
+20:03:05.149 | INFO | Task run 'fetch_stats-258' - Finished in state Cached(type=COMPLETED)
+20:03:05.153 | INFO | Task run 'fetch_stats-924' - Finished in state Cached(type=COMPLETED)
+20:03:05.159 | INFO | Task run 'get_stars-3a9' - Finished in state Completed()
+20:03:05.159 | INFO | Task run 'get_stars-ed3' - Finished in state Completed()
+20:03:05.161 | INFO | Task run 'get_stars-39c' - Finished in state Completed()
+20:03:05.162 | INFO | Flow run 'laughing-nightingale' - PrefectHQ/prefect: 17756 stars
+20:03:05.163 | INFO | Flow run 'laughing-nightingale' - pydantic/pydantic: 21613 stars
+20:03:05.163 | INFO | Flow run 'laughing-nightingale' - huggingface/transformers: 136166 stars
+20:03:05.339 | INFO | Flow run 'laughing-nightingale' - Finished in state Completed()
 ```
 
 ## Next steps

--- a/docs/v3/tutorials/pipelines.mdx
+++ b/docs/v3/tutorials/pipelines.mdx
@@ -91,14 +91,14 @@ if __name__ == "__main__":
 ## Concurrent execution of slow tasks
 
 If individual API requests are slow, you can speed them up in aggregate by making multiple requests concurrently.
-When you call the `map` method on a task, you submit a list of arguments to the task runner to run concurrently (if you want, you could also [`.submit()` each argument individually.](/v3/develop/task-runners#access-results-from-submitted-tasks)).
+When you call the `map` method on a task, you submit a list of arguments to the task runner to run concurrently (alternatively, you could [`.submit()` each argument individually](/v3/develop/task-runners#access-results-from-submitted-tasks)).
 
 ```python
 from prefect import flow
 
 @flow(log_prints=True)
 def show_stars(github_repos: list[str]) -> None:
-    """Flow: Show the number of stars that GitHub repos have"""
+    """Flow: Show number of GitHub repo stars"""
 
     # Task 1: Make HTTP requests concurrently
     stats_futures = fetch_stats.map(github_repos)
@@ -135,7 +135,7 @@ def get_stars(repo_stats: dict[str, Any]) -> int:
 
 @flow(log_prints=True)
 def show_stars(github_repos: list[str]) -> None:
-    """Flow: Show the number of stars that GitHub repos have"""
+    """Flow: Show number of GitHub repo stars"""
 
     # Task 1: Make HTTP requests concurrently
     stats_futures = fetch_stats.map(github_repos)
@@ -162,9 +162,9 @@ if __name__ == "__main__":
 </Expandable>
 
 <Tip>
-Calling `.result()` of the list of futures returned by `.map()` will block until all tasks are complete.
+Calling `.result()` on the list of futures returned by `.map()` will block until all tasks are complete.
 
-You can read more about this in the [`.map()` documentation](/v3/develop/task-runners#mapping-over-iterables).
+Read more in the [`.map()` documentation](/v3/develop/task-runners#mapping-over-iterables).
 </Tip>
 
 
@@ -217,7 +217,7 @@ def get_stars(repo_stats: dict[str, Any]) -> int:
 
 @flow(log_prints=True)
 def show_stars(github_repos: list[str]) -> None:
-    """Flow: Show the number of stars that GitHub repos have"""
+    """Flow: Show number of GitHub repo stars"""
 
     # Task 1: Make HTTP requests concurrently
     stats_futures = fetch_stats.map(github_repos)
@@ -289,7 +289,7 @@ def get_stars(repo_stats: dict[str, Any]) -> int:
 
 @flow(log_prints=True)
 def show_stars(github_repos: list[str]) -> None:
-    """Flow: Show the number of stars that GitHub repos have"""
+    """Flow: Show number of GitHub repo stars"""
 
     # Task 1: Make HTTP requests concurrently
     stats_futures = fetch_stats.map(github_repos)
@@ -344,7 +344,7 @@ def get_stars(repo_stats: dict[str, Any]) -> int:
 
 @flow(log_prints=True)
 def show_stars(github_repos: list[str]) -> None:
-    """Flow: Show the number of stars that GitHub repos have"""
+    """Flow: Show number of GitHub repo stars"""
 
     # Task 1: Make HTTP requests concurrently
     stats_futures = fetch_stats.map(github_repos)


### PR DESCRIPTION
makes a couple updates to the `Build a data pipeline` tutorial

- existing use of `.submit()`/ `.result()` is bit more verbose and I would rather recommend using sequential `.map` calls in cases where the io actually takes a while, bc in this example the second loop blocks at each `result()` call `for` each item, instead of resolving futures concurrently like `.map(list[T]).result()`. i also think its easier to read / reason about

<details>

<summary>for example</summary>

### slower
![image](https://github.com/user-attachments/assets/eba35d9f-583e-4d37-8092-b8a6c78a4441)

### faster
![image](https://github.com/user-attachments/assets/59dee352-9118-4ee8-8933-6bfa1fe686df)


```python
import time
from typing import Any

from prefect import flow, task


@task
def slow_api_call(item: str) -> dict[str, Any]:
    """Simulate a slow API call that takes 1 second"""
    time.sleep(1)  # Simulate network delay
    return {"item": item, "data": f"data for {item}"}


@task
def slow_processing(data: dict[str, Any]) -> str:
    """Simulate slow processing that takes 0.5 seconds"""
    time.sleep(0.5)  # Simulate processing time
    return f"Processed {data['item']}: {data['data']}"


@flow(name="inefficient-flow")
def process_inefficiently(items: list[str]) -> None:
    """
    Inefficient approach using submit/result in sequence.
    For N items, this takes roughly N * (1 + 0.5) seconds because we block
    on each result() call.
    """
    print("\nStarting inefficient flow...")
    start_time = time.time()

    # First phase: submit API calls
    api_futures = []
    for item in items:
        api_futures.append({"item": item, "future": slow_api_call.submit(item)})

    # Second phase: wait for each API call and process
    # This blocks sequentially on each result() call!
    for future_info in api_futures:
        item = future_info["item"]
        api_result = future_info["future"].result()  # Blocks here!
        processed = slow_processing(api_result)  # Waits for processing
        print(f"Completed {item}: {processed}")

    duration = time.time() - start_time
    print(f"Inefficient flow took {duration:.2f} seconds")


@flow(name="efficient-flow")
def process_efficiently(items: list[str]) -> None:
    """
    Efficient approach using map.
    For N items, this takes roughly max(1, 0.5) * N seconds because
    all futures are resolved concurrently.
    """
    print("\nStarting efficient flow...")
    start_time = time.time()

    # Map over all items for API calls
    api_results = slow_api_call.map(items)

    # Map over all results for processing
    # This resolves all futures concurrently!
    processed = slow_processing.map(api_results).result()

    # Print results
    for item, result in zip(items, processed):
        print(f"Completed {item}: {result}")

    duration = time.time() - start_time
    print(f"Efficient flow took {duration:.2f} seconds")


if __name__ == "__main__":
    test_items = ["item1", "item2", "item3", "item4"]

    # Run both flows to compare
    process_inefficiently(test_items)
    process_efficiently(test_items)

```

</details>


- moves `rate_limit` into the task. happy to reconsider this, I was just thinking that i'd want my task runtimes to reflect time waiting for the github api to free up - but i could also see situations where you might want to avoid submission until some resource is free

- keeping with the theme of the tutorial, updates the full examples to compound use of adopted features throughout the page (i.e. continue to use `retries=3` even when adding caching or rate limiting)

- in normal convention, defines tasks that are referenced in the `show_stars` flow before said flow

- uses proper type hinting