### PR TITLE
[Experimental] Include tags as related resources on lineage events

### DIFF
--- a/src/prefect/_experimental/lineage.py
+++ b/src/prefect/_experimental/lineage.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Sequence, TypeAlias, Union
 
 from prefect.events.related import related_resources_from_run_context
 from prefect.events.schemas.events import RelatedResource

--- a/src/prefect/_experimental/lineage.py
+++ b/src/prefect/_experimental/lineage.py
@@ -226,7 +226,8 @@ async def emit_external_resource_lineage(
 
     # Add lineage group label to all resources
     for res in upstream_resources + downstream_resources + context_resources:
-        res["prefect.resource.lineage-group"] = "global"
+        if "prefect.resource.lineage-group" not in res:
+            res["prefect.resource.lineage-group"] = "global"
 
     # For each context resource, emit an event showing it as downstream of upstream resources
     if upstream_resources:

--- a/src/prefect/_experimental/lineage.py
+++ b/src/prefect/_experimental/lineage.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Sequence, TypeAlias, Union
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Sequence, Union
+
+from typing_extensions import TypeAlias
 
 from prefect.events.related import related_resources_from_run_context
 from prefect.events.schemas.events import RelatedResource

--- a/src/prefect/_experimental/lineage.py
+++ b/src/prefect/_experimental/lineage.py
@@ -8,7 +8,7 @@ from prefect.settings import get_current_settings
 if TYPE_CHECKING:
     from prefect.results import ResultStore
 
-LineageResources = Sequence[Union[RelatedResource, dict[str, str]]]
+LineageResources: TypeAlias = Sequence[Union[RelatedResource, dict[str, str]]]
 
 # Map block types to their URI schemes
 STORAGE_URI_SCHEMES = {


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
All upstream, downstream, and direct lineage events will now include any tags in the Prefect context as related resources so we can filter lineage resources by tag in the UI.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
