### PR TITLE
remove hardcoded docs link to localhost:3000

### DIFF
--- a/docs/v3/develop/settings-and-profiles.mdx
+++ b/docs/v3/develop/settings-and-profiles.mdx
@@ -246,7 +246,7 @@ Read more about [managing API keys](/v3/manage/cloud/manage-users/api-keys/).
 ## Common server settings
 
 
-- [`server.database.connection_url`](http://localhost:3000/v3/develop/settings-ref#connection-url): the database connection URL for a self-hosted Prefect server instance.
+- [`server.database.connection_url`](/v3/develop/settings-ref#connection-url): the database connection URL for a self-hosted Prefect server instance.
 Must be provided in a SQLAlchemy-compatible format. Prefect currently supports SQLite and Postgres. 
 
 #### Security settings


### PR DESCRIPTION
fixes https://docs.prefect.io/v3/develop/settings-and-profiles#common-server-settings 

which is .... hardcoded to localhost:3000