### PR TITLE
Add `PrefectFuture` implementation for flow runs

### DIFF
--- a/src/prefect/_waiters.py
+++ b/src/prefect/_waiters.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import asyncio
+import atexit
+import threading
+import uuid
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Self,
+)
+
+import anyio
+from cachetools import TTLCache
+
+from prefect._internal.concurrency.api import create_call, from_async, from_sync
+from prefect._internal.concurrency.threads import get_global_loop
+from prefect.client.schemas.objects import (
+    TERMINAL_STATES,
+)
+from prefect.events.clients import get_events_subscriber
+from prefect.events.filters import EventFilter, EventNameFilter
+from prefect.logging import get_logger
+
+if TYPE_CHECKING:
+    import logging
+
+
+class FlowRunWaiter:
+    """
+    A service used for waiting for a flow run to finish.
+
+    This service listens for flow run events and provides a way to wait for a specific
+    flow run to finish. This is useful for waiting for a flow run to finish before
+    continuing execution.
+
+    The service is a singleton and must be started before use. The service will
+    automatically start when the first instance is created. A single websocket
+    connection is used to listen for flow run events.
+
+    The service can be used to wait for a flow run to finish by calling
+    `FlowRunWaiter.wait_for_flow_run` with the flow run ID to wait for. The method
+    will return when the flow run has finished or the timeout has elapsed.
+
+    The service will automatically stop when the Python process exits or when the
+    global loop thread is stopped.
+
+    Example:
+    ```python
+    import asyncio
+    from uuid import uuid4
+
+    from prefect import flow
+    from prefect.flow_engine import run_flow_async
+    from prefect.flow_runs import FlowRunWaiter
+
+
+    @flow
+    async def test_flow():
+        await asyncio.sleep(5)
+        print("Done!")
+
+
+    async def main():
+        flow_run_id = uuid4()
+        asyncio.create_flow(run_flow_async(flow=test_flow, flow_run_id=flow_run_id))
+
+        await FlowRunWaiter.wait_for_flow_run(flow_run_id)
+        print("Flow run finished")
+
+
+    if __name__ == "__main__":
+        asyncio.run(main())
+    ```
+    """
+
+    _instance: Self | None = None
+    _instance_lock = threading.Lock()
+
+    def __init__(self):
+        self.logger: "logging.Logger" = get_logger("FlowRunWaiter")
+        self._consumer_task: asyncio.Task[None] | None = None
+        self._observed_completed_flow_runs: TTLCache[uuid.UUID, bool] = TTLCache(
+            maxsize=10000, ttl=600
+        )
+        self._completion_events: dict[uuid.UUID, asyncio.Event] = {}
+        self._completion_callbacks: dict[uuid.UUID, Callable[[], None]] = {}
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._observed_completed_flow_runs_lock = threading.Lock()
+        self._completion_events_lock = threading.Lock()
+        self._started = False
+
+    def start(self) -> None:
+        """
+        Start the FlowRunWaiter service.
+        """
+        if self._started:
+            return
+        self.logger.debug("Starting FlowRunWaiter")
+        loop_thread = get_global_loop()
+
+        if not asyncio.get_running_loop() == loop_thread.loop:
+            raise RuntimeError("FlowRunWaiter must run on the global loop thread.")
+
+        self._loop = loop_thread.loop
+        if TYPE_CHECKING:
+            assert self._loop is not None
+
+        consumer_started = asyncio.Event()
+        self._consumer_task = self._loop.create_task(
+            self._consume_events(consumer_started)
+        )
+        asyncio.run_coroutine_threadsafe(consumer_started.wait(), self._loop)
+
+        loop_thread.add_shutdown_call(create_call(self.stop))
+        atexit.register(self.stop)
+        self._started = True
+
+    async def _consume_events(self, consumer_started: asyncio.Event):
+        async with get_events_subscriber(
+            filter=EventFilter(
+                event=EventNameFilter(
+                    name=[
+                        f"prefect.flow-run.{state.name.title()}"
+                        for state in TERMINAL_STATES
+                    ],
+                )
+            )
+        ) as subscriber:
+            consumer_started.set()
+            async for event in subscriber:
+                try:
+                    self.logger.debug(
+                        f"Received event: {event.resource['prefect.resource.id']}"
+                    )
+                    flow_run_id = uuid.UUID(
+                        event.resource["prefect.resource.id"].replace(
+                            "prefect.flow-run.", ""
+                        )
+                    )
+
+                    with self._observed_completed_flow_runs_lock:
+                        # Cache the flow run ID for a short period of time to avoid
+                        # unnecessary waits
+                        self._observed_completed_flow_runs[flow_run_id] = True
+                    with self._completion_events_lock:
+                        # Set the event for the flow run ID if it is in the cache
+                        # so the waiter can wake up the waiting coroutine
+                        if flow_run_id in self._completion_events:
+                            self._completion_events[flow_run_id].set()
+                        if flow_run_id in self._completion_callbacks:
+                            self._completion_callbacks[flow_run_id]()
+                except Exception as exc:
+                    self.logger.error(f"Error processing event: {exc}")
+
+    def stop(self) -> None:
+        """
+        Stop the FlowRunWaiter service.
+        """
+        self.logger.debug("Stopping FlowRunWaiter")
+        if self._consumer_task:
+            self._consumer_task.cancel()
+            self._consumer_task = None
+        self.__class__._instance = None
+        self._started = False
+
+    @classmethod
+    async def wait_for_flow_run(
+        cls, flow_run_id: uuid.UUID, timeout: float | None = None
+    ) -> None:
+        """
+        Wait for a flow run to finish.
+
+        Note this relies on a websocket connection to receive events from the server
+        and will not work with an ephemeral server.
+
+        Args:
+            flow_run_id: The ID of the flow run to wait for.
+            timeout: The maximum time to wait for the flow run to
+                finish. Defaults to None.
+        """
+        instance = cls.instance()
+        with instance._observed_completed_flow_runs_lock:
+            if flow_run_id in instance._observed_completed_flow_runs:
+                return
+
+        # Need to create event in loop thread to ensure it can be set
+        # from the loop thread
+        finished_event = await from_async.wait_for_call_in_loop_thread(
+            create_call(asyncio.Event)
+        )
+        with instance._completion_events_lock:
+            # Cache the event for the flow run ID so the consumer can set it
+            # when the event is received
+            instance._completion_events[flow_run_id] = finished_event
+
+        try:
+            # Now check one more time whether the flow run arrived before we start to
+            # wait on it, in case it came in while we were setting up the event above.
+            with instance._observed_completed_flow_runs_lock:
+                if flow_run_id in instance._observed_completed_flow_runs:
+                    return
+
+            with anyio.move_on_after(delay=timeout):
+                await from_async.wait_for_call_in_loop_thread(
+                    create_call(finished_event.wait)
+                )
+        finally:
+            with instance._completion_events_lock:
+                # Remove the event from the cache after it has been waited on
+                instance._completion_events.pop(flow_run_id, None)
+
+    @classmethod
+    def add_done_callback(
+        cls, flow_run_id: uuid.UUID, callback: Callable[[], None]
+    ) -> None:
+        """
+        Add a callback to be called when a flow run finishes.
+
+        Args:
+            flow_run_id: The ID of the flow run to wait for.
+            callback: The callback to call when the flow run finishes.
+        """
+        instance = cls.instance()
+        with instance._observed_completed_flow_runs_lock:
+            if flow_run_id in instance._observed_completed_flow_runs:
+                callback()
+                return
+
+        with instance._completion_events_lock:
+            # Cache the event for the flow run ID so the consumer can set it
+            # when the event is received
+            instance._completion_callbacks[flow_run_id] = callback
+
+    @classmethod
+    def instance(cls) -> Self:
+        """
+        Get the singleton instance of FlowRunWaiter.
+        """
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = cls._new_instance()
+            return cls._instance
+
+    @classmethod
+    def _new_instance(cls):
+        instance = cls()
+
+        if threading.get_ident() == get_global_loop().thread.ident:
+            instance.start()
+        else:
+            from_sync.call_soon_in_loop_thread(create_call(instance.start)).result()
+
+        return instance

