### PR TITLE
Add missing `load_function_and_convert_to_flow`

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -2360,11 +2360,17 @@ async def load_flow_from_flow_run(
     import_path = relative_path_to_current_platform(deployment.entrypoint)
     run_logger.debug(f"Importing flow code from '{import_path}'")
 
-    flow = await run_sync_in_worker_thread(
-        load_flow_from_entrypoint,
-        str(import_path),
-        use_placeholder_flow=use_placeholder_flow,
-    )
+    try:
+        flow = await run_sync_in_worker_thread(
+            load_flow_from_entrypoint,
+            str(import_path),
+            use_placeholder_flow=use_placeholder_flow,
+        )
+    except MissingFlowError:
+        flow = await run_sync_in_worker_thread(
+            load_function_and_convert_to_flow,
+            str(import_path),
+        )
 
     return flow
 


### PR DESCRIPTION
In https://github.com/PrefectHQ/prefect/pull/17024 I only partially updated `load_flow`. This PR updates the other half of the branching logic under `load_flow_from_flow_run` to handle non flow functions (which to be honest is what I meant to update in the first place).
