### PR TITLE
fix overloads for `wait_for` and `return_state` in  `Task.__call__`

### DIFF
--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -13,7 +13,6 @@ from typing import (
     AsyncGenerator,
     Callable,
     Coroutine,
-    Dict,
     Generator,
     Generic,
     Iterable,
@@ -109,11 +108,11 @@ class TaskRunTimeoutError(TimeoutError):
 class BaseTaskRunEngine(Generic[P, R]):
     task: Union[Task[P, R], Task[P, Coroutine[Any, Any, R]]]
     logger: logging.Logger = field(default_factory=lambda: get_logger("engine"))
-    parameters: Optional[Dict[str, Any]] = None
+    parameters: Optional[dict[str, Any]] = None
     task_run: Optional[TaskRun] = None
     retries: int = 0
-    wait_for: Optional[Iterable[PrefectFuture]] = None
-    context: Optional[Dict[str, Any]] = None
+    wait_for: Optional[Iterable[PrefectFuture[Any]]] = None
+    context: Optional[dict[str, Any]] = None
     # holds the return value from the user code
     _return_value: Union[R, Type[NotSet]] = NotSet
     # holds the exception raised by the user code, if any
@@ -660,7 +659,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
     def initialize_run(
         self,
         task_run_id: Optional[UUID] = None,
-        dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
+        dependencies: Optional[dict[str, Set[TaskRunInput]]] = None,
     ) -> Generator["SyncTaskRunEngine", Any, Any]:
         """
         Enters a client context and creates a task run if needed.
@@ -753,7 +752,7 @@ class SyncTaskRunEngine(BaseTaskRunEngine[P, R]):
     def start(
         self,
         task_run_id: Optional[UUID] = None,
-        dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
+        dependencies: Optional[dict[str, Set[TaskRunInput]]] = None,
     ) -> Generator[None, None, None]:
         with self.initialize_run(task_run_id=task_run_id, dependencies=dependencies):
             with (
@@ -1201,7 +1200,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
     async def initialize_run(
         self,
         task_run_id: Optional[UUID] = None,
-        dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
+        dependencies: Optional[dict[str, Set[TaskRunInput]]] = None,
     ) -> AsyncGenerator["AsyncTaskRunEngine", Any]:
         """
         Enters a client context and creates a task run if needed.
@@ -1292,7 +1291,7 @@ class AsyncTaskRunEngine(BaseTaskRunEngine[P, R]):
     async def start(
         self,
         task_run_id: Optional[UUID] = None,
-        dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
+        dependencies: Optional[dict[str, Set[TaskRunInput]]] = None,
     ) -> AsyncGenerator[None, None]:
         async with self.initialize_run(
             task_run_id=task_run_id, dependencies=dependencies
@@ -1381,11 +1380,11 @@ def run_task_sync(
     task: Task[P, R],
     task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
-    parameters: Optional[Dict[str, Any]] = None,
+    parameters: Optional[dict[str, Any]] = None,
     wait_for: Optional[Iterable[PrefectFuture[R]]] = None,
     return_type: Literal["state", "result"] = "result",
-    dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
-    context: Optional[Dict[str, Any]] = None,
+    dependencies: Optional[dict[str, Set[TaskRunInput]]] = None,
+    context: Optional[dict[str, Any]] = None,
 ) -> Union[R, State, None]:
     engine = SyncTaskRunEngine[P, R](
         task=task,
@@ -1408,11 +1407,11 @@ async def run_task_async(
     task: Task[P, R],
     task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
-    parameters: Optional[Dict[str, Any]] = None,
+    parameters: Optional[dict[str, Any]] = None,
     wait_for: Optional[Iterable[PrefectFuture[R]]] = None,
     return_type: Literal["state", "result"] = "result",
-    dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
-    context: Optional[Dict[str, Any]] = None,
+    dependencies: Optional[dict[str, Set[TaskRunInput]]] = None,
+    context: Optional[dict[str, Any]] = None,
 ) -> Union[R, State, None]:
     engine = AsyncTaskRunEngine[P, R](
         task=task,
@@ -1435,11 +1434,11 @@ def run_generator_task_sync(
     task: Task[P, R],
     task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
-    parameters: Optional[Dict[str, Any]] = None,
+    parameters: Optional[dict[str, Any]] = None,
     wait_for: Optional[Iterable[PrefectFuture[R]]] = None,
     return_type: Literal["state", "result"] = "result",
-    dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
-    context: Optional[Dict[str, Any]] = None,
+    dependencies: Optional[dict[str, Set[TaskRunInput]]] = None,
+    context: Optional[dict[str, Any]] = None,
 ) -> Generator[R, None, None]:
     if return_type != "result":
         raise ValueError("The return_type for a generator task must be 'result'")
@@ -1490,11 +1489,11 @@ async def run_generator_task_async(
     task: Task[P, R],
     task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
-    parameters: Optional[Dict[str, Any]] = None,
+    parameters: Optional[dict[str, Any]] = None,
     wait_for: Optional[Iterable[PrefectFuture[R]]] = None,
     return_type: Literal["state", "result"] = "result",
-    dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
-    context: Optional[Dict[str, Any]] = None,
+    dependencies: Optional[dict[str, Set[TaskRunInput]]] = None,
+    context: Optional[dict[str, Any]] = None,
 ) -> AsyncGenerator[R, None]:
     if return_type != "result":
         raise ValueError("The return_type for a generator task must be 'result'")
@@ -1546,11 +1545,11 @@ def run_task(
     task: Task[P, Union[R, Coroutine[Any, Any, R]]],
     task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
-    parameters: Optional[Dict[str, Any]] = None,
+    parameters: Optional[dict[str, Any]] = None,
     wait_for: Optional[Iterable[PrefectFuture[R]]] = None,
     return_type: Literal["state", "result"] = "result",
-    dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
-    context: Optional[Dict[str, Any]] = None,
+    dependencies: Optional[dict[str, Set[TaskRunInput]]] = None,
+    context: Optional[dict[str, Any]] = None,
 ) -> Union[R, State, None, Coroutine[Any, Any, Union[R, State, None]]]:
     """
     Runs the provided task.

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -103,8 +103,7 @@ class TaskRunTimeoutError(TimeoutError):
     """Raised when a task run exceeds its timeout."""
 
 
-_ResultOrFuture: TypeAlias = Union[PrefectFuture[Any], Any]
-_OneOrManyResultOrFuture: TypeAlias = Union[_ResultOrFuture, Iterable[_ResultOrFuture]]
+_FutureOrResult: TypeAlias = Union[PrefectFuture[Any], Any]
 
 
 @dataclass
@@ -114,7 +113,7 @@ class BaseTaskRunEngine(Generic[P, R]):
     parameters: Optional[dict[str, Any]] = None
     task_run: Optional[TaskRun] = None
     retries: int = 0
-    wait_for: Optional[_OneOrManyResultOrFuture] = None
+    wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None
     context: Optional[dict[str, Any]] = None
     # holds the return value from the user code
     _return_value: Union[R, Type[NotSet]] = NotSet
@@ -1384,7 +1383,7 @@ def run_task_sync(
     task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[dict[str, Any]] = None,
-    wait_for: Optional[_OneOrManyResultOrFuture] = None,
+    wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None,
     return_type: Literal["state", "result"] = "result",
     dependencies: Optional[dict[str, set[TaskRunInput]]] = None,
     context: Optional[dict[str, Any]] = None,
@@ -1411,7 +1410,7 @@ async def run_task_async(
     task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[dict[str, Any]] = None,
-    wait_for: Optional[_OneOrManyResultOrFuture] = None,
+    wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None,
     return_type: Literal["state", "result"] = "result",
     dependencies: Optional[dict[str, set[TaskRunInput]]] = None,
     context: Optional[dict[str, Any]] = None,
@@ -1438,7 +1437,7 @@ def run_generator_task_sync(
     task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[dict[str, Any]] = None,
-    wait_for: Optional[_OneOrManyResultOrFuture] = None,
+    wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None,
     return_type: Literal["state", "result"] = "result",
     dependencies: Optional[dict[str, set[TaskRunInput]]] = None,
     context: Optional[dict[str, Any]] = None,
@@ -1493,7 +1492,7 @@ async def run_generator_task_async(
     task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[dict[str, Any]] = None,
-    wait_for: Optional[_OneOrManyResultOrFuture] = None,
+    wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None,
     return_type: Literal["state", "result"] = "result",
     dependencies: Optional[dict[str, set[TaskRunInput]]] = None,
     context: Optional[dict[str, Any]] = None,
@@ -1549,7 +1548,7 @@ def run_task(
     task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[dict[str, Any]] = None,
-    wait_for: Optional[_OneOrManyResultOrFuture] = None,
+    wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None,
     return_type: Literal["state", "result"] = "result",
     dependencies: Optional[dict[str, set[TaskRunInput]]] = None,
     context: Optional[dict[str, Any]] = None,

--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -15,7 +15,6 @@ from typing import (
     Coroutine,
     Generator,
     Generic,
-    Iterable,
     Literal,
     Optional,
     Sequence,
@@ -28,9 +27,8 @@ from uuid import UUID
 import anyio
 import pendulum
 from opentelemetry import trace
-from typing_extensions import ParamSpec, TypeAlias
+from typing_extensions import ParamSpec
 
-from prefect import Task
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient, get_client
 from prefect.client.schemas import TaskRun
 from prefect.client.schemas.objects import State, TaskRunInput
@@ -53,7 +51,6 @@ from prefect.exceptions import (
     TerminationSignal,
     UpstreamTaskError,
 )
-from prefect.futures import PrefectFuture
 from prefect.logging.loggers import get_logger, patch_print, task_run_logger
 from prefect.results import (
     BaseResult,
@@ -78,6 +75,7 @@ from prefect.states import (
     exception_to_failed_state,
     return_value_to_state,
 )
+from prefect.tasks import OneOrManyFutureOrResult, Task
 from prefect.telemetry.run_telemetry import RunTelemetry
 from prefect.transactions import IsolationLevel, Transaction, transaction
 from prefect.utilities._engine import get_hook_name
@@ -103,9 +101,6 @@ class TaskRunTimeoutError(TimeoutError):
     """Raised when a task run exceeds its timeout."""
 
 
-_FutureOrResult: TypeAlias = Union[PrefectFuture[Any], Any]
-
-
 @dataclass
 class BaseTaskRunEngine(Generic[P, R]):
     task: Union[Task[P, R], Task[P, Coroutine[Any, Any, R]]]
@@ -113,7 +108,7 @@ class BaseTaskRunEngine(Generic[P, R]):
     parameters: Optional[dict[str, Any]] = None
     task_run: Optional[TaskRun] = None
     retries: int = 0
-    wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None
+    wait_for: Optional[OneOrManyFutureOrResult[Any]] = None
     context: Optional[dict[str, Any]] = None
     # holds the return value from the user code
     _return_value: Union[R, Type[NotSet]] = NotSet
@@ -1383,7 +1378,7 @@ def run_task_sync(
     task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[dict[str, Any]] = None,
-    wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None,
+    wait_for: Optional[OneOrManyFutureOrResult[Any]] = None,
     return_type: Literal["state", "result"] = "result",
     dependencies: Optional[dict[str, set[TaskRunInput]]] = None,
     context: Optional[dict[str, Any]] = None,
@@ -1410,7 +1405,7 @@ async def run_task_async(
     task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[dict[str, Any]] = None,
-    wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None,
+    wait_for: Optional[OneOrManyFutureOrResult[Any]] = None,
     return_type: Literal["state", "result"] = "result",
     dependencies: Optional[dict[str, set[TaskRunInput]]] = None,
     context: Optional[dict[str, Any]] = None,
@@ -1437,7 +1432,7 @@ def run_generator_task_sync(
     task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[dict[str, Any]] = None,
-    wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None,
+    wait_for: Optional[OneOrManyFutureOrResult[Any]] = None,
     return_type: Literal["state", "result"] = "result",
     dependencies: Optional[dict[str, set[TaskRunInput]]] = None,
     context: Optional[dict[str, Any]] = None,
@@ -1492,7 +1487,7 @@ async def run_generator_task_async(
     task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[dict[str, Any]] = None,
-    wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None,
+    wait_for: Optional[OneOrManyFutureOrResult[Any]] = None,
     return_type: Literal["state", "result"] = "result",
     dependencies: Optional[dict[str, set[TaskRunInput]]] = None,
     context: Optional[dict[str, Any]] = None,
@@ -1548,7 +1543,7 @@ def run_task(
     task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[dict[str, Any]] = None,
-    wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None,
+    wait_for: Optional[OneOrManyFutureOrResult[Any]] = None,
     return_type: Literal["state", "result"] = "result",
     dependencies: Optional[dict[str, set[TaskRunInput]]] = None,
     context: Optional[dict[str, Any]] = None,

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -977,21 +977,11 @@ class Task(Generic[P, R]):
     ) -> State[T]:
         ...
 
-    @overload
-    def __call__(
-        self: "Task[P, T]",
-        *args: P.args,
-        return_state: Literal[False],
-        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = None,
-        **kwargs: P.kwargs,
-    ) -> T:
-        ...
-
     def __call__(
         self,
         *args: P.args,
         return_state: bool = False,
-        wait_for: Optional[Iterable[Union[PrefectFuture[R], R]]] = None,
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = None,
         **kwargs: P.kwargs,
     ):
         """

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -962,6 +962,7 @@ class Task(Generic[P, R]):
     def __call__(
         self: "Task[P, T]",
         *args: P.args,
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = None,
         **kwargs: P.kwargs,
     ) -> T:
         ...
@@ -971,15 +972,26 @@ class Task(Generic[P, R]):
         self: "Task[P, T]",
         *args: P.args,
         return_state: Literal[True],
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = None,
         **kwargs: P.kwargs,
     ) -> State[T]:
+        ...
+
+    @overload
+    def __call__(
+        self: "Task[P, T]",
+        *args: P.args,
+        return_state: Literal[False],
+        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = None,
+        **kwargs: P.kwargs,
+    ) -> T:
         ...
 
     def __call__(
         self,
         *args: P.args,
         return_state: bool = False,
-        wait_for: Optional[Iterable[PrefectFuture[R]]] = None,
+        wait_for: Optional[Iterable[Any]] = None,
         **kwargs: P.kwargs,
     ):
         """

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -991,7 +991,7 @@ class Task(Generic[P, R]):
         self,
         *args: P.args,
         return_state: bool = False,
-        wait_for: Optional[Iterable[Any]] = None,
+        wait_for: Optional[Iterable[Union[PrefectFuture[R], R]]] = None,
         **kwargs: P.kwargs,
     ):
         """

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -82,6 +82,9 @@ NUM_CHARS_DYNAMIC_KEY = 8
 
 logger = get_logger("tasks")
 
+_ResultOrFuture: TypeAlias = Union[PrefectFuture[Any], Any]
+_OneOrManyResultOrFuture: TypeAlias = Union[_ResultOrFuture, Iterable[_ResultOrFuture]]
+
 
 def task_input_hash(
     context: "TaskRunContext", arguments: dict[str, Any]
@@ -737,7 +740,7 @@ class Task(Generic[P, R]):
         parameters: Optional[dict[str, Any]] = None,
         flow_run_context: Optional[FlowRunContext] = None,
         parent_task_run_context: Optional[TaskRunContext] = None,
-        wait_for: Optional[Iterable[PrefectFuture[R]]] = None,
+        wait_for: Optional[_OneOrManyResultOrFuture] = None,
         extra_task_inputs: Optional[dict[str, set[TaskRunInput]]] = None,
         deferred: bool = False,
     ) -> TaskRun:
@@ -838,7 +841,7 @@ class Task(Generic[P, R]):
         parameters: Optional[dict[str, Any]] = None,
         flow_run_context: Optional[FlowRunContext] = None,
         parent_task_run_context: Optional[TaskRunContext] = None,
-        wait_for: Optional[Iterable[PrefectFuture[R]]] = None,
+        wait_for: Optional[_OneOrManyResultOrFuture] = None,
         extra_task_inputs: Optional[dict[str, set[TaskRunInput]]] = None,
         deferred: bool = False,
     ) -> TaskRun:
@@ -971,7 +974,7 @@ class Task(Generic[P, R]):
     def __call__(
         self: "Task[P, R]",
         *args: P.args,
-        wait_for: Optional[Iterable[Union[PrefectFuture[Any], Any]]] = None,
+        wait_for: Optional[_OneOrManyResultOrFuture] = None,
         **kwargs: P.kwargs,
     ) -> R:
         ...
@@ -981,7 +984,7 @@ class Task(Generic[P, R]):
         self: "Task[P, R]",
         *args: P.args,
         return_state: Literal[False] = False,
-        wait_for: Optional[Iterable[Union[PrefectFuture[Any], Any]]] = None,
+        wait_for: Optional[_OneOrManyResultOrFuture] = None,
         **kwargs: P.kwargs,
     ) -> R:
         ...

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -82,8 +82,7 @@ NUM_CHARS_DYNAMIC_KEY = 8
 
 logger = get_logger("tasks")
 
-_ResultOrFuture: TypeAlias = Union[PrefectFuture[Any], Any]
-_OneOrManyResultOrFuture: TypeAlias = Union[_ResultOrFuture, Iterable[_ResultOrFuture]]
+_FutureOrResult: TypeAlias = Union[PrefectFuture[Any], Any]
 
 
 def task_input_hash(
@@ -740,7 +739,7 @@ class Task(Generic[P, R]):
         parameters: Optional[dict[str, Any]] = None,
         flow_run_context: Optional[FlowRunContext] = None,
         parent_task_run_context: Optional[TaskRunContext] = None,
-        wait_for: Optional[_OneOrManyResultOrFuture] = None,
+        wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None,
         extra_task_inputs: Optional[dict[str, set[TaskRunInput]]] = None,
         deferred: bool = False,
     ) -> TaskRun:
@@ -841,7 +840,7 @@ class Task(Generic[P, R]):
         parameters: Optional[dict[str, Any]] = None,
         flow_run_context: Optional[FlowRunContext] = None,
         parent_task_run_context: Optional[TaskRunContext] = None,
-        wait_for: Optional[_OneOrManyResultOrFuture] = None,
+        wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None,
         extra_task_inputs: Optional[dict[str, set[TaskRunInput]]] = None,
         deferred: bool = False,
     ) -> TaskRun:
