### PR TITLE
Reduces the minimum memory requirement for Prefect Server

### DIFF
--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -59,10 +59,10 @@ PID_FILE = "server.pid"
 def generate_welcome_blurb(base_url, ui_enabled: bool):
     blurb = textwrap.dedent(
         r"""
-         ___ ___ ___ ___ ___ ___ _____ 
-        | _ \ _ \ __| __| __/ __|_   _| 
-        |  _/   / _|| _|| _| (__  | |  
-        |_| |_|_\___|_| |___\___| |_|  
+         ___ ___ ___ ___ ___ ___ _____
+        | _ \ _ \ __| __| __/ __|_   _|
+        |  _/   / _|| _|| _| (__  | |
+        |_| |_|_\___|_| |___\___| |_|
 
         Configure Prefect to communicate with the server with:
 
@@ -232,6 +232,7 @@ async def start(
     server_env["PREFECT_API_SERVICES_UI"] = str(ui)
     server_env["PREFECT_UI_ENABLED"] = str(ui)
     server_env["PREFECT_SERVER_LOGGING_LEVEL"] = log_level
+    server_env["PREFECT__SERVER_FINAL"] = "1"
 
     pid_file = anyio.Path(PREFECT_HOME.value() / PID_FILE)
     # check if port is already in use


### PR DESCRIPTION
This brings the minimum memory requirement for Prefect Server from
~400MB to ~345MB in my testing*.

What I discovered was that when when we use FastAPI's `include_router`,
FastAPI will create _new_ routes rather than using a reference to the
previously declared router's routes.  This is because additional
dependencies may be injected that the original router wasn't aware of,
so the new routes are built using the original router as a reference.

With Prefect's (likely very commonplace) pattern of declaring
module-level routers and then assembling them into a larger FastAPI
`app`, this means that there is an entire copy of the routes left in
memory that will likely never be touched again.  Because the routes may
include dynamically generated Pydantic models representing the bodies of
requests, which themselves may be referring to other models that Prefect
defines, the complexity of the generated validators can balloon quickly.
In our case, something like ~50-55MB is held in references by those
routes.

*Note about the testing approach: I used a script that runs `prefect
server start` in a `cgroup` to constrain the memory it has access to by
setting `memory.max` and by disabling swap memory with `memory.swap=0`.
It then polls the health check for 5 consecutive successes while
confirming that the process remains running.  From there it performs
a binary search over the memory constraint until it finds the minimum
that allows for stable startup and health checks.

This new minimum of 345MB is probably too low for practical use, as some
additional memory would be required to run an actual flow, receive its
logs and events, and run periodic loop services.

<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
