### PR TITLE
Use retry logic of underlying prefect client properly

### DIFF
--- a/src/prefect/client/orchestration/_deployments/client.py
+++ b/src/prefect/client/orchestration/_deployments/client.py
@@ -320,6 +320,7 @@ class DeploymentClient(BaseClient):
         }
 
         response = self.request("POST", "/deployments/filter", json=body)
+        breakpoint()
         return DeploymentResponse.model_validate_list(response.json())
 
     def delete_deployment(

--- a/src/prefect/client/orchestration/_deployments/client.py
+++ b/src/prefect/client/orchestration/_deployments/client.py
@@ -320,7 +320,6 @@ class DeploymentClient(BaseClient):
         }
 
         response = self.request("POST", "/deployments/filter", json=body)
-        breakpoint()
         return DeploymentResponse.model_validate_list(response.json())
 
     def delete_deployment(

--- a/src/prefect/client/orchestration/base.py
+++ b/src/prefect/client/orchestration/base.py
@@ -29,7 +29,8 @@ class BaseClient:
     ) -> "Response":
         if path_params:
             path = path.format(**path_params)  # type: ignore
-        return self._client.request(method, path, params=params, **kwargs)
+        request = self._client.build_request(method, path, params=params, **kwargs)
+        return self._client.send(request)
 
 
 class BaseAsyncClient:
@@ -48,4 +49,5 @@ class BaseAsyncClient:
     ) -> "Response":
         if path_params:
             path = path.format(**path_params)  # type: ignore
-        return await self._client.request(method, path, params=params, **kwargs)
+        request = self._client.build_request(method, path, params=params, **kwargs)
+        return await self._client.send(request)


### PR DESCRIPTION
I noticed that our clients no longer use [the dedicated `send(...)` methods](https://github.com/PrefectHQ/prefect/blob/main/src/prefect/client/base.py#L529) that we built to help with flaky API performance. This PR re-engages that logic. 

[As stated in the `httpx` docs](https://www.python-httpx.org/api/), calling `client.request` is

> Equivalent to:
> 
> ```
> request = client.build_request(...)
> response = client.send(request, ...)
> ```

This also resolves an undetected bug in which `PREFECT_CLIENT_RETRY_EXTRA_CODES` was not being used.