### PR TITLE
fix task overload for decorator kwargs

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1634,9 +1634,7 @@ def task(
     refresh_cache: Optional[bool] = None,
     on_completion: Optional[list[StateHookCallable]] = None,
     on_failure: Optional[list[StateHookCallable]] = None,
-    retry_condition_fn: Optional[
-        Callable[[Task[..., Any], TaskRun, State], bool]
-    ] = None,
+    retry_condition_fn: Optional[Callable[[Task[P, Any], TaskRun, State], bool]] = None,
     viz_return_value: Any = None,
 ) -> Callable[[Callable[P, R]], Task[P, R]]:
     ...
@@ -1673,9 +1671,7 @@ def task(
     refresh_cache: Optional[bool] = None,
     on_completion: Optional[list[StateHookCallable]] = None,
     on_failure: Optional[list[StateHookCallable]] = None,
-    retry_condition_fn: Optional[
-        Callable[[Task[..., Any], TaskRun, State], bool]
-    ] = None,
+    retry_condition_fn: Optional[Callable[[Task[P, Any], TaskRun, State], bool]] = None,
     viz_return_value: Any = None,
 ) -> Callable[[Callable[P, R]], Task[P, R]]:
     ...
@@ -1709,9 +1705,7 @@ def task(
     refresh_cache: Optional[bool] = None,
     on_completion: Optional[list[StateHookCallable]] = None,
     on_failure: Optional[list[StateHookCallable]] = None,
-    retry_condition_fn: Optional[
-        Callable[[Task[..., Any], TaskRun, State], bool]
-    ] = None,
+    retry_condition_fn: Optional[Callable[[Task[P, Any], TaskRun, State], bool]] = None,
     viz_return_value: Any = None,
 ):
     """

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1608,6 +1608,7 @@ def task(__fn: Callable[P, R]) -> Task[P, R]:
 @overload
 def task(
     __fn: Literal[None] = None,
+    cache_policy: Any = None,
 ) -> Callable[[Callable[P, R]], Task[P, R]]:
     ...
 

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1608,7 +1608,33 @@ def task(__fn: Callable[P, R]) -> Task[P, R]:
 @overload
 def task(
     __fn: Literal[None] = None,
-    cache_policy: Any = None,
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    tags: Optional[Iterable[str]] = None,
+    version: Optional[str] = None,
+    cache_policy: Union[CachePolicy, type[NotSet]] = NotSet,
+    cache_key_fn: Optional[
+        Callable[["TaskRunContext", dict[str, Any]], Optional[str]]
+    ] = None,
+    cache_expiration: Optional[datetime.timedelta] = None,
+    task_run_name: Optional[TaskRunNameValueOrCallable] = None,
+    retries: int = 0,
+    retry_delay_seconds: Union[
+        float, int, list[float], Callable[[int], list[float]], None
+    ] = None,
+    retry_jitter_factor: Optional[float] = None,
+    persist_result: Optional[bool] = None,
+    result_storage: Optional[ResultStorage] = None,
+    result_storage_key: Optional[str] = None,
+    result_serializer: Optional[ResultSerializer] = None,
+    cache_result_in_memory: bool = True,
+    timeout_seconds: Union[int, float, None] = None,
+    log_prints: Optional[bool] = None,
+    refresh_cache: Optional[bool] = None,
+    on_completion: Optional[list[StateHookCallable]] = None,
+    on_failure: Optional[list[StateHookCallable]] = None,
+    viz_return_value: Any = None,
 ) -> Callable[[Callable[P, R]], Task[P, R]]:
     ...
 

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1634,12 +1634,15 @@ def task(
     refresh_cache: Optional[bool] = None,
     on_completion: Optional[list[StateHookCallable]] = None,
     on_failure: Optional[list[StateHookCallable]] = None,
+    retry_condition_fn: Optional[
+        Callable[[Task[..., Any], TaskRun, State], bool]
+    ] = None,
     viz_return_value: Any = None,
 ) -> Callable[[Callable[P, R]], Task[P, R]]:
     ...
 
 
-@overload
+@overload  # TODO: do we need this overload?
 def task(
     *,
     name: Optional[str] = None,
@@ -1670,7 +1673,9 @@ def task(
     refresh_cache: Optional[bool] = None,
     on_completion: Optional[list[StateHookCallable]] = None,
     on_failure: Optional[list[StateHookCallable]] = None,
-    retry_condition_fn: Optional[Callable[["Task[P, R]", TaskRun, State], bool]] = None,
+    retry_condition_fn: Optional[
+        Callable[[Task[..., Any], TaskRun, State], bool]
+    ] = None,
     viz_return_value: Any = None,
 ) -> Callable[[Callable[P, R]], Task[P, R]]:
     ...
@@ -1704,7 +1709,9 @@ def task(
     refresh_cache: Optional[bool] = None,
     on_completion: Optional[list[StateHookCallable]] = None,
     on_failure: Optional[list[StateHookCallable]] = None,
-    retry_condition_fn: Optional[Callable[["Task[P, R]", TaskRun, State], bool]] = None,
+    retry_condition_fn: Optional[
+        Callable[[Task[..., Any], TaskRun, State], bool]
+    ] = None,
     viz_return_value: Any = None,
 ):
     """


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/16502


an example like this will complain on `main` about the return value of the task being `None` if `cache_policy=NONE`. the same being true for any kwarg of the task decorator

this PR fixes the typing - its possible the third overload is now not necessary, but we can remove this later as needed

```python
import asyncio

from prefect import flow, task
from prefect.cache_policies import NONE


@task(cache_policy=NONE)
def a_task() -> int:
    return 1


@flow
def a_flow() -> int:
    return a_task()


@task(cache_policy=NONE)
async def an_async_task() -> int:
    return 1


@flow
async def an_async_flow() -> int:
    return await an_async_task()


if __name__ == "__main__":
    a_flow()
    asyncio.run(an_async_flow())
```