### PR TITLE
Unifies background service running between the web server and CLI

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -19,9 +19,9 @@ import subprocess
 import sys
 import time
 from contextlib import asynccontextmanager
-from functools import partial, wraps
+from functools import wraps
 from hashlib import sha256
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Optional
 
 import anyio
 import asyncpg
@@ -42,18 +42,12 @@ from typing_extensions import Self
 
 import prefect
 import prefect.server.api as api
-import prefect.server.services as services
 import prefect.settings
 from prefect.client.constants import SERVER_API_VERSION
 from prefect.logging import get_logger
 from prefect.server.api.dependencies import EnforceMinimumAPIVersion
-from prefect.server.events import stream
-from prefect.server.events.services.actions import Actions
-from prefect.server.events.services.event_persister import EventPersister
-from prefect.server.events.services.triggers import ProactiveTriggers, ReactiveTriggers
 from prefect.server.exceptions import ObjectNotFoundError
-from prefect.server.services.base import Service
-from prefect.server.services.task_run_recorder import TaskRunRecorder
+from prefect.server.services.base import RunInAllServers, Service
 from prefect.server.utilities.database import get_dialect
 from prefect.settings import (
     PREFECT_API_DATABASE_CONNECTION_URL,
@@ -606,88 +600,19 @@ def create_app(
         async with session:
             await run_block_auto_registration(session=session)
 
-    async def start_services():
-        """Start additional services when the Prefect REST API starts up."""
-
-        service_instances: list[Service] = []
-
-        # these services are for events and are not implemented as loop services right now
-        if prefect.settings.PREFECT_API_SERVICES_TASK_RUN_RECORDER_ENABLED:
-            service_instances.append(TaskRunRecorder())
-
-        if prefect.settings.PREFECT_API_SERVICES_EVENT_PERSISTER_ENABLED:
-            service_instances.append(EventPersister())
-
-        if prefect.settings.PREFECT_API_EVENTS_STREAM_OUT_ENABLED:
-            service_instances.append(stream.Distributor())
-
-        if prefect.settings.PREFECT_API_SERVICES_TRIGGERS_ENABLED.value():
-            service_instances.append(ReactiveTriggers())
-            service_instances.append(ProactiveTriggers())
-            service_instances.append(Actions())
-
-        if (
-            not webserver_only
-            and prefect.settings.PREFECT_SERVER_ANALYTICS_ENABLED.value()
-        ):
-            service_instances.append(services.telemetry.Telemetry())
-
-        # don't run services in ephemeral mode
-        if not ephemeral and not webserver_only:
-            if prefect.settings.PREFECT_API_SERVICES_SCHEDULER_ENABLED.value():
-                service_instances.append(services.scheduler.Scheduler())
-                service_instances.append(
-                    services.scheduler.RecentDeploymentsScheduler()
-                )
-
-            if prefect.settings.PREFECT_API_SERVICES_LATE_RUNS_ENABLED.value():
-                service_instances.append(services.late_runs.MarkLateRuns())
-
-            if prefect.settings.PREFECT_API_SERVICES_PAUSE_EXPIRATIONS_ENABLED.value():
-                service_instances.append(services.pause_expirations.FailExpiredPauses())
-
-            if prefect.settings.PREFECT_API_SERVICES_CANCELLATION_CLEANUP_ENABLED.value():
-                service_instances.append(
-                    services.cancellation_cleanup.CancellationCleanup()
-                )
-
-            if prefect.settings.PREFECT_API_SERVICES_FLOW_RUN_NOTIFICATIONS_ENABLED.value():
-                service_instances.append(
-                    services.flow_run_notifications.FlowRunNotifications()
-                )
-
-            if prefect.settings.PREFECT_API_SERVICES_FOREMAN_ENABLED.value():
-                service_instances.append(services.foreman.Foreman())
-
-        loop = asyncio.get_running_loop()
-
-        service_tasks: dict[Service, asyncio.Task[None]] = {}
-        for service in service_instances:
-            service_tasks[service] = loop.create_task(service.start())
-        app.state.services = service_tasks
-
-        for service, task in app.state.services.items():
-            logger.info(f"{service.name} service scheduled to start in-app")
-            task.add_done_callback(partial(on_service_exit, service))
-
-    async def stop_services():
-        """Ensure services are stopped before the Prefect REST API shuts down."""
-        if hasattr(app.state, "services") and app.state.services:
-            service_tasks: dict[Service, asyncio.Task[None]] = app.state.services
-            await asyncio.gather(*[service.stop() for service in service_tasks])
-            await asyncio.gather(*service_tasks.values(), return_exceptions=True)
-
     @asynccontextmanager
-    async def lifespan(app: FastAPI):
+    async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         if app not in LIFESPAN_RAN_FOR_APP:
-            try:
-                await run_migrations()
-                await add_block_types()
-                await start_services()
+            await run_migrations()
+            await add_block_types()
+
+            Services: type[Service] = Service
+            if ephemeral or webserver_only:
+                Services = RunInAllServers
+
+            async with Services.running():
                 LIFESPAN_RAN_FOR_APP.add(app)
                 yield
-            finally:
-                await stop_services()
         else:
             yield
 

--- a/src/prefect/server/events/services/actions.py
+++ b/src/prefect/server/events/services/actions.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, NoReturn
 
 from prefect.logging import get_logger
 from prefect.server.events import actions
-from prefect.server.services.base import Service
+from prefect.server.services.base import RunInAllServers, Service
 from prefect.server.utilities.messaging import Consumer, create_consumer
 from prefect.settings.context import get_current_settings
 from prefect.settings.models.server.services import ServicesBaseSetting
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 logger: "logging.Logger" = get_logger(__name__)
 
 
-class Actions(Service):
+class Actions(RunInAllServers, Service):
     """Runs the actions triggered by automations"""
 
     consumer_task: asyncio.Task[None] | None = None

--- a/src/prefect/server/events/services/event_logger.py
+++ b/src/prefect/server/events/services/event_logger.py
@@ -8,7 +8,7 @@ import rich
 
 from prefect.logging import get_logger
 from prefect.server.events.schemas.events import ReceivedEvent
-from prefect.server.services.base import Service
+from prefect.server.services.base import RunInAllServers, Service
 from prefect.server.utilities.messaging import Consumer, Message, create_consumer
 from prefect.settings.context import get_current_settings
 from prefect.settings.models.server.services import ServicesBaseSetting
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 logger: "logging.Logger" = get_logger(__name__)
 
 
-class EventLogger(Service):
+class EventLogger(RunInAllServers, Service):
     """A debugging service that logs events to the console as they arrive."""
 
     consumer_task: asyncio.Task[None] | None = None

--- a/src/prefect/server/events/services/event_persister.py
+++ b/src/prefect/server/events/services/event_persister.py
@@ -17,7 +17,7 @@ from prefect.logging import get_logger
 from prefect.server.database import provide_database_interface
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.events.storage.database import write_events
-from prefect.server.services.base import Service
+from prefect.server.services.base import RunInAllServers, Service
 from prefect.server.utilities.messaging import (
     Consumer,
     Message,
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 logger: "logging.Logger" = get_logger(__name__)
 
 
-class EventPersister(Service):
+class EventPersister(RunInAllServers, Service):
     """A service that persists events to the database as they arrive."""
 
     consumer_task: asyncio.Task[None] | None = None

--- a/src/prefect/server/events/services/triggers.py
+++ b/src/prefect/server/events/services/triggers.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, NoReturn, Optional
 
 from prefect.logging import get_logger
 from prefect.server.events import triggers
-from prefect.server.services.base import LoopService, Service
+from prefect.server.services.base import LoopService, RunInAllServers, Service
 from prefect.server.utilities.messaging import Consumer, create_consumer
 from prefect.settings import PREFECT_EVENTS_PROACTIVE_GRANULARITY
 from prefect.settings.context import get_current_settings
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 logger: "logging.Logger" = get_logger(__name__)
 
 
-class ReactiveTriggers(Service):
+class ReactiveTriggers(RunInAllServers, Service):
     """Evaluates reactive automation triggers"""
 
     consumer_task: asyncio.Task[None] | None = None
@@ -52,7 +52,7 @@ class ReactiveTriggers(Service):
         logger.debug("Reactive triggers stopped")
 
 
-class ProactiveTriggers(LoopService):
+class ProactiveTriggers(RunInAllServers, LoopService):
     """Evaluates proactive automation triggers"""
 
     @classmethod

--- a/src/prefect/server/events/stream.py
+++ b/src/prefect/server/events/stream.py
@@ -16,7 +16,10 @@ from typing import (
 from prefect.logging import get_logger
 from prefect.server.events.filters import EventFilter
 from prefect.server.events.schemas.events import ReceivedEvent
+from prefect.server.services.base import RunInAllServers, Service
 from prefect.server.utilities import messaging
+from prefect.settings.context import get_current_settings
+from prefect.settings.models.server.services import ServicesBaseSetting
 
 if TYPE_CHECKING:
     import logging
@@ -133,8 +136,20 @@ async def stop_distributor() -> None:
         pass
 
 
-class Distributor:
+class Distributor(RunInAllServers, Service):
     name: str = "Distributor"
+
+    @classmethod
+    def service_settings(cls) -> ServicesBaseSetting:
+        raise NotImplementedError("Distributor does not have settings")
+
+    @classmethod
+    def environment_variable_name(cls) -> dict[str, str]:
+        return "PREFECT_API_EVENTS_STREAM_OUT_ENABLED"
+
+    @classmethod
+    def enabled(cls) -> bool:
+        return get_current_settings().server.events.stream_out_enabled
 
     async def start(self) -> None:
         await start_distributor()

--- a/src/prefect/server/services/base.py
+++ b/src/prefect/server/services/base.py
@@ -114,9 +114,9 @@ class Service(ABC):
     async def run_services(cls) -> NoReturn:
         """Run enabled services until cancelled."""
         async with cls.running():
+            heat_death_of_the_universe = asyncio.get_running_loop().create_future()
             try:
-                while True:
-                    await asyncio.sleep(1)
+                await heat_death_of_the_universe
             except asyncio.CancelledError:
                 logger.info("Received cancellation, stopping services...")
 

--- a/src/prefect/server/services/base.py
+++ b/src/prefect/server/services/base.py
@@ -5,10 +5,11 @@ import asyncio
 import inspect
 import signal
 from abc import ABC, abstractmethod
+from contextlib import asynccontextmanager
 from logging import Logger
 from operator import methodcaller
 from types import ModuleType
-from typing import Any, List, NoReturn, Optional, Sequence, overload
+from typing import Any, AsyncGenerator, List, NoReturn, Optional, Sequence, overload
 
 import anyio
 from typing_extensions import Self
@@ -22,9 +23,12 @@ from prefect.utilities.processutils import (
     _register_signal,  # type: ignore[reportPrivateUsage]
 )
 
+logger = get_logger(__name__)
+
 
 def _known_service_modules() -> list[ModuleType]:
     """Get list of Prefect server modules containing Service subclasses"""
+    from prefect.server.events import stream
     from prefect.server.events.services import actions, triggers
     from prefect.server.services import (
         cancellation_cleanup,
@@ -48,6 +52,7 @@ def _known_service_modules() -> list[ModuleType]:
         telemetry,
         triggers,
         actions,
+        stream,
     ]
 
 
@@ -89,6 +94,32 @@ class Service(ABC):
         """Get list of enabled service classes"""
         return [svc for svc in cls.all_services() if svc.enabled()]
 
+    @classmethod
+    @asynccontextmanager
+    async def running(cls) -> AsyncGenerator[None, None]:
+        """A context manager that runs enabled services on entry and stops them on
+        exit."""
+        service_tasks: dict[Service, asyncio.Task[None]] = {}
+        for service_class in cls.enabled_services():
+            service = service_class()
+            service_tasks[service] = asyncio.create_task(service.start())
+
+        try:
+            yield
+        finally:
+            await asyncio.gather(*[service.stop() for service in service_tasks])
+            await asyncio.gather(*service_tasks.values(), return_exceptions=True)
+
+    @classmethod
+    async def run_services(cls) -> NoReturn:
+        """Run enabled services until cancelled."""
+        async with cls.running():
+            try:
+                while True:
+                    await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                logger.info("Received cancellation, stopping services...")
+
     @abstractmethod
     async def start(self) -> NoReturn:
         """Start running the service, which may run indefinitely"""
@@ -102,6 +133,15 @@ class Service(ABC):
     def __init__(self):
         self.name = self.__class__.__name__
         self.logger = get_logger(f"server.services.{self.name.lower()}")
+
+
+class RunInAllServers(Service, abc.ABC):
+    """
+    A marker class for services that should run in all server processes, both the
+    web server and the standalone services process.
+    """
+
+    pass
 
 
 class LoopService(Service, abc.ABC):

--- a/src/prefect/server/services/base.py
+++ b/src/prefect/server/services/base.py
@@ -23,7 +23,7 @@ from prefect.utilities.processutils import (
     _register_signal,  # type: ignore[reportPrivateUsage]
 )
 
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 def _known_service_modules() -> list[ModuleType]:

--- a/src/prefect/server/services/task_run_recorder.py
+++ b/src/prefect/server/services/task_run_recorder.py
@@ -19,7 +19,7 @@ from prefect.server.events.ordering import CausalOrdering, EventArrivedEarly
 from prefect.server.events.schemas.events import ReceivedEvent
 from prefect.server.schemas.core import TaskRun
 from prefect.server.schemas.states import State
-from prefect.server.services.base import Service
+from prefect.server.services.base import RunInAllServers, Service
 from prefect.server.utilities.messaging import (
     Consumer,
     Message,
@@ -217,7 +217,7 @@ async def consumer() -> AsyncGenerator[MessageHandler, None]:
     yield message_handler
 
 
-class TaskRunRecorder(Service):
+class TaskRunRecorder(RunInAllServers, Service):
     """Constructs task runs and states from client-emitted events"""
 
     consumer_task: asyncio.Task[None] | None = None


### PR DESCRIPTION
In the final step of the plan to unify how services are handled (
after #16898 and #16913), we tie everything together by having both the
API lifespan in `prefect server start` and the CLI `prefect server
services start` use the same service running logic.

At this point, when adding a new service, we should just need to add a
new subclass, implement its settings class, and then make sure its
module is represented in `server/services/base.py`.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
