### PR TITLE
Ensure client tests don't run with SQLite

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -73,7 +73,7 @@ jobs:
           - database: "sqlite"
             test-type:
               name: Client Tests
-              modules: tests/ --ignore=tests/server/ --ignore=tests/events/server --ignore=tests/test_task_runners.py --ignore=tests/runner --ignore=tests/workers
+              modules: tests/ --ignore=tests/typesafety --ignore=tests/server/ --ignore=tests/events/server --ignore=tests/test_task_runners.py --ignore=tests/runner --ignore=tests/workers
           - database: "sqlite"
             test-type:
               name: Runner and Worker Tests


### PR DESCRIPTION
This PR ensures that the `exclude` entry for the client tests with SQLite matches the matrix entry. Previously, client tests were running with SQLite when we only need them to run against PostgreSQL (which is faster).
