### PR TITLE
add `Discriminator` for `dbt` target config union

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/cli/configs/base.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/cli/configs/base.py
@@ -40,15 +40,15 @@ class DbtConfigs(Block, abc.ABC):
 
     def _populate_configs_json(
         self,
-        configs_json: Dict[str, Any],
-        fields: Dict[str, Any],
-        model: BaseModel = None,
-    ) -> Dict[str, Any]:
+        configs_json: dict[str, Any],
+        fields: dict[str, Any],
+        model: Optional[BaseModel] = None,
+    ) -> dict[str, Any]:
         """
         Recursively populate configs_json.
         """
         # if allow_field_overrides is True keys from TargetConfigs take precedence
-        override_configs_json = {}
+        override_configs_json: dict[str, Any] = {}
 
         for field_name, field in fields.items():
             if model is not None:
@@ -93,7 +93,7 @@ class DbtConfigs(Block, abc.ABC):
         configs_json.update(override_configs_json)
         return configs_json
 
-    def get_configs(self) -> Dict[str, Any]:
+    def get_configs(self) -> dict[str, Any]:
         """
         Returns the dbt configs, likely used eventually for writing to profiles.yml.
 
@@ -289,7 +289,7 @@ class GlobalConfigs(DbtConfigs):
     write_json: Optional[bool] = Field(
         default=None,
         description=(
-            "Determines whether dbt writes JSON artifacts to " "the target/ directory."
+            "Determines whether dbt writes JSON artifacts to the target/ directory."
         ),
     )
     warn_error: Optional[bool] = Field(
@@ -321,9 +321,7 @@ class GlobalConfigs(DbtConfigs):
     )
     use_experimental_parser: Optional[bool] = Field(
         default=None,
-        description=(
-            "Opt into the latest experimental version " "of the static parser."
-        ),
+        description=("Opt into the latest experimental version of the static parser."),
     )
     static_parser: Optional[bool] = Field(
         default=None,

--- a/src/integrations/prefect-dbt/tests/cli/test_commands.py
+++ b/src/integrations/prefect-dbt/tests/cli/test_commands.py
@@ -1,5 +1,4 @@
 import datetime
-import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -409,7 +408,9 @@ def test_trigger_dbt_cli_command_find_home(dbt_cli_profile_bare):
 
 
 @pytest.mark.usefixtures("dbt_runner_ls_result")
-def test_trigger_dbt_cli_command_find_env(profiles_dir, dbt_cli_profile_bare, monkeypatch):
+def test_trigger_dbt_cli_command_find_env(
+    profiles_dir, dbt_cli_profile_bare, monkeypatch
+):
     @flow
     def test_flow():
         return trigger_dbt_cli_command("ls", dbt_cli_profile=dbt_cli_profile_bare)

--- a/src/integrations/prefect-dbt/tests/cli/test_credentials.py
+++ b/src/integrations/prefect-dbt/tests/cli/test_credentials.py
@@ -1,10 +1,11 @@
 import pytest
 from prefect_dbt.cli.credentials import DbtCliProfile, GlobalConfigs, TargetConfigs
 from pydantic import ValidationError
+from typing_extensions import Literal
 
 
 @pytest.mark.parametrize("configs_type", ["dict", "model"])
-def test_dbt_cli_profile_init(configs_type):
+def test_dbt_cli_profile_init(configs_type: Literal["dict", "model"]):
     target_configs = dict(type="snowflake", schema="schema")
     global_configs = dict(use_colors=False)
     if configs_type == "model":
@@ -60,7 +61,9 @@ def test_dbt_cli_profile_get_profile():
         "class_target_configs",
     ],
 )
-async def test_dbt_cli_profile_save_load_roundtrip(target_configs_request, request):
+async def test_dbt_cli_profile_save_load_roundtrip(
+    target_configs_request: str, request: pytest.FixtureRequest
+):
     target_configs = request.getfixturevalue(target_configs_request)
     dbt_cli_profile = DbtCliProfile(
         name="my_name",

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -669,7 +669,7 @@ class Block(BaseModel, ABC):
         module_str = ".".join(qualified_name.split(".")[:-1])
         origin = cls.__pydantic_generic_metadata__.get("origin") or cls
         class_name = origin.__name__
-        block_variable_name = f'{cls.get_block_type_slug().replace("-", "_")}_block'
+        block_variable_name = f"{cls.get_block_type_slug().replace('-', '_')}_block"
 
         return dedent(
             f"""\


### PR DESCRIPTION
<details>
<summary>does not load nested blocks</summary>

```python
from typing import Union

from pydantic import Field

from prefect.blocks.core import Block


class ChildBlockX(Block):
    x: int = Field(default=1)


class ChildBlockY(Block):
    y: int = Field(default=2)


class ParentBlock(Block):
    child: Union[ChildBlockX, ChildBlockY] = Field(default=...)


ParentBlock(
    child=ChildBlockX(x=42),
).save("parent-x", overwrite=True)

ParentBlock(
    child=ChildBlockY(y=42),
).save("parent-y", overwrite=True)

print(ParentBlock.load("parent-x"))
print(ParentBlock.load("parent-y"))
```

```
» python sandbox/nested_block_save.py
ParentBlock(child=ChildBlockX(x=42))
ParentBlock(child=ChildBlockY()) # why is this empty?
```
</details>
<details>
<summary>example that appears to</summary>

```python
from typing import Any, Union

from pydantic import Discriminator, Field, Tag
from typing_extensions import Annotated

from prefect.blocks.core import Block


def child_block_discriminator(v: Any) -> str:
    if isinstance(v, dict):
        return v.get("block_type_slug", "")
    if isinstance(v, Block):
        return v.get_block_type_slug()
    return ""


class ChildBlockX(Block):
    x: int = Field(default=1)


class ChildBlockY(Block):
    y: int = Field(default=2)


class ParentBlock(Block):
    child: Annotated[
        Union[
            Annotated[ChildBlockX, Tag("childblockx")],
            Annotated[ChildBlockY, Tag("childblocky")],
        ],
        Discriminator(child_block_discriminator),
    ] = Field(default=...)


ParentBlock(
    child=ChildBlockX(x=42),
).save("parent-x", overwrite=True)

ParentBlock(
    child=ChildBlockY(y=42),
).save("parent-y", overwrite=True)

print(ParentBlock.load("parent-x"))
print(ParentBlock.load("parent-y"))
```


```
» python sandbox/nested_block_save.py
ParentBlock(child=ChildBlockX(x=42))
ParentBlock(child=ChildBlockY(y=42))
```

</details>