### PR TITLE
Add working implementation of basic auth to server and client

### DIFF
--- a/docs/v3/develop/settings-ref.mdx
+++ b/docs/v3/develop/settings-ref.mdx
@@ -179,6 +179,18 @@ The URL of the Prefect API. If not set, the client will attempt to infer it.
 **Supported environment variables**:
 `PREFECT_API_URL`
 
+### `auth_string`
+The auth string used for basic authentication with a self-hosted Prefect API. Should be kept secret.
+
+**Type**: `string | None`
+
+**Default**: `None`
+
+**TOML dotted key path**: `api.auth_string`
+
+**Supported environment variables**:
+`PREFECT_API_AUTH_STRING`
+
 ### `key`
 The API key used for authentication with the Prefect API. Should be kept secret.
 
@@ -850,6 +862,17 @@ Number of seconds a runner should wait between queries for scheduled work.
 ---
 ## ServerAPISettings
 Settings for controlling API server behavior
+### `auth_string`
+
+**Type**: `string | None`
+
+**Default**: `None`
+
+**TOML dotted key path**: `server.api.auth_string`
+
+**Supported environment variables**:
+`PREFECT_SERVER_API_AUTH_STRING`
+
 ### `host`
 The API's host address (defaults to `127.0.0.1`).
 

--- a/docs/v3/develop/settings-ref.mdx
+++ b/docs/v3/develop/settings-ref.mdx
@@ -863,6 +863,7 @@ Number of seconds a runner should wait between queries for scheduled work.
 ## ServerAPISettings
 Settings for controlling API server behavior
 ### `auth_string`
+A string to use for basic authentication with the API; typically in the form 'user:password' but can be any string.
 
 **Type**: `string | None`
 

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -19,6 +19,24 @@
                     ],
                     "title": "Url"
                 },
