### PR TITLE
[UI v2] chore: Removes toggleVariants as an export

### DIFF
--- a/ui-v2/src/components/ui/toggle/index.ts
+++ b/ui-v2/src/components/ui/toggle/index.ts
@@ -1,0 +1,2 @@
+export { Toggle } from "./toggle";
+export { toggleVariants } from "./styles";

--- a/ui-v2/src/components/ui/toggle/styles.ts
+++ b/ui-v2/src/components/ui/toggle/styles.ts
@@ -1,12 +1,6 @@
-"use client";
+import { cva } from "class-variance-authority";
 
-import * as TogglePrimitive from "@radix-ui/react-toggle";
-import { type VariantProps, cva } from "class-variance-authority";
-import * as React from "react";
-
-import { cn } from "@/lib/utils";
-
-const toggleVariants = cva(
+export const toggleVariants = cva(
 	"inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
 	{
 		variants: {
@@ -27,19 +21,3 @@ const toggleVariants = cva(
 		},
 	},
 );
-
-const Toggle = React.forwardRef<
-	React.ElementRef<typeof TogglePrimitive.Root>,
-	React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
-		VariantProps<typeof toggleVariants>
->(({ className, variant, size, ...props }, ref) => (
-	<TogglePrimitive.Root
-		ref={ref}
-		className={cn(toggleVariants({ variant, size, className }))}
-		{...props}
-	/>
-));
-
-Toggle.displayName = TogglePrimitive.Root.displayName;
-
-export { Toggle, toggleVariants };

--- a/ui-v2/src/components/ui/toggle/toggle.tsx
+++ b/ui-v2/src/components/ui/toggle/toggle.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { toggleVariants } from "./styles";
+
+const Toggle = React.forwardRef<
+	React.ElementRef<typeof TogglePrimitive.Root>,
+	React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+		VariantProps<typeof toggleVariants>
+>(({ className, variant, size, ...props }, ref) => (
+	<TogglePrimitive.Root
+		ref={ref}
+		className={cn(toggleVariants({ variant, size, className }))}
+		{...props}
+	/>
+));
+
+Toggle.displayName = TogglePrimitive.Root.displayName;
+
+export { Toggle };


### PR DESCRIPTION
Exporting this would give an eslint warning (which shows up in all UI related PRs).
Separating the variants into another file for now and exporting it through an `index.ts` file 

If needed, we can move `toggleVariant` as its own file and import/export it from there

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Relates to https://github.com/PrefectHQ/prefect/issues/15512
