### PR TITLE
No transaction in `TaskRunRecorder`

### DIFF
--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -161,12 +161,13 @@ async def record_task_run_event(event: ReceivedEvent) -> None:
     }
 
     db = provide_database_interface()
-    async with db.session_context(begin_transaction=True) as session:
+    async with db.session_context() as session:
         await _insert_task_run(session, task_run, task_run_attributes)
         await _insert_task_run_state(session, task_run)
         await _update_task_run_with_state(
             session, task_run, denormalized_state_attributes
         )
+        await session.commit()
 
     logger.debug(
         "Recorded task run state change",


### PR DESCRIPTION
related to https://github.com/PrefectHQ/prefect/issues/16299

in the `TaskRunRecorder` we call `record_task_run_event` which performs
- an insert of the task run where the state timestamp is newer
- an insert of the task run state
- an update of the task run where the timestamp is non-existent or older than the current state's timestamp

`record_task_run_event` wraps these statements in a transaction, but these operations should be idempotent. In the interest of speeding up the many writes that may occur when running task-heavy flows, this PR removes `begin_transaction=True`