### PR TITLE
Add `PrefectDbtRunner`

### DIFF
--- a/src/integrations/prefect-dbt/prefect_dbt/__init__.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/__init__.py
@@ -1,28 +1,45 @@
 from . import _version
+import warnings
 
 from .core import PrefectDbtSettings, PrefectDbtRunner
-from .cloud import DbtCloudCredentials, DbtCloudJob  # noqa
-from .cli import (  # noqa
-    DbtCliProfile,
-    GlobalConfigs,
-    MissingExtrasRequireError,
-    TargetConfigs,
-    DbtCoreOperation,
-)
+from .cloud import DbtCloudCredentials, DbtCloudJob
 
-try:
-    from .cli.configs.snowflake import SnowflakeTargetConfigs  # noqa
-except MissingExtrasRequireError:
-    pass
+# Define the mapping of CLI-related attributes to their import locations
+_public_api: dict[str, tuple[str, str]] = {
+    "DbtCliProfile": ("prefect_dbt", "cli"),
+    "GlobalConfigs": ("prefect_dbt", "cli"),
+    "MissingExtrasRequireError": ("prefect_dbt", "cli"),
+    "TargetConfigs": ("prefect_dbt", "cli"),
+    "DbtCoreOperation": ("prefect_dbt", "cli"),
+    "SnowflakeTargetConfigs": ("prefect_dbt", "cli.configs.snowflake"),
+    "BigQueryTargetConfigs": ("prefect_dbt", "cli.configs.bigquery"),
+    "PostgresTargetConfigs": ("prefect_dbt", "cli.configs.postgres"),
+}
 
-try:
-    from .cli.configs.bigquery import BigQueryTargetConfigs  # noqa
-except MissingExtrasRequireError:
-    pass
+# Declare API for type-checkers
+__all__ = [
+    "__version__",
+    "PrefectDbtSettings",
+    "PrefectDbtRunner",
+    "DbtCloudCredentials",
+    "DbtCloudJob",
+]
 
-try:
-    from .cli.configs.postgres import PostgresTargetConfigs  # noqa
-except MissingExtrasRequireError:
-    pass
+
+def __getattr__(attr_name: str):
+    if attr_name in _public_api:
+        package, module = _public_api[attr_name]
+        try:
+            import importlib
+
+            mod = importlib.import_module(f".{module}", package=package)
+            result = getattr(mod, attr_name)
+            return result
+        except ImportError:
+            if "configs" in module:  # For the database-specific configs
+                return None
+            raise
+    raise AttributeError(f"module '{__name__}' has no attribute '{attr_name}'")
+
 
 __version__ = _version.__version__

--- a/src/integrations/prefect-dbt/prefect_dbt/__init__.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/__init__.py
@@ -1,5 +1,4 @@
 from . import _version
-import warnings
 
 from .core import PrefectDbtSettings, PrefectDbtRunner
 from .cloud import DbtCloudCredentials, DbtCloudJob

--- a/src/integrations/prefect-dbt/prefect_dbt/__init__.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/__init__.py
@@ -1,6 +1,6 @@
 from . import _version
 
