### PR TITLE
[UI v2] feat: Adds npm script to check only typescript types

### DIFF
--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -14,7 +14,8 @@
 		"preview": "vite preview",
 		"service-sync": "uv run --with-editable ../. ../scripts/generate_oss_openapi_schema.py && npx openapi-typescript oss_schema.json -o src/api/prefect.ts && rm oss_schema.json",
 		"storybook": "storybook dev -p 6006",
-		"build-storybook": "storybook build"
+		"build-storybook": "storybook build",
+		"validate:types": "tsc -b --noEmit"
 	},
 	"dependencies": {
 		"@codemirror/lang-json": "^6.0.1",


### PR DESCRIPTION
Adds npm script `validate:types` (same script name from `/ui`) to only validate typescript.

We currently don't have an npm script that does it. We _do_ have `npm run build` which does type checking **and** builds the app.

Adding this command, because before pushing and opening a PR, I would like to validate types on my client. My IDE doesn't always catch all errors

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Relates to https://github.com/PrefectHQ/prefect/issues/15512
