### PR TITLE
Tune CI for efficiency

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -27,10 +27,7 @@ concurrency:
 jobs:
   run-benchmarks:
     name: Benchmark
-    # Runs with ephemeral API and SQLite database right now
-
-    runs-on:
-      group: oss-larger-runners
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/codspeed-benchmarks.yaml
+++ b/.github/workflows/codspeed-benchmarks.yaml
@@ -28,10 +28,7 @@ concurrency:
 jobs:
   run-benchmarks:
     name: Benchmark
-    # Runs with ephemeral API and SQLite database right now
-
-    runs-on:
-      group: oss-larger-runners
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/markdown-tests.yaml
+++ b/.github/workflows/markdown-tests.yaml
@@ -52,8 +52,7 @@ concurrency:
 
 jobs:
   run-markdown-tests:
-    runs-on:
-      group: oss-larger-runners
+    runs-on: ubuntu-latest
     name: markdown:${{ matrix.python-version }}, ${{ matrix.database }}
     strategy:
       matrix:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -49,8 +49,7 @@ concurrency:
 
 jobs:
   run-tests:
-    runs-on:
-      group: oss-larger-runners
+    runs-on: ubuntu-latest
     name: ${{ matrix.test-type.name }} - python:${{ matrix.python-version }}, ${{ matrix.database }}
     strategy:
       matrix:
@@ -148,26 +147,8 @@ jobs:
           --publish 6379:6379
           redis:latest
 
-      - name: Set coverage file and artifact name
-        id: set_coverage_and_artifact_name
-        run: |
-          sanitized_test_type="${{ matrix.test-type.name }}"
-          sanitized_test_type="${sanitized_test_type// /_}"
-          sanitized_database="${{ matrix.database }}"
-          sanitized_database="${sanitized_database//:/\-}"
-          sanitized_python_version="${{ matrix.python-version }}"
-          export COVERAGE_FILE=".coverage.${sanitized_test_type}.${sanitized_python_version}.${sanitized_database}"
-          echo "COVERAGE_FILE=${COVERAGE_FILE}" >> $GITHUB_ENV
-          echo "artifact_name=coverage-data-${sanitized_test_type}-${{ matrix.python-version }}-${sanitized_database}" >> $GITHUB_OUTPUT
-
-      - name: Set coverage core
-        if: ${{ matrix.python-version == '3.12' }}
-        run: |
-          echo "COVERAGE_CORE=sysmon" >> $GITHUB_ENV
-
       - name: Run tests
         run: |
-          echo "Using COVERAGE_FILE=$COVERAGE_FILE"
           pytest ${{ matrix.test-type.modules }} \
           --numprocesses auto \
           --maxprocesses 6 \
@@ -176,17 +157,6 @@ jobs:
           --exclude-service kubernetes \
           --exclude-service docker \
           --durations 26 \
-          --cov=prefect \
-          --cov-config=setup.cfg \
-          --cov-report=''
-
-      - name: Upload coverage data
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.set_coverage_and_artifact_name.outputs.artifact_name }}
-          path: ${{ env.COVERAGE_FILE }}
-          include-hidden-files: true
-          retention-days: 1
 
       - name: Create and Upload failure flag
         if: ${{ failure() }}
@@ -213,8 +183,7 @@ jobs:
           || echo "Ignoring bad exit code"
 
   run-docker-tests:
-    runs-on:
-      group: oss-larger-runners
+    runs-on: ubuntu-latest
     name: docker, python:${{ matrix.python-version }}
     strategy:
       matrix:
@@ -346,21 +315,6 @@ jobs:
           --publish 6379:6379
           redis:latest
 
