### PR TITLE
Add dbt profiles utilities

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/core/profiles.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/profiles.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
 T = TypeVar("T", str, int, float, bool, dict[Any, Any], list[Any], None)
 
 BLOCK_DOCUMENT_PLACEHOLDER_PREFIX = "prefect.blocks."
-VARIABLE_PLACEHOLDER_PREFIX = "prefect.variables."
 
 
 def get_profiles_dir() -> str:

--- a/src/integrations/prefect-dbt/prefect_dbt/core/profiles.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/profiles.py
@@ -104,7 +104,7 @@ async def aresolve_profiles_yml(
         temp_dir_path = Path(temp_dir)
         profiles_yml: dict[str, Any] = load_profiles_yml(profiles_dir)
         profiles_yml = await resolve_block_document_references(
-            profiles_yml, replace_with_env_var_call
+            profiles_yml, value_transformer=replace_with_env_var_call
         )
         profiles_yml = await resolve_variables(profiles_yml)
 
@@ -142,7 +142,9 @@ def resolve_profiles_yml(
         temp_dir_path = Path(temp_dir)
         profiles_yml: dict[str, Any] = load_profiles_yml(profiles_dir)
         profiles_yml = run_coro_as_sync(
-            resolve_block_document_references(profiles_yml, replace_with_env_var_call)
+            resolve_block_document_references(
+                profiles_yml, value_transformer=replace_with_env_var_call
+            )
         )
         profiles_yml = run_coro_as_sync(resolve_variables(profiles_yml))
 

--- a/src/integrations/prefect-dbt/prefect_dbt/core/profiles.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/profiles.py
@@ -1,3 +1,8 @@
+"""
+Utilities for working with dbt profiles.yml files, including resolving 
+block document and variable references.
+"""
+
 import contextlib
 import os
 import shutil

--- a/src/integrations/prefect-dbt/prefect_dbt/core/profiles.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/profiles.py
@@ -68,7 +68,6 @@ def replace_with_env_var_call(placeholder: str, value: Any) -> str:
     Returns:
         The template text for an env var call
     """
-    print("this is being called")
     env_var_name = slugify.slugify(placeholder, separator="_").upper()
 
     os.environ[env_var_name] = str(value)

--- a/src/integrations/prefect-dbt/prefect_dbt/core/profiles.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/profiles.py
@@ -1,5 +1,5 @@
 """
-Utilities for working with dbt profiles.yml files, including resolving 
+Utilities for working with dbt profiles.yml files, including resolving
 block document and variable references.
 """
 

--- a/src/integrations/prefect-dbt/prefect_dbt/core/profiles.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/profiles.py
@@ -1,0 +1,228 @@
+import contextlib
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
+
+import slugify
+import yaml
+
+from prefect.client.utilities import inject_client
+from prefect.utilities.annotations import NotSet
+from prefect.utilities.asyncutils import run_coro_as_sync
+from prefect.utilities.collections import get_from_dict
+from prefect.utilities.templating import (
+    PlaceholderType,
+    find_placeholders,
+    resolve_variables,
+)
+
+if TYPE_CHECKING:
+    from prefect.client.orchestration import PrefectClient
+
+
+T = TypeVar("T", str, int, float, bool, dict[Any, Any], list[Any], None)
+
+BLOCK_DOCUMENT_PLACEHOLDER_PREFIX = "prefect.blocks."
+VARIABLE_PLACEHOLDER_PREFIX = "prefect.variables."
+
+
+def get_profiles_dir() -> str:
+    """Get the dbt profiles directory from environment or default location."""
+    profiles_dir = os.getenv("DBT_PROFILES_DIR")
+    if not profiles_dir:
+        profiles_dir = os.path.expanduser("~/.dbt")
+    return profiles_dir
+
+
+def load_profiles_yml(profiles_dir: Optional[str]) -> dict[str, Any]:
+    """
+    Load and parse the profiles.yml file.
+
+    Args:
+        profiles_dir: Path to the directory containing profiles.yml.
+                     If None, uses the default profiles directory.
+
+    Returns:
+        Dict containing the parsed profiles.yml contents
+
+    Raises:
+        ValueError: If profiles.yml is not found
+    """
+    if profiles_dir is None:
+        profiles_dir = get_profiles_dir()
+
+    profiles_path = os.path.join(profiles_dir, "profiles.yml")
+    if not os.path.exists(profiles_path):
+        raise ValueError(f"No profiles.yml found at {profiles_path}")
+
+    with open(profiles_path, "r") as f:
+        return yaml.safe_load(f)
+
+
+@contextlib.asynccontextmanager
+async def aresolve_profiles_yml(profiles_dir: Optional[str] = None):
+    """
+    Asynchronous context manager that creates a temporary directory with a resolved profiles.yml file.
+
+    Args:
+        profiles_dir: Path to the directory containing profiles.yml.
+                     If None, uses the default profiles directory.
+
+    Yields:
+        str: Path to temporary directory containing the resolved profiles.yml.
+            Directory and contents are automatically cleaned up after context exit.
+
+    Example:        ```python
+        async with aresolve_profiles_yml() as temp_dir:
+            # temp_dir contains resolved profiles.yml
+            # use temp_dir for dbt operations
+        # temp_dir is automatically cleaned up        ```
+    """
+    temp_dir = Path(tempfile.mkdtemp())
+    try:
+        profiles_yml: dict[str, Any] = load_profiles_yml(profiles_dir)
+        profiles_yml = await resolve_block_document_references(profiles_yml)
+        profiles_yml = await resolve_variables(profiles_yml)
+
+        temp_profiles_path = temp_dir / "profiles.yml"
+        temp_profiles_path.write_text(yaml.dump(profiles_yml, default_flow_style=False))
+
+        yield str(temp_dir)
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+@contextlib.contextmanager
+def resolve_profiles_yml(profiles_dir: Optional[str] = None):
+    """
+    Synchronous context manager that creates a temporary directory with a resolved profiles.yml file.
+
+    Args:
+        profiles_dir: Path to the directory containing profiles.yml.
+                     If None, uses the default profiles directory.
+
+    Yields:
+        str: Path to temporary directory containing the resolved profiles.yml.
+            Directory and contents are automatically cleaned up after context exit.
+
+    Example:        ```python
+        with resolve_profiles_yml() as temp_dir:
+            # temp_dir contains resolved profiles.yml
+            # use temp_dir for dbt operations
+        # temp_dir is automatically cleaned up        ```
+    """
+    temp_dir = Path(tempfile.mkdtemp())
+    try:
+        profiles_yml: dict[str, Any] = load_profiles_yml(profiles_dir)
+        profiles_yml = run_coro_as_sync(resolve_block_document_references(profiles_yml))
+        profiles_yml = run_coro_as_sync(resolve_variables(profiles_yml))
+
+        temp_profiles_path = temp_dir / "profiles.yml"
+        temp_profiles_path.write_text(
+            yaml.dump(profiles_yml, default_style=None, default_flow_style=False)
+        )
+
+        yield str(temp_dir)
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+@inject_client
+async def resolve_block_document_references(
+    template: T, client: Optional["PrefectClient"] = None
+) -> Union[T, dict[str, Any]]:
+    """
+    Resolve block document references in a template by replacing each reference with
+    template text that calls dbt's env_var function, like
+    {{ env_var('PREFECT_BLOCK_SECRET_MYSECRET') }}. Creates environment variables
+    for each block document reference, with a name in the format
+    PREFECT_BLOCKS_BLOCK_TYPE_SLUG_BLOCK_DOCUMENT_NAME and optionally BLOCK_DOCUMENT_KEYPATH.
+
+    Recursively searches for block document references in dictionaries and lists.
+
+    Args:
+        template: The template to resolve block documents in
+
+    Returns:
+        The template with block documents resolved
+    """
+    if TYPE_CHECKING:
+        # The @inject_client decorator takes care of providing the client, but
+        # the function signature must mark it as optional to callers.
+        assert client is not None
+
+    if isinstance(template, dict):
+        block_document_id = template.get("$ref", {}).get("block_document_id")
+        if block_document_id:
+            block_document = await client.read_block_document(block_document_id)
+            return block_document.data
+        updated_template: dict[str, Any] = {}
+        for key, value in template.items():
+            updated_value = await resolve_block_document_references(
+                value, client=client
+            )
+            updated_template[key] = updated_value
+        return updated_template
+    elif isinstance(template, list):
+        return [
+            await resolve_block_document_references(item, client=client)
+            for item in template
+        ]
+    elif isinstance(template, str):
+        placeholders = find_placeholders(template)
+        has_block_document_placeholder = any(
+            placeholder.type is PlaceholderType.BLOCK_DOCUMENT
+            for placeholder in placeholders
+        )
+        if not (placeholders and has_block_document_placeholder):
+            return template
+        elif (
+            len(placeholders) == 1
+            and list(placeholders)[0].full_match == template
+            and list(placeholders)[0].type is PlaceholderType.BLOCK_DOCUMENT
+        ):
+            # value_keypath will be a list containing a dot path if additional
+            # attributes are accessed and an empty list otherwise.
+            [placeholder] = placeholders
+            parts = placeholder.name.replace(
+                BLOCK_DOCUMENT_PLACEHOLDER_PREFIX, ""
+            ).split(".", 2)
+            block_type_slug, block_document_name, *value_keypath = parts
+            block_document = await client.read_block_document_by_name(
+                name=block_document_name, block_type_slug=block_type_slug
+            )
+            data = block_document.data
+            value: Union[T, dict[str, Any]] = data
+
+            # resolving system blocks to their data for backwards compatibility
+            if len(data) == 1 and "value" in data:
+                # only resolve the value if the keypath is not already pointing to "value"
+                if not (value_keypath and value_keypath[0].startswith("value")):
+                    data = value = value["value"]
+
+            # resolving keypath/block attributes
+            if value_keypath:
+                from_dict: Any = get_from_dict(data, value_keypath[0], default=NotSet)
+                if from_dict is NotSet:
+                    raise ValueError(
+                        f"Invalid template: {template!r}. Could not resolve the"
+                        " keypath in the block document data."
+                    )
+                value = from_dict
+
+            env_var_name = slugify.slugify(placeholder[0], separator="_").upper()
+
+            os.environ[env_var_name] = str(value)
+
+            template_text = f"{{{{ env_var('{env_var_name}') }}}}"
+
+            return template_text
+        else:
+            raise ValueError(
+                f"Invalid template: {template!r}. Only a single block placeholder is"
+                " allowed in a string and no surrounding text is allowed."
+            )
+
+    return template

--- a/src/integrations/prefect-dbt/tests/core/test_profiles.py
+++ b/src/integrations/prefect-dbt/tests/core/test_profiles.py
@@ -1,0 +1,564 @@
+import os
+import warnings
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+import yaml
+from prefect_dbt.core.profiles import (
+    aresolve_profiles_yml,
+    get_profiles_dir,
+    load_profiles_yml,
+    resolve_block_document_references,
+    resolve_profiles_yml,
+)
+
+from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
+from prefect.blocks.core import Block
+from prefect.blocks.system import JSON, DateTime, Secret, String
+from prefect.blocks.webhook import Webhook
+from prefect.client.orchestration import get_client
+
+
+def should_reraise_warning(warning):
+    """
+    Determine if a deprecation warning should be reraised based on the date.
+
+    Deprecation warnings that have passed the date threshold should be reraised to
+    ensure the deprecated code paths are removed.
+    """
+    message = str(warning.message)
+    try:
+        # Extract the date from the new message format
+        date_str = message.split("not be available in new releases after ")[1].strip(
+            "."
+        )
+        # Parse the date
+        deprecation_date = datetime.strptime(date_str, "%b %Y").date().replace(day=1)
+
+        # Check if the current date is after the start of the month following the deprecation date
+        current_date = datetime.now().date().replace(day=1)
+        return current_date > deprecation_date
+    except Exception:
+        # Reraise in cases of failure
+        return True
+
+
+@pytest.fixture
+def ignore_prefect_deprecation_warnings():
+    """
+    Ignore deprecation warnings from the agent module to avoid
+    test failures.
+    """
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("ignore", category=PrefectDeprecationWarning)
+        yield
+        for warning in w:
+            if isinstance(warning.message, PrefectDeprecationWarning):
+                if should_reraise_warning(warning):
+                    warnings.warn(warning.message, warning.category, stacklevel=2)
+
+
+SAMPLE_PROFILE = {
+    "jaffle_shop": {
+        "outputs": {
+            "dev": {
+                "type": "duckdb",
+                "path": "jaffle_shop.duckdb",
+                "schema": "main",
+                "threads": 4,
+            }
+        }
+    }
+}
+
+VARIABLES_PROFILE = {
+    "jaffle_shop_with_variable_reference": {
+        "outputs": {
+            "dev": {
+                "type": "duckdb",
+                "path": "jaffle_shop.duckdb",
+                "schema": "main",
+                "threads": 4,
+            }
+        },
+        "target": "{{ prefect.variables.target }}",
+    }
+}
+
+BLOCKS_PROFILE = {
+    "jaffle_shop_with_variable_reference": {
+        "outputs": {
+            "dev": {
+                "type": "duckdb",
+                "path": "jaffle_shop.duckdb",
+                "schema": "main",
+                "threads": 4,
+                "password": "{{ prefect.blocks.secret.my-password }}",
+            }
+        },
+        "target": "dev",
+    }
+}
+
+
+@pytest.fixture
+def temp_profiles_dir(tmp_path):
+    profiles_dir = tmp_path / ".dbt"
+    profiles_dir.mkdir()
+
+    profiles_path = profiles_dir / "profiles.yml"
+    with open(profiles_path, "w") as f:
+        yaml.dump(SAMPLE_PROFILE, f)
+
+    return str(profiles_dir)
+
+
+@pytest.fixture
+def temp_variables_profiles_dir(tmp_path):
+    profiles_dir = tmp_path / ".dbt"
+    profiles_dir.mkdir()
+
+    profiles_path = profiles_dir / "profiles.yml"
+    with open(profiles_path, "w") as f:
+        yaml.dump(VARIABLES_PROFILE, f)
+
+    return str(profiles_dir)
+
+
+@pytest.fixture
+def temp_blocks_profiles_dir(tmp_path):
+    """Create a temporary profiles directory with a profile that references a block."""
+    profiles_dir = tmp_path / ".dbt"
+    profiles_dir.mkdir()
+
+    profiles_path = profiles_dir / "profiles.yml"
+    with open(profiles_path, "w") as f:
+        yaml.dump(BLOCKS_PROFILE, f)
+
+    return str(profiles_dir)
+
+
+def test_get_profiles_dir_default():
+    if "DBT_PROFILES_DIR" in os.environ:
+        del os.environ["DBT_PROFILES_DIR"]
+
+    expected = os.path.expanduser("~/.dbt")
+    assert get_profiles_dir() == expected
+
+
+def test_get_profiles_dir_from_env(monkeypatch):
+    test_path = "/custom/path"
+    monkeypatch.setenv("DBT_PROFILES_DIR", test_path)
+    assert get_profiles_dir() == test_path
+
+
+def test_load_profiles_yml_success(temp_profiles_dir):
+    profiles = load_profiles_yml(temp_profiles_dir)
+    assert profiles == SAMPLE_PROFILE
+
+
+def test_load_profiles_yml_default_dir(monkeypatch, temp_profiles_dir):
+    monkeypatch.setenv("DBT_PROFILES_DIR", temp_profiles_dir)
+    profiles = load_profiles_yml(None)
+    assert profiles == SAMPLE_PROFILE
+
+
+def test_load_profiles_yml_file_not_found():
+    nonexistent_dir = "/path/that/does/not/exist"
+    with pytest.raises(
+        ValueError,
+        match=f"No profiles.yml found at {os.path.join(nonexistent_dir, 'profiles.yml')}",
+    ):
+        load_profiles_yml(nonexistent_dir)
+
+
+def test_load_profiles_yml_invalid_yaml(temp_profiles_dir):
+    profiles_path = Path(temp_profiles_dir) / "profiles.yml"
+    with open(profiles_path, "w") as f:
+        f.write("invalid: yaml: content:\nindentation error")
+
+    with pytest.raises(yaml.YAMLError):
+        load_profiles_yml(temp_profiles_dir)
+
+
+async def test_aresolve_profiles_yml_success(
+    temp_profiles_dir,
+):
+    """Test that aresolve_profiles_yml creates and cleans up temporary directory."""
+    async with aresolve_profiles_yml(temp_profiles_dir) as temp_dir:
+        temp_path = Path(temp_dir)
+        profiles_path = temp_path / "profiles.yml"
+
+        # Check temporary directory exists and contains profiles.yml
+        assert temp_path.exists()
+        assert profiles_path.exists()
+
+        # Verify contents match expected profiles
+        loaded_profiles = yaml.safe_load(profiles_path.read_text())
+        assert loaded_profiles == SAMPLE_PROFILE
+
+    # Verify cleanup happened
+    assert not temp_path.exists()
+
+
+def test_resolve_profiles_yml_success(temp_profiles_dir):
+    """Test that resolve_profiles_yml creates and cleans up temporary directory."""
+    with resolve_profiles_yml(temp_profiles_dir) as temp_dir:
+        temp_path = Path(temp_dir)
+        profiles_path = temp_path / "profiles.yml"
+
+        # Check temporary directory exists and contains profiles.yml
+        assert temp_path.exists()
+        assert profiles_path.exists()
+
+        # Verify contents match expected profiles
+        loaded_profiles = yaml.safe_load(profiles_path.read_text())
+        assert loaded_profiles == SAMPLE_PROFILE
+
+    # Verify cleanup happened
+    assert not temp_path.exists()
+
+
+async def test_aresolve_profiles_yml_error_cleanup(temp_profiles_dir):
+    """Test that temporary directory is cleaned up even if an error occurs."""
+    temp_path = None
+
+    with pytest.raises(ValueError):
+        async with aresolve_profiles_yml(temp_profiles_dir) as temp_dir:
+            temp_path = Path(temp_dir)
+            assert temp_path.exists()
+            raise ValueError("Test error")
+
+    # Verify cleanup happened despite error
+    assert temp_path is not None
+    assert not temp_path.exists()
+
+
+def test_resolve_profiles_yml_error_cleanup(temp_profiles_dir):
+    """Test that temporary directory is cleaned up even if an error occurs."""
+    temp_path = None
+
+    with pytest.raises(ValueError):
+        with resolve_profiles_yml(temp_profiles_dir) as temp_dir:
+            temp_path = Path(temp_dir)
+            assert temp_path.exists()
+            raise ValueError("Test error")
+
+    # Verify cleanup happened despite error
+    assert temp_path is not None
+    assert not temp_path.exists()
+
+
+async def test_aresolve_profiles_yml_resolves_variables(temp_variables_profiles_dir):
+    """Test that variables in profiles.yml are properly resolved."""
+    # Create a variable
+    async with get_client() as client:
+        await client._client.post(
+            "/variables/", json={"name": "target", "value": "dev"}
+        )
+
+    # Use the context manager and verify variable resolution
+    async with aresolve_profiles_yml(temp_variables_profiles_dir) as temp_dir:
+        temp_path = Path(temp_dir)
+        profiles_path = temp_path / "profiles.yml"
+
+        # Verify contents have resolved variables
+        loaded_profiles = yaml.safe_load(profiles_path.read_text())
+        assert loaded_profiles["jaffle_shop_with_variable_reference"]["target"] == "dev"
+
+
+def test_resolve_profiles_yml_resolves_variables(temp_variables_profiles_dir):
+    with resolve_profiles_yml(temp_variables_profiles_dir) as temp_dir:
+        temp_path = Path(temp_dir)
+        profiles_path = temp_path / "profiles.yml"
+
+        loaded_profiles = yaml.safe_load(profiles_path.read_text())
+        assert loaded_profiles["jaffle_shop_with_variable_reference"]["target"] == "dev"
+
+
+async def test_aresolve_profiles_yml_resolves_blocks(temp_blocks_profiles_dir):
+    from prefect.blocks.system import Secret
+
+    secret_block = Secret(value="super-secret-password")
+    await secret_block.save("my-password", overwrite=True)
+
+    async with aresolve_profiles_yml(temp_blocks_profiles_dir) as temp_dir:
+        temp_path = Path(temp_dir)
+        profiles_path = temp_path / "profiles.yml"
+
+        loaded_profiles = yaml.safe_load(profiles_path.read_text())
+        assert (
+            loaded_profiles["jaffle_shop_with_variable_reference"]["outputs"]["dev"][
+                "password"
+            ]
+            == "{{ env_var('PREFECT_BLOCKS_SECRET_MY_PASSWORD') }}"
+        )
+
+
+def test_resolve_profiles_yml_resolves_blocks(temp_blocks_profiles_dir):
+    from prefect.blocks.system import Secret
+
+    secret_block = Secret(value="super-secret-password")
+    secret_block.save("my-password", overwrite=True)
+
+    with resolve_profiles_yml(temp_blocks_profiles_dir) as temp_dir:
+        temp_path = Path(temp_dir)
+        profiles_path = temp_path / "profiles.yml"
+
+        loaded_profiles = yaml.safe_load(profiles_path.read_text())
+        assert (
+            loaded_profiles["jaffle_shop_with_variable_reference"]["outputs"]["dev"][
+                "password"
+            ]
+            == "{{ env_var('PREFECT_BLOCKS_SECRET_MY_PASSWORD') }}"
+        )
+
+
+class TestResolveBlockDocumentReferences:
+    @pytest.fixture(autouse=True)
+    def ignore_deprecation_warnings(self, ignore_prefect_deprecation_warnings):
+        """Remove references to deprecated blocks when deprecation period is over."""
+        pass
+
+    @pytest.fixture()
+    async def block_document_id(self):
+        class ArbitraryBlock(Block):
+            a: int
+            b: str
+
+        return await ArbitraryBlock(a=1, b="hello").save(
+            name="arbitrary-block", overwrite=True
+        )
+
+    async def test_resolve_block_document_references_with_no_block_document_references(
+        self,
+    ):
+        assert await resolve_block_document_references({"key": "value"}) == {
+            "key": "value"
+        }
+
+    async def test_resolve_block_document_references_with_one_block_document_reference(
+        self, block_document_id
+    ):
+        async with get_client() as prefect_client:
+            assert {
+                "key": {"a": 1, "b": "hello"}
+            } == await resolve_block_document_references(
+                {"key": {"$ref": {"block_document_id": block_document_id}}},
+                client=prefect_client,
+            )
+
+    async def test_resolve_block_document_references_with_nested_block_document_references(
+        self, block_document_id
+    ):
+        async with get_client() as prefect_client:
+            template = {
+                "key": {
+                    "nested_key": {"$ref": {"block_document_id": block_document_id}},
+                    "other_nested_key": {
+                        "$ref": {"block_document_id": block_document_id}
+                    },
+                }
+            }
+            block_document = await prefect_client.read_block_document(block_document_id)
+
+            result = await resolve_block_document_references(
+                template, client=prefect_client
+            )
+
+            assert result == {
+                "key": {
+                    "nested_key": block_document.data,
+                    "other_nested_key": block_document.data,
+                }
+            }
+
+    async def test_resolve_block_document_references_with_list_of_block_document_references(
+        self, block_document_id
+    ):
+        async with get_client() as prefect_client:
+            template = [{"$ref": {"block_document_id": block_document_id}}]
+            block_document = await prefect_client.read_block_document(block_document_id)
+
+            result = await resolve_block_document_references(
+                template, client=prefect_client
+            )
+
+        assert result == [block_document.data]
+
+    async def test_resolve_block_document_references_with_dot_delimited_syntax(
+        self, block_document_id
+    ):
+        async with get_client() as prefect_client:
+            template = {"key": "{{ prefect.blocks.arbitraryblock.arbitrary-block }}"}
+
+            result = await resolve_block_document_references(
+                template, client=prefect_client
+            )
+
+        assert result == {
+            "key": "{{ env_var('PREFECT_BLOCKS_ARBITRARYBLOCK_ARBITRARY_BLOCK') }}"
+        }
+
+    async def test_resolve_block_document_references_raises_on_multiple_placeholders(
+        self, block_document_id
+    ):
+        async with get_client() as prefect_client:
+            template = {
+                "key": (
+                    "{{ prefect.blocks.arbitraryblock.arbitrary-block }} {{"
+                    " another_placeholder }}"
+                )
+            }
+
+            with pytest.raises(
+                ValueError,
+                match=(
+                    "Only a single block placeholder is allowed in a string and no"
+                    " surrounding text is allowed."
+                ),
+            ):
+                await resolve_block_document_references(template, client=prefect_client)
+
+    async def test_resolve_block_document_references_raises_on_extra_text(
+        self, block_document_id
+    ):
+        async with get_client() as prefect_client:
+            template = {
+                "key": "{{ prefect.blocks.arbitraryblock.arbitrary-block }} extra text"
+            }
+
+            with pytest.raises(
+                ValueError,
+                match=(
+                    "Only a single block placeholder is allowed in a string and no"
+                    " surrounding text is allowed."
+                ),
+            ):
+                await resolve_block_document_references(template, client=prefect_client)
+
+    async def test_resolve_block_document_references_does_not_change_standard_placeholders(
+        self,
+    ):
+        template = {"key": "{{ standard_placeholder }}"}
+
+        result = await resolve_block_document_references(template)
+
+        assert result == template
+
+    async def test_resolve_block_document_unpacks_system_blocks(self):
+        await JSON(value={"key": "value"}).save(name="json-block")
+        await Secret(value="N1nj4C0d3rP@ssw0rd!").save(name="secret-block")
+        await DateTime(value="2020-01-01T00:00:00Z").save(name="datetime-block")
+        await String(value="hello").save(name="string-block")
+
+        template = {
+            "json": "{{ prefect.blocks.json.json-block }}",
+            "secret": "{{ prefect.blocks.secret.secret-block }}",
+            "datetime": "{{ prefect.blocks.date-time.datetime-block }}",
+            "string": "{{ prefect.blocks.string.string-block }}",
+        }
+
+        result = await resolve_block_document_references(template)
+        assert result == {
+            "datetime": "{{ env_var('PREFECT_BLOCKS_DATE_TIME_DATETIME_BLOCK') }}",
+            "json": "{{ env_var('PREFECT_BLOCKS_JSON_JSON_BLOCK') }}",
+            "secret": "{{ env_var('PREFECT_BLOCKS_SECRET_SECRET_BLOCK') }}",
+            "string": "{{ env_var('PREFECT_BLOCKS_STRING_STRING_BLOCK') }}",
+        }
+
+    async def test_resolve_block_document_system_block_resolves_dict_keypath(self):
+        # for backwards compatibility system blocks can be referenced directly
+        # they should still be able to access nested keys
+        await JSON(value={"key": {"nested-key": "nested_value"}}).save(
+            name="nested-json-block"
+        )
+        template = {
+            "value": "{{ prefect.blocks.json.nested-json-block}}",
+            "keypath": "{{ prefect.blocks.json.nested-json-block.key }}",
+            "nested_keypath": "{{ prefect.blocks.json.nested-json-block.key.nested-key }}",
+        }
+
+        result = await resolve_block_document_references(template)
+        assert result == {
+            "keypath": "{{ env_var('PREFECT_BLOCKS_JSON_NESTED_JSON_BLOCK_KEY') }}",
+            "nested_keypath": "{{ env_var('PREFECT_BLOCKS_JSON_NESTED_JSON_BLOCK_KEY_NESTED_KEY') }}",
+            "value": "{{ env_var('PREFECT_BLOCKS_JSON_NESTED_JSON_BLOCK') }}",
+        }
+
+    async def test_resolve_block_document_resolves_dict_keypath(self):
+        await JSON(value={"key": {"nested-key": "nested_value"}}).save(
+            name="nested-json-block-2"
+        )
+        template = {
+            "value": "{{ prefect.blocks.json.nested-json-block-2.value }}",
+            "keypath": "{{ prefect.blocks.json.nested-json-block-2.value.key }}",
+            "nested_keypath": (
+                "{{ prefect.blocks.json.nested-json-block-2.value.key.nested-key }}"
+            ),
+        }
+
+        result = await resolve_block_document_references(template)
+        assert result == {
+            "keypath": "{{ env_var('PREFECT_BLOCKS_JSON_NESTED_JSON_BLOCK_2_VALUE_KEY') }}",
+            "nested_keypath": "{{ env_var('PREFECT_BLOCKS_JSON_NESTED_JSON_BLOCK_2_VALUE_KEY_NESTED_KEY') }}",
+            "value": "{{ env_var('PREFECT_BLOCKS_JSON_NESTED_JSON_BLOCK_2_VALUE') }}",
+        }
+
+    async def test_resolve_block_document_resolves_list_keypath(self):
+        await JSON(value={"key": ["value1", "value2"]}).save(name="json-list-block")
+        await JSON(value=["value1", "value2"]).save(name="list-block")
+        await JSON(
+            value={"key": ["value1", {"nested": ["value2", "value3"]}, "value4"]}
+        ).save(name="nested-json-list-block")
+        template = {
+            "json_list": "{{ prefect.blocks.json.json-list-block.value.key[0] }}",
+            "list": "{{ prefect.blocks.json.list-block.value[1] }}",
+            "nested_json_list": (
+                "{{ prefect.blocks.json.nested-json-list-block.value.key[1].nested[1] }}"
+            ),
+        }
+
+        result = await resolve_block_document_references(template)
+        assert result == {
+            "json_list": "{{ env_var('PREFECT_BLOCKS_JSON_JSON_LIST_BLOCK_VALUE_KEY_0') }}",
+            "list": "{{ env_var('PREFECT_BLOCKS_JSON_LIST_BLOCK_VALUE_1') }}",
+            "nested_json_list": "{{ env_var('PREFECT_BLOCKS_JSON_NESTED_JSON_LIST_BLOCK_VALUE_KEY_1_NESTED_1') }}",
+        }
+
+    async def test_resolve_block_document_raises_on_invalid_keypath(self):
+        await JSON(value={"key": {"nested_key": "value"}}).save(
+            name="nested-json-block-3"
+        )
+        json_template = {
+            "json": "{{ prefect.blocks.json.nested-json-block-3.value.key.does_not_exist }}",
+        }
+        with pytest.raises(ValueError, match="Could not resolve the keypath"):
+            await resolve_block_document_references(json_template)
+
+        await JSON(value=["value1", "value2"]).save(name="index-error-block")
+        index_error_template = {
+            "index_error": "{{ prefect.blocks.json.index-error-block.value[3] }}",
+        }
+        with pytest.raises(ValueError, match="Could not resolve the keypath"):
+            await resolve_block_document_references(index_error_template)
+
+        await Webhook(url="https://example.com").save(name="webhook-block")
+        webhook_template = {
+            "webhook": "{{ prefect.blocks.webhook.webhook-block.value }}",
+        }
+        with pytest.raises(ValueError, match="Could not resolve the keypath"):
+            await resolve_block_document_references(webhook_template)
+
+    async def test_resolve_block_document_resolves_block_attribute(self):
+        await Webhook(url="https://example.com").save(name="webhook-block-2")
+
+        template = {
+            "block_attribute": "{{ prefect.blocks.webhook.webhook-block-2.url }}",
+        }
+        result = await resolve_block_document_references(template)
+
+        assert result == {
+            "block_attribute": "{{ env_var('PREFECT_BLOCKS_WEBHOOK_WEBHOOK_BLOCK_2_URL') }}",
+        }

--- a/src/integrations/prefect-dbt/tests/core/test_profiles.py
+++ b/src/integrations/prefect-dbt/tests/core/test_profiles.py
@@ -1,6 +1,4 @@
 import os
-import warnings
-from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -13,48 +11,7 @@ from prefect_dbt.core.profiles import (
     resolve_profiles_yml,
 )
 
-from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
 from prefect.client.orchestration import get_client
-
-
-def should_reraise_warning(warning):
-    """
-    Determine if a deprecation warning should be reraised based on the date.
-
-    Deprecation warnings that have passed the date threshold should be reraised to
-    ensure the deprecated code paths are removed.
-    """
-    message = str(warning.message)
-    try:
-        # Extract the date from the new message format
-        date_str = message.split("not be available in new releases after ")[1].strip(
-            "."
-        )
-        # Parse the date
-        deprecation_date = datetime.strptime(date_str, "%b %Y").date().replace(day=1)
-
-        # Check if the current date is after the start of the month following the deprecation date
-        current_date = datetime.now().date().replace(day=1)
-        return current_date > deprecation_date
-    except Exception:
-        # Reraise in cases of failure
-        return True
-
-
-@pytest.fixture
-def ignore_prefect_deprecation_warnings():
-    """
-    Ignore deprecation warnings from the agent module to avoid
-    test failures.
-    """
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("ignore", category=PrefectDeprecationWarning)
-        yield
-        for warning in w:
-            if isinstance(warning.message, PrefectDeprecationWarning):
-                if should_reraise_warning(warning):
-                    warnings.warn(warning.message, warning.category, stacklevel=2)
-
 
 SAMPLE_PROFILE = {
     "jaffle_shop": {

--- a/src/prefect/utilities/templating.py
+++ b/src/prefect/utilities/templating.py
@@ -204,7 +204,7 @@ async def resolve_block_document_references(
 ) -> Union[T, dict[str, Any]]:
     """
     Resolve block document references in a template by replacing each reference with
-    the return value of the replacement function.
+    its value or the return value of the transformer function if provided.
 
     Recursively searches for block document references in dictionaries and lists.
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
This module includes utilities for locating and loading dbt profiles from YAML. It also enables the resolution of block and variable references when the `PrefectDbtRunner` executes dbt commands by writing the resolved file to a temporary directory.

```yaml
test:
  outputs:
    dev:
      type: duckdb
      path: dev.duckdb
      threads: 1

    prod:
      type: duckdb
      path: prod.duckdb
      threads: 4
      password: "{{ prefect.blocks.secret.my-password }}"

  target: "{{ prefect.variables.dbt_target }}"
```

At the moment, all block references resolve to calls to dbt's `env_var()` since blocks can contain secrets, and block values are stored as env vars. Variables are resolved directly to text.

```yaml
test:
  outputs:
    dev:
      type: duckdb
      path: dev.duckdb
      threads: 1

    prod:
      type: duckdb
      path: prod.duckdb
      threads: 4
      password: "{{ env_var(PREFECT_BLOCKS_SECRET_MY_PASSWORD) }}"

  target: prod
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
