### PR TITLE
Remove full team from schema json updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 # GitHub takes into account the last file ref for review requests
 # this resets the file to global owners to avoid huge review teams
 /docs/v3/develop/settings-ref.mdx    @cicdw @desertaxle @zzstoatzz
+/docs/v3/api-ref/rest-api/server/schema.json    @cicdw @desertaxle @zzstoatzz
 
 # imports
 /src/prefect/__init__.py             @aaazzam @chrisguidry @cicdw @desertaxle @zzstoatzz


### PR DESCRIPTION
My last few PRs have touched this file and it's spamming lots of people for unnecessary reviews.