### PR TITLE
Add bundle execution capabilities to `Runner`

### DIFF
--- a/src/prefect/_experimental/bundles.py
+++ b/src/prefect/_experimental/bundles.py
@@ -69,6 +69,13 @@ def create_bundle_for_flow_run(
     }
 
 
+def extract_flow_from_bundle(bundle: SerializedBundle) -> Flow[Any, Any]:
+    """
+    Extracts a flow from a bundle.
+    """
+    return _deserialize_bundle_object(bundle["function"])
+
+
 def _extract_and_run_flow(
     bundle: SerializedBundle, env: dict[str, Any] | None = None
 ) -> None:

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -64,9 +64,15 @@ from uuid import UUID, uuid4
 
 import anyio
 import anyio.abc
+import anyio.to_thread
 from cachetools import LRUCache
 from typing_extensions import Self
 
+from prefect._experimental.bundles import (
+    SerializedBundle,
+    execute_bundle_in_subprocess,
+    extract_flow_from_bundle,
+)
 from prefect._internal.concurrency.api import (
     create_call,
     from_async,
@@ -135,7 +141,7 @@ __all__ = ["Runner"]
 
 
 class ProcessMapEntry(TypedDict):
-    flow_run: FlowRun
+    flow_run: "FlowRun"
     pid: int
 
 
@@ -221,6 +227,7 @@ class Runner:
         self._scheduled_task_scopes: set[anyio.abc.CancelScope] = set()
         self._deployment_ids: set[UUID] = set()
         self._flow_run_process_map: dict[UUID, ProcessMapEntry] = dict()
+        self._flow_run_bundle_map: dict[UUID, SerializedBundle] = dict()
 
         self._tmp_dir: Path = (
             Path(tempfile.gettempdir()) / "runner_storage" / str(uuid4())
@@ -508,7 +515,7 @@ class Runner:
         return asyncio.run_coroutine_threadsafe(func(*args, **kwargs), self._loop)
 
     async def cancel_all(self) -> None:
-        runs_to_cancel: list[FlowRun] = []
+        runs_to_cancel: list["FlowRun"] = []
 
         # done to avoid dictionary size changing during iteration
         for info in self._flow_run_process_map.values():
@@ -602,7 +609,120 @@ class Runner:
                             )
                         )
 
