### PR TITLE
Wrap OTLPLogExporter and OTLPSpanExporter in a QueueService to pull them out of the main thread

### DIFF
--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -225,7 +225,9 @@ class QueueService(abc.ABC, Generic[T]):
             return future.result()
 
     @classmethod
-    def drain_all(cls, timeout: Optional[float] = None) -> Union[Awaitable, None]:
+    def drain_all(
+        cls, timeout: Optional[float] = None, at_exit=True
+    ) -> Union[Awaitable, None]:
         """
         Stop all instances of the service and wait for all remaining work to be
         completed.
@@ -237,7 +239,7 @@ class QueueService(abc.ABC, Generic[T]):
             instances = tuple(cls._instances.values())
 
             for instance in instances:
-                futures.append(instance._drain())
+                futures.append(instance._drain(at_exit=at_exit))
 
         if get_running_loop() is not None:
             return (
@@ -376,10 +378,10 @@ class BatchedQueueService(QueueService[T]):
 @contextlib.contextmanager
 def drain_on_exit(service: QueueService):
     yield
-    service.drain_all()
+    service.drain_all(at_exit=True)
 
 
 @contextlib.asynccontextmanager
 async def drain_on_exit_async(service: QueueService):
     yield
-    await service.drain_all()
+    await service.drain_all(at_exit=True)

--- a/src/prefect/telemetry/services.py
+++ b/src/prefect/telemetry/services.py
@@ -1,0 +1,67 @@
+from abc import abstractmethod
+from typing import Union
+
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk._logs import LogData
+from opentelemetry.sdk._logs.export import LogExporter
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter
+
+from prefect._internal.concurrency.services import BatchedQueueService
+
+
+class BaseQueueingExporter(BatchedQueueService):
+    _max_batch_size = 512
+    _min_interval = 5.0
+    _otlp_exporter: Union[SpanExporter, LogExporter]
+
+    def export(self, batch: list) -> None:
+        for item in batch:
+            self.send(item)
+
+    @abstractmethod
+    def _export_batch(self, items: list) -> None:
+        pass
+
+    async def _handle_batch(self, items: list) -> None:
+        try:
+            self._export_batch(items)
+        except Exception as e:
+            self._logger.exception(f"Failed to export batch: {e}")
+            raise
+
+    def shutdown(self) -> None:
+        if self._stopped:
+            return
+
+        self.drain()
+        self._otlp_exporter.shutdown()
+
+
+class QueueingSpanExporter(BaseQueueingExporter, SpanExporter):
+    _otlp_exporter: OTLPSpanExporter
+
+    def __init__(self, endpoint: str, headers: tuple[tuple[str, str]]):
+        super().__init__()
+        self._otlp_exporter = OTLPSpanExporter(
+            endpoint=endpoint,
+            headers=dict(headers),
+        )
+
+    def _export_batch(self, items: list[ReadableSpan]) -> None:
+        self._otlp_exporter.export(items)
+
+
+class QueueingLogExporter(BaseQueueingExporter, LogExporter):
+    _otlp_exporter: OTLPLogExporter
+
+    def __init__(self, endpoint: str, headers: tuple[tuple[str, str]]):
+        super().__init__()
+        self._otlp_exporter = OTLPLogExporter(
+            endpoint=endpoint,
+            headers=dict(headers),
+        )
+
+    def _export_batch(self, items: list[LogData]) -> None:
+        self._otlp_exporter.export(items)

--- a/src/prefect/telemetry/services.py
+++ b/src/prefect/telemetry/services.py
@@ -13,18 +13,18 @@ from prefect._internal.concurrency.services import BatchedQueueService
 
 class BaseQueueingExporter(BatchedQueueService):
     _max_batch_size = 512
-    _min_interval = 5.0
+    _min_interval = 2.0
     _otlp_exporter: Union[SpanExporter, LogExporter]
 
-    def export(self, batch: list) -> None:
+    def export(self, batch: list[Union[ReadableSpan, LogData]]) -> None:
         for item in batch:
             self.send(item)
 
     @abstractmethod
-    def _export_batch(self, items: list) -> None:
+    def _export_batch(self, items: list[Union[ReadableSpan, LogData]]) -> None:
         pass
 
-    async def _handle_batch(self, items: list) -> None:
+    async def _handle_batch(self, items: list[Union[ReadableSpan, LogData]]) -> None:
         try:
             self._export_batch(items)
         except Exception as e:

--- a/tests/telemetry/test_instrumentation.py
+++ b/tests/telemetry/test_instrumentation.py
@@ -4,7 +4,6 @@ from uuid import UUID
 import pytest
 from opentelemetry import metrics, trace
 from opentelemetry._logs._internal import get_logger_provider
-from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import SimpleLogRecordProcessor
@@ -18,6 +17,16 @@ from prefect.telemetry.instrumentation import (
 )
 from prefect.telemetry.logging import get_log_handler
 from prefect.telemetry.processors import InFlightSpanProcessor
+from prefect.telemetry.services import QueueingLogExporter, QueueingSpanExporter
+
+
+@pytest.fixture
+def shutdown_telemetry():
+    yield
+
+    provider = trace.get_tracer_provider()
+    if isinstance(provider, TracerProvider):
+        provider.shutdown()
 
 
 def test_extract_account_and_workspace_id_valid_url(
@@ -88,12 +97,10 @@ def test_trace_provider(
     span_processor = trace_provider._active_span_processor._span_processors[0]
 
     assert isinstance(span_processor, InFlightSpanProcessor)
-    assert (
-        span_processor.span_exporter._endpoint  # type: ignore
-        == (
-            f"https://api.prefect.cloud/api/accounts/{telemetry_account_id}/"
-            f"workspaces/{telemetry_workspace_id}/telemetry/v1/traces"
-        )
+    assert isinstance(span_processor.span_exporter, QueueingSpanExporter)
+    assert span_processor.span_exporter._otlp_exporter._endpoint == (
+        f"https://api.prefect.cloud/api/accounts/{telemetry_account_id}/"
+        f"workspaces/{telemetry_workspace_id}/telemetry/v1/traces"
     )
 
     assert trace.get_tracer_provider() == trace_provider
@@ -147,14 +154,11 @@ def test_logger_provider(
     exporter = processor._exporter  # type: ignore
 
     assert isinstance(processor, SimpleLogRecordProcessor)
-    assert isinstance(exporter, OTLPLogExporter)
+    assert isinstance(exporter, QueueingLogExporter)
 
-    assert (
-        exporter._endpoint  # type: ignore
-        == (
-            f"https://api.prefect.cloud/api/accounts/{telemetry_account_id}/"
-            f"workspaces/{telemetry_workspace_id}/telemetry/v1/logs"
-        )
+    assert exporter._otlp_exporter._endpoint == (
+        f"https://api.prefect.cloud/api/accounts/{telemetry_account_id}/"
+        f"workspaces/{telemetry_workspace_id}/telemetry/v1/logs"
     )
 
     assert get_logger_provider() == logger_provider


### PR DESCRIPTION
Due to the way the OpenTelemetry OTLP Span and Log exporters work they can block execution of flows/tasks if the otel collectors they're sending data to are down. This moves their handling into QueueServices so that we unblock the main thread and flows/tasks can run normally.

Closes CLOUD-872