### PR TITLE
fix link to `serve` docs

### DIFF
--- a/docs/v3/deploy/index.mdx
+++ b/docs/v3/deploy/index.mdx
@@ -146,7 +146,7 @@ The best choice depends on your use case.
 
 ### Static infrastructure
 
-When you have several flows running regularly, [the `serve` method](/v3/develop/write-flows/#serving-a-flow)
+When you have several flows running regularly, [the `serve` method](/v3/deploy/run-flows-in-local-processes#serve-a-flow)
 of the `Flow` object or [the `serve` utility](/v3/develop/write-flows/#serving-multiple-flows-at-once)
 is a great option for managing multiple flows simultaneously.
 


### PR DESCRIPTION
fix broken link

[old link](https://docs-3.prefect.io/v3/develop/write-flows#serve-a-flow) (points to non-existent header)
[new link](https://docs-3.prefect.io/v3/deploy/run-flows-in-local-processes#serve-a-flow)