### PR TITLE
Add `KuberenetesWorker.submit` for ad-hoc submission to a Kubernetes work pool

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -729,7 +729,16 @@ class KubernetesWorker(
         )
         configuration.prepare_for_flow_run(flow_run=flow_run, flow=api_flow)
 
-        await self.run(flow_run, configuration)
+        result = await self.run(flow_run, configuration)
+
+        if result.status_code != 0:
+            await self._propose_crashed_state(
+                flow_run,
+                (
+                    "Flow run infrastructure exited with non-zero status code"
+                    f" {result.status_code}."
+                ),
+            )
 
     async def teardown(self, *exc_info: Any):
         await super().teardown(*exc_info)

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -703,6 +703,7 @@ class KubernetesWorker(
         api_flow = APIFlow(id=flow_run.flow_id, name=flow.name, labels={})
         logger = self.get_flow_run_logger(flow_run)
 
+        # TODO: Migrate steps to their own attributes on work pool when hardening this design
         upload_step = json.loads(
             get_from_dict(
                 self._work_pool.base_job_template,

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -152,6 +152,7 @@ from prefect.client.schemas.objects import Flow as APIFlow
 from prefect.exceptions import (
     InfrastructureError,
 )
+from prefect.futures import PrefectFlowRunFuture
 from prefect.states import Pending
 from prefect.utilities.dockerutils import get_prefect_image_name
 from prefect.utilities.templating import find_placeholders
@@ -646,7 +647,7 @@ class KubernetesWorker(
 
     async def submit(
         self, flow: "Flow[..., R]", parameters: dict[str, Any] | None = None
-    ) -> "FlowRun":
+    ) -> "PrefectFlowRunFuture[R]":
         """
         EXPERIMENTAL: The interface for this method is subject to change.
 
@@ -664,7 +665,7 @@ class KubernetesWorker(
         flow_run = await self._runs_task_group.start(
             self._submit_adhoc_run, flow, parameters
         )
-        return flow_run
+        return PrefectFlowRunFuture(flow_run_id=flow_run.id)
 
     async def _submit_adhoc_run(
         self,

--- a/src/integrations/prefect-kubernetes/tests/test_worker.py
+++ b/src/integrations/prefect-kubernetes/tests/test_worker.py
@@ -3205,6 +3205,7 @@ class TestKubernetesWorker:
                 "my-creds",
                 "--key",
                 str(future.flow_run_id),
+                str(future.flow_run_id),
             ]
             mock_run_process.assert_called_once_with(
                 expected_command,

--- a/src/prefect/_experimental/bundles.py
+++ b/src/prefect/_experimental/bundles.py
@@ -191,7 +191,8 @@ def convert_step_to_command(step: dict[str, Any], key: str) -> list[str]:
     requires: list[str] | str = function_args.get("requires", [])
     if isinstance(requires, str):
         requires = [requires]
-    command.extend(["--with", ",".join(requires)])
+    if requires:
+        command.extend(["--with", ",".join(requires)])
 
     # Add the `--python` argument to handle the Python version for running the step
     python_version = sys.version_info

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -566,8 +566,6 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         healthcheck_thread = None
         try:
             async with self as worker:
-                # wait for an initial heartbeat to configure the worker
-                await worker.sync_with_backend()
                 # schedule the scheduled flow run polling loop
                 async with anyio.create_task_group() as loops_task_group:
                     loops_task_group.start_soon(
@@ -654,6 +652,8 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
 
         await self._exit_stack.enter_async_context(self._client)
         await self._exit_stack.enter_async_context(self._runs_task_group)
+
+        await self.sync_with_backend()
 
         self.is_setup = True
 

--- a/tests/experimental/test_bundles.py
+++ b/tests/experimental/test_bundles.py
@@ -1,6 +1,7 @@
 import signal
 import subprocess
-from typing import Literal
+import sys
+from typing import Any, Literal
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,6 +9,7 @@ import uv
 
 from prefect import flow
 from prefect._experimental.bundles import (
+    convert_step_to_command,
     create_bundle_for_flow_run,
     execute_bundle_in_subprocess,
 )
@@ -279,3 +281,68 @@ class TestExecuteBundleInSubprocess:
         # Stays in running state because the process died
         assert flow_run.state is not None
         assert flow_run.state.is_running()
+
+
+class TestConvertStepToCommand:
+    def test_basic(self):
+        step = {
+            "prefect_aws.experimental.bundles.upload": {
+                "requires": "prefect-aws==0.5.5",
+                "bucket": "test-bucket",
+                "aws_credentials_block_name": "my-creds",
+            }
+        }
+
+        python_version_info = sys.version_info
+        command = convert_step_to_command(step, "test-key")
+        assert command == [
+            "uv",
+            "run",
+            "--with",
+            "prefect-aws==0.5.5",
+            "--python",
+            f"{python_version_info.major}.{python_version_info.minor}",
+            "-m",
+            "prefect_aws.experimental.bundles.upload",
+            "--bucket",
+            "test-bucket",
+            "--aws-credentials-block-name",
+            "my-creds",
+            "--key",
+            "test-key",
+        ]
+
+    def test_with_no_requires(self):
+        step = {
+            "prefect_mock.experimental.bundles.upload": {
+                "bucket": "test-bucket",
+            }
+        }
+
+        python_version_info = sys.version_info
+        command = convert_step_to_command(step, "test-key")
+        assert command == [
+            "uv",
+            "run",
+            "--python",
+            f"{python_version_info.major}.{python_version_info.minor}",
+            "-m",
+            "prefect_mock.experimental.bundles.upload",
+            "--bucket",
+            "test-bucket",
+            "--key",
+            "test-key",
+        ]
+
+    def test_raises_if_multiple_functions_are_provided(self):
+        step: dict[str, Any] = {
+            "prefect_mock.experimental.bundles.upload": {},
+            "prefect_mock.experimental.bundles.download": {},
+        }
+        with pytest.raises(ValueError, match="Expected exactly one function in step"):
+            convert_step_to_command(step, "test-key")
+
+    def test_raises_if_no_function_is_provided(self):
+        step: dict[str, Any] = {}
+        with pytest.raises(ValueError, match="Expected exactly one function in step"):
+            convert_step_to_command(step, "test-key")

--- a/tests/workers/test_process_worker.py
+++ b/tests/workers/test_process_worker.py
@@ -118,16 +118,29 @@ def patch_client(monkeypatch, overrides: Optional[Dict[str, Any]] = None):
         id: UUID = uuid.uuid4()
         name: str = "test-flow"
 
+    class MockWorkPool(BaseModel):
+        id: UUID = uuid.uuid4()
+        name: str = "test-work-pool"
+        type: str = "process"
+        description: str = "None"
+        base_job_template: dict[str, Any] = {}
+
     mock_get_client = MagicMock()
     mock_client = MagicMock()
     mock_read_deployment = AsyncMock()
     mock_read_deployment.return_value = MockDeployment()
     mock_read_flow = AsyncMock()
     mock_read_flow.return_value = MockFlow()
+    mock_read_work_pool = AsyncMock()
+    mock_read_work_pool.return_value = MockWorkPool()
+    mock_update_work_pool = AsyncMock()
+    mock_update_work_pool.return_value = MockWorkPool()
     mock_client.read_deployment = mock_read_deployment
     mock_client.read_flow = mock_read_flow
     mock_get_client.return_value = mock_client
-
+    mock_client.read_work_pool = mock_read_work_pool
+    mock_client.update_work_pool = mock_update_work_pool
+    mock_client.send_worker_heartbeat = AsyncMock()
     monkeypatch.setattr("prefect.workers.base.get_client", mock_get_client)
 
     return mock_read_deployment


### PR DESCRIPTION
This PR adds an experimental `.submit` method to the `KubernetesWorker` class to allow a flow to be submitted to a Kubernetes cluster. The updates to the work pool API haven't been made yet, so the steps for bundle upload and execution are stored within the work pool's `env` field on the base job template.

Here's an example:
```python
import asyncio
import json
import os

from prefect_kubernetes import KubernetesWorker

from prefect import flow

# These steps are stored in `env` in the work pool's base job template
UPLOAD_STEP = {
    "prefect_aws.experimental.bundles.upload": {
        "requires": "prefect-aws==0.5.5",
        "bucket": "storage-blocks-test-bucket",
        "aws_credentials_block_name": "my-creds",
    }
}

EXECUTE_STEP = {
    "prefect_aws.experimental.bundles.execute": {
        "requires": "prefect-aws==0.5.5",
        "bucket": "storage-blocks-test-bucket",
        "aws_credentials_block_name": "my-creds",
    }
}


@flow(log_prints=True, result_storage="s3-bucket/results-bucket")
def my_flow():
    print("Returning greeting...")
    return "Hello, world!"


async def main():
    async with KubernetesWorker(work_pool_name="olympic") as worker:
        future = await worker.submit(flow=my_flow)

    print(future.result()) # prints "Hello, world!"


if __name__ == "__main__":
    asyncio.run(main())
```

Related to https://github.com/PrefectHQ/prefect/issues/17194