### PR TITLE
Move quickstart to immediately before the 'schedule a flow' tutorial in the docs

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -54,9 +54,9 @@
       "group": "Get started",
       "pages": [
         "v3/get-started/index",
-        "v3/get-started/quickstart",
         "v3/get-started/install",
-        "v3/get-started/whats-new-prefect-3"
+        "v3/get-started/whats-new-prefect-3",
+        "v3/get-started/quickstart"
       ],
       "version": "v3"
     },


### PR DESCRIPTION
The next page after the quickstart was 'Install Prefect', which is redundant since the reader has already installed Prefect by virtue of going through the Quickstart.

I've moved the **Quickstart** immediately before the **Schedule a flow** tutorial in the nav, so that the progression makes more sense.

<img width="1103" alt="Screenshot 2025-01-13 at 11 17 53 AM" src="https://github.com/user-attachments/assets/75c149dd-2c9d-47de-a88d-9586cb52372b" />

### Checklist

- [ ] ~This pull request references any related issue by including "closes `<link to issue>`"~
- [ ] ~If this pull request adds new functionality, it includes unit tests that cover the changes~
- [ ] ~If this pull request removes docs files, it includes redirect settings in `mint.json`.~
- [ ] ~If this pull request adds functions or classes, it includes helpful docstrings.~
