### PR TITLE
Fix labeler to remove unnecessary labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,8 @@
 docs:
-  - changed-files:
-      - any-glob-to-any-file: docs/**
+  - all:
+    - changed-files:
+        - any-glob-to-any-file: docs/**
+        - all-globs-to-all-files: '!docs/v3/api-ref/rest-api/server/schema.json'
 
 migration:
   - changed-files:
@@ -17,5 +19,7 @@ upstream dependency:
   - base-branch: '2.x'
 
 ui-replatform:
-  - changed-files:
-      - any-glob-to-any-file: ui-v2/**
+  - all:
+    - changed-files:
+        - any-glob-to-any-file: ui-v2/**
+        - all-globs-to-all-files: '!ui-v2/src/api/prefect.ts'


### PR DESCRIPTION
Adding the top level `all:` key should make the any/all syntax work properly now and avoid the spurious `docs` and `ui-replatform` labels on PRs that update settings and the API.