### PR TITLE
[UI v2] feat: Adds StartTimeCell to flow run data table

### DIFF
--- a/ui-v2/src/components/flow-runs/data-table/data-table.tsx
+++ b/ui-v2/src/components/flow-runs/data-table/data-table.tsx
@@ -20,6 +20,7 @@ import { DeploymentCell } from "./deployment-cell";
 import { DurationCell } from "./duration-cell";
 import { NameCell } from "./name-cell";
 import { ParametersCell } from "./parameters-cell";
+import { StartTimeCell } from "./start-time-cell";
 
 export type FlowRunsDataTableRow = FlowRun & {
 	flow: Flow;
@@ -49,6 +50,11 @@ const createColumns = ({
 				}
 				return <StateBadge type={state.type} name={state.name} />;
 			},
+		}),
+		columnHelper.display({
+			id: "startTime",
+			header: "Start Time",
+			cell: ({ row }) => <StartTimeCell flowRun={row.original} />,
 		}),
 		columnHelper.accessor("parameters", {
 			id: "parameters",

--- a/ui-v2/src/components/flow-runs/data-table/duration-cell.tsx
+++ b/ui-v2/src/components/flow-runs/data-table/duration-cell.tsx
@@ -2,6 +2,7 @@ import {
 	type FlowRunWithDeploymentAndFlow,
 	type FlowRunWithFlow,
 } from "@/api/flow-runs";
+import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icons";
 import {
 	Tooltip,
@@ -9,7 +10,6 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Typography } from "@/components/ui/typography";
 import humanizeDuration from "humanize-duration";
 
 type DurationCellProps = {
@@ -30,12 +30,12 @@ export const DurationCell = ({ flowRun }: DurationCellProps) => {
 		<TooltipProvider>
 			<Tooltip>
 				<TooltipTrigger asChild>
-					<div className="flex items-center">
-						<div className="flex items-center gap-1">
+					<Button variant="ghost">
+						<div className="flex gap-2 items-center text-sm font-mono">
 							<Icon id="Clock" className="h-4 w-4" />
-							<Typography variant="bodySmall">{durationLabel}</Typography>
+							{durationLabel}
 						</div>
-					</div>
+					</Button>
 				</TooltipTrigger>
 				<TooltipContent>{durationTooltip}</TooltipContent>
 			</Tooltip>

--- a/ui-v2/src/components/flow-runs/data-table/start-time-cell.tsx
+++ b/ui-v2/src/components/flow-runs/data-table/start-time-cell.tsx
@@ -1,0 +1,61 @@
+import {
+	type FlowRun,
+	type FlowRunWithDeploymentAndFlow,
+} from "@/api/flow-runs";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icons";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { formatDate } from "@/utils/date";
+import humanizeDuration from "humanize-duration";
+import { useMemo } from "react";
+
+type StartTimeCellProps = {
+	flowRun: FlowRun | FlowRunWithDeploymentAndFlow;
+};
+
+const getDelta = (estimated_start_time_delta: null | number) => {
+	if (!estimated_start_time_delta || estimated_start_time_delta <= 60) {
+		return "";
+	}
+	return `(${humanizeDuration(estimated_start_time_delta, { maxDecimalPoints: 0 })} late)`;
+};
+
+export const StartTimeCell = ({ flowRun }: StartTimeCellProps) => {
+	const { start_time, expected_start_time, estimated_start_time_delta } =
+		flowRun;
+
+	const { text, tooltipText } = useMemo(() => {
+		let text: string | undefined;
+		let tooltipText: string | undefined;
+		if (start_time) {
+			text = `${formatDate(start_time, "dateTimeNumeric")} ${getDelta(estimated_start_time_delta)}`;
+			tooltipText = new Date(start_time).toString();
+		} else if (expected_start_time) {
+			text = `Scheduled for ${formatDate(expected_start_time, "dateTimeNumeric")} ${getDelta(estimated_start_time_delta)}`;
+			tooltipText = new Date(expected_start_time).toString();
+		}
+		return { text, tooltipText };
+	}, [estimated_start_time_delta, expected_start_time, start_time]);
+
+	return (
+		<TooltipProvider>
+			<Tooltip>
+				<TooltipTrigger asChild disabled={!text}>
+					<Button
+						variant="ghost"
+						className="text-sm font-mono flex gap-2 items-center"
+					>
+						<Icon id="Calendar" className="h-4 w-4" />
+						{text ?? "No start time"}
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent>{tooltipText}</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
+};


### PR DESCRIPTION
1. Adds StartTimeCell to the flow-run data table
2. Updates duration cell to have the same hover effect as `StartTimeCell`

https://github.com/user-attachments/assets/72c074a1-ff87-46b3-8021-5ea436fa2b17


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Relates to https://github.com/PrefectHQ/prefect/issues/15512