### PR TITLE
Raise type completeness on `prefect.inputs` to 100%

### DIFF
--- a/src/prefect/client/utilities.py
+++ b/src/prefect/client/utilities.py
@@ -5,7 +5,7 @@ Utilities for working with clients.
 # This module must not import from `prefect.client` when it is imported to avoid
 # circular imports for decorators such as `inject_client` which are widely used.
 
-from collections.abc import Awaitable, Coroutine
+from collections.abc import Coroutine
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
@@ -61,8 +61,8 @@ def get_or_create_client(
 
 
 def client_injector(
-    func: Callable[Concatenate["PrefectClient", P], Awaitable[R]],
-) -> Callable[P, Awaitable[R]]:
+    func: Callable[Concatenate["PrefectClient", P], Coroutine[Any, Any, R]],
+) -> Callable[P, Coroutine[Any, Any, R]]:
     @wraps(func)
     async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         client, _ = get_or_create_client()

--- a/src/prefect/input/actions.py
+++ b/src/prefect/input/actions.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import TYPE_CHECKING, Any, Optional, Set
 from uuid import UUID
 
@@ -44,9 +45,12 @@ async def create_flow_run_input_from_model(
     else:
         json_safe = orjson.loads(model_instance.json())
 
-    await create_flow_run_input(
+    coro = create_flow_run_input(
         key=key, value=json_safe, flow_run_id=flow_run_id, sender=sender
     )
+    if TYPE_CHECKING:
+        assert inspect.iscoroutine(coro)
+    await coro
 
 
 @sync_compatible


### PR DESCRIPTION
Related to #16292 

This one was a bit more involved because I needed to rearrange some class hierarchy to ensure all parameter types and return values where fully known.