### PR TITLE
pin core above `3.1.15` for `prefect-dbt`

### DIFF
--- a/src/integrations/prefect-dbt/pyproject.toml
+++ b/src/integrations/prefect-dbt/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-  "prefect>=3.0.0",
+  "prefect>=3.1.15",
   "dbt-core>=1.7.0",
   "prefect_shell>=0.3.0",
   "sgqlc>=16.0.0",


### PR DESCRIPTION
https://github.com/PrefectHQ/prefect/pull/16877 removed sync_compatible from `prefect.artifacts` which required https://github.com/PrefectHQ/prefect/pull/16926. 

but when using older versions of core (as is the case here https://github.com/PrefectHQ/prefect/issues/17006) the new explicit async artifact methods don't exist yet

so this PR updates the pin in `prefect-dbt` to require sufficiently new `prefect`

closes #17006