### PR TITLE
Bump lower bound on pydantic to 2.9

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -20,7 +20,7 @@ packaging >= 21.3, < 24.3
 pathspec >= 0.8.0
 pendulum >= 3.0.0, <4
 prometheus-client >= 0.20.0
-pydantic >= 2.7, < 3.0.0, != 2.10.0
+pydantic >= 2.8, < 3.0.0, != 2.10.0
 pydantic_core >= 2.12.0, < 3.0.0
 pydantic_extra_types >= 2.8.2, < 3.0.0
 pydantic_settings > 2.2.1

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -20,7 +20,7 @@ packaging >= 21.3, < 24.3
 pathspec >= 0.8.0
 pendulum >= 3.0.0, <4
 prometheus-client >= 0.20.0
-pydantic >= 2.8, < 3.0.0, != 2.10.0
+pydantic >= 2.9, < 3.0.0, != 2.10.0
 pydantic_core >= 2.12.0, < 3.0.0
 pydantic_extra_types >= 2.8.2, < 3.0.0
 pydantic_settings > 2.2.1


### PR DESCRIPTION
Tests fail for me locally with various validation errors under pydantic 2.7.1, but not if I upgrade to 2.9, e.g.,

```
E       pydantic_core._pydantic_core.ValidationError: 1 validation error for ServerEventsSettings
E       prefect_api_events_related_resource_cache_ttl
E         Input should be a valid timedelta, "day" identifier in duration not correctly formatted [type=time_delta_parsing, input_value='0:06:00', input_type=str]
E           For further information visit https://errors.pydantic.dev/2.7/v/time_delta_parsing

../../miniconda3/envs/prefect/lib/python3.10/site-packages/pydantic_settings/main.py:167: ValidationError

FAILED tests/test_settings.py::TestSettingValues::test_set_via_env_var[PREFECT_API_EVENTS_RELATED_RESOURCE_CACHE_TTL] - pydantic_core._pydantic_core.ValidationError: 1 validation error for ServerEventsSettings
```