### PR TITLE
Add event resources to the event cleanup cycle

### DIFF
--- a/src/prefect/server/events/services/event_persister.py
+++ b/src/prefect/server/events/services/event_persister.py
@@ -126,16 +126,25 @@ async def create_handler(
 
         try:
             async with db.session_context() as session:
-                result = await session.execute(
+                resource_result = await session.execute(
+                    sa.delete(db.EventResource).where(
+                        db.EventResource.occurred < older_than
+                    )
+                )
+                event_result = await session.execute(
                     sa.delete(db.Event).where(db.Event.occurred < older_than)
                 )
                 await session.commit()
-                if result.rowcount:
+
+                if resource_result.rowcount or event_result.rowcount:
                     logger.debug(
-                        "Trimmed %s events older than %s.", result.rowcount, older_than
+                        "Trimmed %s events and %s event resources older than %s.",
+                        event_result.rowcount,
+                        resource_result.rowcount,
+                        older_than,
                     )
         except Exception:
-            logger.exception("Error trimming events", exc_info=True)
+            logger.exception("Error trimming events and resources", exc_info=True)
 
     async def flush_periodically():
         try:


### PR DESCRIPTION
Proposed fix for issue https://github.com/PrefectHQ/prefect/issues/16906

Before, events itself were deleted according to the event retention period, but the corresponding event resources would accumulate and block database disk space. This PR adds event resources to the same lifecycle logic as events.

From what I understand, it is safe to delete old event resources the same way as old events. However this assumption is something that someone with more insight than me should challenge - if this PR is merged, the next update of Prefect deletes potentially millions of old event resources in line with the event retention policy.


closes https://github.com/PrefectHQ/prefect/issues/16906

### Checklist

- [x] This pull request references any related issue by including "closes `<link to issue>`"
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
