### PR TITLE
[UI-v2] feat: add jsx support

### DIFF
--- a/ui-v2/biome.json
+++ b/ui-v2/biome.json
@@ -7,7 +7,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"ignore": ["src/api/prefect.ts", "src/routeTree.gen.ts"]
+		"ignore": ["src/api/prefect.ts", "src/routeTree.gen.ts", "dist"]
 	},
 	"formatter": {
 		"enabled": true,

--- a/ui-v2/tests/utils/index.ts
+++ b/ui-v2/tests/utils/index.ts
@@ -1,22 +1,3 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { createElement } from "react";
+export { createWrapper } from "./wrappers";
 export { server } from "./node";
 export { buildApiUrl } from "./handlers";
-
-/* Wraps render() components with app-wide providers
- *
- * @example
- * import { createWrapper } from '@tests/utils'
- *
- * ```tsx
- *	const result = render(<MyComponentToTest />, {
- *		wrapper: createWrapper(),
- *	});
- * ```
- */
-export const createWrapper = ({ queryClient = new QueryClient() } = {}) => {
-	// Written with createElement because our current vite config doesn't support jsx in tests/
-	const Wrapper = ({ children }: { children: React.ReactNode }) =>
-		createElement(QueryClientProvider, { client: queryClient }, children);
-	return Wrapper;
-};

--- a/ui-v2/tests/utils/wrappers.tsx
+++ b/ui-v2/tests/utils/wrappers.tsx
@@ -1,0 +1,20 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement } from "react";
+
+/* Wraps render() components with app-wide providers
+ *
+ * @example
+ * import { createWrapper } from '@tests/utils'
+ *
+ * ```tsx
+ *	const result = render(<MyComponentToTest />, {
+ *		wrapper: createWrapper(),
+ *	});
+ * ```
+ */
+export const createWrapper = ({ queryClient = new QueryClient() } = {}) => {
+	// Written with createElement because our current vite config doesn't support jsx in tests/
+	const Wrapper = ({ children }: { children: React.ReactNode }) =>
+		createElement(QueryClientProvider, { client: queryClient }, children);
+	return Wrapper;
+};

--- a/ui-v2/tsconfig.node.json
+++ b/ui-v2/tsconfig.node.json
@@ -14,7 +14,12 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true,
-		"types": ["vite/client"]
+		"paths": {
+			"@/*": ["./src/*"],
+			"@tests/*": ["./tests/*"]
+		},
+		"types": ["vite/client"],
+		"jsx": "react-jsx"
 	},
 	"include": ["vite.config.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
Add jsx support for tests when building. The `index.ts` file should remain a `.ts` file so I created a wrappers file that will support `.tsx` 


### Checklist
- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
