### PR TITLE
chore: Add additional `reference` redirects

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -742,19 +742,19 @@
   ],
   "redirects": [
     {
-      "destination": "https://reference.prefect.io",
+      "destination": "/v3/api-ref/index",
       "source": "/reference"
     },
     {
-      "destination": "https://reference.prefect.io/:slug*",
+      "destination": "/v3/api-ref/index/:slug*",
       "source": "/reference/:slug*"
     },
     {
-      "destination": "https://reference.prefect.io",
+      "destination": "/v3/api-ref/index",
       "source": "/v3/reference"
     },
     {
-      "destination": "https://reference.prefect.io/:slug*",
+      "destination": "/v3/api-ref/index/:slug*",
       "source": "/v3/reference/:slug*"
     },
     {
@@ -818,11 +818,11 @@
       "source": "/v3/manage/settings-and-profiles"
     },
     {
-      "destination": "https://reference.prefect.io",
+      "destination": "/v3/api-ref/index",
       "source": "/latest/reference"
     },
     {
-      "destination": "https://reference.prefect.io/:slug*",
+      "destination": "/v3/api-ref/index/:slug*",
       "source": "/latest/reference/:slug*"
     },
     {

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -750,6 +750,14 @@
       "destination": "https://reference.prefect.io/:slug*"
     },
     {
+      "source": "v3/reference",
+      "destination": "https://reference.prefect.io"
+    },
+    {
+      "source": "v3/reference/:slug*",
+      "destination": "https://reference.prefect.io/:slug*"
+    },
+    {
       "destination": "/v3/getting-started/:slug*",
       "source": "/getting-started/:slug*"
     },

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -742,20 +742,20 @@
   ],
   "redirects": [
     {
-      "source": "/reference",
-      "destination": "https://reference.prefect.io"
+      "destination": "https://reference.prefect.io",
+      "source": "/reference"
     },
     {
-      "source": "/reference/:slug*",
-      "destination": "https://reference.prefect.io/:slug*"
+      "destination": "https://reference.prefect.io/:slug*",
+      "source": "/reference/:slug*"
     },
     {
-      "source": "v3/reference",
-      "destination": "https://reference.prefect.io"
+      "destination": "https://reference.prefect.io",
+      "source": "/v3/reference"
     },
     {
-      "source": "v3/reference/:slug*",
-      "destination": "https://reference.prefect.io/:slug*"
+      "destination": "https://reference.prefect.io/:slug*",
+      "source": "/v3/reference/:slug*"
     },
     {
       "destination": "/v3/getting-started/:slug*",
@@ -816,6 +816,14 @@
     {
       "destination": "/v3/develop/settings-and-profiles",
       "source": "/v3/manage/settings-and-profiles"
+    },
+    {
+      "destination": "https://reference.prefect.io",
+      "source": "/latest/reference"
+    },
+    {
+      "destination": "https://reference.prefect.io/:slug*",
+      "source": "/latest/reference/:slug*"
     },
     {
       "destination": "/v3",

--- a/docs/v3/api-ref/index.mdx
+++ b/docs/v3/api-ref/index.mdx
@@ -6,7 +6,7 @@ description: Explore Prefect's auto-generated API & SDK reference documentation.
 
 Prefect auto-generates reference documentation for the following components:
 
-- **[Prefect Python SDK](https://prefect-python-sdk-docs.netlify.app/)**: used to build, test, and execute workflows.
+- **[Prefect Python SDK](https://reference.prefect.io)**: used to build, test, and execute workflows.
 - **[Prefect REST API](/v3/api-ref/rest-api)**: used by workflow clients and the Prefect UI for orchestration and data retrieval.
   - Prefect Cloud REST API documentation: <a href="https://app.prefect.cloud/api/docs" target="_blank">https://app.prefect.cloud/api/docs</a>.
   - Self-hosted Prefect server [REST API documentation](/v3/api-ref/rest-api/server/). Additionally, if self-hosting a Prefect server instance, you can access REST API documentation at the `/docs` endpoint of your [`PREFECT_API_URL`](/v3/develop/settings-and-profiles/). For example, if you run `prefect server start` with no additional configuration you can find this reference at <a href="http://localhost:4200/docs" target="_blank">http://localhost:4200/docs</a>.


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
This PR adds additional valid redirects to the docs including `/latest/reference` and `/v3/reference`.  These should capture all available valid paths that someone may hit for v3 docs.  We are now redirecting these requests to the `/api-ref` endpoint rather than reference.prefect.io.
I have also updated the `Prefect Python SDK` linkout to use a valid prefect domain of reference.prefect.io
Closes: PLA-958

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
