### PR TITLE
Add performance_report_path arg to DaskTaskRunner

### DIFF
--- a/src/integrations/prefect-dask/prefect_dask/task_runners.py
+++ b/src/integrations/prefect-dask/prefect_dask/task_runners.py
@@ -405,9 +405,6 @@ class DaskTaskRunner(TaskRunner):
         - Creates a cluster if an external address is not set.
         - Creates a client to connect to the cluster.
         """
-        from contextlib import nullcontext
-        import distributed
-
         in_dask = False
         try:
             client = distributed.get_client()
@@ -457,7 +454,9 @@ class DaskTaskRunner(TaskRunner):
         if self.performance_report_path:
             # Register our client as current so that it's found by distributed.get_client()
             exit_stack.enter_context(distributed.Client.as_current(self._client))
-            exit_stack.enter_context(distributed.performance_report(self.performance_report_path))
+            exit_stack.enter_context(
+                distributed.performance_report(self.performance_report_path)
+            )
 
         if self._client.dashboard_link and not in_dask:
             self.logger.info(

--- a/src/integrations/prefect-dask/prefect_dask/task_runners.py
+++ b/src/integrations/prefect-dask/prefect_dask/task_runners.py
@@ -195,6 +195,8 @@ class DaskTaskRunner(TaskRunner):
             is only enabled if `adapt_kwargs` are provided.
         client_kwargs (dict, optional): Additional kwargs to use when creating a
             [`dask.distributed.Client`](https://distributed.dask.org/en/latest/api.html#client).
+        performance_report_path (str, optional): Path where the Dask performance report
+            will be saved. If not provided, no performance report will be generated.
 
     Examples:
         Using a temporary local dask cluster:
@@ -233,6 +235,7 @@ class DaskTaskRunner(TaskRunner):
         cluster_kwargs: Optional[Dict] = None,
         adapt_kwargs: Optional[Dict] = None,
         client_kwargs: Optional[Dict] = None,
+        performance_report_path: Optional[str] = None,
     ):
         # Validate settings and infer defaults
         if address:
@@ -278,6 +281,7 @@ class DaskTaskRunner(TaskRunner):
         self.cluster_kwargs = cluster_kwargs
         self.adapt_kwargs = adapt_kwargs
         self.client_kwargs = client_kwargs
+        self.performance_report_path = performance_report_path
 
         # Runtime attributes
         self._client: PrefectDaskClient = None
@@ -312,6 +316,7 @@ class DaskTaskRunner(TaskRunner):
             cluster_kwargs=self.cluster_kwargs,
             adapt_kwargs=self.adapt_kwargs,
             client_kwargs=self.client_kwargs,
+            performance_report_path=self.performance_report_path,
         )
 
     @overload
@@ -400,6 +405,9 @@ class DaskTaskRunner(TaskRunner):
         - Creates a cluster if an external address is not set.
         - Creates a client to connect to the cluster.
         """
+        from contextlib import nullcontext
+        import distributed
+
         in_dask = False
         try:
             client = distributed.get_client()
@@ -412,8 +420,10 @@ class DaskTaskRunner(TaskRunner):
             in_dask = True
         except ValueError:
             pass
+
         super().__enter__()
         exit_stack = self._exit_stack.__enter__()
+
         if self._cluster:
             self.logger.info(f"Connecting to existing Dask cluster {self._cluster}")
             self._connect_to = self._cluster
@@ -443,6 +453,11 @@ class DaskTaskRunner(TaskRunner):
         self._client = exit_stack.enter_context(
             PrefectDaskClient(self._connect_to, **self.client_kwargs)
         )
+
+        if self.performance_report_path:
+            # Register our client as current so that it's found by distributed.get_client()
+            exit_stack.enter_context(distributed.Client.as_current(self._client))
+            exit_stack.enter_context(distributed.performance_report(self.performance_report_path))
 
         if self._client.dashboard_link and not in_dask:
             self.logger.info(

--- a/src/integrations/prefect-dask/pyproject.toml
+++ b/src/integrations/prefect-dask/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
+  "bokeh",
   "coverage",
   # Dask and its distributed scheduler follow the same release schedule and version,
   # so here we apply the same restrictions as for the distributed package up above in

--- a/src/integrations/prefect-dask/tests/test_task_runners.py
+++ b/src/integrations/prefect-dask/tests/test_task_runners.py
@@ -502,3 +502,34 @@ class TestDaskTaskRunner:
         a_time, b_time, c_time = test_flow()
 
         assert c_time > a_time and c_time > b_time
+
+    async def test_performance_report_generation(self, tmp_path):
+        report_path = tmp_path / "dask-report.html"
+        task_runner_with_performance_report_path = DaskTaskRunner(
+            performance_report_path=str(report_path)
+        )
+
+        @task
+        def task_a():
+            return "a"
+
+        @task
+        def task_b():
+            return "b"
+
+        @task
+        def task_c(b):
+            return b + "c"
+
+        @flow(version="test", task_runner=task_runner_with_performance_report_path)
+        def test_flow():
+            a = task_a.submit()
+            b = task_b.submit()
+            c = task_c.submit(b)
+            return a, b, c
+
+        test_flow()
+        
+        assert report_path.exists()
+        report_content = report_path.read_text()
+        assert "Dask Performance Report" in report_content

--- a/src/integrations/prefect-dask/tests/test_task_runners.py
+++ b/src/integrations/prefect-dask/tests/test_task_runners.py
@@ -529,7 +529,7 @@ class TestDaskTaskRunner:
             return a, b, c
 
         test_flow()
-        
+
         assert report_path.exists()
         report_content = report_path.read_text()
         assert "Dask Performance Report" in report_content


### PR DESCRIPTION
Prefect 1's `DaskExecutor` had a `performance_report_path` arg that made it straightforward to save out the Dask performance report from a flow run. This PR restores that behavior for `prefect-dask`'s `DaskTaskRunner`.

The only slightly weird thing I ran into was that the `distributed.get_client()` helper does not pick up the task runner's client (` ValueError: No global client found and no address provided`), so I had to add a call to `as_current` to register as the global client...not sure whether it was a deliberate choice to not have our PrefectDaskClient show up as the Dask default (possibly related to #12971?), if it's important to preserve that then I'm not totally sure how else to get `performance_report` to pick up the correct client.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes