### PR TITLE
add warning in docs/client init for new clients with old servers

### DIFF
--- a/docs/v3/develop/settings-ref.mdx
+++ b/docs/v3/develop/settings-ref.mdx
@@ -164,6 +164,20 @@ The URL of the Prefect UI. If not set, the client will attempt to infer it.
 **Supported environment variables**:
 `PREFECT_SILENCE_API_URL_MISCONFIGURATION`
 
+### `silence_client_server_mismatch_warning`
+
+        If `True`, disable the warning when a client version is newer than the server version.
+        
+
+**Type**: `boolean`
+
+**Default**: `False`
+
+**TOML dotted key path**: `silence_client_server_mismatch_warning`
+
+**Supported environment variables**:
+`PREFECT_SILENCE_CLIENT_SERVER_MISMATCH_WARNING`
+
 ---
 ## APISettings
 Settings for interacting with the Prefect API

--- a/docs/v3/manage/self-host.mdx
+++ b/docs/v3/manage/self-host.mdx
@@ -11,11 +11,18 @@ To self-host a Prefect server instance on Kubernetes, check out the prefect-serv
 After installing Prefect, you have a Python SDK client that can communicate with 
 either [Prefect Cloud](/v3/manage/cloud/) or a self-hosted Prefect server, backed by a database and a UI.
 
+
 Prefect Cloud and self-hosted Prefect server share a common set of capabilities. 
 Prefect Cloud provides the additional features required by organizations such as RBAC, Audit logs, and SSO. 
 See the [Prefect Cloud overview](/v3/manage/cloud/) for more information.
 
 ## Self-host a Prefect server
+
+<Warning>
+Though old clients are compatible with new servers, we recommend using the same version of `prefect` for the client and server.
+As server-side schema changes are sometimes released, using new clients with an old server can lead to schema incompatibilities (e.g. 422s) or unexpected behavior.
+</Warning>
+
 
 1. Spin up a self-hosted Prefect server instance UI with the `prefect server start` CLI command in the terminal:
 

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -2396,6 +2396,15 @@
             ],
             "title": "Silence Api Url Misconfiguration",
             "type": "boolean"
+        },
+        "silence_client_server_mismatch_warning": {
+            "default": false,
+            "description": "\n        If `True`, disable the warning when a client version is newer than the server version.\n        ",
+            "supported_environment_variables": [
+                "PREFECT_SILENCE_CLIENT_SERVER_MISMATCH_WARNING"
+            ],
+            "title": "Silence Client Server Mismatch Warning",
+            "type": "boolean"
         }
     },
     "title": "Prefect Settings",

--- a/src/prefect/settings/models/root.py
+++ b/src/prefect/settings/models/root.py
@@ -151,6 +151,13 @@ class Settings(PrefectBaseSettings):
         """,
     )
 
+    silence_client_server_mismatch_warning: bool = Field(
+        default=False,
+        description="""
+        If `True`, disable the warning when a client version is newer than the server version.
+        """,
+    )
+
     ###########################################################################
     # allow deprecated access to PREFECT_SOME_SETTING_NAME
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -413,6 +413,7 @@ SUPPORTED_SETTINGS = {
     "PREFECT_SERVER_UI_SERVE_BASE": {"test_value": "/base"},
     "PREFECT_SERVER_UI_STATIC_DIRECTORY": {"test_value": "/path/to/static"},
     "PREFECT_SILENCE_API_URL_MISCONFIGURATION": {"test_value": True},
+    "PREFECT_SILENCE_CLIENT_SERVER_MISMATCH_WARNING": {"test_value": False},
     "PREFECT_SQLALCHEMY_MAX_OVERFLOW": {"test_value": 10, "legacy": True},
     "PREFECT_SQLALCHEMY_POOL_SIZE": {"test_value": 10, "legacy": True},
     "PREFECT_TASKS_DEFAULT_PERSIST_RESULT": {"test_value": True},


### PR DESCRIPTION
we were previously only checking major versions, which I think we correctly fail on now.

this PR adds docs and a WARNING level log that can be silenced by a setting (`silence_client_server_mismatch_warning: bool = False`) if the semantic version of the client is greater than that of the server