### PR TITLE
Add flow run activity bar graph to deployments table

### DIFF
--- a/ui-v2/src/api/flow-runs/flow-runs.test.ts
+++ b/ui-v2/src/api/flow-runs/flow-runs.test.ts
@@ -1,0 +1,75 @@
+import type { components } from "@/api/prefect";
+import { createFakeFlowRun } from "@/mocks";
+import { QueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { buildApiUrl, createWrapper, server } from "@tests/utils";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { buildListFlowRunsQuery } from ".";
+
+type FlowRun = components["schemas"]["FlowRun"];
+
+describe("flow runs api", () => {
+	const mockFetchFlowRunsAPI = (flowRuns: Array<FlowRun>) => {
+		server.use(
+			http.post(buildApiUrl("/flow_runs/filter"), () => {
+				return HttpResponse.json(flowRuns);
+			}),
+		);
+	};
+
+	describe("flowRunsQueryParams", () => {
+		it("fetches paginated flow runs with default parameters", async () => {
+			const flowRun = createFakeFlowRun();
+			mockFetchFlowRunsAPI([flowRun]);
+
+			const queryClient = new QueryClient();
+			const { result } = renderHook(
+				() => useSuspenseQuery(buildListFlowRunsQuery()),
+				{ wrapper: createWrapper({ queryClient }) },
+			);
+
+			await waitFor(() => {
+				expect(result.current.data).toEqual([flowRun]);
+			});
+		});
+
+		it("fetches paginated flow runs with custom search parameters", async () => {
+			const flowRun = createFakeFlowRun();
+			mockFetchFlowRunsAPI([flowRun]);
+
+			const filter = {
+				offset: 0,
+				limit: 10,
+				sort: "ID_DESC" as const,
+				flow_runs: {
+					operator: "and_" as const,
+					name: { like_: "test-flow-run" },
+				},
+			};
+
+			const queryClient = new QueryClient();
+			const { result } = renderHook(
+				() => useSuspenseQuery(buildListFlowRunsQuery(filter)),
+				{ wrapper: createWrapper({ queryClient }) },
+			);
+
+			await waitFor(() => expect(result.current.isSuccess).toBe(true));
+			expect(result.current.data).toEqual([flowRun]);
+		});
+
+		it("uses the provided refetch interval", () => {
+			const flowRun = createFakeFlowRun();
+			mockFetchFlowRunsAPI([flowRun]);
+
+			const customRefetchInterval = 60_000; // 1 minute
+
+			const { refetchInterval } = buildListFlowRunsQuery(
+				{ sort: "ID_DESC", offset: 0 },
+				customRefetchInterval,
+			);
+
+			expect(refetchInterval).toBe(customRefetchInterval);
+		});
+	});
+});

--- a/ui-v2/src/api/flow-runs/index.ts
+++ b/ui-v2/src/api/flow-runs/index.ts
@@ -1,9 +1,67 @@
+import { queryOptions } from "@tanstack/react-query";
 import { Deployment } from "../deployments";
 import { Flow } from "../flows";
 import { components } from "../prefect";
+import { getQueryService } from "../service";
 
 export type FlowRun = components["schemas"]["FlowRun"];
 export type FlowRunWithDeploymentAndFlow = FlowRun & {
 	deployment: Deployment;
 	flow: Flow;
+};
+export type FlowRunsFilter =
+	components["schemas"]["Body_read_flow_runs_flow_runs_filter_post"];
+
+/**
+ * Query key factory for flows-related queries
+ *
+ * @property {function} all - Returns base key for all flow run queries
+ * @property {function} lists - Returns key for all list-type flow run queries
+ * @property {function} list - Generates key for a specific filtered flow run query
+ *
+ * ```
+ * all    =>   ['flowRuns']
+ * lists  =>   ['flowRuns', 'list']
+ * list   =>   ['flowRuns', 'list', { ...filter }]
+ * ```
+ */
+export const queryKeyFactory = {
+	all: () => ["flowRuns"] as const,
+	lists: () => [...queryKeyFactory.all(), "list"] as const,
+	list: (filter: FlowRunsFilter) =>
+		[...queryKeyFactory.lists(), filter] as const,
+};
+
+/**
+ * Builds a query configuration for fetching filtered flow runs
+ *
+ * @param filter - Filter parameters for the flow runs query.
+ * @returns Query configuration object for use with TanStack Query
+ *
+ * @example
+ * ```ts
+ * const { data, isLoading, error } = useQuery(buildListFlowRunsQuery({
+ *   offset: 0,
+ *   sort: "CREATED_DESC",
+ *   flow_runs: {
+ *     name: { like_: "my-flow-run" }
+ *   }
+ * }));
+ * ```
+ */
+export const buildListFlowRunsQuery = (
+	filter: FlowRunsFilter,
+	refetchInterval: number = 30_000,
+) => {
+	return queryOptions({
+		queryKey: queryKeyFactory.list(filter),
+		queryFn: async () => {
+			const res = await getQueryService().POST("/flow_runs/filter", {
+				body: filter,
+			});
+			return (res.data ?? []) as FlowRun[];
+		},
+		staleTime: 1000,
+		refetchInterval,
+	});
 };

--- a/ui-v2/src/api/flow-runs/index.ts
+++ b/ui-v2/src/api/flow-runs/index.ts
@@ -1,0 +1,9 @@
+import { Deployment } from "../deployments";
+import { Flow } from "../flows";
+import { components } from "../prefect";
+
+export type FlowRun = components["schemas"]["FlowRun"];
+export type FlowRunWithDeploymentAndFlow = FlowRun & {
+	deployment: Deployment;
+	flow: Flow;
+};

--- a/ui-v2/src/api/flow-runs/index.ts
+++ b/ui-v2/src/api/flow-runs/index.ts
@@ -50,7 +50,10 @@ export const queryKeyFactory = {
  * ```
  */
 export const buildListFlowRunsQuery = (
-	filter: FlowRunsFilter,
+	filter: FlowRunsFilter = {
+		sort: "ID_DESC",
+		offset: 0,
+	},
 	refetchInterval: number = 30_000,
 ) => {
 	return queryOptions({

--- a/ui-v2/src/api/flows/index.ts
+++ b/ui-v2/src/api/flows/index.ts
@@ -1,6 +1,7 @@
 import { components } from "@/api/prefect";
 import { getQueryService } from "@/api/service";
 
+export type Flow = components["schemas"]["Flow"];
 export type FlowsFilter =
 	components["schemas"]["Body_read_flows_flows_filter_post"];
 

--- a/ui-v2/src/api/flows/index.ts
+++ b/ui-v2/src/api/flows/index.ts
@@ -1,5 +1,6 @@
 import { components } from "@/api/prefect";
 import { getQueryService } from "@/api/service";
+import { queryOptions } from "@tanstack/react-query";
 
 export type Flow = components["schemas"]["Flow"];
 export type FlowsFilter =
@@ -46,13 +47,14 @@ export const queryKeyFactory = {
  */
 export const buildListFlowsQuery = (
 	filter: FlowsFilter = { offset: 0, sort: "CREATED_DESC" },
-) => ({
-	queryKey: queryKeyFactory.list(filter),
-	queryFn: async () => {
-		const result = await getQueryService().POST("/flows/filter", {
-			body: filter,
-		});
-		return result.data ?? [];
-	},
-	staleTime: 1000,
-});
+) =>
+	queryOptions({
+		queryKey: queryKeyFactory.list(filter),
+		queryFn: async () => {
+			const result = await getQueryService().POST("/flows/filter", {
+				body: filter,
+			});
+			return result.data ?? [];
+		},
+		staleTime: 1000,
+	});

--- a/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
+++ b/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
@@ -1,5 +1,5 @@
 import { createFakeDeployment } from "@/mocks";
-import { toastDecorator } from "@/storybook/utils";
+import { routerDecorator, toastDecorator } from "@/storybook/utils";
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
 import { DeploymentsDataTable } from ".";
@@ -7,11 +7,11 @@ import { DeploymentsDataTable } from ".";
 export default {
 	title: "Components/Deployments/DataTable",
 	component: DeploymentsDataTable,
-	decorators: [toastDecorator],
+	decorators: [toastDecorator, routerDecorator],
 } satisfies Meta<typeof DeploymentsDataTable>;
 
 export const Default: StoryObj = {
-	name: "DataTable",
+	name: "Randomized Data",
 	args: {
 		deployments: Array.from({ length: 10 }, createFakeDeployment),
 		onQuickRun: fn(),

--- a/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
+++ b/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
@@ -1,17 +1,55 @@
-import { createFakeDeployment } from "@/mocks";
-import { routerDecorator, toastDecorator } from "@/storybook/utils";
+import { FlowRunWithDeploymentAndFlow } from "@/api/flow-runs";
+import {
+	createFakeDeployment,
+	createFakeFlow,
+	createFakeFlowRun,
+} from "@/mocks";
+import {
+	reactQueryDecorator,
+	routerDecorator,
+	toastDecorator,
+} from "@/storybook/utils";
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
+import { buildApiUrl } from "@tests/utils/handlers";
+import { http, HttpResponse } from "msw";
 import { DeploymentsDataTable } from ".";
+
+const createFakeFlowRunWithDeploymentAndFlow =
+	(): FlowRunWithDeploymentAndFlow => {
+		const flowRun = createFakeFlowRun();
+
+		return {
+			...flowRun,
+			deployment: createFakeDeployment(),
+			flow: createFakeFlow(),
+		};
+	};
 
 export default {
 	title: "Components/Deployments/DataTable",
 	component: DeploymentsDataTable,
-	decorators: [toastDecorator, routerDecorator],
+	decorators: [toastDecorator, routerDecorator, reactQueryDecorator],
 } satisfies Meta<typeof DeploymentsDataTable>;
 
 export const Default: StoryObj = {
 	name: "Randomized Data",
+	parameters: {
+		msw: {
+			handlers: [
+				http.post(buildApiUrl("/flow_runs/filter"), async ({ request }) => {
+					const { limit } = (await request.json()) as { limit: number };
+
+					return HttpResponse.json(
+						Array.from(
+							{ length: limit },
+							createFakeFlowRunWithDeploymentAndFlow,
+						),
+					);
+				}),
+			],
+		},
+	},
 	args: {
 		deployments: Array.from({ length: 10 }, createFakeDeployment),
 		onQuickRun: fn(),

--- a/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
+++ b/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
@@ -1,9 +1,5 @@
-import { FlowRunWithDeploymentAndFlow } from "@/api/flow-runs";
-import {
-	createFakeDeployment,
-	createFakeFlow,
-	createFakeFlowRun,
-} from "@/mocks";
+import { createFakeDeployment } from "@/mocks";
+import { createFakeFlowRunWithDeploymentAndFlow } from "@/mocks/create-fake-flow-run";
 import {
 	reactQueryDecorator,
 	routerDecorator,
@@ -14,17 +10,6 @@ import { fn } from "@storybook/test";
 import { buildApiUrl } from "@tests/utils/handlers";
 import { http, HttpResponse } from "msw";
 import { DeploymentsDataTable } from ".";
-
-const createFakeFlowRunWithDeploymentAndFlow =
-	(): FlowRunWithDeploymentAndFlow => {
-		const flowRun = createFakeFlowRun();
-
-		return {
-			...flowRun,
-			deployment: createFakeDeployment(),
-			flow: createFakeFlow(),
-		};
-	};
 
 export default {
 	title: "Components/Deployments/DataTable",

--- a/ui-v2/src/components/deployments/data-table/data-table.test.tsx
+++ b/ui-v2/src/components/deployments/data-table/data-table.test.tsx
@@ -1,10 +1,27 @@
 import type { DeploymentWithFlow } from "@/api/deployments";
+import { createFakeFlowRunWithDeploymentAndFlow } from "@/mocks/create-fake-flow-run";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, test, vi } from "vitest";
+import { buildApiUrl, createWrapper, server } from "@tests/utils";
+import { HttpResponse } from "msw";
+import { http } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DeploymentsDataTable } from ".";
 
 describe("DeploymentsDataTable", () => {
+	beforeEach(() => {
+		console.log("beforeEach");
+		server.use(
+			http.post(buildApiUrl("/flow_runs/filter"), async ({ request }) => {
+				const { limit } = (await request.json()) as { limit: number };
+				console.log("limit", limit);
+
+				return HttpResponse.json(
+					Array.from({ length: limit }, createFakeFlowRunWithDeploymentAndFlow),
+				);
+			}),
+		);
+	});
 	const mockDeployment: DeploymentWithFlow = {
 		id: "test-id",
 		created: new Date().toISOString(),
@@ -32,33 +49,41 @@ describe("DeploymentsDataTable", () => {
 		onDuplicate: vi.fn(),
 	};
 
-	test("renders deployment name and flow name", () => {
-		render(<DeploymentsDataTable {...defaultProps} />);
+	it("renders deployment name and flow name", () => {
+		render(<DeploymentsDataTable {...defaultProps} />, {
+			wrapper: createWrapper(),
+		});
 
 		expect(screen.getByText("Test Deployment")).toBeInTheDocument();
 		expect(screen.getByText("test-flow")).toBeInTheDocument();
 	});
 
-	test("renders status badge", () => {
-		render(<DeploymentsDataTable {...defaultProps} />);
+	it("renders status badge", () => {
+		render(<DeploymentsDataTable {...defaultProps} />, {
+			wrapper: createWrapper(),
+		});
 
 		expect(screen.getByText("Ready")).toBeInTheDocument();
 	});
 
-	test("renders tags", () => {
-		render(<DeploymentsDataTable {...defaultProps} />);
+	it("renders tags", () => {
+		render(<DeploymentsDataTable {...defaultProps} />, {
+			wrapper: createWrapper(),
+		});
 
 		expect(screen.getByText("tag1")).toBeInTheDocument();
 		expect(screen.getByText("tag2")).toBeInTheDocument();
 	});
 
-	test("renders with empty deployments array", () => {
-		render(<DeploymentsDataTable {...defaultProps} deployments={[]} />);
+	it("renders with empty deployments array", () => {
+		render(<DeploymentsDataTable {...defaultProps} deployments={[]} />, {
+			wrapper: createWrapper(),
+		});
 
 		expect(screen.queryByText("No Results")).not.toBeInTheDocument();
 	});
 
-	test("renders multiple deployments", () => {
+	it("renders multiple deployments", () => {
 		const multipleDeployments = [
 			mockDeployment,
 			{
@@ -81,6 +106,9 @@ describe("DeploymentsDataTable", () => {
 				{...defaultProps}
 				deployments={multipleDeployments}
 			/>,
+			{
+				wrapper: createWrapper(),
+			},
 		);
 
 		expect(screen.getByText("Test Deployment")).toBeInTheDocument();
@@ -89,9 +117,11 @@ describe("DeploymentsDataTable", () => {
 		expect(screen.getByText("second-flow")).toBeInTheDocument();
 	});
 
-	test("calls onQuickRun when quick run action is clicked", async () => {
+	it("calls onQuickRun when quick run action is clicked", async () => {
 		const onQuickRun = vi.fn();
-		render(<DeploymentsDataTable {...defaultProps} onQuickRun={onQuickRun} />);
+		render(<DeploymentsDataTable {...defaultProps} onQuickRun={onQuickRun} />, {
+			wrapper: createWrapper(),
+		});
 
 		await userEvent.click(screen.getByRole("button", { name: "Open menu" }));
 		const quickRunButton = screen.getByRole("menuitem", { name: "Quick Run" });
@@ -100,10 +130,13 @@ describe("DeploymentsDataTable", () => {
 		expect(onQuickRun).toHaveBeenCalledWith(mockDeployment);
 	});
 
-	test("calls onCustomRun when custom run action is clicked", async () => {
+	it("calls onCustomRun when custom run action is clicked", async () => {
 		const onCustomRun = vi.fn();
 		render(
 			<DeploymentsDataTable {...defaultProps} onCustomRun={onCustomRun} />,
+			{
+				wrapper: createWrapper(),
+			},
 		);
 
 		await userEvent.click(screen.getByRole("button", { name: "Open menu" }));
@@ -115,9 +148,11 @@ describe("DeploymentsDataTable", () => {
 		expect(onCustomRun).toHaveBeenCalledWith(mockDeployment);
 	});
 
-	test("calls onEdit when edit action is clicked", async () => {
+	it("calls onEdit when edit action is clicked", async () => {
 		const onEdit = vi.fn();
-		render(<DeploymentsDataTable {...defaultProps} onEdit={onEdit} />);
+		render(<DeploymentsDataTable {...defaultProps} onEdit={onEdit} />, {
+			wrapper: createWrapper(),
+		});
 
 		await userEvent.click(screen.getByRole("button", { name: "Open menu" }));
 		const editButton = screen.getByRole("menuitem", { name: "Edit" });
@@ -126,9 +161,11 @@ describe("DeploymentsDataTable", () => {
 		expect(onEdit).toHaveBeenCalledWith(mockDeployment);
 	});
 
-	test("calls onDelete when delete action is clicked", async () => {
+	it("calls onDelete when delete action is clicked", async () => {
 		const onDelete = vi.fn();
-		render(<DeploymentsDataTable {...defaultProps} onDelete={onDelete} />);
+		render(<DeploymentsDataTable {...defaultProps} onDelete={onDelete} />, {
+			wrapper: createWrapper(),
+		});
 
 		await userEvent.click(screen.getByRole("button", { name: "Open menu" }));
 		const deleteButton = screen.getByRole("menuitem", { name: "Delete" });
@@ -137,10 +174,13 @@ describe("DeploymentsDataTable", () => {
 		expect(onDelete).toHaveBeenCalledWith(mockDeployment);
 	});
 
-	test("calls onDuplicate when duplicate action is clicked", async () => {
+	it("calls onDuplicate when duplicate action is clicked", async () => {
 		const onDuplicate = vi.fn();
 		render(
 			<DeploymentsDataTable {...defaultProps} onDuplicate={onDuplicate} />,
+			{
+				wrapper: createWrapper(),
+			},
 		);
 
 		await userEvent.click(screen.getByRole("button", { name: "Open menu" }));

--- a/ui-v2/src/components/deployments/data-table/index.tsx
+++ b/ui-v2/src/components/deployments/data-table/index.tsx
@@ -1,5 +1,6 @@
 import { DeploymentWithFlow } from "@/api/deployments";
 import { DataTable } from "@/components/ui/data-table";
+import { FlowRunActivityBarGraphTooltipProvider } from "@/components/ui/flow-run-acitivity-bar-graph";
 import { Icon } from "@/components/ui/icons";
 import { ScheduleBadgeGroup } from "@/components/ui/schedule-badge";
 import { StatusBadge } from "@/components/ui/status-badge";
@@ -9,7 +10,7 @@ import {
 	getCoreRowModel,
 	useReactTable,
 } from "@tanstack/react-table";
-import { ActionsCell } from "./cells";
+import { ActionsCell, ActivityCell } from "./cells";
 
 type DeploymentsDataTableProps = {
 	deployments: DeploymentWithFlow[];
@@ -75,9 +76,9 @@ const createColumns = ({
 	columnHelper.display({
 		id: "activity",
 		header: "Activity",
-		cell: () => (
+		cell: (props) => (
 			<div className="flex flex-row gap-2 items-center min-w-28">
-				<span className="text-sm text-muted-foreground">TODO</span>
+				<ActivityCell {...props} />
 			</div>
 		),
 		size: 300,
@@ -135,5 +136,9 @@ export const DeploymentsDataTable = ({
 			maxSize: 300,
 		},
 	});
-	return <DataTable table={table} />;
+	return (
+		<FlowRunActivityBarGraphTooltipProvider>
+			<DataTable table={table} />
+		</FlowRunActivityBarGraphTooltipProvider>
+	);
 };

--- a/ui-v2/src/components/ui/flow-run-acitivity-bar-graph/context.tsx
+++ b/ui-v2/src/components/ui/flow-run-acitivity-bar-graph/context.tsx
@@ -1,0 +1,18 @@
+import { createContext } from "react";
+
+/**
+ * Context for managing tooltip state across multiple charts.
+ * Only one tooltip can be active at a time, controlled by a holder ID.
+ *
+ * @property currentHolder - Unique identifier of the chart currently displaying a tooltip
+ * @property takeCurrentHolder - Function to set the current tooltip holder
+ * @property releaseCurrentHolder - Function to release the current tooltip holder if it matches
+ */
+export const FlowRunActivityBarGraphTooltipContext = createContext<{
+	currentHolder?: string;
+	takeCurrentHolder: (holder: string) => void;
+	releaseCurrentHolder: (holder: string) => void;
+}>({
+	takeCurrentHolder: () => {},
+	releaseCurrentHolder: () => {},
+});

--- a/ui-v2/src/components/ui/flow-run-acitivity-bar-graph/flow-run-activity-bar-graph.stories.tsx
+++ b/ui-v2/src/components/ui/flow-run-acitivity-bar-graph/flow-run-activity-bar-graph.stories.tsx
@@ -4,95 +4,24 @@ import { FlowRunActivityBarChart } from ".";
 
 import { faker } from "@faker-js/faker";
 
-import type { components } from "@/api/prefect";
-import { QueryClient } from "@tanstack/react-query";
+import { FlowRunWithDeploymentAndFlow } from "@/api/flow-runs";
 import {
-	RouterProvider,
-	createMemoryHistory,
-	createRootRoute,
-	createRouter,
-} from "@tanstack/react-router";
+	createFakeDeployment,
+	createFakeFlow,
+	createFakeFlowRun,
+} from "@/mocks";
+import { routerDecorator } from "@/storybook/utils";
 
-type StateType = components["schemas"]["StateType"];
+const createFakeFlowRunWithDeploymentAndFlow =
+	(): FlowRunWithDeploymentAndFlow => {
+		const flowRun = createFakeFlowRun();
 
-const STATE_TYPE_VALUES = [
-	"COMPLETED",
-	"FAILED",
-	"CRASHED",
-	"CANCELLED",
-	"RUNNING",
-	"PENDING",
-	"SCHEDULED",
-	"PAUSED",
-	"CANCELLING",
-] as const satisfies readonly StateType[];
-
-function createRandomEnrichedFlowRun(): React.ComponentProps<
-	typeof FlowRunActivityBarChart
->["enrichedFlowRuns"][number] {
-	const stateType = faker.helpers.arrayElement(STATE_TYPE_VALUES);
-	const stateName =
-		stateType.charAt(0).toUpperCase() + stateType.slice(1).toLowerCase();
-	return {
-		id: faker.string.uuid(),
-		created: faker.date.past().toISOString(),
-		updated: faker.date.past().toISOString(),
-		name: `${faker.word.adjective()}-${faker.animal.type()}`,
-		flow_id: faker.string.uuid(),
-		state_id: faker.string.uuid(),
-		deployment_id: faker.string.uuid(),
-		work_queue_id: faker.string.uuid(),
-		work_queue_name: faker.string.uuid(),
-		flow_version: faker.string.uuid(),
-		deployment_version: faker.string.uuid(),
-		idempotency_key: faker.string.uuid(),
-		context: {},
-		empirical_policy: {
-			max_retries: faker.number.int(),
-			retry_delay_seconds: faker.number.int(),
-			retries: faker.number.int(),
-			retry_delay: faker.number.int(),
-			pause_keys: [],
-			resuming: faker.datatype.boolean(),
-		},
-		tags: Array.from({ length: faker.number.int({ min: 0, max: 3 }) }, () =>
-			faker.lorem.word(),
-		),
-		parent_task_run_id: faker.string.uuid(),
-		state_type: stateType,
-		state_name: stateName,
-		run_count: faker.number.int(),
-		start_time: faker.date.past({ years: 0.1 }).toISOString(),
-		total_run_time: faker.number.int({ min: 1, max: 100 }),
-		estimated_run_time: faker.number.int({ min: 1, max: 100 }),
-		estimated_start_time_delta: faker.number.int(),
-		auto_scheduled: faker.datatype.boolean(),
-		infrastructure_document_id: faker.string.uuid(),
-		infrastructure_pid: faker.string.uuid(),
-		state: {
-			id: faker.string.uuid(),
-			type: stateType,
-			name: stateName,
-		},
-		job_variables: {},
-		deployment: {
-			id: faker.string.uuid(),
-			name: faker.airline.airplane().name,
-			flow_id: faker.string.uuid(),
-			paused: faker.datatype.boolean(),
-			status: faker.helpers.arrayElement(["READY", "NOT_READY"]),
-			enforce_parameter_schema: faker.datatype.boolean(),
-			created: faker.date.past().toISOString(),
-			updated: faker.date.past().toISOString(),
-		},
-		flow: {
-			id: faker.string.uuid(),
-			name: `${faker.finance.currencyName()} ${faker.commerce.product()}`,
-			created: faker.date.past().toISOString(),
-			updated: faker.date.past().toISOString(),
-		},
+		return {
+			...flowRun,
+			deployment: createFakeDeployment(),
+			flow: createFakeFlow(),
+		};
 	};
-}
 
 export default {
 	title: "UI/FlowRunActivityBarChart",
@@ -106,25 +35,11 @@ export default {
 		endDate: new Date(),
 		numberOfBars: 18,
 	},
+	decorators: [routerDecorator],
 	render: function Render(
 		args: ComponentProps<typeof FlowRunActivityBarChart>,
 	) {
-		args.endDate = new Date(args.endDate);
-		args.startDate = new Date(args.startDate);
-		const rootRoute = createRootRoute({
-			component: () => <FlowRunActivityBarChart {...args} className="h-96" />,
-		});
-		const router = createRouter({
-			routeTree: rootRoute,
-			history: createMemoryHistory({
-				initialEntries: ["/"],
-			}),
-			context: {
-				queryClient: new QueryClient(),
-			},
-		});
-		// @ts-expect-error - Type error from using a test router
-		return <RouterProvider router={router} />;
+		return <FlowRunActivityBarChart {...args} className="h-96" />;
 	},
 } satisfies Meta<typeof FlowRunActivityBarChart>;
 
@@ -134,6 +49,9 @@ export const Randomized: Story = {
 	args: {
 		startDate: faker.date.past(),
 		endDate: new Date(),
-		enrichedFlowRuns: Array.from({ length: 18 }, createRandomEnrichedFlowRun),
+		enrichedFlowRuns: Array.from(
+			{ length: 18 },
+			createFakeFlowRunWithDeploymentAndFlow,
+		),
 	},
 };

--- a/ui-v2/src/components/ui/flow-run-acitivity-bar-graph/flow-run-activity-bar-graph.stories.tsx
+++ b/ui-v2/src/components/ui/flow-run-acitivity-bar-graph/flow-run-activity-bar-graph.stories.tsx
@@ -2,26 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 import type { ComponentProps } from "react";
 import { FlowRunActivityBarChart } from ".";
 
-import { faker } from "@faker-js/faker";
-
-import { FlowRunWithDeploymentAndFlow } from "@/api/flow-runs";
-import {
-	createFakeDeployment,
-	createFakeFlow,
-	createFakeFlowRun,
-} from "@/mocks";
+import { createFakeFlowRunWithDeploymentAndFlow } from "@/mocks/create-fake-flow-run";
 import { routerDecorator } from "@/storybook/utils";
-
-const createFakeFlowRunWithDeploymentAndFlow =
-	(): FlowRunWithDeploymentAndFlow => {
-		const flowRun = createFakeFlowRun();
-
-		return {
-			...flowRun,
-			deployment: createFakeDeployment(),
-			flow: createFakeFlow(),
-		};
-	};
+import { faker } from "@faker-js/faker";
 
 export default {
 	title: "UI/FlowRunActivityBarChart",

--- a/ui-v2/src/components/ui/flow-run-acitivity-bar-graph/index.tsx
+++ b/ui-v2/src/components/ui/flow-run-acitivity-bar-graph/index.tsx
@@ -4,8 +4,18 @@ import { Link } from "@tanstack/react-router";
 import { cva } from "class-variance-authority";
 import { format, formatDistanceStrict } from "date-fns";
 import { Calendar, ChevronRight, Clock, Rocket } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import {
+	RefObject,
+	useCallback,
+	useContext,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+import React from "react";
+import { createPortal } from "react-dom";
 import { Bar, BarChart, Cell, type TooltipProps } from "recharts";
+import { Coordinate } from "recharts/types/util/types";
 import {
 	Card,
 	CardContent,
@@ -15,6 +25,7 @@ import {
 } from "../card";
 import { StateBadge } from "../state-badge";
 import { TagBadgeGroup } from "../tag-badge-group";
+import { FlowRunActivityBarGraphTooltipContext } from "./context";
 import { organizeFlowRunsWithGaps } from "./utils";
 
 type CustomShapeProps = {
@@ -25,9 +36,10 @@ type CustomShapeProps = {
 	radius?: number[];
 	role?: string;
 	flowRun?: EnrichedFlowRun;
+	containerHeight?: number;
 };
 
-const barVariants = cva("gap-1", {
+const barVariants = cva("gap-1 z-1", {
 	variants: {
 		state: {
 			COMPLETED: "fill-green-600",
@@ -51,20 +63,22 @@ const CustomBar = (props: CustomShapeProps) => {
 	const minHeight = 10; // Minimum height for zero values
 	const {
 		x = 0,
-		y = 0,
 		width = 0,
 		height = minHeight,
 		radius = [0, 0, 0, 0],
 		role,
 		flowRun,
+		containerHeight = 32,
 	} = props;
+	const effectiveHeight = Math.max(height, minHeight);
+	const yPosition = containerHeight - effectiveHeight;
 
 	return (
 		<g role={role}>
 			<rect
 				data-testid={`bar-rect-${flowRun?.id}`}
 				x={x}
-				y={y + height - Math.max(height, minHeight, width)}
+				y={yPosition}
 				width={width}
 				height={Math.max(height, minHeight)}
 				rx={radius[0]}
@@ -81,17 +95,20 @@ type EnrichedFlowRun = components["schemas"]["FlowRun"] & {
 };
 
 /**
- * Custom hook to manage tooltip active state with a delayed hide effect. When the tooltip is set to inactive, it will wait for the specified delay before
- * surrendering control.
+ * Custom hook to manage tooltip active state with a delayed hide effect and coordinate between multiple tooltips.
+ * Only one tooltip can be active at a time, controlled by the holder ID.
  *
+ * @param chartId - Unique identifier for the chart instance to coordinate with other charts
  * @param initialValue - Initial active state of the tooltip (default: undefined)
- * @param leaveDelay - Delay in milliseconds before hiding the tooltip after becoming inactive (default: 500ms)
+ * @param leaveDelay - Delay in milliseconds before hiding the tooltip after becoming inactive (default: 200ms)
  * @returns A tuple containing [isActive, setIsActive] where isActive is the current tooltip state
- *          and setIsActive is a function to update the internal state
+ *          and setIsActive is a function to update the internal state. isActive will be false if another
+ *          chart takes control.
  */
 const useIsTooltipActive = (
+	chartId?: string,
 	initialValue: boolean | undefined = undefined,
-	leaveDelay = 500,
+	leaveDelay = 200,
 ) => {
 	const [internalValue, setInternalValue] = useState<boolean | undefined>(
 		initialValue,
@@ -99,22 +116,74 @@ const useIsTooltipActive = (
 	const [externalValue, setExternalValue] = useState<boolean | undefined>(
 		initialValue,
 	);
+	const { currentHolder, takeCurrentHolder, releaseCurrentHolder } = useContext(
+		FlowRunActivityBarGraphTooltipContext,
+	);
 
 	useEffect(() => {
-		if (internalValue) {
+		if (currentHolder && chartId !== currentHolder) {
+			setExternalValue(false);
+		} else if (internalValue) {
+			if (chartId) {
+				takeCurrentHolder(chartId);
+			}
 			setExternalValue(true);
 		} else {
 			const timer = setTimeout(() => {
 				setExternalValue(undefined);
+				if (chartId) {
+					releaseCurrentHolder(chartId);
+				}
 			}, leaveDelay);
 			return () => clearTimeout(timer);
 		}
-	}, [internalValue, leaveDelay]);
+	}, [
+		internalValue,
+		leaveDelay,
+		chartId,
+		currentHolder,
+		takeCurrentHolder,
+		releaseCurrentHolder,
+	]);
 
 	return [externalValue, setInternalValue] as const;
 };
 
+/**
+ * Provider component for FlowRunActivityBarGraphTooltipContext.
+ * Manages tooltip state across multiple charts by tracking which chart is currently displaying a tooltip.
+ */
+export const FlowRunActivityBarGraphTooltipProvider = ({
+	children,
+}: { children: React.ReactNode }) => {
+	const [currentHolder, setCurrentHolder] = useState<string | undefined>(
+		undefined,
+	);
+
+	const takeCurrentHolder = useCallback((holder: string) => {
+		setCurrentHolder(holder);
+	}, []);
+
+	const releaseCurrentHolder = useCallback(
+		(holder: string) => {
+			if (currentHolder === holder) {
+				setCurrentHolder(undefined);
+			}
+		},
+		[currentHolder],
+	);
+
+	return (
+		<FlowRunActivityBarGraphTooltipContext.Provider
+			value={{ currentHolder, takeCurrentHolder, releaseCurrentHolder }}
+		>
+			{children}
+		</FlowRunActivityBarGraphTooltipContext.Provider>
+	);
+};
+
 type FlowRunActivityBarChartProps = {
+	chartId?: string;
 	enrichedFlowRuns: EnrichedFlowRun[];
 	startDate: Date;
 	endDate: Date;
@@ -124,83 +193,167 @@ type FlowRunActivityBarChartProps = {
 	numberOfBars: number;
 };
 
-export const FlowRunActivityBarChart = ({
-	enrichedFlowRuns,
-	startDate,
-	endDate,
-	barWidth = 8,
-	numberOfBars,
-	className,
-}: FlowRunActivityBarChartProps) => {
-	const [isTooltipActive, setIsTooltipActive] = useIsTooltipActive();
-	const containerRef = useRef<HTMLDivElement>(null);
-	const buckets = organizeFlowRunsWithGaps(
-		enrichedFlowRuns,
-		startDate,
-		endDate,
-		numberOfBars,
-	);
+export const FlowRunActivityBarChart = React.forwardRef<
+	HTMLDivElement,
+	FlowRunActivityBarChartProps
+>(
+	(
+		{
+			chartId,
+			enrichedFlowRuns,
+			startDate,
+			endDate,
+			barWidth = 8,
+			numberOfBars,
+			className,
+		},
+		ref,
+	) => {
+		const [isTooltipActive, setIsTooltipActive] = useIsTooltipActive(chartId);
+		const internalRef = useRef<HTMLDivElement>(null);
+		const containerRef =
+			(ref as React.RefObject<HTMLDivElement>) || internalRef;
 
-	const data = buckets.map((flowRun) => ({
-		value: flowRun?.total_run_time,
-		id: flowRun?.id,
-		stateType: flowRun?.state_type,
-		flowRun,
-	}));
-	return (
-		<ChartContainer
-			ref={containerRef}
-			config={{
-				inactivity: {
-					color: "hsl(210 40% 45%)",
-				},
-			}}
-			className={className}
-		>
-			<BarChart
-				data={data}
-				margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
-				barSize={barWidth}
-				onMouseMove={() => {
-					setIsTooltipActive(true);
+		const buckets = organizeFlowRunsWithGaps(
+			enrichedFlowRuns,
+			startDate,
+			endDate,
+			numberOfBars,
+		);
+
+		const data = buckets.map((flowRun) => ({
+			value: flowRun?.total_run_time,
+			id: flowRun?.id,
+			stateType: flowRun?.state_type,
+			flowRun,
+		}));
+		const containerHeight =
+			containerRef.current?.getBoundingClientRect().height ?? 0;
+		return (
+			<ChartContainer
+				ref={containerRef}
+				config={{
+					inactivity: {
+						color: "hsl(210 40% 45%)",
+					},
 				}}
-				onMouseLeave={() => {
-					setIsTooltipActive(undefined);
-				}}
-				role="graphics-document"
+				className={className}
 			>
-				<ChartTooltip
-					content={<FlowRunTooltip />}
-					position={{
-						y: containerRef.current?.getBoundingClientRect().height ?? 0,
+				<BarChart
+					data={data}
+					margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+					barSize={barWidth}
+					onMouseMove={() => {
+						setIsTooltipActive(true);
 					}}
-					isAnimationActive={false}
-					allowEscapeViewBox={{ x: true, y: true }}
-					active={isTooltipActive}
-					// Allows the tooltip to react to mouse events
-					wrapperStyle={{ pointerEvents: "auto" }}
-					cursor={true}
-				/>
-				<Bar
-					dataKey="value"
-					shape={<CustomBar />}
-					radius={[5, 5, 5, 5]}
-					onMouseEnter={() => setIsTooltipActive(true)}
-					onMouseLeave={() => setIsTooltipActive(undefined)}
+					onMouseLeave={() => {
+						setIsTooltipActive(undefined);
+					}}
+					role="graphics-document"
 				>
-					{data.map((entry) => (
-						<Cell key={`cell-${entry.id}`} role="graphics-symbol" />
-					))}
-				</Bar>
-			</BarChart>
-		</ChartContainer>
+					<ChartTooltip
+						content={<FlowRunTooltip containerRef={containerRef} />}
+						position={{
+							y: containerHeight ?? 0,
+						}}
+						isAnimationActive={false}
+						allowEscapeViewBox={{ x: true, y: true }}
+						active={isTooltipActive}
+						// Allows the tooltip to react to mouse events
+						wrapperStyle={{ pointerEvents: "auto" }}
+					/>
+					<Bar
+						dataKey="value"
+						shape={<CustomBar containerHeight={containerHeight} />}
+						radius={[5, 5, 5, 5]}
+						onMouseEnter={() => setIsTooltipActive(true)}
+						onMouseLeave={() => setIsTooltipActive(undefined)}
+					>
+						{data.map((entry) => (
+							<Cell key={`cell-${entry.id}`} role="graphics-symbol" />
+						))}
+					</Bar>
+				</BarChart>
+			</ChartContainer>
+		);
+	},
+);
+
+FlowRunActivityBarChart.displayName = "FlowRunActivityBarChart";
+
+/**
+ * TooltipPortal is a component that renders tooltips in a portal at the correct position relative to their trigger element.
+ * This is necessary because tooltips rendered inside charts can be clipped by the chart's parent's boundaries.
+ * By rendering in a portal at the document root, we ensure the tooltip is always visible and correctly positioned.
+ *
+ * The component takes a containerRef to calculate positioning relative to the chart container,
+ * along with position and coordinate data from the chart tooltip to determine exact placement.
+ * It handles scroll position and viewport coordinates to ensure the tooltip stays aligned with the chart bars.
+ */
+const TooltipPortal = ({
+	containerRef,
+	position,
+	coordinate,
+	children,
+}: {
+	children: React.ReactNode;
+	position: Partial<Coordinate>;
+	coordinate: Partial<Coordinate>;
+	containerRef: RefObject<HTMLDivElement | null>;
+}) => {
+	const [internalPosition, setInternalPosition] = useState<{
+		x: number;
+		y: number;
+	} | null>(null);
+
+	useEffect(() => {
+		if (containerRef.current && position && coordinate) {
+			const container = containerRef.current;
+			const rect = container.getBoundingClientRect();
+
+			// Calculate position relative to viewport and scroll
+			const x =
+				rect.left + (coordinate.x ?? 0) + window.scrollX - rect.width / 2;
+			const y = rect.top + (position.y ?? 0) + window.scrollY;
+
+			setInternalPosition({ x, y });
+		} else {
+			setInternalPosition(null);
+		}
+	}, [coordinate, containerRef, position]);
+
+	if (!internalPosition) {
+		return null;
+	}
+
+	return createPortal(
+		<div
+			style={{
+				position: "absolute",
+				left: 0,
+				top: 0,
+				transform: `translate3d(${internalPosition.x}px, ${internalPosition.y}px, 0)`,
+				zIndex: 9999,
+			}}
+		>
+			{children}
+		</div>,
+		document.body,
 	);
 };
 
-type FlowRunTooltipProps = TooltipProps<number, string>;
+type FlowRunTooltipProps = TooltipProps<number, string> & {
+	containerRef: RefObject<HTMLDivElement | null>;
+};
 
-const FlowRunTooltip = ({ payload, active }: FlowRunTooltipProps) => {
-	if (!active || !payload || !payload.length) {
+const FlowRunTooltip = ({
+	payload,
+	active,
+	containerRef,
+	coordinate,
+	position,
+}: FlowRunTooltipProps) => {
+	if (!active || !payload || !payload.length || !position || !coordinate) {
 		return null;
 	}
 	const nestedPayload: unknown = payload[0]?.payload;
@@ -229,63 +382,71 @@ const FlowRunTooltip = ({ payload, active }: FlowRunTooltipProps) => {
 			: null;
 
 	return (
-		<Card className="-translate-x-1/2">
-			<CardHeader>
-				<CardTitle className="flex items-center gap-1">
-					<Link
-						to={"/flows/flow/$id"}
-						params={{ id: flow.id }}
-						className="text-base font-medium"
-					>
-						{flowRun.flow.name}
-					</Link>
-					<ChevronRight className="w-4 h-4" />
-					<Link
-						to={"/runs/flow-run/$id"}
-						params={{ id: flowRun.id }}
-						className="text-base font-medium"
-					>
-						{flowRun.name}
-					</Link>
-				</CardTitle>
-				{flowRun.state && (
-					<CardDescription>
-						<StateBadge state={flowRun.state} />
-					</CardDescription>
-				)}
-			</CardHeader>
-			<CardContent className="flex flex-col gap-1">
-				{deployment?.id && (
-					<Link
-						to={"/deployments/deployment/$id"}
-						params={{ id: deployment.id }}
-						className="flex items-center gap-1"
-					>
-						<Rocket className="w-4 h-4" />
-						<p className="text-sm font-medium whitespace-nowrap">
-							{deployment.name}
-						</p>
-					</Link>
-				)}
-				<span className="flex items-center gap-1">
-					<Clock className="w-4 h-4" />
-					<p className="text-sm whitespace-nowrap">
-						{formatDistanceStrict(0, flowRun.total_run_time * 1000, {
-							addSuffix: false,
-						})}
-					</p>
-				</span>
-				{startTime && (
+		<TooltipPortal
+			position={position}
+			coordinate={coordinate}
+			containerRef={containerRef}
+		>
+			<Card>
+				<CardHeader>
+					<CardTitle className="flex items-center gap-1">
+						<Link
+							to={"/flows/flow/$id"}
+							params={{ id: flow.id }}
+							className="text-base font-medium"
+						>
+							{flowRun.flow.name}
+						</Link>
+						<ChevronRight className="w-4 h-4" />
+						<Link
+							to={"/runs/flow-run/$id"}
+							params={{ id: flowRun.id }}
+							className="text-base font-medium"
+						>
+							{flowRun.name}
+						</Link>
+					</CardTitle>
+					{flowRun.state && (
+						<CardDescription>
+							<StateBadge state={flowRun.state} />
+						</CardDescription>
+					)}
+				</CardHeader>
+				<CardContent className="flex flex-col gap-1">
+					{deployment?.id && (
+						<Link
+							to={"/deployments/deployment/$id"}
+							params={{ id: deployment.id }}
+							className="flex items-center gap-1"
+						>
+							<Rocket className="w-4 h-4" />
+							<p className="text-sm font-medium whitespace-nowrap">
+								{deployment.name}
+							</p>
+						</Link>
+					)}
 					<span className="flex items-center gap-1">
-						<Calendar className="w-4 h-4" />
-						<p className="text-sm">{format(startTime, "yyyy/MM/dd hh:mm a")}</p>
+						<Clock className="w-4 h-4" />
+						<p className="text-sm whitespace-nowrap">
+							{formatDistanceStrict(0, flowRun.total_run_time * 1000, {
+								addSuffix: false,
+							})}
+						</p>
 					</span>
-				)}
-				<div>
-					<TagBadgeGroup tags={flowRun.tags ?? []} maxTagsDisplayed={5} />
-				</div>
-			</CardContent>
-		</Card>
+					{startTime && (
+						<span className="flex items-center gap-1">
+							<Calendar className="w-4 h-4" />
+							<p className="text-sm">
+								{format(startTime, "yyyy/MM/dd hh:mm a")}
+							</p>
+						</span>
+					)}
+					<div>
+						<TagBadgeGroup tags={flowRun.tags ?? []} maxTagsDisplayed={5} />
+					</div>
+				</CardContent>
+			</Card>
+		</TooltipPortal>
 	);
 };
 

--- a/ui-v2/src/components/ui/flow-run-acitivity-bar-graph/utils.test.ts
+++ b/ui-v2/src/components/ui/flow-run-acitivity-bar-graph/utils.test.ts
@@ -204,7 +204,9 @@ describe("organizeFlowRunsWithGaps", () => {
 				endDate,
 				numberOfBars,
 			),
-		).toThrow("Number of flow runs is greater than the number of buckets");
+		).toThrow(
+			`Number of flow runs (${flowRuns.length}) is greater than the number of buckets (${numberOfBars})`,
+		);
 	});
 
 	it("should sort runs chronologically for future time spans", () => {

--- a/ui-v2/src/components/ui/flow-run-acitivity-bar-graph/utils.ts
+++ b/ui-v2/src/components/ui/flow-run-acitivity-bar-graph/utils.ts
@@ -27,7 +27,7 @@ export function organizeFlowRunsWithGaps(
 
 	if (flowRuns.length > numberOfBuckets) {
 		throw new Error(
-			"Number of flow runs is greater than the number of buckets",
+			`Number of flow runs (${flowRuns.length}) is greater than the number of buckets (${numberOfBuckets})`,
 		);
 	}
 

--- a/ui-v2/src/mocks/create-fake-flow-run.ts
+++ b/ui-v2/src/mocks/create-fake-flow-run.ts
@@ -1,6 +1,10 @@
+import { FlowRunWithDeploymentAndFlow } from "@/api/flow-runs";
 import type { components } from "@/api/prefect";
 import { faker } from "@faker-js/faker";
+import { createFakeDeployment } from "./create-fake-deployment";
+import { createFakeFlow } from "./create-fake-flow";
 import { createFakeState } from "./create-fake-state";
+
 export const createFakeFlowRun = (
 	overrides?: Partial<components["schemas"]["FlowRun"]>,
 ): components["schemas"]["FlowRun"] => {
@@ -77,3 +81,14 @@ export const createFakeFlowRun = (
 		...overrides,
 	};
 };
+
+export const createFakeFlowRunWithDeploymentAndFlow =
+	(): FlowRunWithDeploymentAndFlow => {
+		const flowRun = createFakeFlowRun();
+
+		return {
+			...flowRun,
+			deployment: createFakeDeployment(),
+			flow: createFakeFlow(),
+		};
+	};

--- a/ui-v2/src/mocks/create-fake-flow-run.ts
+++ b/ui-v2/src/mocks/create-fake-flow-run.ts
@@ -1,7 +1,6 @@
 import type { components } from "@/api/prefect";
 import { faker } from "@faker-js/faker";
 import { createFakeState } from "./create-fake-state";
-
 export const createFakeFlowRun = (
 	overrides?: Partial<components["schemas"]["FlowRun"]>,
 ): components["schemas"]["FlowRun"] => {
@@ -39,9 +38,9 @@ export const createFakeFlowRun = (
 		run_count: 1,
 		expected_start_time: faker.date.past().toISOString(),
 		next_scheduled_start_time: null,
-		start_time: faker.date.past().toISOString(),
-		end_time: faker.date.past().toISOString(),
-		total_run_time: 0,
+		start_time: faker.date.past({ years: 0.1 }).toISOString(),
+		end_time: faker.date.past({ years: 0.1 }).toISOString(),
+		total_run_time: faker.number.int({ min: 1, max: 100 }),
 		estimated_run_time: faker.number.float({ max: 30 }),
 		estimated_start_time_delta: faker.number.float({ max: 30 }),
 		auto_scheduled: false,

--- a/ui-v2/tests/utils/handlers.ts
+++ b/ui-v2/tests/utils/handlers.ts
@@ -30,15 +30,18 @@ const flowHandlers = [
 			],
 		});
 	}),
+
+	http.post(buildApiUrl("/deployments/count"), () => {
+		return HttpResponse.json(1);
+	}),
+];
+
+const flowRunHandlers = [
 	http.post(buildApiUrl("/flow_runs/filter"), () => {
 		return HttpResponse.json([
 			{ id: "1", name: "Flow 1", tags: [] },
 			{ id: "2", name: "Flow 2", tags: [] },
 		]);
-	}),
-
-	http.post(buildApiUrl("/deployments/count"), () => {
-		return HttpResponse.json(1);
 	}),
 ];
 
@@ -93,6 +96,7 @@ const variablesHandlers = [
 export const handlers = [
 	...automationsHandlers,
 	...flowHandlers,
+	...flowRunHandlers,
 	...globalConcurrencyLimitsHandlers,
 	...taskRunConcurrencyLimitsHandlers,
 	...variablesHandlers,


### PR DESCRIPTION
This PR integrated the flow run activity bar graph into the deployments table.

Here's what it looks like in action:

https://github.com/user-attachments/assets/6a0ecd1c-a7bf-4d29-8036-ab22605ffd06

A couple of noteworthy things:
- I introduced a context that wraps the deployments table to ensure only one graph displays a tooltip at a time.
- The query for the flow runs lives in a table cell because the number of flow runs to query for is determined by the cell size.


