### PR TITLE
avoid `Path` interpreting `.` in deployment names as the beginning of a file extension

### DIFF
--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -41,6 +41,7 @@ from pydantic import (
     ConfigDict,
     Field,
     PrivateAttr,
+    field_validator,
     model_validator,
 )
 from rich.console import Console
@@ -219,6 +220,14 @@ class RunnerDeployment(BaseModel):
     @property
     def entrypoint_type(self) -> EntrypointType:
         return self._entrypoint_type
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        if value.startswith("."):  # see 16551
+            return value
+
+        return Path(value).stem
 
     @model_validator(mode="after")
     def validate_automation_names(self):
@@ -508,7 +517,7 @@ class RunnerDeployment(BaseModel):
             concurrency_options = None
 
         deployment = cls(
-            name=Path(name).stem,
+            name=name,
             flow_name=flow.name,
             schedules=constructed_schedules,
             concurrency_limit=concurrency_limit,

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -224,10 +224,9 @@ class RunnerDeployment(BaseModel):
     @field_validator("name", mode="before")
     @classmethod
     def validate_name(cls, value: str) -> str:
-        if value.startswith("."):  # see 16551
-            return value
-
-        return Path(value).stem
+        if value.endswith(".py"):
+            return Path(value).stem
+        return value
 
     @model_validator(mode="after")
     def validate_automation_names(self):

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1762,7 +1762,8 @@ class TestRunnerDeployment:
                 ],
             )
 
-    async def test_deployment_name_with_leading_dots(self):
+    async def test_deployment_name_with_dots(self):
+        # regression test for https://github.com/PrefectHQ/prefect/issues/16551
         deployment = RunnerDeployment.from_flow(dummy_flow_1, name="..test-deployment")
         assert deployment.name == "..test-deployment"
 

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1762,6 +1762,10 @@ class TestRunnerDeployment:
                 ],
             )
 
+    async def test_deployment_name_with_leading_dots(self):
+        deployment = RunnerDeployment.from_flow(dummy_flow_1, name="..test-deployment")
+        assert deployment.name == "..test-deployment"
+
 
 class TestServer:
     async def test_healthcheck_fails_as_expected(self):

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1766,6 +1766,11 @@ class TestRunnerDeployment:
         deployment = RunnerDeployment.from_flow(dummy_flow_1, name="..test-deployment")
         assert deployment.name == "..test-deployment"
 
+        deployment2 = RunnerDeployment.from_flow(
+            dummy_flow_1, name="flow-from-my.python.module"
+        )
+        assert deployment2.name == "flow-from-my.python.module"
+
 
 class TestServer:
     async def test_healthcheck_fails_as_expected(self):


### PR DESCRIPTION
closes #16551

though I wouldn't recommend deployment names like `..foo`, we do not explicitly disallow those characters, so we should handle this cleanly