### PR TITLE
Add `Flow.ato_deployment`, `Flow.afrom_source`, and `Runner.afrom_storage`

### DIFF
--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -742,7 +742,7 @@ class RunnerDeployment(BaseModel):
         work_queue_name: Optional[str] = None,
         job_variables: Optional[dict[str, Any]] = None,
         _sla: Optional[Union[SlaTypes, list[SlaTypes]]] = None,  # experimental
-    ):
+    ) -> "RunnerDeployment":
         """
         Create a RunnerDeployment from a flow located at a given entrypoint and stored in a
         local storage location.
@@ -857,7 +857,7 @@ class RunnerDeployment(BaseModel):
         work_queue_name: Optional[str] = None,
         job_variables: Optional[dict[str, Any]] = None,
         _sla: Optional[Union[SlaTypes, list[SlaTypes]]] = None,  # experimental
-    ):
+    ) -> "RunnerDeployment":
         """
         Create a RunnerDeployment from a flow located at a given entrypoint and stored in a
         local storage location.

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -82,6 +82,7 @@ from prefect.types import BANNED_CHARACTERS, WITHOUT_BANNED_CHARACTERS
 from prefect.types.entrypoint import EntrypointType
 from prefect.utilities.annotations import NotSet
 from prefect.utilities.asyncutils import (
+    run_coro_as_sync,
     run_sync_in_worker_thread,
     sync_compatible,
 )
@@ -97,7 +98,7 @@ from prefect.utilities.filesystem import relative_path_to_current_platform
 from prefect.utilities.hashing import file_hash
 from prefect.utilities.importtools import import_object, safe_load_namespace
 
