### PR TITLE
Add slugs to schedules and populate created_by

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -16441,6 +16441,18 @@
                         "type": "object",
                         "title": "Parameters",
                         "description": "A dictionary of parameter value overrides."
+                    },
+                    "slug": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Slug",
+                        "description": "A unique slug for the schedule."
                     }
                 },
                 "type": "object",
@@ -16492,6 +16504,18 @@
                         "type": "object",
                         "title": "Parameters",
                         "description": "A dictionary of parameter value overrides."
+                    },
+                    "slug": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Slug",
+                        "description": "A unique slug for the schedule."
                     }
                 },
                 "additionalProperties": false,

--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -16574,6 +16574,18 @@
                         "type": "object",
                         "title": "Parameters",
                         "description": "A dictionary of parameter value overrides."
+                    },
+                    "slug": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Slug",
+                        "description": "A unique slug for the schedule."
                     }
                 },
                 "additionalProperties": false,

--- a/src/prefect/server/database/_migrations/versions/postgresql/2025_02_05_152418_a03d00b8e275_add_slug_column_to_deployment_schedule.py
+++ b/src/prefect/server/database/_migrations/versions/postgresql/2025_02_05_152418_a03d00b8e275_add_slug_column_to_deployment_schedule.py
@@ -1,0 +1,58 @@
+"""Add slug column to deployment_schedule
+
+Revision ID: a03d00b8e275
+Revises: c163acd7e8e3
+Create Date: 2025-02-05 15:24:18.360147
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import prefect
+
+
+# revision identifiers, used by Alembic.
+revision = 'a03d00b8e275'
+down_revision = 'c163acd7e8e3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.add_column(
+            "deployment_schedule",
+            sa.Column("slug", sa.String, nullable=True),
+        )
+
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_deployment_schedule__slug
+            ON deployment_schedule(slug)
+            """
+        )
+
+        op.execute(
+            """
+            CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
+            ix_deployment_schedule__deployment_id__slug
+            ON deployment_schedule(deployment_id, slug)
+            WHERE slug IS NOT NULL;
+            """
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            DROP INDEX CONCURRENTLY IF EXISTS ix_deployment_schedule__deployment_id__slug
+            """
+        )
+
+        op.execute(
+            """
+            DROP INDEX CONCURRENTLY IF EXISTS ix_deployment_schedule__slug
+            """
+        )
+
+        op.drop_column("deployment_schedule", "slug")

--- a/src/prefect/server/database/_migrations/versions/postgresql/2025_02_05_152418_a03d00b8e275_add_slug_column_to_deployment_schedule.py
+++ b/src/prefect/server/database/_migrations/versions/postgresql/2025_02_05_152418_a03d00b8e275_add_slug_column_to_deployment_schedule.py
@@ -5,14 +5,13 @@ Revises: c163acd7e8e3
 Create Date: 2025-02-05 15:24:18.360147
 
 """
-from alembic import op
-import sqlalchemy as sa
-import prefect
 
+import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = 'a03d00b8e275'
-down_revision = 'c163acd7e8e3'
+revision = "a03d00b8e275"
+down_revision = "c163acd7e8e3"
 branch_labels = None
 depends_on = None
 

--- a/src/prefect/server/database/_migrations/versions/sqlite/2025_02_05_152431_07ecde74d74d_add_slug_column_to_deployment_schedule.py
+++ b/src/prefect/server/database/_migrations/versions/sqlite/2025_02_05_152431_07ecde74d74d_add_slug_column_to_deployment_schedule.py
@@ -44,8 +44,6 @@ def upgrade():
 
 def downgrade():
     with op.batch_alter_table("deployment_schedule", schema=None) as batch_op:
-        batch_op.drop_index(
-            "ix_deployment_schedule__deployment_id__slug", if_exists=True
-        )
-        batch_op.drop_index("ix_deployment_schedule__slug", if_exists=True)
+        batch_op.drop_index("ix_deployment_schedule__deployment_id__slug")
+        batch_op.drop_index("ix_deployment_schedule__slug")
         batch_op.drop_column("slug")

--- a/src/prefect/server/database/_migrations/versions/sqlite/2025_02_05_152431_07ecde74d74d_add_slug_column_to_deployment_schedule.py
+++ b/src/prefect/server/database/_migrations/versions/sqlite/2025_02_05_152431_07ecde74d74d_add_slug_column_to_deployment_schedule.py
@@ -5,18 +5,15 @@ Revises: 67f886da208e
 Create Date: 2025-02-05 15:24:31.503016
 
 """
-from alembic import op
-import sqlalchemy as sa
-import prefect
 
+import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = '07ecde74d74d'
-down_revision = '67f886da208e'
+revision = "07ecde74d74d"
+down_revision = "67f886da208e"
 branch_labels = None
 depends_on = None
-
-
 
 
 def upgrade():

--- a/src/prefect/server/database/_migrations/versions/sqlite/2025_02_05_152431_07ecde74d74d_add_slug_column_to_deployment_schedule.py
+++ b/src/prefect/server/database/_migrations/versions/sqlite/2025_02_05_152431_07ecde74d74d_add_slug_column_to_deployment_schedule.py
@@ -1,0 +1,60 @@
+"""Add slug column to deployment_schedule
+
+Revision ID: 07ecde74d74d
+Revises: 67f886da208e
+Create Date: 2025-02-05 15:24:31.503016
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import prefect
+
+
+# revision identifiers, used by Alembic.
+revision = '07ecde74d74d'
+down_revision = '67f886da208e'
+branch_labels = None
+depends_on = None
+
+
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.add_column(
+            "deployment_schedule",
+            sa.Column("slug", sa.String, nullable=True),
+        )
+
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_deployment_schedule__slug
+            ON deployment_schedule(slug)
+            """
+        )
+
+        op.execute(
+            """
+            CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
+            ix_deployment_schedule__deployment_id__slug
+            ON deployment_schedule(deployment_id, slug)
+            WHERE slug IS NOT NULL;
+            """
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            DROP INDEX CONCURRENTLY IF EXISTS ix_deployment_schedule__deployment_id__slug
+            """
+        )
+
+        op.execute(
+            """
+            DROP INDEX CONCURRENTLY IF EXISTS ix_deployment_schedule__slug
+            """
+        )
+
+        op.drop_column("deployment_schedule", "slug")

