### PR TITLE
don't make extra calls to cloud in `prefect dashboard open`

### DIFF
--- a/src/prefect/cli/dashboard.py
+++ b/src/prefect/cli/dashboard.py
@@ -28,6 +28,9 @@ async def open() -> None:
 
     await run_sync_in_worker_thread(webbrowser.open_new_tab, ui_url)
 
+    if "prefect.cloud" not in ui_url:
+        exit_with_success(f"Opened {ui_url!r} in browser.")
+
     async with get_cloud_client() as client:
         try:
             current_workspace = get_current_workspace(await client.read_workspaces())

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -91,9 +91,9 @@ SlaAdapter: TypeAdapter[SlaTypes] = TypeAdapter(SlaTypes)
 
 @app.command()
 async def init(
-    name: str | None = None,
-    recipe: str | None = None,
-    fields: list[str] | None = typer.Option(
+    name: Optional[str] = None,
+    recipe: Optional[str] = None,
+    fields: Optional[list[str]] = typer.Option(
         None,
         "-f",
         "--field",

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -919,10 +919,8 @@ def _construct_schedules(
     Returns:
         A list of schedule objects
     """
-    schedules = []
-    schedule_configs: list[dict[str, Any]] | NotSet = (
-        deploy_config.get("schedules", []) or []
-    )
+    schedules: list[DeploymentScheduleCreate] = []  # Initialize with empty list
+    schedule_configs = deploy_config.get("schedules", NotSet) or []
 
     if schedule_configs is not NotSet:
         schedules = [

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -91,9 +91,9 @@ SlaAdapter: TypeAdapter[SlaTypes] = TypeAdapter(SlaTypes)
 
 @app.command()
 async def init(
-    name: Optional[str] = None,
-    recipe: Optional[str] = None,
-    fields: Optional[list[str]] = typer.Option(
+    name: str | None = None,
+    recipe: str | None = None,
+    fields: list[str] | None = typer.Option(
         None,
         "-f",
         "--field",
@@ -919,8 +919,10 @@ def _construct_schedules(
     Returns:
         A list of schedule objects
     """
-    schedules: list[DeploymentScheduleCreate] = []  # Initialize with empty list
-    schedule_configs = deploy_config.get("schedules", NotSet) or []
+    schedules = []
+    schedule_configs: list[dict[str, Any]] | NotSet = (
+        deploy_config.get("schedules", []) or []
+    )
 
     if schedule_configs is not NotSet:
         schedules = [

--- a/tests/cli/test_dashboard.py
+++ b/tests/cli/test_dashboard.py
@@ -1,151 +1,39 @@
-import uuid
-from contextlib import contextmanager
-from typing import Generator
 from unittest.mock import MagicMock
 
-import httpx
 import pytest
-from starlette import status
 
-from prefect.client.schemas import Workspace
-from prefect.context import use_profile
 from prefect.settings import (
-    PREFECT_API_KEY,
-    PREFECT_API_URL,
-    PREFECT_CLOUD_API_URL,
-    Profile,
-    ProfilesCollection,
-    save_profiles,
+    PREFECT_UI_URL,
+    temporary_settings,
 )
 from prefect.testing.cli import invoke_and_assert
 
 
-def gen_test_workspace(**kwargs) -> Workspace:
-    defaults = {
-        "account_id": uuid.uuid4(),
-        "account_name": "account name",
-        "account_handle": "account-handle",
-        "workspace_id": uuid.uuid4(),
-        "workspace_name": "workspace name",
-        "workspace_handle": "workspace-handle",
-        "workspace_description": "workspace description",
-    }
-    defaults.update(kwargs)
-    return Workspace(**defaults)
-
-
 @pytest.fixture
-def mock_webbrowser(monkeypatch):
+def mock_webbrowser(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     mock = MagicMock()
     monkeypatch.setattr("prefect.cli.dashboard.webbrowser", mock)
-    yield mock
+    return mock
 
 
-@contextmanager
-def _use_profile(profile_name: str) -> Generator[None, None, None]:
-    with use_profile(profile_name, include_current_context=False):
-        yield
-
-
-def test_open_current_workspace_in_browser_success(mock_webbrowser, respx_mock):
-    foo_workspace = gen_test_workspace(account_handle="test", workspace_handle="foo")
-
-    save_profiles(
-        ProfilesCollection(
-            [
-                Profile(
-                    name="logged-in-profile",
-                    settings={
-                        PREFECT_API_URL: foo_workspace.api_url(),
-                        PREFECT_API_KEY: "foo",
-                    },
-                )
-            ],
-            active="logged-in-profile",
-        )
+def test_open_dashboard_in_browser_success(mock_webbrowser: MagicMock) -> None:
+    invoke_and_assert(
+        ["dashboard", "open"],
+        expected_code=0,
+        expected_output_contains=f"Opened {PREFECT_UI_URL.value()!r} in browser.",
     )
 
-    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
-        return_value=httpx.Response(
-            status.HTTP_200_OK,
-            json=[foo_workspace.model_dump(mode="json")],
-        )
-    )
-    with _use_profile("logged-in-profile"):
+    mock_webbrowser.open_new_tab.assert_called_with(PREFECT_UI_URL.value())
+
+
+def test_open_dashboard_in_browser_failure_no_ui_url(
+    mock_webbrowser: MagicMock,
+) -> None:
+    with temporary_settings({PREFECT_UI_URL: ""}):
         invoke_and_assert(
             ["dashboard", "open"],
-            expected_code=0,
-            expected_output_contains=f"Opened {foo_workspace.handle!r} in browser.",
+            expected_code=1,
+            expected_output_contains="PREFECT_UI_URL` must be set",
         )
 
-    mock_webbrowser.open_new_tab.assert_called_with(foo_workspace.ui_url())
-
-
-@pytest.mark.usefixtures("mock_webbrowser")
-@pytest.mark.parametrize("api_url", ["http://localhost:4200", "https://api.prefect.io"])
-def test_open_current_workspace_in_browser_failure_no_workspace_set(
-    respx_mock, api_url
-):
-    save_profiles(
-        ProfilesCollection(
-            [
-                Profile(
-                    name="logged-in-profile",
-                    settings={
-                        PREFECT_API_URL: api_url,
-                        PREFECT_API_KEY: "foo",
-                    },
-                )
-            ],
-            active="logged-in-profile",
-        )
-    )
-
-    if "prefect.cloud" in api_url:
-        respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
-            return_value=httpx.Response(
-                status.HTTP_200_OK,
-                json=[],
-            )
-        )
-
-    with _use_profile("logged-in-profile"):
-        invoke_and_assert(
-            ["dashboard", "open"],
-            expected_code=0,
-            expected_output_contains=f"Opened {api_url!r} in browser.",
-        )
-
-
-@pytest.mark.usefixtures("mock_webbrowser")
-@pytest.mark.parametrize("api_url", ["http://localhost:4200", "https://api.prefect.io"])
-def test_open_current_workspace_in_browser_failure_unauthorized(respx_mock, api_url):
-    save_profiles(
-        ProfilesCollection(
-            [
-                Profile(
-                    name="logged-in-profile",
-                    settings={
-                        PREFECT_API_URL: api_url,
-                        PREFECT_API_KEY: "invalid_key",
-                    },
-                )
-            ],
-            active="logged-in-profile",
-        )
-    )
-
-    if "prefect.cloud" in api_url:
-        respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
-            return_value=httpx.Response(
-                status.HTTP_401_UNAUTHORIZED,
-                json={"detail": "Unauthorized"},
-            )
-        )
-
-    with _use_profile("logged-in-profile"):
-        invoke_and_assert(
-            ["dashboard", "open"],
-            expected_code=0,
-            expected_output_contains=f"Opened {api_url!r} in browser.",
-        )
+        mock_webbrowser.open_new_tab.assert_not_called()

--- a/tests/cli/test_dashboard.py
+++ b/tests/cli/test_dashboard.py
@@ -101,15 +101,20 @@ def test_open_current_workspace_in_browser_failure_no_workspace_set(
         )
     )
 
-    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
-        return_value=httpx.Response(
-            status.HTTP_200_OK,
-            json=[],
+    if "prefect.cloud" in api_url:
+        respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+            return_value=httpx.Response(
+                status.HTTP_200_OK,
+                json=[],
+            )
         )
-    )
 
     with _use_profile("logged-in-profile"):
-        invoke_and_assert(["dashboard", "open"], expected_code=0)
+        invoke_and_assert(
+            ["dashboard", "open"],
+            expected_code=0,
+            expected_output_contains=f"Opened {api_url!r} in browser.",
+        )
 
 
 @pytest.mark.usefixtures("mock_webbrowser")
@@ -130,12 +135,13 @@ def test_open_current_workspace_in_browser_failure_unauthorized(respx_mock, api_
         )
     )
 
-    respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
-        return_value=httpx.Response(
-            status.HTTP_401_UNAUTHORIZED,
-            json={"detail": "Unauthorized"},
+    if "prefect.cloud" in api_url:
+        respx_mock.get(PREFECT_CLOUD_API_URL.value() + "/me/workspaces").mock(
+            return_value=httpx.Response(
+                status.HTTP_401_UNAUTHORIZED,
+                json={"detail": "Unauthorized"},
+            )
         )
-    )
 
     with _use_profile("logged-in-profile"):
         invoke_and_assert(


### PR DESCRIPTION
if cloud is down (like it was for maintenance) then `prefect dashboard open` hangs as it tries to find your workspace, but you're using OSS this shouldn't matter and it should exit early

stacked on https://github.com/PrefectHQ/prefect/pull/16767