@@ -974,7 +973,7 @@ class Task(Generic[P, R]):
     def __call__(
         self: "Task[P, R]",
         *args: P.args,
-        wait_for: Optional[_OneOrManyResultOrFuture] = None,
+        wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None,
         **kwargs: P.kwargs,
     ) -> R:
         ...
@@ -984,7 +983,7 @@ class Task(Generic[P, R]):
         self: "Task[P, R]",
         *args: P.args,
         return_state: Literal[False] = False,
-        wait_for: Optional[_OneOrManyResultOrFuture] = None,
+        wait_for: Optional[Union[_FutureOrResult, Iterable[_FutureOrResult]]] = None,
         **kwargs: P.kwargs,
     ) -> R:
         ...

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -960,30 +960,39 @@ class Task(Generic[P, R]):
 
     @overload
     def __call__(
-        self: "Task[P, T]",
+        self: "Task[P, R]",
         *args: P.args,
-        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = None,
+        return_state: Literal[True],
         **kwargs: P.kwargs,
-    ) -> T:
+    ) -> State[R]:
         ...
 
     @overload
     def __call__(
-        self: "Task[P, T]",
+        self: "Task[P, R]",
         *args: P.args,
-        return_state: Literal[True],
-        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = None,
+        wait_for: Optional[Iterable[Union[PrefectFuture[Any], Any]]] = None,
         **kwargs: P.kwargs,
-    ) -> State[T]:
+    ) -> R:
+        ...
+
+    @overload
+    def __call__(
+        self: "Task[P, R]",
+        *args: P.args,
+        return_state: Literal[False] = False,
+        wait_for: Optional[Iterable[Union[PrefectFuture[Any], Any]]] = None,
+        **kwargs: P.kwargs,
+    ) -> R:
         ...
 
     def __call__(
         self,
         *args: P.args,
         return_state: bool = False,
-        wait_for: Optional[Iterable[Union[PrefectFuture[T], T]]] = None,
+        wait_for: Optional[Iterable[Any]] = None,
         **kwargs: P.kwargs,
-    ):
+    ) -> Union[R, State[R]]:
         """
         Run the task and return the result. If `return_state` is True returns
         the result is wrapped in a Prefect State which provides error handling.
@@ -1687,10 +1696,10 @@ def task(
             callable that, given the total number of retries, generates a list of retry
             delays. If a number of seconds, that delay will be applied to all retries.
             If a list, each retry will wait for the corresponding delay before retrying.
-            When passing a callable or a list, the number of configured retry delays
-            cannot exceed 50.
-        retry_jitter_factor: An optional factor that defines the factor to which a retry
-            can be jittered in order to avoid a "thundering herd".
+            When passing a callable or a list, the number of
+            configured retry delays cannot exceed 50.
+        retry_jitter_factor: An optional factor that defines the factor to which a
+            retry can be jittered in order to avoid a "thundering herd".
         persist_result: A toggle indicating whether the result of this task
             should be persisted to result storage. Defaults to `None`, which
             indicates that the global default should be used (which is `True` by


### PR DESCRIPTION
adds an overload to make the type checker handle `wait_for` when calling tasks directly, pyright complains on main

also makes various `Dict` -> `dict` changes and adds a private alias to make the overloads as shown by IDE easier to grok

## main

![image](https://github.com/user-attachments/assets/f672f6b4-8074-4af7-b90a-da74fb68d998)


## this branch

![image](https://github.com/user-attachments/assets/04e73a69-fa62-4d53-ae0c-38f6fa1a80e6)

### example

```python
from prefect import flow, task


@task
def double(x: int) -> int:
    return x * 2


@task
def cast_to_float(x: int) -> float:
    return float(x)


@flow
def flow_with_task() -> float:
    result = double(1)
    other_result = cast_to_float(2, wait_for=[result])
    state = cast_to_float(3, wait_for=[other_result], return_state=True)
    last_value = cast_to_float(4, wait_for=[state.result()], return_state=False)
    return last_value
```