### PR TITLE
[typing] prefect.exceptions

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1703,7 +1703,7 @@ def load_flow_from_entrypoint(
         The flow object from the script
 
     Raises:
-        FlowScriptError: If an exception is encountered while running the script
+        ScriptError: If an exception is encountered while running the script
         MissingFlowError: If the flow function specified in the entrypoint does not exist
     """
 


### PR DESCRIPTION
- removed `FlowScriptError.rich_user_traceback()`; it has not been in use since January 2022 (see 1b0e69b19084843598158ac09946eaa0d0d622c9).

References #16292
