### PR TITLE
Update worker to use orchestration client for updating labels

### DIFF
--- a/src/prefect/client/cloud.py
+++ b/src/prefect/client/cloud.py
@@ -1,6 +1,5 @@
 import re
 from typing import Any, NoReturn, Optional, cast
-from uuid import UUID
 
 import anyio
 import httpx
@@ -23,7 +22,6 @@ from prefect.settings import (
     PREFECT_CLOUD_API_URL,
     PREFECT_TESTING_UNIT_TEST_MODE,
 )
-from prefect.types import KeyValueLabels
 
 PARSE_API_URL_REGEX = re.compile(r"accounts/(.{36})/workspaces/(.{36})")
 
@@ -159,25 +157,6 @@ class CloudClient:
     async def check_ip_allowlist_access(self) -> IPAllowlistMyAccessResponse:
         response = await self.get(f"{self.account_base_url}/ip_allowlist/my_access")
         return IPAllowlistMyAccessResponse.model_validate(response)
-
-    async def update_flow_run_labels(
-        self, flow_run_id: UUID, labels: KeyValueLabels
-    ) -> httpx.Response:
-        """
-        Update the labels for a flow run.
-
-        Args:
-            flow_run_id: The identifier for the flow run to update.
-            labels: A dictionary of labels to update for the flow run.
-
-        Returns:
-            an `httpx.Response` object from the PATCH request
-        """
-
-        return await self._client.patch(
-            f"{self.workspace_base_url}/flow_runs/{flow_run_id}/labels",
-            json=labels,
-        )
 
     async def __aenter__(self) -> Self:
         await self._client.__aenter__()

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -18,7 +18,6 @@ from typing_extensions import Literal
 import prefect
 from prefect._internal.schemas.validators import return_v_or_none
 from prefect.client.base import ServerType
-from prefect.client.cloud import CloudClient, get_cloud_client
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas.actions import WorkPoolCreate, WorkPoolUpdate
 from prefect.client.schemas.objects import (
@@ -441,7 +440,6 @@ class BaseWorker(abc.ABC):
         self._exit_stack: AsyncExitStack = AsyncExitStack()
         self._runs_task_group: Optional[anyio.abc.TaskGroup] = None
         self._client: Optional[PrefectClient] = None
-        self._cloud_client: Optional[CloudClient] = None
         self._last_polled_time: pendulum.DateTime = pendulum.now("utc")
         self._limit = limit
         self._limiter: Optional[anyio.CapacityLimiter] = None
@@ -636,11 +634,6 @@ class BaseWorker(abc.ABC):
 
         await self._exit_stack.enter_async_context(self._client)
         await self._exit_stack.enter_async_context(self._runs_task_group)
-
-        if self._client.server_type == ServerType.CLOUD:
-            self._cloud_client = await self._exit_stack.enter_async_context(
-                get_cloud_client()
-            )
 
         self.is_setup = True
 
@@ -989,6 +982,8 @@ class BaseWorker(abc.ABC):
         try:
             configuration = await self._get_configuration(flow_run)
             submitted_event = self._emit_flow_run_submitted_event(configuration)
+            await self._give_worker_labels_to_flow_run(flow_run.id)
+
             result = await self.run(
                 flow_run=flow_run,
                 task_status=task_status,
@@ -1221,7 +1216,7 @@ class BaseWorker(abc.ABC):
         """
         Give this worker's identifying labels to the specified flow run.
         """
-        if self._cloud_client:
+        if self._client:
             labels: KeyValueLabels = {
                 "prefect.worker.name": self.name,
                 "prefect.worker.type": self.type,
@@ -1235,7 +1230,7 @@ class BaseWorker(abc.ABC):
                     }
                 )
 
-            await self._cloud_client.update_flow_run_labels(flow_run_id, labels)
+            await self._client.update_flow_run_labels(flow_run_id, labels)
 
     async def __aenter__(self):
         self._logger.debug("Entering worker context...")


### PR DESCRIPTION
This updates the worker to use the orchestration client for updating labels and removes the method from the CloudClient.

Closes CLOUD-859