### PR TITLE
Fix configuring loggers found in 'PREFECT_LOGGING_EXTRA_LOGGERS'

### DIFF
--- a/src/prefect/logging/configuration.py
+++ b/src/prefect/logging/configuration.py
@@ -94,12 +94,9 @@ def setup_logging(incremental: Optional[bool] = None) -> dict[str, Any]:
 
     for logger_name in PREFECT_LOGGING_EXTRA_LOGGERS.value():
         logger = logging.getLogger(logger_name)
-        for handler in extra_config.handlers:
-            if not config["incremental"]:
+        if not config["incremental"]:
+            for handler in extra_config.handlers:
                 logger.addHandler(handler)
-            if logger.level == logging.NOTSET:
-                logger.setLevel(extra_config.level)
-            logger.propagate = extra_config.propagate
 
     PROCESS_LOGGING_CONFIG = config
 


### PR DESCRIPTION
Each logger defined in 'PREFECT_LOGGING_EXTRA_LOGGERS' now has their level set according to the 'prefect.extra' level. Previously, this only occurred when their level was NOTSET.

Additionally, avoid configuring the logger 'level' and 'propagate' values while iterating over 'extra_config.handlers'

closes https://github.com/PrefectHQ/prefect/issues/15370

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
