### PR TITLE
named deployment schedule integration test

### DIFF
--- a/flows/schedule_statefulness.py
+++ b/flows/schedule_statefulness.py
@@ -1,0 +1,82 @@
+"""
+this integration test should
+
+- start serve w a schedule (no slug)
+- stop the serve process
+- start serve with no schedule
+- observe that deployment has no schedules
+
+
+- start serve with schedule (slug)
+- stop the serve process
+- start serve with no schedule
+- stop the serve process
+- observe that deployment still has that named schedule
+
+"""
+
+import signal
+from typing import Any
+from uuid import UUID
+
+from prefect import flow, get_client
+from prefect.client.schemas.objects import DeploymentSchedule
+from prefect.schedules import Cron, Schedule
+
+DEPLOYMENT_NAME = "my-deployment"
+
+
+@flow
+def my_flow():
+    print("Hello, world!")
+
+
+def _handler(signum: int, frame: Any):
+    raise KeyboardInterrupt("Simulating user interruption")
+
+
+def run_serve_with_schedule(schedule: Schedule | None = None, timeout: int = 2):
+    signal.signal(signal.SIGALRM, _handler)
+    signal.alarm(timeout)
+    try:
+        my_flow.serve(name=DEPLOYMENT_NAME, schedule=schedule)
+    except KeyboardInterrupt:
+        print("Serve interrupted")
+    finally:
+        signal.alarm(0)
+
+
+def delete_deployment(deployment_id: UUID):
+    with get_client(sync_client=True) as client:
+        client.delete_deployment(deployment_id)
+
+
+def check_deployment_schedules(deployment_name: str) -> list[DeploymentSchedule]:
+    with get_client(sync_client=True) as client:
+        deployment = client.read_deployment_by_name(deployment_name)
+        return deployment.schedules
+
+
+def main():
+    # case 1: Schedule without slug
+    print("\nTest case 1: Schedule without slug")
+    run_serve_with_schedule(schedule=Cron("0 9 * * *"))
+    run_serve_with_schedule(schedule=None)
+    schedules = check_deployment_schedules(f"my-flow/{DEPLOYMENT_NAME}")
+    assert not schedules, (
+        f"Expected no schedules after removing unnamed schedule: {schedules}"
+    )
+
+    # case 2: Schedule with slug
+    print("\nTest case 2: Schedule with slug")
+    run_serve_with_schedule(schedule=Cron("0 9 * * *", slug="every-day-at-9am"))
+    run_serve_with_schedule(schedule=None)
+    schedules = check_deployment_schedules(f"my-flow/{DEPLOYMENT_NAME}")
+    assert any(s.slug == "every-day-at-9am" for s in schedules), (
+        f"Expected named schedule to persist: {schedules}"
+    )
+    print("All tests passed!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
adds integration test simulating simple use of `.serve` with named/unnamed schedules