-      - name: Set coverage file and artifact name
-        id: set_coverage_and_artifact_name
-        run: |
-          sanitized_database="${{ matrix.database }}"
-          sanitized_database="${sanitized_database//:/\-}"
-          sanitized_python_version="${{ matrix.python-version }}"
-          export COVERAGE_FILE=".coverage.${sanitized_python_version}.${sanitized_database}"
-          echo "COVERAGE_FILE=${COVERAGE_FILE}" >> $GITHUB_ENV
-          echo "artifact_name=coverage-data-docker-${{ matrix.python-version }}-${sanitized_database}" >> $GITHUB_OUTPUT
-
-      - name: Set coverage core
-        if: ${{ matrix.python-version == '3.12' }}
-        run: |
-          echo "COVERAGE_CORE=sysmon" >> $GITHUB_ENV
-
       - name: Run tests
         run: |
           echo "Using COVERAGE_FILE=$COVERAGE_FILE"
@@ -371,17 +325,6 @@ jobs:
           --disable-docker-image-builds \
           --only-service docker \
           --durations 26 \
-          --cov=prefect \
-          --cov-config=setup.cfg \
-          --cov-report=''
-
-      - name: Upload coverage data
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.set_coverage_and_artifact_name.outputs.artifact_name }}
-          path: ${{ env.COVERAGE_FILE }}
-          include-hidden-files: true
-          retention-days: 1
 
       - name: Create and Upload failure flag
         if: ${{ failure() }}
@@ -406,49 +349,6 @@ jobs:
           docker container inspect postgres \
           && docker container logs postgres \
           || echo "Ignoring bad exit code"
-
-  combine-coverage:
-    runs-on: ubuntu-latest
-    needs:
-      - run-tests
-      - run-docker-tests
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        id: setup_python
-        with:
-          python-version: "3.12"
-
-      - name: Download coverage data artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: coverage-data-*
-          merge-multiple: true
-
-      - name: Install coverage
-        run: pip install coverage
-
-      - name: Combine coverage data
-        run: coverage combine
-
-      - name: Generate HTML coverage report
-        run: coverage html
-
-      - name: Upload combined coverage report
-        uses: actions/upload-artifact@v4
-        with:
-          name: combined-coverage-report
-          path: htmlcov/
-
-      - name: Publish coverage markdown report
-        run: |
-          echo "## Coverage Report" >> $GITHUB_STEP_SUMMARY
-          echo "[Detailed Report](${{ steps.upload_combined_coverage_report.outputs.artifact_url }})" >> $GITHUB_STEP_SUMMARY
-          coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
 
   run-typesafety-test:
     name: typesafety

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -55,15 +55,13 @@ jobs:
       matrix:
         test-type:
           - name: Server Tests
-            modules: tests/server/ tests/events/server --ignore=tests/server/database/
-          - name: Server Database Tests
-            modules: tests/server/database/
+            modules: tests/server/ tests/events/server --ignore=tests/server/database/ --ignore=tests/server/models/
+          - name: Database Tests
+            modules: tests/server/database/ tests/server/models/
           - name: Client Tests
             modules: tests/ --ignore=tests/typesafety --ignore=tests/server/ --ignore=tests/events/server --ignore=tests/test_task_runners.py --ignore=tests/runner --ignore=tests/workers --ignore=tests/cli/
-          - name: Runner and Worker Tests
-            modules: tests/test_task_runners.py tests/runner tests/workers
-          - name: CLI Tests
-            modules: tests/cli/
+          - name: Runner, Worker, and CLI Tests
+            modules: tests/test_task_runners.py tests/runner tests/workers tests/cli/
         database:
           - "postgres:14"
           - "sqlite"
@@ -79,12 +77,8 @@ jobs:
               modules: tests/ --ignore=tests/typesafety --ignore=tests/server/ --ignore=tests/events/server --ignore=tests/test_task_runners.py --ignore=tests/runner --ignore=tests/workers --ignore=tests/cli/
           - database: "sqlite"
             test-type:
-              name: Runner and Worker Tests
-              modules: tests/test_task_runners.py tests/runner tests/workers
-          - database: "sqlite"
-            test-type:
-              name: CLI Tests
-              modules: tests/cli/
+              name: Runner, Worker, and CLI Tests
+              modules: tests/test_task_runners.py tests/runner tests/workers tests/cli/
 
       fail-fast: true
 

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -52,6 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ matrix.test-type.name }} - python:${{ matrix.python-version }}, ${{ matrix.database }}
     strategy:
