### PR TITLE
`DeploymentsDataTable` - Part 1

### DIFF
--- a/ui-v2/src/components/deployments/data-table/cells.tsx
+++ b/ui-v2/src/components/deployments/data-table/cells.tsx
@@ -12,9 +12,22 @@ import type { DeploymentWithFlow } from "@/hooks/deployments";
 import { useToast } from "@/hooks/use-toast";
 import type { CellContext } from "@tanstack/react-table";
 
-type ActionsCellProps = CellContext<DeploymentWithFlow, unknown>;
+type ActionsCellProps = CellContext<DeploymentWithFlow, unknown> & {
+	onQuickRun: (deployment: DeploymentWithFlow) => void;
+	onCustomRun: (deployment: DeploymentWithFlow) => void;
+	onEdit: (deployment: DeploymentWithFlow) => void;
+	onDelete: (deployment: DeploymentWithFlow) => void;
+	onDuplicate: (deployment: DeploymentWithFlow) => void;
+};
 
-export const ActionsCell = ({ row }: ActionsCellProps) => {
+export const ActionsCell = ({
+	row,
+	onQuickRun,
+	onCustomRun,
+	onEdit,
+	onDelete,
+	onDuplicate,
+}: ActionsCellProps) => {
 	const id = row.original.id;
 	const { toast } = useToast();
 	if (!id) return null;
@@ -30,6 +43,12 @@ export const ActionsCell = ({ row }: ActionsCellProps) => {
 				</DropdownMenuTrigger>
 				<DropdownMenuContent align="end">
 					<DropdownMenuLabel>Actions</DropdownMenuLabel>
+					<DropdownMenuItem onClick={() => onQuickRun(row.original)}>
+						Quick Run
+					</DropdownMenuItem>
+					<DropdownMenuItem onClick={() => onCustomRun(row.original)}>
+						Custom Run
+					</DropdownMenuItem>
 					<DropdownMenuItem
 						onClick={() => {
 							void navigator.clipboard.writeText(id);
@@ -40,8 +59,15 @@ export const ActionsCell = ({ row }: ActionsCellProps) => {
 					>
 						Copy ID
 					</DropdownMenuItem>
-					<DropdownMenuItem>Edit</DropdownMenuItem>
-					<DropdownMenuItem>Delete</DropdownMenuItem>
+					<DropdownMenuItem onClick={() => onEdit(row.original)}>
+						Edit
+					</DropdownMenuItem>
+					<DropdownMenuItem onClick={() => onDelete(row.original)}>
+						Delete
+					</DropdownMenuItem>
+					<DropdownMenuItem onClick={() => onDuplicate(row.original)}>
+						Duplicate
+					</DropdownMenuItem>
 				</DropdownMenuContent>
 			</DropdownMenu>
 		</div>

--- a/ui-v2/src/components/deployments/data-table/cells.tsx
+++ b/ui-v2/src/components/deployments/data-table/cells.tsx
@@ -1,0 +1,49 @@
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuLabel,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Icon } from "@/components/ui/icons";
+import type { DeploymentWithFlow } from "@/hooks/deployments";
+import { useToast } from "@/hooks/use-toast";
+import type { CellContext } from "@tanstack/react-table";
+
+type ActionsCellProps = CellContext<DeploymentWithFlow, unknown>;
+
+export const ActionsCell = ({ row }: ActionsCellProps) => {
+	const id = row.original.id;
+	const { toast } = useToast();
+	if (!id) return null;
+
+	return (
+		<div className="flex flex-row justify-end">
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<Button variant="outline" className="h-8 w-8 p-0">
+						<span className="sr-only">Open menu</span>
+						<Icon id="MoreVertical" className="h-4 w-4" />
+					</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end">
+					<DropdownMenuLabel>Actions</DropdownMenuLabel>
+					<DropdownMenuItem
+						onClick={() => {
+							void navigator.clipboard.writeText(id);
+							toast({
+								title: "ID copied",
+							});
+						}}
+					>
+						Copy ID
+					</DropdownMenuItem>
+					<DropdownMenuItem>Edit</DropdownMenuItem>
+					<DropdownMenuItem>Delete</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
+	);
+};

--- a/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
+++ b/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
@@ -1,6 +1,7 @@
 import type { DeploymentWithFlow } from "@/hooks/deployments";
 import { faker } from "@faker-js/faker";
 import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
 import { DeploymentsDataTable } from ".";
 
 export default {
@@ -28,5 +29,19 @@ function createRandomDeployment(): DeploymentWithFlow {
 
 export const Default: StoryObj = {
 	name: "DataTable",
-	args: { deployments: Array.from({ length: 10 }, createRandomDeployment) },
+	args: {
+		deployments: Array.from({ length: 10 }, createRandomDeployment),
+		onQuickRun: fn(),
+		onCustomRun: fn(),
+		onEdit: fn(),
+		onDelete: fn(),
+		onDuplicate: fn(),
+	},
+};
+
+export const Empty: StoryObj = {
+	name: "Empty",
+	args: {
+		deployments: [],
+	},
 };

--- a/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
+++ b/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DeploymentsDataTable } from ".";
+
+export default {
+	title: "Components/Deployments/DataTable",
+	component: DeploymentsDataTable,
+	parameters: {
+		layout: "centered",
+	},
+} satisfies Meta<typeof DeploymentsDataTable>;
+
+export const Default: StoryObj = {
+	name: "DataTable",
+	args: { deployments: [] },
+};

--- a/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
+++ b/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
@@ -1,15 +1,32 @@
+import type { DeploymentWithFlow } from "@/hooks/deployments";
+import { faker } from "@faker-js/faker";
 import type { Meta, StoryObj } from "@storybook/react";
 import { DeploymentsDataTable } from ".";
 
 export default {
 	title: "Components/Deployments/DataTable",
 	component: DeploymentsDataTable,
-	parameters: {
-		layout: "centered",
-	},
 } satisfies Meta<typeof DeploymentsDataTable>;
+
+function createRandomDeployment(): DeploymentWithFlow {
+	return {
+		id: faker.string.uuid(),
+		name: faker.airline.airplane().name,
+		flow_id: faker.string.uuid(),
+		paused: faker.datatype.boolean(),
+		status: faker.helpers.arrayElement(["READY", "NOT_READY"]),
+		enforce_parameter_schema: faker.datatype.boolean(),
+		tags: Array.from({ length: faker.number.int({ min: 0, max: 3 }) }, () =>
+			faker.lorem.word(),
+		),
+		flow: {
+			id: faker.string.uuid(),
+			name: faker.company.catchPhrase().toLowerCase().replace(/\s+/g, "-"),
+		},
+	};
+}
 
 export const Default: StoryObj = {
 	name: "DataTable",
-	args: { deployments: [] },
+	args: { deployments: Array.from({ length: 10 }, createRandomDeployment) },
 };

--- a/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
+++ b/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
@@ -12,6 +12,8 @@ export default {
 function createRandomDeployment(): DeploymentWithFlow {
 	return {
 		id: faker.string.uuid(),
+		created: faker.date.recent().toISOString(),
+		updated: faker.date.recent().toISOString(),
 		name: faker.airline.airplane().name,
 		flow_id: faker.string.uuid(),
 		paused: faker.datatype.boolean(),
@@ -22,6 +24,8 @@ function createRandomDeployment(): DeploymentWithFlow {
 		),
 		flow: {
 			id: faker.string.uuid(),
+			created: faker.date.recent().toISOString(),
+			updated: faker.date.recent().toISOString(),
 			name: faker.company.catchPhrase().toLowerCase().replace(/\s+/g, "-"),
 		},
 	};

--- a/ui-v2/src/components/deployments/data-table/data-table.test.tsx
+++ b/ui-v2/src/components/deployments/data-table/data-table.test.tsx
@@ -7,6 +7,8 @@ import { DeploymentsDataTable } from ".";
 describe("DeploymentsDataTable", () => {
 	const mockDeployment: DeploymentWithFlow = {
 		id: "test-id",
+		created: new Date().toISOString(),
+		updated: new Date().toISOString(),
 		name: "Test Deployment",
 		flow_id: "flow-id",
 		paused: false,
@@ -15,6 +17,8 @@ describe("DeploymentsDataTable", () => {
 		tags: ["tag1", "tag2"],
 		flow: {
 			id: "flow-id",
+			created: new Date().toISOString(),
+			updated: new Date().toISOString(),
 			name: "test-flow",
 		},
 	};
@@ -60,9 +64,13 @@ describe("DeploymentsDataTable", () => {
 			{
 				...mockDeployment,
 				id: "test-id-2",
+				created: new Date().toISOString(),
+				updated: new Date().toISOString(),
 				name: "Second Deployment",
 				flow: {
 					id: "flow-id-2",
+					created: new Date().toISOString(),
+					updated: new Date().toISOString(),
 					name: "second-flow",
 				},
 			},

--- a/ui-v2/src/components/deployments/data-table/data-table.test.tsx
+++ b/ui-v2/src/components/deployments/data-table/data-table.test.tsx
@@ -1,0 +1,144 @@
+import type { DeploymentWithFlow } from "@/hooks/deployments";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+import { DeploymentsDataTable } from ".";
+
+describe("DeploymentsDataTable", () => {
+	const mockDeployment: DeploymentWithFlow = {
+		id: "test-id",
+		name: "Test Deployment",
+		flow_id: "flow-id",
+		paused: false,
+		status: "READY",
+		enforce_parameter_schema: true,
+		tags: ["tag1", "tag2"],
+		flow: {
+			id: "flow-id",
+			name: "test-flow",
+		},
+	};
+
+	const defaultProps = {
+		deployments: [mockDeployment],
+		onQuickRun: vi.fn(),
+		onCustomRun: vi.fn(),
+		onEdit: vi.fn(),
+		onDelete: vi.fn(),
+		onDuplicate: vi.fn(),
+	};
+
+	test("renders deployment name and flow name", () => {
+		render(<DeploymentsDataTable {...defaultProps} />);
+
+		expect(screen.getByText("Test Deployment")).toBeInTheDocument();
+		expect(screen.getByText("test-flow")).toBeInTheDocument();
+	});
+
+	test("renders status badge", () => {
+		render(<DeploymentsDataTable {...defaultProps} />);
+
+		expect(screen.getByText("Ready")).toBeInTheDocument();
+	});
+
+	test("renders tags", () => {
+		render(<DeploymentsDataTable {...defaultProps} />);
+
+		expect(screen.getByText("tag1")).toBeInTheDocument();
+		expect(screen.getByText("tag2")).toBeInTheDocument();
+	});
+
+	test("renders with empty deployments array", () => {
+		render(<DeploymentsDataTable {...defaultProps} deployments={[]} />);
+
+		expect(screen.queryByText("No Results")).not.toBeInTheDocument();
+	});
+
+	test("renders multiple deployments", () => {
+		const multipleDeployments = [
+			mockDeployment,
+			{
+				...mockDeployment,
+				id: "test-id-2",
+				name: "Second Deployment",
+				flow: {
+					id: "flow-id-2",
+					name: "second-flow",
+				},
+			},
+		];
+
+		render(
+			<DeploymentsDataTable
+				{...defaultProps}
+				deployments={multipleDeployments}
+			/>,
+		);
+
+		expect(screen.getByText("Test Deployment")).toBeInTheDocument();
+		expect(screen.getByText("Second Deployment")).toBeInTheDocument();
+		expect(screen.getByText("test-flow")).toBeInTheDocument();
+		expect(screen.getByText("second-flow")).toBeInTheDocument();
+	});
+
+	test("calls onQuickRun when quick run action is clicked", async () => {
+		const onQuickRun = vi.fn();
+		render(<DeploymentsDataTable {...defaultProps} onQuickRun={onQuickRun} />);
+
+		await userEvent.click(screen.getByRole("button", { name: "Open menu" }));
+		const quickRunButton = screen.getByRole("menuitem", { name: "Quick Run" });
+		await userEvent.click(quickRunButton);
+
+		expect(onQuickRun).toHaveBeenCalledWith(mockDeployment);
+	});
+
+	test("calls onCustomRun when custom run action is clicked", async () => {
+		const onCustomRun = vi.fn();
+		render(
+			<DeploymentsDataTable {...defaultProps} onCustomRun={onCustomRun} />,
+		);
+
+		await userEvent.click(screen.getByRole("button", { name: "Open menu" }));
+		const customRunButton = screen.getByRole("menuitem", {
+			name: "Custom Run",
+		});
+		await userEvent.click(customRunButton);
+
+		expect(onCustomRun).toHaveBeenCalledWith(mockDeployment);
+	});
+
+	test("calls onEdit when edit action is clicked", async () => {
+		const onEdit = vi.fn();
+		render(<DeploymentsDataTable {...defaultProps} onEdit={onEdit} />);
+
+		await userEvent.click(screen.getByRole("button", { name: "Open menu" }));
+		const editButton = screen.getByRole("menuitem", { name: "Edit" });
+		await userEvent.click(editButton);
+
+		expect(onEdit).toHaveBeenCalledWith(mockDeployment);
+	});
+
+	test("calls onDelete when delete action is clicked", async () => {
+		const onDelete = vi.fn();
+		render(<DeploymentsDataTable {...defaultProps} onDelete={onDelete} />);
+
+		await userEvent.click(screen.getByRole("button", { name: "Open menu" }));
+		const deleteButton = screen.getByRole("menuitem", { name: "Delete" });
+		await userEvent.click(deleteButton);
+
+		expect(onDelete).toHaveBeenCalledWith(mockDeployment);
+	});
+
+	test("calls onDuplicate when duplicate action is clicked", async () => {
+		const onDuplicate = vi.fn();
+		render(
+			<DeploymentsDataTable {...defaultProps} onDuplicate={onDuplicate} />,
+		);
+
+		await userEvent.click(screen.getByRole("button", { name: "Open menu" }));
+		const duplicateButton = screen.getByRole("menuitem", { name: "Duplicate" });
+		await userEvent.click(duplicateButton);
+
+		expect(onDuplicate).toHaveBeenCalledWith(mockDeployment);
+	});
+});

--- a/ui-v2/src/components/deployments/data-table/index.tsx
+++ b/ui-v2/src/components/deployments/data-table/index.tsx
@@ -1,20 +1,65 @@
 import { DataTable } from "@/components/ui/data-table";
-import type { Deployment } from "@/hooks/deployments";
+import { Icon } from "@/components/ui/icons";
+import { StatusBadge } from "@/components/ui/status-badge";
+import { TagBadgeGroup } from "@/components/ui/tag-badge-group";
+import type { DeploymentWithFlow } from "@/hooks/deployments";
 import {
 	createColumnHelper,
 	getCoreRowModel,
 	useReactTable,
 } from "@tanstack/react-table";
+import { ActionsCell } from "./cells";
 
 type DeploymentsDataTableProps = {
-	deployments: Deployment[];
+	deployments: DeploymentWithFlow[];
 };
 
-const columnHelper = createColumnHelper<Deployment>();
+const columnHelper = createColumnHelper<DeploymentWithFlow>();
 
 const createColumns = () => [
-	columnHelper.accessor("name", {
-		header: "Name",
+	columnHelper.display({
+		id: "name",
+		header: "Deployment",
+		cell: ({ row }) => (
+			<div className="flex flex-col">
+				<span className="text-sm font-medium truncate">
+					{row.original.name}
+				</span>
+				<span className="text-xs text-muted-foreground flex items-center gap-1 truncate">
+					<Icon id="Workflow" size={12} /> {row.original.flow.name}
+				</span>
+			</div>
+		),
+		maxSize: 150,
+	}),
+	columnHelper.accessor("status", {
+		id: "status",
+		header: "Status",
+		cell: ({ row }) => {
+			const status = row.original.status;
+			if (!status) return null;
+			return <StatusBadge status={status} />;
+		},
+		maxSize: 50,
+	}),
+	columnHelper.display({
+		id: "activity",
+		header: "Activity",
+		cell: () => "TODO",
+	}),
+	columnHelper.display({
+		id: "tags",
+		header: () => null,
+		cell: ({ row }) => <TagBadgeGroup tags={row.original.tags ?? []} />,
+	}),
+	columnHelper.display({
+		id: "schedules",
+		header: "Schedules",
+		cell: () => "TODO",
+	}),
+	columnHelper.display({
+		id: "actions",
+		cell: (props) => <ActionsCell {...props} />,
 	}),
 ];
 
@@ -26,6 +71,9 @@ export const DeploymentsDataTable = ({
 		columns: createColumns(),
 		getCoreRowModel: getCoreRowModel(),
 		manualPagination: true,
+		defaultColumn: {
+			maxSize: 300,
+		},
 	});
 	return <DataTable table={table} />;
 };

--- a/ui-v2/src/components/deployments/data-table/index.tsx
+++ b/ui-v2/src/components/deployments/data-table/index.tsx
@@ -1,0 +1,31 @@
+import { DataTable } from "@/components/ui/data-table";
+import type { Deployment } from "@/hooks/deployments";
+import {
+	createColumnHelper,
+	getCoreRowModel,
+	useReactTable,
+} from "@tanstack/react-table";
+
+type DeploymentsDataTableProps = {
+	deployments: Deployment[];
+};
+
+const columnHelper = createColumnHelper<Deployment>();
+
+const createColumns = () => [
+	columnHelper.accessor("name", {
+		header: "Name",
+	}),
+];
+
+export const DeploymentsDataTable = ({
+	deployments,
+}: DeploymentsDataTableProps) => {
+	const table = useReactTable({
+		data: deployments,
+		columns: createColumns(),
+		getCoreRowModel: getCoreRowModel(),
+		manualPagination: true,
+	});
+	return <DataTable table={table} />;
+};

--- a/ui-v2/src/components/deployments/data-table/index.tsx
+++ b/ui-v2/src/components/deployments/data-table/index.tsx
@@ -12,11 +12,28 @@ import { ActionsCell } from "./cells";
 
 type DeploymentsDataTableProps = {
 	deployments: DeploymentWithFlow[];
+	onQuickRun: (deployment: DeploymentWithFlow) => void;
+	onCustomRun: (deployment: DeploymentWithFlow) => void;
+	onEdit: (deployment: DeploymentWithFlow) => void;
+	onDelete: (deployment: DeploymentWithFlow) => void;
+	onDuplicate: (deployment: DeploymentWithFlow) => void;
 };
 
 const columnHelper = createColumnHelper<DeploymentWithFlow>();
 
-const createColumns = () => [
+const createColumns = ({
+	onQuickRun,
+	onCustomRun,
+	onEdit,
+	onDelete,
+	onDuplicate,
+}: {
+	onQuickRun: (deployment: DeploymentWithFlow) => void;
+	onCustomRun: (deployment: DeploymentWithFlow) => void;
+	onEdit: (deployment: DeploymentWithFlow) => void;
+	onDelete: (deployment: DeploymentWithFlow) => void;
+	onDuplicate: (deployment: DeploymentWithFlow) => void;
+}) => [
 	columnHelper.display({
 		id: "name",
 		header: "Deployment",
@@ -59,16 +76,36 @@ const createColumns = () => [
 	}),
 	columnHelper.display({
 		id: "actions",
-		cell: (props) => <ActionsCell {...props} />,
+		cell: (props) => (
+			<ActionsCell
+				{...props}
+				onQuickRun={onQuickRun}
+				onCustomRun={onCustomRun}
+				onEdit={onEdit}
+				onDelete={onDelete}
+				onDuplicate={onDuplicate}
+			/>
+		),
 	}),
 ];
 
 export const DeploymentsDataTable = ({
 	deployments,
+	onQuickRun,
+	onCustomRun,
+	onEdit,
+	onDelete,
+	onDuplicate,
 }: DeploymentsDataTableProps) => {
 	const table = useReactTable({
 		data: deployments,
-		columns: createColumns(),
+		columns: createColumns({
+			onQuickRun,
+			onCustomRun,
+			onEdit,
+			onDelete,
+			onDuplicate,
+		}),
 		getCoreRowModel: getCoreRowModel(),
 		manualPagination: true,
 		defaultColumn: {

--- a/ui-v2/src/components/ui/status-badge/index.tsx
+++ b/ui-v2/src/components/ui/status-badge/index.tsx
@@ -1,0 +1,45 @@
+import type { components } from "@/api/prefect";
+import { cva } from "class-variance-authority";
+import { Circle, Pause } from "lucide-react";
+import { Badge } from "../badge";
+
+type Status =
+	| components["schemas"]["DeploymentStatus"]
+	| components["schemas"]["WorkPoolStatus"];
+
+type StatusBadgeProps = {
+	status: Status;
+};
+
+const STATUS_ICONS = {
+	READY: <Circle size={12} fill="green" />,
+	NOT_READY: <Circle size={12} fill="red" />,
+	PAUSED: <Pause size={12} />,
+} as const satisfies Record<Status, React.ReactNode>;
+
+const statusBadgeVariants = cva(
+	"gap-1 px-2 text-black/80 font-mono font-light border border-black/10",
+	{
+		variants: {
+			status: {
+				READY: "bg-green-100 hover:bg-green-100",
+				NOT_READY: "bg-red-100 hover:bg-red-100",
+				PAUSED: "bg-gray-300 hover:bg-gray-300",
+			} satisfies Record<Status, string>,
+		},
+	},
+);
+
+export const StatusBadge = ({ status }: StatusBadgeProps) => {
+	const Icon = STATUS_ICONS[status];
+	const statusText = status
+		.split("_")
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+		.join(" ");
+	return (
+		<Badge className={statusBadgeVariants({ status })}>
+			{Icon}
+			{statusText}
+		</Badge>
+	);
+};

--- a/ui-v2/src/components/ui/status-badge/index.tsx
+++ b/ui-v2/src/components/ui/status-badge/index.tsx
@@ -18,7 +18,7 @@ const STATUS_ICONS = {
 } as const satisfies Record<Status, React.ReactNode>;
 
 const statusBadgeVariants = cva(
-	"gap-1 px-2 text-black/80 font-mono font-light border border-black/10",
+	"gap-2 px-2 text-black/80 font-mono font-light border border-black/10 shadow-none",
 	{
 		variants: {
 			status: {

--- a/ui-v2/src/components/ui/status-badge/status-badge.stories.tsx
+++ b/ui-v2/src/components/ui/status-badge/status-badge.stories.tsx
@@ -1,0 +1,34 @@
+import type { components } from "@/api/prefect";
+import type { Meta, StoryObj } from "@storybook/react";
+import { StatusBadge } from "./index";
+
+const statuses = ["READY", "NOT_READY", "PAUSED"] as const satisfies (
+	| components["schemas"]["DeploymentStatus"]
+	| components["schemas"]["WorkPoolStatus"]
+)[];
+
+const meta = {
+	title: "UI/StatusBadge",
+	component: function StatusBadgeStories() {
+		return (
+			<div className="flex flex-col gap-4 items-start">
+				{statuses.map((status) => (
+					<StatusBadge key={status} status={status} />
+				))}
+			</div>
+		);
+	},
+	parameters: {
+		layout: "centered",
+	},
+} satisfies Meta<typeof StatusBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	name: "StatusBadge",
+	args: {
+		status: "Active",
+	},
+};

--- a/ui-v2/src/components/ui/status-badge/status-badge.test.tsx
+++ b/ui-v2/src/components/ui/status-badge/status-badge.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { StatusBadge } from ".";
+
+describe("StatusBadge", () => {
+	it("renders READY status correctly", () => {
+		render(<StatusBadge status="READY" />);
+		expect(screen.getByText("Ready")).toBeInTheDocument();
+		const badge = screen.getByText("Ready").closest("div");
+		expect(badge).toHaveClass("bg-green-100");
+	});
+
+	it("renders NOT_READY status correctly", () => {
+		render(<StatusBadge status="NOT_READY" />);
+		expect(screen.getByText("Not Ready")).toBeInTheDocument();
+		const badge = screen.getByText("Not Ready").closest("div");
+		expect(badge).toHaveClass("bg-red-100");
+	});
+
+	it("renders PAUSED status correctly", () => {
+		render(<StatusBadge status="PAUSED" />);
+		expect(screen.getByText("Paused")).toBeInTheDocument();
+		const badge = screen.getByText("Paused").closest("div");
+		expect(badge).toHaveClass("bg-gray-300");
+	});
+});

--- a/ui-v2/src/hooks/deployments/index.ts
+++ b/ui-v2/src/hooks/deployments/index.ts
@@ -7,6 +7,9 @@ import {
 } from "@tanstack/react-query";
 
 export type Deployment = components["schemas"]["DeploymentResponse"];
+export type DeploymentWithFlow = Deployment & {
+	flow: components["schemas"]["Flow"];
+};
 export type DeploymentsFilter =
 	components["schemas"]["Body_read_deployments_deployments_filter_post"];
 export type DeploymentsPaginationFilter =


### PR DESCRIPTION
This PR introduces the `DeploymentsDataTable` component. Not all columns are implemented as part of this PR (https://github.com/PrefectHQ/prefect/pull/16284 needs to be merged to add the activity column), and the table hasn't been wired up to a hook yet, but the interface for the component should be pretty set.

I added a `StatusBadge` component also to support the 'Status' column in the table.

Here's what it looks like so far:
<img width="1199" alt="Screenshot 2024-12-11 at 9 35 44 PM" src="https://github.com/user-attachments/assets/647e9214-bd1c-49b5-a0f8-b0c488ad82cc" />

Related to https://github.com/PrefectHQ/prefect/issues/15512
