### PR TITLE
Add file exclusion to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,11 @@
 
 # documentation
 /docs                                @aaazzam @kevingrismore @daniel-prefect @seanpwlms
+
+# GitHub takes into account the last file ref for review requests
+# this resets the file to global owners to avoid huge review teams
+/docs/v3/develop/settings-ref.mdx
+
 # imports
 /src/prefect/__init__.py             @aaazzam @chrisguidry @cicdw @desertaxle @zzstoatzz
 /src/prefect/main.py                 @aaazzam @chrisguidry @cicdw @desertaxle @zzstoatzz

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,11 +9,11 @@
 
 # GitHub takes into account the last file ref for review requests
 # this resets the file to global owners to avoid huge review teams
-/docs/v3/develop/settings-ref.mdx
+/docs/v3/develop/settings-ref.mdx    @cicdw @desertaxle @zzstoatzz
 
 # imports
 /src/prefect/__init__.py             @aaazzam @chrisguidry @cicdw @desertaxle @zzstoatzz
 /src/prefect/main.py                 @aaazzam @chrisguidry @cicdw @desertaxle @zzstoatzz
 
 # UI Replatform
-/ui-v2                               @aaazzam @cicdw @desertaxle @zzstoatzz @devinvillarosa
+/ui-v2                               @aaazzam @desertaxle @devinvillarosa


### PR DESCRIPTION
As we saw on https://github.com/PrefectHQ/prefect/pull/16921, changes to settings incur a huge review cost in the form of tagging tons of people (unnecessarily). 

CODEOWNERS files take into account the last line referencing a file for review requests, so you can effectively "reset" individual files as needed. This PR uses that pattern for settings related file changes that don't need doc-team review.