### PR TITLE
Disable event persister by default

### DIFF
--- a/docs/v3/develop/settings-ref.mdx
+++ b/docs/v3/develop/settings-ref.mdx
@@ -1476,7 +1476,7 @@ Whether or not to start the event persister service in the server application.
 
 **Type**: `boolean`
 
-**Default**: `True`
+**Default**: `False`
 
 **TOML dotted key path**: `server.services.event_persister.enabled`
 

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1318,7 +1318,7 @@
             "description": "Settings for controlling the event persister service",
             "properties": {
                 "enabled": {
-                    "default": true,
+                    "default": false,
                     "description": "Whether or not to start the event persister service in the server application.",
                     "supported_environment_variables": [
                         "PREFECT_SERVER_SERVICES_EVENT_PERSISTER_ENABLED",

--- a/src/prefect/settings/models/server/services.py
+++ b/src/prefect/settings/models/server/services.py
@@ -43,7 +43,7 @@ class ServerServicesEventPersisterSettings(PrefectBaseSettings):
     model_config = _build_settings_config(("server", "services", "event_persister"))
 
     enabled: bool = Field(
-        default=True,
+        default=False,
         description="Whether or not to start the event persister service in the server application.",
         validation_alias=AliasChoices(
             AliasPath("enabled"),


### PR DESCRIPTION
This PR disables the event persister by default which is unnecessary for any functionality and we believe the source of many DB performance concerns.