### PR TITLE
make `from_source` safe to use concurrently

### DIFF
--- a/flows/load_flows_concurrently.py
+++ b/flows/load_flows_concurrently.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from prefect import Flow
+from prefect.runner.storage import GitRepository
+
+
+async def load_flow(entrypoint: str) -> Flow[..., object]:
+    return await Flow.from_source(  # type: ignore
+        source=GitRepository(
+            url="https://github.com/PrefectHQ/examples.git",
+        ),
+        entrypoint=entrypoint,
+    )
+
+
+async def test_iteration():
+    entrypoints = [
+        "flows/hello-world.py:hello",
+        "flows/whoami.py:whoami",
+    ] * 5  # Load each flow 5 times concurrently
+    futures = [load_flow(entrypoint) for entrypoint in entrypoints]
+    flows = await asyncio.gather(*futures)
+    return len(flows)
+
+
+async def run_stress_test():
+    for i in range(10):  # Run 10 iterations
+        try:
+            count = await test_iteration()
+            print(f"Iteration {i+1}: Successfully loaded {count} flows")
+        except Exception as e:
+            print(f"Iteration {i+1}: Failed with error: {str(e)}")
+            return False
+    return True
+
+
+if __name__ == "__main__":
+    success = asyncio.run(run_stress_test())
+    print(f"\nStress test {'passed' if success else 'failed'}")

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -549,7 +549,9 @@ class RunnerDeployment(BaseModel):
                         module = importlib.import_module(mod_name)
                         flow_file = getattr(module, "__file__", None)
                     except ModuleNotFoundError as exc:
-                        if "__prefect_loader__" in str(exc):
+                        # 16458 adds an identifier to the module name, so checking
+                        # for "__prefect_loader__" (2 underscores) will not match
+                        if "__prefect_loader_" in str(exc):
                             raise ValueError(
                                 "Cannot create a RunnerDeployment from a flow that has been"
                                 " loaded from an entrypoint. To deploy a flow via"

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -364,7 +364,7 @@ class Flow(Generic[P, R]):
         self._entrypoint: Optional[str] = None
 
         module = fn.__module__
-        if module in ("__main__", "__prefect_loader__"):
+        if module == "__main__" or module.startswith("__prefect_loader"):
             module_name = inspect.getfile(fn)
             module = module_name if module_name != "__main__" else module
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -364,7 +364,7 @@ class Flow(Generic[P, R]):
         self._entrypoint: Optional[str] = None
 
         module = fn.__module__
-        if module == "__main__" or module.startswith("__prefect_loader"):
+        if module and (module == "__main__" or module.startswith("__prefect_loader_")):
             module_name = inspect.getfile(fn)
             module = module_name if module_name != "__main__" else module
 

--- a/src/prefect/utilities/importtools.py
+++ b/src/prefect/utilities/importtools.py
@@ -4,6 +4,7 @@ import importlib.util
 import os
 import runpy
 import sys
+import threading
 import warnings
 from collections.abc import Iterable, Sequence
 from importlib.abc import Loader, MetaPathFinder
@@ -22,6 +23,8 @@ from prefect.logging.loggers import get_logger
 from prefect.utilities.filesystem import filename, is_local_path, tmpchdir
 
 logger: Logger = get_logger(__name__)
+
+_SYS_PATH_LOCK = threading.Lock()
 
 
 def to_qualified_name(obj: Any) -> str:
@@ -135,21 +138,11 @@ def objects_from_script(
 
 
 def load_script_as_module(path: str) -> ModuleType:
-    """
-    Execute a script at the given path.
+    """Execute a script at the given path.
 
     Sets the module name to a unique identifier to ensure thread safety.
-
-    If an exception occurs during execution of the script, a
-    `prefect.exceptions.ScriptError` is created to wrap the exception and raised.
-
-    During the duration of this function call, `sys` is modified to support loading.
-    Changes are reverted after completion.
-
-    See https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
+    Uses a lock to safely modify sys.path for relative imports.
     """
-    # We will add the parent directory to search locations to support relative imports
-    # during execution of the script
     if not path.endswith(".py"):
         raise ValueError(f"The provided path does not point to a python file: {path!r}")
 
@@ -162,7 +155,6 @@ def load_script_as_module(path: str) -> ModuleType:
     spec = importlib.util.spec_from_file_location(
         module_name,
         path,
-        # Support explicit relative imports i.e. `from .foo import bar`
         submodule_search_locations=[parent_path, working_directory],
     )
     if TYPE_CHECKING:
@@ -172,17 +164,19 @@ def load_script_as_module(path: str) -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
 
-    # Support implicit relative imports i.e. `from foo import bar`
-    sys.path.insert(0, working_directory)
-    sys.path.insert(0, parent_path)
     try:
-        spec.loader.exec_module(module)
+        with _SYS_PATH_LOCK:
+            sys.path.insert(0, working_directory)
+            sys.path.insert(0, parent_path)
+            try:
+                spec.loader.exec_module(module)
+            finally:
+                sys.path.remove(parent_path)
+                sys.path.remove(working_directory)
     except Exception as exc:
         raise ScriptError(user_exc=exc, path=path) from exc
     finally:
         sys.modules.pop(module_name)
-        sys.path.remove(parent_path)
-        sys.path.remove(working_directory)
 
     return module
 


### PR DESCRIPTION
closes #16452 

as observed in the linked issue
> Sometimes it completes, but other times it errors with `KeyError: __prefect_loader__` as shown below.

we had a race condition where we'd use the  same hardcoded `__prefect_loader__` in `load_script_from_module`, causing issues when you use `from_source` concurrently