+      fail-fast: false
       matrix:
         test-type:
           - name: Server Tests
@@ -215,7 +216,7 @@ jobs:
           - "3.11"
           - "3.12"
 
-      fail-fast: true
+      fail-fast: false
 
     timeout-minutes: 45
 

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -55,11 +55,15 @@ jobs:
       matrix:
         test-type:
           - name: Server Tests
-            modules: tests/server/ tests/events/server
+            modules: tests/server/ tests/events/server --ignore=tests/server/database/
+          - name: Server Database Tests
+            modules: tests/server/database/
           - name: Client Tests
-            modules: tests/ --ignore=tests/typesafety --ignore=tests/server/ --ignore=tests/events/server --ignore=tests/test_task_runners.py --ignore=tests/runner --ignore=tests/workers
+            modules: tests/ --ignore=tests/typesafety --ignore=tests/server/ --ignore=tests/events/server --ignore=tests/test_task_runners.py --ignore=tests/runner --ignore=tests/workers --ignore=tests/cli/
           - name: Runner and Worker Tests
             modules: tests/test_task_runners.py tests/runner tests/workers
+          - name: CLI Tests
+            modules: tests/cli/
         database:
           - "postgres:14"
           - "sqlite"
@@ -72,11 +76,15 @@ jobs:
           - database: "sqlite"
             test-type:
               name: Client Tests
-              modules: tests/ --ignore=tests/typesafety --ignore=tests/server/ --ignore=tests/events/server --ignore=tests/test_task_runners.py --ignore=tests/runner --ignore=tests/workers
+              modules: tests/ --ignore=tests/typesafety --ignore=tests/server/ --ignore=tests/events/server --ignore=tests/test_task_runners.py --ignore=tests/runner --ignore=tests/workers --ignore=tests/cli/
           - database: "sqlite"
             test-type:
               name: Runner and Worker Tests
               modules: tests/test_task_runners.py tests/runner tests/workers
+          - database: "sqlite"
+            test-type:
+              name: CLI Tests
+              modules: tests/cli/
 
       fail-fast: true
 

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -100,8 +100,6 @@ jobs:
               name: Runner, Worker, Settings, Input, and CLI Tests
               modules: tests/test_task_runners.py tests/runner tests/workers tests/cli/ tests/test_settings.py tests/input/
 
-      fail-fast: true
-
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -56,9 +56,9 @@ jobs:
       matrix:
         test-type:
           - name: Server Tests
-            modules: tests/server/ tests/events/server --ignore=tests/server/database/ --ignore=tests/server/models/
+            modules: tests/server/ tests/events/server --ignore=tests/server/database/ --ignore=tests/server/orchestration/
           - name: Database and Orchestration Tests
-            modules: tests/server/database/ tests/server/models/ tests/server/orchestration/
+            modules: tests/server/database/ tests/server/orchestration/
           - name: Client Tests
             modules: >-
               tests/

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -56,12 +56,22 @@ jobs:
         test-type:
           - name: Server Tests
             modules: tests/server/ tests/events/server --ignore=tests/server/database/ --ignore=tests/server/models/
-          - name: Database Tests
-            modules: tests/server/database/ tests/server/models/
+          - name: Database and Orchestration Tests
+            modules: tests/server/database/ tests/server/models/ tests/server/orchestration/
           - name: Client Tests
