### PR TITLE
Subscribe to state changes in wait_for_flow_run

### DIFF
--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -894,7 +894,6 @@ async def run(
         soft_wrap=True,
     )
     if watch:
-        watch_interval = 5 if watch_interval is None else watch_interval
         app.console.print(f"Watching flow run {flow_run.name!r}...")
         finished_flow_run = await wait_for_flow_run(
             flow_run.id,

--- a/src/prefect/cli/deployment.py
+++ b/src/prefect/cli/deployment.py
@@ -735,11 +735,6 @@ async def run(
         "--watch",
         help=("Whether to poll the flow run until a terminal state is reached."),
     ),
-    watch_interval: Optional[int] = typer.Option(
-        None,
-        "--watch-interval",
-        help=("How often to poll the flow run for state changes (in seconds)."),
-    ),
     watch_timeout: Optional[int] = typer.Option(
         None,
         "--watch-timeout",
@@ -768,10 +763,6 @@ async def run(
             multi_params = json.loads(multiparams)
         except ValueError as exc:
             exit_with_error(f"Failed to parse JSON: {exc}")
-        if watch_interval and not watch:
-            exit_with_error(
-                "`--watch-interval` can only be used with `--watch`.",
-            )
     cli_params: dict[str, Any] = _load_json_key_values(params or [], "parameter")
     conflicting_keys = set(cli_params.keys()).intersection(multi_params.keys())
     if conflicting_keys:
@@ -894,12 +885,10 @@ async def run(
         soft_wrap=True,
     )
     if watch:
-        watch_interval = 5 if watch_interval is None else watch_interval
         app.console.print(f"Watching flow run {flow_run.name!r}...")
         finished_flow_run = await wait_for_flow_run(
             flow_run.id,
             timeout=watch_timeout,
-            poll_interval=watch_interval,
             log_states=True,
         )
         finished_flow_run_state = finished_flow_run.state

--- a/src/prefect/flow_runs.py
+++ b/src/prefect/flow_runs.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
 async def wait_for_flow_run(
     flow_run_id: UUID,
     timeout: int | None = 10800,
+    poll_interval: int | None = None,
     client: "PrefectClient | None" = None,
     log_states: bool = False,
 ) -> FlowRun:
@@ -65,6 +66,7 @@ async def wait_for_flow_run(
     Args:
         flow_run_id: The flow run ID for the flow run to wait for.
         timeout: The wait timeout in seconds. Defaults to 10800 (3 hours).
+        poll_interval: Deprecated; polling is no longer used to wait for flow runs.
         client: Optional Prefect client. If not provided, one will be injected.
         log_states: If True, log state changes. Defaults to False.
 
@@ -116,6 +118,11 @@ async def wait_for_flow_run(
 
             ```
     """
+    if poll_interval is not None:
+        get_logger().warning(
+            "The `poll_interval` argument is deprecated and will be removed in a future release. "
+        )
+
     assert client is not None, "Client injection failed"
     logger = get_logger()
 

--- a/src/prefect/flow_runs.py
+++ b/src/prefect/flow_runs.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
 async def wait_for_flow_run(
     flow_run_id: UUID,
     timeout: int | None = 10800,
-    poll_interval: int = 5,
+    poll_interval: int | None = None,
     client: "PrefectClient | None" = None,
     log_states: bool = False,
 ) -> FlowRun:
@@ -118,6 +118,11 @@ async def wait_for_flow_run(
 
             ```
     """
+    if poll_interval is not None:
+        get_logger().warning(
+            "The `poll_interval` argument is deprecated and will be removed in a future release. "
+        )
+
     assert client is not None, "Client injection failed"
     logger = get_logger()
 

--- a/src/prefect/flow_runs.py
+++ b/src/prefect/flow_runs.py
@@ -14,7 +14,7 @@ import anyio
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas import FlowRun
 from prefect.client.schemas.objects import (
-    StateType,
+    State, StateType,
 )
 from prefect.client.schemas.responses import SetStateStatus
 from prefect.client.utilities import inject_client
@@ -22,6 +22,8 @@ from prefect.context import (
     FlowRunContext,
     TaskRunContext,
 )
+from prefect.events.clients import get_events_subscriber
+from prefect.events.filters import EventFilter, EventNameFilter, EventResourceFilter
 from prefect.exceptions import (
     Abort,
     FlowPauseTimeout,
@@ -64,7 +66,9 @@ async def wait_for_flow_run(
     Args:
         flow_run_id: The flow run ID for the flow run to wait for.
         timeout: The wait timeout in seconds. Defaults to 10800 (3 hours).
-        poll_interval: The poll interval in seconds. Defaults to 5.
+        poll_interval: Deprecated; polling is no longer used to wait for flow runs.
+        client: Optional Prefect client. If not provided, one will be injected.
+        log_states: If True, log state changes. Defaults to False.
 
     Returns:
         FlowRun: The finished flow run.
@@ -116,15 +120,30 @@ async def wait_for_flow_run(
     """
     assert client is not None, "Client injection failed"
     logger = get_logger()
+
+    flow_run = await client.read_flow_run(flow_run_id)
+    if flow_run.state and flow_run.state.is_final():
+        if log_states:
+            logger.info(f"Flow run is in state {flow_run.state.name!r}")
+        return flow_run
+
+    filter = EventFilter(
+        event=EventNameFilter(prefix=["prefect.flow-run"]),
+        resource=EventResourceFilter(id=[f"prefect.flow-run.{flow_run_id}"])
+    )
+
     with anyio.move_on_after(timeout):
-        while True:
-            flow_run = await client.read_flow_run(flow_run_id)
-            flow_state = flow_run.state
-            if log_states and flow_state:
-                logger.info(f"Flow run is in state {flow_state.name!r}")
-            if flow_state and flow_state.is_final():
-                return flow_run
-            await anyio.sleep(poll_interval)
+        async with get_events_subscriber(filter=filter) as subscriber:
+            async for event in subscriber:
+                state_type = StateType(event.resource["prefect.state-type"])
+                state = State(type=state_type)
+
+                if log_states:
+                    logger.info(f"Flow run is in state {state.name!r}")
+
+                if state.is_final():
+                    return await client.read_flow_run(flow_run_id)
+
     raise FlowRunWaitTimeout(
         f"Flow run with ID {flow_run_id} exceeded watch timeout of {timeout} seconds"
     )

--- a/src/prefect/flow_runs.py
+++ b/src/prefect/flow_runs.py
@@ -56,7 +56,6 @@ if TYPE_CHECKING:
 async def wait_for_flow_run(
     flow_run_id: UUID,
     timeout: int | None = 10800,
-    poll_interval: int | None = None,
     client: "PrefectClient | None" = None,
     log_states: bool = False,
 ) -> FlowRun:
@@ -66,7 +65,6 @@ async def wait_for_flow_run(
     Args:
         flow_run_id: The flow run ID for the flow run to wait for.
         timeout: The wait timeout in seconds. Defaults to 10800 (3 hours).
-        poll_interval: Deprecated; polling is no longer used to wait for flow runs.
         client: Optional Prefect client. If not provided, one will be injected.
         log_states: If True, log state changes. Defaults to False.
 
@@ -118,11 +116,6 @@ async def wait_for_flow_run(
 
             ```
     """
-    if poll_interval is not None:
-        get_logger().warning(
-            "The `poll_interval` argument is deprecated and will be removed in a future release. "
-        )
-
     assert client is not None, "Client injection failed"
     logger = get_logger()
 

--- a/src/prefect/flow_runs.py
+++ b/src/prefect/flow_runs.py
@@ -14,7 +14,8 @@ import anyio
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas import FlowRun
 from prefect.client.schemas.objects import (
-    State, StateType,
+    State,
+    StateType,
 )
 from prefect.client.schemas.responses import SetStateStatus
 from prefect.client.utilities import inject_client
@@ -126,13 +127,13 @@ async def wait_for_flow_run(
     assert client is not None, "Client injection failed"
     logger = get_logger()
 
-    filter = EventFilter(
+    event_filter = EventFilter(
         event=EventNameFilter(prefix=["prefect.flow-run"]),
-        resource=EventResourceFilter(id=[f"prefect.flow-run.{flow_run_id}"])
+        resource=EventResourceFilter(id=[f"prefect.flow-run.{flow_run_id}"]),
     )
 
     with anyio.move_on_after(timeout):
-        async with get_events_subscriber(filter=filter) as subscriber:
+        async with get_events_subscriber(filter=event_filter) as subscriber:
             flow_run = await client.read_flow_run(flow_run_id)
             if flow_run.state and flow_run.state.is_final():
                 if log_states:

--- a/tests/test_flow_runs.py
+++ b/tests/test_flow_runs.py
@@ -18,7 +18,7 @@ async def test_create_then_wait_for_flow_run(prefect_client: PrefectClient):
     flow_run = await prefect_client.create_flow_run(foo, state=Completed())
     assert isinstance(flow_run, client_schemas.FlowRun)
 
-    lookup = await wait_for_flow_run(flow_run.id, poll_interval=0)
+    lookup = await wait_for_flow_run(flow_run.id)
     # Estimates will not be equal since time has passed
     assert lookup == flow_run
     assert flow_run.state


### PR DESCRIPTION
Sort of a precursor to #17228; the current implementation polls for state changes (and logs on each poll, even when the state has not changed). As a half step towards also streaming other events / logs, I wanted to start by just swapping the polling for an event subscriber. The result is almost the same except for de-duping the repeated logs from the same state.

I went back and forth on whether to remove the `poll_interval`/`watch_interval` argument or warn that it's deprecated or just have it do nothing, I'm not sure if you have a specific policy on little CLI changes like that but either seems fine to me.

Before:
```
Creating flow run for deployment 'hello-flow/hello-flow'...
Created flow run 'belligerent-lobster'.
└── UUID: 322266a2-b2df-488f-9d84-6db32230c8a7
└── Parameters: {}
└── Job Variables: {}
└── Scheduled start time: 2025-02-21 17:15:28 EST (now)
└── URL: https://app.prefect.cloud/account/1e4d7e04-0fb7-4aa3-8ef5-746e9f404f4f/workspace/849a6829-4afb-48c3-9cc2-2dc6b262fd9c/runs/flow-run/322266a2-b2df-488f-9d84-6db32230c8a7
Watching flow run 'belligerent-lobster'...
17:15:28.614 | INFO    | prefect - Flow run is in state 'Scheduled'
17:15:33.718 | INFO    | prefect - Flow run is in state 'Scheduled'
17:15:38.815 | INFO    | prefect - Flow run is in state 'Pending'
17:15:43.932 | INFO    | prefect - Flow run is in state 'Pending'
17:15:49.024 | INFO    | prefect - Flow run is in state 'Pending'
17:15:54.166 | INFO    | prefect - Flow run is in state 'Pending'
17:15:59.262 | INFO    | prefect - Flow run is in state 'Pending'
17:16:04.464 | INFO    | prefect - Flow run is in state 'Pending'
17:16:09.576 | INFO    | prefect - Flow run is in state 'Completed'
Flow run finished successfully in 'Completed'.
```

After:
```
prefect deployment run hello-flow/hello-flow --watch
Creating flow run for deployment 'hello-flow/hello-flow'...
Created flow run 'petite-firefly'.
└── UUID: 688e205f-588d-4503-912e-fd25864e0ea2
└── Parameters: {}
└── Job Variables: {}
└── Scheduled start time: 2025-02-21 17:14:57 EST (now)
└── URL: https://app.prefect.cloud/account/1e4d7e04-0fb7-4aa3-8ef5-746e9f404f4f/workspace/849a6829-4afb-48c3-9cc2-2dc6b262fd9c/runs/flow-run/688e205f-588d-4503-912e-fd25864e0ea2
Watching flow run 'petite-firefly'...
17:14:59.288 | INFO    | prefect - Flow run is in state 'Scheduled'
17:14:59.667 | INFO    | prefect - Flow run is in state 'Pending'
17:15:42.142 | INFO    | prefect - Flow run is in state 'Running'
17:16:21.295 | INFO    | prefect - Flow run is in state 'Completed'
Flow run finished successfully in 'Completed'.
```