-from .core import PrefectDbtSettings
+from .core import PrefectDbtSettings, PrefectDbtRunner
 from .cloud import DbtCloudCredentials, DbtCloudJob  # noqa
 from .cli import (  # noqa
     DbtCliProfile,

--- a/src/integrations/prefect-dbt/prefect_dbt/cli/__init__.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/cli/__init__.py
@@ -1,3 +1,18 @@
+from warnings import warn
+
+from prefect._internal.compatibility.deprecated import generate_deprecation_message
+
+warn(
+    generate_deprecation_message(
+        name="prefect_dbt.cli",
+        start_date="Feb 2025",
+        end_date="Jul 2025",
+        help="Please use the PrefectDbtRunner class in prefect_dbt.core instead.",
+    ),
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 from .credentials import DbtCliProfile  # noqa
 from .commands import DbtCoreOperation  # noqa
 

--- a/src/integrations/prefect-dbt/prefect_dbt/cli/__init__.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/cli/__init__.py
@@ -1,16 +1,10 @@
-from warnings import warn
+import warnings
 
-from prefect._internal.compatibility.deprecated import generate_deprecation_message
-
-warn(
-    generate_deprecation_message(
-        name="prefect_dbt.cli",
-        start_date="Feb 2025",
-        end_date="Jul 2025",
-        help="Please use the PrefectDbtRunner class in prefect_dbt.core instead.",
-    ),
-    DeprecationWarning,
-    stacklevel=2,
+warnings.warn(
+    "prefect_dbt.cli is deprecated and will be removed in a future release. "
+    "Please use prefect_dbt.core instead.",
+    UserWarning,
+    stacklevel=1,
 )
 
 from .credentials import DbtCliProfile  # noqa
@@ -36,3 +30,15 @@ try:
     from .configs.postgres import PostgresTargetConfigs  # noqa
 except MissingExtrasRequireError:
     pass
+
+# Re-export all imports to maintain the public API
+__all__ = [
+    "DbtCliProfile",
+    "DbtCoreOperation",
+    "TargetConfigs",
+    "GlobalConfigs",
+    "MissingExtrasRequireError",
+    "SnowflakeTargetConfigs",
+    "BigQueryTargetConfigs",
+    "PostgresTargetConfigs",
+]

--- a/src/integrations/prefect-dbt/prefect_dbt/core/__init__.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/__init__.py
@@ -1,4 +1,4 @@
-from prefect_dbt.core.runner import PrefectDbtRunner
-from prefect_dbt.core.settings import PrefectDbtSettings
+from .runner import PrefectDbtRunner
+from .settings import PrefectDbtSettings
 
 __all__ = ["PrefectDbtRunner", "PrefectDbtSettings"]

--- a/src/integrations/prefect-dbt/prefect_dbt/core/__init__.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/__init__.py
@@ -1,3 +1,4 @@
+from prefect_dbt.core.runner import PrefectDbtRunner
 from prefect_dbt.core.settings import PrefectDbtSettings
 
-__all__ = ["PrefectDbtSettings"]
+__all__ = ["PrefectDbtRunner", "PrefectDbtSettings"]

--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -112,16 +112,17 @@ class PrefectDbtRunner:
                     if depends_manifest_node.relation_name
                     else None
                 )
-                upstream_manifest_nodes.append(
-                    {
-                        "prefect.resource.id": f"{adapter_type}://{depends_relation_name}",
-                        "prefect.resource.lineage-group": depends_node_prefect_config.get(
-                            "lineage_group", "global"
-                        ),
-                        "prefect.resource.role": depends_manifest_node.resource_type,
-                        "prefect.resource.name": depends_manifest_node.name,
-                    }
-                )
+                if depends_node_prefect_config.get("emit_lineage_events", True):
+                    upstream_manifest_nodes.append(
+                        {
+                            "prefect.resource.id": f"{adapter_type}://{depends_relation_name}",
+                            "prefect.resource.lineage-group": depends_node_prefect_config.get(
+                                "lineage_group", "global"
+                            ),
+                            "prefect.resource.role": depends_manifest_node.resource_type,
+                            "prefect.resource.name": depends_manifest_node.name,
+                        }
+                    )
 
         node_prefect_config: dict[str, Any] = manifest_node.config.meta.get(
             "prefect", {}

--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -34,7 +34,20 @@ FAILURE_STATUSES = [
 ]
 FAILURE_MSG = '{resource_type} {resource_name} {status}ed with message: "{message}"'
 
-REQUIRES_MANIFEST = ["build", "run", "run-operation", "seed", "snapshot", "test"]
+REQUIRES_MANIFEST = [
+    "build",
+    "compile",
+    "docs",
+    "list",
+    "ls",
+    "run",
+    "run-operation",
+    "seed",
+    "show",
+    "snapshot",
+    "source",
+    "test",
+]
 NODE_TYPES_TO_EMIT_LINEAGE = [
     NodeType.Model,
     NodeType.Seed,
@@ -343,7 +356,7 @@ class PrefectDbtRunner:
         async with aresolve_profiles_yml(invoke_kwargs["profiles_dir"]) as profiles_dir:
             invoke_kwargs["profiles_dir"] = profiles_dir
 
-            needs_manifest = any(arg in args for arg in REQUIRES_MANIFEST)
+            needs_manifest = any(arg in REQUIRES_MANIFEST for arg in args)
             if self.manifest is None and "parse" not in args and needs_manifest:
                 self.parse()
 
@@ -358,8 +371,6 @@ class PrefectDbtRunner:
                     f"Failed to invoke dbt command '{''.join(args)}': {res.exception}"
                 )
             elif not res.success and self.raise_on_failure:
-                print(type(res.result))
-
                 assert isinstance(res.result, RunExecutionResult), (
                     "Expected run execution result from failed dbt invoke"
                 )
@@ -407,7 +418,7 @@ class PrefectDbtRunner:
         with resolve_profiles_yml(invoke_kwargs["profiles_dir"]) as profiles_dir:
             invoke_kwargs["profiles_dir"] = profiles_dir
 
-            needs_manifest = any(arg in args for arg in REQUIRES_MANIFEST)
+            needs_manifest = any(arg in REQUIRES_MANIFEST for arg in args)
             if self.manifest is None and "parse" not in args and needs_manifest:
                 self.parse()
 

--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -1,0 +1,483 @@
+"""
+Runner for dbt commands
+"""
+
+import os
+from typing import Any, Callable, Optional
+
+from dbt.artifacts.resources.types import NodeType
+from dbt.artifacts.schemas.results import FreshnessStatus, RunStatus, TestStatus
+from dbt.artifacts.schemas.run import RunExecutionResult
+from dbt.cli.main import dbtRunner, dbtRunnerResult
+from dbt.contracts.graph.manifest import Manifest
+from dbt.contracts.graph.nodes import ManifestNode
+from dbt_common.events.base_types import EventLevel, EventMsg
+from google.protobuf.json_format import MessageToDict
+
+from prefect import get_client, get_run_logger
+from prefect._experimental.lineage import emit_external_resource_lineage
+from prefect.client.orchestration import PrefectClient
+from prefect.events import emit_event
+from prefect.events.related import related_resources_from_run_context
+from prefect.events.schemas.events import RelatedResource
+from prefect.exceptions import MissingContextError
+from prefect.utilities.asyncutils import run_coro_as_sync
+from prefect_dbt.core.profiles import aresolve_profiles_yml, resolve_profiles_yml
+from prefect_dbt.core.settings import PrefectDbtSettings
+
+FAILURE_STATUS = [
+    RunStatus.Error,
+    TestStatus.Error,
+    TestStatus.Fail,
+    FreshnessStatus.Error,
+    FreshnessStatus.RuntimeErr,
+]
+FAILURE_MSG = '{resource_type} {resource_name} {status}ed with message: "{message}"'
+
+REQUIRES_MANIFEST = ["build", "run", "run-operation", "seed", "snapshot", "test"]
+NODE_TYPES_TO_EMIT_LINEAGE = [
+    NodeType.Model,
+    NodeType.Seed,
+    NodeType.Snapshot,
+]
+
+
+class PrefectDbtRunner:
+    """A runner for executing dbt commands with Prefect integration.
+
+    This class provides methods to run dbt commands while integrating with Prefect's
+    logging and events capabilities. It handles manifest parsing, logging,
+    and emitting events for dbt operations.
+
+    Args:
+        manifest: Optional pre-loaded dbt manifest
+        settings: Optional PrefectDbtSettings instance for configuring dbt
+        raise_on_failure: Whether to raise an error if the dbt command encounters a
+            non-exception failure
+        client: Optional Prefect client instance
+    """
+
+    def __init__(
+        self,
+        manifest: Optional[Manifest] = None,
+        settings: Optional[PrefectDbtSettings] = None,
+        raise_on_failure: bool = True,
+        client: Optional[PrefectClient] = None,
+    ):
+        self.settings = settings or PrefectDbtSettings()
+        self.manifest: Optional[Manifest] = manifest
+        self.client = client or get_client()
+        self.raise_on_failure = raise_on_failure
+
+    def _get_manifest_depends_on_nodes(self, manifest_node: ManifestNode) -> list[str]:
+        """Type completeness wrapper for manifest_node.depends_on_nodes"""
+        return manifest_node.depends_on_nodes  # type: ignore[reportUnknownMemberType]
+
+    def _emit_lineage_event(
+        self,
+        manifest_node: ManifestNode,
+        related_prefect_context: list[RelatedResource],
+    ):
+        """Emit a lineage event for a given node"""
+        assert self.manifest is not None  # for type checking
+
+        if manifest_node.resource_type not in NODE_TYPES_TO_EMIT_LINEAGE:
+            return
+
+        adapter_type = self.manifest.metadata.adapter_type
+        node_name = manifest_node.name
+        primary_relation_name = (
+            manifest_node.relation_name.replace('"', "").replace(".", "/")
+            if manifest_node.relation_name
+            else None
+        )
+        related_resources: list[dict[str, str]] = []
+
+        # Add related resources from the prefect context
+        for realted_resource in related_prefect_context:
+            related_resources.append(realted_resource.model_dump())
+
+        # Add upstream nodes from the manifest
+        upstream_manifest_nodes: list[dict[str, Any]] = []
+        for depends_on_node in self._get_manifest_depends_on_nodes(manifest_node):
+            depends_manifest_node = self.manifest.nodes.get(depends_on_node)
+            if depends_manifest_node is not None:
+                print("\nDebug - In implementation:")  # Add debug print
+                print(
+                    f"depends_manifest_node.name: {depends_manifest_node.name}"
+                )  # Add debug print
+                print(
+                    f"depends_manifest_node.unique_id: {depends_manifest_node.unique_id}"
+                )  # Add debug print
+
+                depends_node_prefect_config: dict[str, dict[str, Any]] = (
+                    depends_manifest_node.config.meta.get("prefect", {})
+                )
+                depends_relation_name = (
+                    depends_manifest_node.relation_name.replace('"', "").replace(
+                        ".", "/"
+                    )
+                    if depends_manifest_node.relation_name
+                    else None
+                )
+                upstream_manifest_nodes.append(
+                    {
+                        "prefect.resource.id": f"{adapter_type}://{depends_relation_name}",
+                        "prefect.resource.lineage-group": depends_node_prefect_config.get(
+                            "lineage_group", "global"
+                        ),
+                        "prefect.resource.role": depends_manifest_node.resource_type,
+                        "prefect.resource.name": depends_manifest_node.name,
+                    }
+                )
+
+        node_prefect_config: dict[str, Any] = manifest_node.config.meta.get(
+            "prefect", {}
+        )
+
+        # Add related resources from the node config
+        upstream_config_resources: list[dict[str, str]] = []
+        upstream_resources = node_prefect_config.get("upstream_resources")
+        if upstream_resources:
+            for upstream_resource in upstream_resources:
+                if (resource_id := upstream_resource.get("id")) is None:
+                    raise ValueError("Upstream resources must have an id")
+                elif (resource_name := upstream_resource.get("name")) is None:
+                    raise ValueError("Upstream resources must have a name")
+                else:
+                    resource: dict[str, str] = {
+                        "prefect.resource.id": resource_id,
+                        "prefect.resource.lineage-group": upstream_resource.get(
+                            "lineage_group", "global"
+                        ),
+                        "prefect.resource.role": upstream_resource.get("role", "table"),
+                        "prefect.resource.name": resource_name,
+                    }
+                upstream_config_resources.append(resource)
+
+        primary_resource: dict[str, Any] = {
+            "prefect.resource.id": f"{adapter_type}://{primary_relation_name}",
+            "prefect.resource.lineage-group": node_prefect_config.get(
+                "lineage_group", "global"
+            ),
+            "prefect.resource.role": manifest_node.resource_type,
+            "prefect.resource.name": node_name,
+        }
+
+        if related_prefect_context:
+            run_coro_as_sync(
+                emit_external_resource_lineage(
+                    context_resources=related_prefect_context,
+                    upstream_resources=upstream_manifest_nodes
+                    + upstream_config_resources,
+                    downstream_resources=[primary_resource],
+                )
+            )
+
+    def _emit_node_event(
+        self,
+        manifest_node: ManifestNode,
+        related_prefect_context: list[RelatedResource],
+        dbt_event: EventMsg,
+    ):
+        """Emit a generic event for a given node"""
+        assert self.manifest is not None  # for type checking
+
+        related_resources: list[dict[str, str]] = []
+
+        # Add related resources from the prefect context
+        for resource in related_prefect_context:
+            related_resources.append(resource.model_dump())
+
+        event_data = MessageToDict(dbt_event.data, preserving_proto_field_name=True)
+        node_info = event_data.get("node_info")
+        node_status = node_info.get("node_status") if node_info else None
+
+        emit_event(
+            event="dbt Node Finished",
+            resource={
+                "prefect.resource.id": f"dbt.{manifest_node.unique_id}",
+                "prefect.resource.name": manifest_node.name,
+                "dbt.node.status": node_status or "",
+            },
+            related=related_resources,
+            payload=event_data,
+        )
+
+    def _get_dbt_event_msg(self, event: EventMsg) -> str:
+        return event.info.msg  # type: ignore[reportUnknownMemberType]
+
+    def _create_logging_callback(
+        self, log_level: EventLevel
+    ) -> Callable[[EventMsg], None]:
+        """Creates a callback function for logging dbt events.
+
+        Returns:
+            A callback function that logs dbt events using the Prefect logger.
+            Debug-level events are filtered out.
+        """
+        try:
+            logger = get_run_logger()
+        except MissingContextError:
+            logger = None
+
+        def logging_callback(event: EventMsg):
+            if logger is not None:
+                logger.setLevel(log_level.value.upper())
+                if (
+                    event.info.level == EventLevel.DEBUG
+                    or event.info.level == EventLevel.TEST
+                ):
+                    logger.debug(self._get_dbt_event_msg(event))
+                elif event.info.level == EventLevel.INFO:
+                    logger.info(self._get_dbt_event_msg(event))
+                elif event.info.level == EventLevel.WARN:
+                    logger.warning(self._get_dbt_event_msg(event))
+                elif event.info.level == EventLevel.ERROR:
+                    logger.error(self._get_dbt_event_msg(event))
+
+        return logging_callback
+
+    def _get_dbt_event_node_id(self, event: EventMsg) -> str:
+        return event.data.node_info.unique_id  # type: ignore[reportUnknownMemberType]
+
+    def _create_events_callback(
+        self, related_prefect_context: list[RelatedResource]
+    ) -> Callable[[EventMsg], None]:
+        """Creates a callback function for tracking dbt node lineage.
+
+        Args:
+            related_prefect_context: List of related Prefect resources to include
+                in lineage tracking.
+
+        Returns:
+            A callback function that emits lineage events when dbt nodes finish executing.
+        """
+
+        def events_callback(event: EventMsg):
+            if event.info.name == "NodeFinished" and self.manifest is not None:
+                node_id = self._get_dbt_event_node_id(event)
+                assert isinstance(node_id, str)
+
+                manifest_node = self.manifest.nodes.get(node_id)
+
+                if manifest_node:
+                    prefect_config = manifest_node.config.meta.get("prefect", {})
+                    emit_events = prefect_config.get("emit_events", True)
+                    emit_node_events = prefect_config.get("emit_node_events", True)
+                    emit_lineage_events = prefect_config.get(
+                        "emit_lineage_events", True
+                    )
+
+                    try:
+                        if emit_events and emit_node_events:
+                            self._emit_node_event(
+                                manifest_node, related_prefect_context, event
+                            )
+                        if emit_events and emit_lineage_events:
+                            self._emit_lineage_event(
+                                manifest_node, related_prefect_context
+                            )
+                    except Exception as e:
+                        print(e)
+
+        return events_callback
+
+    def parse(self, **kwargs: Any):
+        """Parses the dbt project and loads the manifest.
+
+        This method runs the dbt parse command to generate and load the manifest
+        if it hasn't been loaded already.
+
+        Raises:
+            ValueError: If the manifest fails to load.
+        """
+        if self.manifest is None:
+            related_prefect_context = run_coro_as_sync(
+                related_resources_from_run_context(self.client),
+            )
+            assert related_prefect_context is not None
+
+            invoke_kwargs = {
+                "project_dir": kwargs.pop("project_dir", self.settings.project_dir),
+                "profiles_dir": kwargs.pop("profiles_dir", self.settings.profiles_dir),
+                "log_level": kwargs.pop(
+                    "log_level",
+                    "none" if related_prefect_context else self.settings.log_level,
+                ),
+                **kwargs,
+            }
+
+            with resolve_profiles_yml(invoke_kwargs["profiles_dir"]) as profiles_dir:
+                invoke_kwargs["profiles_dir"] = profiles_dir
+                res: dbtRunnerResult = dbtRunner(
+                    callbacks=[self._create_logging_callback(self.settings.log_level)]
+                ).invoke(  # type: ignore[reportUnknownMemberType]
+                    ["parse"], **invoke_kwargs
+                )
+
+            if not res.success:
+                raise ValueError(f"Failed to load manifest: {res.exception}")
+
+            assert isinstance(res.result, Manifest), (
+                "Expected manifest result from dbt parse"
+            )
+
+            self.manifest = res.result
+
+    async def ainvoke(self, args: list[str], **kwargs: Any):
+        """Asynchronously invokes a dbt command.
+
+        Args:
+            args: List of dbt command arguments
+            **kwargs: Additional keyword arguments to pass to dbt
+
+        Returns:
+            The result of the dbt command execution
+        """
+        related_prefect_context = await related_resources_from_run_context(self.client)
+
+        invoke_kwargs = {
+            "project_dir": kwargs.pop("project_dir", self.settings.project_dir),
+            "profiles_dir": kwargs.pop("profiles_dir", self.settings.profiles_dir),
+            "log_level": kwargs.pop(
+                "log_level",
+                "none" if related_prefect_context else self.settings.log_level,
+            ),
+            **kwargs,
+        }
+
+        async with aresolve_profiles_yml(invoke_kwargs["profiles_dir"]) as profiles_dir:
+            invoke_kwargs["profiles_dir"] = profiles_dir
+
+            needs_manifest = any(arg in args for arg in REQUIRES_MANIFEST)
+            if self.manifest is None and "parse" not in args and needs_manifest:
+                self.parse()
+
+            callbacks = [
+                self._create_logging_callback(self.settings.log_level),
+                self._create_events_callback(related_prefect_context),
+            ]
+            res = dbtRunner(callbacks=callbacks).invoke(args, **invoke_kwargs)
+
+            if not res.success and res.exception:
+                raise ValueError(
+                    f"Failed to invoke dbt command '{''.join(args)}': {res.exception}"
+                )
+            elif not res.success and self.raise_on_failure:
+                print(type(res.result))
+
+                assert isinstance(res.result, RunExecutionResult), (
+                    "Expected run execution result from failed dbt invoke"
+                )
+
+                failure_results = [
+                    FAILURE_MSG.format(
+                        resource_type=result.node.resource_type.title(),
+                        resource_name=result.node.name,
+                        status=result.status,
+                        message=result.message,
+                    )
+                    for result in res.result.results
+                    if result.status in FAILURE_STATUS
+                ]
+                raise ValueError(
+                    f"Failures detected during invocation of dbt command '{''.join(args)}':\n{os.linesep.join(failure_results)}"
+                )
+            return res
+
+    def invoke(self, args: list[str], **kwargs: Any):
+        """Synchronously invokes a dbt command.
+
+        Args:
+            args: List of dbt command arguments
+            **kwargs: Additional keyword arguments to pass to dbt
+
+        Returns:
+            The result of the dbt command execution
+        """
+        related_prefect_context = run_coro_as_sync(
+            related_resources_from_run_context(self.client),
+        )
+        assert related_prefect_context is not None
+
+        invoke_kwargs = {
+            "project_dir": kwargs.pop("project_dir", self.settings.project_dir),
+            "profiles_dir": kwargs.pop("profiles_dir", self.settings.profiles_dir),
+            "log_level": kwargs.pop(
+                "log_level",
+                "none" if related_prefect_context else self.settings.log_level,
+            ),
+            **kwargs,
+        }
+
+        with resolve_profiles_yml(invoke_kwargs["profiles_dir"]) as profiles_dir:
+            invoke_kwargs["profiles_dir"] = profiles_dir
+
+            needs_manifest = any(arg in args for arg in REQUIRES_MANIFEST)
+            if self.manifest is None and "parse" not in args and needs_manifest:
+                self.parse()
+
+            callbacks = [
+                self._create_logging_callback(self.settings.log_level),
+                self._create_events_callback(related_prefect_context),
+            ]
+            res = dbtRunner(callbacks=callbacks).invoke(args, **invoke_kwargs)  # type: ignore[reportUnknownMemberType]
+
+            if not res.success and res.exception:
+                raise ValueError(
+                    f"Failed to invoke dbt command '{''.join(args)}': {res.exception}"
+                )
+            elif not res.success and self.raise_on_failure:
+                assert isinstance(res.result, RunExecutionResult), (
+                    "Expected run execution result from failed dbt invoke"
+                )
+                failure_results = [
+                    FAILURE_MSG.format(
+                        resource_type=result.node.resource_type.title(),
+                        resource_name=result.node.name,
+                        status=result.status,
+                        message=result.message,
+                    )
+                    for result in res.result.results
+                    if result.status in FAILURE_STATUS
+                ]
+                raise ValueError(
+                    f"Failures detected during invocation of dbt command '{''.join(args)}':\n{os.linesep.join(failure_results)}"
+                )
+            return res
+
+    async def aemit_lineage_events(self):
+        """Asynchronously emit lineage events for all relevant nodes in the dbt manifest.
+
+        This method parses the manifest if not already loaded and emits lineage events for
+        models, seeds, and exposures.
+        """
+        if self.manifest is None:
+            self.parse()
+
+        assert self.manifest is not None  # for type checking
+
+        related_prefect_context = await related_resources_from_run_context(self.client)
+
+        for manifest_node in self.manifest.nodes.values():
+            self._emit_lineage_event(manifest_node, related_prefect_context)
+
+    def emit_lineage_events(self):
+        """Synchronously emit lineage events for all relevant nodes in the dbt manifest.
+
+        This method parses the manifest if not already loaded and emits lineage events for
+        models, seeds, and exposures.
+        """
+        if self.manifest is None:
+            self.parse()
+
+        assert self.manifest is not None  # for type checking
+
+        related_prefect_context = run_coro_as_sync(
+            related_resources_from_run_context(self.client),
+        )
+        assert related_prefect_context is not None
+
+        for manifest_node in self.manifest.nodes.values():
+            self._emit_lineage_event(manifest_node, related_prefect_context)

--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -200,7 +200,7 @@ class PrefectDbtRunner:
         node_status = node_info.get("node_status") if node_info else None
 
         emit_event(
-            event="dbt Node Finished",
+            event=f"{manifest_node.name} {node_status}",
             resource={
                 "prefect.resource.id": f"dbt.{manifest_node.unique_id}",
                 "prefect.resource.name": manifest_node.name,

--- a/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/core/runner.py
@@ -25,7 +25,7 @@ from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect_dbt.core.profiles import aresolve_profiles_yml, resolve_profiles_yml
 from prefect_dbt.core.settings import PrefectDbtSettings
 
-FAILURE_STATUS = [
+FAILURE_STATUSES = [
     RunStatus.Error,
     TestStatus.Error,
     TestStatus.Fail,
@@ -102,14 +102,6 @@ class PrefectDbtRunner:
         for depends_on_node in self._get_manifest_depends_on_nodes(manifest_node):
             depends_manifest_node = self.manifest.nodes.get(depends_on_node)
             if depends_manifest_node is not None:
-                print("\nDebug - In implementation:")  # Add debug print
-                print(
-                    f"depends_manifest_node.name: {depends_manifest_node.name}"
-                )  # Add debug print
-                print(
-                    f"depends_manifest_node.unique_id: {depends_manifest_node.unique_id}"
-                )  # Add debug print
-
                 depends_node_prefect_config: dict[str, dict[str, Any]] = (
                     depends_manifest_node.config.meta.get("prefect", {})
                 )
@@ -379,7 +371,7 @@ class PrefectDbtRunner:
                         message=result.message,
                     )
                     for result in res.result.results
-                    if result.status in FAILURE_STATUS
+                    if result.status in FAILURE_STATUSES
                 ]
                 raise ValueError(
                     f"Failures detected during invocation of dbt command '{''.join(args)}':\n{os.linesep.join(failure_results)}"
@@ -440,7 +432,7 @@ class PrefectDbtRunner:
                         message=result.message,
                     )
                     for result in res.result.results
-                    if result.status in FAILURE_STATUS
+                    if result.status in FAILURE_STATUSES
                 ]
                 raise ValueError(
                     f"Failures detected during invocation of dbt command '{''.join(args)}':\n{os.linesep.join(failure_results)}"

--- a/src/integrations/prefect-dbt/pyproject.toml
+++ b/src/integrations/prefect-dbt/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-  "prefect>=3.1.15",
+  "prefect>=3.1.16.dev2",
   "dbt-core>=1.7.0",
   "prefect_shell>=0.3.0",
   "sgqlc>=16.0.0",

--- a/src/integrations/prefect-dbt/tests/core/test_runner.py
+++ b/src/integrations/prefect-dbt/tests/core/test_runner.py
@@ -990,7 +990,7 @@ class TestPrefectDbtRunnerEvents:
             # Verify node event was emitted
             assert mock_emit.call_count == 1
             node_event_call = mock_emit.call_args_list[0]
-            assert node_event_call.kwargs["event"] == "dbt Node Finished"
+            assert node_event_call.kwargs["event"] == "example success"
             assert node_event_call.kwargs["resource"] == {
                 "prefect.resource.id": "dbt.model.test.example",
                 "prefect.resource.name": "example",
@@ -1076,7 +1076,6 @@ class TestPrefectDbtRunnerEvents:
 
         # Create a mock node in the manifest
         node = Mock()
-        node.unique_id = "model.test.example"
         node.name = "example"
         node.relation_name = '"schema"."example_table"'
         node.depends_on_nodes = []
@@ -1148,6 +1147,7 @@ class TestPrefectDbtRunnerEvents:
         runner.manifest.metadata.adapter_type = "postgres"
 
         node = Mock()
+        node.name = "example"
         node.relation_name = '"schema"."table"'
         node.depends_on_nodes = []
         node.config.meta = {"prefect": {"emit_lineage_events": False}}
@@ -1173,7 +1173,7 @@ class TestPrefectDbtRunnerEvents:
 
             callback(event)
             assert mock_emit.call_count == 1  # Only node event should be emitted
-            assert mock_emit.call_args.kwargs["event"] == "dbt Node Finished"
+            assert mock_emit.call_args.kwargs["event"] == "example success"
 
     def test_events_callback_with_all_events_disabled(self, mock_dbt_runner, settings):
         runner = PrefectDbtRunner(settings=settings)

--- a/src/integrations/prefect-dbt/tests/core/test_runner.py
+++ b/src/integrations/prefect-dbt/tests/core/test_runner.py
@@ -567,11 +567,6 @@ class TestPrefectDbtRunnerEvents:
         upstream_node.resource_type = NodeType.Model
         runner.manifest.nodes["model.test.upstream"] = upstream_node
 
-        # Add debug prints
-        print("\nDebug - Upstream node attributes:")
-        print(f"name: {upstream_node.name}")
-        print(f"unique_id: {upstream_node.unique_id}")
-
         # Create a mock NodeFinished event
         event = Mock()
         event.info.name = "NodeFinished"
@@ -607,11 +602,6 @@ class TestPrefectDbtRunnerEvents:
 
             # Call the callback
             callback(event)
-
-            # Add debug print for lineage call
-            lineage_call = mock_emit_lineage.call_args
-            print("\nDebug - Upstream resources in lineage call:")
-            print(lineage_call.kwargs["upstream_resources"])
 
             # Verify node event was emitted
             assert mock_emit.call_count == 1

--- a/src/integrations/prefect-dbt/tests/core/test_runner.py
+++ b/src/integrations/prefect-dbt/tests/core/test_runner.py
@@ -1,0 +1,953 @@
+import logging
+from pathlib import Path
+from unittest.mock import ANY, Mock, patch
+
+import pytest
+from dbt.artifacts.resources.types import NodeType
+from dbt.artifacts.schemas.results import RunStatus, TestStatus
+from dbt.artifacts.schemas.run import RunExecutionResult
+from dbt.cli.main import dbtRunnerResult
+from dbt.contracts.graph.manifest import Manifest
+from dbt.contracts.graph.nodes import ManifestNode
+from dbt_common.events.base_types import EventLevel
+from prefect_dbt.core.runner import PrefectDbtRunner
+from prefect_dbt.core.settings import PrefectDbtSettings
+
+from prefect import flow
+from prefect.events.schemas.events import RelatedResource
+
+
+@pytest.fixture
+def mock_dbt_runner():
+    with patch("prefect_dbt.core.runner.dbtRunner") as mock_runner:
+        mock_instance = Mock()
+        mock_runner.return_value = mock_instance
+
+        # Setup default successful result
+        result = Mock(spec=dbtRunnerResult)
+        result.success = True
+        # Create a Mock that inherits from Manifest
+        manifest_mock = Mock(spec=Manifest)
+        manifest_mock.metadata = Mock()
+        manifest_mock.metadata.adapter_type = "postgres"
+        result.result = manifest_mock
+        mock_instance.invoke.return_value = result
+
+        yield mock_instance
+
+
+@pytest.fixture
+def settings():
+    return PrefectDbtSettings(
+        profiles_dir=Path("./tests/dbt_configs").resolve(),
+        project_dir=Path("./tests/dbt_configs").resolve(),
+        log_level=EventLevel.DEBUG,
+    )
+
+
+@pytest.fixture
+def mock_manifest():
+    """Create a mock manifest with different node types."""
+    manifest = Mock(spec=Manifest)
+    # Create the metadata structure
+    manifest.metadata = Mock()
+    manifest.metadata.adapter_type = "postgres"
+    return manifest
+
+
+@pytest.fixture
+def mock_nodes():
+    """Create mock nodes of different types."""
+    model_node = Mock()
+    model_node.relation_name = '"schema"."model_table"'
+    model_node.depends_on_nodes = []
+    model_node.config.meta = {}
+    model_node.resource_type = NodeType.Model
+    model_node.unique_id = "model.test.model"
+    model_node.name = "model"
+
+    seed_node = Mock()
+    seed_node.relation_name = '"schema"."seed_table"'
+    seed_node.depends_on_nodes = []
+    seed_node.config.meta = {}
+    seed_node.resource_type = NodeType.Seed
+    seed_node.unique_id = "seed.test.seed"
+    seed_node.name = "seed"
+
+    exposure_node = Mock()
+    exposure_node.relation_name = '"schema"."exposure_table"'
+    exposure_node.depends_on_nodes = []
+    exposure_node.config.meta = {}
+    exposure_node.resource_type = NodeType.Exposure
+    exposure_node.unique_id = "exposure.test.exposure"
+    exposure_node.name = "exposure"
+
+    test_node = Mock()
+    test_node.relation_name = '"schema"."test_table"'
+    test_node.depends_on_nodes = []
+    test_node.config.meta = {}
+    test_node.resource_type = NodeType.Test
+    test_node.unique_id = "test.test.test"
+    test_node.name = "test"
+
+    return {
+        "model": model_node,
+        "seed": seed_node,
+        "exposure": exposure_node,
+        "test": test_node,
+    }
+
+
+@pytest.fixture
+def mock_manifest_with_nodes(mock_manifest, mock_nodes):
+    """Create a mock manifest populated with test nodes."""
+    mock_manifest.nodes = {
+        "model.test.model": mock_nodes["model"],
+        "seed.test.seed": mock_nodes["seed"],
+        "exposure.test.exposure": mock_nodes["exposure"],
+        "test.test.test": mock_nodes["test"],
+    }
+    return mock_manifest
+
+
+class TestPrefectDbtRunnerInitialization:
+    def test_runner_initialization(self, settings):
+        manifest = Mock()
+        client = Mock()
+
+        runner = PrefectDbtRunner(manifest=manifest, settings=settings, client=client)
+
+        assert runner.manifest == manifest
+        assert runner.settings == settings
+        assert runner.client == client
+
+    def test_runner_default_initialization(self):
+        runner = PrefectDbtRunner()
+
+        assert runner.manifest is None
+        assert isinstance(runner.settings, PrefectDbtSettings)
+        assert runner.client is not None
+
+
+class TestPrefectDbtRunnerParse:
+    def test_parse_success(self, mock_dbt_runner, settings):
+        runner = PrefectDbtRunner(settings=settings)
+        runner.parse()
+
+        mock_dbt_runner.invoke.assert_called_once_with(
+            ["parse"],
+            profiles_dir=ANY,
+            project_dir=settings.project_dir,
+            log_level=EventLevel.DEBUG,
+        )
+        assert runner.manifest is not None
+
+    def test_parse_failure(self, mock_dbt_runner, settings):
+        mock_dbt_runner.invoke.return_value.success = False
+        mock_dbt_runner.invoke.return_value.exception = "Parse error"
+
+        runner = PrefectDbtRunner(settings=settings)
+
+        with pytest.raises(ValueError, match="Failed to load manifest"):
+            runner.parse()
+
+
+class TestPrefectDbtRunnerInvoke:
+    # Basic invocation tests
+    def test_invoke_with_custom_kwargs(self, mock_dbt_runner, settings):
+        runner = PrefectDbtRunner(settings=settings)
+
+        runner.invoke(["run"], vars={"custom_var": "value"}, threads=4)
+
+        call_kwargs = mock_dbt_runner.invoke.call_args.kwargs
+        assert call_kwargs["vars"] == {"custom_var": "value"}
+        assert call_kwargs["threads"] == 4
+        assert call_kwargs["profiles_dir"] == ANY
+        assert call_kwargs["project_dir"] == settings.project_dir
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_with_custom_kwargs(self, mock_dbt_runner, settings):
+        runner = PrefectDbtRunner(settings=settings)
+
+        await runner.ainvoke(["run"], vars={"custom_var": "value"}, threads=4)
+
+        call_kwargs = mock_dbt_runner.invoke.call_args.kwargs
+        assert call_kwargs["vars"] == {"custom_var": "value"}
+        assert call_kwargs["threads"] == 4
+        assert call_kwargs["profiles_dir"] == ANY
+        assert call_kwargs["project_dir"] == settings.project_dir
+
+    # Parsing tests
+    def test_invoke_with_parsing(self, mock_dbt_runner, settings):
+        runner = PrefectDbtRunner(settings=settings)
+
+        runner.invoke(["run"])
+
+        assert mock_dbt_runner.invoke.call_count == 2
+        parse_call = mock_dbt_runner.invoke.call_args_list[0]
+        assert parse_call.args[0] == ["parse"]
+
+        run_call = mock_dbt_runner.invoke.call_args_list[1]
+        assert run_call.args[0] == ["run"]
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_with_parsing(self, mock_dbt_runner, settings):
+        runner = PrefectDbtRunner(settings=settings)
+
+        await runner.ainvoke(["run"])
+
+        assert mock_dbt_runner.invoke.call_count == 2
+        parse_call = mock_dbt_runner.invoke.call_args_list[0]
+        assert parse_call.args[0] == ["parse"]
+
+        run_call = mock_dbt_runner.invoke.call_args_list[1]
+        assert run_call.args[0] == ["run"]
+
+    # Single failure tests
+    def test_invoke_raises_on_failure(self, mock_dbt_runner, settings):
+        runner = PrefectDbtRunner(settings=settings)
+
+        # Setup successful parse result first
+        parse_result = Mock(spec=dbtRunnerResult)
+        parse_result.success = True
+        manifest_mock = Mock(Manifest)
+        parse_result.result = manifest_mock
+
+        # Mock a failed run result
+        run_result = Mock(spec=dbtRunnerResult)
+        run_result.success = False
+        run_result.exception = None
+        run_result.result = Mock(spec=RunExecutionResult)
+
+        # Create a failed node result
+        node_result = Mock()
+        node_result.status = RunStatus.Error
+        node_result.node.resource_type = NodeType.Model
+        node_result.node.name = "failed_model"
+        node_result.message = "Something went wrong"
+
+        run_result.result.results = [node_result]
+
+        # Set up the side effects to return parse_result for parse command and run_result for run command
+        def side_effect(args, **kwargs):
+            if args == ["parse"]:
+                return parse_result
+            elif args == ["run"]:
+                return run_result
+            return Mock()
+
+        mock_dbt_runner.invoke.side_effect = side_effect
+
+        with pytest.raises(
+            ValueError, match="Failures detected during invocation of dbt command 'run'"
+        ):
+            runner.invoke(["run"])
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_raises_on_failure(self, mock_dbt_runner, settings):
+        runner = PrefectDbtRunner(settings=settings)
+
+        # Setup successful parse result first
+        parse_result = Mock(spec=dbtRunnerResult)
+        parse_result.success = True
+        manifest_mock = Mock(Manifest)
+        parse_result.result = manifest_mock
+
+        # Mock a failed result
+        run_result = Mock(spec=dbtRunnerResult)
+        run_result.success = False
+        run_result.exception = None
+        run_result.result = Mock(spec=RunExecutionResult)
+        # Create a failed node result
+        node_result = Mock()
+        node_result.status = RunStatus.Error
+        node_result.node.resource_type = NodeType.Model
+        node_result.node.name = "failed_model"
+        node_result.message = "Something went wrong"
+
+        run_result.result.results = [node_result]
+
+        def side_effect(args, **kwargs):
+            if args == ["parse"]:
+                return parse_result
+            elif args == ["run"]:
+                return run_result
+            return Mock()
+
+        mock_dbt_runner.invoke.side_effect = side_effect
+
+        with pytest.raises(
+            ValueError, match="Failures detected during invocation of dbt command 'run'"
+        ):
+            await runner.ainvoke(["run"])
+
+    # Multiple failures tests
+    def test_invoke_multiple_failures(self, mock_dbt_runner, settings):
+        runner = PrefectDbtRunner(settings=settings)
+
+        # Setup successful parse result first
+        parse_result = Mock(spec=dbtRunnerResult)
+        parse_result.success = True
+        manifest_mock = Mock(Manifest)
+        parse_result.result = manifest_mock
+
+        # Mock a failed result with multiple failures
+        run_result = Mock(spec=dbtRunnerResult)
+        run_result.success = False
+        run_result.exception = None
+        run_result.result = Mock(spec=RunExecutionResult)
+
+        # Create multiple failed node results
+        failed_model = Mock()
+        failed_model.status = RunStatus.Error
+        failed_model.node.resource_type = NodeType.Model
+        failed_model.node.name = "failed_model"
+        failed_model.message = "Model error"
+
+        failed_test = Mock()
+        failed_test.status = TestStatus.Fail
+        failed_test.node.resource_type = NodeType.Test
+        failed_test.node.name = "failed_test"
+        failed_test.message = "Test failed"
+
+        run_result.result.results = [failed_model, failed_test]
+
+        def side_effect(args, **kwargs):
+            if args == ["parse"]:
+                return parse_result
+            elif args == ["run"]:
+                return run_result
+            return Mock()
+
+        mock_dbt_runner.invoke.side_effect = side_effect
+
+        with pytest.raises(ValueError) as exc_info:
+            runner.invoke(["run"])
+
+        error_message = str(exc_info.value)
+        assert 'Model failed_model errored with message: "Model error"' in error_message
+        assert 'Test failed_test failed with message: "Test failed"' in error_message
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_multiple_failures(self, mock_dbt_runner, settings):
+        runner = PrefectDbtRunner(settings=settings)
+
+        # Setup successful parse result first
+        parse_result = Mock(spec=dbtRunnerResult)
+        parse_result.success = True
+        manifest_mock = Mock(Manifest)
+        parse_result.result = manifest_mock
+
+        # Mock a failed result with multiple failures
+        run_result = Mock(spec=dbtRunnerResult)
+        run_result.success = False
+        run_result.exception = None
+        run_result.result = Mock(spec=RunExecutionResult)
+
+        # Create multiple failed node results
+        failed_model = Mock()
+        failed_model.status = RunStatus.Error
+        failed_model.node.resource_type = NodeType.Model
+        failed_model.node.name = "failed_model"
+        failed_model.message = "Model error"
+
+        failed_test = Mock()
+        failed_test.status = TestStatus.Fail
+        failed_test.node.resource_type = NodeType.Test
+        failed_test.node.name = "failed_test"
+        failed_test.message = "Test failed"
+
+        run_result.result.results = [failed_model, failed_test]
+
+        def side_effect(args, **kwargs):
+            if args == ["parse"]:
+                return parse_result
+            elif args == ["run"]:
+                return run_result
+            return Mock()
+
+        mock_dbt_runner.invoke.side_effect = side_effect
+
+        with pytest.raises(ValueError) as exc_info:
+            await runner.ainvoke(["run"])
+
+        error_message = str(exc_info.value)
+        assert 'Model failed_model errored with message: "Model error"' in error_message
+        assert 'Test failed_test failed with message: "Test failed"' in error_message
+
+    # No raise on failure tests
+    def test_invoke_no_raise_on_failure(self, mock_dbt_runner, settings):
+        runner = PrefectDbtRunner(settings=settings, raise_on_failure=False)
+
+        # Setup successful parse result first
+        parse_result = Mock(spec=dbtRunnerResult)
+        parse_result.success = True
+        manifest_mock = Mock(Manifest)
+        parse_result.result = manifest_mock
+
+        # Mock a failed result
+        run_result = Mock(spec=dbtRunnerResult)
+        run_result.success = False
+        run_result.exception = None
+
+        # Create a failed node result
+        node_result = Mock()
+        node_result.status = RunStatus.Error
+        node_result.node.resource_type = NodeType.Model
+        node_result.node.name = "failed_model"
+        node_result.message = "Something went wrong"
+
+        run_result.result.results = [node_result]
+
+        def side_effect(args, **kwargs):
+            if args == ["parse"]:
+                return parse_result
+            elif args == ["run"]:
+                return run_result
+            return Mock()
+
+        mock_dbt_runner.invoke.side_effect = side_effect
+
+        # Should not raise an exception
+        result = runner.invoke(["run"])
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_no_raise_on_failure(self, mock_dbt_runner, settings):
+        runner = PrefectDbtRunner(settings=settings, raise_on_failure=False)
+
+        # Setup successful parse result first
+        parse_result = Mock(spec=dbtRunnerResult)
+        parse_result.success = True
+        manifest_mock = Mock(Manifest)
+        parse_result.result = manifest_mock
+
+        # Mock a failed result
+        run_result = Mock(spec=dbtRunnerResult)
+        run_result.success = False
+        run_result.exception = None
+
+        # Create a failed node result
+        node_result = Mock()
+        node_result.status = RunStatus.Error
+        node_result.node.resource_type = NodeType.Model
+        node_result.node.name = "failed_model"
+        node_result.message = "Something went wrong"
+
+        run_result.result.results = [node_result]
+
+        def side_effect(args, **kwargs):
+            if args == ["parse"]:
+                return parse_result
+            elif args == ["run"]:
+                return run_result
+            return Mock()
+
+        mock_dbt_runner.invoke.side_effect = side_effect
+
+        # Should not raise an exception
+        result = await runner.ainvoke(["run"])
+        assert result.success is False
+
+
+class TestPrefectDbtRunnerLogging:
+    def test_logging_callback(self, mock_dbt_runner, settings, caplog):
+        runner = PrefectDbtRunner(settings=settings)
+
+        # Create mock events for different log levels
+        debug_event = Mock()
+        debug_event.info.level = EventLevel.DEBUG
+        debug_event.info.msg = "Debug message"
+
+        info_event = Mock()
+        info_event.info.level = EventLevel.INFO
+        info_event.info.msg = "Info message"
+
+        warn_event = Mock()
+        warn_event.info.level = EventLevel.WARN
+        warn_event.info.msg = "Warning message"
+
+        error_event = Mock()
+        error_event.info.level = EventLevel.ERROR
+        error_event.info.msg = "Error message"
+
+        test_event = Mock()
+        test_event.info.level = EventLevel.TEST
+        test_event.info.msg = "Test message"
+
+        @flow
+        def test_flow():
+            callback = runner._create_logging_callback(EventLevel.DEBUG)
+            callback(debug_event)
+            callback(info_event)
+            callback(warn_event)
+            callback(error_event)
+            callback(test_event)
+
+        caplog.clear()
+
+        with caplog.at_level(logging.DEBUG):
+            test_flow()
+
+            assert "Debug message" in caplog.text
+            assert "Test message" in caplog.text
+            assert "Info message" in caplog.text
+            assert "Warning message" in caplog.text
+            assert "Error message" in caplog.text
+
+            for record in caplog.records:
+                if (
+                    "Debug message" in record.message
+                    or "Test message" in record.message
+                ):
+                    assert record.levelno == logging.DEBUG
+                elif "Info message" in record.message:
+                    assert record.levelno == logging.INFO
+                elif "Warning message" in record.message:
+                    assert record.levelno == logging.WARNING
+                elif "Error message" in record.message:
+                    assert record.levelno == logging.ERROR
+
+    def test_logging_callback_no_flow(self, mock_dbt_runner, settings, caplog):
+        runner = PrefectDbtRunner(settings=settings)
+
+        event = Mock()
+        event.info.level = EventLevel.INFO
+        event.info.msg = "Test message"
+
+        # no flow decorator
+        def test_flow():
+            callback = runner._create_logging_callback(EventLevel.DEBUG)
+            callback(event)
+
+        caplog.clear()
+
+        with caplog.at_level(logging.INFO):
+            test_flow()
+            assert caplog.text == "", (
+                "Expected empty log output when not in flow context"
+            )
+
+
+class TestPrefectDbtRunnerEvents:
+    def test_events_callback_node_finished(self, mock_dbt_runner, settings):
+        """Test that the events callback correctly handles NodeFinished events."""
+        runner = PrefectDbtRunner(settings=settings)
+        runner.manifest = Mock()
+        runner.manifest.metadata.adapter_type = "postgres"
+
+        # Create a mock node in the manifest
+        node = Mock(spec=ManifestNode)
+        node.unique_id = "model.test.example"
+        node.name = "example"
+        node.relation_name = '"schema"."example_table"'
+        node.depends_on_nodes = ["model.test.upstream"]
+        node.config = Mock()
+        node.config.meta = {
+            "prefect": {
+                "upstream_resources": [
+                    {
+                        "id": "s3://bucket/path",
+                        "role": "source",
+                        "name": "upstream_s3_table",
+                    },
+                ]
+            }
+        }
+        node.resource_type = NodeType.Model
+        runner.manifest.nodes = {"model.test.example": node}
+
+        # Create a mock upstream node
+        upstream_node = Mock()
+        upstream_node.name = "upstream"
+        upstream_node.unique_id = "model.test.upstream"
+        upstream_node.relation_name = '"schema"."upstream_table"'
+        upstream_node.config = Mock()
+        upstream_node.config.meta = {}
+        upstream_node.resource_type = NodeType.Model
+        runner.manifest.nodes["model.test.upstream"] = upstream_node
+
+        # Add debug prints
+        print("\nDebug - Upstream node attributes:")
+        print(f"name: {upstream_node.name}")
+        print(f"unique_id: {upstream_node.unique_id}")
+
+        # Create a mock NodeFinished event
+        event = Mock()
+        event.info.name = "NodeFinished"
+        event.data.node_info.unique_id = "model.test.example"
+
+        # Create mock related resources from context
+        related_context = [
+            RelatedResource(
+                root={
+                    "prefect.resource.id": "flow/123",
+                    "prefect.resource.role": "flow",
+                    "prefect.resource.name": "test-flow",
+                }
+            )
+        ]
+
+        callback = runner._create_events_callback(related_context)
+
+        with (
+            patch("prefect_dbt.core.runner.MessageToDict") as mock_to_dict,
+            patch("prefect_dbt.core.runner.emit_event") as mock_emit,
+            patch(
+                "prefect_dbt.core.runner.emit_external_resource_lineage"
+            ) as mock_emit_lineage,
+        ):
+            # Mock the event data dictionary
+            mock_to_dict.return_value = {
+                "node_info": {
+                    "unique_id": "model.test.example",
+                    "node_status": "success",
+                }
+            }
+
+            # Call the callback
+            callback(event)
+
+            # Add debug print for lineage call
+            lineage_call = mock_emit_lineage.call_args
+            print("\nDebug - Upstream resources in lineage call:")
+            print(lineage_call.kwargs["upstream_resources"])
+
+            # Verify node event was emitted
+            assert mock_emit.call_count == 1
+            node_event_call = mock_emit.call_args_list[0]
+            assert node_event_call.kwargs["event"] == "dbt Node Finished"
+            assert node_event_call.kwargs["resource"] == {
+                "prefect.resource.id": "dbt.model.test.example",
+                "prefect.resource.name": "example",
+                "dbt.node.status": "success",
+            }
+            assert any(
+                r["prefect.resource.id"] == "flow/123"
+                for r in node_event_call.kwargs["related"]
+            )
+
+            # Verify lineage was emitted
+            assert mock_emit_lineage.call_count == 1
+            lineage_call = mock_emit_lineage.call_args
+
+            # Check context resources
+            assert lineage_call.kwargs["context_resources"] == related_context
+
+            # Check upstream resources
+            upstream_resources = lineage_call.kwargs["upstream_resources"]
+            assert len(upstream_resources) == 2  # One from depends_on, one from meta
+            # assert {
+            #     "prefect.resource.id": "postgres://schema/upstream_table",
+            #     "prefect.resource.lineage-group": "global",
+            #     "prefect.resource.role": NodeType.Model,
+            #     "prefect.resource.name": "upstream"
+            # } in upstream_resources
+            assert {
+                "prefect.resource.id": "s3://bucket/path",
+                "prefect.resource.lineage-group": "global",
+                "prefect.resource.role": "source",
+                "prefect.resource.name": "upstream_s3_table",
+            } in upstream_resources
+
+            # Check downstream resource
+            assert lineage_call.kwargs["downstream_resources"] == [
+                {
+                    "prefect.resource.id": "postgres://schema/example_table",
+                    "prefect.resource.lineage-group": "global",
+                    "prefect.resource.role": NodeType.Model,
+                    "prefect.resource.name": "example",
+                }
+            ]
+
+    def test_events_callback_with_emit_events_false(self, mock_dbt_runner, settings):
+        runner = PrefectDbtRunner(settings=settings)
+        runner.manifest = Mock()
+        runner.manifest.metadata.adapter_type = "postgres"
+
+        node = Mock()
+        node.relation_name = '"schema"."table"'
+        node.depends_on_nodes = []
+        node.config.meta = {"prefect": {"emit_events": False}}
+        node.resource_type = NodeType.Model
+        runner.manifest.nodes = {"model.test.example": node}
+
+        event = Mock()
+        event.info.name = "NodeFinished"
+        event.data.node_info.unique_id = "model.test.example"
+
+        callback = runner._create_events_callback([])
+
+        with (
+            patch("prefect_dbt.core.runner.MessageToDict") as mock_to_dict,
+            patch("prefect_dbt.core.runner.emit_event") as mock_emit,
+        ):
+            mock_to_dict.return_value = {
+                "node_info": {
+                    "unique_id": "model.test.example",
+                    "node_status": "success",
+                }
+            }
+
+            callback(event)
+            mock_emit.assert_not_called()
+
+    def test_events_callback_with_emit_node_events_false(
+        self, mock_dbt_runner, settings
+    ):
+        """Test that when emit_node_events is False, only lineage events are emitted."""
+        runner = PrefectDbtRunner(settings=settings)
+        runner.manifest = Mock()
+        runner.manifest.metadata.adapter_type = "postgres"
+
+        # Create a mock node in the manifest
+        node = Mock()
+        node.unique_id = "model.test.example"
+        node.name = "example"
+        node.relation_name = '"schema"."example_table"'
+        node.depends_on_nodes = []
+        node.config.meta = {"prefect": {"emit_node_events": False}}
+        node.resource_type = NodeType.Model
+        runner.manifest.nodes = {"model.test.example": node}
+
+        # Create a mock NodeFinished event
+        event = Mock()
+        event.info.name = "NodeFinished"
+        event.data.node_info.unique_id = "model.test.example"
+
+        # Create mock related resources from context
+        related_context = [
+            RelatedResource(
+                root={
+                    "prefect.resource.id": "flow/123",
+                    "prefect.resource.role": "flow",
+                    "prefect.resource.name": "test-flow",
+                }
+            )
+        ]
+
+        callback = runner._create_events_callback(related_context)
+
+        with (
+            patch("prefect_dbt.core.runner.MessageToDict") as mock_to_dict,
+            patch("prefect_dbt.core.runner.emit_event") as mock_emit,
+            patch(
+                "prefect_dbt.core.runner.emit_external_resource_lineage"
+            ) as mock_emit_lineage,
+        ):
+            # Mock the event data dictionary
+            mock_to_dict.return_value = {
+                "node_info": {
+                    "unique_id": "model.test.example",
+                    "node_status": "success",
+                }
+            }
+
+            # Call the callback
+            callback(event)
+
+            # Verify node event was not emitted
+            mock_emit.assert_not_called()
+
+            # Verify lineage was still emitted
+            assert mock_emit_lineage.call_count == 1
+            lineage_call = mock_emit_lineage.call_args
+
+            # Check context resources
+            assert lineage_call.kwargs["context_resources"] == related_context
+
+            # Check downstream resource
+            assert lineage_call.kwargs["downstream_resources"] == [
+                {
+                    "prefect.resource.id": "postgres://schema/example_table",
+                    "prefect.resource.lineage-group": "global",
+                    "prefect.resource.role": NodeType.Model,
+                    "prefect.resource.name": "example",
+                }
+            ]
+
+    def test_events_callback_with_emit_lineage_events_false(
+        self, mock_dbt_runner, settings
+    ):
+        runner = PrefectDbtRunner(settings=settings)
+        runner.manifest = Mock()
+        runner.manifest.metadata.adapter_type = "postgres"
+
+        node = Mock()
+        node.relation_name = '"schema"."table"'
+        node.depends_on_nodes = []
+        node.config.meta = {"prefect": {"emit_lineage_events": False}}
+        node.resource_type = NodeType.Model
+        runner.manifest.nodes = {"model.test.example": node}
+
+        event = Mock()
+        event.info.name = "NodeFinished"
+        event.data.node_info.unique_id = "model.test.example"
+
+        callback = runner._create_events_callback([])
+
+        with (
+            patch("prefect_dbt.core.runner.MessageToDict") as mock_to_dict,
+            patch("prefect_dbt.core.runner.emit_event") as mock_emit,
+        ):
+            mock_to_dict.return_value = {
+                "node_info": {
+                    "unique_id": "model.test.example",
+                    "node_status": "success",
+                }
+            }
+
+            callback(event)
+            assert mock_emit.call_count == 1  # Only node event should be emitted
+            assert mock_emit.call_args.kwargs["event"] == "dbt Node Finished"
+
+    def test_events_callback_with_all_events_disabled(self, mock_dbt_runner, settings):
+        runner = PrefectDbtRunner(settings=settings)
+        runner.manifest = Mock()
+        runner.manifest.metadata.adapter_type = "postgres"
+
+        node = Mock()
+        node.relation_name = '"schema"."table"'
+        node.depends_on_nodes = []
+        node.config.meta = {
+            "prefect": {
+                "emit_events": True,
+                "emit_node_events": False,
+                "emit_lineage_events": False,
+            }
+        }
+        node.resource_type = NodeType.Model
+        runner.manifest.nodes = {"model.test.example": node}
+
+        event = Mock()
+        event.info.name = "NodeFinished"
+        event.data.node_info.unique_id = "model.test.example"
+
+        callback = runner._create_events_callback([])
+
+        with (
+            patch("prefect_dbt.core.runner.MessageToDict") as mock_to_dict,
+            patch("prefect_dbt.core.runner.emit_event") as mock_emit,
+        ):
+            mock_to_dict.return_value = {
+                "node_info": {
+                    "unique_id": "model.test.example",
+                    "node_status": "success",
+                }
+            }
+
+            callback(event)
+            mock_emit.assert_not_called()
+
+
+class TestPrefectDbtRunnerLineage:
+    @pytest.mark.parametrize("provide_manifest", [True, False])
+    def test_emit_lineage_events(
+        self, mock_dbt_runner, settings, mock_manifest_with_nodes, provide_manifest
+    ):
+        """Test that lineage events are emitted correctly for all relevant nodes."""
+        runner = PrefectDbtRunner(
+            settings=settings,
+            manifest=mock_manifest_with_nodes if provide_manifest else None,
+        )
+
+        if not provide_manifest:
+            # Setup the mock to return our manifest when parse() is called
+            mock_dbt_runner.invoke.return_value.result = mock_manifest_with_nodes
+
+        @flow(flow_run_name="test-flow-name")
+        def test_flow():
+            with patch(
+                "prefect_dbt.core.runner.emit_external_resource_lineage"
+            ) as mock_emit_lineage:
+                runner.emit_lineage_events()
+
+                # Should emit lineage for model and seed, but not test or exposure
+                assert mock_emit_lineage.call_count == 2
+
+                # Get all downstream resources that were emitted
+                downstream_resources = [
+                    call.kwargs["downstream_resources"][0]["prefect.resource.id"]
+                    for call in mock_emit_lineage.call_args_list
+                ]
+
+                # Verify correct resources were emitted
+                assert "postgres://schema/model_table" in downstream_resources
+                assert "postgres://schema/seed_table" in downstream_resources
+                assert "postgres://schema/test_table" not in downstream_resources
+                assert "postgres://schema/exposure_table" not in downstream_resources
+
+                # Verify the structure of one of the lineage calls
+                model_call = next(
+                    call
+                    for call in mock_emit_lineage.call_args_list
+                    if call.kwargs["downstream_resources"][0]["prefect.resource.id"]
+                    == "postgres://schema/model_table"
+                )
+                assert model_call.kwargs["downstream_resources"][0] == {
+                    "prefect.resource.id": "postgres://schema/model_table",
+                    "prefect.resource.lineage-group": "global",
+                    "prefect.resource.role": NodeType.Model,
+                    "prefect.resource.name": "model",
+                }
+
+        test_flow()
+
+        # Verify parse was called only when manifest wasn't provided
+        assert mock_dbt_runner.invoke.called == (not provide_manifest)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("provide_manifest", [True, False])
+    async def test_aemit_lineage_events(
+        self, mock_dbt_runner, settings, mock_manifest_with_nodes, provide_manifest
+    ):
+        """Test that lineage events are emitted correctly for all relevant nodes (async version)."""
+        runner = PrefectDbtRunner(
+            settings=settings,
+            manifest=mock_manifest_with_nodes if provide_manifest else None,
+        )
+
+        if not provide_manifest:
+            # Setup the mock to return our manifest when parse() is called
+            mock_dbt_runner.invoke.return_value.result = mock_manifest_with_nodes
+
+        @flow(flow_run_name="test-flow-name")
+        async def test_flow():
+            with patch(
+                "prefect_dbt.core.runner.emit_external_resource_lineage"
+            ) as mock_emit_lineage:
+                await runner.aemit_lineage_events()
+
+                # Should emit lineage for model and seed, but not test or exposure
+                assert mock_emit_lineage.call_count == 2
+
+                # Get all downstream resources that were emitted
+                downstream_resources = [
+                    call.kwargs["downstream_resources"][0]["prefect.resource.id"]
+                    for call in mock_emit_lineage.call_args_list
+                ]
+
+                # Verify correct resources were emitted
+                assert "postgres://schema/model_table" in downstream_resources
+                assert "postgres://schema/seed_table" in downstream_resources
+                assert "postgres://schema/test_table" not in downstream_resources
+                assert "postgres://schema/exposure_table" not in downstream_resources
+
+                # Verify the structure of one of the lineage calls
+                model_call = next(
+                    call
+                    for call in mock_emit_lineage.call_args_list
+                    if call.kwargs["downstream_resources"][0]["prefect.resource.id"]
+                    == "postgres://schema/model_table"
+                )
+                assert model_call.kwargs["downstream_resources"][0] == {
+                    "prefect.resource.id": "postgres://schema/model_table",
+                    "prefect.resource.lineage-group": "global",
+                    "prefect.resource.role": NodeType.Model,
+                    "prefect.resource.name": "model",
+                }
+
+        await test_flow()
+
+        # Verify parse was called only when manifest wasn't provided
+        assert mock_dbt_runner.invoke.called == (not provide_manifest)

--- a/src/integrations/prefect-dbt/tests/dbt_configs/profiles.yml
+++ b/src/integrations/prefect-dbt/tests/dbt_configs/profiles.yml
@@ -1,0 +1,13 @@
+test:
+  outputs:
+    dev:
+      type: duckdb
+      path: dev.duckdb
+      threads: 1
+
+    prod:
+      type: duckdb
+      path: prod.duckdb
+      threads: 4
+
+  target: dev

--- a/src/integrations/prefect-dbt/tests/test_imports.py
+++ b/src/integrations/prefect-dbt/tests/test_imports.py
@@ -1,0 +1,68 @@
+import pytest
+from prefect_dbt import (
+    DbtCloudCredentials,
+    DbtCloudJob,
+    PrefectDbtSettings,
+)
+
+
+def test_direct_imports():
+    """Test that directly imported objects are available."""
+    assert PrefectDbtSettings is not None
+    assert DbtCloudCredentials is not None
+    assert DbtCloudJob is not None
+
+
+def test_lazy_import_dbt_cli_profile():
+    """Test that DbtCliProfile can be lazily imported."""
+    from prefect_dbt import DbtCliProfile
+
+    assert DbtCliProfile is not None
+
+
+def test_lazy_import_global_configs():
+    """Test that GlobalConfigs can be lazily imported."""
+    from prefect_dbt import GlobalConfigs
+
+    assert GlobalConfigs is not None
+
+
+def test_lazy_import_target_configs():
+    """Test that TargetConfigs can be lazily imported."""
+    from prefect_dbt import TargetConfigs
+
+    assert TargetConfigs is not None
+
+
+def test_lazy_import_database_configs():
+    """Test that database-specific configs can be lazily imported."""
+    from prefect_dbt import (
+        BigQueryTargetConfigs,
+        PostgresTargetConfigs,
+        SnowflakeTargetConfigs,
+    )
+
+    assert PostgresTargetConfigs is not None
+    assert BigQueryTargetConfigs is not None
+    assert SnowflakeTargetConfigs is not None
+
+
+def test_invalid_attribute():
+    """Test that accessing an invalid attribute raises ImportError."""
+    with pytest.raises(ImportError) as exc_info:
+        pass
+
+    assert "cannot import name 'NonExistentAttribute' from 'prefect_dbt" in str(
+        exc_info.value
+    )
+
+
+def test_all_exports():
+    """Test that __all__ contains expected exports."""
+    import prefect_dbt
+
+    assert hasattr(prefect_dbt, "__version__")
+    assert hasattr(prefect_dbt, "PrefectDbtSettings")
+    assert hasattr(prefect_dbt, "PrefectDbtRunner")
+    assert hasattr(prefect_dbt, "DbtCloudCredentials")
+    assert hasattr(prefect_dbt, "DbtCloudJob")

--- a/src/integrations/prefect-dbt/tests/test_imports.py
+++ b/src/integrations/prefect-dbt/tests/test_imports.py
@@ -48,11 +48,11 @@ def test_lazy_import_database_configs():
 
 
 def test_invalid_attribute():
-    """Test that accessing an invalid attribute raises AttributeError."""
-    with pytest.raises(AttributeError) as exc_info:
+    """Test that accessing an invalid attribute raises ImportError."""
+    with pytest.raises(ImportError) as exc_info:
         from prefect_dbt import NonExistentAttribute  # noqa: F401
 
-    assert "module 'prefect_dbt' has no attribute 'NonExistentAttribute'" in str(
+    assert "cannot import name 'NonExistentAttribute' from 'prefect_dbt'" in str(
         exc_info.value
     )
 

--- a/src/integrations/prefect-dbt/tests/test_imports.py
+++ b/src/integrations/prefect-dbt/tests/test_imports.py
@@ -48,11 +48,11 @@ def test_lazy_import_database_configs():
 
 
 def test_invalid_attribute():
-    """Test that accessing an invalid attribute raises ImportError."""
-    with pytest.raises(ImportError) as exc_info:
+    """Test that accessing an invalid attribute raises AttributeError."""
+    with pytest.raises(AttributeError) as exc_info:
         pass
 
-    assert "cannot import name 'NonExistentAttribute' from 'prefect_dbt" in str(
+    assert "module 'prefect_dbt' has no attribute 'NonExistentAttribute'" in str(
         exc_info.value
     )
 

--- a/src/integrations/prefect-dbt/tests/test_imports.py
+++ b/src/integrations/prefect-dbt/tests/test_imports.py
@@ -50,7 +50,7 @@ def test_lazy_import_database_configs():
 def test_invalid_attribute():
     """Test that accessing an invalid attribute raises AttributeError."""
     with pytest.raises(AttributeError) as exc_info:
-        pass
+        from prefect_dbt import NonExistentAttribute  # noqa: F401
 
     assert "module 'prefect_dbt' has no attribute 'NonExistentAttribute'" in str(
         exc_info.value


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
This is a new primary interface for dbt Core.

Example usage:
```python
from prefect import flow
from prefect_dbt import PrefectDbtRunner, PrefectDbtSettings


@flow
def run_dbt():
    runner = PrefectDbtRunner(
        settings=PrefectDbtSettings(project_dir="test", profiles_dir="examples/run_dbt")
    )
    runner.invoke(["run"])


if __name__ == "__main__":
    run_dbt()
```

As this will be replacing the functionality of everything in `prefect_dbt.cli`, any imports from that path will raise the following warning:

```
"prefect_dbt.cli is deprecated and will be removed in a future release. Please use prefect_dbt.core instead."
```

## Improved

### Logging

The [previous implementation](https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py#L178) assumed the presence of a Prefect run logger, ignored debug logs, and treated all other log levels as `INFO`.

The `PrefectDbtRunner` translates all log levels from dbt to standard Python logging levels, and logs exclusively to a Prefect run logger or directly to the terminal depending on the context in which it was invoked.


### Failure handling

In the [previous implementation](https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-dbt/prefect_dbt/cli/commands.py#L214), a failed dbt run was handled by returning a `Failed` state with the dbt exception in the state message. However, exceptions from `RunResult`s in dbt are primarily an indication of failure, whereas the `RunExecutionResult` contains more detailed messages about status and failure reason. 

The `PrefectDbtRunner` raises an exception when a dbt run fails, including a standardized message with detailed failure information. It also offers `raise_on_failure`, which controls whether that exception is raised when a dbt run fails, since a failing test does not always constitute a failing project as a whole.

## New

### `PrefectDbtSettings`

Added in #16834

Using Pydantic's `BaseSettings`, this class automatically detects a common set of `DBT_`-prefixed env vars upon instantiation. Creating a `PrefectDbtRunner` without passing in a `PrefectDbtSettings` instance will construct one by default, detecting dbt config from the environment.

### `profiles.yaml` Templating

Added in #16889

When invoking dbt commands through the `PrefectDbtRunner`, templated references to Prefect blocks and Prefect variables in your workspace will be resolved at runtime. This enables users to include their `profiles.yaml` in their dbt project repositories without having to worry about exposing secrets, and allows mapping of dbt target configs to workspaces.

For example, a dbt project executed with the `PrefectDbtRunner` could target a staging database when run in a staging workspace, and a production database when run in a production workspace, without having to deal with managing env vars or other execution environment-specific management by setting a `dbt_target` Prefect variable to `"stg"` in their staging workspace and `"prod"` in their production workspace.

```yaml
test:
  outputs:
    stg:
      type: duckdb
      path: dev.duckdb
      threads: 1

    prod:
      type: duckdb
      path: prod.duckdb
      threads: 4
      password: "{{ prefect.blocks.secret.my-password }}"

  target: "{{ prefect.variables.dbt_target }}"
  ```

### Events

A Prefect event is emitted each time a `Node Finished` event occurs in dbt. The emitted event contains a `dbt.node.status` field on its primary resource, recording the final state of the node's execution. This enables `prefect-dbt` users to create automations that fire conditionally on the state of individual nodes in their dbt DAGs, kicking off downstream jobs after particular table updates or alerting on specific test failures.

`Node Finished` event emission can be disabled for a resource in your dbt project by setting
```yaml
prefect:
  emit_node_events: False
```
in your dbt resource's config.


### Lineage (Prefect Cloud only)

The `PrefectDbtRunner` will automatically emit events describing the lineage graph of your dbt DAG by default.

The dbt resource types that constitute Prefect lineage resources are limited to `NODE_TYPES_TO_EMIT_LINEAGE`, which currently includes models, seeds, and snapshots.

If invoked in a flow run, each node executed during the run will appear as a resource on the flow run page in Prefect Cloud. Clicking "View graph" on a resource will display a lineage graph with several degrees of upstream and downstream resources pre-populated.

A resource in your dbt project can be omitted from the lineage graph by setting
```yaml
prefect:
  emit_lineage_events: False
```
in your dbt resource's config.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
