### PR TITLE
Introduces a `Service` base class to cover loop and other services

### DIFF
--- a/src/prefect/server/events/services/actions.py
+++ b/src/prefect/server/events/services/actions.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, NoReturn
 
 from prefect.logging import get_logger
 from prefect.server.events import actions
+from prefect.server.services.base import Service
 from prefect.server.utilities.messaging import Consumer, create_consumer
 
 if TYPE_CHECKING:
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
 logger: "logging.Logger" = get_logger(__name__)
 
 
-class Actions:
+class Actions(Service):
     """Runs actions triggered by Automatinos"""
 
     name: str = "Actions"

--- a/src/prefect/server/events/services/event_logger.py
+++ b/src/prefect/server/events/services/event_logger.py
@@ -8,6 +8,7 @@ import rich
 
 from prefect.logging import get_logger
 from prefect.server.events.schemas.events import ReceivedEvent
+from prefect.server.services.base import Service
 from prefect.server.utilities.messaging import Consumer, Message, create_consumer
 
 if TYPE_CHECKING:
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 logger: "logging.Logger" = get_logger(__name__)
 
 
-class EventLogger:
+class EventLogger(Service):
     """A debugging service that logs events to the console as they arrive."""
 
     name: str = "EventLogger"

--- a/src/prefect/server/events/services/event_persister.py
+++ b/src/prefect/server/events/services/event_persister.py
@@ -17,6 +17,7 @@ from prefect.logging import get_logger
 from prefect.server.database import provide_database_interface
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.events.storage.database import write_events
+from prefect.server.services.base import Service
 from prefect.server.utilities.messaging import (
     Consumer,
     Message,
@@ -35,7 +36,7 @@ if TYPE_CHECKING:
 logger: "logging.Logger" = get_logger(__name__)
 
 
-class EventPersister:
+class EventPersister(Service):
     """A service that persists events to the database as they arrive."""
 
     name: str = "EventLogger"

--- a/src/prefect/server/events/services/triggers.py
+++ b/src/prefect/server/events/services/triggers.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, NoReturn, Optional
 
 from prefect.logging import get_logger
 from prefect.server.events import triggers
+from prefect.server.services.base import Service
 from prefect.server.services.loop_service import LoopService
 from prefect.server.utilities.messaging import Consumer, create_consumer
 from prefect.settings import PREFECT_EVENTS_PROACTIVE_GRANULARITY
@@ -15,7 +16,7 @@ if TYPE_CHECKING:
 logger: "logging.Logger" = get_logger(__name__)
 
 
-class ReactiveTriggers:
+class ReactiveTriggers(Service):
     """Runs the reactive triggers consumer"""
 
     name: str = "ReactiveTriggers"

--- a/src/prefect/server/services/base.py
+++ b/src/prefect/server/services/base.py
@@ -1,0 +1,12 @@
+from abc import ABC, abstractmethod
+from typing import NoReturn
+
+
+class Service(ABC):
+    @abstractmethod
+    async def start(self) -> NoReturn:
+        ...
+
+    @abstractmethod
+    async def stop(self) -> None:
+        ...

--- a/src/prefect/server/services/loop_service.py
+++ b/src/prefect/server/services/loop_service.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, List, NoReturn, Optional, overload
 import anyio
 
 from prefect.logging import get_logger
+from prefect.server.services.base import Service
 from prefect.settings import PREFECT_API_LOG_RETRYABLE_ERRORS
 from prefect.types import DateTime
 from prefect.utilities.processutils import (
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
     import logging
 
 
-class LoopService:
+class LoopService(Service):
     """
     Loop services are relatively lightweight maintenance routines that need to run periodically.
 
@@ -71,6 +72,10 @@ class LoopService:
         """
         self._is_running = False
         self.logger.debug(f"Stopped {self.name}")
+
+    @overload
+    async def start(self) -> NoReturn:
+        ...
 
     @overload
     async def start(self, loops: None = None) -> NoReturn:

--- a/src/prefect/server/services/loop_service.py
+++ b/src/prefect/server/services/loop_service.py
@@ -74,10 +74,6 @@ class LoopService(Service):
         self.logger.debug(f"Stopped {self.name}")
 
     @overload
-    async def start(self) -> NoReturn:
-        ...
-
-    @overload
     async def start(self, loops: None = None) -> NoReturn:
         ...
 


### PR DESCRIPTION
We have two kinds of background services in the Prefect server: loop
services that run a task periodically, and consumer services that react
to messages on a message bus.  I'd like to unify their treatment in a
series of PRs with a few goals:

- That we can run the consumer-style services along with the loop
  services in the background service process we start with `prefect
  server services`
- That we can either opt-in or opt-out of running services in either
  the API or the background services process
- That we can take the next step in refactoring services following the
  really cool discovery logic that @zzstoatzz added to the CLI:

  - A service knows which setting enables itself
  - There is one routine for finding the relevant services to start or
    stop for a given process
  - The starting and graceful stopping logic is consolidated to one
    place

This will open our options when scaling out Prefect, like running
multiple Prefect server replicas with either the in-process or
out-of-process message brokers, and running multiple services replicas
with different subsets of services.

This PR is just the first step along that path, to introduce a base
class and also to make sure that we're correctly running all the
consumers in web-only processes (this is important for correctness with
the in-memory broker--every process that could emit events will need to
run these consumers when using the in-memory broker).

<!--
Thanks for opening a pull request to Prefect!
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
