### PR TITLE
Allow for updating a deployment's parameter openapi schema

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -16673,6 +16673,18 @@
                         "title": "Parameters",
                         "description": "Parameters for flow runs scheduled by the deployment."
                     },
+                    "parameter_openapi_schema": {
+                        "anyOf": [
+                            {
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Parameter Openapi Schema",
+                        "description": "The parameter schema of the flow, including defaults."
+                    },
                     "tags": {
                         "items": {
                             "type": "string"

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -230,8 +230,13 @@ async def update_deployment(
             else existing_deployment.enforce_parameter_schema
         )
         if enforce_parameter_schema:
-            # ensure that the new parameters conform to the existing schema
-            if not isinstance(existing_deployment.parameter_openapi_schema, dict):
+            # ensure that the new parameters conform to the proposed schema
+            if deployment.parameter_openapi_schema:
+                openapi_schema = deployment.parameter_openapi_schema
+            else:
+                openapi_schema = existing_deployment.parameter_openapi_schema
+
+            if not isinstance(openapi_schema, dict):
                 raise HTTPException(
                     status.HTTP_409_CONFLICT,
                     detail=(
@@ -243,7 +248,7 @@ async def update_deployment(
             try:
                 validate(
                     parameters,
-                    existing_deployment.parameter_openapi_schema,
+                    openapi_schema,
                     raise_on_error=True,
                     ignore_required=True,
                 )

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -295,6 +295,10 @@ class DeploymentUpdate(ActionBaseModel):
         default=None,
         description="Parameters for flow runs scheduled by the deployment.",
     )
+    parameter_openapi_schema: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="The parameter schema of the flow, including defaults.",
+    )
     tags: List[str] = Field(
         default_factory=list,
         description="A list of deployment tags.",

--- a/tests/server/orchestration/api/test_deployments.py
+++ b/tests/server/orchestration/api/test_deployments.py
@@ -1560,6 +1560,7 @@ class TestUpdateDeployment:
         assert response.status_code == 201
         deployment_id = response.json()["id"]
 
+        ## Providing parameters
         response = await client.patch(
             f"/deployments/{deployment_id}",
             json={"parameters": {"num": "foobar"}},
@@ -1570,6 +1571,7 @@ class TestUpdateDeployment:
             in response.text
         )
 
+        ## Providing a new incompatible schema
         response = await client.patch(
             f"/deployments/{deployment_id}",
             json={"parameter_openapi_schema": new_schema},
@@ -1577,6 +1579,17 @@ class TestUpdateDeployment:
         assert response.status_code == 409
         assert (
             "Validation failed for field 'num'. Failure reason: 42 is not of type 'object'"
+            in response.text
+        )
+
+        ## Providing both
+        response = await client.patch(
+            f"/deployments/{deployment_id}",
+            json={"parameter_openapi_schema": new_schema, "parameters": {"num": 11}},
+        )
+        assert response.status_code == 409
+        assert (
+            "Validation failed for field 'num'. Failure reason: 11 is not of type 'object'"
             in response.text
         )
 

--- a/tests/server/orchestration/api/test_deployments.py
+++ b/tests/server/orchestration/api/test_deployments.py
@@ -19,6 +19,7 @@ from prefect.settings import (
     PREFECT_API_SERVICES_SCHEDULER_MAX_SCHEDULED_TIME,
     PREFECT_API_SERVICES_SCHEDULER_MIN_RUNS,
 )
+from prefect.utilities.callables import parameter_schema
 
 
 def assert_status_events(deployment_name: str, events: List[str]):
@@ -1529,6 +1530,92 @@ class TestUpdateDeployment:
             "Validation failed for field 'x'. Failure reason: 1 is not of type 'string'"
             in response.text
         )
+
+    async def test_update_deployment_enforces_new_parameter_schema(
+        self,
+        flow,
+        client,
+    ):
+        def hello(num: int):
+            pass
+
+        def byebye(num: dict):
+            pass
+
+        schema = parameter_schema(hello).model_dump_for_openapi()
+        new_schema = parameter_schema(byebye).model_dump_for_openapi()
+
+        data = DeploymentCreate(  # type: ignore
+            name="test-patch",
+            flow_id=flow.id,
+            enforce_parameter_schema=True,
+            parameters={"num": 42},
+            parameter_openapi_schema=schema,
+        ).model_dump(mode="json")
+
+        response = await client.post(
+            "/deployments/",
+            json=data,
+        )
+        assert response.status_code == 201
+        deployment_id = response.json()["id"]
+
+        response = await client.patch(
+            f"/deployments/{deployment_id}",
+            json={"parameters": {"num": "foobar"}},
+        )
+        assert response.status_code == 409
+        assert (
+            "Validation failed for field 'num'. Failure reason: 'foobar' is not of type 'integer'"
+            in response.text
+        )
+
+        response = await client.patch(
+            f"/deployments/{deployment_id}",
+            json={"parameter_openapi_schema": new_schema},
+        )
+        assert response.status_code == 409
+        assert (
+            "Validation failed for field 'num'. Failure reason: 42 is not of type 'object'"
+            in response.text
+        )
+
+    async def test_update_deployment_allows_the_clearing_of_parameters_when_provided(
+        self,
+        flow,
+        client,
+        session,
+    ):
+        def hello(num: int):
+            pass
+
+        schema = parameter_schema(hello).model_dump_for_openapi()
+
+        data = DeploymentCreate(  # type: ignore
+            name="test-patch-2",
+            flow_id=flow.id,
+            enforce_parameter_schema=True,
+            parameters={"num": 42},
+            parameter_openapi_schema=schema,
+        ).model_dump(mode="json")
+
+        response = await client.post(
+            "/deployments/",
+            json=data,
+        )
+        assert response.status_code == 201
+        deployment_id = response.json()["id"]
+
+        response = await client.patch(
+            f"/deployments/{deployment_id}",
+            json={"parameters": {}},
+        )
+        assert response.status_code == 204
+
+        deployment = await models.deployments.read_deployment(
+            session=session, deployment_id=deployment_id
+        )
+        assert deployment.parameters == {}
 
     async def test_update_deployment_does_not_enforce_parameter_schema_by_default(
         self,

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -5753,6 +5753,11 @@ export interface components {
              */
             parameters?: Record<string, never> | null;
             /**
+             * Parameter Openapi Schema
+             * @description The parameter schema of the flow, including defaults.
+             */
+            parameter_openapi_schema?: Record<string, never> | null;
+            /**
              * Tags
              * @description A list of deployment tags.
              */


### PR DESCRIPTION
In preparation for improving the deployment experience with respect to schedules, this PR allows for deployments to update the parameter openAPI schema and adjusts the server-side validation and testes accordingly.