### PR TITLE
Ensures that the Redis messaging implementation works with event clients

### DIFF
--- a/src/integrations/prefect-redis/prefect_redis/messaging.py
+++ b/src/integrations/prefect-redis/prefect_redis/messaging.py
@@ -5,12 +5,14 @@ import uuid
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from functools import partial
+from types import TracebackType
 from typing import (
     Any,
     AsyncGenerator,
     Awaitable,
     Callable,
     Optional,
+    Type,
     TypeVar,
     Union,
     cast,
@@ -149,7 +151,15 @@ class Publisher(_Publisher):
 
         return self
 
-    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        if not hasattr(self, "_batch"):
+            raise RuntimeError("Use this publisher as an async context manager")
+
         try:
             if self._periodic_task:
                 self._periodic_task.cancel()

--- a/src/prefect/server/events/clients.py
+++ b/src/prefect/server/events/clients.py
@@ -183,12 +183,17 @@ class AssertingEventsClient(EventsClient):
     {payload=}
 
 # of captured events: {len(emitted_events)}
-{chr(10).join(dedent(f'''
+{
+            chr(10).join(
+                dedent(f'''
                     Expected:
                         {expected}
                     Received:
                         {received}
-                ''') for expected, received in mismatch_reasons)}
+                ''')
+                for expected, received in mismatch_reasons
+            )
+        }
 """
 
     @classmethod
@@ -211,7 +216,8 @@ class PrefectServerEventsClient(EventsClient):
     _publisher: messaging.EventPublisher
 
     async def __aenter__(self) -> Self:
-        self._publisher = messaging.create_event_publisher()
+        publisher = messaging.create_event_publisher()
+        self._publisher = await publisher.__aenter__()
         return self
 
     async def __aexit__(
@@ -230,6 +236,7 @@ class PrefectServerEventsClient(EventsClient):
                 "Events may only be emitted while this client is being used as a "
                 "context manager"
             )
+
         received_event = event.receive()
         await self._publisher.publish_event(received_event)
         return received_event

--- a/src/prefect/server/utilities/messaging/__init__.py
+++ b/src/prefect/server/utilities/messaging/__init__.py
@@ -108,7 +108,15 @@ class CapturingPublisher(Publisher):
         self.cache: Cache = cache or create_cache()
         self.deduplicate_by = deduplicate_by
 
-    async def __aexit__(self, *args: Any) -> None:
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         pass
 
     async def publish_data(self, data: bytes, attributes: Mapping[str, str]) -> None:

--- a/src/prefect/server/utilities/messaging/__init__.py
+++ b/src/prefect/server/utilities/messaging/__init__.py
@@ -2,17 +2,20 @@ import abc
 from contextlib import asynccontextmanager, AbstractAsyncContextManager
 from dataclasses import dataclass
 import importlib
+from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Optional,
     Protocol,
+    Type,
     TypeVar,
     Union,
     runtime_checkable,
 )
 from collections.abc import AsyncGenerator, Awaitable, Iterable, Mapping
+from typing_extensions import Self
 
 from prefect.settings import PREFECT_MESSAGING_CACHE, PREFECT_MESSAGING_BROKER
 from prefect.logging import get_logger
@@ -69,6 +72,19 @@ class Publisher(AbstractAsyncContextManager["Publisher"], abc.ABC):
 
     @abc.abstractmethod
     async def publish_data(self, data: bytes, attributes: Mapping[str, str]) -> None:
+        ...
+
+    @abc.abstractmethod
+    async def __aenter__(self) -> Self:
+        ...
+
+    @abc.abstractmethod
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         ...
 
 

--- a/src/prefect/server/utilities/messaging/memory.py
+++ b/src/prefect/server/utilities/messaging/memory.py
@@ -5,12 +5,14 @@ from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Optional, Type, TypeVar, Union
 from uuid import uuid4
 
 import anyio
 from cachetools import TTLCache
 from pydantic_core import to_json
+from typing_extensions import Self
 
 from prefect.logging import get_logger
 from prefect.server.utilities.messaging import Cache as _Cache
@@ -236,7 +238,15 @@ class Publisher(_Publisher):
         self.deduplicate_by = deduplicate_by
         self._cache = cache
 
-    async def __aexit__(self, *args: Any) -> None:
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         return None
 
     async def publish_data(self, data: bytes, attributes: Mapping[str, str]) -> None:


### PR DESCRIPTION
There was a small gap where the base `EventPublisher` wasn't calling
`__aenter__` on the underlying messaging `Publisher` implementation.
I wanted to add compatibility tests to make sure this was true in both
the memory and redis implementations, and firm up the interface.

Prior to the fix, trying to use the Redis messaging system lead to this error:

```
server-7bf457464-kwmhn prefect-server     async with PrefectServerEventsClient() as events:
server-7bf457464-kwmhn prefect-server                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
server-7bf457464-kwmhn prefect-server   File "/usr/local/lib/python3.12/site-packages/prefect/server/events/clients.py", line 223, in __aexit__
server-7bf457464-kwmhn prefect-server     await self._publisher.__aexit__(exc_type, exc_val, exc_tb)
server-7bf457464-kwmhn prefect-server   File "/usr/local/lib/python3.12/site-packages/prefect/server/events/messaging.py", line 39, in __aexit__
server-7bf457464-kwmhn prefect-server     await self._publisher.__aexit__(*args)
server-7bf457464-kwmhn prefect-server   File "/usr/local/lib/python3.12/site-packages/prefect_redis/messaging.py", line 159, in __aexit__
server-7bf457464-kwmhn prefect-server     await self.cache.forget_duplicates(self.deduplicate_by, self._batch)
server-7bf457464-kwmhn prefect-server                                                             ^^^^^^^^^^^
```

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
