### PR TITLE
Add support for secure Mattermost notifications

### DIFF
--- a/src/prefect/blocks/notifications.py
+++ b/src/prefect/blocks/notifications.py
@@ -570,6 +570,10 @@ class MattermostWebhook(AbstractAppriseNotificationBlock):
         description="The hostname of your Mattermost server.",
         examples=["Mattermost.example.com"],
     )
+    secure: bool = Field(
+        default=False,
+        description="Whether to use secure https connection.",
+    )
 
     token: SecretStr = Field(
         default=...,
@@ -621,6 +625,7 @@ class MattermostWebhook(AbstractAppriseNotificationBlock):
                 channels=self.channels,
                 include_image=self.include_image,
                 port=self.port,
+                secure=self.secure,
             ).url()  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType] incomplete type hints in apprise
         )
         self._start_apprise_client(url)

--- a/tests/blocks/test_notifications.py
+++ b/tests/blocks/test_notifications.py
@@ -170,6 +170,30 @@ class TestMattermostWebhook:
                 body="test", title="", notify_type=PREFECT_NOTIFY_TYPE_DEFAULT
             )
 
+    def test_notify_secure(self):
+        with patch("apprise.Apprise", autospec=True) as AppriseMock:
+            apprise_instance_mock = AppriseMock.return_value
+            apprise_instance_mock.async_notify = AsyncMock()
+
+            mm_block = MattermostWebhook(
+                hostname="example.com", token="token", secure=True, port=443
+            )
+
+            @flow
+            def test_flow():
+                mm_block.notify("test")
+
+            test_flow()
+
+            AppriseMock.assert_called_once()
+            apprise_instance_mock.add.assert_called_once_with(
+                f"mmosts://{mm_block.hostname}/{mm_block.token.get_secret_value()}/"
+                "?image=no&format=text&overflow=upstream"
+            )
+            apprise_instance_mock.async_notify.assert_called_once_with(
+                body="test", title="", notify_type=PREFECT_NOTIFY_TYPE_DEFAULT
+            )
+
     def test_notify_sync(self):
         with patch("apprise.Apprise", autospec=True) as AppriseMock:
             apprise_instance_mock = AppriseMock.return_value


### PR DESCRIPTION
Apprise supports this but we need to surface the configuration part and pass it on. Keeping default to insecure connection to not break compatibility, but perhaps worth reconsidering.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
  -  I think this is small enough of a fix?
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
