### PR TITLE
fix `fetch_one` and `fetch_many` in `prefect-snowflake`

### DIFF
--- a/src/integrations/prefect-snowflake/prefect_snowflake/database.py
+++ b/src/integrations/prefect-snowflake/prefect_snowflake/database.py
@@ -307,9 +307,7 @@ class SnowflakeConnector(DatabaseBlock):
         )
         new, cursor = self._get_cursor(inputs, cursor_type=cursor_type)
         if new:
-            self.execute(
-                operation, parameters, cursor_type=cursor_type, **execute_kwargs
-            )
+            cursor.execute(operation, params=parameters, **execute_kwargs)
         self.logger.debug("Preparing to fetch a row.")
         return cursor.fetchone()
 
@@ -439,7 +437,7 @@ class SnowflakeConnector(DatabaseBlock):
         )
         new, cursor = self._get_cursor(inputs, cursor_type)
         if new:
-            self.execute(cursor, inputs)
+            cursor.execute(operation, params=parameters, **execute_kwargs)
         size = size or self.fetch_size
         self.logger.debug(f"Preparing to fetch {size} rows.")
         return cursor.fetchmany(size=size)

--- a/src/integrations/prefect-snowflake/tests/test_database.py
+++ b/src/integrations/prefect-snowflake/tests/test_database.py
@@ -295,6 +295,36 @@ class TestSnowflakeConnector:
         mock_cursor.fetchall.assert_called_once()
         assert result == [(1,)]
 
+    def test_fetch_one_executes_directly_on_cursor(
+        self, snowflake_connector: SnowflakeConnector
+    ):
+        """Test that fetch_one executes directly on the cursor instead of using self.execute."""
+        snowflake_connector._start_connection()
+        mock_cursor = MagicMock()
+        snowflake_connector._connection.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = (1,)
+
+        result = snowflake_connector.fetch_one("SELECT 1")
+
+        mock_cursor.execute.assert_called_once_with("SELECT 1", params=None)
+        mock_cursor.fetchone.assert_called_once()
+        assert result == (1,)
+
+    def test_fetch_many_executes_directly_on_cursor(
+        self, snowflake_connector: SnowflakeConnector
+    ):
+        """Test that fetch_many executes directly on the cursor instead of using self.execute."""
+        snowflake_connector._start_connection()
+        mock_cursor = MagicMock()
+        snowflake_connector._connection.cursor.return_value = mock_cursor
+        mock_cursor.fetchmany.return_value = [(1,), (2,)]
+
+        result = snowflake_connector.fetch_many("SELECT 1", size=2)
+
+        mock_cursor.execute.assert_called_once_with("SELECT 1", params=None)
+        mock_cursor.fetchmany.assert_called_once_with(size=2)
+        assert result == [(1,), (2,)]
+
     @pytest.mark.parametrize("fetch_function_name", ["fetch_many", "fetch_many_async"])
     async def test_fetch_many(self, fetch_function_name, snowflake_connector):
         fetch_function = getattr(snowflake_connector, fetch_function_name)


### PR DESCRIPTION
Fixes #15712

The `fetch_one` and `fetch_many` methods were being used incorrectly internally, causing both:
- trying to call `.strip()` on a cursor
- `TypeError: 'NoneType' object is not an iterator`

Here we follow the pattern established in #16511 by ensuring synchronous fetch methods use synchronous execution.

Changes:
- Update `fetch_one` and `fetch_many` to use `cursor.execute()` directly instead of async execution
- Fix parameter name from `parameters` to `params` to match Snowflake's API

The fix ensures the cursor's result iterator is properly initialized before fetch operations.

### example
```python
from prefect_snowflake import SnowflakeConnector

from prefect import flow, task


@task
def fetch_data(block_name: str) -> list[tuple[str]]:
    all_rows: list[tuple[str]] = []
    with SnowflakeConnector.load(block_name) as connector:
        # Simple SELECT that should work on any Snowflake instance
        query = "SELECT 'JxUxzzA9UwMZhRNqknJ9X8' AS id UNION ALL SELECT 'dvXvY4uSYSCX4Wyiaryh3Q' AS id;"

        # Test fetch_one
        print("Testing fetch_one:")
        one_row = connector.fetch_one(query)
        print(f"First row: {one_row}")

        # Test fetch_many
        print("\nTesting fetch_many:")
        new_rows = connector.fetch_many(query, size=2)
        print(f"Both rows: {new_rows}")
        all_rows.append(new_rows)
    return all_rows


@flow(log_prints=True)
def snowflake_flow(block_name: str) -> list[tuple[str]]:
    all_rows = fetch_data(block_name)
    return all_rows


if __name__ == "__main__":
    snowflake_flow("sandbox-troubleshoot-snowflake-connector")
```