### PR TITLE
Drains all queue services after executing a flow run

### DIFF
--- a/src/prefect/engine.py
+++ b/src/prefect/engine.py
@@ -116,6 +116,7 @@ if __name__ == "__main__":
                 "Unexpected exception encountered when trying to load flow",
                 exc_info=True,
             )
+            QueueService.drain_all()
             raise
 
         try:


### PR DESCRIPTION
Today, when a problem occurs installing `EXTRA_PIP_PACKAGES` or
running deployment pull steps, those logs are effectively lost to the
end user and masked by a generic error just saying that the flow run
process exited with a non-zero exit code.

I initially expected that we weren't using flow run loggers for those
steps, but it turns out that we generally are!  We just aren't draining
the `APILogWorker` and other queue services after the flow run finishes.
I expect this may also affect event emission in some cases.

Before:

![image](https://github.com/user-attachments/assets/c1cce99f-875c-492c-9ade-a101da0866a7)


After:

![image](https://github.com/user-attachments/assets/9a72440f-ea5b-4897-899d-2af35e5d1744)
