### PR TITLE
Remove switching logic within settings config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,4 +19,4 @@ upstream dependency:
 ui-replatform:
   - changed-files:
       - any-glob-to-any-file: ui-v2/**
-      - all-globs-to-all-files: !ui-v2/src/api/prefect.ts
+      - all-globs-to-all-files: '!ui-v2/src/api/prefect.ts'

--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -3,7 +3,6 @@ Utilities for creating and working with Prefect REST API schemas.
 """
 
 import datetime
-import os
 from typing import Any, ClassVar, Optional, TypeVar, cast
 from uuid import UUID, uuid4
 
@@ -25,9 +24,7 @@ class PrefectBaseModel(BaseModel):
     fields that are passed to it at instantiation. Because adding new fields to
     API payloads is not considered a breaking change, this ensures that any
     Prefect client loading data from a server running a possibly-newer version
-    of Prefect will be able to process those new fields gracefully. However,
-    when PREFECT_TEST_MODE is on, extra fields are forbidden in order to catch
-    subtle unintentional testing errors.
+    of Prefect will be able to process those new fields gracefully.
     """
 
     _reset_fields: ClassVar[set[str]] = set()
@@ -35,16 +32,11 @@ class PrefectBaseModel(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(
         ser_json_timedelta="float",
         defer_build=True,
-        extra=(
-            "ignore"
-            if os.getenv("PREFECT_TEST_MODE", "0").lower() not in ["true", "1"]
-            and os.getenv("PREFECT_TESTING_TEST_MODE", "0").lower() not in ["true", "1"]
-            else "forbid"
-        ),
+        extra="ignore",
     )
 
     def __eq__(self, other: Any) -> bool:
-        """Equaltiy operator that ignores the resettable fields of the PrefectBaseModel.
+        """Equality operator that ignores the resettable fields of the PrefectBaseModel.
 
         NOTE: this equality operator will only be applied if the PrefectBaseModel is
         the left-hand operand. This is a limitation of Python.

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -1,5 +1,4 @@
 import datetime
-import os
 from abc import ABC, abstractmethod
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypeVar
@@ -65,26 +64,19 @@ class PrefectBaseModel(BaseModel):
     fields that are passed to it at instantiation. Because adding new fields to
     API payloads is not considered a breaking change, this ensures that any
     Prefect client loading data from a server running a possibly-newer version
-    of Prefect will be able to process those new fields gracefully. However,
-    when PREFECT_TEST_MODE is on, extra fields are forbidden in order to catch
-    subtle unintentional testing errors.
+    of Prefect will be able to process those new fields gracefully.
     """
 
     _reset_fields: ClassVar[set[str]] = set()
 
     model_config: ClassVar[ConfigDict] = ConfigDict(
         ser_json_timedelta="float",
-        extra=(
-            "ignore"
-            if os.getenv("PREFECT_TEST_MODE", "0").lower() not in ["true", "1"]
-            and os.getenv("PREFECT_TESTING_TEST_MODE", "0").lower() not in ["true", "1"]
-            else "forbid"
-        ),
+        extra="ignore",
         ignored_types=(PrefectDescriptorBase,),
     )
 
     def __eq__(self, other: Any) -> bool:
-        """Equaltiy operator that ignores the resettable fields of the PrefectBaseModel.
+        """Equality operator that ignores the resettable fields of the PrefectBaseModel.
 
         NOTE: this equality operator will only be applied if the PrefectBaseModel is
         the left-hand operand. This is a limitation of Python.

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 from abc import ABC, abstractmethod
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypeVar
@@ -64,14 +65,22 @@ class PrefectBaseModel(BaseModel):
     fields that are passed to it at instantiation. Because adding new fields to
     API payloads is not considered a breaking change, this ensures that any
     Prefect client loading data from a server running a possibly-newer version
-    of Prefect will be able to process those new fields gracefully.
+    of Prefect will be able to process those new fields gracefully. However,
+    when PREFECT_TEST_MODE is on, extra fields are forbidden in order to catch
+    subtle unintentional testing errors.
     """
 
     _reset_fields: ClassVar[set[str]] = set()
 
+    # TODO: investigate why removing this fails composite trigger tests?
     model_config: ClassVar[ConfigDict] = ConfigDict(
         ser_json_timedelta="float",
-        extra="ignore",
+        extra=(
+            "ignore"
+            if os.getenv("PREFECT_TEST_MODE", "0").lower() not in ["true", "1"]
+            and os.getenv("PREFECT_TESTING_TEST_MODE", "0").lower() not in ["true", "1"]
+            else "forbid"
+        ),
         ignored_types=(PrefectDescriptorBase,),
     )
 

--- a/tests/server/utilities/test_schemas.py
+++ b/tests/server/utilities/test_schemas.py
@@ -48,12 +48,39 @@ def reload_prefect_base_model(
 
 
 class TestExtraForbidden:
-    @pytest.mark.parametrize("falsey_value", ["0", "False", "", None])
-    def test_extra_attributes_are_allowed(self, falsey_value: Optional[str]):
+    def test_extra_attributes_are_forbidden_during_unit_tests(self):
         class Model(PrefectBaseModel):
             x: int
 
+        with pytest.raises(
+            pydantic.ValidationError, match="Extra inputs are not permitted"
+        ):
+            Model(x=1, y=2)
+
+    @pytest.mark.parametrize("falsey_value", ["0", "False", "", None])
+    def test_extra_attributes_are_allowed_outside_test_mode(
+        self, falsey_value: Optional[str]
+    ):
+        with reload_prefect_base_model(falsey_value) as PrefectBaseModel:
+
+            class Model(PrefectBaseModel):
+                x: int
+
         Model(x=1, y=2)
+
+    @pytest.mark.parametrize("truthy_value", ["1", "True", "true"])
+    def test_extra_attributes_are_not_allowed_with_truthy_test_mode(
+        self, truthy_value: Optional[str]
+    ):
+        with reload_prefect_base_model(truthy_value) as PrefectBaseModel:
+
+            class Model(PrefectBaseModel):
+                x: int
+
+        with pytest.raises(
+            pydantic.ValidationError, match="Extra inputs are not permitted"
+        ):
+            Model(x=1, y=2)
 
 
 class TestNestedDict:

--- a/tests/server/utilities/test_schemas.py
+++ b/tests/server/utilities/test_schemas.py
@@ -48,39 +48,12 @@ def reload_prefect_base_model(
 
 
 class TestExtraForbidden:
-    def test_extra_attributes_are_forbidden_during_unit_tests(self):
+    @pytest.mark.parametrize("falsey_value", ["0", "False", "", None])
+    def test_extra_attributes_are_allowed(self, falsey_value: Optional[str]):
         class Model(PrefectBaseModel):
             x: int
 
-        with pytest.raises(
-            pydantic.ValidationError, match="Extra inputs are not permitted"
-        ):
-            Model(x=1, y=2)
-
-    @pytest.mark.parametrize("falsey_value", ["0", "False", "", None])
-    def test_extra_attributes_are_allowed_outside_test_mode(
-        self, falsey_value: Optional[str]
-    ):
-        with reload_prefect_base_model(falsey_value) as PrefectBaseModel:
-
-            class Model(PrefectBaseModel):
-                x: int
-
         Model(x=1, y=2)
-
-    @pytest.mark.parametrize("truthy_value", ["1", "True", "true"])
-    def test_extra_attributes_are_not_allowed_with_truthy_test_mode(
-        self, truthy_value: Optional[str]
-    ):
-        with reload_prefect_base_model(truthy_value) as PrefectBaseModel:
-
-            class Model(PrefectBaseModel):
-                x: int
-
-        with pytest.raises(
-            pydantic.ValidationError, match="Extra inputs are not permitted"
-        ):
-            Model(x=1, y=2)
 
 
 class TestNestedDict:


### PR DESCRIPTION
This is making test-writing harder and prevents us from making server changes independently of client changes easily. (ref: #16951 )