### PR TITLE
[UI v2] chore: Clean out id field type check after schema got fixed

### DIFF
--- a/ui-v2/src/components/concurrency/global-concurrency-limits/global-concurrency-limits-data-table/actions-cell.tsx
+++ b/ui-v2/src/components/concurrency/global-concurrency-limits/global-concurrency-limits-data-table/actions-cell.tsx
@@ -19,10 +19,7 @@ type Props = CellContext<GlobalConcurrencyLimit, unknown> & {
 export const ActionsCell = ({ onEditRow, onDeleteRow, ...props }: Props) => {
 	const { toast } = useToast();
 
-	const handleCopyId = (id: string | undefined) => {
-		if (!id) {
-			throw new Error("'id' field expected in GlobalConcurrencyLimit");
-		}
+	const handleCopyId = (id: string) => {
 		void navigator.clipboard.writeText(id);
 		toast({ title: "ID copied" });
 	};

--- a/ui-v2/src/components/concurrency/global-concurrency-limits/global-concurrency-limits-data-table/active-cell.tsx
+++ b/ui-v2/src/components/concurrency/global-concurrency-limits/global-concurrency-limits-data-table/active-cell.tsx
@@ -13,11 +13,7 @@ export const ActiveCell = (
 	const { toast } = useToast();
 	const { updateGlobalConcurrencyLimit } = useUpdateGlobalConcurrencyLimit();
 
-	const handleCheckedChange = (checked: boolean, id: string | undefined) => {
-		if (!id) {
-			throw new Error("Expecting 'id' of global concurrency limit");
-		}
-
+	const handleCheckedChange = (checked: boolean, id: string) => {
 		updateGlobalConcurrencyLimit(
 			{
 				id_or_name: id,

--- a/ui-v2/src/components/concurrency/task-run-concurrency-limits/task-run-concurrency-limits-actions-menu/task-run-concurrency-limits-actions-menu.tsx
+++ b/ui-v2/src/components/concurrency/task-run-concurrency-limits/task-run-concurrency-limits-actions-menu/task-run-concurrency-limits-actions-menu.tsx
@@ -10,7 +10,7 @@ import { Icon } from "@/components/ui/icons";
 import { useToast } from "@/hooks/use-toast";
 
 type Props = {
-	id: string | undefined;
+	id: string;
 	onDelete: () => void;
 	onReset: () => void;
 };
@@ -22,10 +22,7 @@ export const TaskRunConcurrencyLimitsActionsMenu = ({
 }: Props) => {
 	const { toast } = useToast();
 
-	const handleCopyId = (id: string | undefined) => {
-		if (!id) {
-			throw new Error("'id' field expected in GlobalConcurrencyLimit");
-		}
+	const handleCopyId = (id: string) => {
 		void navigator.clipboard.writeText(id);
 		toast({ title: "ID copied" });
 	};

--- a/ui-v2/src/components/concurrency/task-run-concurrency-limits/task-run-concurrency-limits-data-table/tag-cell.tsx
+++ b/ui-v2/src/components/concurrency/task-run-concurrency-limits/task-run-concurrency-limits-data-table/tag-cell.tsx
@@ -7,9 +7,6 @@ type Props = CellContext<TaskRunConcurrencyLimit, string>;
 export const TagCell = (props: Props) => {
 	const tag = props.getValue();
 	const id = props.row.original.id;
-	if (!id) {
-		throw new Error("Expecting 'id' field");
-	}
 	return (
 		<Link params={{ id }} to={"/concurrency-limits/concurrency-limit/$id"}>
 			{tag}

--- a/ui-v2/src/components/concurrency/task-run-concurrency-limits/task-run-concurrency-limits-delete-dialog/task-run-concurrency-limits-delete-dialog.tsx
+++ b/ui-v2/src/components/concurrency/task-run-concurrency-limits/task-run-concurrency-limits-delete-dialog/task-run-concurrency-limits-delete-dialog.tsx
@@ -29,10 +29,7 @@ export const TaskRunConcurrencyLimitsDeleteDialog = ({
 	const { deleteTaskRunConcurrencyLimit, isPending } =
 		useDeleteTaskRunConcurrencyLimit();
 
-	const handleOnClick = (id: string | undefined) => {
-		if (!id) {
-			throw new Error("'id' field expected in GlobalConcurrencyLimit");
-		}
+	const handleOnClick = (id: string) => {
 		deleteTaskRunConcurrencyLimit(id, {
 			onSuccess: () => {
 				toast({ description: "Concurrency limit deleted" });


### PR DESCRIPTION
After the schema for concurrency limits got fixed such that `id` is expected, cleans out the falsey checks for type checking


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
