### PR TITLE
[UI v2] feat: Moves delete deployment confirmation dialog logic to a re-usable hook

### DIFF
--- a/ui-v2/src/components/deployments/data-table/index.tsx
+++ b/ui-v2/src/components/deployments/data-table/index.tsx
@@ -1,13 +1,8 @@
-import {
-	type DeploymentWithFlow,
-	useDeleteDeployment,
-} from "@/api/deployments";
+import { type DeploymentWithFlow } from "@/api/deployments";
 import type { components } from "@/api/prefect";
+import { useDeleteDeploymentConfirmationDialog } from "@/components/deployments/use-delete-deployment-confirmation-dialog";
 import { DataTable } from "@/components/ui/data-table";
-import {
-	DeleteConfirmationDialog,
-	useDeleteConfirmationDialog,
-} from "@/components/ui/delete-confirmation-dialog";
+import { DeleteConfirmationDialog } from "@/components/ui/delete-confirmation-dialog";
 import { FlowRunActivityBarGraphTooltipProvider } from "@/components/ui/flow-run-activity-bar-graph";
 import { Icon } from "@/components/ui/icons";
 import { SearchInput } from "@/components/ui/input";
@@ -22,7 +17,6 @@ import {
 import { StatusBadge } from "@/components/ui/status-badge";
 import { TagBadgeGroup } from "@/components/ui/tag-badge-group";
 import { TagsInput } from "@/components/ui/tags-input";
-import { useToast } from "@/hooks/use-toast";
 import { pluralize } from "@/utils";
 import { Link } from "@tanstack/react-router";
 import type {
@@ -167,9 +161,7 @@ export const DeploymentsDataTable = ({
 	onDuplicate,
 }: DeploymentsDataTableProps) => {
 	const [deleteConfirmationDialogState, confirmDelete] =
-		useDeleteConfirmationDialog();
-	const { deleteDeployment } = useDeleteDeployment();
-	const { toast } = useToast();
+		useDeleteDeploymentConfirmationDialog();
 
 	const nameSearchValue = (columnFilters.find(
 		(filter) => filter.id === "flowOrDeploymentName",
@@ -224,19 +216,7 @@ export const DeploymentsDataTable = ({
 				const name = deployment.flow?.name
 					? `${deployment.flow?.name}/${deployment.name}`
 					: deployment.name;
-				confirmDelete({
-					title: "Delete Deployment",
-					description: `Are you sure you want to delete ${name}? This action cannot be undone.`,
-					onConfirm: () => {
-						deleteDeployment(deployment.id, {
-							onSuccess: () => {
-								toast({
-									title: "Deployment deleted",
-								});
-							},
-						});
-					},
-				});
+				confirmDelete({ ...deployment, name });
 			},
 			onDuplicate,
 		}),

--- a/ui-v2/src/components/deployments/use-delete-deployment-confirmation-dialog.ts
+++ b/ui-v2/src/components/deployments/use-delete-deployment-confirmation-dialog.ts
@@ -1,0 +1,45 @@
+import { Deployment, useDeleteDeployment } from "@/api/deployments";
+import { useDeleteConfirmationDialog } from "@/components/ui/delete-confirmation-dialog";
+import { useToast } from "@/hooks/use-toast";
+import { getRouteApi } from "@tanstack/react-router";
+
+const routeApi = getRouteApi("/deployments/");
+
+export const useDeleteDeploymentConfirmationDialog = () => {
+	const navigate = routeApi.useNavigate();
+	const { toast } = useToast();
+	const [dialogState, confirmDelete] = useDeleteConfirmationDialog();
+
+	const { deleteDeployment } = useDeleteDeployment();
+
+	const handleConfirmDelete = (
+		deployment: Deployment,
+		{
+			shouldNavigate = false,
+		}: {
+			/** Should navigate back to /deployments */
+			shouldNavigate?: boolean;
+		} = {},
+	) =>
+		confirmDelete({
+			title: "Delete Deployment",
+			description: `Are you sure you want to delete ${deployment.name}? This action cannot be undone.`,
+			onConfirm: () => {
+				deleteDeployment(deployment.id, {
+					onSuccess: () => {
+						toast({ title: "Deployment deleted" });
+						if (shouldNavigate) {
+							void navigate({ to: "/deployments" });
+						}
+					},
+					onError: (error) => {
+						const message =
+							error.message || "Unknown error while deleting deployment.";
+						console.error(message);
+					},
+				});
+			},
+		});
+
+	return [dialogState, handleConfirmDelete] as const;
+};


### PR DESCRIPTION
Moves logic for deleting deployment confirmation dialog to a re-usable hook.
This re-usable hook will be used in the deployment details page for its own action menu.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Relates to https://github.com/PrefectHQ/prefect/issues/15512