--- a/src/prefect/server/database/_migrations/versions/sqlite/2025_02_05_152431_07ecde74d74d_add_slug_column_to_deployment_schedule.py
+++ b/src/prefect/server/database/_migrations/versions/sqlite/2025_02_05_152431_07ecde74d74d_add_slug_column_to_deployment_schedule.py
@@ -48,4 +48,4 @@ def downgrade():
             "ix_deployment_schedule__deployment_id__slug", if_exists=True
         )
         batch_op.drop_index("ix_deployment_schedule__slug", if_exists=True)
-        batch_op.drop_column("deployment_schedule", "slug")
+        batch_op.drop_column("slug")

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -787,7 +787,7 @@ class DeploymentSchedule(Base):
     parameters: Mapped[dict[str, Any]] = mapped_column(
         JSON, server_default="{}", default=dict, nullable=False
     )
-    slug: Mapped[str | None] = mapped_column(sa.String, nullable=True)
+    slug: Mapped[Optional[str]] = mapped_column(sa.String, nullable=True)
 
 
 class Deployment(Base):

--- a/src/prefect/server/database/orm_models.py
+++ b/src/prefect/server/database/orm_models.py
@@ -787,6 +787,7 @@ class DeploymentSchedule(Base):
     parameters: Mapped[dict[str, Any]] = mapped_column(
         JSON, server_default="{}", default=dict, nullable=False
     )
+    slug: Mapped[str | None] = mapped_column(sa.String, nullable=True)
 
 
 class Deployment(Base):

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -739,6 +739,12 @@ async def _generate_scheduled_flow_runs(
                     "state_name": "Scheduled",
                     "next_scheduled_start_time": date,
                     "expected_start_time": date,
+                    "created_by": {
+                        "id": deployment_schedule.id,
+                        "display_value": deployment_schedule.slug
+                        or deployment_schedule.schedule.__class__.__name__,
+                        "type": "SCHEDULE",
+                    },
                 }
             )
 

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -144,6 +144,10 @@ class DeploymentScheduleUpdate(ActionBaseModel):
     parameters: dict[str, Any] = Field(
         default_factory=dict, description="A dictionary of parameter value overrides."
     )
+    slug: Optional[str] = Field(
+        default=None,
+        description="A unique slug for the schedule.",
+    )
 
     @field_validator("max_scheduled_runs")
     @classmethod

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -114,6 +114,10 @@ class DeploymentScheduleCreate(ActionBaseModel):
     parameters: dict[str, Any] = Field(
         default_factory=dict, description="A dictionary of parameter value overrides."
     )
+    slug: Optional[str] = Field(
+        default=None,
+        description="A unique slug for the schedule.",
+    )
 
     @field_validator("max_scheduled_runs")
     @classmethod

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -560,6 +560,10 @@ class DeploymentSchedule(ORMBaseModel):
     parameters: dict[str, Any] = Field(
         default_factory=dict, description="A dictionary of parameter value overrides."
     )
+    slug: Optional[str] = Field(
+        default=None,
+        description="A unique slug for the schedule.",
+    )
 
     @field_validator("max_scheduled_runs")
     @classmethod

