### PR TITLE
[UI v2] feat: Start transition flow runs list form data table to cards

### DIFF
--- a/ui-v2/src/components/flow-runs/flow-runs-list/flow-run-card.tsx
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/flow-run-card.tsx
@@ -1,0 +1,48 @@
+import { components } from "@/api/prefect";
+import { Card } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Typography } from "@/components/ui/typography";
+import { cva } from "class-variance-authority";
+import type { FlowRunRow } from "./types";
+
+type FlowRunCardProps =
+	| {
+			flowRun: FlowRunRow;
+	  }
+	| {
+			flowRun: FlowRunRow;
+			checked: boolean;
+			onCheckedChange: (checked: boolean) => void;
+	  };
+
+export const FlowRunCard = ({ flowRun, ...props }: FlowRunCardProps) => {
+	return (
+		<Card className={stateCardVariants({ state: flowRun.state?.type })}>
+			<div className="flex items-center gap-2">
+				{"checked" in props && "onCheckedChange" in props && (
+					<Checkbox
+						checked={props.checked}
+						onCheckedChange={props.onCheckedChange}
+					/>
+				)}
+				<Typography>{flowRun.name}</Typography>
+			</div>
+		</Card>
+	);
+};
+
+const stateCardVariants = cva("flex flex-col gap-2 p-4 border-l-8", {
+	variants: {
+		state: {
+			COMPLETED: "border-l-green-600",
+			FAILED: "border-l-red-600",
+			RUNNING: "border-l-blue-700",
+			CANCELLED: "border-l-gray-800",
+			CANCELLING: "border-l-gray-800",
+			CRASHED: "border-l-orange-600",
+			PAUSED: "border-l-gray-800",
+			PENDING: "border-l-gray-800",
+			SCHEDULED: "border-l-yellow-700",
+		} satisfies Record<components["schemas"]["StateType"], string>,
+	},
+});

--- a/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters.tsx
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters.tsx
@@ -1,0 +1,47 @@
+import { RunNameSearch } from "./flow-runs-filters/run-name-search";
+import { SortFilter } from "./flow-runs-filters/sort-filter";
+import type { SortFilters } from "./flow-runs-filters/sort-filter.constants";
+import { StateFilter } from "./flow-runs-filters/state-filter";
+import type { FlowRunState } from "./flow-runs-filters/state-filters.constants";
+
+export type FlowRunsFiltersProps = {
+	search: {
+		onChange: (value: string) => void;
+		value: string;
+	};
+	stateFilter: {
+		value: Set<FlowRunState>;
+		onSelect: (filters: Set<FlowRunState>) => void;
+	};
+	sort: {
+		value: SortFilters | undefined;
+		onSelect: (sort: SortFilters) => void;
+	};
+};
+
+export const FlowRunsFilters = ({
+	search,
+	sort,
+	stateFilter,
+}: FlowRunsFiltersProps) => {
+	return (
+		<div className="flex items-center gap-2">
+			<div className="flex items-center gap-2 pr-2 border-r-2">
+				<div className="min-w-56">
+					<RunNameSearch
+						value={search.value}
+						onChange={(e) => search.onChange(e.target.value)}
+						placeholder="Search by run name"
+					/>
+				</div>
+				<div className="min-w-56">
+					<StateFilter
+						selectedFilters={stateFilter.value}
+						onSelectFilter={stateFilter.onSelect}
+					/>
+				</div>
+			</div>
+			<SortFilter value={sort.value} onSelect={sort.onSelect} />
+		</div>
+	);
+};

--- a/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/run-name-search.tsx
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/run-name-search.tsx
@@ -1,0 +1,20 @@
+import { Icon } from "@/components/ui/icons";
+import { Input, type InputProps } from "@/components/ui/input";
+
+export const RunNameSearch = (props: InputProps) => {
+	return (
+		<div className="relative">
+			<Input
+				aria-label="search by run name"
+				placeholder="Search by run name"
+				className="pl-10"
+				{...props}
+			/>
+			<Icon
+				id="Search"
+				className="absolute left-3 top-2.5 text-muted-foreground"
+				size={18}
+			/>
+		</div>
+	);
+};

--- a/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/sort-filter.constants.ts
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/sort-filter.constants.ts
@@ -1,0 +1,7 @@
+export const SORT_FILTERS = [
+	"START_TIME_ASC",
+	"START_TIME_DESC",
+	"NAME_ASC",
+	"NAME_DESC",
+] as const;
+export type SortFilters = (typeof SORT_FILTERS)[number];

