### PR TITLE
Handles the instrumentation case where a future is only used to wait_for

### DIFF
--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -757,12 +757,19 @@ def resolve_to_final_result(expr: Any, context: dict[str, Any]) -> Any:
         parameter_context = propagate.extract(
             {"traceparent": state.state_details.traceparent}
         )
-        trace.get_current_span().add_link(
-            context=trace.get_current_span(parameter_context).get_span_context(),
-            attributes={
+        attributes = {}
+
+        # If this future is being used as a parameter (as opposed to just a wait_for),
+        # add attributes to the span to indicate the parameter name and type
+        if "parameter_name" in context:
+            attributes = {
                 "prefect.input.name": context["parameter_name"],
                 "prefect.input.type": type(result).__name__,
-            },
+            }
+
+        trace.get_current_span().add_link(
+            context=trace.get_current_span(parameter_context).get_span_context(),
+            attributes=attributes,
         )
 
     return result


### PR DESCRIPTION
In our OpenTelemetry instrumentation, we were assuming that if we were
resolving a future before running a task, it must be a parameter.  This
isn't true in the case where a future is used in `wait_for`, where the
context's `parameter_name` won't be set.

Fixes #16708

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
