### PR TITLE
Ignore VCS changes in `prefect-client` version determiniation

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -86,7 +86,7 @@ path = "src/prefect/_build_info.py"
 [tool.versioningit.format]
 distance = "{base_version}+{distance}.{vcs}{rev}"
 dirty = "{base_version}"
-distance-dirty = "{base_version}"
+distance-dirty = "{base_version}+{distance}.{vcs}{rev}"
 
 [tool.hatch.build]
 artifacts = ["src/prefect/_build_info.py"]

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -84,9 +84,9 @@ method = { module = "write_build_info", value = "write_build_info", module-dir =
 path = "src/prefect/_build_info.py"
 
 [tool.versioningit.format]
-distance = "{base_version}+{distance}.{vcs}{rev}"
-dirty = "{base_version}+{distance}.{vcs}{rev}"
-distance-dirty = "{base_version}+{distance}.{vcs}{rev}"
+distance = "{base_version}"
+dirty = "{base_version}"
+distance-dirty = "{base_version}"
 
 [tool.hatch.build]
 artifacts = ["src/prefect/_build_info.py"]

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -84,7 +84,7 @@ method = { module = "write_build_info", value = "write_build_info", module-dir =
 path = "src/prefect/_build_info.py"
 
 [tool.versioningit.format]
-distance = "{base_version}"
+distance = "{base_version}+{distance}.{vcs}{rev}"
 dirty = "{base_version}"
 distance-dirty = "{base_version}"
 


### PR DESCRIPTION
This change ensures the version of `prefect-client` matches the version of `prefect` when building `prefect-client`.