### PR TITLE
fix: check the type of dbt result when converting to markdown

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py
@@ -870,7 +870,7 @@ def create_summary_markdown(run_results: dict, command: str) -> str:
             if isinstance(r, RunResult):
                 successful_runs_str += f"* {r.node.name}\n"
             elif isinstance(r, RunResultOutput):
-                successful_runs_str += f"* {r.relation_name}\n"
+                successful_runs_str += f"* {r.unique_id}\n"
         markdown += f"""\n## Successful Nodes ✅\n\n{successful_runs_str}\n\n"""
 
     return markdown

--- a/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py
@@ -5,6 +5,7 @@ from pathlib import Path, PosixPath
 from typing import Any, Dict, List, Optional, Union
 
 import yaml
+from dbt.artifacts.schemas.run.v5.run import RunResultOutput, RunResult
 from dbt.cli.main import dbtRunner, dbtRunnerResult
 from dbt.contracts.results import ExecutionResult, NodeStatus
 from prefect_shell.commands import ShellOperation
@@ -864,9 +865,12 @@ def create_summary_markdown(run_results: dict, command: str) -> str:
         markdown += _create_unsuccessful_markdown(run_results=run_results)
 
     if run_results["Success"] != []:
-        successful_runs_str = "\n".join(
-            [f"* {r.node.name}" for r in run_results["Success"]]
-        )
+        successful_runs_str = ""
+        for r in run_results["Success"]:
+            if isinstance(r, RunResult):
+                successful_runs_str += f"* {r.node.name}\n"
+            elif isinstance(r, RunResultOutput):
+                successful_runs_str += f"* {r.relation_name}\n"
         markdown += f"""\n## Successful Nodes ✅\n\n{successful_runs_str}\n\n"""
 
     return markdown


### PR DESCRIPTION
Closes #16868

This change makes `create_summary_markdown` use different variables depending on the dbt command's output type.

`RunResult` -> `.node.name`
`RunResultOutput` -> `.unique_id`

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
