### PR TITLE
Adds a link to the span that each parameter came from

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -22044,6 +22044,28 @@
                             }
                         ],
                         "title": "Task Parameters Id"
+                    },
+                    "trace_id": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Trace Id"
+                    },
+                    "span_id": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Span Id"
                     }
                 },
                 "type": "object",

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -190,6 +190,9 @@ class StateDetails(PrefectBaseModel):
     retriable: Optional[bool] = None
     transition_id: Optional[UUID] = None
     task_parameters_id: Optional[UUID] = None
+    # Captures the trace_id and span_id of the span where this state was created
+    trace_id: Optional[int] = None
+    span_id: Optional[int] = None
 
 
 def data_discriminator(x: Any) -> str:

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -221,7 +221,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
                     return_data=True,
                     max_depth=-1,
                     remove_annotations=True,
-                    context={},
+                    context={"parameter_name": parameter},
                 )
             except UpstreamTaskError:
                 raise
@@ -784,7 +784,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                     return_data=True,
                     max_depth=-1,
                     remove_annotations=True,
-                    context={},
+                    context={"parameter_name": parameter},
                 )
             except UpstreamTaskError:
                 raise

--- a/src/prefect/server/schemas/states.py
+++ b/src/prefect/server/schemas/states.py
@@ -86,6 +86,9 @@ class StateDetails(PrefectBaseModel):
     retriable: Optional[bool] = None
     transition_id: Optional[UUID] = None
     task_parameters_id: Optional[UUID] = None
+    # Captures the trace_id and span_id of the span where this state was created
+    trace_id: Optional[int] = None
+    span_id: Optional[int] = None
 
 
 class StateBaseModel(IDBaseModel):

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -640,7 +640,14 @@ def Failed(cls: Type[State[R]] = State, **kwargs: Any) -> State[R]:
     Returns:
         State: a Failed state
     """
-    return cls(type=StateType.FAILED, **kwargs)
+    state_details = StateDetails.model_validate(kwargs.pop("state_details", {}))
+
+    context = trace.get_current_span().get_span_context()
+    if context.is_valid:
+        state_details.trace_id = context.trace_id
+        state_details.span_id = context.span_id
+
+    return cls(type=StateType.FAILED, state_details=state_details, **kwargs)
 
 
 def Crashed(cls: Type[State[R]] = State, **kwargs: Any) -> State[R]:

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -618,8 +618,9 @@ def Completed(cls: Type[State[R]] = State, **kwargs: Any) -> State[R]:
     state_details = StateDetails.model_validate(kwargs.pop("state_details", {}))
 
     context = trace.get_current_span().get_span_context()
-    state_details.trace_id = context.trace_id
-    state_details.span_id = context.span_id
+    if context.is_valid:
+        state_details.trace_id = context.trace_id
+        state_details.span_id = context.span_id
 
     return cls(type=StateType.COMPLETED, state_details=state_details, **kwargs)
 

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -182,7 +182,7 @@ class BaseTaskRunEngine(Generic[P, R]):
                     return_data=True,
                     max_depth=-1,
                     remove_annotations=True,
-                    context={},
+                    context={"parameter_name": parameter},
                 )
             except UpstreamTaskError:
                 raise

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -18,6 +18,7 @@ from typing import (
 from uuid import UUID
 
 import anyio
+from opentelemetry import trace
 from typing_extensions import TypeIs
 
 import prefect
@@ -767,6 +768,20 @@ def resolve_to_final_result(expr: Any, context: dict[str, Any]) -> Any:
     result = state.result(raise_on_failure=False, fetch=True)
     if asyncio.iscoroutine(result):
         result = run_coro_as_sync(result)
+
+    if state.state_details.trace_id and state.state_details.span_id:
+        trace.get_current_span().add_link(
+            context=trace.SpanContext(
+                trace_id=state.state_details.trace_id,
+                span_id=state.state_details.span_id,
+                is_remote=True,
+            ),
+            attributes={
+                "prefect.input.name": context["parameter_name"],
+                "prefect.input.type": type(result).__name__,
+            },
+        )
+
     return result
 
 
@@ -796,7 +811,7 @@ def resolve_inputs_sync(
                 return_data=return_data,
                 max_depth=max_depth,
                 remove_annotations=True,
-                context={},
+                context={"parameter_name": parameter},
             )
         except UpstreamTaskError:
             raise

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -8285,6 +8285,10 @@ export interface components {
             transition_id?: string | null;
             /** Task Parameters Id */
             task_parameters_id?: string | null;
+            /** Trace Id */
+            trace_id?: number | null;
+            /** Span Id */
+            span_id?: number | null;
         };
         /**
          * StateRejectDetails


### PR DESCRIPTION
As part of our ongoing initiative to emit high quality OpenTelemetry
traces from Prefect, this adds a span link for each parameter back to
the flow or task that produced it.  Like all of our input tracing, this
is able to connect upstream runs to downstream runs if the parameter is
passed as a `PrefectFuture`.  The links mention the parameter's name and
the type of the result that will be used as the final parameter when
invoking the flow/task function.

Closes CLOUD-697
Closes CLOUD-739

<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
