### PR TITLE
Refactor Log CRUD methods in client

### DIFF
--- a/src/prefect/client/orchestration/__init__.py
+++ b/src/prefect/client/orchestration/__init__.py
@@ -154,13 +154,15 @@ def get_client(
     *,
     httpx_settings: Optional[dict[str, Any]] = ...,
     sync_client: Literal[False] = False,
-) -> "PrefectClient": ...
+) -> "PrefectClient":
+    ...
 
 
 @overload
 def get_client(
     *, httpx_settings: Optional[dict[str, Any]] = ..., sync_client: Literal[True] = ...
-) -> "SyncPrefectClient": ...
+) -> "SyncPrefectClient":
+    ...
 
 
 def get_client(

--- a/src/prefect/client/orchestration/_logs/client.py
+++ b/src/prefect/client/orchestration/_logs/client.py
@@ -30,7 +30,7 @@ class LogClient(BaseClient):
             log.model_dump(mode="json") if isinstance(log, LogCreate) else log
             for log in logs
         ]
-        self._client.post("/logs/", json=serialized_logs)
+        self.request("POST", "/logs/", json=serialized_logs)
 
     def read_logs(
         self,
@@ -48,7 +48,7 @@ class LogClient(BaseClient):
             "offset": offset,
             "sort": sort,
         }
-        response = self._client.post("/logs/filter", json=body)
+        response = self.request("POST", "/logs/filter", json=body)
         from prefect.client.schemas.objects import Log
 
         return Log.model_validate_list(response.json())
@@ -70,7 +70,7 @@ class LogAsyncClient(BaseAsyncClient):
             log.model_dump(mode="json") if isinstance(log, LogCreate) else log
             for log in logs
         ]
-        await self._client.post("/logs/", json=serialized_logs)
+        await self.request("POST", "/logs/", json=serialized_logs)
 
     async def read_logs(
         self,
@@ -89,7 +89,7 @@ class LogAsyncClient(BaseAsyncClient):
             "sort": sort,
         }
 
-        response = await self._client.post("/logs/filter", json=body)
+        response = await self.request("POST", "/logs/filter", json=body)
         from prefect.client.schemas.objects import Log
 
         return Log.model_validate_list(response.json())

--- a/src/prefect/client/orchestration/_logs/client.py
+++ b/src/prefect/client/orchestration/_logs/client.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Union
+
+from prefect.client.orchestration.base import BaseAsyncClient, BaseClient
+from prefect.client.schemas.sorting import (
+    LogSort,
+)
+
+if TYPE_CHECKING:
+    from prefect.client.schemas.actions import (
+        LogCreate,
+    )
+    from prefect.client.schemas.filters import (
+        LogFilter,
+    )
+    from prefect.client.schemas.objects import (
+        Log,
+    )
+
+
+class LogClient(BaseClient):
+    def create_logs(self, logs: Iterable[Union["LogCreate", dict[str, Any]]]) -> None:
+        """
+        Create logs for a flow or task run
+        """
+        from prefect.client.schemas.actions import LogCreate
+
+        serialized_logs = [
+            log.model_dump(mode="json") if isinstance(log, LogCreate) else log
+            for log in logs
+        ]
+        self._client.post("/logs/", json=serialized_logs)
+
+    def read_logs(
+        self,
+        log_filter: Optional["LogFilter"] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        sort: "LogSort" = LogSort.TIMESTAMP_ASC,
+    ) -> list["Log"]:
+        """
+        Read flow and task run logs.
+        """
+        body: dict[str, Any] = {
+            "logs": log_filter.model_dump(mode="json") if log_filter else None,
+            "limit": limit,
+            "offset": offset,
+            "sort": sort,
+        }
+        response = self._client.post("/logs/filter", json=body)
+        from prefect.client.schemas.objects import Log
+
+        return Log.model_validate_list(response.json())
+
+
+class LogAsyncClient(BaseAsyncClient):
+    async def create_logs(
+        self, logs: Iterable[Union["LogCreate", dict[str, Any]]]
+    ) -> None:
+        """
+        Create logs for a flow or task run
+
+        Args:
+            logs: An iterable of `LogCreate` objects or already json-compatible dicts
+        """
+        from prefect.client.schemas.actions import LogCreate
+
+        serialized_logs = [
+            log.model_dump(mode="json") if isinstance(log, LogCreate) else log
+            for log in logs
+        ]
+        await self._client.post("/logs/", json=serialized_logs)
+
+    async def read_logs(
+        self,
+        log_filter: Optional["LogFilter"] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        sort: "LogSort" = LogSort.TIMESTAMP_ASC,
+    ) -> list[Log]:
+        """
+        Read flow and task run logs.
+        """
+        body: dict[str, Any] = {
+            "logs": log_filter.model_dump(mode="json") if log_filter else None,
+            "limit": limit,
+            "offset": offset,
+            "sort": sort,
+        }
+
+        response = await self._client.post("/logs/filter", json=body)
+        from prefect.client.schemas.objects import Log
+
+        return Log.model_validate_list(response.json())


### PR DESCRIPTION
Related to #16472, this PR continues the optimization pattern established for Artifacts. Like the previous PRs, it:
* Refactors the client's Log CR methods into a standalone module
* Uses ForwardRefs for heavy imports, moving them into the call itself
