### PR TITLE
Enable virtual environment execution for docker - poc

### DIFF
--- a/src/prefect/settings/models/experiments.py
+++ b/src/prefect/settings/models/experiments.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 from pydantic import AliasChoices, AliasPath, Field
 from pydantic_settings import SettingsConfigDict

--- a/src/prefect/settings/models/experiments.py
+++ b/src/prefect/settings/models/experiments.py
@@ -1,4 +1,4 @@
-from typing import ClassVar
+from typing import ClassVar, Optional
 
 from pydantic import AliasChoices, AliasPath, Field
 from pydantic_settings import SettingsConfigDict

--- a/src/prefect/utilities/processutils.py
+++ b/src/prefect/utilities/processutils.py
@@ -474,9 +474,8 @@ def setup_signal_handlers_worker(
 
 def get_sys_executable() -> str:
     # python executable needs to be quotable on windows
+    executable_path = os.environ["EXECUTABLE_PATH"] if "EXECUTABLE_PATH" in os.environ else sys.executable
     if os.name == "nt":
-        executable_path = f'"{sys.executable}"'
-    else:
-        executable_path = sys.executable
+        executable_path = f'"{executable_path}"'
 
     return executable_path

--- a/tests/utilities/test_processutils.py
+++ b/tests/utilities/test_processutils.py
@@ -1,11 +1,12 @@
 import subprocess
 import sys
+import os
 from unittest import mock
 
 import pytest
 
 import prefect.utilities.processutils
-from prefect.utilities.processutils import open_process, run_process
+from prefect.utilities.processutils import open_process, run_process, get_sys_executable
 
 
 class TestRunProcess:
@@ -135,3 +136,14 @@ class TestOpenProcess:
             creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
         )
         mock_set_console_ctrl_handler.assert_called_once_with(mock_ctrl_c_handler, 1)
+
+class TestGetExecutablePath:
+    def test_get_executable_path(self):
+        executable_path = get_sys_executable()
+        assert executable_path == sys.executable
+
+    def test_get_executable_path_with_env(self):
+        with mock.patch.dict("os.environ", {"EXECUTABLE_PATH": "/opt/.venv/bin/python"}, clear=True):
+            assert os.environ["EXECUTABLE_PATH"] == "/opt/.venv/bin/python"
+            executable_path = get_sys_executable()
+            assert executable_path == "/opt/.venv/bin/python"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.


This pull request enables prefect flows to be run in a different python environment to the prefect execution. The reason for this is that prefect is relativity heavy with it's requirements and we don't want to have to mix prefect's requirements with our own. For example our code is not running SQA v2, we should upgrade, but we don't want to adopt prefect and then be beholden to prefects dependencies upgrade cycle. Even though `prefect-client` exists, when using the prefect base docker image or building a custom image the cli is required for the docker command (flow-run execute? https://github.com/PrefectHQ/prefect/blob/1262485071d645198e5b376317e104dc5f3f3aac/src/prefect/cli/flow_run.py#L344). Therefore even if we use `prefect-client` we are installing our flow requirements into a docker image with full prefect. I could have missed something here?

The flow is run in a subprocess using a python module command, and the prefect engine does not need (I think?) full prefect but only prefect client to work. Currently the subprocess is spawn using `sys.executable` but this POC allows the over-writing of  `get_sys_executable` with an environmental variable. This means that we can make a Dockerfile like:

```Dockerfile
FROM prefecthq/prefect:3.1.7-python3.11
COPY . /opt/prefect/prefect_demo/
WORKDIR /opt/prefect/prefect_demo/
# Install poetry
RUN curl -sSL https://install.python-poetry.org | python3 - \
    && poetry --version \
    && poetry config virtualenvs.in-project true
RUN poetry install --no-interaction --no-ansi -vv
ENV EXECUTABLE_PATH=/opt/prefect/prefect_demo/.venv/bin/python
RUN prefect version
```

The flow sub process will run in the poetry virtual environment while the default python in the docker container container does not have to mix with the requirements of the flow code. 

If it's thought this is not a completely crazy idea this PR could be made mergeable. I assume that the variable coming via job_variables might be better etc?