### PR TITLE
[UI v2] feat: Adds basic string utils that can be re-used throughout the app

### DIFF
--- a/ui-v2/src/components/automations/action-details/action-details.tsx
+++ b/ui-v2/src/components/automations/action-details/action-details.tsx
@@ -22,6 +22,7 @@ import {
 	createFakeWorkPool,
 	createFakeWorkQueue,
 } from "@/mocks";
+import { capitalize } from "@/utils";
 import { Link } from "@tanstack/react-router";
 
 const ACTION_TYPE_TO_STRING = {
@@ -227,7 +228,7 @@ const RunDeploymentJsonDialog = ({
 		<Dialog>
 			<DialogTrigger asChild>
 				<Button variant="secondary" size="sm">
-					Show {title.charAt(0).toUpperCase() + title.slice(1).toLowerCase()}
+					Show {capitalize(title)}
 				</Button>
 			</DialogTrigger>
 			<DialogContent aria-describedby={undefined}>

--- a/ui-v2/src/components/automations/automation-details.tsx
+++ b/ui-v2/src/components/automations/automation-details.tsx
@@ -1,6 +1,7 @@
 import { type Automation } from "@/api/automations";
 import { ActionDetails } from "@/components/automations/action-details";
 import { Typography } from "@/components/ui/typography";
+import { pluralize } from "@/utils";
 
 type AutomationDetailsProps = {
 	data: Automation;
@@ -43,7 +44,7 @@ const AutomationActions = ({ data }: AutomationDetailsProps) => {
 	const { actions } = data;
 	return (
 		<div className="flex flex-col gap-1">
-			<Typography>{`Action${actions.length > 1 ? "s" : ""}`}</Typography>
+			<Typography>{pluralize(actions.length, "Action")}</Typography>
 			<ul className="flex flex-col gap-2">
 				{actions.map((action, i) => (
 					<li key={i}>

--- a/ui-v2/src/components/deployments/data-table/index.tsx
+++ b/ui-v2/src/components/deployments/data-table/index.tsx
@@ -23,6 +23,7 @@ import { StatusBadge } from "@/components/ui/status-badge";
 import { TagBadgeGroup } from "@/components/ui/tag-badge-group";
 import { TagsInput } from "@/components/ui/tags-input";
 import { useToast } from "@/hooks/use-toast";
+import { pluralize } from "@/utils";
 import type {
 	ColumnFiltersState,
 	OnChangeFn,
@@ -249,8 +250,8 @@ export const DeploymentsDataTable = ({
 			<div className="grid sm:grid-cols-2 md:grid-cols-6 lg:grid-cols-12 gap-2 pb-4 items-center">
 				<div className="sm:col-span-2 md:col-span-6 lg:col-span-4 order-last lg:order-first">
 					<p className="text-sm text-muted-foreground">
-						{currentDeploymentsCount} Deployment
-						{currentDeploymentsCount === 1 ? "" : "s"}
+						{currentDeploymentsCount}{" "}
+						{pluralize(currentDeploymentsCount, "Deployment")}
 					</p>
 				</div>
 				<div className="sm:col-span-2 md:col-span-2 lg:col-span-3">

--- a/ui-v2/src/components/ui/schedule-badge/index.tsx
+++ b/ui-v2/src/components/ui/schedule-badge/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useIsOverflowing } from "@/hooks/use-is-overflowing";
 import { cn } from "@/lib/utils";
+import { capitalize } from "@/utils";
 import cronstrue from "cronstrue";
 import { format } from "date-fns";
 import humanizeDuration from "humanize-duration";
@@ -132,8 +133,7 @@ const RRuleScheduleBadge = ({
 	schedule: RRuleSchedule;
 }) => {
 	const scheduleText = rrulestr(schedule.rrule).toText();
-	const capitalizedScheduleText =
-		scheduleText.charAt(0).toUpperCase() + scheduleText.slice(1);
+	const capitalizedScheduleText = capitalize(scheduleText);
 	const detailedScheduleText = `${active ? "" : "(Paused)"} ${capitalizedScheduleText} (${schedule.timezone})`;
 	return (
 		<TooltipProvider>

--- a/ui-v2/src/components/ui/state-badge/index.tsx
+++ b/ui-v2/src/components/ui/state-badge/index.tsx
@@ -3,6 +3,7 @@ import { cva } from "class-variance-authority";
 
 import { ICONS as COMPONENT_ICONS } from "@/components/ui/icons";
 
+import { capitalize } from "@/utils";
 import { Badge } from "../badge";
 
 const ICONS = {
@@ -49,8 +50,4 @@ export const StateBadge = ({ type, name }: StateBadgeProps) => {
 			{name ?? capitalize(type)}
 		</Badge>
 	);
-};
-
-const capitalize = (str: string) => {
-	return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 };

--- a/ui-v2/src/components/ui/status-badge/index.tsx
+++ b/ui-v2/src/components/ui/status-badge/index.tsx
@@ -1,4 +1,5 @@
 import type { components } from "@/api/prefect";
+import { capitalize } from "@/utils";
 import { cva } from "class-variance-authority";
 import { Circle, Pause } from "lucide-react";
 import { Badge } from "../badge";
@@ -32,10 +33,7 @@ const statusBadgeVariants = cva(
 
 export const StatusBadge = ({ status }: StatusBadgeProps) => {
 	const Icon = STATUS_ICONS[status];
-	const statusText = status
-		.split("_")
-		.map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-		.join(" ");
+	const statusText = status.split("_").map(capitalize).join(" ");
 	return (
 		<Badge className={statusBadgeVariants({ status })}>
 			{Icon}

--- a/ui-v2/src/components/variables/data-table/data-table.tsx
+++ b/ui-v2/src/components/variables/data-table/data-table.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/select";
 import { TagBadgeGroup } from "@/components/ui/tag-badge-group";
 import { TagsInput } from "@/components/ui/tags-input";
+import { pluralize } from "@/utils";
 import {
 	type ColumnFiltersState,
 	type OnChangeFn,
@@ -154,7 +155,7 @@ export const VariablesDataTable = ({
 			<div className="grid sm:grid-cols-2 md:grid-cols-6 lg:grid-cols-12 gap-2 pb-4 items-center">
 				<div className="sm:col-span-2 md:col-span-6 lg:col-span-4 order-last lg:order-first">
 					<p className="text-sm text-muted-foreground">
-						{currentVariableCount} Variables
+						{currentVariableCount} {pluralize(currentVariableCount, "Variable")}
 					</p>
 				</div>
 				<div className="sm:col-span-2 md:col-span-2 lg:col-span-3">

--- a/ui-v2/src/mocks/create-fake-state.ts
+++ b/ui-v2/src/mocks/create-fake-state.ts
@@ -1,4 +1,5 @@
 import type { components } from "@/api/prefect";
+import { capitalize } from "@/utils";
 import { faker } from "@faker-js/faker";
 
 type StateType = components["schemas"]["StateType"];
@@ -17,8 +18,7 @@ const STATE_TYPE_VALUES = [
 
 export const createFakeState = () => {
 	const stateType = faker.helpers.arrayElement(STATE_TYPE_VALUES);
-	const stateName =
-		stateType.charAt(0).toUpperCase() + stateType.slice(1).toLowerCase();
+	const stateName = capitalize(stateType);
 
 	return { stateType, stateName };
 };

--- a/ui-v2/src/utils/index.ts
+++ b/ui-v2/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { pluralize, capitalize } from "./utils";

--- a/ui-v2/src/utils/utils.test.ts
+++ b/ui-v2/src/utils/utils.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "vitest";
+import { capitalize, pluralize } from "./utils";
+
+test("capitalize", () => {
+	const TEST_STRING = "teststring";
+
+	const RESULT = capitalize(TEST_STRING);
+	const EXPECTED = "Teststring";
+
+	expect(RESULT).toEqual(EXPECTED);
+});
+
+test("pluralize -- single", () => {
+	const FRUITS = ["apple"];
+
+	const RESULT = pluralize(FRUITS.length, "Fruit");
+	const EXPECTED = "Fruit";
+
+	expect(RESULT).toEqual(EXPECTED);
+});
+
+test("pluralize -- plural", () => {
+	const FRUITS = ["apple", "banana"];
+
+	const RESULT = pluralize(FRUITS.length, "Fruit");
+	const EXPECTED = "Fruits";
+
+	expect(RESULT).toEqual(EXPECTED);
+});
+
+test("pluralize -- custom pluralization", () => {
+	const FRUITS = ["Alice", "Bob"];
+
+	const RESULT = pluralize(FRUITS.length, "child", "children");
+	const EXPECTED = "children";
+
+	expect(RESULT).toEqual(EXPECTED);
+});

--- a/ui-v2/src/utils/utils.ts
+++ b/ui-v2/src/utils/utils.ts
@@ -1,0 +1,35 @@
+/**
+ *
+ * @param str
+ * @returns a string to a capitalized format.
+ *
+ * @example
+ * ```ts;
+ * const x = capitalize("hello World") // Hello world
+ * ```
+ */
+export const capitalize = (str: string) => {
+	return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+};
+
+/**
+ *
+ * @param str
+ * @returns a pluralized string based on the count
+ *
+ * @example
+ * ```ts;
+ * const fruits = ["apple", "banana"]
+ * const x = pluralize(fruits.length, "fruit") // Fruits
+ * ```
+ */
+export const pluralize = (
+	count: number,
+	singular: string,
+	plural?: string,
+): string => {
+	if (count === 1) {
+		return singular;
+	}
+	return plural || singular + "s";
+};


### PR DESCRIPTION
When doing the UI replatforming, there's a few string utililties that can be re-used via a function:
`pluralize` and `capitalize`


- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Relates to: https://github.com/PrefectHQ/prefect/issues/15512

CC @devangrose 