-    def _get_flow_run_logger(self, flow_run: "FlowRun | FlowRun") -> PrefectLogAdapter:
+    async def execute_bundle(self, bundle: SerializedBundle) -> None:
+        """
+        Executes a bundle in a subprocess.
+        """
+        from prefect.client.schemas.objects import FlowRun
+
+        self.pause_on_shutdown = False
+        context = self if not self.started else asyncnullcontext()
+
+        flow_run = FlowRun.model_validate(bundle["flow_run"])
+
+        async with context:
+            if not self._acquire_limit_slot(flow_run.id):
+                return
+
+            process = execute_bundle_in_subprocess(bundle)
+
+            if process.pid is None:
+                # This shouldn't happen because `execute_bundle_in_subprocess` starts the process
+                # but we'll handle it gracefully anyway
+                msg = "Failed to start process for flow execution. No PID returned."
+                await self._propose_crashed_state(flow_run, msg)
+                raise RuntimeError(msg)
+
+            self._flow_run_process_map[flow_run.id] = ProcessMapEntry(
+                pid=process.pid, flow_run=flow_run
+            )
+            self._flow_run_bundle_map[flow_run.id] = bundle
+
+            tasks: list[asyncio.Task[None]] = []
+            tasks.append(
+                asyncio.create_task(
+                    critical_service_loop(
+                        workload=self._check_for_cancelled_flow_runs,
+                        interval=self.query_seconds,
+                        jitter_range=0.3,
+                    )
+                )
+            )
+            if self.heartbeat_seconds is not None:
+                tasks.append(
+                    asyncio.create_task(
+                        critical_service_loop(
+                            workload=self._emit_flow_run_heartbeats,
+                            interval=self.heartbeat_seconds,
+                            jitter_range=0.1,
+                        )
+                    )
+                )
+
+            await anyio.to_thread.run_sync(process.join)
+
+            for task in tasks:
+                task.cancel()
+
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+            self._flow_run_process_map.pop(flow_run.id)
+
+            flow_run_logger = self._get_flow_run_logger(flow_run)
+            if process.exitcode is None:
+                raise RuntimeError("Process has no exit code")
+
+            if process.exitcode:
+                help_message = None
+                level = logging.ERROR
+                if process.exitcode == -9:
+                    level = logging.INFO
+                    help_message = (
+                        "This indicates that the process exited due to a SIGKILL signal. "
+                        "Typically, this is either caused by manual cancellation or "
+                        "high memory usage causing the operating system to "
+                        "terminate the process."
+                    )
+                if process.exitcode == -15:
+                    level = logging.INFO
+                    help_message = (
+                        "This indicates that the process exited due to a SIGTERM signal. "
+                        "Typically, this is caused by manual cancellation."
+                    )
+                elif process.exitcode == 247:
+                    help_message = (
+                        "This indicates that the process was terminated due to high "
+                        "memory usage."
+                    )
+                elif (
+                    sys.platform == "win32"
+                    and process.returncode == STATUS_CONTROL_C_EXIT
+                ):
+                    level = logging.INFO
+                    help_message = (
+                        "Process was terminated due to a Ctrl+C or Ctrl+Break signal. "
+                        "Typically, this is caused by manual cancellation."
+                    )
+
+                flow_run_logger.log(
+                    level,
+                    f"Process for flow run {flow_run.name!r} exited with status code:"
+                    f" {process.exitcode}"
+                    + (f"; {help_message}" if help_message else ""),
+                )
+                terminal_state = await self._propose_crashed_state(
+                    flow_run, help_message or "Process exited with non-zero exit code"
+                )
+                if terminal_state:
+                    await self._run_on_crashed_hooks(
+                        flow_run=flow_run, state=terminal_state
+                    )
+            else:
+                flow_run_logger.info(
+                    f"Process for flow run {flow_run.name!r} exited cleanly."
+                )
+
+    def _get_flow_run_logger(self, flow_run: "FlowRun") -> PrefectLogAdapter:
         return flow_run_logger(flow_run=flow_run).getChild(
             "runner",
             extra={
@@ -1308,8 +1428,11 @@ class Runner:
                 exc_info=True,
             )
 
-    async def _propose_crashed_state(self, flow_run: "FlowRun", message: str) -> None:
+    async def _propose_crashed_state(
+        self, flow_run: "FlowRun", message: str
+    ) -> State[Any] | None:
         run_logger = self._get_flow_run_logger(flow_run)
+        state = None
         try:
             state = await propose_state(
                 self._client,
@@ -1326,6 +1449,7 @@ class Runner:
                 run_logger.info(
                     f"Reported flow run '{flow_run.id}' as crashed: {message}"
                 )
+        return state
 
     async def _mark_flow_run_as_cancelled(
         self, flow_run: "FlowRun", state_updates: Optional[dict[str, Any]] = None
@@ -1391,9 +1515,14 @@ class Runner:
         """
         if state.is_cancelling():
             try:
-                flow = await load_flow_from_flow_run(
-                    flow_run, storage_base_path=str(self._tmp_dir)
-                )
+                if flow_run.id in self._flow_run_bundle_map:
+                    flow = extract_flow_from_bundle(
+                        self._flow_run_bundle_map[flow_run.id]
+                    )
+                else:
+                    flow = await load_flow_from_flow_run(
+                        flow_run, storage_base_path=str(self._tmp_dir)
+                    )
                 hooks = flow.on_cancellation_hooks or []
 
                 await _run_hooks(hooks, flow_run, flow, state)
@@ -1412,9 +1541,12 @@ class Runner:
         Run the hooks for a flow.
         """
         if state.is_crashed():
-            flow = await load_flow_from_flow_run(
-                flow_run, storage_base_path=str(self._tmp_dir)
-            )
+            if flow_run.id in self._flow_run_bundle_map:
+                flow = extract_flow_from_bundle(self._flow_run_bundle_map[flow_run.id])
+            else:
+                flow = await load_flow_from_flow_run(
+                    flow_run, storage_base_path=str(self._tmp_dir)
+                )
             hooks = flow.on_crashed_hooks or []
 
             await _run_hooks(hooks, flow_run, flow, state)

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -23,10 +23,13 @@ from starlette import status
 import prefect.runner
 from prefect import __version__, aserve, flow, serve, task
 from prefect.cli.deploy import _PullStepStorage
+from prefect._experimental.bundles import create_bundle_for_flow_run
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient
 from prefect.client.schemas.actions import DeploymentScheduleCreate
 from prefect.client.schemas.objects import (
     ConcurrencyLimitConfig,
+    FlowRun,
+    State,
     StateType,
     Worker,
     WorkerStatus,
@@ -43,7 +46,7 @@ from prefect.events.clients import AssertingEventsClient
 from prefect.events.schemas.automations import Posture
 from prefect.events.schemas.deployment_triggers import DeploymentEventTrigger
 from prefect.events.worker import EventsWorker
-from prefect.flows import load_flow_from_entrypoint
+from prefect.flows import Flow, load_flow_from_entrypoint
 from prefect.logging.loggers import flow_run_logger
 from prefect.runner.runner import Runner
 from prefect.runner.server import perform_health_check, start_webserver
@@ -57,6 +60,7 @@ from prefect.settings import (
     PREFECT_RUNNER_SERVER_ENABLE,
     temporary_settings,
 )
+from prefect.states import Cancelling
 from prefect.testing.utilities import AsyncMock
 from prefect.utilities.dockerutils import parse_image_tag
 from prefect.utilities.filesystem import tmpchdir
@@ -1130,6 +1134,170 @@ class TestRunner:
             runner.stopping = True
             runner._cancelling_flow_run_ids.add(flow_run.id)
             await runner._cancel_run(flow_run)
+
+    class TestRunnerBundleExecution:
+        async def test_basic(self, prefect_client: PrefectClient):
+            runner = Runner()
+
+            @flow(persist_result=True)
+            def simple_flow():
+                return "Be a simple kind of flow"
+
+            flow_run = await prefect_client.create_flow_run(simple_flow)
+
+            bundle = create_bundle_for_flow_run(simple_flow, flow_run)
+            await runner.execute_bundle(bundle)
+
+            flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+            assert flow_run.state
+            assert flow_run.state.is_completed()
+            assert await flow_run.state.result() == "Be a simple kind of flow"
+
+        async def test_with_parameters(self, prefect_client: PrefectClient):
+            runner = Runner()
+
+            @flow(persist_result=True)
+            def flow_with_parameters(x: int, y: str):
+                return f"Be a simple kind of flow with {x} and {y}"
+
+            flow_run = await prefect_client.create_flow_run(
+                flow_with_parameters,
+                parameters={"x": 42, "y": "hello"},
+            )
+
+            bundle = create_bundle_for_flow_run(flow_with_parameters, flow_run)
+            await runner.execute_bundle(bundle)
+
+            flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+            assert flow_run.state
+            assert flow_run.state.is_completed()
+            assert (
+                await flow_run.state.result()
+                == "Be a simple kind of flow with 42 and hello"
+            )
+
+        async def test_failed_flow(self, prefect_client: PrefectClient):
+            runner = Runner()
+
+            @flow
+            def total_and_utter_failure():
+                raise ValueError("This flow failed!")
+
+            flow_run = await prefect_client.create_flow_run(total_and_utter_failure)
+
+            bundle = create_bundle_for_flow_run(total_and_utter_failure, flow_run)
+            await runner.execute_bundle(bundle)
+
+            flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+            assert flow_run.state
+            assert flow_run.state.is_failed()
+
+        async def test_cancel_bundle_execution(
+            self, prefect_client: PrefectClient, caplog: pytest.LogCaptureFixture
+        ):
+            runner = Runner(query_seconds=1)
+
+            @flow
+            def flow_to_cancel():
+                sleep(100)
+
+            @flow_to_cancel.on_cancellation
+            def da_hook(
+                flow: "Flow[Any, Any]", flow_run: "FlowRun", state: "State[Any]"
+            ):
+                flow_run_logger(flow_run, flow).info("This flow was cancelled!")
+
+            flow_run = await prefect_client.create_flow_run(flow_to_cancel)
+
+            bundle = create_bundle_for_flow_run(flow_to_cancel, flow_run)
+            execution_task = asyncio.create_task(runner.execute_bundle(bundle))
+
+            flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+            assert flow_run.state is not None
+            while not flow_run.state.is_running():
+                assert not execution_task.done(), (
+                    "Execution ended earlier than expected"
+                )
+                flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+                assert flow_run.state is not None
+
+            await prefect_client.set_flow_run_state(
+                flow_run_id=flow_run.id,
+                state=Cancelling(),
+            )
+
+            await execution_task
+
+            flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+            assert flow_run.state
+            assert flow_run.state.is_cancelled()
+
+            assert "This flow was cancelled!" in caplog.text
+
+        async def test_crashed_bundle_execution(
+            self, prefect_client: PrefectClient, caplog: pytest.LogCaptureFixture
+        ):
+            runner = Runner()
+
+            @flow
+            def crashed_flow():
+                os.kill(os.getpid(), signal.SIGTERM)
+
+            @crashed_flow.on_crashed
+            def da_hook(
+                flow: "Flow[Any, Any]", flow_run: "FlowRun", state: "State[Any]"
+            ):
+                flow_run_logger(flow_run, flow).info("This flow crashed!")
+
+            flow_run = await prefect_client.create_flow_run(crashed_flow)
+
+            bundle = create_bundle_for_flow_run(crashed_flow, flow_run)
+            await runner.execute_bundle(bundle)
+
+            flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+            assert flow_run.state
+            assert flow_run.state.is_crashed()
+
+            assert "This flow crashed!" in caplog.text
+
+        async def test_heartbeats_for_bundle_execution(
+            self, prefect_client: PrefectClient, asserting_events_worker: EventsWorker
+        ):
+            runner = Runner(heartbeat_seconds=30)
+
+            @flow
+            def heartbeat_flow():
+                return "a low, dull, quick sound — much such a sound as a watch makes when enveloped in cotton"
+
+            flow_run = await prefect_client.create_flow_run(heartbeat_flow)
+
+            bundle = create_bundle_for_flow_run(heartbeat_flow, flow_run)
+            await runner.execute_bundle(bundle)
+
+            flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+            assert flow_run.state
+            assert flow_run.state.is_completed()
+
+            await asserting_events_worker.drain()
+
+            heartbeat_events = list(
+                filter(
+                    lambda e: e.event == "prefect.flow-run.heartbeat",
+                    asserting_events_worker._client.events,
+                )
+            )
+            assert len(heartbeat_events) == 1
+            assert heartbeat_events[0].resource.id == f"prefect.flow-run.{flow_run.id}"
+
+            related = [dict(r.items()) for r in heartbeat_events[0].related]
+
+            assert related == [
+                {
+                    "prefect.resource.id": f"prefect.flow.{flow_run.flow_id}",
+                    "prefect.resource.role": "flow",
+                    "prefect.resource.name": heartbeat_flow.name,
+                },
+            ]
 
 
 @pytest.mark.usefixtures("use_hosted_api_server")

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -22,8 +22,8 @@ from starlette import status
 
 import prefect.runner
 from prefect import __version__, aserve, flow, serve, task
-from prefect.cli.deploy import _PullStepStorage
 from prefect._experimental.bundles import create_bundle_for_flow_run
+from prefect.cli.deploy import _PullStepStorage
 from prefect.client.orchestration import PrefectClient, SyncPrefectClient
 from prefect.client.schemas.actions import DeploymentScheduleCreate
 from prefect.client.schemas.objects import (


### PR DESCRIPTION
This PR uses the utilities introduced in #17178 to outfit the `Runner` class to kick off and monitor the execution of a bundle. The `Runner` can handle cancellation and crash detection for flow runs initiated via bundle the same as if execution was kicked off by a normally scheduled run.

The `execute_bundle` method duplicates some logic because I want to move the `Runner` control flow towards one where we kick off subprocess via `multiprocessing` rather than `subprocess`. I think that flow is substantially easier to understand and should be possible with the `run_flow_in_subprocess` utility in a later PR. 