### PR TITLE
support providing schedule parameters via `prefect deploy`

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -928,9 +928,8 @@ def _construct_schedules(
             _schedule_config_to_deployment_schedule(schedule_config)
             for schedule_config in apply_values(schedule_configs, step_outputs)
         ]
-    elif schedule_configs is NotSet:
-        if is_interactive():
-            schedules = prompt_schedules(app.console)
+    elif schedule_configs is NotSet and is_interactive():
+        schedules = prompt_schedules(app.console)
 
     return schedules
 

--- a/src/prefect/deployments/base.py
+++ b/src/prefect/deployments/base.py
@@ -196,7 +196,7 @@ def initialize_project(
 
     project_name = name or dir_name
 
-    files = []
+    files: list[str] = []
     if create_default_ignore_file("."):
         files.append(".prefectignore")
     if create_default_prefect_yaml(".", name=project_name, contents=configuration):
@@ -236,6 +236,7 @@ def _format_deployment_for_saving_to_prefect_file(
                 schedule_config = deployment_schedule.schedule.model_dump()
 
             schedule_config["active"] = deployment_schedule.active
+            schedule_config["parameters"] = deployment_schedule.parameters
             schedules.append(schedule_config)
 
         deployment["schedules"] = schedules
@@ -290,7 +291,6 @@ def _save_deployment_to_prefect_file(
         - deployment: a dictionary containing a deployment configuration
     """
     deployment = _format_deployment_for_saving_to_prefect_file(deployment)
-
     current_directory_name = os.path.basename(os.getcwd())
     if not prefect_file.exists():
         create_default_prefect_yaml(

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -2900,8 +2900,8 @@ class TestSchedules:
                 + readchar.key.ENTER
                 # Decline adding another schedule
                 + readchar.key.ENTER
-                # Decline save
-                + "n"
+                # Accept saving
+                + "y"
                 + readchar.key.ENTER
             ),
             expected_code=0,
@@ -2912,6 +2912,19 @@ class TestSchedules:
         )
         assert deployment.schedules[0].active is True
         assert deployment.schedules[0].parameters == {
+            "question": "ultimate",
+            "answer": 42,
+        }
+
+        with open("prefect.yaml", "r") as f:
+            deploy_config = yaml.safe_load(f)
+
+        deployment_config = next(
+            (d for d in deploy_config["deployments"] if d["name"] == "test-name"),
+            None,
+        )
+        assert deployment_config is not None
+        assert deployment_config["schedules"][0]["parameters"] == {
             "question": "ultimate",
             "answer": 42,
         }


### PR DESCRIPTION
`prefect deploy` didn't ask if a user wanted to bind parameters to their schedules when constructing it interactively

<details>
<summary>sample run</summary>

```python
» prefect deploy -n test-name
? Your Prefect workers will need access to this flow's code in order to run it. Would you like your workers to pull your flow code from a remote storage location when running this flow?
[y/n] (y): n
Your Prefect workers will attempt to load your flow from: /Users/nate/github.com/prefecthq/prefect/flows/hello_world.py. To see more options for managing your flow's code, run:

        $ prefect init

? Would you like to configure schedules for this deployment? [y/n] (y): y
? What type of schedule would you like to use? [Use arrows to move; enter to select]
┏━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃    ┃ Schedule Type ┃ Description                                                                              ┃
┡━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ >  │ Interval      │ Allows you to set flow runs to be executed at fixed time intervals.                      │
│    │ Cron          │ Allows you to define recurring flow runs based on a specified pattern using cron syntax. │
│    │ RRule         │ Allows you to define recurring flow runs using RFC 2445 recurrence rules.                │
└────┴───────────────┴──────────────────────────────────────────────────────────────────────────────────────────┘
? Seconds between scheduled runs (3600):
? Would you like to activate this schedule? [y/n] (y):
? Would you like to configure default parameters for this schedule? [y/n] (n): n
? Would you like to add another schedule? [y/n] (n): y
? What type of schedule would you like to use? [Use arrows to move; enter to select]
┏━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃    ┃ Schedule Type ┃ Description                                                                              ┃
┡━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ >  │ Interval      │ Allows you to set flow runs to be executed at fixed time intervals.                      │
│    │ Cron          │ Allows you to define recurring flow runs based on a specified pattern using cron syntax. │
│    │ RRule         │ Allows you to define recurring flow runs using RFC 2445 recurrence rules.                │
└────┴───────────────┴──────────────────────────────────────────────────────────────────────────────────────────┘
? Seconds between scheduled runs (3600):
? Would you like to activate this schedule? [y/n] (y):
? Would you like to configure default parameters for this schedule? [y/n] (n): y
? Enter schedule parameters as a JSON string: reeeeeeee
Please enter a valid JSON object
? Enter schedule parameters as a JSON string: {"asdf": 42}
? Would you like to add another schedule? [y/n] (n): n
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Deployment 'hello/test-name' successfully created with id '057452ec-40c4-4930-af56-528a61f13a5e'.                                                                                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

View Deployment in UI: https://app.prefect.cloud/account/12242a57-9f05-4bf5-8853-9bff595d4bab/workspace/cafa2ffa-f6cc-4ed6-ab76-eaa4ba1ad40e/deployments/deployment/057452ec-40c4-4930-af56-528a61f13a5e

? Would you like to save configuration for this deployment for faster deployments in the future? [y/n]: y
? Found existing deployment configuration with name: test-name and entrypoint: ./flows/hello_world.py:hello in the prefect.yaml file at prefect.yaml. Would you like to overwrite that
entry? [y/n]: y

Deployment configuration saved to prefect.yaml! You can now deploy using this deployment configuration with:

        $ prefect deploy -n test-name

You can also make changes to this deployment configuration by making changes to the YAML file.

To execute flow runs from these deployments, start a worker in a separate terminal that pulls work from the 'local' work pool:

        $ prefect worker start --pool 'local'

To schedule a run for this deployment, use the following command:

        $ prefect deployment run 'hello/test-name'
```

```yaml
deployments:
- entrypoint: ./flows/hello_world.py:hello
  name: test-name
  work_pool:
    name: local
    work_queue_name:
    job_variables: {}
  version:
  tags: []
  concurrency_limit:
  description:
  parameters: {}
  schedules:
  - interval: 3600.0
    anchor_date: '2025-02-06T05:09:02.646930+00:00'
    timezone: UTC
    active: true
    parameters: {}
  - interval: 3600.0
    anchor_date: '2025-02-06T05:09:14.953317+00:00'
    timezone: UTC
    active: true
    parameters:
      asdf: 42
  pull:
  - prefect.deployments.steps.set_working_directory:
      directory: /Users/nate/github.com/prefecthq/prefect

```

</details>