### PR TITLE
#16397 - Fix quotes in 2022_07_07_111208_061c7e518b40_removes_debugprintnotification_block_.py

### DIFF
--- a/src/prefect/server/database/_migrations/versions/sqlite/2022_07_07_111208_061c7e518b40_removes_debugprintnotification_block_.py
+++ b/src/prefect/server/database/_migrations/versions/sqlite/2022_07_07_111208_061c7e518b40_removes_debugprintnotification_block_.py
@@ -18,7 +18,7 @@ depends_on = None
 def upgrade():
     op.execute(
         """
-        DELETE FROM block_type WHERE name = "Debug Print Notification"
+        DELETE FROM block_type WHERE name = 'Debug Print Notification'
         """
     )
 


### PR DESCRIPTION
Related to #16397 . 

We observed `RuntimeError: Timed out while attempting to connect to ephemeral Prefect API server` when running tests with `prefect_test_harness()`. This seems to have been caused by
```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such column: "Debug Print Notification" - should this be a string literal in single-quotes?
[SQL: 
        DELETE FROM block_type WHERE name = "Debug Print Notification"
        ]
```

Locally changing double quotes to single quotes resolved the issue to me - the `prefect_test_harness()` is not hanging any more.

AFAIK, double quotes are syntactically not correct in SQL and single quotes shall be used to indicate strings.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