-from ._internal.compatibility.async_dispatch import is_in_async_context
+from ._internal.compatibility.async_dispatch import async_dispatch, is_in_async_context
 from ._internal.pydantic.v2_schema import is_v2_type
 from ._internal.pydantic.v2_validated_func import V2ValidatedFunction
 from ._internal.pydantic.v2_validated_func import (
@@ -654,8 +655,138 @@ class Flow(Generic[P, R]):
                 serialized_parameters[key] = f"<{type(value).__name__}>"
         return serialized_parameters
 
-    @sync_compatible
-    async def to_deployment(
+    async def ato_deployment(
+        self,
+        name: str,
+        interval: Optional[
+            Union[
+                Iterable[Union[int, float, datetime.timedelta]],
+                int,
+                float,
+                datetime.timedelta,
+            ]
+        ] = None,
+        cron: Optional[Union[Iterable[str], str]] = None,
+        rrule: Optional[Union[Iterable[str], str]] = None,
+        paused: Optional[bool] = None,
+        schedules: Optional["FlexibleScheduleList"] = None,
+        concurrency_limit: Optional[Union[int, ConcurrencyLimitConfig, None]] = None,
+        parameters: Optional[dict[str, Any]] = None,
+        triggers: Optional[list[Union[DeploymentTriggerTypes, TriggerTypes]]] = None,
+        description: Optional[str] = None,
+        tags: Optional[list[str]] = None,
+        version: Optional[str] = None,
+        enforce_parameter_schema: bool = True,
+        work_pool_name: Optional[str] = None,
+        work_queue_name: Optional[str] = None,
+        job_variables: Optional[dict[str, Any]] = None,
+        entrypoint_type: EntrypointType = EntrypointType.FILE_PATH,
+        _sla: Optional[Union[SlaTypes, list[SlaTypes]]] = None,  # experimental
+    ) -> "RunnerDeployment":
+        """
+        Asynchronously creates a runner deployment object for this flow.
+
+        Args:
+            name: The name to give the created deployment.
+            interval: An interval on which to execute the new deployment. Accepts either a number
+                or a timedelta object. If a number is given, it will be interpreted as seconds.
+            cron: A cron schedule of when to execute runs of this deployment.
+            rrule: An rrule schedule of when to execute runs of this deployment.
+            paused: Whether or not to set this deployment as paused.
+            schedules: A list of schedule objects defining when to execute runs of this deployment.
+                Used to define multiple schedules or additional scheduling options such as `timezone`.
+            concurrency_limit: The maximum number of runs of this deployment that can run at the same time.
+            parameters: A dictionary of default parameter values to pass to runs of this deployment.
+            triggers: A list of triggers that will kick off runs of this deployment.
+            description: A description for the created deployment. Defaults to the flow's
+                description if not provided.
+            tags: A list of tags to associate with the created deployment for organizational
+                purposes.
+            version: A version for the created deployment. Defaults to the flow's version.
+            enforce_parameter_schema: Whether or not the Prefect API should enforce the
+                parameter schema for the created deployment.
+            work_pool_name: The name of the work pool to use for this deployment.
+            work_queue_name: The name of the work queue to use for this deployment's scheduled runs.
+                If not provided the default work queue for the work pool will be used.
+            job_variables: Settings used to override the values specified default base job template
+                of the chosen work pool. Refer to the base job template of the chosen work pool for
+            entrypoint_type: Type of entrypoint to use for the deployment. When using a module path
+                entrypoint, ensure that the module will be importable in the execution environment.
+            _sla: (Experimental) SLA configuration for the deployment. May be removed or modified at any time. Currently only supported on Prefect Cloud.
+
+        Examples:
+            Prepare two deployments and serve them:
+
+            ```python
+            from prefect import flow, serve
+
+            @flow
+            def my_flow(name):
+                print(f"hello {name}")
+
+            @flow
+            def my_other_flow(name):
+                print(f"goodbye {name}")
+
+            if __name__ == "__main__":
+                hello_deploy = my_flow.to_deployment("hello", tags=["dev"])
+                bye_deploy = my_other_flow.to_deployment("goodbye", tags=["dev"])
+                serve(hello_deploy, bye_deploy)
+            ```
+        """
+        from prefect.deployments.runner import RunnerDeployment
+
+        if not name.endswith(".py"):
+            _raise_on_name_with_banned_characters(name)
+
+        if self._storage and self._entrypoint:
+            return await RunnerDeployment.afrom_storage(
+                storage=self._storage,
+                entrypoint=self._entrypoint,
+                name=name,
+                flow_name=self.name,
+                interval=interval,
+                cron=cron,
+                rrule=rrule,
+                paused=paused,
+                schedules=schedules,
+                concurrency_limit=concurrency_limit,
+                tags=tags,
+                triggers=triggers,
+                parameters=parameters or {},
+                description=description,
+                version=version,
+                enforce_parameter_schema=enforce_parameter_schema,
+                work_pool_name=work_pool_name,
+                work_queue_name=work_queue_name,
+                job_variables=job_variables,
+                _sla=_sla,
+            )
+        else:
+            return RunnerDeployment.from_flow(
+                flow=self,
+                name=name,
+                interval=interval,
+                cron=cron,
+                rrule=rrule,
+                paused=paused,
+                schedules=schedules,
+                concurrency_limit=concurrency_limit,
+                tags=tags,
+                triggers=triggers,
+                parameters=parameters or {},
+                description=description,
+                version=version,
+                enforce_parameter_schema=enforce_parameter_schema,
+                work_pool_name=work_pool_name,
+                work_queue_name=work_queue_name,
+                job_variables=job_variables,
+                entrypoint_type=entrypoint_type,
+                _sla=_sla,
+            )
+
+    @async_dispatch(ato_deployment)
+    def to_deployment(
         self,
         name: str,
         interval: Optional[
@@ -740,28 +871,32 @@ class Flow(Generic[P, R]):
             _raise_on_name_with_banned_characters(name)
 
         if self._storage and self._entrypoint:
-            return await RunnerDeployment.from_storage(
-                storage=self._storage,
-                entrypoint=self._entrypoint,
-                name=name,
-                flow_name=self.name,
-                interval=interval,
-                cron=cron,
-                rrule=rrule,
-                paused=paused,
-                schedules=schedules,
-                concurrency_limit=concurrency_limit,
-                tags=tags,
-                triggers=triggers,
-                parameters=parameters or {},
-                description=description,
-                version=version,
-                enforce_parameter_schema=enforce_parameter_schema,
-                work_pool_name=work_pool_name,
-                work_queue_name=work_queue_name,
-                job_variables=job_variables,
-                _sla=_sla,
-            )  # type: ignore # TODO: remove sync_compatible
+            return cast(
+                RunnerDeployment,
+                RunnerDeployment.from_storage(
+                    storage=self._storage,
+                    entrypoint=self._entrypoint,
+                    name=name,
+                    flow_name=self.name,
+                    interval=interval,
+                    cron=cron,
+                    rrule=rrule,
+                    paused=paused,
+                    schedules=schedules,
+                    concurrency_limit=concurrency_limit,
+                    tags=tags,
+                    triggers=triggers,
+                    parameters=parameters or {},
+                    description=description,
+                    version=version,
+                    enforce_parameter_schema=enforce_parameter_schema,
+                    work_pool_name=work_pool_name,
+                    work_queue_name=work_queue_name,
+                    job_variables=job_variables,
+                    _sla=_sla,
+                    _sync=True,  # pyright: ignore[reportCallIssue] _sync is valid because .from_storage is decorated with async_dispatch
+                ),
+            )
         else:
             return RunnerDeployment.from_flow(
                 flow=self,
@@ -957,14 +1092,13 @@ class Flow(Generic[P, R]):
                 loop.stop()
 
     @classmethod
-    @sync_compatible
-    async def from_source(
+    async def afrom_source(
         cls,
         source: Union[str, "RunnerStorage", ReadableDeploymentStorage],
         entrypoint: str,
     ) -> "Flow[..., Any]":
         """
-        Loads a flow from a remote source.
+        Loads a flow from a remote source asynchronously.
 
         Args:
             source: Either a URL to a git repository or a storage object.
@@ -1065,6 +1199,115 @@ class Flow(Generic[P, R]):
                     create_call(load_flow_from_entrypoint, full_entrypoint)
                 ),
             )
+            flow._storage = storage
+            flow._entrypoint = entrypoint
+
+        return flow
+
+    @classmethod
+    @async_dispatch(afrom_source)
+    def from_source(
+        cls,
+        source: Union[str, "RunnerStorage", ReadableDeploymentStorage],
+        entrypoint: str,
+    ) -> "Flow[..., Any]":
+        """
+        Loads a flow from a remote source.
+
+        Args:
+            source: Either a URL to a git repository or a storage object.
+            entrypoint:  The path to a file containing a flow and the name of the flow function in
+                the format `./path/to/file.py:flow_func_name`.
+
+        Returns:
+            A new `Flow` instance.
+
+        Examples:
+            Load a flow from a public git repository:
+
+
+            ```python
+            from prefect import flow
+            from prefect.runner.storage import GitRepository
+            from prefect.blocks.system import Secret
+
+            my_flow = flow.from_source(
+                source="https://github.com/org/repo.git",
+                entrypoint="flows.py:my_flow",
+            )
+
+            my_flow()
+            ```
+
+            Load a flow from a private git repository using an access token stored in a `Secret` block:
+
+            ```python
+            from prefect import flow
+            from prefect.runner.storage import GitRepository
+            from prefect.blocks.system import Secret
+
+            my_flow = flow.from_source(
+                source=GitRepository(
+                    url="https://github.com/org/repo.git",
+                    credentials={"access_token": Secret.load("github-access-token")}
+                ),
+                entrypoint="flows.py:my_flow",
+            )
+
+            my_flow()
+            ```
+
+            Load a flow from a local directory:
+
+            ``` python
+            # from_local_source.py
+
+            from pathlib import Path
+            from prefect import flow
+
+            @flow(log_prints=True)
+            def my_flow(name: str = "world"):
+                print(f"Hello {name}! I'm a flow from a Python script!")
+
+            if __name__ == "__main__":
+                my_flow.from_source(
+                    source=str(Path(__file__).parent),
+                    entrypoint="from_local_source.py:my_flow",
+                ).deploy(
+                    name="my-deployment",
+                    parameters=dict(name="Marvin"),
+                    work_pool_name="local",
+                )
+            ```
+        """
+
+        from prefect.runner.storage import (
+            BlockStorageAdapter,
+            LocalStorage,
+            RunnerStorage,
+            create_storage_from_source,
+        )
+
+        if isinstance(source, (Path, str)):
+            if isinstance(source, Path):
+                source = str(source)
+            storage = create_storage_from_source(source)
+        elif isinstance(source, RunnerStorage):
+            storage = source
+        elif hasattr(source, "get_directory"):
+            storage = BlockStorageAdapter(source)
+        else:
+            raise TypeError(
+                f"Unsupported source type {type(source).__name__!r}. Please provide a"
+                " URL to remote storage or a storage object."
+            )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            if not isinstance(storage, LocalStorage):
+                storage.set_base_path(Path(tmpdir))
+                run_coro_as_sync(storage.pull_code())
+
+            full_entrypoint = str(storage.destination / entrypoint)
+            flow = load_flow_from_entrypoint(full_entrypoint)
             flow._storage = storage
             flow._entrypoint = entrypoint
 

--- a/src/prefect/testing/utilities.py
+++ b/src/prefect/testing/utilities.py
@@ -18,6 +18,7 @@ import prefect.settings
 from prefect.blocks.core import Block
 from prefect.client.orchestration import get_client
 from prefect.client.schemas import sorting
+from prefect.client.schemas.filters import FlowFilter, FlowFilterName
 from prefect.client.utilities import inject_client
 from prefect.logging.handlers import APILogWorker
 from prefect.results import (
@@ -181,12 +182,18 @@ def prefect_test_harness(server_startup_timeout: int | None = 30):
         test_server.stop()
 
 
-async def get_most_recent_flow_run(client: "PrefectClient | None" = None) -> "FlowRun":
+async def get_most_recent_flow_run(
+    client: "PrefectClient | None" = None, flow_name: str | None = None
+) -> "FlowRun":
     if client is None:
         client = get_client()
 
     flow_runs = await client.read_flow_runs(
-        sort=sorting.FlowRunSort.EXPECTED_START_TIME_ASC, limit=1
+        sort=sorting.FlowRunSort.EXPECTED_START_TIME_ASC,
+        limit=1,
+        flow_filter=FlowFilter(name=FlowFilterName(any_=[flow_name]))
+        if flow_name
+        else None,
     )
 
     return flow_runs[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,7 @@ EXCLUDE_FROM_CLEAR_DB_AUTO_MARK = [
     "tests/test_settings.py",
     "tests/_internal",
     "tests/server/orchestration/test_rules.py",
+    "tests/test_flows.py",
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,7 @@ EXCLUDE_FROM_CLEAR_DB_AUTO_MARK = [
     "tests/_internal",
     "tests/server/orchestration/test_rules.py",
     "tests/test_flows.py",
+    "tests/runner/test_runner.py",
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,11 @@ def pytest_addoption(parser):
     )
 
 
+# The following tests are excluded from the clear_db fixture because they are
+# are safe to run without first clearing the database. Not clearing the database
+# after each run generally results in a 25 to 100% speed up of the test suite, so
+# if you run across tests that don't rely on a clean database, you can add them
+# to this list to speed up the test suite.
 EXCLUDE_FROM_CLEAR_DB_AUTO_MARK = [
     "tests/utilities",
     "tests/agent",

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -688,7 +688,7 @@ async def work_pool_with_image_variable(session):
     model = await models.workers.create_work_pool(
         session=session,
         work_pool=schemas.actions.WorkPoolCreate(
-            name="test-work-pool",
+            name=f"test-work-pool-{uuid.uuid4()}",
             type="test-type",
             base_job_template={
                 "job_configuration": {
@@ -727,7 +727,7 @@ async def process_work_pool(session):
     model = await models.workers.create_work_pool(
         session=session,
         work_pool=schemas.actions.WorkPoolCreate(
-            name="process-work-pool",
+            name=f"process-work-pool-{uuid.uuid4()}",
             type=ProcessWorker.type,
             base_job_template=ProcessWorker.get_default_base_job_template(),
         ),
@@ -741,7 +741,7 @@ async def push_work_pool(session):
     model = await models.workers.create_work_pool(
         session=session,
         work_pool=schemas.actions.WorkPoolCreate(
-            name="push-work-pool",
+            name=f"push-work-pool-{uuid.uuid4()}",
             type="push-work-pool:push",
             base_job_template={
                 "job_configuration": {
@@ -773,7 +773,7 @@ async def managed_work_pool(session):
     model = await models.workers.create_work_pool(
         session=session,
         work_pool=schemas.actions.WorkPoolCreate(
-            name="mex-work-pool",
+            name=f"mex-work-pool-{uuid.uuid4()}",
             type="mex-work-pool:managed",
             base_job_template={
                 "job_configuration": {
@@ -805,7 +805,7 @@ async def prefect_agent_work_pool(session):
     model = await models.workers.create_work_pool(
         session=session,
         work_pool=schemas.actions.WorkPoolCreate(
-            name="process-work-pool",
+            name=f"process-work-pool-{uuid.uuid4()}",
             type="prefect-agent",
         ),
     )

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -7,6 +7,7 @@ import signal
 import sys
 import threading
 import time
+import uuid
 import warnings
 from functools import partial
 from itertools import combinations
@@ -553,24 +554,24 @@ class TestFlowWithOptions:
 
 class TestFlowCall:
     async def test_call_creates_flow_run_and_runs(self):
-        @flow(version="test")
+        @flow(version="test", name=f"foo-{uuid.uuid4()}")
         def foo(x, y=3, z=3):
             return x + y + z
 
         assert foo(1, 2) == 6
 
-        flow_run = await get_most_recent_flow_run()
+        flow_run = await get_most_recent_flow_run(flow_name=foo.name)
         assert flow_run.parameters == {"x": 1, "y": 2, "z": 3}
         assert flow_run.flow_version == foo.version
 
     async def test_async_call_creates_flow_run_and_runs(self):
-        @flow(version="test")
+        @flow(version="test", name=f"foo-{uuid.uuid4()}")
         async def foo(x, y=3, z=3):
             return x + y + z
 
         assert await foo(1, 2) == 6
 
-        flow_run = await get_most_recent_flow_run()
+        flow_run = await get_most_recent_flow_run(flow_name=foo.name)
         assert flow_run.parameters == {"x": 1, "y": 2, "z": 3}
         assert flow_run.flow_version == foo.version
 


### PR DESCRIPTION
Introduces new explicitly async methods to use `async_dispatch` instead of `sync_compatible`.

Related to https://github.com/PrefectHQ/prefect/issues/15008
