### PR TITLE
Adds `prefect-redis` to the Prefect image

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -115,7 +115,7 @@ jobs:
             PYTHON_VERSION=${{ matrix.python-version }}
             NODE_VERSION=${{ steps.get_node_version.outputs.NODE_VERSION }}
             ${{ ( endsWith(matrix.flavor, 'conda') && 'BASE_IMAGE=prefect-conda' ) || '' }}
-            ${{ ( endsWith(matrix.flavor, 'kubernetes') && 'PREFECT_EXTRAS=[kubernetes]' ) || '' }}
+            ${{ ( endsWith(matrix.flavor, 'kubernetes') && 'PREFECT_EXTRAS=[redis,kubernetes]' ) || '' }}
           tags: ${{ join(steps.metadata-dev.outputs.tags) }},${{ join(steps.metadata-prod.outputs.tags) }}
           labels: ${{ steps.metadata-dev.outputs.labels }}
           push: true

--- a/.github/workflows/time-docker-build.yaml
+++ b/.github/workflows/time-docker-build.yaml
@@ -30,6 +30,7 @@ jobs:
         with:
           ref: ${{ github.base_ref }}
           clean: true
+          fetch-depth: 0
 
       - name: Clean Docker system
         run: |
@@ -53,6 +54,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           clean: true
+          fetch-depth: 0
 
       - name: Clean Docker system again
         run: |
@@ -74,16 +76,16 @@ jobs:
 
           if [ "${{ github.base_ref }}" != "" ]; then
             BASE_TIME=${{ steps.base_build_time.outputs.base_time }}
-            
+
             echo "### 🏗️ Docker Build Time Comparison" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "| Branch | Build Time | Difference |" >> $GITHUB_STEP_SUMMARY
             echo "|--------|------------|------------|" >> $GITHUB_STEP_SUMMARY
             echo "| base (${{ github.base_ref }}) | ${BASE_TIME}s | - |" >> $GITHUB_STEP_SUMMARY
-            
+
             DIFF=$((CURRENT_TIME - BASE_TIME))
             PERCENT=$(echo "scale=2; ($CURRENT_TIME - $BASE_TIME) * 100 / $BASE_TIME" | bc)
-            
+
             if [ $DIFF -gt 0 ]; then
               DIFF_TEXT="⬆️ +${DIFF}s (+${PERCENT}%)"
             elif [ $DIFF -lt 0 ]; then
@@ -91,9 +93,9 @@ jobs:
             else
               DIFF_TEXT="✨ No change"
             fi
-            
+
             echo "| current (${{ github.head_ref }}) | ${CURRENT_TIME}s | $DIFF_TEXT |" >> $GITHUB_STEP_SUMMARY
-            
+
             # Fail if build time increased by more than 5%
             if (( $(echo "$PERCENT > 5" | bc -l) )); then
               echo "" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ RUN --mount=type=bind,source=requirements-client.txt,target=/tmp/requirements-cl
 COPY --from=python-builder /opt/prefect/dist ./dist
 
 # Extras to include during installation
-ARG PREFECT_EXTRAS
+ARG PREFECT_EXTRAS=[redis]
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install "./dist/prefect.tar.gz${PREFECT_EXTRAS:-""}" && \
     rm -rf dist/


### PR DESCRIPTION
In the interest of helping folks looking to horizontally scale out
Prefect, we want to include `prefect-redis` in the base image.  This is
unusual for a Prefect integration, but we feel that including the
Redis implementation of messaging and caching will enable folks to make
a simpler transition to running the server and services separately.
Since `redis` is already a dependency of Prefect, this will add very
minimal heft to the image (<1MB).

<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
