### PR TITLE
Fix bug where schedules without a slug or active raise a 500

### DIFF
--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -155,7 +155,7 @@ async def create_deployment(
             schedules=[
                 schemas.actions.DeploymentScheduleCreate(
                     schedule=schedule.schedule,
-                    active=schedule.active,  # type: ignore[call-arg]
+                    active=schedule.active,
                     parameters=schedule.parameters,
                     slug=schedule.slug,
                 )
@@ -274,11 +274,12 @@ async def update_deployment(
             schedules=[
                 schemas.actions.DeploymentScheduleCreate(
                     schedule=schedule.schedule,
-                    active=schedule.active,  # type: ignore[call-arg]
+                    active=schedule.active if schedule.active is not None else True,
                     parameters=schedule.parameters,
                     slug=schedule.slug,
                 )
                 for schedule in schedules
+                if schedule.schedule is not None
             ],
         )
 


### PR DESCRIPTION
This PR ensures that we default to `active=True` when schedules are recreated via a call to the `POST /deployments` endpoint. This preserves the behavior exhibited prior to the introduction of deployment schedule slugs.