### PR TITLE
backport retry delay type fix

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -342,6 +342,10 @@ class Task(Generic[P, R]):
 
         if callable(retry_delay_seconds):
             self.retry_delay_seconds = retry_delay_seconds(retries)
+        elif not isinstance(retry_delay_seconds, (list, int, float, type(None))):
+            raise TypeError(
+                f"Invalid `retry_delay_seconds` provided; must be an int, float, list or callable. Received type {type(retry_delay_seconds)}"
+            )
         else:
             self.retry_delay_seconds = retry_delay_seconds
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3381,6 +3381,21 @@ class TestTaskMap:
 
 
 class TestTaskConstructorValidation:
+    async def test_task_cannot_configure_poorly_typed_retry_delay(self):
+        with pytest.raises(TypeError, match="Invalid"):
+
+            @task(retries=42, retry_delay_seconds=dict(x=4))
+            async def insanity():
+                raise RuntimeError("try again!")
+
+        with pytest.raises(TypeError, match="Invalid"):
+
+            @task(retries=42, retry_delay_seconds=2)
+            async def sanity():
+                raise RuntimeError("try again!")
+
+            more_insanity = sanity.with_options(retry_delay_seconds=dict(x=4))  # noqa: F841
+
     async def test_task_cannot_configure_too_many_custom_retry_delays(self):
         with pytest.raises(ValueError, match="Can not configure more"):
 


### PR DESCRIPTION
the original issue was about 2.x, so we should backport #16369

related to https://github.com/PrefectHQ/prefect/issues/16357