### PR TITLE
Reduces the memory requirement of a standalone Prefect server again

### DIFF
--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -2,18 +2,22 @@
 Command line interface for working with Prefect
 """
 
-import logging
 import os
 import shlex
+import signal
 import socket
+import subprocess
 import sys
 import textwrap
+from pathlib import Path
 
 import anyio
 import anyio.abc
 import typer
+import uvicorn
 
 import prefect
+import prefect.settings
 from prefect.cli._prompts import prompt
 from prefect.cli._types import PrefectTyper, SettingsOption
 from prefect.cli._utilities import exit_with_error, exit_with_success
@@ -37,11 +41,8 @@ from prefect.settings import (
     save_profiles,
     update_current_profile,
 )
+from prefect.settings.context import temporary_settings
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
-from prefect.utilities.processutils import (
-    consume_process_output,
-    setup_signal_handlers_server,
-)
 
 server_app = PrefectTyper(
     name="server",
@@ -200,7 +201,7 @@ def prestart_check(base_url: str):
 
 
 @server_app.command()
-async def start(
+def start(
     host: str = SettingsOption(PREFECT_SERVER_API_HOST),
     port: int = SettingsOption(PREFECT_SERVER_API_PORT),
     keep_alive_timeout: int = SettingsOption(PREFECT_SERVER_API_KEEPALIVE_TIMEOUT),
@@ -225,22 +226,21 @@ async def start(
         except Exception:
             pass
 
-    server_env = os.environ.copy()
-    server_env["PREFECT_API_SERVICES_SCHEDULER_ENABLED"] = str(scheduler)
-    server_env["PREFECT_SERVER_ANALYTICS_ENABLED"] = str(analytics)
-    server_env["PREFECT_API_SERVICES_LATE_RUNS_ENABLED"] = str(late_runs)
-    server_env["PREFECT_API_SERVICES_UI"] = str(ui)
-    server_env["PREFECT_UI_ENABLED"] = str(ui)
-    server_env["PREFECT_SERVER_LOGGING_LEVEL"] = log_level
-    server_env["PREFECT__SERVER_FINAL"] = "1"
+    server_settings = {
+        "PREFECT_API_SERVICES_SCHEDULER_ENABLED": str(scheduler),
+        "PREFECT_SERVER_ANALYTICS_ENABLED": str(analytics),
+        "PREFECT_API_SERVICES_LATE_RUNS_ENABLED": str(late_runs),
+        "PREFECT_UI_ENABLED": str(ui),
+        "PREFECT_SERVER_LOGGING_LEVEL": log_level,
+    }
 
-    pid_file = anyio.Path(PREFECT_HOME.value() / PID_FILE)
+    pid_file = Path(PREFECT_HOME.value() / PID_FILE)
     # check if port is already in use
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind((host, port))
     except socket.error:
-        if await pid_file.exists():
+        if pid_file.exists():
             exit_with_error(
                 f"A background server process is already running on port {port}. "
                 "Run `prefect server stop` to stop it or specify a different port "
@@ -254,7 +254,7 @@ async def start(
     # check if server is already running in the background
     if background:
         try:
-            await pid_file.touch(mode=0o600, exist_ok=False)
+            pid_file.touch(mode=0o600, exist_ok=False)
         except FileExistsError:
             exit_with_error(
                 "A server is already running in the background. To stop it,"
@@ -264,58 +264,74 @@ async def start(
     app.console.print(generate_welcome_blurb(base_url, ui_enabled=ui))
     app.console.print("\n")
 
-    try:
-        command = [
-            sys.executable,
-            "-m",
-            "uvicorn",
-            "--app-dir",
-            str(prefect.__module_path__.parent),
-            "--factory",
-            "prefect.server.api.server:create_app",
-            "--host",
-            str(host),
-            "--port",
-            str(port),
-            "--timeout-keep-alive",
-            str(keep_alive_timeout),
-        ]
-        logger.debug("Opening server process with command: %s", shlex.join(command))
-        process = await anyio.open_process(
-            command=command,
-            env=server_env,
+    if background:
+        _run_in_background(pid_file, server_settings, host, port, keep_alive_timeout)
+    else:
+        _run_in_foreground(pid_file, server_settings, host, port, keep_alive_timeout)
+
+
+def _run_in_background(
+    pid_file: Path,
+    server_settings: dict[str, str],
+    host: str,
+    port: int,
+    keep_alive_timeout: int,
+) -> None:
+    command = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "--app-dir",
+        str(prefect.__module_path__.parent),
+        "--factory",
+        "prefect.server.api.server:create_app",
+        "--host",
+        str(host),
+        "--port",
+        str(port),
+        "--timeout-keep-alive",
+        str(keep_alive_timeout),
+    ]
+    logger.debug("Opening server process with command: %s", shlex.join(command))
+    process = subprocess.Popen(
+        command,
+        env={
+            **os.environ,
+            **server_settings,
+            "PREFECT__SERVER_FINAL": "1",
+        },
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    process_id = process.pid
+    pid_file.write_text(str(process_id))
+
+    app.console.print(
+        "The Prefect server is running in the background. Run `prefect"
+        " server stop` to stop it."
+    )
+
+
+def _run_in_foreground(
+    pid_file: Path,
+    server_settings: dict[str, str],
+    host: str,
+    port: int,
+    keep_alive_timeout: int,
+) -> None:
+    from prefect.server.api.server import create_app
+
+    with temporary_settings(
+        {getattr(prefect.settings, k): v for k, v in server_settings.items()}
+    ):
+        uvicorn.run(
+            app=create_app(final=True),
+            app_dir=str(prefect.__module_path__.parent),
+            host=host,
+            port=port,
+            timeout_keep_alive=keep_alive_timeout,
         )
-
-        process_id = process.pid
-        if background:
-            await pid_file.write_text(str(process_id))
-
-            app.console.print(
-                "The Prefect server is running in the background. Run `prefect"
-                " server stop` to stop it."
-            )
-            return
-
-        async with process:
-            # Explicitly handle the interrupt signal here, as it will allow us to
-            # cleanly stop the uvicorn server. Failing to do that may cause a
-            # large amount of anyio error traces on the terminal, because the
-            # SIGINT is handled by Typer/Click in this process (the parent process)
-            # and will start shutting down subprocesses:
-            # https://github.com/PrefectHQ/server/issues/2475
-
-            setup_signal_handlers_server(
-                process_id, "the Prefect server", app.console.print
-            )
-
-            await consume_process_output(process, sys.stdout, sys.stderr)
-
-    except anyio.EndOfStream:
-        logging.error("Subprocess stream ended unexpectedly")
-
-    # This should only be reached if the server crashed, or was forcibly terminated,
-    # hence we exit with an error
-    exit_with_error("Server stopped!", code=process.returncode)
 
 
 @server_app.command()
@@ -326,7 +342,7 @@ async def stop():
         exit_with_success("No server running in the background.")
     pid = int(await pid_file.read_text())
     try:
-        os.kill(pid, 15)
+        os.kill(pid, signal.SIGTERM)
     except ProcessLookupError:
         exit_with_success(
             "The server process is not running. Cleaning up stale PID file."


### PR DESCRIPTION
In #16644, we were able to get the standalone Prefect server we run in
`prefect server start` from 400MB to 343MB.  By running `uvicorn`
directly in the parent process, we further reduce that to **266MB**.  I
measured this using the same process as before, using a `cgroup` with
no swap to constrain the memory until I found the minimum.

There are two main changes here:

1. Making `prefect server start` a synchronous command in both the
   background and the foreground cases.  This helps to simplify the
   handling of signals and removes the need for `anyio` or piping the
   streams of a child process manually.

2. Splitting the paths between background and foreground servers.  In
   the case of the background server, we run the subprocess as usual and
   then exit leaving it running.  In the case of the foreground server,
   we run it with `uvicorn.run` as the final call, letting `uvicorn`
   handle signals.  `uvicorn` already handles `SIGINT` and `SIGTERM` to
   cleanly shutdown, so we don't need to do anything additional here.

I'm removing the two tests that were testing what happens when the
signals are sent in escalating succession, as they aren't materially
different now.  In both cases, `uvicorn` will attempt to shutdown
cleanly.  I also updated the tests to reflect that `SIGINT` will lead to
a successful exit, while `SIGTERM` will lead to a -15 exit (pretty
standard).

<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
