### PR TITLE
Fix `prefect-dask` test suite

### DIFF
--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -50,7 +50,8 @@ jobs:
 
     name: Run Tests for ${{ matrix.package }} on Python ${{ matrix.python-version }}
     needs: prepare-matrix
-    runs-on: oss-larger-runners
+    runs-on: 
+       group: oss-larger-runners
     strategy:
       matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix)}}
       fail-fast: false

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -50,7 +50,7 @@ jobs:
 
     name: Run Tests for ${{ matrix.package }} on Python ${{ matrix.python-version }}
     needs: prepare-matrix
-    runs-on: ubuntu-latest
+    runs-on: oss-larger-runners
     strategy:
       matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix)}}
       fail-fast: false

--- a/.github/workflows/integration-package-tests.yaml
+++ b/.github/workflows/integration-package-tests.yaml
@@ -50,8 +50,7 @@ jobs:
 
     name: Run Tests for ${{ matrix.package }} on Python ${{ matrix.python-version }}
     needs: prepare-matrix
-    runs-on: 
-       group: oss-larger-runners
+    runs-on: ubuntu-latest
     strategy:
       matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix)}}
       fail-fast: false

--- a/src/integrations/prefect-dask/tests/conftest.py
+++ b/src/integrations/prefect-dask/tests/conftest.py
@@ -1,7 +1,3 @@
-import asyncio
-import logging
-import sys
-
 import pytest
 
 from prefect.testing.utilities import prefect_test_harness
