### PR TITLE
Fix subtraction logic on non-input cache policies

### DIFF
--- a/src/prefect/cache_policies.py
+++ b/src/prefect/cache_policies.py
@@ -216,8 +216,15 @@ class CompoundCachePolicy(CachePolicy):
     def __sub__(self, other: str) -> "CachePolicy":
         if not isinstance(other, str):  # type: ignore[reportUnnecessaryIsInstance]
             raise TypeError("Can only subtract strings from key policies.")
-        new = Inputs(exclude=[other])
-        return CompoundCachePolicy(policies=[*self.policies, new])
+
+        inputs_policies = [p for p in self.policies if isinstance(p, Inputs)]
+
+        if inputs_policies:
+            new = Inputs(exclude=[other])
+            return CompoundCachePolicy(policies=[*self.policies, new])
+        else:
+            # no dependency on inputs already
+            return self
 
 
 @dataclass

--- a/src/prefect/cache_policies.py
+++ b/src/prefect/cache_policies.py
@@ -80,10 +80,12 @@ class CachePolicy:
         raise NotImplementedError
 
     def __sub__(self, other: str) -> "CachePolicy":
+        "No-op for all policies except Inputs and Compound"
+
+        # for interface compatibility
         if not isinstance(other, str):  # type: ignore[reportUnnecessaryIsInstance]
             raise TypeError("Can only subtract strings from key policies.")
-        new = Inputs(exclude=[other])
-        return CompoundCachePolicy(policies=[self, new])
+        return self
 
     def __add__(self, other: "CachePolicy") -> "CachePolicy":
         # adding _None is a no-op

--- a/tests/test_cache_policies.py
+++ b/tests/test_cache_policies.py
@@ -93,11 +93,23 @@ class TestInputsPolicy:
             )
             assert new_key == key
 
-    def test_subtraction_results_in_new_policy(self):
+    def test_subtraction_results_in_new_policy_for_inputs(self):
         policy = Inputs()
         new_policy = policy - "foo"
         assert policy != new_policy
         assert policy.exclude != new_policy.exclude
+
+    def test_subtraction_is_noop_for_non_inputs_policies(self):
+        policy = RunId()
+        new_policy = policy - "foo"
+        assert policy is new_policy
+        assert policy.compute_key(
+            task_ctx=None,
+            inputs={"foo": 42, "y": "changing-value"},
+            flow_parameters=None,
+        ) == policy.compute_key(
+            task_ctx=None, inputs={"foo": 42, "y": "changed"}, flow_parameters=None
+        )
 
     def test_excluded_can_be_manipulated_via_subtraction(self):
         policy = Inputs() - "y"
@@ -137,7 +149,7 @@ class TestCompoundPolicy:
         assert policy.policies != new_policy.policies
 
     def test_creation_via_subtraction(self):
-        one = RunId()
+        one = DEFAULT
         policy = one - "y"
         assert isinstance(policy, CompoundCachePolicy)
 

--- a/tests/test_cache_policies.py
+++ b/tests/test_cache_policies.py
@@ -99,8 +99,8 @@ class TestInputsPolicy:
         assert policy != new_policy
         assert policy.exclude != new_policy.exclude
 
-    def test_subtraction_is_noop_for_non_inputs_policies(self):
-        policy = RunId()
+    @pytest.mark.parametrize("policy", [RunId(), RunId() + TaskSource()])
+    def test_subtraction_is_noop_for_non_inputs_policies(self, policy):
         new_policy = policy - "foo"
         assert policy is new_policy
         assert policy.compute_key(
@@ -141,8 +141,8 @@ class TestCompoundPolicy:
         assert policy != two
         assert policy.policies != two.policies
 
-    def test_subtraction_creates_new_policies(self):
-        policy = CompoundCachePolicy(policies=[])
+    def test_subtraction_creates_new_policies_if_input_dependency(self):
+        policy = CompoundCachePolicy(policies=[Inputs()])
         new_policy = policy - "foo"
         assert isinstance(new_policy, CompoundCachePolicy)
         assert policy != new_policy


### PR DESCRIPTION
This PR implements @a14e's suggested bug fix as discussed [here](https://github.com/PrefectHQ/prefect/issues/16773#issuecomment-2605390190).

In particular, cache policies which do not already rely on run inputs should _not_ implicitly begin relying on run inputs just because the subtraction operator was used. 