### PR TITLE
[UI v2] experiment: Adds dark mode decorator for all stories

### DIFF
--- a/ui-v2/.storybook/preview-body.html
+++ b/ui-v2/.storybook/preview-body.html
@@ -1,0 +1,2 @@
+<html class="bg-slate-800">
+</html>

--- a/ui-v2/.storybook/preview.ts
+++ b/ui-v2/.storybook/preview.ts
@@ -1,3 +1,4 @@
+import { ModeDecorator } from "@/storybook/utils";
 import type { Preview } from "@storybook/react";
 import { handlers } from "@tests/utils/handlers";
 import { initialize, mswLoader } from "msw-storybook-addon";
@@ -16,6 +17,7 @@ export default {
 			},
 		},
 	},
+	decorators: [ModeDecorator],
 	// Provide the MSW addon loader globally
 	loaders: [mswLoader],
 } satisfies Preview;

--- a/ui-v2/src/storybook/utils/index.ts
+++ b/ui-v2/src/storybook/utils/index.ts
@@ -1,3 +1,4 @@
 export { routerDecorator } from "./router-decorator";
 export { reactQueryDecorator } from "./react-query-decorator";
 export { toastDecorator } from "./toast-decorator";
+export { ModeDecorator } from "./mode-decorator";

--- a/ui-v2/src/storybook/utils/mode-decorator.tsx
+++ b/ui-v2/src/storybook/utils/mode-decorator.tsx
@@ -1,0 +1,31 @@
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { StoryFn } from "@storybook/react";
+import { useEffect, useState } from "react";
+
+export const ModeDecorator = (Story: StoryFn) => {
+	const [isDarkMode, setIsDarkMode] = useState(false);
+	const toggleMode = () => {
+		setIsDarkMode((curr) => !curr);
+	};
+
+	// sync external css  with state
+	useEffect(() => {
+		document.documentElement.classList.toggle("dark", isDarkMode);
+	}, [isDarkMode]);
+
+	return (
+		<>
+			<div className="absolute bottom-4 left-4 z-50">
+				<div className="flex items-center space-x-2">
+					<Switch id="theme-mode" checked={isDarkMode} onClick={toggleMode} />
+					<Label htmlFor="theme-mode">
+						{isDarkMode ? "Light Mode" : "Dark Mode (experimental)"}
+					</Label>
+				</div>
+			</div>
+			{/** @ts-expect-error Error typing from React 19 types upgrade. Will need to wait for this up be updated */}
+			<Story />
+		</>
+	);
+};


### PR DESCRIPTION
Adds a dark mode storybook decorator, and applies it to all stories.
Although dark mode does not seem to be a priority, it will help developers be more conscious about it when developing components

https://github.com/user-attachments/assets/427975e3-1ee0-4330-8b56-f5417ebeeec7

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Relates to https://github.com/PrefectHQ/prefect/issues/15512