### PR TITLE
[UI v2] feat: Adds dependabot groupings for ui-v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,31 @@ updates:
       interval: "weekly"
     labels: ["ui", "ui-dependency"]
 
+  - package-ecosystem: "npm"
+    directory: '/ui-v2/'
+    schedule:
+      interval: "weekly"
+    labels: ["ui-v2", "ui-v2-dependency"]
+    groups:
+      # This is the name of your group, it will be used in PR titles and branch names
+      radix:
+        patterns:
+          - "@radix-ui*"
+      eslint:
+        patterns:
+          - "@eslint*"
+          - "eslint*"
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook*"
+      testling-library:
+        patterns:
+          - "@testing-library*"
+      tanstack:
+        patterns:
+          - "@tanstack*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Adds dependabot groupings for `/ui-v2`. [Using grouping method](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/). Using groupings due to most grouped dependencies _should_ be upgraded together. This should signal us when we can upgrade to React 19 with our dependencies



- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Relates to https://github.com/PrefectHQ/prefect/issues/15512