### PR TITLE
call `FlowRunContext.model_rebuild()` in `hydrate_context`

### DIFF
--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -52,7 +52,6 @@ def serialize_context() -> dict[str, Any]:
     """
     Serialize the current context for use in a remote execution environment.
     """
-
     flow_run_context = EngineContext.get()
     task_run_context = TaskRunContext.get()
     tags_context = TagsContext.get()
@@ -71,6 +70,8 @@ def hydrated_context(
     serialized_context: Optional[dict[str, Any]] = None,
     client: Union[PrefectClient, SyncPrefectClient, None] = None,
 ) -> Generator[None, Any, None]:
+    from prefect.main import _types
+
     with ExitStack() as stack:
         if serialized_context:
             # Set up settings context
@@ -81,6 +82,7 @@ def hydrated_context(
             if flow_run_context := serialized_context.get("flow_run_context"):
                 flow = flow_run_context["flow"]
                 task_runner = stack.enter_context(flow.task_runner.duplicate())
+                FlowRunContext.model_rebuild(_types_namespace=_types)
                 flow_run_context = FlowRunContext(
                     **flow_run_context,
                     client=client,

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -70,7 +70,7 @@ def hydrated_context(
     serialized_context: Optional[dict[str, Any]] = None,
     client: Union[PrefectClient, SyncPrefectClient, None] = None,
 ) -> Generator[None, Any, None]:
-    from prefect.main import _types
+    import prefect.main  # noqa # type: ignore
 
     with ExitStack() as stack:
         if serialized_context:
@@ -82,7 +82,6 @@ def hydrated_context(
             if flow_run_context := serialized_context.get("flow_run_context"):
                 flow = flow_run_context["flow"]
                 task_runner = stack.enter_context(flow.task_runner.duplicate())
-                FlowRunContext.model_rebuild(_types_namespace=_types)
                 flow_run_context = FlowRunContext(
                     **flow_run_context,
                     client=client,

--- a/src/prefect/context.py
+++ b/src/prefect/context.py
@@ -70,7 +70,20 @@ def hydrated_context(
     serialized_context: Optional[dict[str, Any]] = None,
     client: Union[PrefectClient, SyncPrefectClient, None] = None,
 ) -> Generator[None, Any, None]:
-    import prefect.main  # noqa # type: ignore
+    # We need to rebuild the models because we might be hydrating in a remote
+    # environment where the models are not available.
+    # TODO: Remove this once we have fixed our circular imports and we don't need to rebuild models any more.
+    from prefect.flows import Flow
+    from prefect.results import ResultRecordMetadata
+    from prefect.tasks import Task
+
+    _types: dict[str, Any] = dict(
+        Flow=Flow,
+        Task=Task,
+        ResultRecordMetadata=ResultRecordMetadata,
+    )
+    FlowRunContext.model_rebuild(_types_namespace=_types)
+    TaskRunContext.model_rebuild(_types_namespace=_types)
 
     with ExitStack() as stack:
         if serialized_context:

--- a/src/prefect/telemetry/services.py
+++ b/src/prefect/telemetry/services.py
@@ -53,6 +53,8 @@ class QueueingSpanExporter(BaseQueueingExporter[ReadableSpan], SpanExporter):
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         for item in spans:
+            if self._stopped:
+                break
             self.send(item)
         return SpanExportResult.SUCCESS
 
@@ -65,4 +67,6 @@ class QueueingLogExporter(BaseQueueingExporter[LogData], LogExporter):
 
     def export(self, batch: Sequence[LogData]) -> None:
         for item in batch:
+            if self._stopped:
+                break
             self.send(item)


### PR DESCRIPTION
fixes `EngineContext` rebuild error, which when occurring was causing this downstream error, as the pydantic error could not be serialized
```
ray.exceptions.RaySystemError: System error: Failed to unpickle serialized exception
traceback: Traceback (most recent call last):
  File "/Users/nate/Library/Caches/uv/archive-v0/9aF8mmPcr6WgOvDDdAgDC/lib/python3.12/site-packages/ray/exceptions.py", line 51, in from_ray_exception
    return pickle.loads(ray_exception.serialized_exception)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: PydanticErrorMixin.__init__() missing 1 required keyword-only argument: 'code'
```

and assorted typing improvements