### PR TITLE
Add mini-history of Prefect to the introduction page of the docs

### DIFF
--- a/docs/v3/get-started/index.mdx
+++ b/docs/v3/get-started/index.mdx
@@ -70,6 +70,26 @@ Prefect is an open-source orchestration engine that turns your Python functions 
   </Card>
 </CardGroup>
 
+## Mini history of Prefect
+
+<Steps>
+<Step title="2018-2021">
+Our story begins with Prefect 1.0, in which we introduced the idea that workflow orchestration should be Pythonic.
+Inspired by distributed tools like Dask and building on Jeremiah's experience as a PMC member of Apache Airflow, we created a system based on simple Python decorators for tasks and flows.
+But what made it truly special was our introduction of task mapping—a feature that would later become foundational to our dynamic execution capabilities (and eventually imitated by other orchestration SDKs).
+</Step>
+
+<Step title="2022-2024">
+Prefect's 2.0 release became inevitable once we recognized that real-world workflows don't always fit into neat, pre-planned DAG structures: sometimes you need to update a job definition based on runtime information, e.g. skipping a branch of your workflow.
+So we removed a key constraint that workflows be written explicitly as DAGs, fully embracing native Python control flow—if/else conditionals, while loops, everything that makes Python…Python.
+</Step>
+
+<Step title="2025 and beyond">
+With our release of Prefect 3.0 in fall 2024, we fully embraced these dynamic patterns by open-sourcing our events and automations backend, allowing users to natively represent event-driven workflows and gain additional observability into their execution.
+Prefect 3.0 also unlocked a leap forward in performance, improving the runtime overhead of Prefect by up to 90%.
+</Step>
+</Steps>
+
 ## Join our community
 
 Join Prefect's vibrant [community of nearly 30,000 engineers](/contribute/index/) to learn with others and share your knowledge!

--- a/docs/v3/get-started/index.mdx
+++ b/docs/v3/get-started/index.mdx
@@ -75,17 +75,17 @@ Prefect is an open-source orchestration engine that turns your Python functions 
 <Steps>
 <Step title="2018-2021">
 Our story begins with Prefect 1.0, in which we introduced the idea that workflow orchestration should be Pythonic.
-Inspired by distributed tools like Dask and building on Jeremiah's experience as a PMC member of Apache Airflow, we created a system based on simple Python decorators for tasks and flows.
-But what made it truly special was our introduction of task mapping—a feature that would later become foundational to our dynamic execution capabilities (and eventually imitated by other orchestration SDKs).
+Inspired by distributed tools like Dask and building on our founder, Jeremiah Lowin's experience as a PMC member of Apache Airflow, we created a system based on simple Python decorators for tasks and flows.
+But what made Prefect truly special was our introduction of task mapping—a feature that would later become foundational to our dynamic execution capabilities (and eventually imitated by other orchestration SDKs).
 </Step>
 
 <Step title="2022-2024">
-Prefect's 2.0 release became inevitable once we recognized that real-world workflows don't always fit into neat, pre-planned DAG structures: sometimes you need to update a job definition based on runtime information, e.g. skipping a branch of your workflow.
-So we removed a key constraint that workflows be written explicitly as DAGs, fully embracing native Python control flow—if/else conditionals, while loops, everything that makes Python…Python.
+Prefect's 2.0 release became inevitable once we recognized that real-world workflows don't always fit into neat, pre-planned DAG structures: sometimes you need to update a job definition based on runtime information, for example by skipping a branch of your workflow.
+So we removed a key constraint that workflows be written explicitly as DAGs, fully embracing native Python control flow—if/else conditionals, while loops-everything that makes Python…Python.
 </Step>
 
-<Step title="2025 and beyond">
-With our release of Prefect 3.0 in fall 2024, we fully embraced these dynamic patterns by open-sourcing our events and automations backend, allowing users to natively represent event-driven workflows and gain additional observability into their execution.
+<Step title="2024 and beyond">
+With our release of Prefect 3.0 in 2024, we fully embraced these dynamic patterns by open-sourcing our events and automations backend, allowing users to natively represent event-driven workflows and gain additional observability into their execution.
 Prefect 3.0 also unlocked a leap forward in performance, improving the runtime overhead of Prefect by up to 90%.
 </Step>
 </Steps>

--- a/docs/v3/get-started/index.mdx
+++ b/docs/v3/get-started/index.mdx
@@ -70,7 +70,7 @@ Prefect is an open-source orchestration engine that turns your Python functions 
   </Card>
 </CardGroup>
 
-## Mini history of Prefect
+## Mini-history of Prefect
 
 <Steps>
 <Step title="2018-2021">


### PR DESCRIPTION
Closes https://linear.app/prefect/issue/DOC-136/mini-history-of-prefect-new-sub-section

Preview: https://prefect-bd373955-add_timeline_to_introduction_doc.mintlify.app/v3/get-started/index#mini-history-of-prefect

### Checklist

- [X] This pull request references any related issue by including "closes `<link to issue>`"
- [ ] ~If this pull request adds new functionality, it includes unit tests that cover the changes~
- [ ] ~If this pull request removes docs files, it includes redirect settings in `mint.json`.~
- [ ] ~If this pull request adds functions or classes, it includes helpful docstrings.~
