### PR TITLE
Enable `run-integration-flows` to validate the version of prefect

### DIFF
--- a/scripts/run-integration-flows.py
+++ b/scripts/run-integration-flows.py
@@ -13,6 +13,7 @@ Example:
     PREFECT_API_URL="http://localhost:4200/api" ./scripts/run-integration-flows.py
 """
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -28,6 +29,24 @@ DEFAULT_PATH = (
     )
     / "flows"
 )
+
+
+def validate_version():
+    expected_version = os.environ.get("EXPECTED_PREFECT_VERSION")
+
+    if not expected_version:
+        return
+    elif expected_version == "main":
+        print(f"✓ Running with Prefect version: {__version__}")
+        return
+
+    installed_version = ".".join(__version__.split(".")[:2])
+    if installed_version != expected_version:
+        print("Version mismatch!")
+        print(f"Expected Prefect version: {expected_version}")
+        print(f"Installed Prefect version: {installed_version}")
+        sys.exit(1)
+    print(f"✓ Prefect version {installed_version} matches expected version")
 
 
 def run_script(script_path: str):
@@ -57,4 +76,5 @@ def run_flows(search_path: Union[str, Path]):
 
 
 if __name__ == "__main__":
+    validate_version()
     run_flows(sys.argv[1] if len(sys.argv) > 1 else DEFAULT_PATH)


### PR DESCRIPTION
This adds a validate_version call to run-integration-flows. This is to help with Prefect Cloud's client compatibility checks to ensure that the version we believe we're testing against is actually what's installed.