### PR TITLE
Fix connection string handling when individual components are provided via settings

### DIFF
--- a/src/prefect/settings/base.py
+++ b/src/prefect/settings/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 from functools import partial
 from typing import Any, Dict, Tuple, Type
@@ -43,13 +45,17 @@ class PrefectBaseSettings(BaseSettings):
 
         See https://docs.pydantic.dev/latest/concepts/pydantic_settings/#customise-settings-sources
         """
-        env_filter = set()
+        env_filter: set[str] = set()
         for field_name, field in settings_cls.model_fields.items():
             if field.validation_alias is not None and isinstance(
                 field.validation_alias, AliasChoices
             ):
                 for alias in field.validation_alias.choices:
-                    if isinstance(alias, AliasPath) and len(alias.path) > 0:
+                    if (
+                        isinstance(alias, AliasPath)
+                        and len(alias.path) > 0
+                        and isinstance(alias.path[0], str)
+                    ):
                         env_filter.add(alias.path[0])
             env_filter.add(field_name)
         return (
@@ -88,13 +94,12 @@ class PrefectBaseSettings(BaseSettings):
         include_secrets: bool = True,
     ) -> Dict[str, str]:
         """Convert the settings object to a dictionary of environment variables."""
-
         env: Dict[str, Any] = self.model_dump(
             exclude_unset=exclude_unset,
             mode="json",
             context={"include_secrets": include_secrets},
         )
-        env_variables = {}
+        env_variables: dict[str, str] = {}
         for key in self.model_fields.keys():
             if isinstance(child_settings := getattr(self, key), PrefectBaseSettings):
                 child_env = child_settings.to_environment_variables(
@@ -175,7 +180,7 @@ def _add_environment_variables(
     schema: Dict[str, Any], model: Type[PrefectBaseSettings]
 ) -> None:
     for property in schema["properties"]:
-        env_vars = []
+        env_vars: list[str] = []
         schema["properties"][property]["supported_environment_variables"] = env_vars
         field = model.model_fields[property]
         if inspect.isclass(field.annotation) and issubclass(
@@ -191,7 +196,7 @@ def _add_environment_variables(
             env_vars.append(f"{model.model_config.get('env_prefix')}{property.upper()}")
 
 
-def _build_settings_config(
+def _build_settings_config(  # pyright: ignore[reportUnusedFunction] This is used elsewhere. TODO: update to be a public function because it is used in integration libraries.
     path: Tuple[str, ...] = tuple(), frozen: bool = False
 ) -> PrefectSettingsConfigDict:
     env_prefix = f"PREFECT_{'_'.join(path).upper()}_" if path else "PREFECT_"
@@ -207,7 +212,9 @@ def _build_settings_config(
     )
 
 
-def _to_environment_variable_value(value: Any) -> str:
+def _to_environment_variable_value(
+    value: list[object] | set[object] | tuple[object] | Any,
+) -> str:
     if isinstance(value, (list, set, tuple)):
         return ",".join(str(v) for v in value)
     return str(value)

--- a/src/prefect/settings/models/root.py
+++ b/src/prefect/settings/models/root.py
@@ -210,11 +210,11 @@ class Settings(PrefectBaseSettings):
         if self.logging.config_path is None:
             self.logging.config_path = Path(f"{self.home}/logging.yml")
             self.logging.__pydantic_fields_set__.remove("config_path")
-        db_url: str = (
-            self.server.database.connection_url.get_secret_value()
-            if self.server.database.connection_url
-            else _default_database_connection_url(self).get_secret_value()
-        )
+        # Set default database connection URL if not provided
+        if self.server.database.connection_url is None:
+            self.server.database.connection_url = _default_database_connection_url(self)
+            self.server.database.__pydantic_fields_set__.remove("connection_url")
+        db_url = self.server.database.connection_url.get_secret_value()
         if (
             "PREFECT_API_DATABASE_PASSWORD" in db_url
             or "PREFECT_SERVER_DATABASE_PASSWORD" in db_url

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -991,6 +991,26 @@ class TestDatabaseSettings:
             assert url.database == "the-database"
             assert url.password == "the-password"
 
+    def test_postgres_connection_url_is_secret_when_parts_are_individually_set(self):
+        """
+        Regression test for https://github.com/PrefectHQ/prefect/issues/16657
+        """
+        with temporary_settings(
+            {
+                PREFECT_SERVER_DATABASE_CONNECTION_URL: None,
+                PREFECT_API_DATABASE_DRIVER: "postgresql+asyncpg",
+                PREFECT_API_DATABASE_HOST: "the-database-server.example.com",
+                PREFECT_API_DATABASE_PORT: 15432,
+                PREFECT_API_DATABASE_USER: "the-user",
+                PREFECT_API_DATABASE_NAME: "the-database",
+                PREFECT_API_DATABASE_PASSWORD: "the-password",
+            }
+        ):
+            assert isinstance(
+                get_current_settings().server.database.connection_url,
+                pydantic.SecretStr,
+            )
+
     def test_postgres_password_is_quoted(self):
         with temporary_settings(
             {


### PR DESCRIPTION
In some cases, the connection URL is set to a plain string instead of a `SecretStr`, which causes serialization to fail when serializing to a JSON-compatible form. This fixes that.

Closes https://github.com/PrefectHQ/prefect/issues/16657
