### PR TITLE
Transitions to using `traceparent` instead of separate IDs

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -22059,27 +22059,16 @@
                         ],
                         "title": "Task Parameters Id"
                     },
-                    "trace_id": {
+                    "traceparent": {
                         "anyOf": [
                             {
-                                "type": "integer"
+                                "type": "string"
                             },
                             {
                                 "type": "null"
                             }
                         ],
-                        "title": "Trace Id"
-                    },
-                    "span_id": {
-                        "anyOf": [
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Span Id"
+                        "title": "Traceparent"
                     }
                 },
                 "type": "object",

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -191,8 +191,7 @@ class StateDetails(PrefectBaseModel):
     transition_id: Optional[UUID] = None
     task_parameters_id: Optional[UUID] = None
     # Captures the trace_id and span_id of the span where this state was created
-    trace_id: Optional[int] = None
-    span_id: Optional[int] = None
+    traceparent: Optional[str] = None
 
 
 def data_discriminator(x: Any) -> str:

--- a/src/prefect/server/schemas/states.py
+++ b/src/prefect/server/schemas/states.py
@@ -96,8 +96,7 @@ class StateDetails(PrefectBaseModel):
     transition_id: Optional[UUID] = None
     task_parameters_id: Optional[UUID] = None
     # Captures the trace_id and span_id of the span where this state was created
-    trace_id: Optional[int] = None
-    span_id: Optional[int] = None
+    traceparent: Optional[str] = None
 
 
 class StateBaseModel(IDBaseModel):

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -8282,10 +8282,8 @@ export interface components {
             transition_id?: string | null;
             /** Task Parameters Id */
             task_parameters_id?: string | null;
-            /** Trace Id */
-            trace_id?: number | null;
-            /** Span Id */
-            span_id?: number | null;
+            /** Traceparent */
+            traceparent?: string | null;
         };
         /**
          * StateRejectDetails


### PR DESCRIPTION
In a prior change, we added the `trace_id` and `span_id` as separate
fields to the `StateDetails`.  However, because `trace_id` is a 128-bit
integer, we could get inconsistencies and errors serializing that to and
from JSON.  For example, browsers usually only support 53-bit integers
in JSON, which means these trace IDs become floating point values.  In
`orjson`, it strictly validates that integers are at most 64-bit and
raises an error if not.

Because of these compatibility issues, we're going to change this to
the more standard abstraction of the string-based `traceparent`, which
encodes the trace and span IDs along with additional flags.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/latest/contributing/overview/
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
