### PR TITLE
Remove DB interface from `_on_start`

### DIFF
--- a/src/prefect/server/services/loop_service.py
+++ b/src/prefect/server/services/loop_service.py
@@ -10,7 +10,6 @@ import anyio
 import pendulum
 
 from prefect.logging import get_logger
-from prefect.server.database import PrefectDBInterface, inject_db
 from prefect.settings import PREFECT_API_LOG_RETRYABLE_ERRORS
 from prefect.utilities.processutils import _register_signal
 
@@ -46,8 +45,7 @@ class LoopService:
             _register_signal(signal.SIGINT, self._stop)
             _register_signal(signal.SIGTERM, self._stop)
 
-    @inject_db
-    async def _on_start(self, db: PrefectDBInterface) -> None:
+    async def _on_start(self) -> None:
         """
         Called prior to running the service
         """


### PR DESCRIPTION
I've been investigating our DB connection / performance issues which has led me to looking at how and when we create engines and connection pools; in my investigations I realized that this db interface was unused, and [the commit that removed its use](https://github.com/PrefectHQ/prefect/commit/6e360f4485157f219d4938c452859976d21fe267) appears to have kept the kwarg around out of oversight, not with any specific intent.

I figured the more of these imports we can remove, the better. I'll probably have some more slight refactors of the DB engine at various points as I continue to look into it.