### PR TITLE
[UI v2] feat: Adds Server Settings component

### DIFF
--- a/ui-v2/src/components/settings/server-settings.tsx
+++ b/ui-v2/src/components/settings/server-settings.tsx
@@ -1,3 +1,5 @@
+import { JsonInput } from "@/components/ui/json-input";
+
 type ServerSettingsProps = {
 	settings: Record<string, unknown>;
 };
@@ -6,9 +8,13 @@ export const ServerSettings = ({ settings }: ServerSettingsProps) => {
 	return (
 		<div className="flex flex-col gap-1">
 			<label htmlFor="server-settings">Server Settings</label>
-			<div id="server-settings" className="p-2 bg-slate-100 rounded-sm">
-				TODO: {JSON.stringify(settings)}
-			</div>
+			<JsonInput
+				id="server-settings"
+				className="p-2 rounded-sm"
+				value={JSON.stringify(settings, null, 2)}
+				disabled
+				hideLineNumbers
+			/>
 		</div>
 	);
 };

--- a/ui-v2/src/components/ui/json-input.tsx
+++ b/ui-v2/src/components/ui/json-input.tsx
@@ -16,11 +16,20 @@ type JsonInputProps = React.ComponentProps<"div"> & {
 	onBlur?: () => void;
 	disabled?: boolean;
 	className?: string;
+	hideLineNumbers?: boolean;
 };
 
 export const JsonInput = React.forwardRef<HTMLDivElement, JsonInputProps>(
 	(
-		{ className, value, onChange, onBlur, disabled, ...props },
+		{
+			className,
+			value,
+			onChange,
+			onBlur,
+			disabled,
+			hideLineNumbers = false,
+			...props
+		},
 		forwardedRef,
 	) => {
 		const editor = useRef<HTMLDivElement | null>(null);
@@ -29,6 +38,7 @@ export const JsonInput = React.forwardRef<HTMLDivElement, JsonInputProps>(
 		let basicSetup: BasicSetupOptions | undefined;
 		if (disabled) {
 			basicSetup = {
+				lineNumbers: !hideLineNumbers,
 				highlightActiveLine: false,
 				foldGutter: false,
 				highlightActiveLineGutter: false,


### PR DESCRIPTION
1, Adds server settings UI by re-using `JsonInput` component.
2. Adds prop to `JsonInput` component to exclude line numbers


https://github.com/user-attachments/assets/bf765ded-ab51-4203-8708-0cbcc9822908



- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Relates to https://github.com/PrefectHQ/prefect/issues/15512
