### PR TITLE
allow templating `schedules` in `prefect.yaml`

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -705,7 +705,7 @@ async def _run_single_deploy(
     if not deploy_config.get("description"):
         deploy_config["description"] = flow.description
 
-    deploy_config["schedules"] = _construct_schedules(deploy_config)
+    deploy_config["schedules"] = _construct_schedules(deploy_config, step_outputs)
 
     # save deploy_config before templating
     deploy_config_before_templating = deepcopy(deploy_config)
@@ -909,13 +909,14 @@ async def _run_multi_deploy(
 
 def _construct_schedules(
     deploy_config: dict[str, Any],
+    step_outputs: dict[str, Any],
 ) -> list[DeploymentScheduleCreate]:
     """
     Constructs a schedule from a deployment configuration.
 
     Args:
         deploy_config: A deployment configuration
-
+        step_outputs: A dictionary of step outputs
     Returns:
         A list of schedule objects
     """
@@ -925,7 +926,7 @@ def _construct_schedules(
     if schedule_configs is not NotSet:
         schedules = [
             _schedule_config_to_deployment_schedule(schedule_config)
-            for schedule_config in schedule_configs
+            for schedule_config in apply_values(schedule_configs, step_outputs)
         ]
     elif schedule_configs is NotSet:
         if is_interactive():

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -529,11 +529,9 @@ async def _run_single_deploy(
 
     deploy_config["parameter_openapi_schema"] = parameter_schema(flow)
 
-    deploy_config["schedules"] = _construct_schedules(
-        deploy_config,
-    )
-    # determine work pool
     work_pool_name = get_from_dict(deploy_config, "work_pool.name")
+
+    # determine work pool
     if work_pool_name:
         try:
             work_pool = await client.read_work_pool(deploy_config["work_pool"]["name"])
@@ -706,6 +704,8 @@ async def _run_single_deploy(
 
     if not deploy_config.get("description"):
         deploy_config["description"] = flow.description
+
+    deploy_config["schedules"] = _construct_schedules(deploy_config)
 
     # save deploy_config before templating
     deploy_config_before_templating = deepcopy(deploy_config)

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
 from uuid import UUID, uuid4
 
 import jsonschema
@@ -92,6 +92,16 @@ class DeploymentScheduleCreate(ActionBaseModel):
         default=None,
         description="The maximum number of scheduled runs for the schedule.",
     )
+
+    @field_validator("active", mode="wrap")
+    @classmethod
+    def validate_active(cls, v: Any, handler: Callable[[Any], Any]) -> bool:
+        try:
+            return handler(v)
+        except Exception:
+            raise ValueError(
+                f"active must be able to be parsed as a boolean, got {v!r} of type {type(v)}"
+            )
 
     @field_validator("max_scheduled_runs")
     @classmethod

--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -10,12 +10,11 @@ from __future__ import annotations
 import os
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional
 
 import yaml
 from ruamel.yaml import YAML
 
-from prefect.client.schemas.actions import DeploymentScheduleCreate
 from prefect.client.schemas.objects import ConcurrencyLimitStrategy
 from prefect.client.schemas.schedules import IntervalSchedule
 from prefect.utilities._git import get_git_branch, get_git_remote_origin_url
@@ -207,8 +206,8 @@ def initialize_project(
 
 
 def _format_deployment_for_saving_to_prefect_file(
-    deployment: Dict,
-) -> Dict:
+    deployment: dict[str, Any],
+) -> dict[str, Any]:
     """
     Formats a deployment into a templated deploy config for saving to prefect.yaml.
 
@@ -227,10 +226,8 @@ def _format_deployment_for_saving_to_prefect_file(
     deployment.pop("flow_name", None)
 
     if deployment.get("schedules"):
-        schedules = []
-        for deployment_schedule in cast(
-            List[DeploymentScheduleCreate], deployment["schedules"]
-        ):
+        schedules: list[dict[str, Any]] = []
+        for deployment_schedule in deployment["schedules"]:
             if isinstance(deployment_schedule.schedule, IntervalSchedule):
                 schedule_config = _interval_schedule_to_dict(
                     deployment_schedule.schedule
@@ -257,7 +254,7 @@ def _format_deployment_for_saving_to_prefect_file(
     return deployment
 
 
-def _interval_schedule_to_dict(schedule: IntervalSchedule) -> Dict:
+def _interval_schedule_to_dict(schedule: IntervalSchedule) -> dict[str, Any]:
     """
     Converts an IntervalSchedule to a dictionary.
 
@@ -265,7 +262,7 @@ def _interval_schedule_to_dict(schedule: IntervalSchedule) -> Dict:
         - schedule (IntervalSchedule): the schedule to convert
 
     Returns:
-        - Dict: the schedule as a dictionary
+        - dict[str, Any]: the schedule as a dictionary
     """
     schedule_config = schedule.model_dump()
     schedule_config["interval"] = schedule_config["interval"].total_seconds()
@@ -275,12 +272,12 @@ def _interval_schedule_to_dict(schedule: IntervalSchedule) -> Dict:
 
 
 def _save_deployment_to_prefect_file(
-    deployment: Dict,
-    build_steps: Optional[List[Dict]] = None,
-    push_steps: Optional[List[Dict]] = None,
-    pull_steps: Optional[List[Dict]] = None,
-    triggers: Optional[List[Dict]] = None,
-    sla: Optional[list[dict]] = None,
+    deployment: dict[str, Any],
+    build_steps: list[dict[str, Any]] | None = None,
+    push_steps: list[dict[str, Any]] | None = None,
+    pull_steps: list[dict[str, Any]] | None = None,
+    triggers: list[dict[str, Any]] | None = None,
+    sla: list[dict[str, Any]] | None = None,
     prefect_file: Path = Path("prefect.yaml"),
 ):
     """

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import json
 import os
@@ -1490,7 +1492,10 @@ class TestProjectDeploy:
 
     @pytest.mark.usefixtures("project_dir")
     async def test_project_deploy_templates_env_var_values(
-        self, prefect_client, work_pool, monkeypatch
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         # prepare a templated deployment
         prefect_file = Path("prefect.yaml")
@@ -1553,7 +1558,7 @@ class TestProjectDeploy:
 
     @pytest.mark.usefixtures("project_dir")
     async def test_project_deploy_with_default_parameters(
-        self, prefect_client, work_pool
+        self, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -1617,7 +1622,7 @@ class TestProjectDeploy:
 
     @pytest.mark.usefixtures("project_dir")
     async def test_project_deploy_templates_pull_step_safely(
-        self, prefect_client, work_pool
+        self, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         """
         We want step outputs to get templated, but block references to only be
@@ -1686,7 +1691,7 @@ class TestProjectDeploy:
 
     @pytest.mark.usefixtures("project_dir")
     async def test_project_deploy_templates_pull_step_in_deployments_section_safely(
-        self, prefect_client, work_pool
+        self, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         """
         We want step outputs to get templated, but block references to only be
@@ -1754,7 +1759,9 @@ class TestProjectDeploy:
         ]
 
     @pytest.mark.usefixtures("project_dir")
-    async def test_project_deploy_reads_entrypoint_from_prefect_yaml(self, work_pool):
+    async def test_project_deploy_reads_entrypoint_from_prefect_yaml(
+        self, work_pool: WorkPool
+    ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
@@ -1774,7 +1781,9 @@ class TestProjectDeploy:
         )
 
     @pytest.mark.usefixtures("project_dir")
-    async def test_project_deploy_exits_with_no_entrypoint_configured(self, work_pool):
+    async def test_project_deploy_exits_with_no_entrypoint_configured(
+        self, work_pool: WorkPool
+    ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
@@ -2126,7 +2135,10 @@ class TestProjectDeploy:
 
     @pytest.mark.usefixtures("project_dir")
     async def test_deploy_templates_env_vars(
-        self, prefect_client, monkeypatch, work_pool
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         # set up environment variables
         monkeypatch.setenv("WORK_POOL", work_pool.name)
@@ -2197,7 +2209,10 @@ class TestProjectDeploy:
     class TestRemoteStoragePicklist:
         @pytest.mark.usefixtures("uninitialized_project_dir_with_git_no_remote")
         async def test_no_git_option_when_no_remote_url(
-            self, docker_work_pool, aws_credentials, monkeypatch
+            self,
+            docker_work_pool: WorkPool,
+            aws_credentials: Any,
+            monkeypatch: pytest.MonkeyPatch,
         ):
             mock_step = mock.MagicMock()
             monkeypatch.setattr(
@@ -2241,7 +2256,7 @@ class TestProjectDeploy:
 
         @pytest.mark.usefixtures("uninitialized_project_dir_with_git_with_remote")
         async def test_git_option_present_when_remote_url(
-            self, docker_work_pool, monkeypatch
+            self, docker_work_pool: WorkPool, monkeypatch: pytest.MonkeyPatch
         ):
             mock_step = mock.MagicMock()
             monkeypatch.setattr(
@@ -2319,7 +2334,9 @@ class TestProjectDeploy:
 
 class TestSchedules:
     @pytest.mark.usefixtures("project_dir")
-    async def test_passing_cron_schedules_to_deploy(self, work_pool, prefect_client):
+    async def test_passing_cron_schedules_to_deploy(
+        self, work_pool: WorkPool, prefect_client: PrefectClient
+    ):
         result = await run_sync_in_worker_thread(
             invoke_and_assert,
             command=(
@@ -2338,7 +2355,9 @@ class TestSchedules:
         assert schedule.timezone == "Europe/Berlin"
 
     @pytest.mark.usefixtures("project_dir")
-    async def test_deployment_yaml_cron_schedule(self, work_pool, prefect_client):
+    async def test_deployment_yaml_cron_schedule(
+        self, work_pool: WorkPool, prefect_client: PrefectClient
+    ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
@@ -2367,7 +2386,7 @@ class TestSchedules:
 
     @pytest.mark.usefixtures("project_dir")
     async def test_deployment_yaml_cron_schedule_timezone_cli(
-        self, work_pool, prefect_client
+        self, work_pool: WorkPool, prefect_client: PrefectClient
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -2399,7 +2418,7 @@ class TestSchedules:
 
     @pytest.mark.usefixtures("project_dir")
     async def test_passing_interval_schedules_to_deploy(
-        self, work_pool, prefect_client
+        self, work_pool: WorkPool, prefect_client: PrefectClient
     ):
         result = await run_sync_in_worker_thread(
             invoke_and_assert,
@@ -2453,7 +2472,7 @@ class TestSchedules:
 
     @pytest.mark.usefixtures("project_dir")
     async def test_parsing_rrule_schedule_string_literal(
-        self, prefect_client, work_pool
+        self, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         await run_sync_in_worker_thread(
             invoke_and_assert,
@@ -2475,7 +2494,9 @@ class TestSchedules:
         )
 
     @pytest.mark.usefixtures("project_dir")
-    async def test_rrule_deployment_yaml(self, work_pool, prefect_client):
+    async def test_rrule_deployment_yaml(
+        self, work_pool: WorkPool, prefect_client: PrefectClient
+    ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
@@ -2508,7 +2529,7 @@ class TestSchedules:
 
     @pytest.mark.usefixtures("project_dir")
     async def test_can_provide_multiple_schedules_via_command(
-        self, prefect_client, work_pool
+        self, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         await run_sync_in_worker_thread(
             invoke_and_assert,
@@ -2543,7 +2564,7 @@ class TestSchedules:
 
     @pytest.mark.usefixtures("project_dir")
     async def test_can_provide_multiple_schedules_via_yaml(
-        self, prefect_client, work_pool
+        self, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         prefect_yaml = Path("prefect.yaml")
         with prefect_yaml.open(mode="r") as f:
@@ -2591,7 +2612,9 @@ class TestSchedules:
         }
 
     @pytest.mark.usefixtures("project_dir")
-    async def test_yaml_with_schedule_and_schedules_raises_error(self, work_pool):
+    async def test_yaml_with_schedule_and_schedules_raises_error(
+        self, work_pool: WorkPool
+    ):
         prefect_yaml = Path("prefect.yaml")
         with prefect_yaml.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
@@ -2614,7 +2637,7 @@ class TestSchedules:
 
     @pytest.mark.usefixtures("project_dir")
     async def test_can_provide_multiple_schedules_of_the_same_type_via_command(
-        self, prefect_client, work_pool
+        self, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         await run_sync_in_worker_thread(
             invoke_and_assert,
@@ -2642,7 +2665,7 @@ class TestSchedules:
 
     @pytest.mark.usefixtures("interactive_console", "project_dir")
     async def test_deploy_interval_schedule_interactive(
-        self, prefect_client, work_pool
+        self, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         await run_sync_in_worker_thread(
             invoke_and_assert,
@@ -2686,7 +2709,7 @@ class TestSchedules:
 
     @pytest.mark.usefixtures("interactive_console", "project_dir")
     async def test_deploy_default_interval_schedule_interactive(
-        self, prefect_client, work_pool
+        self, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         await run_sync_in_worker_thread(
             invoke_and_assert,
@@ -2720,7 +2743,9 @@ class TestSchedules:
         assert deployment.schedules[0].schedule.interval == timedelta(seconds=3600)
 
     @pytest.mark.usefixtures("interactive_console", "project_dir")
-    async def test_deploy_cron_schedule_interactive(self, prefect_client, work_pool):
+    async def test_deploy_cron_schedule_interactive(
+        self, prefect_client: PrefectClient, work_pool: WorkPool
+    ):
         await run_sync_in_worker_thread(
             invoke_and_assert,
             command=(
@@ -2766,7 +2791,9 @@ class TestSchedules:
         assert deployment.schedules[0].schedule.cron == "* * * * *"
 
     @pytest.mark.usefixtures("interactive_console", "project_dir")
-    async def test_deploy_rrule_schedule_interactive(self, prefect_client, work_pool):
+    async def test_deploy_rrule_schedule_interactive(
+        self, prefect_client: PrefectClient, work_pool: WorkPool
+    ):
         await run_sync_in_worker_thread(
             invoke_and_assert,
             command=(
@@ -2810,7 +2837,9 @@ class TestSchedules:
         )
 
     @pytest.mark.usefixtures("interactive_console", "project_dir")
-    async def test_deploy_no_schedule_interactive(self, prefect_client, work_pool):
+    async def test_deploy_no_schedule_interactive(
+        self, prefect_client: PrefectClient, work_pool: WorkPool
+    ):
         await run_sync_in_worker_thread(
             invoke_and_assert,
             command=(
@@ -2836,7 +2865,9 @@ class TestSchedules:
         assert len(deployment.schedules) == 0
 
     @pytest.mark.usefixtures("project_dir")
-    async def test_deploy_with_inactive_schedule(self, work_pool, prefect_client):
+    async def test_deploy_with_inactive_schedule(
+        self, work_pool: WorkPool, prefect_client: PrefectClient
+    ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
             deploy_config = yaml.safe_load(f)
@@ -2867,7 +2898,9 @@ class TestSchedules:
         assert deployment_schedule.schedule.timezone == "America/Chicago"
 
     @pytest.mark.usefixtures("project_dir")
-    async def test_yaml_null_schedules(self, prefect_client, work_pool):
+    async def test_yaml_null_schedules(
+        self, prefect_client: PrefectClient, work_pool: WorkPool
+    ):
         prefect_yaml_content = f"""
         deployments:
           - name: test-name
@@ -2894,7 +2927,7 @@ class TestSchedules:
 
     @pytest.mark.usefixtures("project_dir")
     async def test_yaml_with_shell_script_step_to_determine_schedule_is_active(
-        self, prefect_client, work_pool
+        self, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         prefect_yaml = Path("prefect.yaml")
         with prefect_yaml.open(mode="r") as f:
@@ -2940,7 +2973,11 @@ class TestSchedules:
     @pytest.mark.parametrize("schedule_is_active", [True, False])
     @pytest.mark.usefixtures("project_dir")
     async def test_yaml_with_env_var_to_determine_schedule_is_active(
-        self, prefect_client, work_pool, monkeypatch, schedule_is_active
+        self,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+        monkeypatch: pytest.MonkeyPatch,
+        schedule_is_active: bool,
     ):
         monkeypatch.setenv(
             "SCHEDULE_IS_ACTIVE", "true" if schedule_is_active else "false"
@@ -2982,7 +3019,7 @@ class TestSchedules:
 
 class TestMultiDeploy:
     @pytest.mark.usefixtures("project_dir")
-    async def test_deploy_all(self, prefect_client, work_pool):
+    async def test_deploy_all(self, prefect_client: PrefectClient, work_pool: WorkPool):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
             contents = yaml.safe_load(f)
@@ -3034,7 +3071,7 @@ class TestMultiDeploy:
 
     @pytest.mark.usefixtures("project_dir")
     async def test_deploy_all_schedules_remain_inactive(
-        self, prefect_client, work_pool
+        self, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -3086,7 +3123,7 @@ class TestMultiDeploy:
         assert deployment2.schedules[0].active is False
 
     async def test_deploy_selected_deployments(
-        self, project_dir, prefect_client, work_pool
+        self, project_dir: Path, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -3164,7 +3201,7 @@ class TestMultiDeploy:
             )
 
     async def test_deploy_single_with_cron_schedule(
-        self, project_dir, prefect_client, work_pool
+        self, project_dir: Path, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -3220,7 +3257,11 @@ class TestMultiDeploy:
         "deployment_selector_options", ["--all", "-n test-name-1 -n test-name-2"]
     )
     async def test_deploy_multiple_with_cli_options(
-        self, project_dir, prefect_client, work_pool, deployment_selector_options
+        self,
+        project_dir: Path,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+        deployment_selector_options: str,
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -3317,7 +3358,9 @@ class TestMultiDeploy:
         deployment.name = "from-cli-name"
 
     @pytest.mark.usefixtures("project_dir")
-    async def test_deploy_without_name_in_prefect_yaml(self, prefect_client, work_pool):
+    async def test_deploy_without_name_in_prefect_yaml(
+        self, prefect_client: PrefectClient, work_pool: WorkPool
+    ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
             contents = yaml.safe_load(f)
@@ -3356,7 +3399,7 @@ class TestMultiDeploy:
 
     @pytest.mark.usefixtures("interactive_console", "project_dir")
     async def test_deploy_without_name_in_prefect_yaml_interactive(
-        self, prefect_client, work_pool
+        self, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -3416,7 +3459,7 @@ class TestMultiDeploy:
 
     @pytest.mark.usefixtures("interactive_console", "project_dir")
     async def test_deploy_without_name_in_prefect_yaml_interactive_user_skips(
-        self, prefect_client: PrefectClient, work_pool
+        self, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -3467,7 +3510,7 @@ class TestMultiDeploy:
         assert len(await prefect_client.read_deployments()) == 1
 
     async def test_deploy_with_name_not_in_prefect_yaml(
-        self, project_dir, prefect_client, work_pool
+        self, project_dir: Path, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -3514,7 +3557,7 @@ class TestMultiDeploy:
             )
 
     async def test_deploy_with_single_deployment_with_name_in_file(
-        self, project_dir, prefect_client, work_pool
+        self, project_dir: Path, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -3570,7 +3613,7 @@ class TestMultiDeploy:
         )
 
     async def test_deploy_single_allows_options_override(
-        self, project_dir, prefect_client, work_pool
+        self, project_dir: Path, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -3608,7 +3651,7 @@ class TestMultiDeploy:
         assert deployment.job_variables == {"env": "prod"}
 
     async def test_deploy_single_deployment_with_name_in_cli(
-        self, project_dir, prefect_client, work_pool
+        self, project_dir: Path, prefect_client: PrefectClient, work_pool: WorkPool
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -3657,7 +3700,11 @@ class TestMultiDeploy:
         ],
     )
     async def test_deploy_existing_deployment_and_nonexistent_deployment_deploys_former(
-        self, deploy_names, project_dir, prefect_client, work_pool
+        self,
+        deploy_names: tuple[str, str],
+        project_dir: Path,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -3725,7 +3772,11 @@ class TestDeployPattern:
         ],
     )
     async def test_pattern_deploy_multiple_existing_deployments(
-        self, deploy_name, project_dir, prefect_client, work_pool
+        self,
+        deploy_name: str | tuple[str, ...],
+        project_dir: Path,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -3885,7 +3936,11 @@ class TestDeployPattern:
         ],
     )
     async def test_pattern_deploy_one_existing_deployment_one_nonexistent_deployment(
-        self, project_dir, prefect_client, work_pool, deploy_name
+        self,
+        project_dir: Path,
+        prefect_client: PrefectClient,
+        work_pool: WorkPool,
+        deploy_name: tuple[str, str],
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:
@@ -3965,7 +4020,10 @@ class TestDeployPattern:
     )
     @pytest.mark.usefixtures("project_dir")
     async def test_deploy_multiple_nonexistent_deployments_raises(
-        self, deploy_names, work_pool, prefect_client
+        self,
+        deploy_names: tuple[str, str],
+        work_pool: WorkPool,
+        prefect_client: PrefectClient,
     ):
         prefect_file = Path("prefect.yaml")
         with prefect_file.open(mode="r") as f:

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -4308,10 +4308,6 @@ class TestSaveUserInputs:
                 # Accept default deployment name
                 readchar.key.ENTER
                 +
-                # decline schedule
-                "n"
-                + readchar.key.ENTER
-                +
                 # accept create work pool
                 readchar.key.ENTER
                 +
@@ -4321,8 +4317,12 @@ class TestSaveUserInputs:
                 # enter work pool name
                 "inflatable"
                 + readchar.key.ENTER
-                # Decline remote storage
+                # decline schedule
                 + "n"
+                + readchar.key.ENTER
+                +
+                # Decline remote storage
+                "n"
                 + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
@@ -4358,10 +4358,6 @@ class TestSaveUserInputs:
                 # Accept default deployment name
                 readchar.key.ENTER
                 +
-                # decline schedule
-                "n"
-                + readchar.key.ENTER
-                +
                 # accept create work pool
                 readchar.key.ENTER
                 +
@@ -4370,6 +4366,9 @@ class TestSaveUserInputs:
                 +
                 # enter work pool name
                 "inflatable"
+                + readchar.key.ENTER
+                # decline schedule
+                + "n"
                 + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
@@ -4399,14 +4398,14 @@ class TestSaveUserInputs:
             command="deploy flows/hello.py:my_flow",
             prompts_and_responses=[
                 ("? Deployment name (default)", ""),
+                ("you don't have any work pools", "y"),
+                ("What infrastructure type", "", "process"),
+                ("Work pool name", "inflatable"),
                 ("Would you like to configure schedules for this deployment?", ""),
                 ("What type of schedule would you like to use?", "", "Interval"),
                 ("Seconds between scheduled runs", "3600"),
                 ("Would you like to activate this schedule?", "y"),
                 ("Would you like to add another schedule?", "n"),
-                ("you don't have any work pools", "y"),
-                ("What infrastructure type", "", "process"),
-                ("Work pool name", "inflatable"),
                 ("Would you like to save configuration", "y"),
             ],
             expected_code=0,
@@ -4438,15 +4437,15 @@ class TestSaveUserInputs:
             command="deploy flows/hello.py:my_flow",
             prompts_and_responses=[
                 ("? Deployment name (default)", ""),
+                ("you don't have any work pools", "y"),
+                ("What infrastructure type", "", "process"),
+                ("Work pool name", "inflatable"),
                 ("Would you like to configure schedules for this deployment?", ""),
                 ("What type of schedule would you like to use?", "↓", "Cron"),
                 ("Cron string (0 0 * * *)", "* * * * *"),
                 ("Timezone (UTC)", ""),
                 ("Would you like to activate this schedule?", "y"),
                 ("Would you like to add another schedule?", "n"),
-                ("you don't have any work pools", "y"),
-                ("What infrastructure type", "", "process"),
-                ("Work pool name", "inflatable"),
                 ("Would you like to save configuration", "y"),
             ],
             expected_code=0,
@@ -4481,15 +4480,15 @@ class TestSaveUserInputs:
             command="deploy flows/hello.py:my_flow",
             prompts_and_responses=[
                 ("? Deployment name (default)", "existing-deployment"),
+                ("you don't have any work pools", "y"),
+                ("What infrastructure type", "", "process"),
+                ("Work pool name", "inflatable"),
                 ("Would you like to configure schedules for this deployment?", ""),
                 ("What type of schedule would you like to use?", "↓", "Cron"),
                 ("Cron string (0 0 * * *)", "* * * * *"),
                 ("Timezone (UTC)", ""),
                 ("Would you like to activate this schedule?", "y"),
                 ("Would you like to add another schedule?", "n"),
-                ("you don't have any work pools", "y"),
-                ("What infrastructure type", "", "process"),
-                ("Work pool name", "inflatable"),
                 ("Would you like to save configuration", "y"),
             ],
             expected_code=0,
@@ -4557,9 +4556,6 @@ class TestSaveUserInputs:
                 # enter deployment name
                 "existing-deployment"
                 + readchar.key.ENTER
-                # reject create schedule
-                + "n"
-                + readchar.key.ENTER
                 +
                 # accept create work pool
                 readchar.key.ENTER
@@ -4569,6 +4565,9 @@ class TestSaveUserInputs:
                 +
                 # enter work pool name
                 "inflatable"
+                + readchar.key.ENTER
+                # reject create schedule
+                + "n"
                 + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
@@ -4639,9 +4638,16 @@ class TestSaveUserInputs:
             user_input=(
                 # Accept default deployment name
                 readchar.key.ENTER
+                # accept create work pool
+                + readchar.key.ENTER
                 +
-                # accept schedule
+                # create process work pool
                 readchar.key.ENTER
+                # enter work pool name
+                + "inflatable"
+                + readchar.key.ENTER
+                # accept schedule
+                + readchar.key.ENTER
                 +
                 # select rrule schedule
                 readchar.key.DOWN
@@ -4651,21 +4657,11 @@ class TestSaveUserInputs:
                 # enter rrule schedule
                 "FREQ=MINUTELY"
                 + readchar.key.ENTER
+                # accept default timezone
+                + readchar.key.ENTER
                 # accept schedule being active
                 + readchar.key.ENTER
                 # decline adding another schedule
-                + readchar.key.ENTER
-                # accept create work pool
-                + readchar.key.ENTER
-                +
-                # accept create work pool
-                readchar.key.ENTER
-                +
-                # choose process work pool
-                readchar.key.ENTER
-                +
-                # enter work pool name
-                "inflatable"
                 + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
@@ -4821,15 +4817,15 @@ class TestSaveUserInputs:
             user_input=(
                 # Accept default deployment name
                 readchar.key.ENTER
-                # decline schedule
-                + "n"
-                + readchar.key.ENTER
                 # accept create work pool
                 + readchar.key.ENTER
                 # choose process work pool
                 + readchar.key.ENTER
                 # enter work pool name
                 + "inflatable"
+                + readchar.key.ENTER
+                # decline schedule configuration
+                + "n"
                 + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
@@ -4861,16 +4857,6 @@ class TestSaveUserInputs:
                 "n"
                 + readchar.key.ENTER
                 +
-                # accept schedule
-                readchar.key.ENTER
-                +
-                # select interval schedule
-                readchar.key.ENTER
-                +
-                # enter interval schedule
-                "3600"
-                + readchar.key.ENTER
-                +
                 # accept create work pool
                 readchar.key.ENTER
                 +
@@ -4879,6 +4865,19 @@ class TestSaveUserInputs:
                 +
                 # enter work pool name
                 "inflatable"
+                + readchar.key.ENTER
+                # accept schedule
+                + readchar.key.ENTER
+                +
+                # select interval schedule
+                readchar.key.ENTER
+                +
+                # enter interval schedule
+                "3600"
+                + readchar.key.ENTER
+                # accept activating schedule
+                + readchar.key.ENTER
+                # decline adding another schedule
                 + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
@@ -4910,10 +4909,6 @@ class TestSaveUserInputs:
                 # accept default deployment name
                 readchar.key.ENTER
                 +
-                # decline schedule
-                "n"
-                + readchar.key.ENTER
-                +
                 # accept create work pool
                 readchar.key.ENTER
                 +
@@ -4922,6 +4917,9 @@ class TestSaveUserInputs:
                 +
                 # enter work pool name
                 "inflatable"
+                + readchar.key.ENTER
+                # decline schedule
+                + "n"
                 + readchar.key.ENTER
                 # accept save user inputs
                 + "y"
@@ -5160,12 +5158,12 @@ class TestDeployWithoutEntrypoint:
                 # Accept default deployment name
                 readchar.key.ENTER
                 +
+                # accept first work pool
+                readchar.key.ENTER
+                +
                 # decline schedule
                 "n"
                 + readchar.key.ENTER
-                +
-                # accept first work pool
-                readchar.key.ENTER
                 +
                 # Decline remote storage
                 "n"
@@ -5209,12 +5207,12 @@ class TestDeployWithoutEntrypoint:
                 # Accept default deployment name
                 readchar.key.ENTER
                 +
+                # accept first work pool
+                readchar.key.ENTER
+                +
                 # decline schedule
                 "n"
                 + readchar.key.ENTER
-                +
-                # accept first work pool
-                readchar.key.ENTER
                 +
                 # Decline remote storage
                 "n"
@@ -5266,12 +5264,12 @@ class TestDeployWithoutEntrypoint:
                 # Accept default deployment name
                 readchar.key.ENTER
                 +
+                # accept first work pool
+                readchar.key.ENTER
+                +
                 # decline schedule
                 "n"
                 + readchar.key.ENTER
-                +
-                # accept first work pool
-                readchar.key.ENTER
                 +
                 # Decline remote storage
                 "n"


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/16826

this PR constructs schedules later so we can template in step outputs, tests are updated as the user is prompted after work pool info for a given deployment (which changes the expected outputs of all the interactive tests)

consider an example like this
```python
  - entrypoint: repros/16826/main.py:scheduled_flow
    name: schedule-active-flag-repro
    work_pool:
      name: local
    build:
      - prefect.deployments.steps.run_shell_script:
          id: get-schedule-isactive
          script: sh repros/16826/get-schedule-isactive.sh
          stream_output: false
    schedules:
      - cron: "*/5 * * * *"
        timezone: "America/Chicago"
        active: "{{ get-schedule-isactive.stdout }}"
```

where that bash is just doing
```python
#!/bin/sh
echo "false" 
```

historically, this would not work, as schedule fields were not templatable with step outputs