### PR TITLE
Add tutorials to the overview page of the docs

### DIFF
--- a/docs/v3/get-started/index.mdx
+++ b/docs/v3/get-started/index.mdx
@@ -25,13 +25,36 @@ if __name__ == "__main__":
 
 <CardGroup cols={3}>
   <Card title="Quickstart" icon="play" href="/v3/get-started/quickstart">
-    Learn how to schedule a script to run on remote infrastructure and observe its state.
+    In five minutes, create your first deployable workflow tracked with Prefect.
   </Card>
   <Card title="Prefect Cloud" icon="cloud" href="/v3/manage/cloud/index">
     Supercharge Prefect with enhanced governance, security, and performance capabilities.
   </Card>
   <Card title="Upgrade to Prefect 3" icon="sparkles" href="/v3/resources/upgrade-to-prefect-3">
     Upgrade from Prefect 2 to Prefect 3 to get the latest features and performance enhancements.
+  </Card>
+</CardGroup>
+
+## Tutorials for data engineers and platform engineers
+
+<CardGroup cols={3}>
+  <Card title="Schedule a flow" icon="calendar" href="/v3/tutorials/schedule">
+    Get a workflow off of your laptop and run it on remote infrastructure on a schedule.
+  </Card>
+  <Card title="Build a data pipeline" icon="database" href="/v3/tutorials/pipelines">
+    Build a resilient and performant data pipeline with Prefect's primitives.
+  </Card>
+  <Card title="Extract data from websites" icon="globe" href="/v3/tutorials/scraping">
+    Handle data dependencies and use pagination to efficiently extract data from websites.
+  </Card>
+  <Card title="Set up a platform" icon="code" href="/v3/tutorials/platform">
+    Use Prefect as a platform for your teams' data pipelines.
+  </Card>
+  <Card title="Debug a data pipeline" icon="bug" href="/v3/tutorials/debug">
+    Learn how to debug flow runs that fail, crash, or hang.
+  </Card>
+  <Card title="Send alerts on failure" icon="bell" href="/v3/tutorials/alerts">
+    Set up an email alert to notify your teams about failures.
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
Closes https://linear.app/prefect/issue/DOC-106/update-the-overview-page-to-include-references-to-the-new-tutorials

Now that we've deployed the first set of data engineer and platform engineer tutorials, let's add them to the overview page to encourage people to dive into the use cases that matter the most to them.

### Checklist

- [X] This pull request references any related issue by including "closes `<link to issue>`"
- [ ] ~If this pull request adds new functionality, it includes unit tests that cover the changes~
- [ ] ~If this pull request removes docs files, it includes redirect settings in `mint.json`.~
- [ ] ~If this pull request adds functions or classes, it includes helpful docstrings.~
