### PR TITLE
[typing] Remove overload from inject_client

### DIFF
--- a/src/prefect/client/utilities.py
+++ b/src/prefect/client/utilities.py
@@ -7,7 +7,7 @@ Utilities for working with clients.
 
 from collections.abc import Awaitable, Coroutine
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union, overload
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from typing_extensions import Concatenate, ParamSpec, TypeGuard, TypeVar
 
@@ -71,23 +71,9 @@ def client_injector(
     return wrapper
 
 
-@overload
 def inject_client(
     fn: Callable[P, Coroutine[Any, Any, R]],
 ) -> Callable[P, Coroutine[Any, Any, R]]:
-    ...
-
-
-@overload
-def inject_client(
-    fn: Callable[P, R],
-) -> Callable[P, R]:
-    ...
-
-
-def inject_client(
-    fn: Callable[P, Union[Coroutine[Any, Any, R], R]],
-) -> Callable[P, Union[Coroutine[Any, Any, R], R]]:
     """
     Simple helper to provide a context managed client to an asynchronous function.
 


### PR DESCRIPTION
The decorator can't accept a regular callable (it uses `await` when calling the wrapped function), and has so far never been used on anything but coroutines.

References #16292 and #16341.
