### PR TITLE
Deprecate custom `JsonPatch` implementation

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run.py
@@ -166,12 +166,12 @@ from anyio.abc import TaskStatus  # noqa
 from google.api_core.client_options import ClientOptions
 from googleapiclient import discovery
 from googleapiclient.discovery import Resource
+from jsonpatch import JsonPatch
 from pydantic import Field, field_validator
 
 from prefect.logging.loggers import PrefectLogAdapter
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.dockerutils import get_prefect_image_name
-from prefect.utilities.pydantic import JsonPatch
 from prefect.workers.base import (
     BaseJobConfiguration,
     BaseVariables,

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/cloud_run_v2.py
@@ -11,12 +11,12 @@ from googleapiclient import discovery
 # noinspection PyProtectedMember
 from googleapiclient.discovery import Resource
 from googleapiclient.errors import HttpError
+from jsonpatch import JsonPatch
 from pydantic import Field, PrivateAttr, field_validator
 
 from prefect.logging.loggers import PrefectLogAdapter
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.dockerutils import get_prefect_image_name
-from prefect.utilities.pydantic import JsonPatch
 from prefect.workers.base import (
     BaseJobConfiguration,
     BaseVariables,

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -28,11 +28,11 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 from uuid import uuid4
 
 import anyio
+from jsonpatch import JsonPatch
 from pydantic import Field, field_validator
 from slugify import slugify
 
 from prefect.logging.loggers import PrefectLogAdapter
-from prefect.utilities.pydantic import JsonPatch
 from prefect.workers.base import (
     BaseJobConfiguration,
     BaseVariables,

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -121,6 +121,7 @@ from typing import (
 import aiohttp
 import anyio.abc
 import kubernetes_asyncio
+from jsonpatch import JsonPatch
 from kubernetes_asyncio import config
 from kubernetes_asyncio.client import (
     ApiClient,
@@ -148,7 +149,6 @@ from prefect.exceptions import (
 from prefect.server.schemas.core import Flow
 from prefect.server.schemas.responses import DeploymentResponse
 from prefect.utilities.dockerutils import get_prefect_image_name
-from prefect.utilities.pydantic import JsonPatch
 from prefect.utilities.templating import find_placeholders
 from prefect.utilities.timeout import timeout_async
 from prefect.workers.base import (

--- a/src/prefect/utilities/_deprecated.py
+++ b/src/prefect/utilities/_deprecated.py
@@ -1,0 +1,38 @@
+from typing import Any
+
+from jsonpatch import (  # type: ignore  # no typing stubs available, see https://github.com/stefankoegl/python-json-patch/issues/158
+    JsonPatch as JsonPatchBase,
+)
+from pydantic import GetJsonSchemaHandler
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import core_schema
+
+
+class JsonPatch(JsonPatchBase):
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetJsonSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.typed_dict_schema(
+            {"patch": core_schema.typed_dict_field(core_schema.dict_schema())}
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        json_schema = handler(core_schema)
+        json_schema = handler.resolve_ref_schema(json_schema)
+        json_schema.pop("required", None)
+        json_schema.pop("properties", None)
+        json_schema.update(
+            {
+                "type": "array",
+                "format": "rfc6902",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": {"type": "string"},
+                },
+            }
+        )
+        return json_schema

--- a/tests/utilities/test_pydantic.py
+++ b/tests/utilities/test_pydantic.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 import cloudpickle
@@ -6,11 +7,14 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from prefect.utilities.dispatch import register_type
 from prefect.utilities.pydantic import (
-    JsonPatch,
     PartialModel,
     add_cloudpickle_reduction,
     get_class_fields_only,
 )
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    from prefect.utilities.pydantic import JsonPatch
 
 
 class SimplePydantic(BaseModel):


### PR DESCRIPTION
Our `JsonPatch` subclass is harshing our type completeness vibes. We don't use it internally any longer, so this PR deprecates it and moves it to a `_deprecated` module so `pyright` will ignore it during type completeness checks. Our `JsonPatch` subclass will remain available for import, but doing so will raise a `DeprecationWarning`. 
