### PR TITLE
Stop making useless query

### DIFF
--- a/src/prefect/server/models/concurrency_limits.py
+++ b/src/prefect/server/models/concurrency_limits.py
@@ -122,6 +122,9 @@ async def filter_concurrency_limits_for_orchestration(
     the concurrency limit on these tags from being temporarily exceeded.
     """
 
+    if not tags:
+        return []
+
     query = (
         sa.select(db.ConcurrencyLimit)
         .filter(db.ConcurrencyLimit.tag.in_(tags))


### PR DESCRIPTION
@zzstoatzz observed an excessive amount of pointless DB queries looking for old-style concurrency limits by tag, filtering on `WHERE concurrency_limit.tag in (NULL)`.

I did some digging and found the following sequence:
- subflow runs create "dummy" task runs that reflect their state in the parent flow run
- these are created through the standard `create_task_run` API logic, which invokes the old orchestration policies
- the standard orchestration policies include [this line](https://github.com/PrefectHQ/prefect/blob/131136b419df6fe32bfc39d8e8664523719f8768/src/prefect/server/orchestration/core_policy.py#L324) which looks up any relevant concurrency limits

That lookup is _not_ gated by `tags` being non-empty, so the query is actually made even though we know it will return an empty list. This PR bypasses the query in that scenario.