### PR TITLE
[UI v2] feat: Adds hook to join deployment and flow data

### DIFF
--- a/ui-v2/src/api/deployments/use-list-deployments-with-flows/index.ts
+++ b/ui-v2/src/api/deployments/use-list-deployments-with-flows/index.ts
@@ -1,0 +1,1 @@
+export { useListDeploymentsWithFlows } from "./use-list-deployments-with-flows";

--- a/ui-v2/src/api/deployments/use-list-deployments-with-flows/use-list-deployments-with-flows.test.ts
+++ b/ui-v2/src/api/deployments/use-list-deployments-with-flows/use-list-deployments-with-flows.test.ts
@@ -1,0 +1,49 @@
+import { createFakeDeployment, createFakeFlow } from "@/mocks";
+import { QueryClient } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { buildApiUrl, createWrapper, server } from "@tests/utils";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { useListDeploymentsWithFlows } from "./use-list-deployments-with-flows";
+
+describe("buildPaginateDeploymentsWithFlowQuery", () => {
+	it("fetches deplyoments pagination and flow filter APIs and joins data", async () => {
+		const MOCK_DEPLOYMENTS = [
+			createFakeDeployment({ id: "0", flow_id: "a" }),
+			createFakeDeployment({ id: "1", flow_id: "a" }),
+		];
+		const MOCK_FLOW = createFakeFlow({ id: "a" });
+
+		server.use(
+			http.post(buildApiUrl("/deployments/paginate"), () => {
+				return HttpResponse.json({
+					results: MOCK_DEPLOYMENTS,
+					count: MOCK_DEPLOYMENTS.length,
+					page: 1,
+					pages: 1,
+					limit: 10,
+				});
+			}),
+			http.post(buildApiUrl("/flows/filter"), () => {
+				return HttpResponse.json([MOCK_FLOW]);
+			}),
+		);
+
+		const queryClient = new QueryClient();
+
+		const { result } = renderHook(useListDeploymentsWithFlows, {
+			wrapper: createWrapper({ queryClient }),
+		});
+
+		await waitFor(() => {
+			expect(result.current.status).toEqual("success");
+		});
+
+		const EXPECTED = MOCK_DEPLOYMENTS.map((deployment) => ({
+			...deployment,
+			flow: MOCK_FLOW,
+		}));
+
+		expect(EXPECTED).toEqual(result.current.data?.results);
+	});
+});

--- a/ui-v2/src/api/flows/index.ts
+++ b/ui-v2/src/api/flows/index.ts
@@ -47,6 +47,7 @@ export const queryKeyFactory = {
  */
 export const buildListFlowsQuery = (
 	filter: FlowsFilter = { offset: 0, sort: "CREATED_DESC" },
+	{ enabled = true }: { enabled?: boolean } = {},
 ) =>
 	queryOptions({
 		queryKey: queryKeyFactory.list(filter),
@@ -58,4 +59,5 @@ export const buildListFlowsQuery = (
 		},
 		staleTime: 1000,
 		placeholderData: keepPreviousData,
+		enabled,
 	});

--- a/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
+++ b/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
@@ -1,5 +1,5 @@
 import type { FlowRunWithDeploymentAndFlow } from "@/api/flow-runs";
-import { createFakeDeployment } from "@/mocks";
+import { createFakeDeploymentWithFlow } from "@/mocks";
 import { createFakeFlowRunWithDeploymentAndFlow } from "@/mocks/create-fake-flow-run";
 import {
 	reactQueryDecorator,
@@ -73,7 +73,10 @@ export const Default: StoryObj<StoryArgs> = {
 
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const deployments = useMemo(() => {
-			return Array.from({ length: numberOfDeployments }, createFakeDeployment);
+			return Array.from(
+				{ length: numberOfDeployments },
+				createFakeDeploymentWithFlow,
+			);
 		}, [numberOfDeployments]);
 
 		return (

--- a/ui-v2/src/mocks/create-fake-deployment.ts
+++ b/ui-v2/src/mocks/create-fake-deployment.ts
@@ -1,8 +1,10 @@
-import { DeploymentWithFlow } from "@/api/deployments";
+import { components } from "@/api/prefect";
 import { faker } from "@faker-js/faker";
 import { createFakeSchedule } from "./create-fake-schedule";
 
-export function createFakeDeployment(): DeploymentWithFlow {
+export function createFakeDeployment(
+	overrides?: Partial<components["schemas"]["DeploymentResponse"]>,
+): components["schemas"]["DeploymentResponse"] {
 	return {
 		id: faker.string.uuid(),
 		created: faker.date.recent().toISOString(),
@@ -19,6 +21,15 @@ export function createFakeDeployment(): DeploymentWithFlow {
 			{ length: faker.number.int({ min: 0, max: 3 }) },
 			() => createFakeSchedule(),
 		),
+		...overrides,
+	};
+}
+
+export function createFakeDeploymentWithFlow(
+	overrides?: Partial<components["schemas"]["DeploymentResponse"]>,
+) {
+	return {
+		...createFakeDeployment(overrides),
 		flow: {
 			id: faker.string.uuid(),
 			created: faker.date.recent().toISOString(),

--- a/ui-v2/src/mocks/index.ts
+++ b/ui-v2/src/mocks/index.ts
@@ -1,5 +1,8 @@
 export { createFakeAutomation } from "./create-fake-automation";
-export { createFakeDeployment } from "./create-fake-deployment";
+export {
+	createFakeDeployment,
+	createFakeDeploymentWithFlow,
+} from "./create-fake-deployment";
 export { createFakeFlow } from "./create-fake-flow";
 export { createFakeFlowRun } from "./create-fake-flow-run";
 export { createFakeGlobalConcurrencyLimit } from "./create-fake-global-concurrency-limit";


### PR DESCRIPTION
1. Updates `createFakeDeployment` to only return the deployment object (with override options).
2. Adds `useListDeploymentsWithFlows` hook to join the flow and deployments query data together

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Relates to https://github.com/PrefectHQ/prefect/issues/15512
