### PR TITLE
Fix bug where a flow's parameter schema is not included in deployment create/update requests when using `prefect deploy`

### DIFF
--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -774,12 +774,13 @@ async def _run_single_deploy(
         tags=deploy_config.get("tags"),
         concurrency_limit=deploy_config.get("concurrency_limit"),
         concurrency_options=deploy_config.get("concurrency_options"),
-        parameter_openapi_schema=deploy_config.get("parameter_openapi_schema"),
         schedules=deploy_config.get("schedules"),
         paused=deploy_config.get("paused"),
         storage=_PullStepStorage(pull_steps),
         job_variables=get_from_dict(deploy_config, "work_pool.job_variables"),
     )
+
+    deployment._parameter_openapi_schema = deploy_config["parameter_openapi_schema"]
 
     if deploy_config.get("enforce_parameter_schema") is not None:
         deployment.enforce_parameter_schema = deploy_config.get(

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -2363,6 +2363,8 @@ class TestProjectDeploy:
             "An important name/test-name"
         )
         assert not deployment.enforce_parameter_schema
+        assert deployment.parameter_openapi_schema
+        parameter_openapi_schema = deployment.parameter_openapi_schema
 
         prefect_yaml_file = Path("prefect.yaml")
         with prefect_yaml_file.open(mode="r") as f:
@@ -2390,6 +2392,7 @@ class TestProjectDeploy:
             "An important name/test-name"
         )
         assert not deployment.enforce_parameter_schema
+        assert deployment.parameter_openapi_schema == parameter_openapi_schema
 
 
 class TestSchedules:


### PR DESCRIPTION
Fixes a bug where `prefect deploy` will wipe the parameter schema for a deployment.