### PR TITLE
Reject task run state change if the cache key is too large

### DIFF
--- a/tests/server/orchestration/api/test_task_runs.py
+++ b/tests/server/orchestration/api/test_task_runs.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 import pendulum
 import pytest
+from httpx import AsyncClient
 from starlette import status
 
 from prefect.client.orchestration import PrefectClient
@@ -584,7 +585,7 @@ class TestSetTaskRunState:
         assert response_2.status == responses.SetStateStatus.ABORT
 
     async def test_set_task_run_state_with_long_cache_key_rejects_transition(
-        self, task_run, client, session
+        self, task_run: TaskRun, client: AsyncClient
     ):
         await client.post(
             f"/flow_runs/{task_run.flow_run_id}/set_state",


### PR DESCRIPTION
This is the OSS side of https://github.com/PrefectHQ/nebula/pull/9069. In Cloud we had an issue where a task run caused a 500 error because the cache key was too long. This adds some validation to the CacheInsertion policy to reject these task runs rather than let them cause the 500.

Related to CLOUD-900