### PR TITLE
Add warning of potential client/server incompatibilities

### DIFF
--- a/docs/v3/manage/self-host.mdx
+++ b/docs/v3/manage/self-host.mdx
@@ -17,6 +17,13 @@ See the [Prefect Cloud overview](/v3/manage/cloud/) for more information.
 
 ## Self-host a Prefect server
 
+<Warning>
+Though old clients are compatible with new servers, we recommend using the same version of `prefect` for the client and server.
+As new fields are added to the REST API, using a newer client version with an older server version can lead to incompatibilities or unexpected behavior. 
+These issues will normally manifest as responses from the server with a 422 status code.
+</Warning>
+
+
 1. Spin up a self-hosted Prefect server instance UI with the `prefect server start` CLI command in the terminal:
 
 ```bash

--- a/docs/v3/manage/self-host.mdx
+++ b/docs/v3/manage/self-host.mdx
@@ -18,9 +18,9 @@ See the [Prefect Cloud overview](/v3/manage/cloud/) for more information.
 ## Self-host a Prefect server
 
 <Warning>
-Though old clients are compatible with new servers, we recommend using the same version of `prefect` for the client and server.
-As new fields are added to the REST API, using a newer client version with an older server version can lead to incompatibilities or unexpected behavior. 
-These issues will normally manifest as responses from the server with a 422 status code.
+We recommend using the same version of `prefect` for the client and server.
+Old clients are compatible with new servers, but new clients can be incompatible with old servers as new fields are added to the REST API.
+The server will typically return a 422 status code if any issues occur.
 </Warning>
 
 

--- a/src/prefect/client/orchestration/__init__.py
+++ b/src/prefect/client/orchestration/__init__.py
@@ -7,6 +7,7 @@ from contextlib import AsyncExitStack
 from logging import Logger
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, Optional, Union, overload
 from uuid import UUID
+import warnings
 
 import certifi
 import httpcore
@@ -1182,8 +1183,15 @@ class PrefectClient(
         if api_version.major != client_version.major:
             raise RuntimeError(
                 f"Found incompatible versions: client: {client_version}, server: {api_version}. "
-                f"Major versions must match."
+                "Major versions must match."
             )
+        if api_version < client_version:
+            warning_message = (
+                "Your Prefect server is running an older version of Prefect than your client which may result in unexpected behavior. "
+                f"Please upgrade your Prefect server from version {api_version} to version {client_version} or higher."
+            )
+            warnings.filterwarnings("once", message=warning_message)
+            warnings.warn(warning_message)
 
     async def __aenter__(self) -> Self:
         """
@@ -1523,8 +1531,15 @@ class SyncPrefectClient(
         if api_version.major != client_version.major:
             raise RuntimeError(
                 f"Found incompatible versions: client: {client_version}, server: {api_version}. "
-                f"Major versions must match."
+                "Major versions must match."
             )
+        if api_version < client_version:
+            warning_message = (
+                "Your Prefect server is running an older version of Prefect than your client which may result in unexpected behavior. "
+                f"Please upgrade your Prefect server from version {api_version} to version {client_version} or higher."
+            )
+            warnings.filterwarnings("once", message=warning_message)
+            warnings.warn(warning_message)
 
     def set_task_run_name(self, task_run_id: UUID, name: str) -> httpx.Response:
         task_run_data = TaskRunUpdate(name=name)

--- a/src/prefect/client/orchestration/__init__.py
+++ b/src/prefect/client/orchestration/__init__.py
@@ -7,7 +7,6 @@ from contextlib import AsyncExitStack
 from logging import Logger
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, Optional, Union, overload
 from uuid import UUID
-import warnings
 
 import certifi
 import httpcore
@@ -82,6 +81,7 @@ from prefect.client.orchestration._blocks_types.client import (
 
 import prefect
 import prefect.exceptions
+from prefect.logging.loggers import get_run_logger
 import prefect.settings
 import prefect.states
 from prefect.client.constants import SERVER_API_VERSION
@@ -1190,8 +1190,10 @@ class PrefectClient(
                 "Your Prefect server is running an older version of Prefect than your client which may result in unexpected behavior. "
                 f"Please upgrade your Prefect server from version {api_version} to version {client_version} or higher."
             )
-            warnings.filterwarnings("once", message=warning_message)
-            warnings.warn(warning_message)
+            try:
+                get_run_logger().warning(warning_message)
+            except prefect.context.MissingContextError:
+                self.logger.warning(warning_message)
 
     async def __aenter__(self) -> Self:
         """
@@ -1538,8 +1540,10 @@ class SyncPrefectClient(
                 "Your Prefect server is running an older version of Prefect than your client which may result in unexpected behavior. "
                 f"Please upgrade your Prefect server from version {api_version} to version {client_version} or higher."
             )
-            warnings.filterwarnings("once", message=warning_message)
-            warnings.warn(warning_message)
+            try:
+                get_run_logger().warning(warning_message)
+            except prefect.context.MissingContextError:
+                self.logger.warning(warning_message)
 
     def set_task_run_name(self, task_run_id: UUID, name: str) -> httpx.Response:
         task_run_data = TaskRunUpdate(name=name)

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -1,7 +1,6 @@
 import json
 import os
 import ssl
-import warnings
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import Generator, List
@@ -2785,20 +2784,19 @@ class TestPrefectClientRaiseForAPIVersionMismatch:
             in str(e.value)
         )
 
-    async def test_warn_on_server_incompatibility(self, prefect_client, monkeypatch):
+    async def test_warn_on_server_incompatibility(
+        self, prefect_client, monkeypatch, caplog
+    ):
         mock_version = "3.0.0"
         assert version.parse(mock_version) < version.parse(prefect.__version__)
         monkeypatch.setattr(
             prefect_client, "api_version", AsyncMock(return_value=mock_version)
         )
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings("always")
-            await prefect_client.raise_for_api_version_mismatch()
+        await prefect_client.raise_for_api_version_mismatch()
 
-        assert len(w) == 1
         assert (
             "Your Prefect server is running an older version of Prefect than your client which may result in unexpected behavior."
-            in str(w[0].message)
+            in caplog.text
         )
 
 
@@ -2871,21 +2869,17 @@ class TestSyncClientRaiseForAPIVersionMismatch:
         )
 
     async def test_warn_on_server_incompatibility(
-        self, sync_prefect_client, monkeypatch
+        self, sync_prefect_client, monkeypatch, caplog
     ):
         mock_version = "3.0.0"
         assert version.parse(mock_version) < version.parse(prefect.__version__)
         monkeypatch.setattr(
             sync_prefect_client, "api_version", Mock(return_value=mock_version)
         )
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings("always")
-            sync_prefect_client.raise_for_api_version_mismatch()
-
-        assert len(w) == 1
+        sync_prefect_client.raise_for_api_version_mismatch()
         assert (
             "Your Prefect server is running an older version of Prefect than your client which may result in unexpected behavior."
-            in str(w[0].message)
+            in caplog.text
         )
 
 


### PR DESCRIPTION
Clients generally need to be the same version as the server or earlier to accommodate adding new fields to the REST API. This PR adds a warning to the client to alert users if their client is a newer version than the server they are running against and provides the version the user needs to upgrade their server to.

Here's what the warning looks like:
```python
>>> from prefect import flow
>>> @flow
... def my_flow():
...     print("Hello world!")
... 
>>> my_flow()
21:32:29.962 | WARNING | prefect.client - Your Prefect server is running an older version of Prefect than your client which may result in unexpected behavior. Please upgrade your Prefect server from version 3.2.3 to version 3.2.6 or higher.
21:32:30.035 | INFO    | Flow run 'daffodil-jackdaw' - Beginning flow run 'daffodil-jackdaw' for flow 'my-flow'
21:32:30.036 | INFO    | Flow run 'daffodil-jackdaw' - View at http://127.0.0.1:4200/runs/flow-run/fa61e1b3-cec6-4f32-a7ea-b79244f164ca
Hello world!
21:32:30.048 | INFO    | Flow run 'daffodil-jackdaw' - Finished in state Completed()
```