### PR TITLE
rm deprecation warning for `schedule` key

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -1757,22 +1757,9 @@ def _handle_deprecated_schedule_fields(deploy_config: dict[str, Any]):
         )
 
     if legacy_schedule and isinstance(legacy_schedule, dict):
-        # The yaml has a legacy schedule key, we should honor whatever
+        # The yaml has the original schedule key, we should honor whatever
         # is there while still appending these new schedules.
         deploy_config["schedules"] = [deploy_config["schedule"]]
-
-        app.console.print(
-            generate_deprecation_message(
-                "Defining a schedule via the `schedule` key in the deployment",
-                start_date="Mar 2024",
-                help=(
-                    "Please use `schedules` instead by renaming the "
-                    "`schedule` key to `schedules` and providing a list of "
-                    "schedule objects."
-                ),
-            ),
-            style="yellow",
-        )
 
     return deploy_config
 

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -2613,27 +2613,6 @@ class TestSchedules:
         )
 
     @pytest.mark.usefixtures("project_dir")
-    async def test_yaml_with_schedule_prints_deprecation_warning(self, work_pool):
-        prefect_yaml = Path("prefect.yaml")
-        with prefect_yaml.open(mode="r") as f:
-            deploy_config = yaml.safe_load(f)
-
-        deploy_config["deployments"][0]["name"] = "test-name"
-        deploy_config["deployments"][0]["schedule"]["interval"] = 42
-
-        with prefect_yaml.open(mode="w") as f:
-            yaml.safe_dump(deploy_config, f)
-
-        await run_sync_in_worker_thread(
-            invoke_and_assert,
-            command=(
-                f"deploy ./flows/hello.py:my_flow -n test-name --pool {work_pool.name}"
-            ),
-            expected_code=0,
-            expected_output_contains="Defining a schedule via the `schedule` key in the deployment",
-        )
-
-    @pytest.mark.usefixtures("project_dir")
     async def test_can_provide_multiple_schedules_of_the_same_type_via_command(
         self, prefect_client, work_pool
     ):


### PR DESCRIPTION
do we still want to be emitting this?