### PR TITLE
Refactor Variable CRUD methods in client

### DIFF
--- a/src/prefect/client/orchestration/__init__.py
+++ b/src/prefect/client/orchestration/__init__.py
@@ -153,13 +153,15 @@ def get_client(
     *,
     httpx_settings: Optional[dict[str, Any]] = ...,
     sync_client: Literal[False] = False,
-) -> "PrefectClient": ...
+) -> "PrefectClient":
+    ...
 
 
 @overload
 def get_client(
     *, httpx_settings: Optional[dict[str, Any]] = ..., sync_client: Literal[True] = ...
-) -> "SyncPrefectClient": ...
+) -> "SyncPrefectClient":
+    ...
 
 
 def get_client(

--- a/src/prefect/client/orchestration/_variables/client.py
+++ b/src/prefect/client/orchestration/_variables/client.py
@@ -38,7 +38,9 @@ class VariableClient(BaseClient):
     def read_variable_by_name(self, name: str) -> "Variable | None":
         """Reads a variable by name. Returns None if no variable is found."""
         try:
-            response = self._client.get(f"/variables/name/{name}")
+            response = self.request(
+                "GET", "/variables/name/{name}", path_params={"name": name}
+            )
             from prefect.client.schemas.objects import Variable
 
             return Variable(**response.json())
@@ -50,7 +52,7 @@ class VariableClient(BaseClient):
 
     def read_variables(self, limit: int | None = None) -> list["Variable"]:
         """Reads all variables."""
-        response = self._client.post("/variables/filter", json={"limit": limit})
+        response = self.request("POST", "/variables/filter", json={"limit": limit})
         from prefect.client.schemas.objects import Variable
 
         return Variable.model_validate_list(response.json())
@@ -73,7 +75,11 @@ class VariableClient(BaseClient):
     def delete_variable_by_name(self, name: str) -> None:
         """Deletes a variable by name."""
         try:
-            self._client.delete(f"/variables/name/{name}")
+            self.request(
+                "DELETE",
+                "/variables/name/{name}",
+                path_params={"name": name},
+            )
             return None
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
@@ -96,7 +102,11 @@ class VariableAsyncClient(BaseAsyncClient):
     async def read_variable_by_name(self, name: str) -> "Variable | None":
         """Reads a variable by name. Returns None if no variable is found."""
         try:
-            response = await self._client.get(f"/variables/name/{name}")
+            response = await self.request(
+                "GET",
+                "/variables/name/{name}",
+                path_params={"name": name},
+            )
             from prefect.client.schemas.objects import Variable
 
             return Variable.model_validate(response.json())
@@ -108,7 +118,9 @@ class VariableAsyncClient(BaseAsyncClient):
 
     async def read_variables(self, limit: int | None = None) -> list["Variable"]:
         """Reads all variables."""
-        response = await self._client.post("/variables/filter", json={"limit": limit})
+        response = await self.request(
+            "POST", "/variables/filter", json={"limit": limit}
+        )
         from prefect.client.schemas.objects import Variable
 
         return Variable.model_validate_list(response.json())
@@ -122,8 +134,10 @@ class VariableAsyncClient(BaseAsyncClient):
         Returns:
             Information about the updated variable.
         """
-        await self._client.patch(
-            f"/variables/name/{variable.name}",
+        await self.request(
+            "PATCH",
+            "/variables/name/{name}",
+            path_params={"name": variable.name},
             json=variable.model_dump(mode="json", exclude_unset=True),
         )
         return None
@@ -131,7 +145,11 @@ class VariableAsyncClient(BaseAsyncClient):
     async def delete_variable_by_name(self, name: str) -> None:
         """Deletes a variable by name."""
         try:
-            await self._client.delete(f"/variables/name/{name}")
+            await self.request(
+                "DELETE",
+                "/variables/name/{name}",
+                path_params={"name": name},
+            )
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
                 raise ObjectNotFound(http_exc=e) from e

--- a/src/prefect/client/orchestration/_variables/client.py
+++ b/src/prefect/client/orchestration/_variables/client.py
@@ -43,7 +43,7 @@ class VariableClient(BaseClient):
 
             return Variable(**response.json())
         except httpx.HTTPStatusError as e:
-            if e.response.status_code == status.HTTP_404_NOT_FOUND:
+            if e.response.status_code == 404:
                 return None
             else:
                 raise

--- a/src/prefect/client/orchestration/_variables/client.py
+++ b/src/prefect/client/orchestration/_variables/client.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+
+from prefect.client.orchestration.base import BaseAsyncClient, BaseClient
+from prefect.exceptions import ObjectNotFound
+
+if TYPE_CHECKING:
+    from prefect.client.schemas.actions import (
+        VariableCreate,
+        VariableUpdate,
+    )
+    from prefect.client.schemas.objects import (
+        Variable,
+    )
+
+
+class VariableClient(BaseClient):
+    def create_variable(self, variable: "VariableCreate") -> "Variable":
+        """
+        Creates an variable with the provided configuration.
+
+        Args:
+            variable: Desired configuration for the new variable.
+        Returns:
+            Information about the newly created variable.
+        """
+        response = self._client.post(
+            "/variables/",
+            json=variable.model_dump(mode="json", exclude_unset=True),
+        )
+        from prefect.client.schemas.objects import Variable
+
+        return Variable.model_validate(response.json())
+
+    def read_variable_by_name(self, name: str) -> "Variable | None":
+        """Reads a variable by name. Returns None if no variable is found."""
+        try:
+            response = self._client.get(f"/variables/name/{name}")
+            from prefect.client.schemas.objects import Variable
+
+            return Variable(**response.json())
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == status.HTTP_404_NOT_FOUND:
+                return None
+            else:
+                raise
+
+    def read_variables(self, limit: int | None = None) -> list["Variable"]:
+        """Reads all variables."""
+        response = self._client.post("/variables/filter", json={"limit": limit})
+        from prefect.client.schemas.objects import Variable
+
+        return Variable.model_validate_list(response.json())
+
+    def update_variable(self, variable: "VariableUpdate") -> None:
+        """
+        Updates a variable with the provided configuration.
+
+        Args:
+            variable: Desired configuration for the updated variable.
+        Returns:
+            Information about the updated variable.
+        """
+        self._client.patch(
+            f"/variables/name/{variable.name}",
+            json=variable.model_dump(mode="json", exclude_unset=True),
+        )
+        return None
+
+    def delete_variable_by_name(self, name: str) -> None:
+        """Deletes a variable by name."""
+        try:
+            self._client.delete(f"/variables/name/{name}")
+            return None
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            else:
+                raise
+
+
+class VariableAsyncClient(BaseAsyncClient):
+    async def create_variable(self, variable: "VariableCreate") -> "Variable":
+        """Creates a variable with the provided configuration."""
+        response = await self._client.post(
+            "/variables/",
+            json=variable.model_dump(mode="json", exclude_unset=True),
+        )
+        from prefect.client.schemas.objects import Variable
+
+        return Variable.model_validate(response.json())
+
+    async def read_variable_by_name(self, name: str) -> "Variable | None":
+        """Reads a variable by name. Returns None if no variable is found."""
+        try:
+            response = await self._client.get(f"/variables/name/{name}")
+            from prefect.client.schemas.objects import Variable
+
+            return Variable.model_validate(response.json())
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return None
+            else:
+                raise
+
+    async def read_variables(self, limit: int | None = None) -> list["Variable"]:
+        """Reads all variables."""
+        response = await self._client.post("/variables/filter", json={"limit": limit})
+        from prefect.client.schemas.objects import Variable
+
+        return Variable.model_validate_list(response.json())
+
+    async def update_variable(self, variable: "VariableUpdate") -> None:
+        """
+        Updates a variable with the provided configuration.
+
+        Args:
+            variable: Desired configuration for the updated variable.
+        Returns:
+            Information about the updated variable.
+        """
+        await self._client.patch(
+            f"/variables/name/{variable.name}",
+            json=variable.model_dump(mode="json", exclude_unset=True),
+        )
+        return None
+
+    async def delete_variable_by_name(self, name: str) -> None:
+        """Deletes a variable by name."""
+        try:
+            await self._client.delete(f"/variables/name/{name}")
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            else:
+                raise


### PR DESCRIPTION
Related to #16472, this PR continues the optimization pattern established for Artifacts, though with a smaller impact since Variables is one of our lighter primitives. The memory footprint reduction is negligible in this case, but the PR:

* Refactors the client's Variable CRUD methods into a standalone module
* Uses ForwardRefs for heavy imports, moving them into the call itself

While the memory impact is minimal for Variables specifically, applying this pattern consistently across all primitives will help us reach our optimization targets in #16472. The refactoring maintains full feature parity while improving the module's organization and type safety.

fun fact: our previous async client didn't have a create method, while our sync one didn't have a read_variables method