### PR TITLE
Remove "Pod ... has started." log from `KubernetesWorker`

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -1127,7 +1127,6 @@ class KubernetesWorker(BaseWorker):
             ):
                 pod: V1Pod = event["object"]
                 last_pod_name = pod.metadata.name
-                logger.info(f"Job {job_name!r}: Pod {last_pod_name!r} has started.")
                 phase = pod.status.phase
                 if phase != last_phase:
                     logger.info(f"Job {job_name!r}: Pod has status {phase!r}.")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
Closes #17141

The "Pod has started." log seems unnecessary since we're logging pod statuses if it exists, and otherwise logging that it didn't start. As it was, the log was repeated for every event from the pod.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
