### PR TITLE
[UI v2] feat: Adds deployments filter query

### DIFF
--- a/ui-v2/src/api/deployments/deployments.test.ts
+++ b/ui-v2/src/api/deployments/deployments.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import type { Deployment } from "./index";
 import {
 	buildCountDeploymentsQuery,
+	buildFilterDeploymentsQuery,
 	buildPaginateDeploymentsQuery,
 	queryKeyFactory,
 	useDeleteDeployment,
@@ -29,6 +30,14 @@ describe("deployments api", () => {
 			}),
 			http.post(buildApiUrl("/deployments/count"), () => {
 				return HttpResponse.json(total);
+			}),
+		);
+	};
+
+	const mockFilterDeploymentsAPI = (deployments: Array<Deployment>) => {
+		server.use(
+			http.post(buildApiUrl("/deployments/filter"), () => {
+				return HttpResponse.json(deployments);
 			}),
 		);
 	};
@@ -80,6 +89,23 @@ describe("deployments api", () => {
 				limit: 10,
 				count: 1,
 			});
+		});
+	});
+
+	describe("buildFilterDeploymentsQuery", () => {
+		it("fetches filtered deployments", async () => {
+			const queryClient = new QueryClient();
+
+			const mockResponse = [createFakeDeployment()];
+			mockFilterDeploymentsAPI(mockResponse);
+
+			const { result } = renderHook(
+				() => useSuspenseQuery(buildFilterDeploymentsQuery()),
+				{ wrapper: createWrapper({ queryClient }) },
+			);
+
+			await waitFor(() => expect(result.current.isSuccess).toBe(true));
+			expect(result.current.data).toEqual(mockResponse);
 		});
 	});
 

--- a/ui-v2/tests/utils/handlers.ts
+++ b/ui-v2/tests/utils/handlers.ts
@@ -22,6 +22,10 @@ const automationsHandlers = [
 ];
 
 const deploymentsHandlers = [
+	http.post(buildApiUrl("/deployments/filter"), () => {
+		return HttpResponse.json([]);
+	}),
+
 	http.delete(buildApiUrl("/deployments/:id"), () => {
 		return HttpResponse.json({ status: 204 });
 	}),


### PR DESCRIPTION
Needed to cal the /filter endpoint for deployments in the automations page.

This PR re-organizes the hierarchy of `deployments` query keys to add another layer for `lists`

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Relates to https://github.com/PrefectHQ/prefect/issues/15512