--- a/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/sort-filter.test.tsx
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/sort-filter.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { mockPointerEvents } from "@tests/utils/browser";
+import { SortFilter } from "./sort-filter";
+
+describe("FlowRunsDataTable -- SortFilter", () => {
+	beforeAll(mockPointerEvents);
+
+	it("returns correct sort filter for Newest to oldest", async () => {
+		// Setup
+		const user = userEvent.setup();
+		const mockOnSelectFn = vi.fn();
+		render(<SortFilter value={undefined} onSelect={mockOnSelectFn} />);
+
+		// Test
+		await user.click(
+			screen.getByRole("combobox", { name: /flow run sort order/i }),
+		);
+		await user.click(screen.getByRole("option", { name: /newest to oldest/i }));
+
+		// Assert
+		expect(mockOnSelectFn).toBeCalledWith("START_TIME_DESC");
+	});
+
+	it("returns correct sort filter for Oldest to newest", async () => {
+		// Setup
+		const user = userEvent.setup();
+		const mockOnSelectFn = vi.fn();
+		render(<SortFilter value={undefined} onSelect={mockOnSelectFn} />);
+
+		// Test
+		await user.click(
+			screen.getByRole("combobox", { name: /flow run sort order/i }),
+		);
+		await user.click(screen.getByRole("option", { name: /oldest to newest/i }));
+
+		// Assert
+		expect(mockOnSelectFn).toBeCalledWith("START_TIME_ASC");
+	});
+
+	it("returns correct sort filter for A to Z", async () => {
+		// Setup
+		const user = userEvent.setup();
+		const mockOnSelectFn = vi.fn();
+		render(<SortFilter value={undefined} onSelect={mockOnSelectFn} />);
+
+		// Test
+		await user.click(
+			screen.getByRole("combobox", { name: /flow run sort order/i }),
+		);
+		await user.click(screen.getByRole("option", { name: /a to z/i }));
+
+		// Assert
+		expect(mockOnSelectFn).toBeCalledWith("NAME_ASC");
+	});
+
+	it("returns correct sort filter for Z to A", async () => {
+		// Setup
+		const user = userEvent.setup();
+		const mockOnSelectFn = vi.fn();
+		render(<SortFilter value={undefined} onSelect={mockOnSelectFn} />);
+
+		// Test
+		await user.click(
+			screen.getByRole("combobox", { name: /flow run sort order/i }),
+		);
+		await user.click(screen.getByRole("option", { name: /z to a/i }));
+
+		// Assert
+		expect(mockOnSelectFn).toBeCalledWith("NAME_DESC");
+	});
+});

--- a/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/sort-filter.tsx
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/sort-filter.tsx
@@ -1,0 +1,34 @@
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { SortFilters } from "./sort-filter.constants";
+
+type SortFilterProps = {
+	defaultValue?: SortFilters;
+	onSelect: (filter: SortFilters) => void;
+	value: undefined | SortFilters;
+};
+
+export const SortFilter = ({
+	defaultValue,
+	value,
+	onSelect,
+}: SortFilterProps) => {
+	return (
+		<Select defaultValue={defaultValue} value={value} onValueChange={onSelect}>
+			<SelectTrigger aria-label="Flow run sort order">
+				<SelectValue placeholder="Sort by" />
+			</SelectTrigger>
+			<SelectContent>
+				<SelectItem value="START_TIME_DESC">Newest to oldest</SelectItem>
+				<SelectItem value="START_TIME_ASC">Oldest to newest</SelectItem>
+				<SelectItem value="NAME_ASC">A to Z</SelectItem>
+				<SelectItem value="NAME_DESC">Z to A</SelectItem>
+			</SelectContent>
+		</Select>
+	);
+};

--- a/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/state-filter.stories.tsx
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/state-filter.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { useState } from "react";
+import { StateFilter } from "./state-filter";
+import { FlowRunState } from "./state-filters.constants";
+
+const meta: Meta<typeof StateFilter> = {
+	title: "Components/FlowRuns/StateFilter",
+	component: StateFilterStory,
+};
+export default meta;
+
+function StateFilterStory() {
+	const [filters, setFilters] = useState<Set<FlowRunState>>();
+	return <StateFilter selectedFilters={filters} onSelectFilter={setFilters} />;
+}
+
+export const story: StoryObj = { name: "StateFilter" };