@@ -14,34 +10,3 @@ def prefect_db():
     """
     with prefect_test_harness():
         yield
-
-
-@pytest.fixture(scope="session")
-def event_loop(request):
-    """
-    Redefine the event loop to support session/module-scoped fixtures;
-    see https://github.com/pytest-dev/pytest-asyncio/issues/68
-    When running on Windows we need to use a non-default loop for subprocess support.
-    """
-    if sys.platform == "win32":
-        asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
-
-    policy = asyncio.get_event_loop_policy()
-
-    loop = policy.new_event_loop()
-
-    # configure asyncio logging to capture long running tasks
-    asyncio_logger = logging.getLogger("asyncio")
-    asyncio_logger.setLevel("WARNING")
-    asyncio_logger.addHandler(logging.StreamHandler())
-    loop.set_debug(True)
-    loop.slow_callback_duration = 0.25
-
-    try:
-        yield loop
-    finally:
-        loop.close()
-
-    # Workaround for failures in pytest_asyncio 0.17;
-    # see https://github.com/pytest-dev/pytest-asyncio/issues/257
-    policy.set_event_loop(loop)

--- a/src/integrations/prefect-dask/tests/test_client.py
+++ b/src/integrations/prefect-dask/tests/test_client.py
@@ -1,4 +1,3 @@
-import pytest
 from prefect_dask.client import PrefectDaskClient
 
 from prefect.client.orchestration import get_client
@@ -13,12 +12,6 @@ from prefect.client.schemas.sorting import TaskRunSort
 from prefect.context import FlowRunContext
 from prefect.flows import flow
 from prefect.tasks import task
-from prefect.testing.fixtures import (  # noqa: F401
-    hosted_api_server,
-    use_hosted_api_server,
-)
-
-pytestmark = pytest.mark.usefixtures("use_hosted_api_server")
 
 
 class TestSubmit:

--- a/src/integrations/prefect-dask/tests/test_task_runners.py
+++ b/src/integrations/prefect-dask/tests/test_task_runners.py
@@ -42,35 +42,17 @@ def dask_task_runner_with_existing_cluster_address(use_hosted_api_server):  # no
 
 @pytest.fixture
 def dask_task_runner_with_process_pool(use_hosted_api_server):  # noqa
-    yield DaskTaskRunner(
-        cluster_kwargs={
-            "processes": True,
-            "connect_options": {"timeout": 60},
-            "worker_kwargs": {"timeout": 60},
-        }
-    )
+    yield DaskTaskRunner(cluster_kwargs={"processes": True})
 
 
 @pytest.fixture
 def dask_task_runner_with_thread_pool(use_hosted_api_server):  # noqa
-    yield DaskTaskRunner(
-        cluster_kwargs={
-            "processes": False,
-            "connect_options": {"timeout": 60},
-            "worker_kwargs": {"timeout": 60},
-        }
-    )
+    yield DaskTaskRunner(cluster_kwargs={"processes": False})
 
 
 @pytest.fixture
 def default_dask_task_runner(use_hosted_api_server):  # noqa
-    yield DaskTaskRunner(
-        cluster_kwargs={
-            "scheduler_port": 0,
-            "connect_options": {"timeout": 60},
-            "worker_kwargs": {"timeout": 60},
-        }
-    )
+    yield DaskTaskRunner()
 
 
 class TestDaskTaskRunner:

--- a/src/integrations/prefect-dask/tests/test_task_runners.py
+++ b/src/integrations/prefect-dask/tests/test_task_runners.py
@@ -25,7 +25,7 @@ def dask_task_runner_with_existing_cluster(use_hosted_api_server):  # noqa
     """
     Generate a dask task runner that's connected to a local cluster
     """
-    with distributed.LocalCluster(n_workers=2) as cluster:
+    with distributed.LocalCluster() as cluster:
         yield DaskTaskRunner(cluster=cluster)
 
 
@@ -34,7 +34,7 @@ def dask_task_runner_with_existing_cluster_address(use_hosted_api_server):  # no
     """
     Generate a dask task runner that's connected to a local cluster
     """
-    with distributed.LocalCluster() as cluster:
+    with distributed.LocalCluster(n_workers=2) as cluster:
         with distributed.Client(cluster) as client:
             address = client.scheduler.address
             yield DaskTaskRunner(address=address)

--- a/src/integrations/prefect-dask/tests/test_task_runners.py
+++ b/src/integrations/prefect-dask/tests/test_task_runners.py
@@ -14,45 +14,49 @@ from prefect import flow, task
 from prefect.futures import as_completed
 from prefect.server.schemas.states import StateType
 from prefect.states import State
-from prefect.testing.fixtures import (  # noqa: F401
-    hosted_api_server,
-    use_hosted_api_server,
-)
+
+
+@pytest.fixture(scope="module")
+def cluster():
+    with distributed.LocalCluster(dashboard_address=None) as cluster:
+        yield cluster
 
 
 @pytest.fixture
-def dask_task_runner_with_existing_cluster(use_hosted_api_server):  # noqa
+def dask_task_runner_with_existing_cluster(cluster: distributed.LocalCluster):  # noqa
     """
     Generate a dask task runner that's connected to a local cluster
     """
-    with distributed.LocalCluster() as cluster:
-        yield DaskTaskRunner(cluster=cluster)
+    yield DaskTaskRunner(cluster=cluster)
 
 
 @pytest.fixture
-def dask_task_runner_with_existing_cluster_address(use_hosted_api_server):  # noqa
+def dask_task_runner_with_existing_cluster_address(cluster: distributed.LocalCluster):  # noqa
     """
     Generate a dask task runner that's connected to a local cluster
     """
-    with distributed.LocalCluster(n_workers=2) as cluster:
-        with distributed.Client(cluster) as client:
-            address = client.scheduler.address
-            yield DaskTaskRunner(address=address)
+    with distributed.Client(cluster) as client:
+        address = client.scheduler.address
+        yield DaskTaskRunner(address=address)
 
 
 @pytest.fixture
-def dask_task_runner_with_process_pool(use_hosted_api_server):  # noqa
-    yield DaskTaskRunner(cluster_kwargs={"processes": True})
+def dask_task_runner_with_process_pool():  # noqa
+    yield DaskTaskRunner(cluster_kwargs={"processes": True, "dashboard_address": None})
 
 
 @pytest.fixture
-def dask_task_runner_with_thread_pool(use_hosted_api_server):  # noqa
-    yield DaskTaskRunner(cluster_kwargs={"processes": False})
+def dask_task_runner_with_thread_pool():  # noqa
+    yield DaskTaskRunner(cluster_kwargs={"processes": False, "dashboard_address": None})
 
 
 @pytest.fixture
-def default_dask_task_runner(use_hosted_api_server):  # noqa
-    yield DaskTaskRunner()
+def default_dask_task_runner():  # noqa
+    yield DaskTaskRunner(
+        cluster_kwargs={
+            "dashboard_address": None,  # Prevent port conflicts
+        }
+    )
 
 
 class TestDaskTaskRunner:
@@ -192,7 +196,7 @@ class TestDaskTaskRunner:
             state = future.state
             assert await state.result() == "a"
 
-    async def test_async_task_timeout(self, task_runner):
+    async def test_async_task_timeout(self, task_runner: DaskTaskRunner):
         @task(timeout_seconds=0.1)
         async def my_timeout_task():
             await asyncio.sleep(2)
@@ -342,9 +346,9 @@ class TestDaskTaskRunner:
             with task_runner:
                 assert task_runner._cluster._adapt_called
 
-    def test_warns_if_future_garbage_collection_before_resolving(
-        self, caplog, task_runner
-    ):
+    def test_warns_if_future_garbage_collection_before_resolving(self, caplog):
+        task_runner = DaskTaskRunner(cluster_kwargs={"dashboard_address": None})
+
         @task
         def test_task():
             return 42
@@ -358,9 +362,9 @@ class TestDaskTaskRunner:
 
         assert "A future was garbage collected before it resolved" in caplog.text
 
-    def test_does_not_warn_if_future_resolved_when_garbage_collected(
-        self, task_runner, caplog
-    ):
+    def test_does_not_warn_if_future_resolved_when_garbage_collected(self, caplog):
+        task_runner = DaskTaskRunner(cluster_kwargs={"dashboard_address": None})
+
         @task
         def test_task():
             return 42

--- a/src/integrations/prefect-dask/tests/test_task_runners.py
+++ b/src/integrations/prefect-dask/tests/test_task_runners.py
@@ -34,7 +34,7 @@ def dask_task_runner_with_existing_cluster_address(use_hosted_api_server):  # no
     """
     Generate a dask task runner that's connected to a local cluster
     """
-    with distributed.LocalCluster(n_workers=2) as cluster:
+    with distributed.LocalCluster() as cluster:
         with distributed.Client(cluster) as client:
             address = client.scheduler.address
             yield DaskTaskRunner(address=address)

--- a/src/integrations/prefect-dask/tests/test_task_runners.py
+++ b/src/integrations/prefect-dask/tests/test_task_runners.py
@@ -42,17 +42,35 @@ def dask_task_runner_with_existing_cluster_address(use_hosted_api_server):  # no
 
 @pytest.fixture
 def dask_task_runner_with_process_pool(use_hosted_api_server):  # noqa
-    yield DaskTaskRunner(cluster_kwargs={"processes": True})
+    yield DaskTaskRunner(
+        cluster_kwargs={
+            "processes": True,
+            "connect_options": {"timeout": 60},
+            "worker_kwargs": {"timeout": 60},
+        }
+    )
 
 
 @pytest.fixture
 def dask_task_runner_with_thread_pool(use_hosted_api_server):  # noqa
-    yield DaskTaskRunner(cluster_kwargs={"processes": False})
+    yield DaskTaskRunner(
+        cluster_kwargs={
+            "processes": False,
+            "connect_options": {"timeout": 60},
+            "worker_kwargs": {"timeout": 60},
+        }
+    )
 
 
 @pytest.fixture
 def default_dask_task_runner(use_hosted_api_server):  # noqa
-    yield DaskTaskRunner()
+    yield DaskTaskRunner(
+        cluster_kwargs={
+            "scheduler_port": 0,
+            "connect_options": {"timeout": 60},
+            "worker_kwargs": {"timeout": 60},
+        }
+    )
 
 
 class TestDaskTaskRunner:


### PR DESCRIPTION
`prefect-dask` tests are failing on `main`. This PR fixes that by removing unnecessary fixtures like the scoped event loop and `use_hosted_api_server` (`prefect_test_harness` takes care of that), reusing Dask clusters where possible, and updating two tests to run with only a single task runner because they aren't dependent on the task runner configuration.