### PR TITLE
fix paths in GHAs

### DIFF
--- a/.github/workflows/api-compatibility-tests.yaml
+++ b/.github/workflows/api-compatibility-tests.yaml
@@ -5,8 +5,7 @@ on:
     paths:
       - .github/workflows/api-compatibility-tests.yaml
       - "**/*.py"
-      - requirements*.txt
-      - setup.cfg
+      - pyproject.toml
       - compat-tests
   push:
     branches:

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -9,9 +9,7 @@ on:
       - .github/workflows/benchmarks.yaml
       - .github/workflows/python-tests.yaml
       - "src/prefect/**/*.py"
-      - requirements.txt
-      - requirements-dev.txt
-      - setup.cfg
+      - pyproject.toml
       - Dockerfile
   push:
     branches:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,9 +13,7 @@ on:
       - "**/*.py"
       - "**/*.js"
       - "**/*.ts"
-      - requirements.txt
-      - requirements-dev.txt
-      - setup.cfg
+      - pyproject.toml
       - alembic.ini
 
   schedule:

--- a/.github/workflows/codspeed-benchmarks.yaml
+++ b/.github/workflows/codspeed-benchmarks.yaml
@@ -9,9 +9,7 @@ on:
       - .github/workflows/codspeed-benchmarks.yaml
       - .github/workflows/python-tests.yaml
       - "src/prefect/**/*.py"
-      - requirements.txt
-      - requirements-dev.txt
-      - setup.cfg
+      - pyproject.toml
       - Dockerfile
   push:
     branches:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -7,9 +7,7 @@ on:
     paths:
       - .github/workflows/integration-tests.yaml
       - "src/prefect/**/*.py"
-      - requirements.txt
-      - requirements-client.txt
-      - requirements-dev.txt
+      - pyproject.toml
       - ui/**
       - .nvmrc
       - Dockerfile
@@ -20,9 +18,7 @@ on:
     paths:
       - .github/workflows/integration-tests.yaml
       - "**/*.py"
-      - requirements.txt
-      - requirements-client.txt
-      - requirements-dev.txt
+      - pyproject.toml
       - ui/**
       - .nvmrc
       - Dockerfile

--- a/.github/workflows/markdown-tests.yaml
+++ b/.github/workflows/markdown-tests.yaml
@@ -13,11 +13,7 @@ on:
     paths:
       - .github/workflows/markdown-tests.yaml
       - "docs/**"
-      - requirements-client.txt
-      - requirements-dev.txt
-      - requirements-markdown-tests.txt
-      - requirements.txt
-      - setup.cfg
+      - pyproject.toml
       - Dockerfile
 
   push:
@@ -27,11 +23,7 @@ on:
       - .github/workflows/markdown-tests.yaml
       - "src/prefect/**/*.py"
       - "tests/**/*.py"
-      - requirements-client.txt
-      - requirements-dev.txt
-      - requirements-markdown-tests.txt
-      - requirements.txt
-      - setup.cfg
+      - pyproject.toml
       - Dockerfile
 
 permissions:

--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -9,9 +9,7 @@ on:
       - .github/workflows/proxy-test.yaml
       - scripts/proxy-test/*
       - "src/prefect/events/clients.py"
-      - requirements.txt
-      - requirements-client.txt
-      - requirements-dev.txt
+      - pyproject.toml
   push:
     branches:
       - main
@@ -19,9 +17,7 @@ on:
       - .github/workflows/proxy-test.yaml
       - scripts/proxy-test/*
       - "src/prefect/events/clients.py"
-      - requirements.txt
-      - requirements-client.txt
-      - requirements-dev.txt
+      - pyproject.toml
 
 jobs:
   proxy-test:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -11,10 +11,7 @@ on:
       - .github/workflows/python-tests.yaml
       - "src/prefect/**/*.py"
       - "tests/**/*.py"
-      - requirements.txt
-      - requirements-client.txt
-      - requirements-dev.txt
-      - setup.cfg
+      - pyproject.toml
       - Dockerfile
       - scripts/entrypoint.sh
   push:
@@ -24,10 +21,7 @@ on:
       - .github/workflows/python-tests.yaml
       - "src/prefect/**/*.py"
       - "tests/**/*.py"
-      - requirements.txt
-      - requirements-client.txt
-      - requirements-dev.txt
-      - setup.cfg
+      - pyproject.toml
       - Dockerfile
       - scripts/entrypoint.sh
 permissions:


### PR DESCRIPTION
the old `paths` had not yet been updated per https://github.com/PrefectHQ/prefect/pull/17116

tldr: `pyproject.toml` should now be used to trigger checks rather than `requirements*.txt`