### PR TITLE
adhoc fix for a issue on Custom Webhook block: only header no body in the POST request

### DIFF
--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -814,9 +814,11 @@ class CustomWebhookNotificationBlock(NotificationBlock):
         # use 'null' when subject is None
         values.update(
             {
-                "subject": "null" if subject is None else subject,
-                "body": body,
-                "name": self.name,
+                "json": {
+                    "subject": "null" if subject is None else subject,
+                    "body": body,
+                    "name": self.name,
+                }
             }
         )
         # do substution
@@ -826,7 +828,7 @@ class CustomWebhookNotificationBlock(NotificationBlock):
                 "url": self.url,
                 "params": self.params,
                 "data": self.form_data,
-                "json": self.json_data,
+                "json": values['json'],
                 "headers": self.headers,
                 "cookies": self.cookies,
                 "timeout": self.timeout,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
adhoc fix for a issue on Custom Webhook block: only header no body in the POST request

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.

This issue is related to the discussion on Slack: https://prefect-community.slack.com/archives/CL09KU1K7/p1737742902411919

- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