-            modules: tests/ --ignore=tests/typesafety --ignore=tests/server/ --ignore=tests/events/server --ignore=tests/test_task_runners.py --ignore=tests/runner --ignore=tests/workers --ignore=tests/cli/
-          - name: Runner, Worker, and CLI Tests
-            modules: tests/test_task_runners.py tests/runner tests/workers tests/cli/
+            modules: >-
+              tests/
+              --ignore=tests/typesafety
+              --ignore=tests/server/
+              --ignore=tests/events/server
+              --ignore=tests/test_task_runners.py
+              --ignore=tests/runner
+              --ignore=tests/workers
+              --ignore=tests/cli/
+              --ignore=tests/test_settings.py
+              --ignore=tests/input/
+          - name: Runner, Worker, Settings, Input, and CLI Tests
+            modules: tests/test_task_runners.py tests/runner tests/workers tests/cli/ tests/test_settings.py tests/input/
         database:
           - "postgres:14"
           - "sqlite"
@@ -74,11 +84,21 @@ jobs:
           - database: "sqlite"
             test-type:
               name: Client Tests
-              modules: tests/ --ignore=tests/typesafety --ignore=tests/server/ --ignore=tests/events/server --ignore=tests/test_task_runners.py --ignore=tests/runner --ignore=tests/workers --ignore=tests/cli/
+              modules: >-
+                tests/
+                --ignore=tests/typesafety
+                --ignore=tests/server/
+                --ignore=tests/events/server
+                --ignore=tests/test_task_runners.py
+                --ignore=tests/runner
+                --ignore=tests/workers
+                --ignore=tests/cli/
+                --ignore=tests/test_settings.py
+                --ignore=tests/input/
           - database: "sqlite"
             test-type:
-              name: Runner, Worker, and CLI Tests
-              modules: tests/test_task_runners.py tests/runner tests/workers tests/cli/
+              name: Runner, Worker, Settings, Input, and CLI Tests
+              modules: tests/test_task_runners.py tests/runner tests/workers tests/cli/ tests/test_settings.py tests/input/
 
       fail-fast: true
 

--- a/tests/cli/test_prompts.py
+++ b/tests/cli/test_prompts.py
@@ -83,7 +83,9 @@ class TestDiscoverFlows:
         )
 
     async def test_find_all_flows_works_on_large_directory_structures(self):
-        flows = await search_for_flow_functions(str(prefect.__development_base_path__))
+        flows = await search_for_flow_functions(
+            str(prefect.__development_base_path__ / "tests")
+        )
         assert len(flows) > 500
 
     async def test_find_flow_functions_in_file_returns_empty_list_on_file_error(

--- a/tests/telemetry/test_instrumentation.py
+++ b/tests/telemetry/test_instrumentation.py
@@ -122,7 +122,14 @@ def test_meter_provider(telemetry_account_id: UUID, telemetry_workspace_id: UUID
     _, meter_provider, _ = setup_telemetry()
     assert isinstance(meter_provider, MeterProvider)
 
-    metric_reader = list(meter_provider._all_metric_readers)[0]
+    metric_reader = next(
+        (
+            reader
+            for reader in meter_provider._all_metric_readers
+            if isinstance(reader, PeriodicExportingMetricReader)
+        ),
+        None,
+    )
     assert isinstance(metric_reader, PeriodicExportingMetricReader)
     exporter = metric_reader._exporter
     assert isinstance(exporter, OTLPMetricExporter)

--- a/tests/telemetry/test_instrumentation.py
+++ b/tests/telemetry/test_instrumentation.py
@@ -123,8 +123,8 @@ def test_meter_provider(telemetry_account_id: UUID, telemetry_workspace_id: UUID
     assert isinstance(meter_provider, MeterProvider)
 
     metric_reader = list(meter_provider._all_metric_readers)[0]
-    exporter = metric_reader._exporter
     assert isinstance(metric_reader, PeriodicExportingMetricReader)
+    exporter = metric_reader._exporter
     assert isinstance(exporter, OTLPMetricExporter)
 
     resource_attributes = {


### PR DESCRIPTION
This PR tweaks our testing setup to optimize our runner usage. I removed coverage collection because it added overhead to our test suite and provided little value. If we want to gather coverage, we can create an on-demand job to gather coverage data when needed. I also split up the test suite between jobs more effectively and updated all jobs to use the default Ubuntu runners. With these changes we get roughly the same speed at a fraction of the cost.
