### PR TITLE
Remove failure flag

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -179,22 +179,6 @@ jobs:
           --exclude-service docker \
           --durations 26 \
 
-      - name: Create and Upload failure flag
-        if: ${{ failure() }}
-        id: create_failure_flag
-        run: |
-          sanitized_name="${{ matrix.python-version }}-${{ matrix.database }}"
-          sanitized_name="${sanitized_name//:/-}"
-          echo "Failure in $sanitized_name" > "${sanitized_name}-failure.txt"
-          echo "artifact_name=${sanitized_name}-failure" >> $GITHUB_OUTPUT
-
-      - name: Upload failure flag
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.create_failure_flag.outputs.artifact_name }}
-          path: "${{ steps.create_failure_flag.outputs.artifact_name }}.txt"
-
       - name: Check database container
         # Only applicable for Postgres, but we want this to run even when tests fail
         if: always()


### PR DESCRIPTION
I don't think this is being used anywhere and it is friction to getting to test failures because the artifact name creation is many-to-one.