### PR TITLE
feat: Add support for NO_PROXY for websocket connections

### DIFF
--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -109,6 +109,9 @@ class WebsocketProxyConnect(Connect):
         u = urlparse(uri)
         host = u.hostname
 
+        if not host:
+            raise ValueError("Invalid URI %s" % uri)
+
         if u.scheme == "ws":
             port = u.port or 80
             proxy_url = os.environ.get("HTTP_PROXY")
@@ -121,7 +124,11 @@ class WebsocketProxyConnect(Connect):
                 "Unsupported scheme %s. Expected 'ws' or 'wss'. " % u.scheme
             )
 
-        self._proxy = Proxy.from_url(proxy_url) if proxy_url and not _host_matches_no_proxy(host) else None
+        self._proxy = (
+            Proxy.from_url(proxy_url)
+            if proxy_url and not _host_matches_no_proxy(host)
+            else None
+        )
         self._host = host
         self._port = port
 

--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -16,6 +16,7 @@ from typing import (
     cast,
 )
 from urllib.parse import urlparse
+from urllib.request import proxy_bypass
 from uuid import UUID
 
 import orjson
@@ -84,20 +85,6 @@ def events_out_socket_from_api_url(url: str):
     return http_to_ws(url) + "/events/out"
 
 
-def _host_matches_no_proxy(host: str) -> bool:
-    """Checks whether a given host matches NO_PROXY configuration.
-    NO_PROXY entries with a leading dot are treated as domain suffixes, while all others are treated as exact matches.
-    """
-    if no_proxy := os.environ.get("NO_PROXY"):
-        for no_proxy_host in no_proxy.split(","):
-            if no_proxy_host.startswith("."):
-                if host.endswith(no_proxy_host):
-                    return True
-            elif no_proxy_host == host:
-                return True
-    return False
-
-
 class WebsocketProxyConnect(Connect):
     def __init__(self: Self, uri: str, **kwargs: Any):
         # super() is intentionally deferred to the _proxy_connect method
@@ -125,9 +112,7 @@ class WebsocketProxyConnect(Connect):
             )
 
         self._proxy = (
-            Proxy.from_url(proxy_url)
-            if proxy_url and not _host_matches_no_proxy(host)
-            else None
+            Proxy.from_url(proxy_url) if proxy_url and not proxy_bypass(host) else None
         )
         self._host = host
         self._port = port

--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -110,7 +110,7 @@ class WebsocketProxyConnect(Connect):
         host = u.hostname
 
         if not host:
-            raise ValueError("Invalid URI %s" % uri)
+            raise ValueError(f"Invalid URI {uri}, no hostname found")
 
         if u.scheme == "ws":
             port = u.port or 80

--- a/tests/utilities/test_proxy.py
+++ b/tests/utilities/test_proxy.py
@@ -1,4 +1,6 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
+
+import pytest
 
 from prefect.events.clients import WebsocketProxyConnect
 
@@ -32,11 +34,37 @@ def test_init_ws_with_proxy(monkeypatch):
 
 
 def test_init_wss_with_proxy(monkeypatch):
-    monkeypatch.setenv("HTTPS_PROXY", "https://proxy:3128")
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy:3128")
     mock_proxy = Mock()
     monkeypatch.setattr("prefect.events.clients.Proxy", mock_proxy)
 
     client = WebsocketProxyConnect("wss://example.com")
 
-    mock_proxy.from_url.assert_called_once_with("https://proxy:3128")
+    mock_proxy.from_url.assert_called_once_with("http://proxy:3128")
     assert client._proxy is not None
+
+
+@pytest.mark.parametrize("no_proxy", ["example.com", ".com", "example.com,example2.com"])
+def test_init_ws_with_no_proxy(monkeypatch, no_proxy: str):
+    # Validate http proxy is set
+    monkeypatch.setenv("HTTP_PROXY", "http://proxy:3128")
+    client = WebsocketProxyConnect("ws://example.com")
+    assert client._proxy is not None
+
+    # Keeping existing proxy configuration, validate we can disable it with NO_PROXY
+    monkeypatch.setenv("NO_PROXY", no_proxy)
+    client = WebsocketProxyConnect("ws://example.com")
+    assert client._proxy is None
+
+
+@pytest.mark.parametrize("no_proxy", ["example.com", ".com", "example.com,example2.com"])
+def test_init_wss_with_no_proxy(monkeypatch, no_proxy: str):
+    # Validate https proxy is set
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy:3128")
+    client = WebsocketProxyConnect("wss://example.com")
+    assert client._proxy is not None
+
+    # Keeping existing proxy configuration, validate we can disable it with NO_PROXY
+    monkeypatch.setenv("NO_PROXY", no_proxy)
+    client = WebsocketProxyConnect("wss://example.com")
+    assert client._proxy is None

--- a/tests/utilities/test_proxy.py
+++ b/tests/utilities/test_proxy.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -44,7 +44,9 @@ def test_init_wss_with_proxy(monkeypatch):
     assert client._proxy is not None
 
 
-@pytest.mark.parametrize("no_proxy", ["example.com", ".com", "example.com,example2.com"])
+@pytest.mark.parametrize(
+    "no_proxy", ["example.com", ".com", "example.com,example2.com"]
+)
 def test_init_ws_with_no_proxy(monkeypatch, no_proxy: str):
     # Validate http proxy is set
     monkeypatch.setenv("HTTP_PROXY", "http://proxy:3128")
@@ -57,7 +59,9 @@ def test_init_ws_with_no_proxy(monkeypatch, no_proxy: str):
     assert client._proxy is None
 
 
-@pytest.mark.parametrize("no_proxy", ["example.com", ".com", "example.com,example2.com"])
+@pytest.mark.parametrize(
+    "no_proxy", ["example.com", ".com", "example.com,example2.com"]
+)
 def test_init_wss_with_no_proxy(monkeypatch, no_proxy: str):
     # Validate https proxy is set
     monkeypatch.setenv("HTTPS_PROXY", "http://proxy:3128")


### PR DESCRIPTION
In https://github.com/PrefectHQ/prefect/pull/16326 the team added support for HTTP_PROXY & HTTPS_PROXY for the websocket connection used by the agent to submit events (such as task runs).
However in some environments these proxies are necessary to route connection for the flow itself running (i.e. to connect to external in an air gapped environment).
Having the events routed through the proxy might mean they cannot reach the server.

This PR adds basic support for the NO_PROXY variable for the websocket connection, allowing to ignore the proxy for the server connection.


### Checklist
- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- ~~[ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.~~
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

This stemmed from the discussion around https://github.com/PrefectHQ/prefect/issues/15153 and closes https://github.com/PrefectHQ/prefect/issues/16537
