### PR TITLE
Enhance `Runner` to send heartbeat events for flow runs

### DIFF
--- a/docs/v3/develop/settings-ref.mdx
+++ b/docs/v3/develop/settings-ref.mdx
@@ -844,9 +844,9 @@ Number of seconds a runner should wait between queries for scheduled work.
 ### `heartbeat_frequency`
 Number of seconds a runner should wait between heartbeats for flow runs.
 
-**Type**: `integer`
+**Type**: `integer | None`
 
-**Default**: `30`
+**Default**: `None`
 
 **TOML dotted key path**: `runner.heartbeat_frequency`
 

--- a/docs/v3/develop/settings-ref.mdx
+++ b/docs/v3/develop/settings-ref.mdx
@@ -841,6 +841,18 @@ Number of seconds a runner should wait between queries for scheduled work.
 **Supported environment variables**:
 `PREFECT_RUNNER_POLL_FREQUENCY`
 
+### `heartbeat_frequency`
+Number of seconds a runner should wait between heartbeats for flow runs.
+
+**Type**: `integer`
+
+**Default**: `30`
+
+**TOML dotted key path**: `runner.heartbeat_frequency`
+
+**Supported environment variables**:
+`PREFECT_RUNNER_HEARTBEAT_FREQUENCY`
+
 ### `server`
 
 **Type**: [RunnerServerSettings](#runnerserversettings)

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -697,13 +697,21 @@
                     "type": "integer"
                 },
                 "heartbeat_frequency": {
-                    "default": 30,
+                    "anyOf": [
+                        {
+                            "minimum": 30,
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
                     "description": "Number of seconds a runner should wait between heartbeats for flow runs.",
                     "supported_environment_variables": [
                         "PREFECT_RUNNER_HEARTBEAT_FREQUENCY"
                     ],
-                    "title": "Heartbeat Frequency",
-                    "type": "integer"
+                    "title": "Heartbeat Frequency"
                 },
                 "server": {
                     "$ref": "#/$defs/RunnerServerSettings",

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -696,6 +696,15 @@
                     "title": "Poll Frequency",
                     "type": "integer"
                 },
+                "heartbeat_frequency": {
+                    "default": 30,
+                    "description": "Number of seconds a runner should wait between heartbeats for flow runs.",
+                    "supported_environment_variables": [
+                        "PREFECT_RUNNER_HEARTBEAT_FREQUENCY"
+                    ],
+                    "title": "Heartbeat Frequency",
+                    "type": "integer"
+                },
                 "server": {
                     "$ref": "#/$defs/RunnerServerSettings",
                     "supported_environment_variables": []

--- a/src/prefect/settings/models/runner.py
+++ b/src/prefect/settings/models/runner.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import Field
 
 from prefect.settings.base import PrefectBaseSettings, _build_settings_config
@@ -54,9 +56,10 @@ class RunnerSettings(PrefectBaseSettings):
         description="Number of seconds a runner should wait between queries for scheduled work.",
     )
 
-    heartbeat_frequency: int = Field(
-        default=30,
+    heartbeat_frequency: Optional[int] = Field(
+        default=None,
         description="Number of seconds a runner should wait between heartbeats for flow runs.",
+        ge=30,
     )
 
     server: RunnerServerSettings = Field(

--- a/src/prefect/settings/models/runner.py
+++ b/src/prefect/settings/models/runner.py
@@ -54,6 +54,11 @@ class RunnerSettings(PrefectBaseSettings):
         description="Number of seconds a runner should wait between queries for scheduled work.",
     )
 
+    heartbeat_frequency: int = Field(
+        default=30,
+        description="Number of seconds a runner should wait between heartbeats for flow runs.",
+    )
+
     server: RunnerServerSettings = Field(
         default_factory=RunnerServerSettings,
         description="Settings for controlling runner server behavior",

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -185,6 +185,12 @@ class TestInit:
     async def test_runner_respects_heartbeat_setting(self):
         runner = Runner()
         assert runner.heartbeat_seconds == PREFECT_RUNNER_HEARTBEAT_FREQUENCY.value()
+        assert runner.heartbeat_seconds is None
+
+        with pytest.raises(
+            ValueError, match="Heartbeat must be 30 seconds or greater."
+        ):
+            Runner(heartbeat_seconds=29)
 
         runner = Runner(heartbeat_seconds=50)
         assert runner.heartbeat_seconds == 50
@@ -513,12 +519,50 @@ class TestRunner:
         assert "All deployments have been paused" in caplog.text
 
     @pytest.mark.usefixtures("use_hosted_api_server")
-    async def test_runner_executes_flow_runs(
+    async def test_runner_does_not_emit_heartbeats_if_not_set(
         self,
         prefect_client: PrefectClient,
         asserting_events_worker: EventsWorker,
     ):
         runner = Runner()
+
+        deployment = await dummy_flow_1.to_deployment(__file__)
+
+        await runner.add_deployment(deployment)
+
+        await runner.start(run_once=True)
+
+        deployment = await prefect_client.read_deployment_by_name(
+            name="dummy-flow-1/test_runner"
+        )
+
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment.id
+        )
+
+        await runner.start(run_once=True)
+        flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+
+        assert flow_run.state
+        assert flow_run.state.is_completed()
+
+        await asserting_events_worker.drain()
+
+        heartbeat_events = list(
+            filter(
+                lambda e: e.event == "prefect.flow-run.heartbeat",
+                asserting_events_worker._client.events,
+            )
+        )
+        assert len(heartbeat_events) == 0
+
+    @pytest.mark.usefixtures("use_hosted_api_server")
+    async def test_runner_executes_flow_runs(
+        self,
+        prefect_client: PrefectClient,
+        asserting_events_worker: EventsWorker,
+    ):
+        runner = Runner(heartbeat_seconds=30)
 
         deployment = await dummy_flow_1.to_deployment(__file__)
 
@@ -747,10 +791,37 @@ class TestRunner:
         assert "This flow crashed!" in caplog.text
 
     @pytest.mark.usefixtures("use_hosted_api_server")
-    async def test_runner_can_execute_a_single_flow_run(
+    async def test_runner_does_not_emit_heartbeats_for_single_flow_run_if_not_set(
         self, prefect_client: PrefectClient, asserting_events_worker: EventsWorker
     ):
         runner = Runner()
+
+        deployment_id = await (await dummy_flow_1.to_deployment(__file__)).apply()
+
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+        await runner.execute_flow_run(flow_run.id)
+
+        flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+        assert flow_run.state
+        assert flow_run.state.is_completed()
+
+        await asserting_events_worker.drain()
+
+        heartbeat_events = list(
+            filter(
+                lambda e: e.event == "prefect.flow-run.heartbeat",
+                asserting_events_worker._client.events,
+            )
+        )
+        assert len(heartbeat_events) == 0
+
+    @pytest.mark.usefixtures("use_hosted_api_server")
+    async def test_runner_can_execute_a_single_flow_run(
+        self, prefect_client: PrefectClient, asserting_events_worker: EventsWorker
+    ):
+        runner = Runner(heartbeat_seconds=30)
 
         deployment_id = await (await dummy_flow_1.to_deployment(__file__)).apply()
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -268,6 +268,7 @@ SUPPORTED_SETTINGS = {
     "PREFECT_RESULTS_DEFAULT_STORAGE_BLOCK": {"test_value": "block"},
     "PREFECT_RESULTS_LOCAL_STORAGE_PATH": {"test_value": Path("/path/to/storage")},
     "PREFECT_RESULTS_PERSIST_BY_DEFAULT": {"test_value": True},
+    "PREFECT_RUNNER_HEARTBEAT_FREQUENCY": {"test_value": 10},
     "PREFECT_RUNNER_POLL_FREQUENCY": {"test_value": 10},
     "PREFECT_RUNNER_PROCESS_LIMIT": {"test_value": 10},
     "PREFECT_RUNNER_SERVER_ENABLE": {"test_value": True},

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -268,7 +268,7 @@ SUPPORTED_SETTINGS = {
     "PREFECT_RESULTS_DEFAULT_STORAGE_BLOCK": {"test_value": "block"},
     "PREFECT_RESULTS_LOCAL_STORAGE_PATH": {"test_value": Path("/path/to/storage")},
     "PREFECT_RESULTS_PERSIST_BY_DEFAULT": {"test_value": True},
-    "PREFECT_RUNNER_HEARTBEAT_FREQUENCY": {"test_value": 10},
+    "PREFECT_RUNNER_HEARTBEAT_FREQUENCY": {"test_value": 30},
     "PREFECT_RUNNER_POLL_FREQUENCY": {"test_value": 10},
     "PREFECT_RUNNER_PROCESS_LIMIT": {"test_value": 10},
     "PREFECT_RUNNER_SERVER_ENABLE": {"test_value": True},


### PR DESCRIPTION
This PR enhances the `Runner` by sending heartbeat events for flow runs it is managing with an eye toward creating automations that can update flow run state in the absence of heartbeats.