### PR TITLE
[UI v2] feat: Have Breadcrumb link be connected with tanstack router

### DIFF
--- a/ui-v2/src/components/concurrency/task-run-concurrency-limits/task-run-concurrency-limit-header/nav-header.tsx
+++ b/ui-v2/src/components/concurrency/task-run-concurrency-limits/task-run-concurrency-limit-header/nav-header.tsx
@@ -6,7 +6,6 @@ import {
 	BreadcrumbPage,
 	BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
-import { Link } from "@tanstack/react-router";
 
 type Props = {
 	tag: string;
@@ -17,8 +16,11 @@ export const NavHeader = ({ tag }: Props) => {
 		<div className="flex items-center gap-2">
 			<Breadcrumb>
 				<BreadcrumbList>
-					<BreadcrumbLink asChild className="text-xl font-semibold">
-						<Link to="/concurrency-limits">Concurrency Limits </Link>
+					<BreadcrumbLink
+						to="/concurrency-limits"
+						className="text-xl font-semibold"
+					>
+						Concurrency Limits
 					</BreadcrumbLink>
 					<BreadcrumbSeparator />
 					<BreadcrumbItem className="text-xl font-semibold">

--- a/ui-v2/src/components/ui/breadcrumb.tsx
+++ b/ui-v2/src/components/ui/breadcrumb.tsx
@@ -1,5 +1,7 @@
 import { ChevronRightIcon, DotsHorizontalIcon } from "@radix-ui/react-icons";
 import { Slot } from "@radix-ui/react-slot";
+import { createLink } from "@tanstack/react-router";
+
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
@@ -50,20 +52,22 @@ type BreadcrumbLinkProps = React.ComponentPropsWithoutRef<"a"> & {
 	className?: string;
 };
 
-const BreadcrumbLink = React.forwardRef<HTMLAnchorElement, BreadcrumbLinkProps>(
-	({ asChild, className, ...props }, ref) => {
-		const Comp = asChild ? Slot : "a";
+const BreadcrumbLinkComponent = React.forwardRef<
+	HTMLAnchorElement,
+	BreadcrumbLinkProps
+>(({ asChild, className, ...props }, ref) => {
+	const Comp = asChild ? Slot : "a";
 
-		return (
-			<Comp
-				ref={ref}
-				className={cn("transition-colors hover:text-foreground", className)}
-				{...props}
-			/>
-		);
-	},
-);
-BreadcrumbLink.displayName = "BreadcrumbLink";
+	return (
+		<Comp
+			ref={ref}
+			className={cn("transition-colors hover:text-foreground", className)}
+			{...props}
+		/>
+	);
+});
+BreadcrumbLinkComponent.displayName = "BreadcrumbLink";
+const BreadcrumbLink = createLink(BreadcrumbLinkComponent);
 
 type BreadcrumbPageProps = React.ComponentPropsWithoutRef<"span"> & {
 	className?: string;

--- a/ui-v2/src/components/ui/run-card/run-card.tsx
+++ b/ui-v2/src/components/ui/run-card/run-card.tsx
@@ -1,7 +1,7 @@
 import type { components } from "@/api/prefect";
 import {
 	Breadcrumb,
-	BreadcrumbItem,
+	BreadcrumbLink,
 	BreadcrumbList,
 	BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
@@ -10,7 +10,6 @@ import { Icon } from "@/components/ui/icons";
 import { StateBadge } from "@/components/ui/state-badge";
 import { TagBadgeGroup } from "@/components/ui/tag-badge-group";
 import { Typography } from "@/components/ui/typography";
-import { Link } from "@tanstack/react-router";
 import { cva } from "class-variance-authority";
 import { format, parseISO } from "date-fns";
 import humanizeDuration from "humanize-duration";
@@ -81,27 +80,25 @@ const ConcurrencyLimitTaskRunBreadcrumb = ({
 		<Breadcrumb>
 			<BreadcrumbList>
 				{flow && (
-					<BreadcrumbItem className="text-lg font-semibold">
-						<Link to="/flows/flow/$id" params={{ id: flow.id }}>
-							{flow.name}
-						</Link>
-					</BreadcrumbItem>
+					<BreadcrumbLink
+						className="text-lg font-semibold"
+						to="/flows/flow/$id"
+						params={{ id: flow.id }}
+					>
+						{flow.name}
+					</BreadcrumbLink>
 				)}
 				{flow && flowRun && <BreadcrumbSeparator />}
 				{flowRun && (
-					<BreadcrumbItem>
-						<Link to="/runs/flow-run/$id" params={{ id: flowRun.id }}>
-							{flowRun.name}
-						</Link>
-					</BreadcrumbItem>
+					<BreadcrumbLink to="/runs/flow-run/$id" params={{ id: flowRun.id }}>
+						{flowRun.name}
+					</BreadcrumbLink>
 				)}
 				{flowRun && taskRun && <BreadcrumbSeparator />}
 				{taskRun && (
-					<BreadcrumbItem>
-						<Link to="/runs/task-run/$id" params={{ id: taskRun.id }}>
-							{taskRun.name}
-						</Link>
-					</BreadcrumbItem>
+					<BreadcrumbLink to="/runs/task-run/$id" params={{ id: taskRun.id }}>
+						{taskRun.name}
+					</BreadcrumbLink>
 				)}
 			</BreadcrumbList>
 		</Breadcrumb>


### PR DESCRIPTION
1. Updates `BreadcrumbLink` to be usable with `tanstack router`.
2. Update Breadcrumb components to use `BreadcrumbLink` instead of a nested `Link` component

https://tanstack.com/router/latest/docs/framework/react/guide/custom-link

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Relates to https://github.com/PrefectHQ/prefect/issues/15512
