### PR TITLE
Ensures that `QueueService` instances are unique within types

### DIFF
--- a/src/prefect/_internal/concurrency/services.py
+++ b/src/prefect/_internal/concurrency/services.py
@@ -32,7 +32,7 @@ class _QueueServiceBase(abc.ABC, Generic[T]):
         self._task: Optional[asyncio.Task[None]] = None
         self._stopped: bool = False
         self._started: bool = False
-        self._key = hash(args)
+        self._key = hash((self.__class__, *args))
         self._lock = threading.Lock()
         self._queue_get_thread = WorkerThread(
             # TODO: This thread should not need to be a daemon but when it is not, it
@@ -256,7 +256,7 @@ class _QueueServiceBase(abc.ABC, Generic[T]):
         If an instance already exists with the given arguments, it will be returned.
         """
         with cls._instance_lock:
-            key = hash(args)
+            key = hash((cls, *args))
             if key not in cls._instances:
                 cls._instances[key] = cls._new_instance(*args)
 

--- a/tests/_internal/concurrency/test_services.py
+++ b/tests/_internal/concurrency/test_services.py
@@ -97,6 +97,14 @@ def test_instance_returns_new_instance_with_unique_key():
     assert isinstance(new_instance, MockService)
 
 
+def test_different_subclasses_have_unique_instances():
+    instance = MockService.instance()
+    assert isinstance(instance, MockService)
+    new_instance = MockBatchedService.instance()
+    assert new_instance is not instance
+    assert isinstance(new_instance, MockBatchedService)
+
+
 def test_instance_returns_same_instance_after_error():
     event = threading.Event()
 


### PR DESCRIPTION
As @jakekaplan and I were debugging a different issue, we realized that
the implementation of `QueueServiceBase.instance` would return an
instance of the wrong type if there were two subclasses that both used
the same `args` (including the empty `args`).  Luckily, the subclasses
of `QueueService` we have so far seem to avoid this by overriding
`instance` or by using different `args`, but this leaves a trap for
folks implementing services in the future.

<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
