### PR TITLE
Fix type analysis check for PRs from forks

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -102,10 +102,6 @@ jobs:
           BASE_SCORE=$(jq -r '.typeCompleteness.completenessScore' prefect-analysis-base.json)
           echo "base_score=$BASE_SCORE" >> $GITHUB_OUTPUT
 
-      - name: Checkout current branch
-        run: |
-          git checkout ${{ github.head_ref || github.ref_name }}
-
       - name: Compare scores
         run: |
           CURRENT_SCORE=$(echo ${{ steps.calculate_current_score.outputs.current_score }})


### PR DESCRIPTION
Looks like PRs from forks are failing when switching back to the current branch (example: https://github.com/PrefectHQ/prefect/actions/runs/12291713039/job/34300966606?pr=16328). Now that the script to diff `pyright` failures is on `main`, this step shouldn't be necessary any longer.
