### PR TITLE
[typing] prefect.server.utilities.database

### DIFF
--- a/src/prefect/server/api/run_history.py
+++ b/src/prefect/server/api/run_history.py
@@ -102,12 +102,14 @@ async def run_history(
                     # estimated run times only includes positive run times (to avoid any unexpected corner cases)
                     "sum_estimated_run_time",
                     sa.func.sum(
-                        db.greatest(0, sa.extract("epoch", runs.c.estimated_run_time))
+                        sa.func.greatest(
+                            0, sa.extract("epoch", runs.c.estimated_run_time)
+                        )
                     ),
                     # estimated lateness is the sum of any positive start time deltas
                     "sum_estimated_lateness",
                     sa.func.sum(
-                        db.greatest(
+                        sa.func.greatest(
                             0, sa.extract("epoch", runs.c.estimated_start_time_delta)
                         )
                     ),

--- a/src/prefect/server/database/configurations.py
+++ b/src/prefect/server/database/configurations.py
@@ -8,16 +8,9 @@ from functools import partial
 from typing import Dict, Hashable, Optional, Tuple
 
 import sqlalchemy as sa
-
-try:
-    from sqlalchemy import AdaptedConnection
-    from sqlalchemy.pool import ConnectionPoolEntry
-except ImportError:
-    # SQLAlchemy 1.4 equivalents
-    from sqlalchemy.pool import _ConnectionFairy as AdaptedConnection
-    from sqlalchemy.pool.base import _ConnectionRecord as ConnectionPoolEntry
-
+from sqlalchemy import AdaptedConnection
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
+from sqlalchemy.pool import ConnectionPoolEntry
 from typing_extensions import Literal
 
 from prefect.settings import (

--- a/src/prefect/server/database/interface.py
+++ b/src/prefect/server/database/interface.py
@@ -359,9 +359,6 @@ class PrefectDBInterface(metaclass=DBSingleton):
         """INSERTs a model into the database"""
         return self.queries.insert(model)
 
-    def greatest(self, *values):
-        return self.queries.greatest(*values)
-
     def make_timestamp_intervals(
         self,
         start_time: datetime.datetime,

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -1,22 +1,21 @@
 import datetime
 import uuid
 from abc import ABC, abstractmethod
+from collections.abc import Hashable, Iterable
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
     Dict,
-    Hashable,
-    Iterable,
     Optional,
     Union,
-    cast,
 )
 
 import pendulum
 import sqlalchemy as sa
 from sqlalchemy import FetchedValue
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import (
@@ -46,18 +45,19 @@ from prefect.server.schemas.statuses import (
     WorkQueueStatus,
 )
 from prefect.server.utilities.database import (
+    CAMEL_TO_SNAKE,
     JSON,
     UUID,
     GenerateUUID,
     Pydantic,
     Timestamp,
-    camel_to_snake,
-    date_diff,
-    interval_add,
-    now,
 )
 from prefect.server.utilities.encryption import decrypt_fernet, encrypt_fernet
 from prefect.utilities.names import generate_slug
+
+# for 'plain JSON' columns, use the postgresql variant (which comes with an
+# extra operator) and fall back to the generic JSON variant for SQLite
+sa_JSON = postgresql.JSON().with_variant(sa.JSON(), "sqlite")
 
 
 class Base(DeclarativeBase):
@@ -117,7 +117,7 @@ class Base(DeclarativeBase):
         into a snake-case table name. Override by providing
         an explicit `__tablename__` class property.
         """
-        return camel_to_snake.sub("_", cls.__name__).lower()
+        return CAMEL_TO_SNAKE.sub("_", cls.__name__).lower()
 
     id: Mapped[uuid.UUID] = mapped_column(
         primary_key=True,
@@ -126,7 +126,7 @@ class Base(DeclarativeBase):
     )
 
     created: Mapped[pendulum.DateTime] = mapped_column(
-        server_default=now(), default=lambda: pendulum.now("UTC")
+        server_default=sa.func.now(), default=lambda: pendulum.now("UTC")
     )
 
     # onupdate is only called when statements are actually issued
@@ -134,9 +134,9 @@ class Base(DeclarativeBase):
     # will not be updated
     updated: Mapped[pendulum.DateTime] = mapped_column(
         index=True,
-        server_default=now(),
+        server_default=sa.func.now(),
         default=lambda: pendulum.now("UTC"),
-        onupdate=now(),
+        onupdate=sa.func.now(),
         server_onupdate=FetchedValue(),
     )
 
@@ -175,7 +175,7 @@ class FlowRunState(Base):
         sa.Enum(schemas.states.StateType, name="state_type"), index=True
     )
     timestamp: Mapped[pendulum.DateTime] = mapped_column(
-        server_default=now(), default=lambda: pendulum.now("UTC")
+        server_default=sa.func.now(), default=lambda: pendulum.now("UTC")
     )
     name: Mapped[str] = mapped_column(index=True)
     message: Mapped[Optional[str]]
@@ -240,7 +240,7 @@ class TaskRunState(Base):
         sa.Enum(schemas.states.StateType, name="state_type"), index=True
     )
     timestamp: Mapped[pendulum.DateTime] = mapped_column(
-        server_default=now(), default=lambda: pendulum.now("UTC")
+        server_default=sa.func.now(), default=lambda: pendulum.now("UTC")
     )
     name: Mapped[str] = mapped_column(index=True)
     message: Mapped[Optional[str]]
@@ -303,11 +303,11 @@ class Artifact(Base):
     flow_run_id: Mapped[Optional[uuid.UUID]] = mapped_column(index=True)
 
     type: Mapped[Optional[str]]
-    data: Mapped[Optional[Any]] = mapped_column(sa.JSON)
+    data: Mapped[Optional[Any]] = mapped_column(sa_JSON)
     description: Mapped[Optional[str]]
 
     # Suffixed with underscore as attribute name 'metadata' is reserved for the MetaData instance when using a declarative base class.
-    metadata_: Mapped[Optional[dict[str, str]]] = mapped_column(sa.JSON)
+    metadata_: Mapped[Optional[dict[str, str]]] = mapped_column(sa_JSON)
 
     @declared_attr.directive
     @classmethod
@@ -342,9 +342,9 @@ class ArtifactCollection(Base):
     flow_run_id: Mapped[Optional[uuid.UUID]]
 
     type: Mapped[Optional[str]]
-    data: Mapped[Optional[Any]] = mapped_column(sa.JSON)
+    data: Mapped[Optional[Any]] = mapped_column(sa_JSON)
     description: Mapped[Optional[str]]
-    metadata_: Mapped[Optional[dict[str, str]]] = mapped_column(sa.JSON)
+    metadata_: Mapped[Optional[dict[str, str]]] = mapped_column(sa_JSON)
 
     __table_args__: Any = (
         sa.UniqueConstraint("key"),
@@ -419,9 +419,9 @@ class Run(Base):
                 sa.case(
                     (
                         cls.state_type == schemas.states.StateType.RUNNING,
-                        interval_add(
+                        sa.func.interval_add(
                             cls.total_run_time,
-                            date_diff(now(), cls.state_timestamp),
+                            sa.func.date_diff(sa.func.now(), cls.state_timestamp),
                         ),
                     ),
                     else_=cls.total_run_time,
@@ -464,15 +464,15 @@ class Run(Base):
         return sa.case(
             (
                 cls.start_time > cls.expected_start_time,
-                date_diff(cls.start_time, cls.expected_start_time),
+                sa.func.date_diff(cls.start_time, cls.expected_start_time),
             ),
             (
                 sa.and_(
                     cls.start_time.is_(None),
                     cls.state_type.not_in(schemas.states.TERMINAL_STATES),
-                    cls.expected_start_time < now(),
+                    cls.expected_start_time < sa.func.now(),
                 ),
-                date_diff(now(), cls.expected_start_time),
+                sa.func.date_diff(sa.func.now(), cls.expected_start_time),
             ),
             else_=datetime.timedelta(0),
         )
@@ -1165,7 +1165,7 @@ class Worker(Base):
 
     name: Mapped[str]
     last_heartbeat_time: Mapped[pendulum.DateTime] = mapped_column(
-        server_default=now(), default=lambda: pendulum.now("UTC")
+        server_default=sa.func.now(), default=lambda: pendulum.now("UTC")
     )
     heartbeat_interval_seconds: Mapped[Optional[int]]
 
@@ -1195,7 +1195,7 @@ class Agent(Base):
     )
 
     last_activity_time: Mapped[pendulum.DateTime] = mapped_column(
-        server_default=now(), default=lambda: pendulum.now("UTC")
+        server_default=sa.func.now(), default=lambda: pendulum.now("UTC")
     )
 
     __table_args__: Any = (sa.UniqueConstraint("name"),)
@@ -1277,11 +1277,11 @@ class Automation(Base):
     @classmethod
     def sort_expression(cls, value: AutomationSort) -> sa.ColumnExpressionArgument[Any]:
         """Return an expression used to sort Automations"""
-        sort_mapping = {
+        sort_mapping: dict[AutomationSort, sa.ColumnExpressionArgument[Any]] = {
             AutomationSort.CREATED_DESC: cls.created.desc(),
             AutomationSort.UPDATED_DESC: cls.updated.desc(),
-            AutomationSort.NAME_ASC: cast(sa.Column, cls.name).asc(),
-            AutomationSort.NAME_DESC: cast(sa.Column, cls.name).desc(),
+            AutomationSort.NAME_ASC: cls.name.asc(),
+            AutomationSort.NAME_DESC: cls.name.desc(),
         }
         return sort_mapping[value]
 
@@ -1439,7 +1439,7 @@ class EventResource(Base):
     occurred: Mapped[pendulum.DateTime]
     resource_id: Mapped[str] = mapped_column(sa.Text())
     resource_role: Mapped[str] = mapped_column(sa.Text())
-    resource: Mapped[dict[str, Any]] = mapped_column(sa.JSON())
+    resource: Mapped[dict[str, Any]] = mapped_column(sa_JSON)
     event_id: Mapped[uuid.UUID]
 
 

--- a/src/prefect/server/events/counting.py
+++ b/src/prefect/server/events/counting.py
@@ -8,7 +8,6 @@ from sqlalchemy.sql.selectable import Select
 
 from prefect.server.database.dependencies import provide_database_interface
 from prefect.server.database.interface import PrefectDBInterface
-from prefect.server.utilities.database import json_extract
 from prefect.types import DateTime
 from prefect.utilities.collections import AutoEnum
 
@@ -290,16 +289,8 @@ class Countable(AutoEnum):
             return db.Event.event
         elif self == self.resource:
             return sa.func.coalesce(
-                json_extract(
-                    db.Event.resource,
-                    "prefect.resource.name",
-                    wrap_quotes=db.dialect.name == "sqlite",
-                ),
-                json_extract(
-                    db.Event.resource,
-                    "prefect.name",
-                    wrap_quotes=db.dialect.name == "sqlite",
-                ),
+                db.Event.resource["prefect.resource.name"].astext,
+                db.Event.resource["prefect.name"].astext,
                 db.Event.resource_id,
             )
         else:

--- a/src/prefect/server/events/filters.py
+++ b/src/prefect/server/events/filters.py
@@ -15,7 +15,6 @@ from prefect.server.schemas.filters import (
     PrefectFilterBaseModel,
     PrefectOperatorFilterBaseModel,
 )
-from prefect.server.utilities.database import json_extract
 from prefect.types import DateTime
 from prefect.utilities.collections import AutoEnum
 
@@ -309,9 +308,7 @@ class EventResourceFilter(EventDataFilter):
                 for _, (label, values) in enumerate(labels.items()):
                     label_ops = LabelOperations(values)
 
-                    label_column = json_extract(
-                        orm_models.EventResource.resource, label
-                    )
+                    label_column = orm_models.EventResource.resource[label].astext
 
                     # With negative labels, the resource _must_ have the label
                     if label_ops.negative.simple or label_ops.negative.prefixes:
@@ -404,9 +401,7 @@ class EventRelatedFilter(EventDataFilter):
                 for _, (label, values) in enumerate(labels.items()):
                     label_ops = LabelOperations(values)
 
-                    label_column = json_extract(
-                        orm_models.EventResource.resource, label
-                    )
+                    label_column = orm_models.EventResource.resource[label].astext
 
                     if label_ops.negative.simple or label_ops.negative.prefixes:
                         label_filters.append(label_column.is_not(None))
@@ -518,9 +513,7 @@ class EventAnyResourceFilter(EventDataFilter):
                 for _, (label, values) in enumerate(labels.items()):
                     label_ops = LabelOperations(values)
 
-                    label_column = json_extract(
-                        orm_models.EventResource.resource, label
-                    )
+                    label_column = orm_models.EventResource.resource[label].astext
 
                     if label_ops.negative.simple or label_ops.negative.prefixes:
                         label_filters.append(label_column.is_not(None))

--- a/src/prefect/server/models/concurrency_limits_v2.py
+++ b/src/prefect/server/models/concurrency_limits_v2.py
@@ -12,51 +12,25 @@ from prefect.server.database.dependencies import db_injector
 from prefect.server.database.interface import PrefectDBInterface
 
 
-def greatest(
-    db: PrefectDBInterface, clamped_value: int, sql_value: ColumnElement
-) -> ColumnElement:
-    # Determine the greatest value based on the database type
-    if db.dialect.name == "sqlite":
-        # `sa.func.greatest` isn't available in SQLite, fallback to using a
-        # `case` statement.
-        return sa.case((clamped_value > sql_value, clamped_value), else_=sql_value)
-    else:
-        return sa.func.greatest(clamped_value, sql_value)
-
-
-def seconds_ago(db: PrefectDBInterface, field: ColumnElement) -> ColumnElement:
-    if db.dialect.name == "sqlite":
-        # `sa.func.timezone` isn't available in SQLite, fallback to using
-        # `julianday` .
-        return (sa.func.julianday("now") - sa.func.julianday(field)) * 86400.0
-    else:
-        return sa.func.extract(
-            "epoch",
-            sa.func.timezone("UTC", sa.func.now()) - sa.func.timezone("UTC", field),
-        ).cast(sa.Float)
-
-
-def active_slots_after_decay(db: PrefectDBInterface) -> ColumnElement[float]:
+def active_slots_after_decay() -> ColumnElement[float]:
     # Active slots will decay at a rate of `slot_decay_per_second` per second.
-    return greatest(
-        db,
+    return sa.func.greatest(
         0,
         orm_models.ConcurrencyLimitV2.active_slots
         - sa.func.floor(
             orm_models.ConcurrencyLimitV2.slot_decay_per_second
-            * seconds_ago(db, orm_models.ConcurrencyLimitV2.updated)
+            * sa.func.date_diff_seconds(orm_models.ConcurrencyLimitV2.updated)
         ),
     )
 
 
-def denied_slots_after_decay(db: PrefectDBInterface) -> ColumnElement[float]:
+def denied_slots_after_decay() -> ColumnElement[float]:
     # Denied slots decay at a rate of `slot_decay_per_second` per second if it's
     # greater than 0, otherwise it decays at a rate of `avg_slot_occupancy_seconds`.
     # The combination of `denied_slots` and `slot_decay_per_second` /
     # `avg_slot_occupancy_seconds` is used to by the API to give a best guess at
     # when slots will be available again.
-    return greatest(
-        db,
+    return sa.func.greatest(
         0,
         orm_models.ConcurrencyLimitV2.denied_slots
         - sa.func.floor(
@@ -73,7 +47,7 @@ def denied_slots_after_decay(db: PrefectDBInterface) -> ColumnElement[float]:
                     )
                 ),
             )
-            * seconds_ago(db, orm_models.ConcurrencyLimitV2.updated)
+            * sa.func.date_diff_seconds(orm_models.ConcurrencyLimitV2.updated)
         ),
     )
 
@@ -232,8 +206,8 @@ async def bulk_increment_active_slots(
     concurrency_limit_ids: List[UUID],
     slots: int,
 ) -> bool:
-    active_slots = active_slots_after_decay(db)
-    denied_slots = denied_slots_after_decay(db)
+    active_slots = active_slots_after_decay()
+    denied_slots = denied_slots_after_decay()
 
     query = (
         sa.update(orm_models.ConcurrencyLimitV2)
@@ -272,13 +246,10 @@ async def bulk_decrement_active_slots(
         )
         .values(
             active_slots=sa.case(
-                (
-                    active_slots_after_decay(db) - slots < 0,
-                    0,
-                ),
-                else_=active_slots_after_decay(db) - slots,
+                (active_slots_after_decay() - slots < 0, 0),
+                else_=active_slots_after_decay() - slots,
             ),
-            denied_slots=denied_slots_after_decay(db),
+            denied_slots=denied_slots_after_decay(),
         )
     )
 
@@ -320,7 +291,7 @@ async def bulk_update_denied_slots(
                 orm_models.ConcurrencyLimitV2.active == True,  # noqa
             )
         )
-        .values(denied_slots=denied_slots_after_decay(db) + slots)
+        .values(denied_slots=denied_slots_after_decay() + slots)
     )
 
     result = await session.execute(query)

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -4,12 +4,13 @@ Intended for internal use by the Prefect REST API.
 """
 
 import datetime
-from typing import Dict, Iterable, List, Optional, Sequence, TypeVar, cast
+from typing import Any, Dict, Iterable, List, Optional, Sequence, TypeVar, cast
 from uuid import UUID, uuid4
 
 import pendulum
 import sqlalchemy as sa
 from sqlalchemy import delete, or_, select
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import Select
 
@@ -21,7 +22,6 @@ from prefect.server.events.clients import PrefectServerEventsClient
 from prefect.server.exceptions import ObjectNotFoundError
 from prefect.server.models.events import deployment_status_event
 from prefect.server.schemas.statuses import DeploymentStatus
-from prefect.server.utilities.database import json_contains
 from prefect.settings import (
     PREFECT_API_SERVICES_SCHEDULER_MAX_RUNS,
     PREFECT_API_SERVICES_SCHEDULER_MAX_SCHEDULED_TIME,
@@ -795,7 +795,7 @@ async def check_work_queues_for_deployment(
 
     - Our database currently allows either "null" and empty lists as
     null values in filters, so we need to catch both cases with "or".
-    - `json_contains(A, B)` should be interpreted as "True if A
+    - `A.contains(B)` should be interpreted as "True if A
     contains B".
 
     Returns:
@@ -804,6 +804,9 @@ async def check_work_queues_for_deployment(
     deployment = await session.get(orm_models.Deployment, deployment_id)
     if not deployment:
         raise ObjectNotFoundError(f"Deployment with id {deployment_id} not found")
+
+    def json_contains(a: Any, b: Any) -> sa.ColumnElement[bool]:
+        return sa.type_coerce(a, type_=JSONB).contains(sa.type_coerce(b, type_=JSONB))
 
     query = (
         select(orm_models.WorkQueue)

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -4,6 +4,7 @@ Schemas that define Prefect REST API filtering operations.
 Each filter schema includes logic for transforming itself into a SQL `where` clause.
 """
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, List, Optional
 from uuid import UUID
 
@@ -17,13 +18,20 @@ from prefect.utilities.collections import AutoEnum
 from prefect.utilities.importtools import lazy_import
 
 if TYPE_CHECKING:
+    import sqlalchemy as sa
+    from sqlalchemy.dialects import postgresql
     from sqlalchemy.sql.elements import BooleanClauseList
-
-sa = lazy_import("sqlalchemy")
+else:
+    sa = lazy_import("sqlalchemy")
+    postgresql = lazy_import("sqlalchemy.dialects.postgresql")
 
 # TODO: Consider moving the `as_sql_filter` functions out of here since they are a
 #       database model level function and do not properly separate concerns when
 #       present in the schemas module
+
+
+def _as_array(elems: Sequence[str]) -> sa.ColumnElement[Sequence[str]]:
+    return sa.cast(postgresql.array(elems), type_=postgresql.ARRAY(sa.String()))
 
 
 class Operator(AutoEnum):
@@ -150,12 +158,10 @@ class FlowFilterTags(PrefectOperatorFilterBaseModel):
         default=None, description="If true, only include flows without tags"
     )
 
-    def _get_filter_list(self) -> List:
-        from prefect.server.utilities.database import json_has_all_keys
-
-        filters = []
+    def _get_filter_list(self) -> list[sa.ColumnElement[bool]]:
+        filters: list[sa.ColumnElement[bool]] = []
         if self.all_ is not None:
-            filters.append(json_has_all_keys(orm_models.Flow.tags, self.all_))
+            filters.append(orm_models.Flow.tags.has_all(_as_array(self.all_)))
         if self.is_null_ is not None:
             filters.append(
                 orm_models.Flow.tags == []
@@ -265,17 +271,15 @@ class FlowRunFilterTags(PrefectOperatorFilterBaseModel):
         default=None, description="If true, only include flow runs without tags"
     )
 
-    def _get_filter_list(self) -> List:
-        from prefect.server.utilities.database import (
-            json_has_all_keys,
-            json_has_any_key,
-        )
+    def _get_filter_list(self) -> list[sa.ColumnElement[bool]]:
+        def as_array(elems: Sequence[str]) -> sa.ColumnElement[Sequence[str]]:
+            return sa.cast(postgresql.array(elems), type_=postgresql.ARRAY(sa.String()))
 
-        filters = []
+        filters: list[sa.ColumnElement[bool]] = []
         if self.all_ is not None:
-            filters.append(json_has_all_keys(orm_models.FlowRun.tags, self.all_))
+            filters.append(orm_models.FlowRun.tags.has_all(as_array(self.all_)))
         if self.any_ is not None:
-            filters.append(json_has_any_key(orm_models.FlowRun.tags, self.any_))
+            filters.append(orm_models.FlowRun.tags.has_any(as_array(self.any_)))
         if self.is_null_ is not None:
             filters.append(
                 orm_models.FlowRun.tags == []
@@ -764,12 +768,10 @@ class TaskRunFilterTags(PrefectOperatorFilterBaseModel):
         default=None, description="If true, only include task runs without tags"
     )
 
-    def _get_filter_list(self) -> List:
-        from prefect.server.utilities.database import json_has_all_keys
-
-        filters = []
+    def _get_filter_list(self) -> list[sa.ColumnElement[bool]]:
+        filters: list[sa.ColumnElement[bool]] = []
         if self.all_ is not None:
-            filters.append(json_has_all_keys(orm_models.TaskRun.tags, self.all_))
+            filters.append(orm_models.TaskRun.tags.has_all(_as_array(self.all_)))
         if self.is_null_ is not None:
             filters.append(
                 orm_models.TaskRun.tags == []
@@ -1082,12 +1084,10 @@ class DeploymentFilterTags(PrefectOperatorFilterBaseModel):
         default=None, description="If true, only include deployments without tags"
     )
 
-    def _get_filter_list(self) -> List:
-        from prefect.server.utilities.database import json_has_all_keys
-
-        filters = []
+    def _get_filter_list(self) -> list[sa.ColumnElement[bool]]:
+        filters: list[sa.ColumnElement[bool]] = []
         if self.all_ is not None:
-            filters.append(json_has_all_keys(orm_models.Deployment.tags, self.all_))
+            filters.append(orm_models.Deployment.tags.has_all(_as_array(self.all_)))
         if self.is_null_ is not None:
             filters.append(
                 orm_models.Deployment.tags == []
@@ -1419,13 +1419,11 @@ class BlockSchemaFilterCapabilities(PrefectFilterBaseModel):
         ),
     )
 
-    def _get_filter_list(self) -> List:
-        from prefect.server.utilities.database import json_has_all_keys
-
-        filters = []
+    def _get_filter_list(self) -> list[sa.ColumnElement[bool]]:
+        filters: list[sa.ColumnElement[bool]] = []
         if self.all_ is not None:
             filters.append(
-                json_has_all_keys(orm_models.BlockSchema.capabilities, self.all_)
+                orm_models.BlockSchema.capabilities.has_all(_as_array(self.all_))
             )
         return filters
 
@@ -2168,12 +2166,10 @@ class VariableFilterTags(PrefectOperatorFilterBaseModel):
         default=None, description="If true, only include Variables without tags"
     )
 
-    def _get_filter_list(self) -> List:
-        from prefect.server.utilities.database import json_has_all_keys
-
-        filters = []
+    def _get_filter_list(self) -> list[sa.ColumnElement[bool]]:
+        filters: list[sa.ColumnElement[bool]] = []
         if self.all_ is not None:
-            filters.append(json_has_all_keys(orm_models.Variable.tags, self.all_))
+            filters.append(orm_models.Variable.tags.has_all(_as_array(self.all_)))
         if self.is_null_ is not None:
             filters.append(
                 orm_models.Variable.tags == []


### PR DESCRIPTION
This is a complete refactor of this module.

- Move functions into the `sqlalchemy.func` namespace so they don't need to be imported everywhere
- Re-use SQLAlchemy's Postgresql JSONB operators by providing SQLite equivalents
- Provide a new function that calculates the difference between timestamps as seconds.

This removes the need for many separate PostgreSQL vs SQLite queries.

Related to #16292
