### PR TITLE
Remove some log noise in pause and abort handling

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -62,18 +62,13 @@ if __name__ == "__main__":
         else:
             run_flow(flow, flow_run=flow_run, error_logger=run_logger)
 
-    except Abort as abort_signal:
-        abort_signal: Abort
+    except Abort:
         engine_logger.info(
-            f"Engine execution of flow run '{flow_run_id}' aborted by orchestrator:"
-            f" {abort_signal}"
+            "Engine execution of flow run '{flow_run_id}' aborted by orchestrator."
         )
         exit(0)
-    except Pause as pause_signal:
-        pause_signal: Pause
-        engine_logger.info(
-            f"Engine execution of flow run '{flow_run_id}' is paused: {pause_signal}"
-        )
+    except Pause:
+        engine_logger.info(f"Engine execution of flow run '{flow_run_id}' is paused.")
         exit(0)
     except Exception:
         engine_logger.error(

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -1518,6 +1518,8 @@ def run_flow(
             ret_val = run_flow_async(**kwargs)
         else:
             ret_val = run_flow_sync(**kwargs)
+    except (Abort, Pause):
+        raise
     except:
         if error_logger:
             error_logger.error(
@@ -1597,20 +1599,18 @@ def run_flow_in_subprocess(
                     # This is running in a brand new process, so there won't be an existing
                     # event loop.
                     asyncio.run(maybe_coro)
-            except Abort as abort_signal:
-                abort_signal: Abort
+            except Abort:
                 if flow_run:
-                    msg = f"Execution of flow run '{flow_run.id}' aborted by orchestrator: {abort_signal}"
+                    msg = f"Execution of flow run '{flow_run.id}' aborted by orchestrator."
                 else:
-                    msg = f"Execution aborted by orchestrator: {abort_signal}"
+                    msg = "Execution aborted by orchestrator."
                 engine_logger.info(msg)
                 exit(0)
-            except Pause as pause_signal:
-                pause_signal: Pause
+            except Pause:
                 if flow_run:
-                    msg = f"Execution of flow run '{flow_run.id}' is paused: {pause_signal}"
+                    msg = f"Execution of flow run '{flow_run.id}' is paused."
                 else:
-                    msg = f"Execution is paused: {pause_signal}"
+                    msg = "Execution is paused."
                 engine_logger.info(msg)
                 exit(0)
             except Exception:


### PR DESCRIPTION
Two things:
- our exception types have no repr/str of value; `f"{Pause()}"` prints an empty string, so I removed this from the log
- we log "unexpected exception" when catching exceptions that are more expected than unexpected; we have special handling for these exception types so shouldn't say they were unexpected

Closes https://github.com/PrefectHQ/prefect/issues/16915