--- a/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/state-filter.test.tsx
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/state-filter.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { mockPointerEvents } from "@tests/utils/browser";
+import { useState } from "react";
+import { StateFilter } from "./state-filter";
+import type { FlowRunState } from "./state-filters.constants";
+
+describe("FlowRunsDataTable -- StateFilter", () => {
+	beforeAll(mockPointerEvents);
+
+	const TestStateFilter = () => {
+		const [filters, setFilters] = useState<Set<FlowRunState>>();
+		return (
+			<StateFilter selectedFilters={filters} onSelectFilter={setFilters} />
+		);
+	};
+
+	it("selects All except scheduled option", async () => {
+		// Setup
+		const user = userEvent.setup();
+		render(<TestStateFilter />);
+		// Test
+		await user.click(screen.getByRole("button", { name: /all run states/i }));
+		await user.click(
+			screen.getByRole("menuitem", { name: /all except scheduled/i }),
+		);
+		await user.keyboard("{Escape}");
+
+		// Assert
+		expect(
+			screen.getByRole("button", { name: /all except scheduled/i }),
+		).toBeVisible();
+	});
+
+	it("selects All run states option", async () => {
+		// Setup
+		const user = userEvent.setup();
+		render(<TestStateFilter />);
+		// Test
+		await user.click(screen.getByRole("button", { name: /all run states/i }));
+		await user.click(screen.getByRole("menuitem", { name: /all run states/i }));
+		await user.keyboard("{Escape}");
+
+		// Assert
+		expect(
+			screen.getByRole("button", { name: /all run states/i }),
+		).toBeVisible();
+	});
+
+	it("selects a single run state option", async () => {
+		// Setup
+		const user = userEvent.setup();
+		render(<TestStateFilter />);
+		// Test
+		await user.click(screen.getByRole("button", { name: /all run states/i }));
+		await user.click(screen.getByRole("menuitem", { name: /failed/i }));
+
+		await user.keyboard("{Escape}");
+
+		// Assert
+		expect(screen.getByRole("button", { name: /failed/i })).toBeVisible();
+	});
+
+	it("selects multiple run state options", async () => {
+		// Setup
+		const user = userEvent.setup();
+		render(<TestStateFilter />);
+		// Test
+		await user.click(screen.getByRole("button", { name: /all run states/i }));
+		await user.click(screen.getByRole("menuitem", { name: /timedout/i }));
+		await user.click(screen.getByRole("menuitem", { name: /crashed/i }));
+
+		await user.click(screen.getByRole("menuitem", { name: /failed/i }));
+		await user.click(screen.getByRole("menuitem", { name: /running/i }));
+		await user.click(screen.getByRole("menuitem", { name: /retrying/i }));
+
+		await user.keyboard("{Escape}");
+
+		// Assert
+		expect(
+			screen.getByRole("button", {
+				name: /timedout crashed failed running \+ 1/i,
+			}),
+		).toBeVisible();
+	});
+});

