### PR TITLE
Remove FastAPI from prefect.flow's default import path.

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1245,14 +1245,16 @@ class Flow(Generic[P, R]):
     @overload
     def __call__(
         self: "Flow[P, Coroutine[Any, Any, T]]", *args: P.args, **kwargs: P.kwargs
-    ) -> Coroutine[Any, Any, T]: ...
+    ) -> Coroutine[Any, Any, T]:
+        ...
 
     @overload
     def __call__(
         self: "Flow[P, T]",
         *args: P.args,
         **kwargs: P.kwargs,
-    ) -> T: ...
+    ) -> T:
+        ...
 
     @overload
     def __call__(
@@ -1260,7 +1262,8 @@ class Flow(Generic[P, R]):
         *args: P.args,
         return_state: Literal[True],
         **kwargs: P.kwargs,
-    ) -> Awaitable[State[T]]: ...
+    ) -> Awaitable[State[T]]:
+        ...
 
     @overload
     def __call__(
@@ -1268,7 +1271,8 @@ class Flow(Generic[P, R]):
         *args: P.args,
         return_state: Literal[True],
         **kwargs: P.kwargs,
-    ) -> State[T]: ...
+    ) -> State[T]:
+        ...
 
     def __call__(
         self,
@@ -1407,7 +1411,8 @@ class Flow(Generic[P, R]):
 
 class FlowDecorator:
     @overload
-    def __call__(self, __fn: Callable[P, R]) -> Flow[P, R]: ...
+    def __call__(self, __fn: Callable[P, R]) -> Flow[P, R]:
+        ...
 
     @overload
     def __call__(
@@ -1433,7 +1438,8 @@ class FlowDecorator:
         on_cancellation: Optional[list[StateHookCallable]] = None,
         on_crashed: Optional[list[StateHookCallable]] = None,
         on_running: Optional[list[StateHookCallable]] = None,
-    ) -> Callable[[Callable[P, R]], Flow[P, R]]: ...
+    ) -> Callable[[Callable[P, R]], Flow[P, R]]:
+        ...
 
     @overload
     def __call__(
@@ -1459,7 +1465,8 @@ class FlowDecorator:
         on_cancellation: Optional[list[StateHookCallable]] = None,
         on_crashed: Optional[list[StateHookCallable]] = None,
         on_running: Optional[list[StateHookCallable]] = None,
-    ) -> Callable[[Callable[P, R]], Flow[P, R]]: ...
+    ) -> Callable[[Callable[P, R]], Flow[P, R]]:
+        ...
 
     def __call__(
         self,
@@ -1653,7 +1660,8 @@ class FlowDecorator:
         def from_source(
             source: Union[str, "RunnerStorage", ReadableDeploymentStorage],
             entrypoint: str,
-        ) -> Union["Flow[..., Any]", Coroutine[Any, Any, "Flow[..., Any]"]]: ...
+        ) -> Union["Flow[..., Any]", Coroutine[Any, Any, "Flow[..., Any]"]]:
+            ...
 
 
 flow = FlowDecorator()


### PR DESCRIPTION
In #16472, you can see that Prefect allocates around 13MB of memory to import `RunnerStorage`. 

<img width="1387" alt="Screenshot 2024-12-20 at 8 57 39 PM" src="https://github.com/user-attachments/assets/567c1090-06ef-416f-b387-267b3c9e5b89" />

After some digging, this is largely owed to importing jsonable_encoder inside `prefect.flows`. Making that a lazy import eliminates ~12.9MB of that 13MB import. 