### PR TITLE
use correct async method on storage blocks

### DIFF
--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -524,17 +524,14 @@ class NullFileSystem(BaseModel):
     A file system that does not store any data.
     """
 
-    async def read_path(self, path: str, _sync: bool = False) -> None:
+    async def read_path(self, path: str) -> None:
         pass
 
-    async def write_path(self, path: str, content: bytes, _sync: bool = False) -> None:
+    async def write_path(self, path: str, content: bytes) -> None:
         pass
 
     async def get_directory(
-        self,
-        from_path: Optional[str] = None,
-        local_path: Optional[str] = None,
-        _sync: bool = False,
+        self, from_path: Optional[str] = None, local_path: Optional[str] = None
     ) -> None:
         pass
 
@@ -543,7 +540,6 @@ class NullFileSystem(BaseModel):
         local_path: Optional[str] = None,
         to_path: Optional[str] = None,
         ignore_file: Optional[str] = None,
-        _sync: bool = False,
     ) -> None:
         pass
 

--- a/src/prefect/filesystems.py
+++ b/src/prefect/filesystems.py
@@ -524,14 +524,17 @@ class NullFileSystem(BaseModel):
     A file system that does not store any data.
     """
 
-    async def read_path(self, path: str) -> None:
+    async def read_path(self, path: str, _sync: bool = False) -> None:
         pass
 
-    async def write_path(self, path: str, content: bytes) -> None:
+    async def write_path(self, path: str, content: bytes, _sync: bool = False) -> None:
         pass
 
     async def get_directory(
-        self, from_path: Optional[str] = None, local_path: Optional[str] = None
+        self,
+        from_path: Optional[str] = None,
+        local_path: Optional[str] = None,
+        _sync: bool = False,
     ) -> None:
         pass
 
@@ -540,6 +543,7 @@ class NullFileSystem(BaseModel):
         local_path: Optional[str] = None,
         to_path: Optional[str] = None,
         ignore_file: Optional[str] = None,
+        _sync: bool = False,
     ) -> None:
         pass
 

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -245,7 +245,6 @@ async def _call_explicitly_async_block_method(
     see https://github.com/PrefectHQ/prefect/issues/15008
     """
     if hasattr(block, f"a{method}"):  # explicit async method
-        logger.debug(f"Calling explicit async method {block}.a{method}")
         return await getattr(block.__class__.__name__, f"a{method}")(*args, **kwargs)
     elif hasattr(getattr(block, method, None), "aio"):  # sync_compatible
         return await getattr(block, method).aio(block, *args, **kwargs)

--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -245,7 +245,8 @@ async def _call_explicitly_async_block_method(
     see https://github.com/PrefectHQ/prefect/issues/15008
     """
     if hasattr(block, f"a{method}"):  # explicit async method
-        return await getattr(block, f"a{method}")(*args, **kwargs)
+        logger.debug(f"Calling explicit async method {block}.a{method}")
+        return await getattr(block.__class__.__name__, f"a{method}")(*args, **kwargs)
     elif hasattr(getattr(block, method, None), "aio"):  # sync_compatible
         return await getattr(block, method).aio(block, *args, **kwargs)
     else:  # should not happen in prefect, but users can override impls


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/16428

another issue related to #15008 

this is a bit of compatibility code required due to the fact that `async_dispatch` is aware of run contexts, and that all blocks are not yet migrated off sync_compatible (and users may subclass these methods without adding the compat decorators) - this can be simplified/removed once all block implementations behave the same way (though we'd still have to handle the possibility of user subclasses)