### PR TITLE
Update CODEOWNERS for /docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 /ui                                  @znicholasbrown
 
 # documentation
-/docs                                @discdiver @cicdw @desertaxle @zzstoatzz
+/docs                                @aaazzam @kevingrismore @daniel-prefect @seanpwlms
 # imports
 /src/prefect/__init__.py             @aaazzam @chrisguidry @cicdw @desertaxle @zzstoatzz
 /src/prefect/main.py                 @aaazzam @chrisguidry @cicdw @desertaxle @zzstoatzz


### PR DESCRIPTION
this PR is a changing of the guard on /docs. 

an immense gratitude to @discdiver for carrying docs on his shoulders for so long. 

excited to take on that burden with @daniel-prefect , @kevingrismore  and @seanpwlms 