### PR TITLE
Fix script to run server with local telemetry

### DIFF
--- a/load_testing/run-server.sh
+++ b/load_testing/run-server.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 DB_TYPE=${1:-sqlite}  # Default to sqlite if no argument provided
-NO_SERVICES=${2:-false}  # Default to false if no argument provided
 
 # Function to start postgres container
 start_postgres() {
@@ -73,17 +72,29 @@ else
 fi
 
 PREFECT_API_URL=http://localhost:4200/api \
-PREFECT__SERVER_WEBSERVER_ONLY=$NO_SERVICES \
 OTEL_SERVICE_NAME=prefect-server \
 OTEL_TRACES_EXPORTER=otlp \
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
 OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
 OTEL_LOG_LEVEL=debug \
+PREFECT_SERVER_ANALYTICS_ENABLED=false \
+PREFECT_API_SERVICES_SCHEDULER_ENABLED=true \
+PREFECT_API_SERVICES_LATE_RUNS_ENABLED=true \
+PREFECT_UI_ENABLED=true \
+PREFECT_SERVER_LOGGING_LEVEL=info \
 PYTHONPATH=src \
-  opentelemetry-instrument \
-  uvicorn \
-  --app-dir src \
-  --factory prefect.server.api.server:create_app \
-  --host 127.0.0.1 \
-  --port 4200 \
-  --timeout-keep-alive 5
+opentelemetry-instrument \
+python -c "
+import uvicorn
+from prefect.server.api.server import create_app
+
+app = create_app(final=True, webserver_only=False)
+uvicorn.run(
+    app=app,
+    app_dir='src',
+    host='127.0.0.1',
+    port=4200,
+    timeout_keep_alive=5,
+    log_level='info'
+)
+"

--- a/load_testing/run-server.sh
+++ b/load_testing/run-server.sh
@@ -2,7 +2,7 @@
 
 DB_TYPE=${1:-sqlite}  # Default to sqlite if no argument provided
 NO_SERVICES=${2:-False}  # Default to False if no argument provided
-SERVER_LOGGING_LEVEL=${3:-info}
+SERVER_LOGGING_LEVEL=${3:-warning}
 
 # Function to start postgres container
 start_postgres() {

--- a/load_testing/run-server.sh
+++ b/load_testing/run-server.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 DB_TYPE=${1:-sqlite}  # Default to sqlite if no argument provided
+NO_SERVICES=${2:-False}  # Default to False if no argument provided
+SERVER_LOGGING_LEVEL=${3:-info}
 
 # Function to start postgres container
 start_postgres() {
@@ -81,20 +83,19 @@ PREFECT_SERVER_ANALYTICS_ENABLED=false \
 PREFECT_API_SERVICES_SCHEDULER_ENABLED=true \
 PREFECT_API_SERVICES_LATE_RUNS_ENABLED=true \
 PREFECT_UI_ENABLED=true \
-PREFECT_SERVER_LOGGING_LEVEL=info \
 PYTHONPATH=src \
 opentelemetry-instrument \
 python -c "
 import uvicorn
 from prefect.server.api.server import create_app
 
-app = create_app(final=True, webserver_only=False)
+app = create_app(final=True, webserver_only=eval('${NO_SERVICES}'.title()))
 uvicorn.run(
     app=app,
     app_dir='src',
     host='127.0.0.1',
     port=4200,
     timeout_keep_alive=5,
-    log_level='info'
+    log_level='${SERVER_LOGGING_LEVEL}'
 )
 "

--- a/load_testing/track_cnx.py
+++ b/load_testing/track_cnx.py
@@ -1,0 +1,125 @@
+import asyncio
+
+import asyncpg
+from rich.console import Console
+from rich.live import Live
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+
+def make_table(connections: list[dict]) -> tuple[Table, list[str]]:
+    table = Table(show_header=True, expand=True)
+
+    table.add_column("PID", style="cyan")
+    table.add_column("State", style="green")
+    table.add_column("Duration", justify="right")
+    table.add_column("Wait Event")
+    table.add_column("Query", max_width=60)
+
+    # Track problem states
+    stuck_reads = []
+    long_transactions = []
+    blocked_queries = []
+
+    for conn in sorted(
+        connections, key=lambda c: c["state_duration"] or 0, reverse=True
+    ):
+        pid = conn["pid"]
+        state = conn["state"]
+        duration = f"{conn['state_duration']:.1f}s"
+        wait_event = (
+            f"{conn['wait_event_type']}.{conn['wait_event']}"
+            if conn["wait_event_type"]
+            else "-"
+        )
+        query = conn["query"] or "-"
+
+        # Track issues
+        if (
+            state == "idle"
+            and wait_event == "Client.ClientRead"
+            and conn["state_duration"] > 5
+        ):
+            stuck_reads.append(pid)
+            duration = Text(duration, style="red")
+
+        if "transaction" in state and conn["state_duration"] > 10:
+            long_transactions.append(pid)
+            state = Text(state, style="red")
+
+        if wait_event.startswith("Lock"):
+            blocked_queries.append(pid)
+            wait_event = Text(wait_event, style="red")
+
+        table.add_row(str(pid), str(state), str(duration), wait_event, query)
+
+    summary = []
+    if stuck_reads:
+        summary.append(
+            f"[red]PIDs stuck in ClientRead > 5s: {', '.join(str(p) for p in stuck_reads)}[/]"
+        )
+    if long_transactions:
+        summary.append(
+            f"[red]PIDs in transaction > 10s: {', '.join(str(p) for p in long_transactions)}[/]"
+        )
+    if blocked_queries:
+        summary.append(
+            f"[red]PIDs waiting on locks: {', '.join(str(p) for p in blocked_queries)}[/]"
+        )
+
+    return table, summary
+
+
+async def monitor_connections():
+    console = Console()
+
+    conn = await asyncpg.connect(
+        "postgresql://postgres:yourTopSecretPassword@localhost:5432/prefect"
+    )
+
+    with Live(console=console, refresh_per_second=1) as live:
+        while True:
+            results = await conn.fetch(
+                """
+                SELECT 
+                    pid,
+                    state,
+                    wait_event_type,
+                    wait_event,
+                    query,
+                    xact_start,
+                    EXTRACT(EPOCH FROM (now() - state_change)) as state_duration,
+                    EXTRACT(EPOCH FROM (now() - xact_start)) as transaction_duration
+                FROM pg_stat_activity 
+                WHERE datname = 'prefect'
+                    AND pid != pg_backend_pid()
+            """
+            )
+
+            conns = [dict(r) for r in results]
+
+            table, issues = make_table(conns)
+            total_active = sum(1 for c in conns if c["state"] == "active")
+            total_idle = sum(1 for c in conns if c["state"] == "idle")
+            # Only count actual blocking wait states like locks
+            total_waiting = sum(
+                1
+                for c in conns
+                if c["wait_event_type"] == "Lock"
+                or (c["wait_event_type"] == "Client" and c["state"] != "idle")
+            )
+
+            status = f"Total: {len(conns)} connections ({total_active} active, {total_idle} idle, {total_waiting} waiting)"
+            if issues:
+                status += "\n" + "\n".join(issues)
+
+            live.update(Panel(table, title=status))
+            await asyncio.sleep(1)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(monitor_connections())
+    except KeyboardInterrupt:
+        print("\nStopped monitoring")

--- a/load_testing/track_cnx.py
+++ b/load_testing/track_cnx.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any
 
 import asyncpg
 from rich.console import Console
@@ -8,7 +9,7 @@ from rich.table import Table
 from rich.text import Text
 
 
-def make_table(connections: list[dict]) -> tuple[Table, list[str]]:
+def make_table(connections: list[dict[str, Any]]) -> tuple[Table, list[str]]:
     table = Table(show_header=True, expand=True)
 
     table.add_column("PID", style="cyan")
@@ -18,9 +19,9 @@ def make_table(connections: list[dict]) -> tuple[Table, list[str]]:
     table.add_column("Query", max_width=60)
 
     # Track problem states
-    stuck_reads = []
-    long_transactions = []
-    blocked_queries = []
+    stuck_reads: list[int] = []
+    long_transactions: list[int] = []
+    blocked_queries: list[int] = []
 
     for conn in sorted(
         connections, key=lambda c: c["state_duration"] or 0, reverse=True
@@ -54,7 +55,7 @@ def make_table(connections: list[dict]) -> tuple[Table, list[str]]:
 
         table.add_row(str(pid), str(state), str(duration), wait_event, query)
 
-    summary = []
+    summary: list[str] = []
     if stuck_reads:
         summary.append(
             f"[red]PIDs stuck in ClientRead > 5s: {', '.join(str(p) for p in stuck_reads)}[/]"


### PR DESCRIPTION
after https://github.com/PrefectHQ/prefect/pull/16651, wrapping `create_app` as the telemetry entrypoint for the server no longer worked, since it would not run the services, so this PR updates the entrypoint used by the local telemetry harness

also adds a script to view / inspect the state of active db connections