### PR TITLE
add `prefect server services` CLI commands

### DIFF
--- a/load_testing/run-server.sh
+++ b/load_testing/run-server.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 DB_TYPE=${1:-sqlite}  # Default to sqlite if no argument provided
+NO_SERVICES=${2:-false}  # Default to false if no argument provided
 
 # Function to start postgres container
 start_postgres() {
@@ -65,13 +66,14 @@ if [[ $DB_TYPE == sqlite ]]; then
 elif [[ $DB_TYPE == postgres:* ]]; then
     PG_VERSION=${DB_TYPE#postgres:}
     start_postgres $PG_VERSION
-    export PREFECT_API_DATABASE_CONNECTION_URL="postgresql+asyncpg://postgres:yourTopSecretPassword@localhost:5432/prefect"
+    prefect config set PREFECT_API_DATABASE_CONNECTION_URL="postgresql+asyncpg://postgres:yourTopSecretPassword@localhost:5432/prefect"
 else
     echo "Invalid database type. Use 'sqlite' or 'postgres:<version>'"
     exit 1
 fi
 
 PREFECT_API_URL=http://localhost:4200/api \
+PREFECT__SERVER_WEBSERVER_ONLY=$NO_SERVICES \
 OTEL_SERVICE_NAME=prefect-server \
 OTEL_TRACES_EXPORTER=otlp \
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -656,7 +656,7 @@ def run_manager_process():
         logger.error("No services are enabled! Exiting manager.")
         sys.exit(1)
 
-    logger.info("Manager process started. Starting services...")
+    logger.debug("Manager process started. Starting services...")
     try:
         asyncio.run(_run_services(enabled_services))
     except KeyboardInterrupt:

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -15,7 +15,6 @@ import sys
 import textwrap
 from pathlib import Path
 from types import ModuleType
-from typing import NamedTuple
 
 import anyio
 import anyio.abc
@@ -510,14 +509,6 @@ async def stamp(revision: str):
     app.console.print("Stamping database with revision ...")
     await run_sync_in_worker_thread(alembic_stamp, revision=revision)
     exit_with_success("Stamping database with revision succeeded!")
-
-
-class ServiceInfo(NamedTuple):
-    """Information about a discovered service and its configuration."""
-
-    name: str
-    setting: "prefect.settings.Setting"
-    enabled: bool
 
 
 def _get_service_settings() -> dict[str, "prefect.settings.Setting"]:

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -2,6 +2,8 @@
 Command line interface for working with the Prefect API and server.
 """
 
+from __future__ import annotations
+
 import asyncio
 import inspect
 import os

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -662,7 +662,7 @@ def run_manager_process():
     except KeyboardInterrupt:
         pass
     finally:
-        logger.info("Manager process has exited.")
+        logger.debug("Manager process has exited.")
 
 
 # public, user-facing `prefect server services` commands

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -588,7 +588,7 @@ def _get_service_map(
     }
 
 
-@services_app.command(aliases=["list"])
+@services_app.command(aliases=["ls", "list"])
 async def list_services():
     """List all services"""
     import inspect

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -607,7 +607,7 @@ async def _run_services(
         logger.info("Received cancellation, stopping services...")
         for task, service in tasks:
             task.cancel()
-            logger.info(f"Stopped service: {service.name}")
+            logger.debug(f"Stopped service: {service.name}")
         await asyncio.gather(*(t for t, _ in tasks), return_exceptions=True)
 
 

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -60,7 +60,7 @@ app.add_typer(server_app)
 
 logger = get_logger(__name__)
 
-SERVER_PID_FILE = Path(PREFECT_HOME.value()) / "server.pid"
+SERVER_PID_FILE_NAME = "server.pid"
 SERVICES_PID_FILE = Path(PREFECT_HOME.value()) / "services.pid"
 
 
@@ -247,7 +247,7 @@ def start(
     if no_services:
         server_settings["PREFECT_SERVER_ANALYTICS_ENABLED"] = "False"
 
-    pid_file = SERVER_PID_FILE
+    pid_file = Path(PREFECT_HOME.value()) / SERVER_PID_FILE_NAME
     # check if port is already in use
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -357,7 +357,7 @@ def _run_in_foreground(
 @server_app.command()
 async def stop():
     """Stop a Prefect server instance running in the background"""
-    pid_file = SERVER_PID_FILE
+    pid_file = Path(PREFECT_HOME.value()) / SERVER_PID_FILE_NAME
     if not pid_file.exists():
         exit_with_success("No server running in the background.")
     pid = int(pid_file.read_text())

--- a/src/prefect/cli/server.py
+++ b/src/prefect/cli/server.py
@@ -599,7 +599,7 @@ async def _run_services(
     for service in services:
         task = asyncio.create_task(service.start())
         tasks.append((task, service))
-        logger.info(f"Started service: {service.name}")
+        logger.debug(f"Started service: {service.name}")
 
     try:
         await asyncio.gather(*(t for t, _ in tasks))

--- a/src/prefect/server/events/services/triggers.py
+++ b/src/prefect/server/events/services/triggers.py
@@ -48,6 +48,8 @@ class ReactiveTriggers:
 
 
 class ProactiveTriggers(LoopService):
+    """A loop service that runs the proactive triggers consumer"""
+
     def __init__(self, loop_seconds: Optional[float] = None, **kwargs: Any):
         super().__init__(
             loop_seconds=(

--- a/src/prefect/server/services/loop_service.py
+++ b/src/prefect/server/services/loop_service.py
@@ -164,6 +164,8 @@ class LoopService:
         self._stop()
 
         if block:
+            # if block=True, sleep until the service stops running,
+            # but no more than `loop_seconds` to avoid a deadlock
             with anyio.move_on_after(self.loop_seconds):
                 while self._is_running:
                     await asyncio.sleep(0.1)

--- a/src/prefect/server/services/loop_service.py
+++ b/src/prefect/server/services/loop_service.py
@@ -70,7 +70,7 @@ class LoopService:
         Called after running the service
         """
         self._is_running = False
-        self.logger.info(f"Stopped {self.name}")
+        self.logger.debug(f"Stopped {self.name}")
 
     @overload
     async def start(self, loops: None = None) -> NoReturn:

--- a/src/prefect/server/services/loop_service.py
+++ b/src/prefect/server/services/loop_service.py
@@ -160,7 +160,7 @@ class LoopService:
                 the service may still be running a final loop.
 
         """
-        self.logger.info(f"Stopping {self.name}...")
+        self.logger.debug(f"Stopping {self.name}...")
         self._stop()
 
         if block:

--- a/src/prefect/server/services/loop_service.py
+++ b/src/prefect/server/services/loop_service.py
@@ -63,7 +63,7 @@ class LoopService:
         """
         self._should_stop = False
         self._is_running = True
-        self.logger.info(f"Starting {self.name}")
+        self.logger.debug(f"Starting {self.name}")
 
     async def _on_stop(self) -> None:
         """

--- a/src/prefect/server/services/loop_service.py
+++ b/src/prefect/server/services/loop_service.py
@@ -10,11 +10,13 @@ from operator import methodcaller
 from typing import TYPE_CHECKING, Any, List, NoReturn, Optional, overload
 
 import anyio
-import pendulum
 
 from prefect.logging import get_logger
 from prefect.settings import PREFECT_API_LOG_RETRYABLE_ERRORS
-from prefect.utilities.processutils import _register_signal
+from prefect.types import DateTime
+from prefect.utilities.processutils import (
+    _register_signal,  # type: ignore[reportPrivateUsage]
+)
 
 if TYPE_CHECKING:
     import logging
@@ -59,17 +61,16 @@ class LoopService:
         """
         Called prior to running the service
         """
-        # reset the _should_stop flag
         self._should_stop = False
-        # set the _is_running flag
         self._is_running = True
+        self.logger.info(f"Starting {self.name}")
 
     async def _on_stop(self) -> None:
         """
         Called after running the service
         """
-        # reset the _is_running flag
         self._is_running = False
+        self.logger.info(f"Stopped {self.name}")
 
     @overload
     async def start(self, loops: None = None) -> NoReturn:
@@ -86,12 +87,11 @@ class LoopService:
         Args:
             loops (int, optional): the number of loops to run before exiting.
         """
-
         await self._on_start()
 
         i = 0
         while not self._should_stop:
-            start_time = pendulum.now("UTC")
+            start_time = DateTime.now("UTC")
 
             try:
                 self.logger.debug(f"About to run {self.name}...")
@@ -100,9 +100,11 @@ class LoopService:
             except NotImplementedError as exc:
                 raise exc from None
 
-            # if an error is raised, log and continue
+            except asyncio.CancelledError:
+                self.logger.info(f"Received cancellation signal for {self.name}")
+                raise
+
             except Exception as exc:
-                # avoid circular import
                 from prefect.server.api.server import is_client_retryable_exception
 
                 retryable_error = is_client_retryable_exception(exc)
@@ -113,35 +115,28 @@ class LoopService:
                         f"Unexpected error in: {repr(exc)}", exc_info=True
                     )
 
-            end_time = pendulum.now("UTC")
+            end_time = DateTime.now("UTC")
 
-            # if service took longer than its loop interval, log a warning
-            # that the interval might be too short
             if (end_time - start_time).total_seconds() > self.loop_seconds:
                 self.logger.warning(
-                    f"{self.name} took {(end_time-start_time).total_seconds()} seconds"
+                    f"{self.name} took {(end_time - start_time).total_seconds()} seconds"
                     " to run, which is longer than its loop interval of"
                     f" {self.loop_seconds} seconds."
                 )
 
-            # check if early stopping was requested
             i += 1
             if loops is not None and i == loops:
                 self.logger.debug(f"{self.name} exiting after {loops} loop(s).")
                 await self.stop(block=False)
 
-            # next run is every "loop seconds" after each previous run *started*.
-            # note that if the loop took unexpectedly long, the "next_run" time
-            # might be in the past, which will result in an instant start
             next_run = max(
-                start_time.add(seconds=self.loop_seconds), pendulum.now("UTC")
+                start_time.add(seconds=self.loop_seconds), DateTime.now("UTC")
             )
             self.logger.debug(f"Finished running {self.name}. Next run at {next_run}")
 
-            # check the `_should_stop` flag every 1 seconds until the next run time is reached
-            while pendulum.now("UTC") < next_run and not self._should_stop:
+            while DateTime.now("UTC") < next_run and not self._should_stop:
                 await asyncio.sleep(
-                    min(1, (next_run - pendulum.now("UTC")).total_seconds())
+                    min(1, (next_run - DateTime.now("UTC")).total_seconds())
                 )
 
         await self._on_stop()
@@ -157,16 +152,14 @@ class LoopService:
                 the service may still be running a final loop.
 
         """
+        self.logger.info(f"Stopping {self.name}...")
         self._stop()
 
         if block:
-            # if block=True, sleep until the service stops running,
-            # but no more than `loop_seconds` to avoid a deadlock
             with anyio.move_on_after(self.loop_seconds):
                 while self._is_running:
                     await asyncio.sleep(0.1)
 
-            # if the service is still running after `loop_seconds`, something's wrong
             if self._is_running:
                 self.logger.warning(
                     f"`stop(block=True)` was called on {self.name} but more than one"

--- a/src/prefect/testing/cli.py
+++ b/src/prefect/testing/cli.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import contextlib
 import re
 import textwrap
-from typing import Iterable, List, Tuple, Union
+from typing import Iterable
 
 import readchar
+from rich.console import Console
 from typer.testing import CliRunner, Result  # type: ignore
 
 from prefect.cli import app
@@ -46,16 +49,16 @@ def check_contains(cli_result: Result, content: str, should_contain: bool):
 
 
 def invoke_and_assert(
-    command: Union[str, List[str]],
-    user_input: Union[str, None] = None,
-    prompts_and_responses: List[Union[Tuple[str, str], Tuple[str, str, str]]] = [],
-    expected_output: Union[str, None] = None,
-    expected_output_contains: Union[str, Iterable[str], None] = None,
-    expected_output_does_not_contain: Union[str, Iterable[str], None] = None,
-    expected_line_count: Union[int, None] = None,
-    expected_code: int = 0,
+    command: str | list[str],
+    user_input: str | None = None,
+    prompts_and_responses: list[tuple[str, str] | tuple[str, str, str]] | None = None,
+    expected_output: str | None = None,
+    expected_output_contains: str | Iterable[str] | None = None,
+    expected_output_does_not_contain: str | Iterable[str] | None = None,
+    expected_line_count: int | None = None,
+    expected_code: int | None = 0,
     echo: bool = True,
-    temp_dir: Union[str, None] = None,
+    temp_dir: str | None = None,
 ) -> Result:
     """
     Test utility for the Prefect CLI application, asserts exact match with CLI output.
@@ -75,6 +78,7 @@ def invoke_and_assert(
         temp_dir: if provided, the CLI command will be run with this as its present
             working directory.
     """
+    prompts_and_responses = prompts_and_responses or []
     if in_async_main_thread():
         raise RuntimeError(
             textwrap.dedent(
@@ -192,11 +196,11 @@ def invoke_and_assert(
 
 
 @contextlib.contextmanager
-def temporary_console_width(console, width):
+def temporary_console_width(console: Console, width: int):
     original = console.width
 
     try:
-        console._width = width
+        console._width = width  # type: ignore
         yield
     finally:
-        console._width = original
+        console._width = original  # type: ignore

--- a/tests/cli/test_server_services.py
+++ b/tests/cli/test_server_services.py
@@ -22,7 +22,7 @@ def enable_all_services():
 @pytest.fixture
 def pid_file(monkeypatch: pytest.MonkeyPatch) -> Path:
     pid_file = Path(PREFECT_HOME.value()) / "services.pid"
-    monkeypatch.setattr("prefect.cli.server.PID_FILE", pid_file)
+    monkeypatch.setattr("prefect.cli.server.SERVICES_PID_FILE", pid_file)
     return pid_file
 
 

--- a/tests/cli/test_server_services.py
+++ b/tests/cli/test_server_services.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+
+import pytest
+
+from prefect.settings import PREFECT_HOME
+from prefect.settings.context import temporary_settings
+from prefect.testing.cli import invoke_and_assert
+
+
+@pytest.fixture(autouse=True)
+def enable_all_services():
+    from prefect.cli.server import (
+        _get_service_settings,  # type: ignore[reportPrivateUsage]
+    )
+
+    with temporary_settings(
+        {enable_service: True for enable_service in _get_service_settings().values()}
+    ):
+        yield
+
+
+class TestBackgroundServices:
+    def test_start_and_stop_services(self):
+        invoke_and_assert(
+            command=[
+                "server",
+                "services",
+                "start",
+                "--background",
+            ],
+            expected_output_contains="Services are running in the background.",
+            expected_code=0,
+        )
+
+        pid_file = Path(PREFECT_HOME.value()) / "services" / "manager.pid"
+        assert pid_file.exists(), "Services PID file does not exist"
+
+        invoke_and_assert(
+            command=[
+                "server",
+                "services",
+                "stop",
+            ],
+            expected_output_contains="All services stopped.",
+            expected_code=0,
+        )
+
+        assert not pid_file.exists(), "Services PID file still exists"
+
+    def test_start_duplicate_services(self):
+        invoke_and_assert(
+            command=[
+                "server",
+                "services",
+                "start",
+                "--background",
+            ],
+            expected_output_contains="Services are running in the background.",
+            expected_code=0,
+        )
+
+        invoke_and_assert(
+            command=[
+                "server",
+                "services",
+                "start",
+                "--background",
+            ],
+            expected_output_contains="Services are already running in the background.",
+            expected_code=1,
+        )
+
+        invoke_and_assert(
+            command=[
+                "server",
+                "services",
+                "stop",
+            ],
+            expected_output_contains="All services stopped.",
+            expected_code=0,
+        )
+
+    def test_stop_stale_pid_file(self):
+        pid_file = Path(PREFECT_HOME.value()) / "services" / "manager.pid"
+        pid_file.parent.mkdir(parents=True, exist_ok=True)
+        pid_file.write_text("99999")
+
+        invoke_and_assert(
+            command=[
+                "server",
+                "services",
+                "stop",
+            ],
+            expected_output_contains="Services were not running",
+            expected_output_does_not_contain="All services stopped.",
+            expected_code=0,
+        )
+
+        assert not pid_file.exists(), "Services PID file still exists"
+
+    def test_list_services(self):
+        invoke_and_assert(
+            command=[
+                "server",
+                "services",
+                "ls",
+            ],
+            expected_output_contains=[
+                "Available Services",
+                "Name",
+                "Enabled?",
+                "Description",
+            ],
+            expected_code=0,
+        )

--- a/tests/cli/test_start_server.py
+++ b/tests/cli/test_start_server.py
@@ -15,6 +15,7 @@ import readchar
 from anyio.abc import Process
 from typer import Exit
 
+from prefect.cli.server import SERVER_PID_FILE_NAME
 from prefect.context import get_settings_context
 from prefect.settings import (
     PREFECT_API_URL,
@@ -188,7 +189,7 @@ class TestBackgroundServer:
             )
 
     def test_start_port_in_use_by_background_server(self, unused_tcp_port: int):
-        pid_file = Path(PREFECT_HOME.value()) / "server.pid"
+        pid_file = PREFECT_HOME.value() / SERVER_PID_FILE_NAME
         pid_file.write_text("99999")
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(("127.0.0.1", unused_tcp_port))
@@ -206,7 +207,7 @@ class TestBackgroundServer:
             )
 
     def test_stop_stale_pid_file(self, unused_tcp_port: int):
-        pid_file = Path(PREFECT_HOME.value()) / "server.pid"
+        pid_file = PREFECT_HOME.value() / SERVER_PID_FILE_NAME
         pid_file.write_text("99999")
 
         invoke_and_assert(
@@ -295,7 +296,7 @@ class TestUvicornSignalForwarding:
 
 class TestPrestartCheck:
     @pytest.fixture(autouse=True)
-    def interactive_console(self, monkeypatch):
+    def interactive_console(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr("prefect.cli.server.is_interactive", lambda: True)
 
         # `readchar` does not like the fake stdin provided by typer isolation so we provide

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -72,7 +72,7 @@ from prefect.workers.base import BaseJobConfiguration, BaseWorker
 
 
 @pytest.fixture
-def dictConfigMock(monkeypatch):
+def dictConfigMock(monkeypatch: pytest.MonkeyPatch):
     mock = MagicMock()
     monkeypatch.setattr("logging.config.dictConfig", mock)
     # Reset the process global since we're testing `setup_logging`


### PR DESCRIPTION
wondering if maybe should be `experimental` as I think we may want to add some logging config and maybe update the signature of things  - feedback?

- `start`: start all loop services in the foreground
  - `--background` start them in the background
- `ls`: list all known loop services and whether they are enabled
- `stop`: stop any running loop services


both `start` and `stop` should be idempotent

in order to ensure the `--background` option can be managed by a single process, I created a hidden `manager` command under `services` (which does not show up in `--help`). open to other suggestions

<details>
<summary>demo usage</summary>

```
» prefect server services start

Starting services... Press CTRL+C to stop

23:16:55.600 | INFO    | prefect.cli.server - Started service: CancellationCleanup
23:16:55.601 | INFO    | prefect.cli.server - Started service: FlowRunNotifications
23:16:55.601 | INFO    | prefect.cli.server - Started service: Foreman
23:16:55.601 | INFO    | prefect.cli.server - Started service: MarkLateRuns
23:16:55.601 | INFO    | prefect.cli.server - Started service: FailExpiredPauses
23:16:55.601 | INFO    | prefect.cli.server - Started service: RecentDeploymentsScheduler
23:16:55.602 | INFO    | prefect.cli.server - Started service: Scheduler
23:16:55.602 | INFO    | prefect.cli.server - Started service: Telemetry
23:16:55.602 | INFO    | prefect.cli.server - Started service: ProactiveTriggers
^C23:16:56.784 | INFO    | prefect.cli.server - Received cancellation, stopping services...
23:16:56.784 | INFO    | prefect.cli.server - Stopped service: CancellationCleanup
23:16:56.784 | INFO    | prefect.cli.server - Stopped service: FlowRunNotifications
23:16:56.785 | INFO    | prefect.cli.server - Stopped service: Foreman
23:16:56.785 | INFO    | prefect.cli.server - Stopped service: MarkLateRuns
23:16:56.785 | INFO    | prefect.cli.server - Stopped service: FailExpiredPauses
23:16:56.785 | INFO    | prefect.cli.server - Stopped service: RecentDeploymentsScheduler
23:16:56.785 | INFO    | prefect.cli.server - Stopped service: Scheduler
23:16:56.785 | INFO    | prefect.cli.server - Stopped service: Telemetry
23:16:56.786 | INFO    | prefect.cli.server - Stopped service: ProactiveTriggers

All services stopped.
» prefect server services start --background
Starting service: CancellationCleanup
Starting service: FlowRunNotifications
Starting service: Foreman
Starting service: MarkLateRuns
Starting service: FailExpiredPauses
Starting service: RecentDeploymentsScheduler
Starting service: Scheduler
Starting service: Telemetry
Starting service: ProactiveTriggers

Services are running in the background.
Use `prefect server services stop` to stop them.
» prefect server services stop

Shutting down...
✓ Services stopped

All services stopped.
» prefect server services ls
                                                                  Available Services
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Name                         ┃ Enabled?  ┃ Description                                                                                             ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ CancellationCleanup          │ True      │ A simple loop service responsible for cancelling tasks and subflows left over from                      │
│ FlowRunNotifications         │ True      │ A loop service that checks for flow run notifications that need to be sent.                             │
│ Foreman                      │ True      │ A loop service responsible for monitoring the status of workers.                                        │
│ MarkLateRuns                 │ True      │ A simple loop service responsible for identifying flow runs that are "late".                            │
│ FailExpiredPauses            │ True      │ A simple loop service responsible for identifying Paused flow runs that no longer can be resumed.       │
│ RecentDeploymentsScheduler   │ True      │ A scheduler that only schedules deployments that were updated very recently.                            │
│ Scheduler                    │ True      │ A loop service that schedules flow runs from deployments.                                               │
│ Telemetry                    │ True      │ This service sends anonymous data (e.g. count of flow runs) to Prefect to help us                       │
│ ProactiveTriggers            │ True      │ A loop service that runs the proactive triggers consumer                                                │
└──────────────────────────────┴───────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```
</details>