+                "auth_string": {
+                    "anyOf": [
+                        {
+                            "format": "password",
+                            "type": "string",
+                            "writeOnly": true
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "The auth string used for basic authentication with a self-hosted Prefect API. Should be kept secret.",
+                    "supported_environment_variables": [
+                        "PREFECT_API_AUTH_STRING"
+                    ],
+                    "title": "Auth String"
+                },
                 "key": {
                     "anyOf": [
                         {
@@ -707,6 +725,23 @@
         "ServerAPISettings": {
             "description": "Settings for controlling API server behavior",
             "properties": {
+                "auth_string": {
+                    "anyOf": [
+                        {
+                            "format": "password",
+                            "type": "string",
+                            "writeOnly": true
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "supported_environment_variables": [
+                        "PREFECT_SERVER_API_AUTH_STRING"
+                    ],
+                    "title": "Auth String"
+                },
                 "host": {
                     "default": "127.0.0.1",
                     "description": "The API's host address (defaults to `127.0.0.1`).",

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -737,6 +737,7 @@
                         }
                     ],
                     "default": null,
+                    "description": "A string to use for basic authentication with the API; typically in the form 'user:password' but can be any string.",
                     "supported_environment_variables": [
                         "PREFECT_SERVER_API_AUTH_STRING"
                     ],

--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -3478,6 +3478,8 @@ class PrefectClient:
         try:
             api_version = await self.api_version()
         except Exception as e:
+            if "Unauthorized" in str(e):
+                raise e
             raise RuntimeError(f"Failed to reach API at {self.api_url}") from e
 
         api_version = version.parse(api_version)
@@ -3814,6 +3816,8 @@ class SyncPrefectClient:
         try:
             api_version = self.api_version()
         except Exception as e:
+            if "Unauthorized" in str(e):
+                raise e
             raise RuntimeError(f"Failed to reach API at {self.api_url}") from e
 
         api_version = version.parse(api_version)

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -330,10 +330,8 @@ def create_api_app(
                 decoded = base64.b64decode(creds).decode("utf-8")
             except Exception:
                 return JSONResponse(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    content={
-                        "exception_message": "Incorrectly formatted Authorization header."
-                    },
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    content={"exception_message": "Unauthorized"},
                 )
             if decoded != auth_string:
                 return JSONResponse(

--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -4,6 +4,7 @@ Defines the Prefect REST API FastAPI app.
 
 import asyncio
 import atexit
+import base64
 import contextlib
 import mimetypes
 import os
@@ -314,6 +315,32 @@ def create_api_app(
 
     for router in API_ROUTERS:
         api_app.include_router(router, dependencies=dependencies)
+
+    auth_string = prefect.settings.PREFECT_SERVER_API_AUTH_STRING.value()
+
+    if auth_string is not None:
+
+        @api_app.middleware("http")
+        async def token_validation(request: Request, call_next):
+            header_token = request.headers.get("Authorization")
+
+            try:
+                scheme, creds = header_token.split()
+                assert scheme == "Basic"
+                decoded = base64.b64decode(creds).decode("utf-8")
+            except Exception:
+                return JSONResponse(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    content={
+                        "exception_message": "Incorrectly formatted Authorization header."
+                    },
+                )
+            if decoded != auth_string:
+                return JSONResponse(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    content={"exception_message": "Unauthorized"},
+                )
+            return await call_next(request)
 
     return api_app
 

--- a/src/prefect/settings/__init__.py
+++ b/src/prefect/settings/__init__.py
@@ -53,6 +53,7 @@ __all__ = [  # noqa: F822
     "temporary_settings",
     "DEFAULT_PROFILES_PATH",
     # add public settings here for auto-completion
+    "PREFECT_API_AUTH_STRING",  # type: ignore
     "PREFECT_API_KEY",  # type: ignore
     "PREFECT_API_URL",  # type: ignore
     "PREFECT_UI_URL",  # type: ignore

--- a/src/prefect/settings/models/api.py
+++ b/src/prefect/settings/models/api.py
@@ -19,6 +19,10 @@ class APISettings(PrefectBaseSettings):
         default=None,
         description="The URL of the Prefect API. If not set, the client will attempt to infer it.",
     )
+    auth_string: Optional[SecretStr] = Field(
+        default=None,
+        description="The auth string used for basic authentication with a self-hosted Prefect API. Should be kept secret.",
+    )
     key: Optional[SecretStr] = Field(
         default=None,
         description="The API key used for authentication with the Prefect API. Should be kept secret.",

--- a/src/prefect/settings/models/server/api.py
+++ b/src/prefect/settings/models/server/api.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
+from typing import Optional
 
-from pydantic import AliasChoices, AliasPath, Field
+from pydantic import AliasChoices, AliasPath, Field, SecretStr
 
 from prefect.settings.base import PrefectBaseSettings, _build_settings_config
 
@@ -11,6 +12,8 @@ class ServerAPISettings(PrefectBaseSettings):
     """
 
     model_config = _build_settings_config(("server", "api"))
+
+    auth_string: Optional[SecretStr] = Field(default=None)
 
     host: str = Field(
         default="127.0.0.1",

--- a/src/prefect/settings/models/server/api.py
+++ b/src/prefect/settings/models/server/api.py
@@ -13,7 +13,10 @@ class ServerAPISettings(PrefectBaseSettings):
 
     model_config = _build_settings_config(("server", "api"))
 
-    auth_string: Optional[SecretStr] = Field(default=None)
+    auth_string: Optional[SecretStr] = Field(
+        default=None,
+        description="A string to use for basic authentication with the API; typically in the form 'user:password' but can be any string.",
+    )
 
     host: str = Field(
         default="127.0.0.1",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -67,6 +67,7 @@ from prefect.utilities.collections import get_from_dict, set_in_dict
 from prefect.utilities.filesystem import tmpchdir
 
 SUPPORTED_SETTINGS = {
+    "PREFECT_API_AUTH_STRING": {"test_value": "admin:admin"},
     "PREFECT_API_BLOCKS_REGISTER_ON_START": {"test_value": True, "legacy": True},
     "PREFECT_API_DATABASE_CONNECTION_TIMEOUT": {"test_value": 10.0, "legacy": True},
     "PREFECT_API_DATABASE_CONNECTION_URL": {"test_value": "sqlite:///", "legacy": True},
@@ -276,6 +277,7 @@ SUPPORTED_SETTINGS = {
     "PREFECT_RUNNER_SERVER_MISSED_POLLS_TOLERANCE": {"test_value": 10},
     "PREFECT_RUNNER_SERVER_PORT": {"test_value": 8080},
     "PREFECT_SERVER_ALLOW_EPHEMERAL_MODE": {"test_value": True, "legacy": True},
+    "PREFECT_SERVER_API_AUTH_STRING": {"test_value": "admin:admin"},
     "PREFECT_SERVER_ANALYTICS_ENABLED": {"test_value": True},
     "PREFECT_SERVER_API_CORS_ALLOWED_HEADERS": {"test_value": "foo"},
     "PREFECT_SERVER_API_CORS_ALLOWED_METHODS": {"test_value": "foo"},


### PR DESCRIPTION
Adds basic auth to both the server and the client; still needs tests and QA.

## Example

Start a protected server:
```
PREFECT_SERVER_API_AUTH_STRING="admin:admin" prefect server start
```

Run a flow:
```
PREFECT_API_AUTH_STRING="admin:admin" python -c "from prefect import flow; flow(lambda: None)()"
```

Closes https://github.com/PrefectHQ/prefect/issues/15711