### PR TITLE
Refactor ConcurrencyLimit CRUD methods in client 

### DIFF
--- a/src/prefect/client/orchestration/__init__.py
+++ b/src/prefect/client/orchestration/__init__.py
@@ -152,13 +152,15 @@ def get_client(
     *,
     httpx_settings: Optional[dict[str, Any]] = ...,
     sync_client: Literal[False] = False,
-) -> "PrefectClient": ...
+) -> "PrefectClient":
+    ...
 
 
 @overload
 def get_client(
     *, httpx_settings: Optional[dict[str, Any]] = ..., sync_client: Literal[True] = ...
-) -> "SyncPrefectClient": ...
+) -> "SyncPrefectClient":
+    ...
 
 
 def get_client(

--- a/src/prefect/client/orchestration/__init__.py
+++ b/src/prefect/client/orchestration/__init__.py
@@ -29,6 +29,8 @@ from prefect.client.orchestration._artifacts.client import (
 from prefect.client.orchestration._concurrency_limits.client import (
     ConcurrencyLimitAsyncClient,
     ConcurrencyLimitClient,
+)
+
 from prefect.client.orchestration._logs.client import (
     LogClient,
     LogAsyncClient,
@@ -252,7 +254,7 @@ class PrefectClient(
     ArtifactCollectionAsyncClient,
     LogAsyncClient,
     VariableAsyncClient,
-    ConcurrencyLimitAsyncClient
+    ConcurrencyLimitAsyncClient,
 ):
     """
     An asynchronous client for interacting with the [Prefect REST API](/api-ref/rest-api/).
@@ -3023,7 +3025,7 @@ class SyncPrefectClient(
     ArtifactCollectionClient,
     LogClient,
     VariableClient,
-    ConcurrencyLimitClient
+    ConcurrencyLimitClient,
 ):
     """
     A synchronous client for interacting with the [Prefect REST API](/api-ref/rest-api/).

--- a/src/prefect/client/orchestration/_concurrency_limits/client.py
+++ b/src/prefect/client/orchestration/_concurrency_limits/client.py
@@ -219,8 +219,8 @@ class ConcurrencyLimitClient(BaseClient):
         Decrement concurrency limit slots for the specified limits.
 
         Args:
-            names (List[str]): A list of limit names to decrement.
-            task_run_id (UUID): The task run ID that incremented the limits.
+            names: A list of limit names to decrement.
+            task_run_id: The task run ID that incremented the limits.
             occupancy_seconds (float): The duration in seconds that the limits
                 were held.
 

--- a/src/prefect/client/orchestration/_concurrency_limits/client.py
+++ b/src/prefect/client/orchestration/_concurrency_limits/client.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from httpx import HTTPStatusError, RequestError
+
+from prefect.client.orchestration.base import BaseAsyncClient, BaseClient
+from prefect.exceptions import ObjectNotFound
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from httpx import Response
+
+    from prefect.client.schemas.actions import ConcurrencyLimitCreate
+    from prefect.client.schemas.objects import ConcurrencyLimit
+
+
+class ConcurrencyLimitClient(BaseClient):
+    def create_concurrency_limit(
+        self,
+        tag: str,
+        concurrency_limit: int,
+    ) -> "UUID":
+        """
+        Create a tag concurrency limit in the Prefect API. These limits govern concurrently
+        running tasks.
+
+        Args:
+            tag: a tag the concurrency limit is applied to
+            concurrency_limit: the maximum number of concurrent task runs for a given tag
+
+        Raises:
+            httpx.RequestError: if the concurrency limit was not created for any reason
+
+        Returns:
+            the ID of the concurrency limit in the backend
+        """
+
+        concurrency_limit_create = ConcurrencyLimitCreate(
+            tag=tag,
+            concurrency_limit=concurrency_limit,
+        )
+        response = self.request(
+            "POST",
+            "/concurrency_limits/",
+            json=concurrency_limit_create.model_dump(mode="json"),
+        )
+
+        concurrency_limit_id = response.json().get("id")
+
+        if not concurrency_limit_id:
+            raise RequestError(f"Malformed response: {response}")
+        from uuid import UUID
+
+        return UUID(concurrency_limit_id)
+
+    def read_concurrency_limit_by_tag(
+        self,
+        tag: str,
+    ) -> "ConcurrencyLimit":
+        """
+        Read the concurrency limit set on a specific tag.
+
+        Args:
+            tag: a tag the concurrency limit is applied to
+
+        Raises:
+            prefect.exceptions.ObjectNotFound: If request returns 404
+            httpx.RequestError: if the concurrency limit was not created for any reason
+
+        Returns:
+            the concurrency limit set on a specific tag
+        """
+        try:
+            response = self.request(
+                "GET",
+                "/concurrency_limits/tag/{tag}",
+                path_params={"tag": tag},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            else:
+                raise
+
+        concurrency_limit_id = response.json().get("id")
+
+        if not concurrency_limit_id:
+            raise RequestError(f"Malformed response: {response}")
+        from prefect.client.schemas.objects import ConcurrencyLimit
+
+        return ConcurrencyLimit.model_validate(response.json())
+
+    def read_concurrency_limits(
+        self,
+        limit: int,
+        offset: int,
+    ) -> list["ConcurrencyLimit"]:
+        """
+        Lists concurrency limits set on task run tags.
+
+        Args:
+            limit: the maximum number of concurrency limits returned
+            offset: the concurrency limit query offset
+
+        Returns:
+            a list of concurrency limits
+        """
+
+        body = {
+            "limit": limit,
+            "offset": offset,
+        }
+
+        response = self.request("POST", "/concurrency_limits/filter", json=body)
+        from prefect.client.schemas.objects import ConcurrencyLimit
+
+        return ConcurrencyLimit.model_validate_list(response.json())
+
+    def reset_concurrency_limit_by_tag(
+        self,
+        tag: str,
+        slot_override: list["UUID | str"] | None = None,
+    ) -> None:
+        """
+        Resets the concurrency limit slots set on a specific tag.
+
+        Args:
+            tag: a tag the concurrency limit is applied to
+            slot_override: a list of task run IDs that are currently using a
+                concurrency slot, please check that any task run IDs included in
+                `slot_override` are currently running, otherwise those concurrency
+                slots will never be released.
+
+        Raises:
+            prefect.exceptions.ObjectNotFound: If request returns 404
+            httpx.RequestError: If request fails
+
+        """
+        if slot_override is not None:
+            slot_override = [str(slot) for slot in slot_override]
+
+        try:
+            self.request(
+                "POST",
+                "/concurrency_limits/tag/{tag}/reset",
+                path_params={"tag": tag},
+                json=dict(slot_override=slot_override),
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            else:
+                raise
+
+    def delete_concurrency_limit_by_tag(
+        self,
+        tag: str,
+    ) -> None:
+        """
+        Delete the concurrency limit set on a specific tag.
+
+        Args:
+            tag: a tag the concurrency limit is applied to
+
+        Raises:
+            prefect.exceptions.ObjectNotFound: If request returns 404
+            httpx.RequestError: If request fails
+
+        """
+        try:
+            self.request(
+                "DELETE",
+                "/concurrency_limits/tag/{tag}",
+                path_params={"tag": tag},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            else:
+                raise
+
+    def increment_v1_concurrency_slots(
+        self,
+        names: list[str],
+        task_run_id: "UUID",
+    ) -> "Response":
+        """
+        Increment concurrency limit slots for the specified limits.
+
+        Args:
+            names (List[str]): A list of limit names for which to increment limits.
+            task_run_id (UUID): The task run ID incrementing the limits.
+        """
+        data: dict[str, Any] = {
+            "names": names,
+            "task_run_id": str(task_run_id),
+        }
+
+        return self.request(
+            "POST",
+            "/concurrency_limits/increment",
+            json=data,
+        )
+
+    def decrement_v1_concurrency_slots(
+        self,
+        names: list[str],
+        task_run_id: "UUID",
+        occupancy_seconds: float,
+    ) -> "Response":
+        """
+        Decrement concurrency limit slots for the specified limits.
+
+        Args:
+            names (List[str]): A list of limit names to decrement.
+            task_run_id (UUID): The task run ID that incremented the limits.
+            occupancy_seconds (float): The duration in seconds that the limits
+                were held.
+
+        Returns:
+            httpx.Response: The HTTP response from the server.
+        """
+        data: dict[str, Any] = {
+            "names": names,
+            "task_run_id": str(task_run_id),
+            "occupancy_seconds": occupancy_seconds,
+        }
+
+        return self.request(
+            "POST",
+            "/concurrency_limits/decrement",
+            json=data,
+        )
+
+
+class ConcurrencyLimitAsyncClient(BaseAsyncClient):
+    async def create_concurrency_limit(
+        self,
+        tag: str,
+        concurrency_limit: int,
+    ) -> "UUID":
+        """
+        Create a tag concurrency limit in the Prefect API. These limits govern concurrently
+        running tasks.
+
+        Args:
+            tag: a tag the concurrency limit is applied to
+            concurrency_limit: the maximum number of concurrent task runs for a given tag
+
+        Raises:
+            httpx.RequestError: if the concurrency limit was not created for any reason
+
+        Returns:
+            the ID of the concurrency limit in the backend
+        """
+
+        concurrency_limit_create = ConcurrencyLimitCreate(
+            tag=tag,
+            concurrency_limit=concurrency_limit,
+        )
+        response = await self.request(
+            "POST",
+            "/concurrency_limits/",
+            json=concurrency_limit_create.model_dump(mode="json"),
+        )
+
+        concurrency_limit_id = response.json().get("id")
+
+        if not concurrency_limit_id:
+            raise RequestError(f"Malformed response: {response}")
+        from uuid import UUID
+
+        return UUID(concurrency_limit_id)
+
+    async def read_concurrency_limit_by_tag(
+        self,
+        tag: str,
+    ) -> "ConcurrencyLimit":
+        """
+        Read the concurrency limit set on a specific tag.
+
+        Args:
+            tag: a tag the concurrency limit is applied to
+
+        Raises:
+            prefect.exceptions.ObjectNotFound: If request returns 404
+            httpx.RequestError: if the concurrency limit was not created for any reason
+
+        Returns:
+            the concurrency limit set on a specific tag
+        """
+        try:
+            response = await self.request(
+                "GET",
+                "/concurrency_limits/tag/{tag}",
+                path_params={"tag": tag},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            else:
+                raise
+
+        concurrency_limit_id = response.json().get("id")
+
+        if not concurrency_limit_id:
+            raise RequestError(f"Malformed response: {response}")
+        from prefect.client.schemas.objects import ConcurrencyLimit
+
+        return ConcurrencyLimit.model_validate(response.json())
+
+    async def read_concurrency_limits(
+        self,
+        limit: int,
+        offset: int,
+    ) -> list["ConcurrencyLimit"]:
+        """
+        Lists concurrency limits set on task run tags.
+
+        Args:
+            limit: the maximum number of concurrency limits returned
+            offset: the concurrency limit query offset
+
+        Returns:
+            a list of concurrency limits
+        """
+
+        body = {
+            "limit": limit,
+            "offset": offset,
+        }
+
+        response = await self.request("POST", "/concurrency_limits/filter", json=body)
+        from prefect.client.schemas.objects import ConcurrencyLimit
+
+        return ConcurrencyLimit.model_validate_list(response.json())
+
+    async def reset_concurrency_limit_by_tag(
+        self,
+        tag: str,
+        slot_override: list["UUID | str"] | None = None,
+    ) -> None:
+        """
+        Resets the concurrency limit slots set on a specific tag.
+
+        Args:
+            tag: a tag the concurrency limit is applied to
+            slot_override: a list of task run IDs that are currently using a
+                concurrency slot, please check that any task run IDs included in
+                `slot_override` are currently running, otherwise those concurrency
+                slots will never be released.
+
+        Raises:
+            prefect.exceptions.ObjectNotFound: If request returns 404
+            httpx.RequestError: If request fails
+
+        """
+        if slot_override is not None:
+            slot_override = [str(slot) for slot in slot_override]
+
+        try:
+            await self.request(
+                "POST",
+                "/concurrency_limits/tag/{tag}/reset",
+                path_params={"tag": tag},
+                json=dict(slot_override=slot_override),
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            else:
+                raise
+
+    async def delete_concurrency_limit_by_tag(
+        self,
+        tag: str,
+    ) -> None:
+        """
+        Delete the concurrency limit set on a specific tag.
+
+        Args:
+            tag: a tag the concurrency limit is applied to
+
+        Raises:
+            prefect.exceptions.ObjectNotFound: If request returns 404
+            httpx.RequestError: If request fails
+
+        """
+        try:
+            await self.request(
+                "DELETE",
+                "/concurrency_limits/tag/{tag}",
+                path_params={"tag": tag},
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ObjectNotFound(http_exc=e) from e
+            else:
+                raise
+
+    async def increment_v1_concurrency_slots(
+        self,
+        names: list[str],
+        task_run_id: "UUID",
+    ) -> "Response":
+        """
+        Increment concurrency limit slots for the specified limits.
+
+        Args:
+            names (List[str]): A list of limit names for which to increment limits.
+            task_run_id (UUID): The task run ID incrementing the limits.
+        """
+        data: dict[str, Any] = {
+            "names": names,
+            "task_run_id": str(task_run_id),
+        }
+
+        return await self.request(
+            "POST",
+            "/concurrency_limits/increment",
+            json=data,
+        )
+
+    async def decrement_v1_concurrency_slots(
+        self,
+        names: list[str],
+        task_run_id: "UUID",
+        occupancy_seconds: float,
+    ) -> "Response":
+        """
+        Decrement concurrency limit slots for the specified limits.
+
+        Args:
+            names (List[str]): A list of limit names to decrement.
+            task_run_id (UUID): The task run ID that incremented the limits.
+            occupancy_seconds (float): The duration in seconds that the limits
+                were held.
+
+        Returns:
+            httpx.Response: The HTTP response from the server.
+        """
+        data: dict[str, Any] = {
+            "names": names,
+            "task_run_id": str(task_run_id),
+            "occupancy_seconds": occupancy_seconds,
+        }
+
+        return await self.request(
+            "POST",
+            "/concurrency_limits/decrement",
+            json=data,
+        )

--- a/src/prefect/client/orchestration/_concurrency_limits/client.py
+++ b/src/prefect/client/orchestration/_concurrency_limits/client.py
@@ -41,6 +41,7 @@ class ConcurrencyLimitClient(BaseClient):
         Returns:
             the ID of the concurrency limit in the backend
         """
+        from prefect.client.schemas.actions import ConcurrencyLimitCreate
 
         concurrency_limit_create = ConcurrencyLimitCreate(
             tag=tag,
@@ -351,7 +352,10 @@ class ConcurrencyLimitClient(BaseClient):
 
         Note: This is not done atomically.
         """
-        from prefect.client.schemas.actions import GlobalConcurrencyLimitCreate
+        from prefect.client.schemas.actions import (
+            GlobalConcurrencyLimitCreate,
+            GlobalConcurrencyLimitUpdate,
+        )
 
         try:
             existing_limit = self.read_global_concurrency_limit_by_name(name)

--- a/src/prefect/client/orchestration/_concurrency_limits/client.py
+++ b/src/prefect/client/orchestration/_concurrency_limits/client.py
@@ -634,8 +634,8 @@ class ConcurrencyLimitAsyncClient(BaseAsyncClient):
         Release concurrency slots for the specified limits.
 
         Args:
-            names (List[str]): A list of limit names for which to release slots.
-            slots (int): The number of concurrency slots to release.
+            names: A list of limit names for which to release slots.
+            slots: The number of concurrency slots to release.
             occupancy_seconds (float): The duration in seconds that the slots
                 were occupied.
 

--- a/src/prefect/client/orchestration/_concurrency_limits/client.py
+++ b/src/prefect/client/orchestration/_concurrency_limits/client.py
@@ -565,8 +565,8 @@ class ConcurrencyLimitAsyncClient(BaseAsyncClient):
         Increment concurrency limit slots for the specified limits.
 
         Args:
-            names (List[str]): A list of limit names for which to increment limits.
-            task_run_id (UUID): The task run ID incrementing the limits.
+            names: A list of limit names for which to increment limits.
+            task_run_id: The task run ID incrementing the limits.
         """
         data: dict[str, Any] = {
             "names": names,

--- a/src/prefect/client/orchestration/_concurrency_limits/client.py
+++ b/src/prefect/client/orchestration/_concurrency_limits/client.py
@@ -13,7 +13,6 @@ if TYPE_CHECKING:
     from httpx import Response
 
     from prefect.client.schemas.actions import (
-        ConcurrencyLimitCreate,
         GlobalConcurrencyLimitCreate,
         GlobalConcurrencyLimitUpdate,
     )
@@ -411,6 +410,7 @@ class ConcurrencyLimitAsyncClient(BaseAsyncClient):
         Returns:
             the ID of the concurrency limit in the backend
         """
+        from prefect.client.schemas.actions import ConcurrencyLimitCreate
 
         concurrency_limit_create = ConcurrencyLimitCreate(
             tag=tag,
@@ -723,7 +723,10 @@ class ConcurrencyLimitAsyncClient(BaseAsyncClient):
 
         Note: This is not done atomically.
         """
-        from prefect.client.schemas.actions import GlobalConcurrencyLimitCreate
+        from prefect.client.schemas.actions import (
+            GlobalConcurrencyLimitCreate,
+            GlobalConcurrencyLimitUpdate,
+        )
 
         try:
             existing_limit = await self.read_global_concurrency_limit_by_name(name)

--- a/src/prefect/client/orchestration/_concurrency_limits/client.py
+++ b/src/prefect/client/orchestration/_concurrency_limits/client.py
@@ -264,8 +264,8 @@ class ConcurrencyLimitClient(BaseClient):
         Release concurrency slots for the specified limits.
 
         Args:
-            names (List[str]): A list of limit names for which to release slots.
-            slots (int): The number of concurrency slots to release.
+            names: A list of limit names for which to release slots.
+            slots: The number of concurrency slots to release.
             occupancy_seconds (float): The duration in seconds that the slots
                 were occupied.
 

--- a/src/prefect/client/orchestration/_concurrency_limits/client.py
+++ b/src/prefect/client/orchestration/_concurrency_limits/client.py
@@ -589,8 +589,8 @@ class ConcurrencyLimitAsyncClient(BaseAsyncClient):
         Decrement concurrency limit slots for the specified limits.
 
         Args:
-            names (List[str]): A list of limit names to decrement.
-            task_run_id (UUID): The task run ID that incremented the limits.
+            names: A list of limit names to decrement.
+            task_run_id: The task run ID that incremented the limits.
             occupancy_seconds (float): The duration in seconds that the limits
                 were held.
 


### PR DESCRIPTION
Related to https://github.com/PrefectHQ/prefect/issues/16472, this PR continues the optimization pattern established for Artifacts. Like the previous PRs, it:

- Refactors the client's ConcurrencyLimit CRUD methods into a standalone module
- Uses ForwardRefs for heavy imports, moving them into the call itself