### PR TITLE
Use nvm in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
         args:
           [
             "-c",
-            "cd ui-v2 && npm i --no-upgrade --silent --no-progress && npm run lint",
+            ". $NVM_DIR/nvm.sh && cd ui-v2 && nvm use && npm i --no-upgrade --silent --no-progress && npm run lint",
           ]
         files: |
           (?x)^(
@@ -89,7 +89,7 @@ repos:
         args:
           [
             "-c",
-            "cd ui-v2 && npm i --no-upgrade --silent --no-progress && npm run format",
+            ". $NVM_DIR/nvm.sh && cd ui-v2 && nvm use && npm i --no-upgrade --silent --no-progress && npm run format",
           ]
         files: |
           (?x)^(
@@ -104,7 +104,7 @@ repos:
         args:
           [
             "-c",
-            "cd ui-v2 && npm i --no-upgrade --silent --no-progress && npm run service-sync",
+            ". $NVM_DIR/nvm.sh && cd ui-v2 && nvm use && npm i --no-upgrade --silent --no-progress && npm run service-sync",
           ]
         files: |
           (?x)^(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
         args:
           [
             "-c",
-            ". $NVM_DIR/nvm.sh && cd ui-v2 && nvm use && npm i --no-upgrade --silent --no-progress && npm run lint",
+            ". $NVM_DIR/nvm.sh || true && cd ui-v2 && nvm use || true && npm i --no-upgrade --silent --no-progress && npm run lint",
           ]
         files: |
           (?x)^(
@@ -89,7 +89,7 @@ repos:
         args:
           [
             "-c",
-            ". $NVM_DIR/nvm.sh && cd ui-v2 && nvm use && npm i --no-upgrade --silent --no-progress && npm run format",
+            ". $NVM_DIR/nvm.sh || true && cd ui-v2 && nvm use || true && npm i --no-upgrade --silent --no-progress && npm run format",
           ]
         files: |
           (?x)^(
@@ -104,7 +104,7 @@ repos:
         args:
           [
             "-c",
-            ". $NVM_DIR/nvm.sh && cd ui-v2 && nvm use && npm i --no-upgrade --silent --no-progress && npm run service-sync",
+            ". $NVM_DIR/nvm.sh || true && cd ui-v2 && nvm use || true && npm i --no-upgrade --silent --no-progress && npm run service-sync",
           ]
         files: |
           (?x)^(


### PR DESCRIPTION
I routinely run into a situation where my UI pre-commit hooks fail, and in doing so they also update `package-lock.json`; this PR ensures that all UI-related pre-commit hooks use `nvm` which prevents this sort of thing from happening.