### PR TITLE
Add handling to propagate dependencies for submitted flow runs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ dependencies = [
     "ujson>=5.8.0,<6.0.0",
     "uvicorn>=0.14.0,!=0.29.0",
     "websockets>=10.4,<14.0",
+    "uv>=0.6.0",
 ]
 [project.urls]
 Changelog = "https://github.com/PrefectHQ/prefect/releases"

--- a/src/prefect/_experimental/bundles.py
+++ b/src/prefect/_experimental/bundles.py
@@ -69,7 +69,13 @@ def create_bundle_for_flow_run(
         "function": _serialize_bundle_object(flow),
         "context": _serialize_bundle_object(context),
         "flow_run": flow_run.model_dump(mode="json"),
-        "dependencies": subprocess.check_output([uv.find_uv_bin(), "pip", "freeze"])
+        "dependencies": subprocess.check_output(
+            [
+                uv.find_uv_bin(),
+                "pip",
+                "freeze",
+            ]
+        )
         .decode()
         .strip(),
     }

--- a/src/prefect/_experimental/bundles.py
+++ b/src/prefect/_experimental/bundles.py
@@ -144,9 +144,7 @@ def execute_bundle_in_subprocess(
     # Install dependencies if necessary
     if dependencies := bundle.get("dependencies"):
         subprocess.check_call(
-            [uv.find_uv_bin(), "pip", "install", *dependencies.split()],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            [uv.find_uv_bin(), "pip", "install", *dependencies.split("\n")],
         )
 
     process = ctx.Process(

--- a/src/prefect/_experimental/bundles.py
+++ b/src/prefect/_experimental/bundles.py
@@ -74,6 +74,7 @@ def create_bundle_for_flow_run(
                 uv.find_uv_bin(),
                 "pip",
                 "freeze",
+                # Exclude editable installs because we won't be able to install them in the execution environment
                 "--exclude-editable",
             ]
         )

--- a/src/prefect/_experimental/bundles.py
+++ b/src/prefect/_experimental/bundles.py
@@ -74,6 +74,7 @@ def create_bundle_for_flow_run(
                 uv.find_uv_bin(),
                 "pip",
                 "freeze",
+                "--exclude-editable",
             ]
         )
         .decode()


### PR DESCRIPTION
This PR adds `dependencies` to a serialized flow bundle. Dependencies are gathered via `uv pip freeze` and then installed via `uv pip install` before executing the bundle in a subprocess. Because this functionality depends on `uv`, this PR also adds `uv` as a dependency.

Related to #17194