### PR TITLE
Set `cache_ok` flag to true for UUIDList

### DIFF
--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -923,7 +923,7 @@ class UUIDList(sa.TypeDecorator[list[UUID]]):
     """Map a JSON list of strings back to a list of UUIDs at the result loading stage"""
 
     impl: Union[TypeEngine[Any], type[TypeEngine[Any]]] = sa.JSON()
-    cache_ok: bool = True
+    cache_ok: Optional[bool] = True
 
     def process_result_value(
         self, value: Optional[list[Union[str, UUID]]], dialect: sa.Dialect

--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -923,6 +923,7 @@ class UUIDList(sa.TypeDecorator[list[UUID]]):
     """Map a JSON list of strings back to a list of UUIDs at the result loading stage"""
 
     impl: Union[TypeEngine[Any], type[TypeEngine[Any]]] = sa.JSON()
+    cache_ok: bool = True
 
     def process_result_value(
         self, value: Optional[list[Union[str, UUID]]], dialect: sa.Dialect


### PR DESCRIPTION
Closes #17231 

This PR sets the `cache_ok` flag to `True` for our custom `UUIDList` type in the sqlalchemy layer of the server. From the SA docs:
> If the TypeDecorator is not guaranteed to produce the same bind/result behavior and SQL generation every time, this flag should be set to False; otherwise if the class produces the same behavior each time, it may be set to True. See TypeDecorator.cache_ok for further notes on how this works.

I'm still reading a little bit but this class should be fully deterministic, including preserving the order in which values are given, so this should be a strict improvement AFAIK.