--- a/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/state-filter.tsx
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/state-filter.tsx
@@ -1,0 +1,153 @@
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Icon } from "@/components/ui/icons";
+import { StateBadge } from "@/components/ui/state-badge";
+import { Typography } from "@/components/ui/typography";
+import { useMemo, useState } from "react";
+import {
+	FLOW_RUN_STATES_MAP,
+	FLOW_RUN_STATES_NO_SCHEDULED,
+	type FlowRunState,
+} from "./state-filters.constants";
+
+const MAX_FILTERS_DISPLAYED = 4;
+
+type StateFilterProps = {
+	defaultValue?: Set<FlowRunState>;
+	selectedFilters: Set<FlowRunState> | undefined;
+	onSelectFilter: (filters: Set<FlowRunState>) => void;
+};
+
+export const StateFilter = ({
+	defaultValue,
+	selectedFilters = defaultValue || new Set(),
+	onSelectFilter,
+}: StateFilterProps) => {
+	const [open, setOpen] = useState(false);
+
+	const isAllButScheduled = useMemo(() => {
+		const flowRunStatesNoScheduleSet = new Set<FlowRunState>(
+			FLOW_RUN_STATES_NO_SCHEDULED,
+		);
+		if (
+			selectedFilters.has("Scheduled") ||
+			flowRunStatesNoScheduleSet.size !== selectedFilters.size
+		) {
+			return false;
+		}
+		return Array.from(selectedFilters).every((filter) =>
+			flowRunStatesNoScheduleSet.has(filter),
+		);
+	}, [selectedFilters]);
+
+	const handleSelectAllExceptScheduled = () => {
+		onSelectFilter(new Set(FLOW_RUN_STATES_NO_SCHEDULED));
+	};
+
+	const handleSelectAllRunState = () => {
+		onSelectFilter(new Set());
+	};
+
+	const handleSelectFilter = (filter: FlowRunState) => {
+		// if all but scheduled is already selected, create a new set with the single filter
+		if (isAllButScheduled) {
+			onSelectFilter(new Set([filter]));
+			return;
+		}
+		const updatedFilters = new Set(selectedFilters);
+		if (selectedFilters.has(filter)) {
+			updatedFilters.delete(filter);
+		} else {
+			updatedFilters.add(filter);
+		}
+		onSelectFilter(updatedFilters);
+	};
+
+	const renderSelectedTags = () => {
+		if (selectedFilters.size === 0) {
+			return "All run states";
+		}
+		if (isAllButScheduled) {
+			return "All except scheduled";
+		}
+
+		return (
+			<div className="flex gap-2">
+				{Array.from(selectedFilters)
+					.slice(0, MAX_FILTERS_DISPLAYED)
+					.map((filter) => (
+						<StateBadge
+							key={filter}
+							name={filter}
+							type={FLOW_RUN_STATES_MAP[filter]}
+						/>
+					))}
+				{selectedFilters.size > MAX_FILTERS_DISPLAYED && (
+					<Typography variant="bodySmall">
+						+ {selectedFilters.size - MAX_FILTERS_DISPLAYED}
+					</Typography>
+				)}
+			</div>
+		);
+	};
+
+	return (
+		<DropdownMenu open={open} onOpenChange={setOpen}>
+			<DropdownMenuTrigger asChild>
+				<Button variant="outline" className="justify-between w-full">
+					<span>{renderSelectedTags()}</span>
+					<Icon id="ChevronDown" className="ml-2 h-4 w-4 flex-shrink-0" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent>
+				<DropdownMenuItem
+					onSelect={(e) => {
+						e.preventDefault();
+						handleSelectAllExceptScheduled();
+					}}
+				>
+					<Checkbox checked={isAllButScheduled} className="mr-2" />
+					All except scheduled
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					onSelect={(e) => {
+						e.preventDefault();
+						handleSelectAllRunState();
+					}}
+				>
+					<Checkbox checked={selectedFilters.size === 0} className="mr-2" />
+					All run states
+				</DropdownMenuItem>
+				{Object.keys(FLOW_RUN_STATES_MAP).map((filterKey) => (
+					<DropdownMenuItem
+						aria-label={filterKey}
+						key={filterKey}
+						onSelect={(e) => {
+							e.preventDefault();
+							handleSelectFilter(filterKey as FlowRunState);
+						}}
+					>
+						<Checkbox
+							aria-label={filterKey}
+							className="mr-2"
+							checked={
+								!isAllButScheduled &&
+								selectedFilters.has(filterKey as FlowRunState)
+							}
+						/>
+						<StateBadge
+							name={filterKey}
+							type={FLOW_RUN_STATES_MAP[filterKey as FlowRunState]}
+						/>
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+};

--- a/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/state-filters.constants.ts
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-filters/state-filters.constants.ts
@@ -1,0 +1,44 @@
+import { components } from "@/api/prefect";
+
+export const FLOW_RUN_STATES = [
+	"Scheduled",
+	"Late",
+	"Resuming",
+	"AwaitingRetry",
+	"AwaitingConcurrencySlot",
+	"Pending",
+	"Paused",
+	"Suspended",
+	"Running",
+	"Retrying",
+	"Completed",
+	"Cached",
+	"Cancelled",
+	"Cancelling",
+	"Crashed",
+	"Failed",
+	"TimedOut",
+] as const;
+export type FlowRunState = (typeof FLOW_RUN_STATES)[number];
+export const FLOW_RUN_STATES_NO_SCHEDULED = FLOW_RUN_STATES.filter(
+	(flowStateFilter) => flowStateFilter !== "Scheduled",
+);
+export const FLOW_RUN_STATES_MAP = {
+	Scheduled: "SCHEDULED",
+	Late: "SCHEDULED",
+	Resuming: "SCHEDULED",
+	AwaitingRetry: "SCHEDULED",
+	AwaitingConcurrencySlot: "SCHEDULED",
+	Pending: "PENDING",
+	Paused: "PAUSED",
+	Suspended: "PAUSED",
+	Running: "RUNNING",
+	Retrying: "RUNNING",
+	Completed: "COMPLETED",
+	Cached: "COMPLETED",
+	Cancelled: "CANCELLED",
+	Cancelling: "CANCELLING",
+	Crashed: "CRASHED",
+	Failed: "FAILED",
+	TimedOut: "FAILED",
+} satisfies Record<FlowRunState, components["schemas"]["StateType"]>;

--- a/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-list.stories.tsx
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-list.stories.tsx
@@ -1,0 +1,146 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { createFakeFlowRunWithDeploymentAndFlow } from "@/mocks/create-fake-flow-run";
+import {
+	reactQueryDecorator,
+	routerDecorator,
+	toastDecorator,
+} from "@/storybook/utils";
+import { faker } from "@faker-js/faker";
+import { fn } from "@storybook/test";
+import { buildApiUrl } from "@tests/utils/handlers";
+import { http, HttpResponse } from "msw";
+import { useMemo, useState } from "react";
+import { FlowRunsFilters } from "./flow-runs-filters";
+import type { FlowRunState } from "./flow-runs-filters/state-filters.constants";
+import { FlowRunsList } from "./flow-runs-list";
+import { FlowRunsPagination, PaginationState } from "./flow-runs-pagination";
+import { FlowRunsRowCount } from "./flow-runs-row-count";
+
+const MOCK_DATA = [
+	createFakeFlowRunWithDeploymentAndFlow({
+		id: "0",
+		state: { type: "SCHEDULED", name: "Late", id: "0" },
+	}),
+	createFakeFlowRunWithDeploymentAndFlow({
+		id: "1",
+		state: { type: "COMPLETED", name: "Cached", id: "0" },
+	}),
+	createFakeFlowRunWithDeploymentAndFlow({
+		id: "2",
+		state: { type: "SCHEDULED", name: "Scheduled", id: "0" },
+	}),
+	createFakeFlowRunWithDeploymentAndFlow({
+		id: "3",
+		state: { type: "COMPLETED", name: "Completed", id: "0" },
+	}),
+	createFakeFlowRunWithDeploymentAndFlow({
+		id: "4",
+		state: { type: "FAILED", name: "Failed", id: "0" },
+	}),
+];
+
+const MOCK_FLOW_RUNS_TASK_COUNT = {
+	"0": faker.number.int({ min: 0, max: 5 }),
+	"1": faker.number.int({ min: 0, max: 5 }),
+	"2": faker.number.int({ min: 0, max: 5 }),
+	"3": faker.number.int({ min: 0, max: 5 }),
+	"4": faker.number.int({ min: 0, max: 5 }),
+};
+
+const meta = {
+	title: "Components/FlowRuns/FlowRunsList",
+	render: () => <FlowRunsListStory />,
+	decorators: [routerDecorator, reactQueryDecorator, toastDecorator],
+	parameters: {
+		msw: {
+			handlers: [
+				http.post(buildApiUrl("/ui/flow_runs/count-task-runs"), () => {
+					return HttpResponse.json(MOCK_FLOW_RUNS_TASK_COUNT);
+				}),
+			],
+		},
+	},
+} satisfies Meta<typeof FlowRunsList>;
+
+export default meta;
+
+export const story: StoryObj = { name: "FlowRunsList" };
+
+const FlowRunsListStory = () => {
+	const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
+	const [pagination, setPagination] = useState<PaginationState>({
+		limit: 5,
+		page: 1,
+	});
+	const [search, setSearch] = useState("");
+	const [filters, setFilters] = useState<Set<FlowRunState>>(new Set());
+
+	const flowRuns = useMemo(() => {
+		return MOCK_DATA.filter((flowRun) =>
+			flowRun.name?.toLocaleLowerCase().includes(search.toLowerCase()),
+		).filter((flowRun) =>
+			filters.size === 0
+				? flowRun
+				: filters.has(flowRun.state?.name as FlowRunState),
+		);
+	}, [filters, search]);
+
+	const addRow = (id: string) =>
+		setSelectedRows((curr) => new Set([...Array.from(curr), id]));
+
+	const removeRow = (id: string) =>
+		setSelectedRows(
+			(curr) => new Set([...Array.from(curr).filter((i) => i !== id)]),
+		);
+	const handleSelectRow = (id: string, checked: boolean) => {
+		if (checked) {
+			addRow(id);
+		} else {
+			removeRow(id);
+		}
+	};
+
+	const handleResetFilters = () => {
+		setSelectedRows(new Set());
+		setSearch("");
+		setFilters(new Set());
+	};
+
+	return (
+		<div className="flex flex-col gap-2">
+			<div className="flex items-center justify-between">
+				<FlowRunsRowCount
+					count={MOCK_DATA.length}
+					results={flowRuns}
+					selectedRows={selectedRows}
+					setSelectedRows={setSelectedRows}
+				/>
+				<FlowRunsFilters
+					search={{ value: search, onChange: setSearch }}
+					stateFilter={{
+						value: filters,
+						onSelect: setFilters,
+					}}
+					sort={{
+						value: "NAME_ASC",
+						onSelect: fn(),
+					}}
+				/>
+			</div>
+
+			<FlowRunsList
+				flowRuns={flowRuns}
+				selectedRows={selectedRows}
+				onSelect={handleSelectRow}
+				onClearFilters={handleResetFilters}
+			/>
+
+			<FlowRunsPagination
+				pagination={pagination}
+				onChangePagination={setPagination}
+				pages={20}
+			/>
+		</div>
+	);
+};

--- a/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-list.tsx
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-list.tsx
@@ -1,0 +1,66 @@
+import { Button } from "@/components/ui/button";
+import { Typography } from "@/components/ui/typography";
+import { FlowRunCard } from "./flow-run-card";
+import type { FlowRunRow } from "./types";
+
+type FlowRunCardProps =
+	| {
+			flowRuns: Array<FlowRunRow> | undefined;
+			onClearFilters?: () => void;
+	  }
+	| {
+			flowRuns: Array<FlowRunRow> | undefined;
+			onSelect: (id: string, checked: boolean) => void;
+			selectedRows: Set<string>;
+			onClearFilters?: () => void;
+	  };
+
+export const FlowRunsList = ({
+	flowRuns,
+	onClearFilters,
+	...props
+}: FlowRunCardProps) => {
+	if (!flowRuns) {
+		// Todo: Add Skeleton Loading UX
+		return "Loading...";
+	}
+
+	if (flowRuns.length === 0) {
+		return (
+			<div className="flex justify-center py-4">
+				<div className="flex flex-col gap-2">
+					<Typography>No runs found</Typography>
+					{onClearFilters && (
+						<Button onClick={onClearFilters}>Clear Filters</Button>
+					)}
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<ul className="flex flex-col gap-2">
+			{flowRuns.map((flowRun) => {
+				// Variant for selectable list
+				if ("onSelect" in props && "selectedRows" in props) {
+					return (
+						<li key={flowRun.id}>
+							<FlowRunCard
+								flowRun={flowRun}
+								checked={props.selectedRows.has(flowRun.id)}
+								onCheckedChange={(checked) =>
+									props.onSelect(flowRun.id, checked)
+								}
+							/>
+						</li>
+					);
+				}
+				return (
+					<li key={flowRun.id}>
+						<FlowRunCard flowRun={flowRun} />
+					</li>
+				);
+			})}
+		</ul>
+	);
+};

--- a/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-pagination.tsx
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-pagination.tsx
@@ -1,0 +1,104 @@
+import {
+	Pagination,
+	PaginationContent,
+	PaginationFirstButton,
+	PaginationItem,
+	PaginationLastButton,
+	PaginationNextButton,
+	PaginationPreviousButton,
+} from "@/components/ui/pagination";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+
+const PAGINATION_INCREMENTS = [5, 10, 25, 50];
+
+export type PaginationState = {
+	limit: number;
+	page: number;
+};
+export type PaginationStateUpdater = (
+	prevState: PaginationState,
+) => PaginationState;
+
+type FlowRunsPaginationProps = {
+	pages: number;
+	pagination: PaginationState;
+	onChangePagination: (pagination: PaginationState) => void;
+};
+export const FlowRunsPagination = ({
+	pages,
+	pagination,
+	onChangePagination,
+}: FlowRunsPaginationProps) => {
+	const handleFirstPage = () =>
+		onChangePagination({ limit: pagination.limit, page: 1 });
+	const handlePreviousPage = () =>
+		onChangePagination({ limit: pagination.limit, page: pagination.page - 1 });
+	const handleNextPage = () =>
+		onChangePagination({ limit: pagination.limit, page: pagination.page + 1 });
+
+	const handleLastPage = () =>
+		onChangePagination({ limit: pagination.limit, page: pages });
+
+	const disablePreviousPage = pagination.page <= 1;
+	const disableNextPage = pagination.page >= pages;
+
+	return (
+		<div className="flex flex-row justify-between items-center">
+			<div className="flex flex-row items-center gap-2 text-xs text-muted-foreground">
+				<span className="whitespace-nowrap">Items per page</span>
+				<Select
+					value={String(pagination.limit)}
+					onValueChange={(value) =>
+						onChangePagination({ limit: Number(value), page: pagination.page })
+					}
+				>
+					<SelectTrigger aria-label="Items per page">
+						<SelectValue placeholder="Theme" />
+					</SelectTrigger>
+					<SelectContent>
+						{PAGINATION_INCREMENTS.map((increment) => (
+							<SelectItem key={increment} value={String(increment)}>
+								{increment}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
+			<Pagination className="justify-end">
+				<PaginationContent>
+					<PaginationItem>
+						<PaginationFirstButton
+							onClick={handleFirstPage}
+							disabled={disablePreviousPage}
+						/>
+						<PaginationPreviousButton
+							onClick={handlePreviousPage}
+							disabled={disablePreviousPage}
+						/>
+					</PaginationItem>
+					<PaginationItem className="text-sm">
+						Page {pagination.page} of {pages}
+					</PaginationItem>
+					<PaginationItem>
+						<PaginationNextButton
+							onClick={handleNextPage}
+							disabled={disableNextPage}
+						/>
+					</PaginationItem>
+					<PaginationItem>
+						<PaginationLastButton
+							onClick={handleLastPage}
+							disabled={disableNextPage}
+						/>
+					</PaginationItem>
+				</PaginationContent>
+			</Pagination>
+		</div>
+	);
+};

--- a/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-row-count.tsx
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/flow-runs-row-count.tsx
@@ -1,0 +1,129 @@
+import { Button } from "@/components/ui/button";
+import { DeleteConfirmationDialog } from "@/components/ui/delete-confirmation-dialog";
+import { Icon } from "@/components/ui/icons";
+import { Typography } from "@/components/ui/typography";
+import { pluralize } from "@/utils";
+
+import { FlowRunWithFlow } from "@/api/flow-runs";
+import { Checkbox } from "@/components/ui/checkbox";
+import { CheckedState } from "@radix-ui/react-checkbox";
+import { useMemo } from "react";
+import { useDeleteFlowRunsDialog } from "./use-delete-flow-runs-dialog";
+
+// type FlowRunsRowCountProps = {
+// 	count: number | undefined;
+// 	results?: Array<FlowRunWithFlow>;
+// 	setSelectedRows?: (rows: Set<string>) => void;
+// 	selectedRows?: Set<string>;
+// };
+
+type CountOnlyProps = {
+	count: number | undefined;
+};
+type SelectableProps = {
+	count: number | undefined;
+	results: Array<FlowRunWithFlow> | undefined;
+	setSelectedRows: (rows: Set<string>) => void;
+	selectedRows: Set<string>;
+};
+type FlowRunsRowCountProps = CountOnlyProps | SelectableProps;
+
+export const FlowRunsRowCount = ({
+	count = 0,
+	...props
+}: FlowRunsRowCountProps) => {
+	// Selectable UX
+	if (
+		"results" in props &&
+		"setSelectedRows" in props &&
+		"selectedRows" in props
+	) {
+		return <SelectedCount count={count} {...props} />;
+	}
+
+	// Count only UX
+	return (
+		<Typography variant="bodySmall" className="text-muted-foreground">
+			{count} {pluralize(count, "Flow run")}
+		</Typography>
+	);
+};
+
+function SelectedCount({
+	count = 0,
+	results = [],
+	setSelectedRows,
+	selectedRows,
+}: SelectableProps) {
+	const [deleteConfirmationDialogState, confirmDelete] =
+		useDeleteFlowRunsDialog();
+
+	const resultsIds = useMemo(() => results.map(({ id }) => id), [results]);
+
+	const selectedRowsList = Array.from(selectedRows);
+
+	const ToggleCheckbox = () => {
+		const isAllRowsSelected = resultsIds.every((id) => selectedRows.has(id));
+		const isSomeRowsSelected = resultsIds.some((id) => selectedRows.has(id));
+		let checkedState: CheckedState = false;
+		if (isAllRowsSelected) {
+			checkedState = true;
+		} else if (isSomeRowsSelected) {
+			checkedState = "indeterminate";
+		}
+		return (
+			<Checkbox
+				checked={checkedState}
+				onCheckedChange={(checked) => {
+					if (checked) {
+						setSelectedRows(new Set(resultsIds));
+					} else {
+						setSelectedRows(new Set());
+					}
+				}}
+				aria-label="Toggle all"
+			/>
+		);
+	};
+
+	// If has selected rows
+	if (selectedRows.size > 0)
+		return (
+			<>
+				<div className="flex items-center gap-1">
+					<ToggleCheckbox />
+					<Typography variant="bodySmall" className="text-muted-foreground">
+						{selectedRowsList.length} selected
+					</Typography>
+					<Button
+						aria-label="Delete rows"
+						size="icon"
+						variant="secondary"
+						onClick={() => {
+							confirmDelete(selectedRowsList, () => setSelectedRows(new Set()));
+						}}
+					>
+						<Icon id="Trash2" className="h-4 w-4" />
+					</Button>
+				</div>
+				<DeleteConfirmationDialog {...deleteConfirmationDialogState} />
+			</>
+		);
+
+	return (
+		<div className="flex items-center gap-1">
+			{results && setSelectedRows && selectedRows && (
+				<Checkbox
+					checked={false}
+					onCheckedChange={(checked) => {
+						setSelectedRows(new Set(checked ? resultsIds : undefined));
+					}}
+					aria-label="Toggle all"
+				/>
+			)}
+			<Typography variant="bodySmall" className="text-muted-foreground">
+				{count} {pluralize(count, "Flow run")}
+			</Typography>
+		</div>
+	);
+}

--- a/ui-v2/src/components/flow-runs/flow-runs-list/index.ts
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/index.ts
@@ -1,0 +1,8 @@
+export { FlowRunsFilters } from "./flow-runs-filters";
+export { FlowRunsRowCount } from "./flow-runs-row-count";
+export {
+	FlowRunsPagination,
+	type PaginationState,
+} from "./flow-runs-pagination";
+export { FlowRunCard } from "./flow-run-card";
+export { FlowRunsList } from "./flow-runs-list";

--- a/ui-v2/src/components/flow-runs/flow-runs-list/types.ts
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/types.ts
@@ -1,0 +1,8 @@
+import { Deployment } from "@/api/deployments";
+import { FlowRun } from "@/api/flow-runs";
+import { Flow } from "@/api/flows";
+
+export type FlowRunRow = FlowRun & {
+	flow: Flow;
+	deployment?: Deployment;
+};

--- a/ui-v2/src/components/flow-runs/flow-runs-list/use-delete-flow-runs-dialog.ts
+++ b/ui-v2/src/components/flow-runs/flow-runs-list/use-delete-flow-runs-dialog.ts
@@ -1,0 +1,60 @@
+import { useDeleteFlowRun } from "@/api/flow-runs";
+import { useDeleteConfirmationDialog } from "@/components/ui/delete-confirmation-dialog";
+import { useToast } from "@/hooks/use-toast";
+
+export const useDeleteFlowRunsDialog = () => {
+	const { toast } = useToast();
+	const [dialogState, confirmDelete] = useDeleteConfirmationDialog();
+
+	const { mutateAsync } = useDeleteFlowRun();
+
+	const handleDeletes = async (
+		flowRunIds: Array<string>,
+		onConfirm = () => {},
+	) => {
+		try {
+			const res = await Promise.allSettled(
+				flowRunIds.map((id) => mutateAsync(id)),
+			);
+			const { numFails, numSuccess } = res.reduce(
+				(accumulator, currentValue) => {
+					if (currentValue.status === "rejected") {
+						accumulator.numFails += 1;
+					} else {
+						accumulator.numSuccess += 1;
+					}
+					return accumulator;
+				},
+				{ numFails: 0, numSuccess: 0 },
+			);
+			if (numFails > 1) {
+				toast({ title: `${numFails} flow runs failed to delete` });
+			} else if (numFails === 1) {
+				toast({ title: "Flow run failed to delete" });
+			} else if (numSuccess > 1) {
+				toast({ title: `${numSuccess} flow runs deleted` });
+			} else {
+				toast({ title: "Flow run deleted" });
+			}
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		} catch (error) {
+			console.error("Unknown error while deleting flow run.");
+		} finally {
+			onConfirm();
+		}
+	};
+
+	const handleConfirmDelete = (
+		flowRunIds: Array<string>,
+		onConfirm = () => {},
+	) =>
+		confirmDelete({
+			title: "Delete Flow Runs",
+			description: "Are you sure you want to delete selected flow runs?",
+			onConfirm: () => {
+				void handleDeletes(flowRunIds, onConfirm);
+			},
+		});
+
+	return [dialogState, handleConfirmDelete] as const;
+};


### PR DESCRIPTION
Start transition flow runs list form data table to cards

After discussion to use a card UX instead, this PR starts the transition to use cards. Future PRs will slowly build up the cards.
This PR copies over pagination features over from the data table UX


https://github.com/user-attachments/assets/d1216c5b-f2bc-43d5-b5a2-063be39e22ce



### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.

Relates to https://github.com/PrefectHQ/prefect/issues/15512
