### PR TITLE
Add additional `validation_alias` to `SnowflakeConnector`

### DIFF
--- a/src/integrations/prefect-snowflake/prefect_snowflake/database.py
+++ b/src/integrations/prefect-snowflake/prefect_snowflake/database.py
@@ -4,7 +4,7 @@ import asyncio
 from time import sleep
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 
-from pydantic import Field
+from pydantic import AliasChoices, Field
 from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 
@@ -89,7 +89,9 @@ class SnowflakeConnector(DatabaseBlock):
     )
     schema_: str = Field(
         default=...,
-        alias="schema",
+        serialization_alias="schema",
+        # Handles cases where the model was dumped with `by_alias=False` or `by_alias=True`
+        validation_alias=AliasChoices("schema_", "schema"),
         description="The name of the default schema to use.",
     )
     fetch_size: int = Field(

--- a/src/integrations/prefect-snowflake/tests/test_database.py
+++ b/src/integrations/prefect-snowflake/tests/test_database.py
@@ -223,6 +223,19 @@ class TestSnowflakeConnector:
         connector = SnowflakeConnector(**connector_params)
         return connector
 
+    def test_block_initialization_handles_schema_alias(self, connector_params):
+        # First, test the case where the schema is set with the alias
+        connector_params["schema"] = "schema_input"
+        connector_params.pop("schema_", None)
+        connector = SnowflakeConnector(**connector_params)
+        assert connector.schema_ == "schema_input"
+
+        # Now, test the case where the schema is set with the field name
+        connector_params["schema_"] = "schema_input"
+        connector_params.pop("schema", None)
+        connector = SnowflakeConnector(**connector_params)
+        assert connector.schema_ == "schema_input"
+
     def test_block_initialization(self, snowflake_connector):
         assert snowflake_connector._connection is None
         assert snowflake_connector._unique_cursors is None


### PR DESCRIPTION
This PR updates `SnowflakeConnector` to handle setting `schema_` with different keys. This update helps the block handle cases where the data was dumped without using the serialization alias, which was seen in https://github.com/PrefectHQ/prefect/pull/16834.
