### PR TITLE
Skip parameter validation check for a more consistent benchmark reading

### DIFF
--- a/.github/workflows/codspeed-benchmarks.yaml
+++ b/.github/workflows/codspeed-benchmarks.yaml
@@ -13,6 +13,7 @@ on:
       - requirements-dev.txt
       - setup.cfg
       - Dockerfile
+      - benches/**/*.py
   push:
     branches:
       - main

--- a/benches/bench_flows.py
+++ b/benches/bench_flows.py
@@ -22,7 +22,7 @@ async def anoop_function():
 
 
 def bench_flow_decorator(benchmark: "BenchmarkFixture"):
-    benchmark(flow, noop_function)
+    benchmark(flow, noop_function, should_validate_parameters=False)
 
 
 @pytest.mark.parametrize("options", [{}, {"timeout_seconds": 10}])

--- a/benches/bench_flows.py
+++ b/benches/bench_flows.py
@@ -22,7 +22,7 @@ async def anoop_function():
 
 
 def bench_flow_decorator(benchmark: "BenchmarkFixture"):
-    benchmark(flow, noop_function, should_validate_parameters=False)
+    benchmark(flow(validate_parameters=False), noop_function)
 
 
 @pytest.mark.parametrize("options", [{}, {"timeout_seconds": 10}])


### PR DESCRIPTION
When the `Flow` class checks if parameters can be validated, `pydantic` makes some system calls that are difficult for CodSpeed to benchmark consistently. This had led to instability in this check. This PR updates the benchmark to skip this validation check to remove the system calls that were causing instability. To CodSpeed, it looks faster, but not changes where made to effect the performance of the underlying code.