### PR TITLE
prefect-snowflake - Bump snowflake dependency

### DIFF
--- a/src/integrations/prefect-snowflake/pyproject.toml
+++ b/src/integrations/prefect-snowflake/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prefect-snowflake"
-dependencies = ["snowflake-connector-python>=2.7.6", "prefect>=3.0.0"]
+dependencies = ["snowflake-connector-python>=3.0.4", "prefect>=3.0.0"]
 dynamic = ["version"]
 description = "Prefect integrations for interacting with Snowflake"
 readme = "README.md"


### PR DESCRIPTION
Updates `snowflake-connector-python` minimum to be above the End-of-Support version as of May 1, 2025. Snowflake's recommended version is `3.13.2`, so we could also bump it to that. 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
