### PR TITLE
Refactor Client's Block CRUD methods into Mixin

### DIFF
--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -16,6 +16,7 @@ from pydantic import (
 from typing_extensions import Self
 
 from prefect.types import DateTime
+from prefect.utilities.generics import validate_list
 
 T = TypeVar("T")
 
@@ -58,6 +59,17 @@ class PrefectBaseModel(BaseModel):
             return copy_dict == other.model_dump()
         else:
             return copy_dict == other
+
+    @classmethod
+    def model_validate_list(
+        cls,
+        obj: Any,
+        *,
+        strict: bool | None = None,
+        from_attributes: bool | None = None,
+        context: Any | None = None,
+    ) -> list[Self]:
+        return validate_list(cls, obj)
 
     def __rich_repr__(self) -> Generator[tuple[str, Any, Any], None, None]:
         # Display all of the fields in the model if they differ from the default value

--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -65,9 +65,9 @@ class PrefectBaseModel(BaseModel):
         cls,
         obj: Any,
         *,
-        strict: bool | None = None,
-        from_attributes: bool | None = None,
-        context: Any | None = None,
+        strict: Optional[bool] = None,
+        from_attributes: Optional[bool] = None,
+        context: Optional[Any] = None,
     ) -> list[Self]:
         return validate_list(cls, obj)
 

--- a/src/prefect/client/orchestration/__init__.py
+++ b/src/prefect/client/orchestration/__init__.py
@@ -19,6 +19,8 @@ from packaging import version
 from starlette import status
 from typing_extensions import ParamSpec, Self, TypeVar
 
+from prefect.client.orchestration.artifacts import ArtifactClient, ArtifactAsyncClient
+
 import prefect
 import prefect.exceptions
 import prefect.settings
