### PR TITLE
Add missing function body import in client.find_automation

### DIFF
--- a/src/prefect/client/orchestration/_automations/client.py
+++ b/src/prefect/client/orchestration/_automations/client.py
@@ -45,6 +45,8 @@ class AutomationClient(BaseClient):
         return Automation.model_validate_list(response.json())
 
     def find_automation(self, id_or_name: "str | UUID") -> "Automation | None":
+        from uuid import UUID
+
         if isinstance(id_or_name, str):
             name = id_or_name
             try:
@@ -202,6 +204,8 @@ class AutomationAsyncClient(BaseAsyncClient):
         return Automation.model_validate_list(response.json())
 
     async def find_automation(self, id_or_name: "str | UUID") -> "Automation | None":
+        from uuid import UUID
+
         if isinstance(id_or_name, str):
             name = id_or_name
             try:


### PR DESCRIPTION
In #16822, a user shared that a refactor in #16579 to address the memory footprint of the client omitted an import of `UUID` in the `find_automation` method of the client, a bug that was missed to incomplete test coverage.

This PR closes #16822 and adds the missing test. We should inspect more broadly about whether there are more holes in our test coverage of the client. 

