### PR TITLE
Use newer `npm` version in Docker UI build

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'release' && github.event.release.prerelease && 'pre-release' || github.event_name == 'release' && 'prod' || 'dev' }}
     strategy:
+      fail-fast: false
       matrix:
         flavor:
           - ""

--- a/.github/workflows/time-docker-build.yaml
+++ b/.github/workflows/time-docker-build.yaml
@@ -14,8 +14,7 @@ on:
 
 jobs:
   benchmark:
-    runs-on:
-      group: oss-larger-runners
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/time-docker-build.yaml
+++ b/.github/workflows/time-docker-build.yaml
@@ -14,7 +14,8 @@ on:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: oss-larger-runners
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/time-docker-build.yaml
+++ b/.github/workflows/time-docker-build.yaml
@@ -20,6 +20,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -42,7 +45,11 @@ jobs:
         id: base_build_time
         run: |
           start_time=$(date +%s)
-          DOCKER_BUILDKIT=1 docker build . --no-cache --progress=plain
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --no-cache \
+            --progress=plain \
+            .
           end_time=$(date +%s)
           base_time=$((end_time - start_time))
           echo "base_time=$base_time" >> $GITHUB_OUTPUT
@@ -65,7 +72,11 @@ jobs:
         id: build_time
         run: |
           start_time=$(date +%s)
-          DOCKER_BUILDKIT=1 docker build . --no-cache --progress=plain
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --no-cache \
+            --progress=plain \
+            .
           end_time=$(date +%s)
           build_time=$((end_time - start_time))
           echo "build_time=$build_time" >> $GITHUB_OUTPUT

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,6 @@ RUN apt-get update && \
     chromium \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install a newer npm to avoid esbuild errors
-RUN npm install -g npm@8
-
 # Install dependencies separately so they cache
 COPY ./ui/package*.json ./
 RUN npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG NODE_VERSION=18.18.0
 ARG EXTRA_PIP_PACKAGES=""
 
 # Build the UI distributable.
-FROM node:${NODE_VERSION}-bullseye-slim AS ui-builder
+FROM --platform=$BUILDPLATFORM node:${NODE_VERSION}-bullseye-slim AS ui-builder
 
 WORKDIR /opt/ui
 


### PR DESCRIPTION
Docker builds have been running offensively long when running `npm ci`. This wasn't shown in our Docker build benchmark because we were only building for `amd64` and `arm64` was causing the issue. I belive the issue is because some of the `npm` dependeices (namely `esbuilt`) rely on C binaries that need to be recompiles for `arm64`.

This PR updates the Docker build benchmark workflow to perform a multi-platform build to get a more accurate read of build performance. It also updates the Dockerfile to only run the UI build step for the current build platform. Since the UI build step produces static HTML, JS, and CSS files, it is not platform-dependent. The result of this change is a ~90% reduction in build time.

![Screenshot 2025-02-09 at 3 04 12 PM](https://github.com/user-attachments/assets/0e617af4-aa0c-49ef-bd5d-e5db6893f6e9)