@@ -26,8 +28,6 @@ import prefect.states
 from prefect.client.constants import SERVER_API_VERSION
 from prefect.client.schemas import FlowRun, OrchestrationResult, TaskRun, sorting
 from prefect.client.schemas.actions import (
-    ArtifactCreate,
-    ArtifactUpdate,
     BlockDocumentCreate,
     BlockDocumentUpdate,
     BlockSchemaCreate,
@@ -57,8 +57,6 @@ from prefect.client.schemas.actions import (
     WorkQueueUpdate,
 )
 from prefect.client.schemas.filters import (
-    ArtifactCollectionFilter,
-    ArtifactFilter,
     DeploymentFilter,
     FlowFilter,
     FlowRunFilter,
@@ -71,8 +69,6 @@ from prefect.client.schemas.filters import (
     WorkQueueFilterName,
 )
 from prefect.client.schemas.objects import (
-    Artifact,
-    ArtifactCollection,
     BlockDocument,
     BlockSchema,
     BlockType,
@@ -103,8 +99,6 @@ from prefect.client.schemas.responses import (
 )
 from prefect.client.schemas.schedules import SCHEDULE_TYPES
 from prefect.client.schemas.sorting import (
-    ArtifactCollectionSort,
-    ArtifactSort,
     DeploymentSort,
     FlowRunSort,
     FlowSort,
@@ -153,15 +147,13 @@ def get_client(
     *,
     httpx_settings: Optional[dict[str, Any]] = ...,
     sync_client: Literal[False] = False,
-) -> "PrefectClient":
-    ...
+) -> "PrefectClient": ...
 
 
 @overload
 def get_client(
     *, httpx_settings: Optional[dict[str, Any]] = ..., sync_client: Literal[True] = ...
-) -> "SyncPrefectClient":
-    ...
+) -> "SyncPrefectClient": ...
 
 
 def get_client(
@@ -245,7 +237,7 @@ def get_client(
         )
 
 
-class PrefectClient:
+class PrefectClient(ArtifactAsyncClient):
     """
     An asynchronous client for interacting with the [Prefect REST API](/api-ref/rest-api/).
 
@@ -2952,142 +2944,6 @@ class PrefectClient:
             response.json()
         )
 
-    async def create_artifact(
-        self,
-        artifact: ArtifactCreate,
-    ) -> Artifact:
-        """
-        Creates an artifact with the provided configuration.
-
-        Args:
-            artifact: Desired configuration for the new artifact.
-        Returns:
-            Information about the newly created artifact.
-        """
-
-        response = await self._client.post(
-            "/artifacts/",
-            json=artifact.model_dump(mode="json", exclude_unset=True),
-        )
-
-        return Artifact.model_validate(response.json())
-
-    async def update_artifact(
-        self,
-        artifact_id: UUID,
-        artifact: ArtifactUpdate,
-    ) -> None:
-        """
-        Updates an artifact
-
-        Args:
-            artifact: Desired values for the updated artifact.
-        Returns:
-            Information about the updated artifact.
-        """
-
-        await self._client.patch(
-            f"/artifacts/{artifact_id}",
-            json=artifact.model_dump(mode="json", exclude_unset=True),
-        )
-
-    async def read_artifacts(
-        self,
-        *,
-        artifact_filter: Optional[ArtifactFilter] = None,
-        flow_run_filter: Optional[FlowRunFilter] = None,
-        task_run_filter: Optional[TaskRunFilter] = None,
-        sort: Optional[ArtifactSort] = None,
-        limit: Optional[int] = None,
-        offset: int = 0,
-    ) -> list[Artifact]:
-        """
-        Query the Prefect API for artifacts. Only artifacts matching all criteria will
-        be returned.
-        Args:
-            artifact_filter: filter criteria for artifacts
-            flow_run_filter: filter criteria for flow runs
-            task_run_filter: filter criteria for task runs
-            sort: sort criteria for the artifacts
-            limit: limit for the artifact query
-            offset: offset for the artifact query
-        Returns:
-            a list of Artifact model representations of the artifacts
-        """
-        body: dict[str, Any] = {
-            "artifacts": (
-                artifact_filter.model_dump(mode="json") if artifact_filter else None
-            ),
-            "flow_runs": (
-                flow_run_filter.model_dump(mode="json") if flow_run_filter else None
-            ),
-            "task_runs": (
-                task_run_filter.model_dump(mode="json") if task_run_filter else None
-            ),
-            "sort": sort,
-            "limit": limit,
-            "offset": offset,
-        }
-        response = await self._client.post("/artifacts/filter", json=body)
-        return pydantic.TypeAdapter(list[Artifact]).validate_python(response.json())
-
-    async def read_latest_artifacts(
-        self,
-        *,
-        artifact_filter: Optional[ArtifactCollectionFilter] = None,
-        flow_run_filter: Optional[FlowRunFilter] = None,
-        task_run_filter: Optional[TaskRunFilter] = None,
-        sort: Optional[ArtifactCollectionSort] = None,
-        limit: Optional[int] = None,
-        offset: int = 0,
-    ) -> list[ArtifactCollection]:
-        """
-        Query the Prefect API for artifacts. Only artifacts matching all criteria will
-        be returned.
-        Args:
-            artifact_filter: filter criteria for artifacts
-            flow_run_filter: filter criteria for flow runs
-            task_run_filter: filter criteria for task runs
-            sort: sort criteria for the artifacts
-            limit: limit for the artifact query
-            offset: offset for the artifact query
-        Returns:
-            a list of Artifact model representations of the artifacts
-        """
-        body: dict[str, Any] = {
-            "artifacts": (
-                artifact_filter.model_dump(mode="json") if artifact_filter else None
-            ),
-            "flow_runs": (
-                flow_run_filter.model_dump(mode="json") if flow_run_filter else None
-            ),
-            "task_runs": (
-                task_run_filter.model_dump(mode="json") if task_run_filter else None
-            ),
-            "sort": sort,
-            "limit": limit,
-            "offset": offset,
-        }
-        response = await self._client.post("/artifacts/latest/filter", json=body)
-        return pydantic.TypeAdapter(list[ArtifactCollection]).validate_python(
-            response.json()
-        )
-
-    async def delete_artifact(self, artifact_id: UUID) -> None:
-        """
-        Deletes an artifact with the provided id.
-
-        Args:
-            artifact_id: The id of the artifact to delete.
-        """
-        try:
-            await self._client.delete(f"/artifacts/{artifact_id}")
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                raise prefect.exceptions.ObjectNotFound(http_exc=e) from e
-            else:
-                raise
-
     async def create_variable(self, variable: VariableCreate) -> Variable:
         """
         Creates an variable with the provided configuration.
@@ -3571,7 +3427,7 @@ class PrefectClient:
         assert False, "This should never be called but must be defined for __enter__"
 
 
-class SyncPrefectClient:
+class SyncPrefectClient(ArtifactClient):
     """
     A synchronous client for interacting with the [Prefect REST API](/api-ref/rest-api/).
 
@@ -4353,26 +4209,6 @@ class SyncPrefectClient:
                 raise
 
         return DeploymentResponse.model_validate(response.json())
-
-    def create_artifact(
-        self,
-        artifact: ArtifactCreate,
-    ) -> Artifact:
-        """
-        Creates an artifact with the provided configuration.
-
-        Args:
-            artifact: Desired configuration for the new artifact.
-        Returns:
-            Information about the newly created artifact.
-        """
-
-        response = self._client.post(
-            "/artifacts/",
-            json=artifact.model_dump(mode="json", exclude_unset=True),
-        )
-
-        return Artifact.model_validate(response.json())
 
     def release_concurrency_slots(
         self, names: list[str], slots: int, occupancy_seconds: float

--- a/src/prefect/client/orchestration/__init__.py
+++ b/src/prefect/client/orchestration/__init__.py
@@ -152,13 +152,15 @@ def get_client(
     *,
     httpx_settings: Optional[dict[str, Any]] = ...,
     sync_client: Literal[False] = False,
-) -> "PrefectClient": ...
+) -> "PrefectClient":
+    ...
 
 
 @overload
 def get_client(
     *, httpx_settings: Optional[dict[str, Any]] = ..., sync_client: Literal[True] = ...
-) -> "SyncPrefectClient": ...
+) -> "SyncPrefectClient":
+    ...
 
 
 def get_client(

--- a/src/prefect/client/orchestration/__init__.py
+++ b/src/prefect/client/orchestration/__init__.py
@@ -19,7 +19,12 @@ from packaging import version
 from starlette import status
 from typing_extensions import ParamSpec, Self, TypeVar
 
-from prefect.client.orchestration.artifacts import ArtifactClient, ArtifactAsyncClient
+from prefect.client.orchestration.artifacts import (
+    ArtifactClient,
+    ArtifactAsyncClient,
+    ArtifactCollectionClient,
+    ArtifactCollectionAsyncClient,
+)
 
 import prefect
 import prefect.exceptions
@@ -237,7 +242,7 @@ def get_client(
         )
 
 
-class PrefectClient(ArtifactAsyncClient):
+class PrefectClient(ArtifactAsyncClient, ArtifactCollectionAsyncClient):
     """
     An asynchronous client for interacting with the [Prefect REST API](/api-ref/rest-api/).
 
@@ -3427,7 +3432,7 @@ class PrefectClient(ArtifactAsyncClient):
         assert False, "This should never be called but must be defined for __enter__"
 
 
-class SyncPrefectClient(ArtifactClient):
+class SyncPrefectClient(ArtifactClient, ArtifactCollectionClient):
     """
     A synchronous client for interacting with the [Prefect REST API](/api-ref/rest-api/).
 

--- a/src/prefect/client/orchestration/artifacts.py
+++ b/src/prefect/client/orchestration/artifacts.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, Optional
 
 from httpx import AsyncClient, Client, HTTPStatusError

--- a/src/prefect/client/orchestration/artifacts.py
+++ b/src/prefect/client/orchestration/artifacts.py
@@ -41,7 +41,6 @@ class ArtifactCollectionReadParams(BaseArtifactReadParams, total=False):
     sort: Annotated[Optional["ArtifactCollectionSort"], Field(default=None)]
 
 
-@dataclass
 class ArtifactClient:
     def __init__(self, client: Client):
         self._client = client
@@ -200,7 +199,26 @@ class ArtifactCollectionClient:
             self._client,
             "POST",
             "/artifacts/latest/filter",
-            json=kwargs,
+            json={
+                "artifact_filter": (
+                    artifact_filter.model_dump(mode="json", exclude_unset=True)
+                    if (artifact_filter := kwargs.get("artifact_filter"))
+                    else None
+                ),
+                "flow_run_filter": (
+                    flow_run_filter.model_dump(mode="json", exclude_unset=True)
+                    if (flow_run_filter := kwargs.get("flow_run_filter"))
+                    else None
+                ),
+                "task_run_filter": (
+                    task_run_filter.model_dump(mode="json", exclude_unset=True)
+                    if (task_run_filter := kwargs.get("task_run_filter"))
+                    else None
+                ),
+                "limit": kwargs.get("limit", None),
+                "offset": kwargs.get("offset", 0),
+                "sort": kwargs.get("sort", None),
+            },
         )
         return ArtifactCollection.model_validate_list(response.json())
 
@@ -216,6 +234,25 @@ class ArtifactCollectionAsyncClient:
             self._client,
             "POST",
             "/artifacts/latest/filter",
-            json=kwargs,
+            json={
+                "artifact_filter": (
+                    artifact_filter.model_dump(mode="json", exclude_unset=True)
+                    if (artifact_filter := kwargs.get("artifact_filter"))
+                    else None
+                ),
+                "flow_run_filter": (
+                    flow_run_filter.model_dump(mode="json", exclude_unset=True)
+                    if (flow_run_filter := kwargs.get("flow_run_filter"))
+                    else None
+                ),
+                "task_run_filter": (
+                    task_run_filter.model_dump(mode="json", exclude_unset=True)
+                    if (task_run_filter := kwargs.get("task_run_filter"))
+                    else None
+                ),
+                "limit": kwargs.get("limit", None),
+                "offset": kwargs.get("offset", 0),
+                "sort": kwargs.get("sort", None),
+            },
         )
         return ArtifactCollection.model_validate_list(response.json())

--- a/src/prefect/client/orchestration/artifacts.py
+++ b/src/prefect/client/orchestration/artifacts.py
@@ -43,7 +43,8 @@ class ArtifactCollectionReadParams(BaseArtifactReadParams, total=False):
 
 @dataclass
 class ArtifactClient:
-    _client: Client
+    def __init__(self, client: Client):
+        self._client = client
 
     def create_artifact(self, artifact: "ArtifactCreate") -> "Artifact":
         response = request(
@@ -113,42 +114,10 @@ class ArtifactClient:
 
         return Artifact.model_validate_list(response.json())
 
-    def read_latest_artifacts(
-        self, **kwargs: Unpack["ArtifactCollectionReadParams"]
-    ) -> list["ArtifactCollection"]:
-        response = request(
-            self._client,
-            "POST",
-            "/artifacts/latest/filter",
-            json={
-                "artifact_filter": (
-                    artifact_filter.model_dump(mode="json", exclude_unset=True)
-                    if (artifact_filter := kwargs.get("artifact_filter"))
-                    else None
-                ),
-                "flow_run_filter": (
-                    flow_run_filter.model_dump(mode="json", exclude_unset=True)
-                    if (flow_run_filter := kwargs.get("flow_run_filter"))
-                    else None
-                ),
-                "task_run_filter": (
-                    task_run_filter.model_dump(mode="json", exclude_unset=True)
-                    if (task_run_filter := kwargs.get("task_run_filter"))
-                    else None
-                ),
-                "limit": kwargs.get("limit"),
-                "offset": kwargs.get("offset"),
-                "sort": kwargs.get("sort"),
-            },
-        )
-        from prefect.client.schemas.objects import ArtifactCollection
 
-        return ArtifactCollection.model_validate_list(response.json())
-
-
-@dataclass
 class ArtifactAsyncClient:
-    _client: AsyncClient
+    def __init__(self, client: AsyncClient):
+        self._client = client
 
     async def create_artifact(self, artifact: "ArtifactCreate") -> "Artifact":
         response = await arequest(
@@ -205,38 +174,6 @@ class ArtifactAsyncClient:
 
         return Artifact.model_validate_list(response.json())
 
-    async def read_latest_artifacts(
-        self, **kwargs: Unpack["ArtifactCollectionReadParams"]
-    ) -> list["ArtifactCollection"]:
-        response = await arequest(
-            self._client,
-            "POST",
-            "/artifacts/latest/filter",
-            json={
-                "artifact_filter": (
-                    artifact_filter.model_dump(mode="json", exclude_unset=True)
-                    if (artifact_filter := kwargs.get("artifact_filter"))
-                    else None
-                ),
-                "flow_run_filter": (
-                    flow_run_filter.model_dump(mode="json", exclude_unset=True)
-                    if (flow_run_filter := kwargs.get("flow_run_filter"))
-                    else None
-                ),
-                "task_run_filter": (
-                    task_run_filter.model_dump(mode="json", exclude_unset=True)
-                    if (task_run_filter := kwargs.get("task_run_filter"))
-                    else None
-                ),
-                "limit": kwargs.get("limit", None),
-                "offset": kwargs.get("offset", 0),
-                "sort": kwargs.get("sort", None),
-            },
-        )
-        from prefect.client.schemas.objects import ArtifactCollection
-
-        return ArtifactCollection.model_validate_list(response.json())
-
     async def delete_artifact(self, artifact_id: "UUID") -> None:
         try:
             await arequest(
@@ -250,3 +187,35 @@ class ArtifactAsyncClient:
                 raise ObjectNotFound(http_exc=e) from e
             else:
                 raise
+
+
+class ArtifactCollectionClient:
+    def __init__(self, client: Client):
+        self._client = client
+
+    def read_latest_artifacts(
+        self, **kwargs: Unpack["ArtifactCollectionReadParams"]
+    ) -> list["ArtifactCollection"]:
+        response = request(
+            self._client,
+            "POST",
+            "/artifacts/latest/filter",
+            json=kwargs,
+        )
+        return ArtifactCollection.model_validate_list(response.json())
+
+
+class ArtifactCollectionAsyncClient:
+    def __init__(self, client: AsyncClient):
+        self._client = client
+
+    async def read_latest_artifacts(
+        self, **kwargs: Unpack["ArtifactCollectionReadParams"]
+    ) -> list["ArtifactCollection"]:
+        response = await arequest(
+            self._client,
+            "POST",
+            "/artifacts/latest/filter",
+            json=kwargs,
+        )
+        return ArtifactCollection.model_validate_list(response.json())

--- a/src/prefect/client/orchestration/artifacts.py
+++ b/src/prefect/client/orchestration/artifacts.py
@@ -1,0 +1,252 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Annotated, Optional
+
+from httpx import AsyncClient, Client, HTTPStatusError
+from pydantic import Field
+from typing_extensions import TypedDict, Unpack
+
+from prefect.client.orchestration.routes import arequest, request
+from prefect.exceptions import ObjectNotFound
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from prefect.client.schemas.actions import ArtifactCreate, ArtifactUpdate
+    from prefect.client.schemas.filters import (
+        ArtifactCollectionFilter,
+        ArtifactFilter,
+        FlowRunFilter,
+        TaskRunFilter,
+    )
+    from prefect.client.schemas.objects import Artifact, ArtifactCollection
+    from prefect.client.schemas.sorting import ArtifactCollectionSort, ArtifactSort
+
+
+class BaseArtifactReadParams(TypedDict, total=False):
+    flow_run_filter: Annotated[Optional["FlowRunFilter"], Field(default=None)]
+    task_run_filter: Annotated[Optional["TaskRunFilter"], Field(default=None)]
+    limit: Annotated[Optional[int], Field(default=None)]
+    offset: Annotated[int, Field(default=0)]
+
+
+class ArtifactReadParams(BaseArtifactReadParams, total=False):
+    artifact_filter: Annotated[Optional["ArtifactFilter"], Field(default=None)]
+    sort: Annotated[Optional["ArtifactSort"], Field(default=None)]
+
+
+class ArtifactCollectionReadParams(BaseArtifactReadParams, total=False):
+    artifact_filter: Annotated[
+        Optional["ArtifactCollectionFilter"], Field(default=None)
+    ]
+    sort: Annotated[Optional["ArtifactCollectionSort"], Field(default=None)]
+
+
+@dataclass
+class ArtifactClient:
+    _client: Client
+
+    def create_artifact(self, artifact: "ArtifactCreate") -> "Artifact":
+        response = request(
+            self._client,
+            "POST",
+            "/artifacts/",
+            json=artifact.model_dump(mode="json", exclude_unset=True),
+        )
+        from prefect.client.schemas.objects import Artifact
+
+        return Artifact.model_validate(response.json())
+
+    def update_artifact(self, artifact_id: "UUID", artifact: "ArtifactUpdate") -> None:
+        request(
+            self._client,
+            "PATCH",
+            "/artifacts/{artifact_id}",
+            json=artifact.model_dump(mode="json", exclude_unset=True),
+            path_params={"artifact_id": artifact_id},
+        )
+        return None
+
+    def delete_artifact(self, artifact_id: "UUID") -> None:
+        try:
+            request(
+                self._client,
+                "DELETE",
+                "/artifacts/{artifact_id}",
+                path_params={"artifact_id": artifact_id},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            else:
+                raise
+        return None
+
+    def read_artifacts(
+        self, **kwargs: Unpack["ArtifactReadParams"]
+    ) -> list["Artifact"]:
+        response = request(
+            self._client,
+            "POST",
+            "/artifacts/",
+            json={
+                "artifact_filter": (
+                    artifact_filter.model_dump(mode="json", exclude_unset=True)
+                    if (artifact_filter := kwargs.get("artifact_filter"))
+                    else None
+                ),
+                "flow_run_filter": (
+                    flow_run_filter.model_dump(mode="json", exclude_unset=True)
+                    if (flow_run_filter := kwargs.get("flow_run_filter"))
+                    else None
+                ),
+                "task_run_filter": (
+                    task_run_filter.model_dump(mode="json", exclude_unset=True)
+                    if (task_run_filter := kwargs.get("task_run_filter"))
+                    else None
+                ),
+                "limit": kwargs.get("limit"),
+                "offset": kwargs.get("offset"),
+                "sort": kwargs.get("sort"),
+            },
+        )
+        from prefect.client.schemas.objects import Artifact
+
+        return Artifact.model_validate_list(response.json())
+
+    def read_latest_artifacts(
+        self, **kwargs: Unpack["ArtifactCollectionReadParams"]
+    ) -> list["ArtifactCollection"]:
+        response = request(
+            self._client,
+            "POST",
+            "/artifacts/latest/filter",
+            json={
+                "artifact_filter": (
+                    artifact_filter.model_dump(mode="json", exclude_unset=True)
+                    if (artifact_filter := kwargs.get("artifact_filter"))
+                    else None
+                ),
+                "flow_run_filter": (
+                    flow_run_filter.model_dump(mode="json", exclude_unset=True)
+                    if (flow_run_filter := kwargs.get("flow_run_filter"))
+                    else None
+                ),
+                "task_run_filter": (
+                    task_run_filter.model_dump(mode="json", exclude_unset=True)
+                    if (task_run_filter := kwargs.get("task_run_filter"))
+                    else None
+                ),
+                "limit": kwargs.get("limit"),
+                "offset": kwargs.get("offset"),
+                "sort": kwargs.get("sort"),
+            },
+        )
+        from prefect.client.schemas.objects import ArtifactCollection
+
+        return ArtifactCollection.model_validate_list(response.json())
+
+
+@dataclass
+class ArtifactAsyncClient:
+    _client: AsyncClient
+
+    async def create_artifact(self, artifact: "ArtifactCreate") -> "Artifact":
+        response = await arequest(
+            self._client,
+            "POST",
+            "/artifacts/",
+            json=artifact.model_dump(mode="json", exclude_unset=True),
+        )
+        from prefect.client.schemas.objects import Artifact
+
+        return Artifact.model_validate(response.json())
+
+    async def update_artifact(
+        self, artifact_id: "UUID", artifact: "ArtifactUpdate"
+    ) -> None:
+        await arequest(
+            self._client,
+            "PATCH",
+            "/artifacts/{artifact_id}",
+            path_params={"artifact_id": artifact_id},
+            json=artifact.model_dump(mode="json", exclude_unset=True),
+        )
+        return None
+
+    async def read_artifacts(
+        self, **kwargs: Unpack["ArtifactReadParams"]
+    ) -> list["Artifact"]:
+        response = await arequest(
+            self._client,
+            "POST",
+            "/artifacts/",
+            params={
+                "artifact_filter": (
+                    artifact_filter.model_dump(mode="json", exclude_unset=True)
+                    if (artifact_filter := kwargs.get("artifact_filter"))
+                    else None
+                ),
+                "flow_run_filter": (
+                    flow_run_filter.model_dump(mode="json", exclude_unset=True)
+                    if (flow_run_filter := kwargs.get("flow_run_filter"))
+                    else None
+                ),
+                "task_run_filter": (
+                    task_run_filter.model_dump(mode="json", exclude_unset=True)
+                    if (task_run_filter := kwargs.get("task_run_filter"))
+                    else None
+                ),
+                "limit": kwargs.get("limit", None),
+                "offset": kwargs.get("offset", 0),
+                "sort": kwargs.get("sort", None),
+            },
+        )
+        from prefect.client.schemas.objects import Artifact
+
+        return Artifact.model_validate_list(response.json())
+
+    async def read_latest_artifacts(
+        self, **kwargs: Unpack["ArtifactCollectionReadParams"]
+    ) -> list["ArtifactCollection"]:
+        response = await arequest(
+            self._client,
+            "POST",
+            "/artifacts/latest/filter",
+            json={
+                "artifact_filter": (
+                    artifact_filter.model_dump(mode="json", exclude_unset=True)
+                    if (artifact_filter := kwargs.get("artifact_filter"))
+                    else None
+                ),
+                "flow_run_filter": (
+                    flow_run_filter.model_dump(mode="json", exclude_unset=True)
+                    if (flow_run_filter := kwargs.get("flow_run_filter"))
+                    else None
+                ),
+                "task_run_filter": (
+                    task_run_filter.model_dump(mode="json", exclude_unset=True)
+                    if (task_run_filter := kwargs.get("task_run_filter"))
+                    else None
+                ),
+                "limit": kwargs.get("limit", None),
+                "offset": kwargs.get("offset", 0),
+                "sort": kwargs.get("sort", None),
+            },
+        )
+        from prefect.client.schemas.objects import ArtifactCollection
+
+        return ArtifactCollection.model_validate_list(response.json())
+
+    async def delete_artifact(self, artifact_id: "UUID") -> None:
+        try:
+            await arequest(
+                self._client,
+                "DELETE",
+                "/artifacts/{artifact_id}",
+                path_params={"artifact_id": artifact_id},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            else:
+                raise

--- a/src/prefect/client/orchestration/artifacts.py
+++ b/src/prefect/client/orchestration/artifacts.py
@@ -4,6 +4,7 @@ from httpx import AsyncClient, Client, HTTPStatusError
 from pydantic import Field
 from typing_extensions import TypedDict, Unpack
 
+from prefect.client.orchestration.base import BaseAsyncClient, BaseClient
 from prefect.client.orchestration.routes import arequest, request
 from prefect.exceptions import ObjectNotFound
 
@@ -40,10 +41,7 @@ class ArtifactCollectionReadParams(BaseArtifactReadParams, total=False):
     sort: Annotated[Optional["ArtifactCollectionSort"], Field(default=None)]
 
 
-class ArtifactClient:
-    def __init__(self, client: Client):
-        self._client = client
-
+class ArtifactClient(BaseClient):
     def create_artifact(self, artifact: "ArtifactCreate") -> "Artifact":
         response = request(
             self._client,
@@ -113,10 +111,7 @@ class ArtifactClient:
         return Artifact.model_validate_list(response.json())
 
 
-class ArtifactAsyncClient:
-    def __init__(self, client: AsyncClient):
-        self._client = client
-
+class ArtifactAsyncClient(BaseAsyncClient):
     async def create_artifact(self, artifact: "ArtifactCreate") -> "Artifact":
         response = await arequest(
             self._client,
@@ -187,7 +182,7 @@ class ArtifactAsyncClient:
                 raise
 
 
-class ArtifactCollectionClient:
+class ArtifactCollectionClient(BaseClient):
     def __init__(self, client: Client):
         self._client = client
 
@@ -222,7 +217,7 @@ class ArtifactCollectionClient:
         return ArtifactCollection.model_validate_list(response.json())
 
 
-class ArtifactCollectionAsyncClient:
+class ArtifactCollectionAsyncClient(BaseAsyncClient):
     def __init__(self, client: AsyncClient):
         self._client = client
 

--- a/src/prefect/client/orchestration/base.py
+++ b/src/prefect/client/orchestration/base.py
@@ -1,0 +1,14 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient, Client
+
+
+class BaseClient:
+    def __init__(self, client: "Client"):
+        self._client = client
+
+
+class BaseAsyncClient:
+    def __init__(self, client: "AsyncClient"):
+        self._client = client

--- a/src/prefect/client/orchestration/blocks.py
+++ b/src/prefect/client/orchestration/blocks.py
@@ -75,6 +75,8 @@ class BlockTypeClient(BaseClient):
     ) -> None:
         """Update a block type."""
         try:
+            from prefect.client.schemas.actions import BlockTypeUpdate
+
             request(
                 self._client,
                 "PATCH",
@@ -194,6 +196,8 @@ class BlockTypeAsyncClient(BaseAsyncClient):
     ) -> None:
         """Update a block type."""
         try:
+            from prefect.client.schemas.actions import BlockTypeUpdate
+
             await arequest(
                 self._client,
                 "PATCH",

--- a/src/prefect/client/orchestration/blocks.py
+++ b/src/prefect/client/orchestration/blocks.py
@@ -1,0 +1,695 @@
+from typing import TYPE_CHECKING, Optional, Union
+
+from httpx import HTTPStatusError
+
+from prefect.client.orchestration.base import BaseAsyncClient, BaseClient
+from prefect.client.orchestration.routes import arequest, request
+from prefect.exceptions import ObjectAlreadyExists, ObjectNotFound, ProtectedBlockError
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from prefect.client.schemas.actions import (
+        BlockDocumentCreate,
+        BlockDocumentUpdate,
+        BlockSchemaCreate,
+        BlockTypeCreate,
+        BlockTypeUpdate,
+    )
+    from prefect.client.schemas.objects import BlockDocument, BlockSchema, BlockType
+
+
+class BlockTypeClient(BaseClient):
+    def create_block_type(self, block_type: "BlockTypeCreate") -> "BlockType":
+        """Create a block type in the Prefect API."""
+        try:
+            response = request(
+                self._client,
+                "POST",
+                "/block_types/",
+                json=block_type.model_dump(
+                    mode="json", exclude_unset=True, exclude={"id"}
+                ),
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 409:
+                raise ObjectAlreadyExists(http_exc=e) from e
+            raise
+
+        from prefect.client.schemas.objects import BlockType
+
+        return BlockType.model_validate(response.json())
+
+    def read_block_type_by_slug(self, slug: str) -> "BlockType":
+        """Read a block type by its slug."""
+        try:
+            response = request(
+                self._client,
+                "GET",
+                "/block_types/slug/{slug}",
+                path_params={"slug": slug},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            raise
+
+        from prefect.client.schemas.objects import BlockType
+
+        return BlockType.model_validate(response.json())
+
+    def read_block_types(self) -> list["BlockType"]:
+        """Read all block types."""
+        response = request(
+            self._client,
+            "POST",
+            "/block_types/filter",
+            json={},
+        )
+        from prefect.client.schemas.objects import BlockType
+
+        return BlockType.model_validate_list(response.json())
+
+    def update_block_type(
+        self, block_type_id: "UUID", block_type: "BlockTypeUpdate"
+    ) -> None:
+        """Update a block type."""
+        try:
+            request(
+                self._client,
+                "PATCH",
+                "/block_types/{block_type_id}",
+                path_params={"block_type_id": block_type_id},
+                json=block_type.model_dump(
+                    mode="json",
+                    exclude_unset=True,
+                    include=BlockTypeUpdate.updatable_fields(),
+                ),
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            raise
+
+    def delete_block_type(self, block_type_id: "UUID") -> None:
+        """Delete a block type."""
+        try:
+            request(
+                self._client,
+                "DELETE",
+                "/block_types/{block_type_id}",
+                path_params={"block_type_id": block_type_id},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            elif (
+                e.response.status_code == 403
+                and e.response.json()["detail"]
+                == "protected block types cannot be deleted."
+            ):
+                raise ProtectedBlockError(
+                    "Protected block types cannot be deleted."
+                ) from e
+            raise
+
+    def read_block_documents_by_type(
+        self,
+        block_type_slug: str,
+        *,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+        include_secrets: bool = True,
+    ) -> list["BlockDocument"]:
+        """Read block documents by block type slug."""
+        response = request(
+            self._client,
+            "GET",
+            "/block_types/slug/{block_type_slug}/block_documents",
+            path_params={"block_type_slug": block_type_slug},
+            params={
+                "offset": offset,
+                "limit": limit,
+                "include_secrets": include_secrets,
+            },
+        )
+        from prefect.client.schemas.objects import BlockDocument
+
+        return BlockDocument.model_validate_list(response.json())
+
+
+class BlockTypeAsyncClient(BaseAsyncClient):
+    async def create_block_type(self, block_type: "BlockTypeCreate") -> "BlockType":
+        """Create a block type in the Prefect API."""
+        try:
+            response = await arequest(
+                self._client,
+                "POST",
+                "/block_types/",
+                json=block_type.model_dump(
+                    mode="json", exclude_unset=True, exclude={"id"}
+                ),
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 409:
+                raise ObjectAlreadyExists(http_exc=e) from e
+            raise
+
+        from prefect.client.schemas.objects import BlockType
+
+        return BlockType.model_validate(response.json())
+
+    async def read_block_type_by_slug(self, slug: str) -> "BlockType":
+        """Read a block type by its slug."""
+        try:
+            response = await arequest(
+                self._client,
+                "GET",
+                "/block_types/slug/{slug}",
+                path_params={"slug": slug},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            raise
+
+        from prefect.client.schemas.objects import BlockType
+
+        return BlockType.model_validate(response.json())
+
+    async def read_block_types(self) -> list["BlockType"]:
+        """Read all block types."""
+        response = await arequest(
+            self._client,
+            "POST",
+            "/block_types/filter",
+            json={},
+        )
+        from prefect.client.schemas.objects import BlockType
+
+        return BlockType.model_validate_list(response.json())
+
+    async def update_block_type(
+        self, block_type_id: "UUID", block_type: "BlockTypeUpdate"
+    ) -> None:
+        """Update a block type."""
+        try:
+            await arequest(
+                self._client,
+                "PATCH",
+                "/block_types/{block_type_id}",
+                path_params={"block_type_id": block_type_id},
+                json=block_type.model_dump(
+                    mode="json",
+                    exclude_unset=True,
+                    include=BlockTypeUpdate.updatable_fields(),
+                ),
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            raise
+
+    async def delete_block_type(self, block_type_id: "UUID") -> None:
+        """Delete a block type."""
+        try:
+            await arequest(
+                self._client,
+                "DELETE",
+                "/block_types/{block_type_id}",
+                path_params={"block_type_id": block_type_id},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            elif (
+                e.response.status_code == 403
+                and e.response.json()["detail"]
+                == "protected block types cannot be deleted."
+            ):
+                raise ProtectedBlockError(
+                    "Protected block types cannot be deleted."
+                ) from e
+            raise
+
+    async def read_block_documents_by_type(
+        self,
+        block_type_slug: str,
+        *,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+        include_secrets: bool = True,
+    ) -> list["BlockDocument"]:
+        """Read block documents by block type slug."""
+        response = await arequest(
+            self._client,
+            "GET",
+            "/block_types/slug/{block_type_slug}/block_documents",
+            path_params={"block_type_slug": block_type_slug},
+            params={
+                "offset": offset,
+                "limit": limit,
+                "include_secrets": include_secrets,
+            },
+        )
+        from prefect.client.schemas.objects import BlockDocument
+
+        return BlockDocument.model_validate_list(response.json())
+
+
+class BlockSchemaClient(BaseClient):
+    def create_block_schema(self, block_schema: "BlockSchemaCreate") -> "BlockSchema":
+        """Create a block schema in the Prefect API."""
+        try:
+            response = request(
+                self._client,
+                "POST",
+                "/block_schemas/",
+                json=block_schema.model_dump(
+                    mode="json",
+                    exclude_unset=True,
+                    exclude={"id", "block_type", "checksum"},
+                ),
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 409:
+                raise ObjectAlreadyExists(http_exc=e) from e
+            raise
+
+        from prefect.client.schemas.objects import BlockSchema
+
+        return BlockSchema.model_validate(response.json())
+
+    def read_block_schemas(self) -> list["BlockSchema"]:
+        """Read all block schemas."""
+        response = request(
+            self._client,
+            "POST",
+            "/block_schemas/filter",
+            json={},
+        )
+        from prefect.client.schemas.objects import BlockSchema
+
+        return BlockSchema.model_validate_list(response.json())
+
+    def read_block_schema_by_checksum(
+        self, checksum: str, version: Optional[str] = None
+    ) -> "BlockSchema":
+        """Read a block schema by its checksum."""
+        try:
+            url = "/block_schemas/checksum/{checksum}"
+            if version:
+                url += "?version={version}"
+
+            response = request(
+                self._client,
+                "GET",
+                url,
+                path_params={
+                    "checksum": checksum,
+                    "version": version,
+                },
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            raise
+
+        from prefect.client.schemas.objects import BlockSchema
+
+        return BlockSchema.model_validate(response.json())
+
+    def get_most_recent_block_schema_for_block_type(
+        self, block_type_id: "UUID"
+    ) -> Optional["BlockSchema"]:
+        """Get the most recent block schema for a block type."""
+        response = request(
+            self._client,
+            "POST",
+            "/block_schemas/filter",
+            json={
+                "block_schemas": {"block_type_id": {"any_": [str(block_type_id)]}},
+                "limit": 1,
+            },
+        )
+
+        from prefect.client.schemas.objects import BlockSchema
+
+        results = BlockSchema.model_validate_list(response.json())
+        return results[0] if results else None
+
+
+class BlockSchemaAsyncClient(BaseAsyncClient):
+    async def create_block_schema(
+        self, block_schema: "BlockSchemaCreate"
+    ) -> "BlockSchema":
+        """Create a block schema in the Prefect API."""
+        try:
+            response = await arequest(
+                self._client,
+                "POST",
+                "/block_schemas/",
+                json=block_schema.model_dump(
+                    mode="json",
+                    exclude_unset=True,
+                    exclude={"id", "block_type", "checksum"},
+                ),
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 409:
+                raise ObjectAlreadyExists(http_exc=e) from e
+            raise
+
+        from prefect.client.schemas.objects import BlockSchema
+
+        return BlockSchema.model_validate(response.json())
+
+    async def read_block_schemas(self) -> list["BlockSchema"]:
+        """Read all block schemas."""
+        response = await arequest(
+            self._client,
+            "POST",
+            "/block_schemas/filter",
+            json={},
+        )
+        from prefect.client.schemas.objects import BlockSchema
+
+        return BlockSchema.model_validate_list(response.json())
+
+    async def read_block_schema_by_checksum(
+        self, checksum: str, version: Optional[str] = None
+    ) -> "BlockSchema":
+        """Read a block schema by its checksum."""
+        try:
+            url = "/block_schemas/checksum/{checksum}"
+            if version:
+                url += "?version={version}"
+
+            response = await arequest(
+                self._client,
+                "GET",
+                url,
+                path_params={
+                    "checksum": checksum,
+                    "version": version,
+                },
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            raise
+
+        from prefect.client.schemas.objects import BlockSchema
+
+        return BlockSchema.model_validate(response.json())
+
+    async def get_most_recent_block_schema_for_block_type(
+        self, block_type_id: "UUID"
+    ) -> Optional["BlockSchema"]:
+        """Get the most recent block schema for a block type."""
+        response = await arequest(
+            self._client,
+            "POST",
+            "/block_schemas/filter",
+            json={
+                "block_schemas": {"block_type_id": {"any_": [str(block_type_id)]}},
+                "limit": 1,
+            },
+        )
+
+        from prefect.client.schemas.objects import BlockSchema
+
+        results = BlockSchema.model_validate_list(response.json())
+        return results[0] if results else None
+
+
+class BlockDocumentClient(BaseClient):
+    def create_block_document(
+        self,
+        block_document: "Union[BlockDocument, BlockDocumentCreate]",
+        include_secrets: bool = True,
+    ) -> "BlockDocument":
+        """Create a block document in the Prefect API."""
+        try:
+            response = request(
+                self._client,
+                "POST",
+                "/block_documents/",
+                json=block_document.model_dump(
+                    mode="json",
+                    exclude_unset=True,
+                    exclude={"id", "block_schema", "block_type"},
+                    context={"include_secrets": include_secrets},
+                    serialize_as_any=True,
+                ),
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 409:
+                raise ObjectAlreadyExists(http_exc=e) from e
+            raise
+
+        from prefect.client.schemas.objects import BlockDocument
+
+        return BlockDocument.model_validate(response.json())
+
+    def read_block_document(
+        self, block_document_id: "UUID", include_secrets: bool = True
+    ) -> "BlockDocument":
+        """Read a block document by ID."""
+        try:
+            response = request(
+                self._client,
+                "GET",
+                "/block_documents/{block_document_id}",
+                path_params={"block_document_id": block_document_id},
+                params={"include_secrets": include_secrets},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            raise
+
+        from prefect.client.schemas.objects import BlockDocument
+
+        return BlockDocument.model_validate(response.json())
+
+    def read_block_documents(
+        self,
+        block_schema_type: Optional[str] = None,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+        include_secrets: bool = True,
+    ) -> list["BlockDocument"]:
+        """Read multiple block documents with filtering."""
+        response = request(
+            self._client,
+            "POST",
+            "/block_documents/filter",
+            json={
+                "block_schema_type": block_schema_type,
+                "offset": offset,
+                "limit": limit,
+                "include_secrets": include_secrets,
+            },
+        )
+        from prefect.client.schemas.objects import BlockDocument
+
+        return BlockDocument.model_validate_list(response.json())
+
+    def read_block_document_by_name(
+        self,
+        name: str,
+        block_type_slug: str,
+        include_secrets: bool = True,
+    ) -> "BlockDocument":
+        """Read a block document by name and type slug."""
+        try:
+            response = request(
+                self._client,
+                "GET",
+                "/block_types/slug/{block_type_slug}/block_documents/name/{name}",
+                path_params={
+                    "block_type_slug": block_type_slug,
+                    "name": name,
+                },
+                params={"include_secrets": include_secrets},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            raise
+
+        from prefect.client.schemas.objects import BlockDocument
+
+        return BlockDocument.model_validate(response.json())
+
+    def update_block_document(
+        self, block_document_id: "UUID", block_document: "BlockDocumentUpdate"
+    ) -> None:
+        """Update a block document."""
+        try:
+            request(
+                self._client,
+                "PATCH",
+                "/block_documents/{block_document_id}",
+                path_params={"block_document_id": block_document_id},
+                json=block_document.model_dump(
+                    mode="json",
+                    exclude_unset=True,
+                    include={"data", "merge_existing_data", "block_schema_id"},
+                ),
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            raise
+
+    def delete_block_document(self, block_document_id: "UUID") -> None:
+        """Delete a block document."""
+        try:
+            request(
+                self._client,
+                "DELETE",
+                "/block_documents/{block_document_id}",
+                path_params={"block_document_id": block_document_id},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            raise
+
+
+class BlockDocumentAsyncClient(BaseAsyncClient):
+    async def create_block_document(
+        self,
+        block_document: "Union[BlockDocument, BlockDocumentCreate]",
+        include_secrets: bool = True,
+    ) -> "BlockDocument":
+        """Create a block document in the Prefect API."""
+        try:
+            response = await arequest(
+                self._client,
+                "POST",
+                "/block_documents/",
+                json=block_document.model_dump(
+                    mode="json",
+                    exclude_unset=True,
+                    exclude={"id", "block_schema", "block_type"},
+                    context={"include_secrets": include_secrets},
+                    serialize_as_any=True,
+                ),
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 409:
+                raise ObjectAlreadyExists(http_exc=e) from e
+            raise
+
+        from prefect.client.schemas.objects import BlockDocument
+
+        return BlockDocument.model_validate(response.json())
+
+    async def read_block_document(
+        self, block_document_id: "UUID", include_secrets: bool = True
+    ) -> "BlockDocument":
+        """Read a block document by ID."""
+        try:
+            response = await arequest(
+                self._client,
+                "GET",
+                "/block_documents/{block_document_id}",
+                path_params={"block_document_id": block_document_id},
+                params={"include_secrets": include_secrets},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            raise
+
+        from prefect.client.schemas.objects import BlockDocument
+
+        return BlockDocument.model_validate(response.json())
+
+    async def read_block_documents(
+        self,
+        block_schema_type: Optional[str] = None,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+        include_secrets: bool = True,
+    ) -> list["BlockDocument"]:
+        """Read multiple block documents with filtering."""
+        response = await arequest(
+            self._client,
+            "POST",
+            "/block_documents/filter",
+            json={
+                "block_schema_type": block_schema_type,
+                "offset": offset,
+                "limit": limit,
+                "include_secrets": include_secrets,
+            },
+        )
+        from prefect.client.schemas.objects import BlockDocument
+
+        return BlockDocument.model_validate_list(response.json())
+
+    async def read_block_document_by_name(
+        self,
+        name: str,
+        block_type_slug: str,
+        include_secrets: bool = True,
+    ) -> "BlockDocument":
+        """Read a block document by name and type slug."""
+        try:
+            response = await arequest(
+                self._client,
+                "GET",
+                "/block_types/slug/{block_type_slug}/block_documents/name/{name}",
+                path_params={
+                    "block_type_slug": block_type_slug,
+                    "name": name,
+                },
+                params={"include_secrets": include_secrets},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            raise
+
+        from prefect.client.schemas.objects import BlockDocument
+
+        return BlockDocument.model_validate(response.json())
+
+    async def update_block_document(
+        self, block_document_id: "UUID", block_document: "BlockDocumentUpdate"
+    ) -> None:
+        """Update a block document."""
+        try:
+            await arequest(
+                self._client,
+                "PATCH",
+                "/block_documents/{block_document_id}",
+                path_params={"block_document_id": block_document_id},
+                json=block_document.model_dump(
+                    mode="json",
+                    exclude_unset=True,
+                    include={"data", "merge_existing_data", "block_schema_id"},
+                ),
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            raise
+
+    async def delete_block_document(self, block_document_id: "UUID") -> None:
+        """Delete a block document."""
+        try:
+            await arequest(
+                self._client,
+                "DELETE",
+                "/block_documents/{block_document_id}",
+                path_params={"block_document_id": block_document_id},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            raise

--- a/src/prefect/client/orchestration/routes.py
+++ b/src/prefect/client/orchestration/routes.py
@@ -18,6 +18,7 @@ ServerRoutes = Literal[
     "/block_documents/{block_document_id}",
     "/block_schemas/",
     "/block_schemas/checksum/{checksum}",
+    "/block_schemas/checksum/{checksum}?version={version}",
     "/block_schemas/filter",
     "/block_types/",
     "/block_types/filter",

--- a/src/prefect/client/orchestration/routes.py
+++ b/src/prefect/client/orchestration/routes.py
@@ -1,0 +1,121 @@
+from typing import Any, Literal, Optional
+
+from httpx import AsyncClient, Client, Response
+
+ServerRoutes = Literal[
+    "/admin/version",
+    "/artifacts/",
+    "/artifacts/filter",
+    "/artifacts/latest/filter",
+    "/artifacts/{artifact_id}",
+    "/automations/",
+    "/automations/filter",
+    "/automations/owned",
+    "/automations/related",
+    "/automations/{automation_id}",
+    "/block_documents/",
+    "/block_documents/filter",
+    "/block_documents/{block_document_id}",
+    "/block_schemas/",
+    "/block_schemas/checksum/{checksum}",
+    "/block_schemas/filter",
+    "/block_types/",
+    "/block_types/filter",
+    "/block_types/slug/{block_type_slug}/block_documents",
+    "/block_types/slug/{block_type_slug}/block_documents/name/{name}",
+    "/block_types/slug/{slug}",
+    "/block_types/{block_type_id}",
+    "/concurrency_limits/",
+    "/concurrency_limits/decrement",
+    "/concurrency_limits/filter",
+    "/concurrency_limits/increment",
+    "/concurrency_limits/tag/{tag}",
+    "/concurrency_limits/tag/{tag}/reset",
+    "/deployments/",
+    "/deployments/filter",
+    "/deployments/get_scheduled_flow_runs",
+    "/deployments/name/{name}",
+    "/deployments/{deployment_id}",
+    "/deployments/{deployment_id}/create_flow_run",
+    "/deployments/{deployment_id}/schedules",
+    "/deployments/{deployment_id}/schedules/{schedule_id}",
+    "/flow_run_notification_policies/",
+    "/flow_run_notification_policies/filter",
+    "/flow_run_notification_policies/{id}",
+    "/flow_run_states/",
+    "/flow_runs/",
+    "/flow_runs/filter",
+    "/flow_runs/{flow_run_id}",
+    "/flow_runs/{flow_run_id}/input",
+    "/flow_runs/{flow_run_id}/input/filter",
+    "/flow_runs/{flow_run_id}/input/{key}",
+    "/flow_runs/{flow_run_id}/labels",
+    "/flow_runs/{flow_run_id}/resume",
+    "/flow_runs/{flow_run_id}/set_state",
+    "/flows/",
+    "/flows/filter",
+    "/flows/name/{flow_name}",
+    "/flows/{flow_id}",
+    "/health",
+    "/hello",
+    "/logs/",
+    "/logs/filter",
+    "/task_run_states/",
+    "/task_runs/",
+    "/task_runs/filter",
+    "/task_runs/{task_run_id}",
+    "/task_runs/{task_run_id}/set_state",
+    "/v2/concurrency_limits/",
+    "/v2/concurrency_limits/decrement",
+    "/v2/concurrency_limits/filter",
+    "/v2/concurrency_limits/increment",
+    "/v2/concurrency_limits/{name}",
+    "/variables/",
+    "/variables/filter",
+    "/variables/name/{name}",
+    "/variables/name/{variable",
+    "/work_pools/",
+    "/work_pools/filter",
+    "/work_pools/{work_pool",
+    "/work_pools/{work_pool_name}",
+    "/work_pools/{work_pool_name}/get_scheduled_flow_runs",
+    "/work_pools/{work_pool_name}/queues",
+    "/work_pools/{work_pool_name}/queues/filter",
+    "/work_pools/{work_pool_name}/queues/{name}",
+    "/work_pools/{work_pool_name}/workers/filter",
+    "/work_pools/{work_pool_name}/workers/heartbeat",
+    "/work_queues/",
+    "/work_queues/filter",
+    "/work_queues/name/{name}",
+    "/work_queues/{id}",
+    "/work_queues/{id}/get_runs",
+    "/work_queues/{id}/status",
+]
+
+SERVER_ROUTE_METHODS: dict[
+    ServerRoutes, list[Literal["GET", "POST", "PUT", "DELETE"]]
+] = {}
+
+
+def request(
+    client: Client,
+    method: Literal["GET", "POST", "PUT", "DELETE", "PATCH"],
+    path: ServerRoutes,
+    path_params: Optional[dict[str, Any]] = None,
+    **kwargs: Any,
+) -> Response:
+    if path_params:
+        path = path.format(**path_params)  # type: ignore
+    return client.request(method, path, **kwargs)
+
+
+async def arequest(
+    client: AsyncClient,
+    method: Literal["GET", "POST", "PUT", "DELETE", "PATCH"],
+    path: ServerRoutes,
+    path_params: Optional[dict[str, Any]] = None,
+    **kwargs: Any,
+) -> Response:
+    if path_params:
+        path = path.format(**path_params)  # type: ignore
+    return await client.request(method, path, **kwargs)

--- a/src/prefect/utilities/generics.py
+++ b/src/prefect/utilities/generics.py
@@ -1,4 +1,3 @@
-from importlib import import_module
 from typing import Any, Callable, TypeVar
 
 from pydantic import BaseModel

--- a/src/prefect/utilities/generics.py
+++ b/src/prefect/utilities/generics.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Any, Callable, TypeVar
 
 from pydantic import BaseModel
@@ -19,4 +20,4 @@ def validate_list(model: type[T], input: Any) -> list[T]:
 
 
 def ListAdapter(model: type[T]) -> Callable[[Any], list[T]]:
-    return lambda input: validate_list(model, input)
+    return partial(validate_list, model=model)

--- a/src/prefect/utilities/generics.py
+++ b/src/prefect/utilities/generics.py
@@ -16,9 +16,7 @@ ListValidator = SchemaValidator(
 
 
 def validate_list(model: type[T], input: Any) -> list[T]:
-    return [
-        model.model_validate(**item) for item in ListValidator.validate_python(input)
-    ]
+    return [model.model_validate(item) for item in ListValidator.validate_python(input)]
 
 
 def ListAdapter(model: type[T]) -> Callable[[Any], list[T]]:

--- a/src/prefect/utilities/generics.py
+++ b/src/prefect/utilities/generics.py
@@ -1,0 +1,25 @@
+from importlib import import_module
+from typing import Any, Callable, TypeVar
+
+from pydantic import BaseModel
+from pydantic_core import SchemaValidator, core_schema
+
+T = TypeVar("T", bound=BaseModel)
+
+ListValidator = SchemaValidator(
+    schema=core_schema.list_schema(
+        items_schema=core_schema.dict_schema(
+            keys_schema=core_schema.str_schema(), values_schema=core_schema.any_schema()
+        )
+    )
+)
+
+
+def validate_list(model: type[T], input: Any) -> list[T]:
+    return [
+        model.model_validate(**item) for item in ListValidator.validate_python(input)
+    ]
+
+
+def ListAdapter(model: type[T]) -> Callable[[Any], list[T]]:
+    return lambda input: validate_list(model, input)


### PR DESCRIPTION
Related to #16472 this PR builds on (and follows the patterns of) #16496 to reduce the memory footprint of importing PrefectClient from 34MB to 29.9MB. This represents a 10% reduction in footprint from #16496 and 12% reduction from where we started. 