### PR TITLE
Allow servers to start with no background services

### DIFF
--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -213,7 +213,7 @@ def start(
     late_runs: bool = SettingsOption(PREFECT_API_SERVICES_LATE_RUNS_ENABLED),
     ui: bool = SettingsOption(PREFECT_UI_ENABLED),
     no_services: bool = typer.Option(
-        False, "--no-services", help="Only run the webserver API"
+        False, "--no-services", help="Only run the webserver API and UI"
     ),
     background: bool = typer.Option(
         False, "--background", "-b", help="Run the server in the background"
@@ -307,7 +307,7 @@ def _run_in_background(
 
     env = {**os.environ, **server_settings, "PREFECT__SERVER_FINAL": "1"}
     if no_services:
-        env["PREFECT__SERVER_EPHEMERAL"] = "1"
+        env["PREFECT__SERVER_WEBSERVER_ONLY"] = "1"
 
     process = subprocess.Popen(
         command,
@@ -339,7 +339,7 @@ def _run_in_foreground(
         {getattr(prefect.settings, k): v for k, v in server_settings.items()}
     ):
         uvicorn.run(
-            app=create_app(final=True, ephemeral=no_services),
+            app=create_app(final=True, webserver_only=no_services),
             app_dir=str(prefect.__module_path__.parent),
             host=host,
             port=port,


### PR DESCRIPTION
This PR enhances the `prefect server start` command to allow for:

```
prefect server start --no-services
```

Which starts only the webserver and the "services" necessary for event processing (which aren't actual loop services).

I realized that `prefect server start` creates a _single_ connection pool to the database that is shared across both the webserver and all running loop services; this seems problematic to me in high scale / high traffic situations - those connection pools have fundamentally different properties (timeout configuration, pool configuration, etc.). 

The eventual idea is to recommend pairing this new flag with a new CLI command `prefect services start` that starts _only_ the background loop services. This allows users to easily decouple these two components of the backend, scale them independently, etc. and in the short term will allow us to see if there are differences in connection statistics between services and the webserver through the new [`PREFECT_SERVER_DATABASE_CONNECTION_APP_NAME` setting](https://github.com/PrefectHQ/prefect/pull/16690).