--- a/src/prefect/_waiters.py
+++ b/src/prefect/_waiters.py
@@ -7,11 +7,11 @@ import uuid
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Self,
 )
 
 import anyio
 from cachetools import TTLCache
+from typing_extensions import Self
 
 from prefect._internal.concurrency.api import create_call, from_async, from_sync
 from prefect._internal.concurrency.threads import get_global_loop

--- a/src/prefect/flow_runs.py
+++ b/src/prefect/flow_runs.py
@@ -1,14 +1,8 @@
 from __future__ import annotations
 
-import asyncio
-import atexit
-import threading
-import uuid
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
-    Self,
     Type,
     TypeVar,
     overload,
@@ -16,14 +10,10 @@ from typing import (
 from uuid import UUID, uuid4
 
 import anyio
-from cachetools import TTLCache
 
-from prefect._internal.concurrency.api import create_call, from_async, from_sync
-from prefect._internal.concurrency.threads import get_global_loop
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas import FlowRun
 from prefect.client.schemas.objects import (
-    TERMINAL_STATES,
     StateType,
 )
 from prefect.client.schemas.responses import SetStateStatus
@@ -32,8 +22,6 @@ from prefect.context import (
     FlowRunContext,
     TaskRunContext,
 )
-from prefect.events.clients import get_events_subscriber
-from prefect.events.filters import EventFilter, EventNameFilter
 from prefect.exceptions import (
     Abort,
     FlowPauseTimeout,
@@ -59,8 +47,6 @@ from prefect.utilities.engine import (
 )
 
 if TYPE_CHECKING:
-    import logging
-
     from prefect.client.orchestration import PrefectClient
 
 
@@ -479,231 +465,3 @@ def _observed_flow_pauses(context: FlowRunContext) -> int:
     else:
         context.observed_flow_pauses["counter"] += 1
     return context.observed_flow_pauses["counter"]
-
-
-class FlowRunWaiter:
-    """
-    A service used for waiting for a flow run to finish.
-
-    This service listens for flow run events and provides a way to wait for a specific
-    flow run to finish. This is useful for waiting for a flow run to finish before
-    continuing execution.
-
-    The service is a singleton and must be started before use. The service will
-    automatically start when the first instance is created. A single websocket
-    connection is used to listen for flow run events.
-
-    The service can be used to wait for a flow run to finish by calling
-    `FlowRunWaiter.wait_for_flow_run` with the flow run ID to wait for. The method
-    will return when the flow run has finished or the timeout has elapsed.
-
-    The service will automatically stop when the Python process exits or when the
-    global loop thread is stopped.
-
-    Example:
-    ```python
-    import asyncio
-    from uuid import uuid4
-
-    from prefect import flow
-    from prefect.flow_engine import run_flow_async
-    from prefect.flow_runs import FlowRunWaiter
-
-
-    @flow
-    async def test_flow():
-        await asyncio.sleep(5)
-        print("Done!")
-
-
-    async def main():
-        flow_run_id = uuid4()
-        asyncio.create_flow(run_flow_async(flow=test_flow, flow_run_id=flow_run_id))
-
-        await FlowRunWaiter.wait_for_flow_run(flow_run_id)
-        print("Flow run finished")
-
-
-    if __name__ == "__main__":
-        asyncio.run(main())
-    ```
-    """
-
-    _instance: Self | None = None
-    _instance_lock = threading.Lock()
-
-    def __init__(self):
-        self.logger: "logging.Logger" = get_logger("FlowRunWaiter")
-        self._consumer_task: asyncio.Task[None] | None = None
-        self._observed_completed_flow_runs: TTLCache[uuid.UUID, bool] = TTLCache(
-            maxsize=10000, ttl=600
-        )
-        self._completion_events: dict[uuid.UUID, asyncio.Event] = {}
-        self._completion_callbacks: dict[uuid.UUID, Callable[[], None]] = {}
-        self._loop: asyncio.AbstractEventLoop | None = None
-        self._observed_completed_flow_runs_lock = threading.Lock()
-        self._completion_events_lock = threading.Lock()
-        self._started = False
-
-    def start(self) -> None:
-        """
-        Start the FlowRunWaiter service.
-        """
-        if self._started:
-            return
-        self.logger.debug("Starting FlowRunWaiter")
-        loop_thread = get_global_loop()
-
-        if not asyncio.get_running_loop() == loop_thread.loop:
-            raise RuntimeError("FlowRunWaiter must run on the global loop thread.")
-
-        self._loop = loop_thread.loop
-        if TYPE_CHECKING:
-            assert self._loop is not None
-
-        consumer_started = asyncio.Event()
-        self._consumer_task = self._loop.create_task(
-            self._consume_events(consumer_started)
-        )
-        asyncio.run_coroutine_threadsafe(consumer_started.wait(), self._loop)
-
-        loop_thread.add_shutdown_call(create_call(self.stop))
-        atexit.register(self.stop)
-        self._started = True
-
-    async def _consume_events(self, consumer_started: asyncio.Event):
-        async with get_events_subscriber(
-            filter=EventFilter(
-                event=EventNameFilter(
-                    name=[
-                        f"prefect.flow-run.{state.name.title()}"
-                        for state in TERMINAL_STATES
-                    ],
-                )
-            )
-        ) as subscriber:
-            consumer_started.set()
-            async for event in subscriber:
-                try:
-                    self.logger.debug(
-                        f"Received event: {event.resource['prefect.resource.id']}"
-                    )
-                    flow_run_id = uuid.UUID(
-                        event.resource["prefect.resource.id"].replace(
-                            "prefect.flow-run.", ""
-                        )
-                    )
-
-                    with self._observed_completed_flow_runs_lock:
-                        # Cache the flow run ID for a short period of time to avoid
-                        # unnecessary waits
-                        self._observed_completed_flow_runs[flow_run_id] = True
-                    with self._completion_events_lock:
-                        # Set the event for the flow run ID if it is in the cache
-                        # so the waiter can wake up the waiting coroutine
-                        if flow_run_id in self._completion_events:
-                            self._completion_events[flow_run_id].set()
-                        if flow_run_id in self._completion_callbacks:
-                            self._completion_callbacks[flow_run_id]()
-                except Exception as exc:
-                    self.logger.error(f"Error processing event: {exc}")
-
-    def stop(self) -> None:
-        """
-        Stop the FlowRunWaiter service.
-        """
-        self.logger.debug("Stopping FlowRunWaiter")
-        if self._consumer_task:
-            self._consumer_task.cancel()
-            self._consumer_task = None
-        self.__class__._instance = None
-        self._started = False
-
-    @classmethod
-    async def wait_for_flow_run(
-        cls, flow_run_id: uuid.UUID, timeout: float | None = None
-    ) -> None:
-        """
-        Wait for a flow run to finish.
-
-        Note this relies on a websocket connection to receive events from the server
-        and will not work with an ephemeral server.
-
-        Args:
-            flow_run_id: The ID of the flow run to wait for.
-            timeout: The maximum time to wait for the flow run to
-                finish. Defaults to None.
-        """
-        instance = cls.instance()
-        with instance._observed_completed_flow_runs_lock:
-            if flow_run_id in instance._observed_completed_flow_runs:
-                return
-
-        # Need to create event in loop thread to ensure it can be set
-        # from the loop thread
-        finished_event = await from_async.wait_for_call_in_loop_thread(
-            create_call(asyncio.Event)
-        )
-        with instance._completion_events_lock:
-            # Cache the event for the flow run ID so the consumer can set it
-            # when the event is received
-            instance._completion_events[flow_run_id] = finished_event
-
-        try:
-            # Now check one more time whether the flow run arrived before we start to
-            # wait on it, in case it came in while we were setting up the event above.
-            with instance._observed_completed_flow_runs_lock:
-                if flow_run_id in instance._observed_completed_flow_runs:
-                    return
-
-            with anyio.move_on_after(delay=timeout):
-                await from_async.wait_for_call_in_loop_thread(
-                    create_call(finished_event.wait)
-                )
-        finally:
-            with instance._completion_events_lock:
-                # Remove the event from the cache after it has been waited on
-                instance._completion_events.pop(flow_run_id, None)
-
-    @classmethod
-    def add_done_callback(
-        cls, flow_run_id: uuid.UUID, callback: Callable[[], None]
-    ) -> None:
-        """
-        Add a callback to be called when a flow run finishes.
-
-        Args:
-            flow_run_id: The ID of the flow run to wait for.
-            callback: The callback to call when the flow run finishes.
-        """
-        instance = cls.instance()
-        with instance._observed_completed_flow_runs_lock:
-            if flow_run_id in instance._observed_completed_flow_runs:
-                callback()
-                return
-
-        with instance._completion_events_lock:
-            # Cache the event for the flow run ID so the consumer can set it
-            # when the event is received
-            instance._completion_callbacks[flow_run_id] = callback
-
-    @classmethod
-    def instance(cls) -> Self:
-        """
-        Get the singleton instance of FlowRunWaiter.
-        """
-        with cls._instance_lock:
-            if cls._instance is None:
-                cls._instance = cls._new_instance()
-            return cls._instance
-
-    @classmethod
-    def _new_instance(cls):
-        instance = cls()
-
-        if threading.get_ident() == get_global_loop().thread.ident:
-            instance.start()
-        else:
-            from_sync.call_soon_in_loop_thread(create_call(instance.start)).result()
-
-        return instance

--- a/src/prefect/flow_runs.py
+++ b/src/prefect/flow_runs.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
+import asyncio
+import atexit
+import threading
+import uuid
 from typing import (
     TYPE_CHECKING,
     Any,
-    Optional,
+    Callable,
+    Self,
     Type,
     TypeVar,
     overload,
@@ -9,10 +16,14 @@ from typing import (
 from uuid import UUID, uuid4
 
 import anyio
+from cachetools import TTLCache
 
+from prefect._internal.concurrency.api import create_call, from_async, from_sync
+from prefect._internal.concurrency.threads import get_global_loop
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas import FlowRun
 from prefect.client.schemas.objects import (
+    TERMINAL_STATES,
     StateType,
 )
 from prefect.client.schemas.responses import SetStateStatus
@@ -21,6 +32,8 @@ from prefect.context import (
     FlowRunContext,
     TaskRunContext,
 )
+from prefect.events.clients import get_events_subscriber
+from prefect.events.filters import EventFilter, EventNameFilter
 from prefect.exceptions import (
     Abort,
     FlowPauseTimeout,
@@ -46,15 +59,17 @@ from prefect.utilities.engine import (
 )
 
 if TYPE_CHECKING:
+    import logging
+
     from prefect.client.orchestration import PrefectClient
 
 
 @inject_client
 async def wait_for_flow_run(
     flow_run_id: UUID,
-    timeout: Optional[int] = 10800,
+    timeout: int | None = 10800,
     poll_interval: int = 5,
-    client: Optional["PrefectClient"] = None,
+    client: "PrefectClient | None" = None,
     log_states: bool = False,
 ) -> FlowRun:
     """
@@ -119,8 +134,8 @@ async def wait_for_flow_run(
         while True:
             flow_run = await client.read_flow_run(flow_run_id)
             flow_state = flow_run.state
-            if log_states:
-                logger.info(f"Flow run is in state {flow_run.state.name!r}")
+            if log_states and flow_state:
+                logger.info(f"Flow run is in state {flow_state.name!r}")
             if flow_state and flow_state.is_final():
                 return flow_run
             await anyio.sleep(poll_interval)
@@ -138,7 +153,7 @@ async def pause_flow_run(
     wait_for_input: None = None,
     timeout: int = 3600,
     poll_interval: int = 10,
-    key: Optional[str] = None,
+    key: str | None = None,
 ) -> None: ...
 
 
@@ -147,17 +162,17 @@ async def pause_flow_run(
     wait_for_input: Type[T],
     timeout: int = 3600,
     poll_interval: int = 10,
-    key: Optional[str] = None,
+    key: str | None = None,
 ) -> T: ...
 
 
 @sync_compatible
 async def pause_flow_run(
-    wait_for_input: Optional[Type[T]] = None,
+    wait_for_input: Type[T] | None = None,
     timeout: int = 3600,
     poll_interval: int = 10,
-    key: Optional[str] = None,
-) -> Optional[T]:
+    key: str | None = None,
+) -> T | None:
     """
     Pauses the current flow run by blocking execution until resumed.
 
@@ -213,10 +228,13 @@ async def pause_flow_run(
 async def _in_process_pause(
     timeout: int = 3600,
     poll_interval: int = 10,
-    key: Optional[str] = None,
-    client=None,
-    wait_for_input: Optional[T] = None,
-) -> Optional[T]:
+    key: str | None = None,
+    client: "PrefectClient | None" = None,
+    wait_for_input: Type[T] | None = None,
+) -> T | None:
+    if TYPE_CHECKING:
+        assert client is not None
+
     if TaskRunContext.get():
         raise RuntimeError("Cannot pause task runs.")
 
@@ -302,32 +320,32 @@ async def _in_process_pause(
 @overload
 async def suspend_flow_run(
     wait_for_input: None = None,
-    flow_run_id: Optional[UUID] = None,
-    timeout: Optional[int] = 3600,
-    key: Optional[str] = None,
-    client: Optional[PrefectClient] = None,
+    flow_run_id: UUID | None = None,
+    timeout: int | None = 3600,
+    key: str | None = None,
+    client: "PrefectClient | None" = None,
 ) -> None: ...
 
 
 @overload
 async def suspend_flow_run(
     wait_for_input: Type[T],
-    flow_run_id: Optional[UUID] = None,
-    timeout: Optional[int] = 3600,
-    key: Optional[str] = None,
-    client: Optional[PrefectClient] = None,
+    flow_run_id: UUID | None = None,
+    timeout: int | None = 3600,
+    key: str | None = None,
+    client: "PrefectClient | None" = None,
 ) -> T: ...
 
 
 @sync_compatible
 @inject_client
 async def suspend_flow_run(
-    wait_for_input: Optional[Type[T]] = None,
-    flow_run_id: Optional[UUID] = None,
-    timeout: Optional[int] = 3600,
-    key: Optional[str] = None,
-    client: Optional[PrefectClient] = None,
-) -> Optional[T]:
+    wait_for_input: Type[T] | None = None,
+    flow_run_id: UUID | None = None,
+    timeout: int | None = 3600,
+    key: str | None = None,
+    client: "PrefectClient | None" = None,
+) -> T | None:
     """
     Suspends a flow run by stopping code execution until resumed.
 
@@ -357,6 +375,9 @@ async def suspend_flow_run(
             resumed with the input, the flow will resume and the input will be
             loaded and returned from this function.
     """
+    if TYPE_CHECKING:
+        assert client is not None
+
     context = FlowRunContext.get()
 
     if flow_run_id is None:
@@ -427,7 +448,7 @@ async def suspend_flow_run(
 
 @sync_compatible
 async def resume_flow_run(
-    flow_run_id: UUID, run_input: Optional[dict[str, Any]] = None
+    flow_run_id: UUID, run_input: dict[str, Any] | None = None
 ) -> None:
     """
     Resumes a paused flow.
@@ -458,3 +479,231 @@ def _observed_flow_pauses(context: FlowRunContext) -> int:
     else:
         context.observed_flow_pauses["counter"] += 1
     return context.observed_flow_pauses["counter"]
+
+
+class FlowRunWaiter:
+    """
+    A service used for waiting for a flow run to finish.
+
+    This service listens for flow run events and provides a way to wait for a specific
+    flow run to finish. This is useful for waiting for a flow run to finish before
+    continuing execution.
+
+    The service is a singleton and must be started before use. The service will
+    automatically start when the first instance is created. A single websocket
+    connection is used to listen for flow run events.
+
+    The service can be used to wait for a flow run to finish by calling
+    `FlowRunWaiter.wait_for_flow_run` with the flow run ID to wait for. The method
+    will return when the flow run has finished or the timeout has elapsed.
+
+    The service will automatically stop when the Python process exits or when the
+    global loop thread is stopped.
+
+    Example:
+    ```python
+    import asyncio
+    from uuid import uuid4
+
+    from prefect import flow
+    from prefect.flow_engine import run_flow_async
+    from prefect.flow_runs import FlowRunWaiter
+
+
+    @flow
+    async def test_flow():
+        await asyncio.sleep(5)
+        print("Done!")
+
+
+    async def main():
+        flow_run_id = uuid4()
+        asyncio.create_flow(run_flow_async(flow=test_flow, flow_run_id=flow_run_id))
+
+        await FlowRunWaiter.wait_for_flow_run(flow_run_id)
+        print("Flow run finished")
+
+
+    if __name__ == "__main__":
+        asyncio.run(main())
+    ```
+    """
+
+    _instance: Self | None = None
+    _instance_lock = threading.Lock()
+
+    def __init__(self):
+        self.logger: "logging.Logger" = get_logger("FlowRunWaiter")
+        self._consumer_task: asyncio.Task[None] | None = None
+        self._observed_completed_flow_runs: TTLCache[uuid.UUID, bool] = TTLCache(
+            maxsize=10000, ttl=600
+        )
+        self._completion_events: dict[uuid.UUID, asyncio.Event] = {}
+        self._completion_callbacks: dict[uuid.UUID, Callable[[], None]] = {}
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._observed_completed_flow_runs_lock = threading.Lock()
+        self._completion_events_lock = threading.Lock()
+        self._started = False
+
+    def start(self) -> None:
+        """
+        Start the FlowRunWaiter service.
+        """
+        if self._started:
+            return
+        self.logger.debug("Starting FlowRunWaiter")
+        loop_thread = get_global_loop()
+
+        if not asyncio.get_running_loop() == loop_thread.loop:
+            raise RuntimeError("FlowRunWaiter must run on the global loop thread.")
+
+        self._loop = loop_thread.loop
+        if TYPE_CHECKING:
+            assert self._loop is not None
+
+        consumer_started = asyncio.Event()
+        self._consumer_task = self._loop.create_task(
+            self._consume_events(consumer_started)
+        )
+        asyncio.run_coroutine_threadsafe(consumer_started.wait(), self._loop)
+
+        loop_thread.add_shutdown_call(create_call(self.stop))
+        atexit.register(self.stop)
+        self._started = True
+
+    async def _consume_events(self, consumer_started: asyncio.Event):
+        async with get_events_subscriber(
+            filter=EventFilter(
+                event=EventNameFilter(
+                    name=[
+                        f"prefect.flow-run.{state.name.title()}"
+                        for state in TERMINAL_STATES
+                    ],
+                )
+            )
+        ) as subscriber:
+            consumer_started.set()
+            async for event in subscriber:
+                try:
+                    self.logger.debug(
+                        f"Received event: {event.resource['prefect.resource.id']}"
+                    )
+                    flow_run_id = uuid.UUID(
+                        event.resource["prefect.resource.id"].replace(
+                            "prefect.flow-run.", ""
+                        )
+                    )
+
+                    with self._observed_completed_flow_runs_lock:
+                        # Cache the flow run ID for a short period of time to avoid
+                        # unnecessary waits
+                        self._observed_completed_flow_runs[flow_run_id] = True
+                    with self._completion_events_lock:
+                        # Set the event for the flow run ID if it is in the cache
+                        # so the waiter can wake up the waiting coroutine
+                        if flow_run_id in self._completion_events:
+                            self._completion_events[flow_run_id].set()
+                        if flow_run_id in self._completion_callbacks:
+                            self._completion_callbacks[flow_run_id]()
+                except Exception as exc:
+                    self.logger.error(f"Error processing event: {exc}")
+
+    def stop(self) -> None:
+        """
+        Stop the FlowRunWaiter service.
+        """
+        self.logger.debug("Stopping FlowRunWaiter")
+        if self._consumer_task:
+            self._consumer_task.cancel()
+            self._consumer_task = None
+        self.__class__._instance = None
+        self._started = False
+
+    @classmethod
+    async def wait_for_flow_run(
+        cls, flow_run_id: uuid.UUID, timeout: float | None = None
+    ) -> None:
+        """
+        Wait for a flow run to finish.
+
+        Note this relies on a websocket connection to receive events from the server
+        and will not work with an ephemeral server.
+
+        Args:
+            flow_run_id: The ID of the flow run to wait for.
+            timeout: The maximum time to wait for the flow run to
+                finish. Defaults to None.
+        """
+        instance = cls.instance()
+        with instance._observed_completed_flow_runs_lock:
+            if flow_run_id in instance._observed_completed_flow_runs:
+                return
+
+        # Need to create event in loop thread to ensure it can be set
+        # from the loop thread
+        finished_event = await from_async.wait_for_call_in_loop_thread(
+            create_call(asyncio.Event)
+        )
+        with instance._completion_events_lock:
+            # Cache the event for the flow run ID so the consumer can set it
+            # when the event is received
+            instance._completion_events[flow_run_id] = finished_event
+
+        try:
+            # Now check one more time whether the flow run arrived before we start to
+            # wait on it, in case it came in while we were setting up the event above.
+            with instance._observed_completed_flow_runs_lock:
+                if flow_run_id in instance._observed_completed_flow_runs:
+                    return
+
+            with anyio.move_on_after(delay=timeout):
+                await from_async.wait_for_call_in_loop_thread(
+                    create_call(finished_event.wait)
+                )
+        finally:
+            with instance._completion_events_lock:
+                # Remove the event from the cache after it has been waited on
+                instance._completion_events.pop(flow_run_id, None)
+
+    @classmethod
+    def add_done_callback(
+        cls, flow_run_id: uuid.UUID, callback: Callable[[], None]
+    ) -> None:
+        """
+        Add a callback to be called when a flow run finishes.
+
+        Args:
+            flow_run_id: The ID of the flow run to wait for.
+            callback: The callback to call when the flow run finishes.
+        """
+        instance = cls.instance()
+        with instance._observed_completed_flow_runs_lock:
+            if flow_run_id in instance._observed_completed_flow_runs:
+                callback()
+                return
+
+        with instance._completion_events_lock:
+            # Cache the event for the flow run ID so the consumer can set it
+            # when the event is received
+            instance._completion_callbacks[flow_run_id] = callback
+
+    @classmethod
+    def instance(cls) -> Self:
+        """
+        Get the singleton instance of FlowRunWaiter.
+        """
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = cls._new_instance()
+            return cls._instance
+
+    @classmethod
+    def _new_instance(cls):
+        instance = cls()
+
+        if threading.get_ident() == get_global_loop().thread.ident:
+            instance.start()
+        else:
+            from_sync.call_soon_in_loop_thread(create_call(instance.start)).result()
+
+        return instance

--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -42,7 +42,8 @@ class PrefectFuture(abc.ABC, Generic[R]):
     def __init__(self, task_run_id: uuid.UUID):
         warnings.warn(
             "The __init__ method of PrefectFuture is deprecated and will be removed in a future release. "
-            "If you are subclassing PrefectFuture, please implement the __init__ method in your subclass.",
+            "If you are subclassing PrefectFuture, please implement the __init__ method in your subclass or "
+            "subclass PrefectTaskRunFuture instead.",
             DeprecationWarning,
         )
         self._task_run_id = task_run_id
@@ -53,7 +54,8 @@ class PrefectFuture(abc.ABC, Generic[R]):
         """The ID of the task run associated with this future"""
         warnings.warn(
             "The task_run_id property of PrefectFuture is deprecated and will be removed in a future release. "
-            "If you are subclassing PrefectFuture, please implement the task_run_id property in your subclass.",
+            "If you are subclassing PrefectFuture, please implement the task_run_id property in your subclass or "
+            "subclass PrefectTaskRunFuture instead.",
             DeprecationWarning,
         )
 
@@ -64,7 +66,8 @@ class PrefectFuture(abc.ABC, Generic[R]):
         """The current state of the task run associated with this future"""
         warnings.warn(
             "The state property of PrefectFuture is deprecated and will be removed in a future release. "
-            "If you are subclassing PrefectFuture, please implement the state property in your subclass.",
+            "If you are subclassing PrefectFuture, please implement the state property in your subclass or "
+            "subclass PrefectTaskRunFuture instead.",
             DeprecationWarning,
         )
 
@@ -636,7 +639,7 @@ def resolve_futures_to_states(
         expr,
         visit_fn=partial(_collect_futures, futures),
         return_data=False,
-        context={"annotation": None},
+        context={},
     )
 
     # if no futures were found, return the original expression
@@ -665,5 +668,5 @@ def resolve_futures_to_states(
         expr,
         visit_fn=replace_futures_with_states,
         return_data=True,
-        context={"annotation": None},
+        context={},
     )

--- a/tests/test_flow_runs.py
+++ b/tests/test_flow_runs.py
@@ -1,40 +1,161 @@
+import asyncio
 import time
 
 import pytest
 
 import prefect.client.schemas as client_schemas
 from prefect import flow
+from prefect.client.orchestration import PrefectClient
 from prefect.exceptions import FlowRunWaitTimeout
-from prefect.flow_runs import wait_for_flow_run
-from prefect.states import Completed
+from prefect.flow_engine import run_flow_async
+from prefect.flow_runs import FlowRunWaiter, wait_for_flow_run
+from prefect.server.events.pipeline import EventsPipeline
+from prefect.states import Completed, Pending
 
 
-async def test_create_then_wait_for_flow_run(prefect_client):
+async def test_create_then_wait_for_flow_run(prefect_client: PrefectClient):
     @flow
     def foo():
         pass
 
-    flow_run = await prefect_client.create_flow_run(
-        foo, name="petes-flow-run", state=Completed()
-    )
+    flow_run = await prefect_client.create_flow_run(foo, state=Completed())
     assert isinstance(flow_run, client_schemas.FlowRun)
 
     lookup = await wait_for_flow_run(flow_run.id, poll_interval=0)
     # Estimates will not be equal since time has passed
     assert lookup == flow_run
+    assert flow_run.state
     assert flow_run.state.is_final()
 
 
-async def test_create_then_wait_timeout(prefect_client):
+async def test_create_then_wait_timeout(prefect_client: PrefectClient):
     @flow
     def foo():
         time.sleep(9999)
 
     flow_run = await prefect_client.create_flow_run(
         foo,
-        name="petes-flow-run",
     )
     assert isinstance(flow_run, client_schemas.FlowRun)
 
     with pytest.raises(FlowRunWaitTimeout):
         await wait_for_flow_run(flow_run.id, timeout=0)
+
+
+class TestFlowRunWaiter:
+    @pytest.fixture(autouse=True)
+    def teardown(self):
+        yield
+
+        FlowRunWaiter.instance().stop()
+
+    def test_instance_returns_singleton(self):
+        assert FlowRunWaiter.instance() is FlowRunWaiter.instance()
+
+    def test_instance_returns_instance_after_stop(self):
+        instance = FlowRunWaiter.instance()
+        instance.stop()
+        assert FlowRunWaiter.instance() is not instance
+
+    @pytest.mark.timeout(20)
+    async def test_wait_for_flow_run(
+        self, prefect_client: PrefectClient, emitting_events_pipeline: EventsPipeline
+    ):
+        """This test will fail with a timeout error if waiting is not working correctly."""
+
+        @flow
+        async def test_flow():
+            await asyncio.sleep(1)
+
+        flow_run = await prefect_client.create_flow_run(test_flow, state=Pending())
+        asyncio.create_task(run_flow_async(flow=test_flow, flow_run=flow_run))
+
+        await FlowRunWaiter.wait_for_flow_run(flow_run.id)
+
+        await emitting_events_pipeline.process_events()
+
+        flow_run = await prefect_client.read_flow_run(flow_run.id)
+        assert flow_run.state
+        assert flow_run.state.is_completed()
+
+    async def test_wait_for_flow_run_with_timeout(self, prefect_client: PrefectClient):
+        @flow
+        async def test_flow():
+            await asyncio.sleep(5)
+
+        flow_run = await prefect_client.create_flow_run(test_flow, state=Pending())
+        run = asyncio.create_task(run_flow_async(flow=test_flow, flow_run=flow_run))
+
+        await FlowRunWaiter.wait_for_flow_run(flow_run.id, timeout=1)
+
+        # FlowRunWaiter stopped waiting before the task finished
+        assert not run.done()
+        await run
+
+    @pytest.mark.timeout(20)
+    async def test_non_singleton_mode(
+        self, prefect_client: PrefectClient, emitting_events_pipeline: EventsPipeline
+    ):
+        waiter = FlowRunWaiter()
+        assert waiter is not FlowRunWaiter.instance()
+
+        @flow
+        async def test_flow():
+            await asyncio.sleep(1)
+
+        flow_run = await prefect_client.create_flow_run(test_flow, state=Pending())
+        asyncio.create_task(run_flow_async(flow=test_flow, flow_run=flow_run))
+
+        await waiter.wait_for_flow_run(flow_run.id)
+
+        await emitting_events_pipeline.process_events()
+
+        flow_run = await prefect_client.read_flow_run(flow_run.id)
+        assert flow_run.state
+        assert flow_run.state.is_completed()
+
+        waiter.stop()
+
+    @pytest.mark.timeout(20)
+    async def test_handles_concurrent_task_runs(
+        self, prefect_client: PrefectClient, emitting_events_pipeline: EventsPipeline
+    ):
+        @flow
+        async def fast_flow():
+            await asyncio.sleep(1)
+
+        @flow
+        async def slow_flow():
+            await asyncio.sleep(5)
+
+        flow_run_1 = await prefect_client.create_flow_run(fast_flow, state=Pending())
+        flow_run_2 = await prefect_client.create_flow_run(slow_flow, state=Pending())
+
+        asyncio.create_task(run_flow_async(flow=fast_flow, flow_run=flow_run_1))
+        asyncio.create_task(run_flow_async(flow=slow_flow, flow_run=flow_run_2))
+
+        await FlowRunWaiter.wait_for_flow_run(flow_run_1.id)
+
+        await emitting_events_pipeline.process_events()
+
+        flow_run_1 = await prefect_client.read_flow_run(flow_run_1.id)
+        flow_run_2 = await prefect_client.read_flow_run(flow_run_2.id)
+
+        assert flow_run_1.state
+        assert flow_run_1.state.is_completed()
+
+        assert flow_run_2.state
+        assert not flow_run_2.state.is_completed()
+
+        await FlowRunWaiter.wait_for_flow_run(flow_run_2.id)
+
+        await emitting_events_pipeline.process_events()
+
+        flow_run_1 = await prefect_client.read_flow_run(flow_run_1.id)
+        flow_run_2 = await prefect_client.read_flow_run(flow_run_2.id)
+
+        assert flow_run_1.state
+        assert flow_run_1.state.is_completed()
+
+        assert flow_run_2.state
+        assert flow_run_2.state.is_completed()

--- a/tests/test_flow_runs.py
+++ b/tests/test_flow_runs.py
@@ -1,4 +1,3 @@
-import asyncio
 import time
 
 import pytest
@@ -7,10 +6,8 @@ import prefect.client.schemas as client_schemas
 from prefect import flow
 from prefect.client.orchestration import PrefectClient
 from prefect.exceptions import FlowRunWaitTimeout
-from prefect.flow_engine import run_flow_async
-from prefect.flow_runs import FlowRunWaiter, wait_for_flow_run
-from prefect.server.events.pipeline import EventsPipeline
-from prefect.states import Completed, Pending
+from prefect.flow_runs import wait_for_flow_run
+from prefect.states import Completed
 
 
 async def test_create_then_wait_for_flow_run(prefect_client: PrefectClient):
@@ -40,122 +37,3 @@ async def test_create_then_wait_timeout(prefect_client: PrefectClient):
 
     with pytest.raises(FlowRunWaitTimeout):
         await wait_for_flow_run(flow_run.id, timeout=0)
-
-
-class TestFlowRunWaiter:
-    @pytest.fixture(autouse=True)
-    def teardown(self):
-        yield
-
-        FlowRunWaiter.instance().stop()
-
-    def test_instance_returns_singleton(self):
-        assert FlowRunWaiter.instance() is FlowRunWaiter.instance()
-
-    def test_instance_returns_instance_after_stop(self):
-        instance = FlowRunWaiter.instance()
-        instance.stop()
-        assert FlowRunWaiter.instance() is not instance
-
-    @pytest.mark.timeout(20)
-    async def test_wait_for_flow_run(
-        self, prefect_client: PrefectClient, emitting_events_pipeline: EventsPipeline
-    ):
-        """This test will fail with a timeout error if waiting is not working correctly."""
-
-        @flow
-        async def test_flow():
-            await asyncio.sleep(1)
-
-        flow_run = await prefect_client.create_flow_run(test_flow, state=Pending())
-        asyncio.create_task(run_flow_async(flow=test_flow, flow_run=flow_run))
-
-        await FlowRunWaiter.wait_for_flow_run(flow_run.id)
-
-        await emitting_events_pipeline.process_events()
-
-        flow_run = await prefect_client.read_flow_run(flow_run.id)
-        assert flow_run.state
-        assert flow_run.state.is_completed()
-
-    async def test_wait_for_flow_run_with_timeout(self, prefect_client: PrefectClient):
-        @flow
-        async def test_flow():
-            await asyncio.sleep(5)
-
-        flow_run = await prefect_client.create_flow_run(test_flow, state=Pending())
-        run = asyncio.create_task(run_flow_async(flow=test_flow, flow_run=flow_run))
-
-        await FlowRunWaiter.wait_for_flow_run(flow_run.id, timeout=1)
-
-        # FlowRunWaiter stopped waiting before the task finished
-        assert not run.done()
-        await run
-
-    @pytest.mark.timeout(20)
-    async def test_non_singleton_mode(
-        self, prefect_client: PrefectClient, emitting_events_pipeline: EventsPipeline
-    ):
-        waiter = FlowRunWaiter()
-        assert waiter is not FlowRunWaiter.instance()
-
-        @flow
-        async def test_flow():
-            await asyncio.sleep(1)
-
-        flow_run = await prefect_client.create_flow_run(test_flow, state=Pending())
-        asyncio.create_task(run_flow_async(flow=test_flow, flow_run=flow_run))
-
-        await waiter.wait_for_flow_run(flow_run.id)
-
-        await emitting_events_pipeline.process_events()
-
-        flow_run = await prefect_client.read_flow_run(flow_run.id)
-        assert flow_run.state
-        assert flow_run.state.is_completed()
-
-        waiter.stop()
-
-    @pytest.mark.timeout(20)
-    async def test_handles_concurrent_task_runs(
-        self, prefect_client: PrefectClient, emitting_events_pipeline: EventsPipeline
-    ):
-        @flow
-        async def fast_flow():
-            await asyncio.sleep(1)
-
-        @flow
-        async def slow_flow():
-            await asyncio.sleep(5)
-
-        flow_run_1 = await prefect_client.create_flow_run(fast_flow, state=Pending())
-        flow_run_2 = await prefect_client.create_flow_run(slow_flow, state=Pending())
-
-        asyncio.create_task(run_flow_async(flow=fast_flow, flow_run=flow_run_1))
-        asyncio.create_task(run_flow_async(flow=slow_flow, flow_run=flow_run_2))
-
-        await FlowRunWaiter.wait_for_flow_run(flow_run_1.id)
-
-        await emitting_events_pipeline.process_events()
-
-        flow_run_1 = await prefect_client.read_flow_run(flow_run_1.id)
-        flow_run_2 = await prefect_client.read_flow_run(flow_run_2.id)
-
-        assert flow_run_1.state
-        assert flow_run_1.state.is_completed()
-
-        assert flow_run_2.state
-        assert not flow_run_2.state.is_completed()
-
-        await FlowRunWaiter.wait_for_flow_run(flow_run_2.id)
-
-        await emitting_events_pipeline.process_events()
-
-        flow_run_1 = await prefect_client.read_flow_run(flow_run_1.id)
-        flow_run_2 = await prefect_client.read_flow_run(flow_run_2.id)
-
-        assert flow_run_1.state
-        assert flow_run_1.state.is_completed()
-
-        assert flow_run_2.state
-        assert flow_run_2.state.is_completed()

--- a/tests/test_waiters.py
+++ b/tests/test_waiters.py
@@ -1,0 +1,129 @@
+import asyncio
+
+import pytest
+
+from prefect import flow
+from prefect._waiters import FlowRunWaiter
+from prefect.client.orchestration import PrefectClient
+from prefect.flow_engine import run_flow_async
+from prefect.server.events.pipeline import EventsPipeline
+from prefect.states import Pending
+
+
+class TestFlowRunWaiter:
+    @pytest.fixture(autouse=True)
+    def teardown(self):
+        yield
+
+        FlowRunWaiter.instance().stop()
+
+    def test_instance_returns_singleton(self):
+        assert FlowRunWaiter.instance() is FlowRunWaiter.instance()
+
+    def test_instance_returns_instance_after_stop(self):
+        instance = FlowRunWaiter.instance()
+        instance.stop()
+        assert FlowRunWaiter.instance() is not instance
+
+    @pytest.mark.timeout(20)
+    async def test_wait_for_flow_run(
+        self, prefect_client: PrefectClient, emitting_events_pipeline: EventsPipeline
+    ):
+        """This test will fail with a timeout error if waiting is not working correctly."""
+
+        @flow
+        async def test_flow():
+            await asyncio.sleep(1)
+
+        flow_run = await prefect_client.create_flow_run(test_flow, state=Pending())
+        asyncio.create_task(run_flow_async(flow=test_flow, flow_run=flow_run))
+
+        await FlowRunWaiter.wait_for_flow_run(flow_run.id)
+
+        await emitting_events_pipeline.process_events()
+
+        flow_run = await prefect_client.read_flow_run(flow_run.id)
+        assert flow_run.state
+        assert flow_run.state.is_completed()
+
+    async def test_wait_for_flow_run_with_timeout(self, prefect_client: PrefectClient):
+        @flow
+        async def test_flow():
+            await asyncio.sleep(5)
+
+        flow_run = await prefect_client.create_flow_run(test_flow, state=Pending())
+        run = asyncio.create_task(run_flow_async(flow=test_flow, flow_run=flow_run))
+
+        await FlowRunWaiter.wait_for_flow_run(flow_run.id, timeout=1)
+
+        # FlowRunWaiter stopped waiting before the task finished
+        assert not run.done()
+        await run
+
+    @pytest.mark.timeout(20)
+    async def test_non_singleton_mode(
+        self, prefect_client: PrefectClient, emitting_events_pipeline: EventsPipeline
+    ):
+        waiter = FlowRunWaiter()
+        assert waiter is not FlowRunWaiter.instance()
+
+        @flow
+        async def test_flow():
+            await asyncio.sleep(1)
+
+        flow_run = await prefect_client.create_flow_run(test_flow, state=Pending())
+        asyncio.create_task(run_flow_async(flow=test_flow, flow_run=flow_run))
+
+        await waiter.wait_for_flow_run(flow_run.id)
+
+        await emitting_events_pipeline.process_events()
+
+        flow_run = await prefect_client.read_flow_run(flow_run.id)
+        assert flow_run.state
+        assert flow_run.state.is_completed()
+
+        waiter.stop()
+
+    @pytest.mark.timeout(20)
+    async def test_handles_concurrent_task_runs(
+        self, prefect_client: PrefectClient, emitting_events_pipeline: EventsPipeline
+    ):
+        @flow
+        async def fast_flow():
+            await asyncio.sleep(1)
+
+        @flow
+        async def slow_flow():
+            await asyncio.sleep(5)
+
+        flow_run_1 = await prefect_client.create_flow_run(fast_flow, state=Pending())
+        flow_run_2 = await prefect_client.create_flow_run(slow_flow, state=Pending())
+
+        asyncio.create_task(run_flow_async(flow=fast_flow, flow_run=flow_run_1))
+        asyncio.create_task(run_flow_async(flow=slow_flow, flow_run=flow_run_2))
+
+        await FlowRunWaiter.wait_for_flow_run(flow_run_1.id)
+
+        await emitting_events_pipeline.process_events()
+
+        flow_run_1 = await prefect_client.read_flow_run(flow_run_1.id)
+        flow_run_2 = await prefect_client.read_flow_run(flow_run_2.id)
+
+        assert flow_run_1.state
+        assert flow_run_1.state.is_completed()
+
+        assert flow_run_2.state
+        assert not flow_run_2.state.is_completed()
+
+        await FlowRunWaiter.wait_for_flow_run(flow_run_2.id)
+
+        await emitting_events_pipeline.process_events()
+
+        flow_run_1 = await prefect_client.read_flow_run(flow_run_1.id)
+        flow_run_2 = await prefect_client.read_flow_run(flow_run_2.id)
+
+        assert flow_run_1.state
+        assert flow_run_1.state.is_completed()
+
+        assert flow_run_2.state
+        assert flow_run_2.state.is_completed()


### PR DESCRIPTION
This PR adds a `PrefectFuture` implementation for tracking flow run execution that works similarly to the `PrefectDistributedFuture` for task runs. To support the operation of the new `PrefectFlowRunFuture`, this PR also adds a `FlowRunWaiter` to monitor the execution of flow runs via events.

To make the inheritance hierarchy of `PrefectFuture` make a little more sense, I also added a  `PrefectTaskRunFuture` class to hold some of the implementations that were on `PrefectFuture` so that `PrefectFuture` can be purely an interface and not a Frankenstein class. The implementations on `PrefectFutrue` have been deprecated and should be removed in a later release. This should only affect users that might be subclassing `PrefectFuture`.

This new future type will be used to track flow runs submitted to remote infrastructure via a worker.

Related to https://github.com/PrefectHQ/prefect/issues/17194