### PR TITLE
[UI v2] chore: Deprecates notifications route from react webapp

### DIFF
--- a/ui-v2/src/components/ui/app-sidebar.tsx
+++ b/ui-v2/src/components/ui/app-sidebar.tsx
@@ -128,15 +128,6 @@ export function AppSidebar() {
 							</Link>
 						</SidebarMenuItem>
 						<SidebarMenuItem>
-							<Link to="/notifications">
-								{({ isActive }) => (
-									<SidebarMenuButton asChild isActive={isActive}>
-										<span>Notifications</span>
-									</SidebarMenuButton>
-								)}
-							</Link>
-						</SidebarMenuItem>
-						<SidebarMenuItem>
 							<Link to="/concurrency-limits">
 								{({ isActive }) => (
 									<SidebarMenuButton asChild isActive={isActive}>

--- a/ui-v2/src/routeTree.gen.ts
+++ b/ui-v2/src/routeTree.gen.ts
@@ -13,7 +13,6 @@
 import { Route as rootRoute } from './routes/__root'
 import { Route as VariablesImport } from './routes/variables'
 import { Route as SettingsImport } from './routes/settings'
-import { Route as NotificationsImport } from './routes/notifications'
 import { Route as EventsImport } from './routes/events'
 import { Route as DashboardImport } from './routes/dashboard'
 import { Route as BlocksImport } from './routes/blocks'
@@ -50,12 +49,6 @@ const VariablesRoute = VariablesImport.update({
 const SettingsRoute = SettingsImport.update({
   id: '/settings',
   path: '/settings',
-  getParentRoute: () => rootRoute,
-} as any)
-
-const NotificationsRoute = NotificationsImport.update({
-  id: '/notifications',
-  path: '/notifications',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -237,13 +230,6 @@ declare module '@tanstack/react-router' {
       path: '/events'
       fullPath: '/events'
       preLoaderRoute: typeof EventsImport
-      parentRoute: typeof rootRoute
-    }
-    '/notifications': {
-      id: '/notifications'
-      path: '/notifications'
-      fullPath: '/notifications'
-      preLoaderRoute: typeof NotificationsImport
       parentRoute: typeof rootRoute
     }
     '/settings': {
@@ -454,7 +440,6 @@ export interface FileRoutesByFullPath {
   '/blocks': typeof BlocksRouteWithChildren
   '/dashboard': typeof DashboardRoute
   '/events': typeof EventsRoute
-  '/notifications': typeof NotificationsRoute
   '/settings': typeof SettingsRoute
   '/variables': typeof VariablesRoute
   '/automations/create': typeof AutomationsCreateRoute
@@ -483,7 +468,6 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/dashboard': typeof DashboardRoute
   '/events': typeof EventsRoute
-  '/notifications': typeof NotificationsRoute
   '/settings': typeof SettingsRoute
   '/variables': typeof VariablesRoute
   '/automations/create': typeof AutomationsCreateRoute
@@ -514,7 +498,6 @@ export interface FileRoutesById {
   '/blocks': typeof BlocksRouteWithChildren
   '/dashboard': typeof DashboardRoute
   '/events': typeof EventsRoute
-  '/notifications': typeof NotificationsRoute
   '/settings': typeof SettingsRoute
   '/variables': typeof VariablesRoute
   '/automations/create': typeof AutomationsCreateRoute
@@ -546,7 +529,6 @@ export interface FileRouteTypes {
     | '/blocks'
     | '/dashboard'
     | '/events'
-    | '/notifications'
     | '/settings'
     | '/variables'
     | '/automations/create'
@@ -574,7 +556,6 @@ export interface FileRouteTypes {
     | '/'
     | '/dashboard'
     | '/events'
-    | '/notifications'
     | '/settings'
     | '/variables'
     | '/automations/create'
@@ -603,7 +584,6 @@ export interface FileRouteTypes {
     | '/blocks'
     | '/dashboard'
     | '/events'
-    | '/notifications'
     | '/settings'
     | '/variables'
     | '/automations/create'
@@ -634,7 +614,6 @@ export interface RootRouteChildren {
   BlocksRoute: typeof BlocksRouteWithChildren
   DashboardRoute: typeof DashboardRoute
   EventsRoute: typeof EventsRoute
-  NotificationsRoute: typeof NotificationsRoute
   SettingsRoute: typeof SettingsRoute
   VariablesRoute: typeof VariablesRoute
   AutomationsCreateRoute: typeof AutomationsCreateRoute
@@ -659,7 +638,6 @@ const rootRouteChildren: RootRouteChildren = {
   BlocksRoute: BlocksRouteWithChildren,
   DashboardRoute: DashboardRoute,
   EventsRoute: EventsRoute,
-  NotificationsRoute: NotificationsRoute,
   SettingsRoute: SettingsRoute,
   VariablesRoute: VariablesRoute,
   AutomationsCreateRoute: AutomationsCreateRoute,
@@ -695,7 +673,6 @@ export const routeTree = rootRoute
         "/blocks",
         "/dashboard",
         "/events",
-        "/notifications",
         "/settings",
         "/variables",
         "/automations/create",
@@ -731,9 +708,6 @@ export const routeTree = rootRoute
     },
     "/events": {
       "filePath": "events.tsx"
-    },
-    "/notifications": {
-      "filePath": "notifications.tsx"
     },
     "/settings": {
       "filePath": "settings.tsx"

--- a/ui-v2/src/routes/notifications.tsx
+++ b/ui-v2/src/routes/notifications.tsx
@@ -1,9 +1,0 @@
-import { createFileRoute } from "@tanstack/react-router";
-
-export const Route = createFileRoute("/notifications")({
-	component: RouteComponent,
-});
-
-function RouteComponent() {
-	return "🚧🚧 Pardon our dust! 🚧🚧";
-}

--- a/ui-v2/tests/app.test.tsx
+++ b/ui-v2/tests/app.test.tsx
@@ -14,7 +14,6 @@ describe("Navigation tests", () => {
 		["/variables", "Variables"],
 		["/automations", "Automations"],
 		["/events", "Event Feed"],
-		["/notifications", "Notifications"],
 		["/concurrency-limits", "Concurrency"],
 		["/settings", "Settings"],
 	])("can navigate to %s", async (path, text) => {


### PR DESCRIPTION
`/notifications` is deprecated in favor for `/automations`.
Deprecating route from `ui-v2` efforts

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Relates to https://github.com/PrefectHQ/prefect/issues/15512