--- a/tests/server/database/test_migrations.py
+++ b/tests/server/database/test_migrations.py
@@ -690,10 +690,11 @@ async def test_migrate_variables_to_json(db):
     else:
         revisions = ("20fbd53b3cef", "2ac65f1758c2")
 
+    session = await db.session()
+
     try:
         await run_sync_in_worker_thread(alembic_downgrade, revision=revisions[0])
 
-        session = await db.session()
         async with session:
             # clear the variables table
             await session.execute(sa.text("DELETE FROM variable;"))

--- a/tests/server/orchestration/api/test_deployment_schedules.py
+++ b/tests/server/orchestration/api/test_deployment_schedules.py
@@ -259,9 +259,9 @@ class TestUpdateDeploymentSchedule:
         )
         response = await client.patch(
             url,
-            json=schemas.actions.DeploymentScheduleUpdate(active=False).model_dump(
-                exclude_unset=True
-            ),
+            json=schemas.actions.DeploymentScheduleUpdate(
+                active=False, slug="new-slug"
+            ).model_dump(exclude_unset=True),
         )
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
@@ -277,6 +277,7 @@ class TestUpdateDeploymentSchedule:
         )
 
         assert the_schedule.active is False
+        assert the_schedule.slug == "new-slug"
 
     async def test_404_non_existent_deployment(
         self,

--- a/tests/server/orchestration/api/test_deployment_schedules.py
+++ b/tests/server/orchestration/api/test_deployment_schedules.py
@@ -110,11 +110,13 @@ class TestCreateDeploymentSchedules:
                     schedule=schemas.schedules.IntervalSchedule(
                         interval=timedelta(days=1)
                     ),
+                    slug="test-schedule-1",
                 ).model_dump(mode="json"),
                 schemas.actions.DeploymentScheduleCreate(
                     schedule=schemas.schedules.IntervalSchedule(
                         interval=timedelta(days=2)
                     ),
+                    slug="test-schedule-2",
                 ).model_dump(mode="json"),
             ],
         )
@@ -128,6 +130,45 @@ class TestCreateDeploymentSchedules:
         )
         assert len(created) == 2
         assert {s.id for s in schedules} == {s.id for s in created}
+
+        # asserting on base response for the purposes of isolating server changes from client
+        schedule_slugs = {ds["slug"] for ds in response.json()}
+        assert schedule_slugs == {"test-schedule-1", "test-schedule-2"}
+
+    async def test_schedule_slug_must_be_unique_within_deployment(
+        self,
+        get_server_session: AsyncSessionGetter,
+        client: AsyncClient,
+        schedules_url: Callable[..., str],
+        deployment,
+    ):
+        async with get_server_session() as session:
+            await models.deployments.delete_schedules_for_deployment(
+                session=session, deployment_id=deployment.id
+            )
+            await session.commit()
+
+        url = schedules_url(deployment.id)
+
+        response = await client.post(
+            url,
+            json=[
+                schemas.actions.DeploymentScheduleCreate(
+                    schedule=schemas.schedules.IntervalSchedule(
+                        interval=timedelta(days=1)
+                    ),
+                    slug="test-schedule-1",
+                ).model_dump(mode="json"),
+                schemas.actions.DeploymentScheduleCreate(
+                    schedule=schemas.schedules.IntervalSchedule(
+                        interval=timedelta(days=2)
+                    ),
+                    slug="test-schedule-1",
+                ).model_dump(mode="json"),
+            ],
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
 
     async def test_404_non_existent_deployment(
         self,

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -5707,6 +5707,11 @@ export interface components {
              * @description A dictionary of parameter value overrides.
              */
             parameters?: Record<string, never>;
+            /**
+             * Slug
+             * @description A unique slug for the schedule.
+             */
+            slug?: string | null;
         };
         /**
          * DeploymentSort

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -5650,6 +5650,11 @@ export interface components {
              * @description A dictionary of parameter value overrides.
              */
             parameters?: Record<string, never>;
+            /**
+             * Slug
+             * @description A unique slug for the schedule.
+             */
+            slug?: string | null;
         };
         /** DeploymentScheduleCreate */
         DeploymentScheduleCreate: {
@@ -5674,6 +5679,11 @@ export interface components {
              * @description A dictionary of parameter value overrides.
              */
             parameters?: Record<string, never>;
+            /**
+             * Slug
+             * @description A unique slug for the schedule.
+             */
+            slug?: string | null;
         };
         /** DeploymentScheduleUpdate */
         DeploymentScheduleUpdate: {


### PR DESCRIPTION
This PR adds a new `slug` column to `deployment_schedules` that is a user-friendly, unique identifier for the schedule. This field is also used for populating `created_by` on scheduled flow runs, falling back to the schedule type if not present. The `created_by` field is already displayed in the UI if present.

Closes https://github.com/PrefectHQ/prefect/issues/13210