### PR TITLE
Small clean-ups to mini history in get-started

### DIFF
--- a/docs/v3/get-started/index.mdx
+++ b/docs/v3/get-started/index.mdx
@@ -72,19 +72,19 @@ Prefect is an open-source orchestration engine that turns your Python functions 
 
 ## Mini-history of Prefect
 
-**2018-2021:** Our story begins in 2018, when we introduced the idea that workflow orchestration should be Pythonic.
+**2018:** Our story begins in 2018, when we introduced the idea that workflow orchestration should be Pythonic.
 Inspired by distributed tools like Dask, and building on the experience of our founder, Jeremiah Lowin (a PMC member of Apache Airflow), we created a system based on simple Python decorators for tasks and flows.
 But what made Prefect truly special was our introduction of task mapping—a feature that would later become foundational to our dynamic execution capabilities (and eventually imitated by other orchestration SDKs).
 
 
 **2022:** Prefect's 2.0 release became inevitable once we recognized that real-world workflows don't always fit into neat, pre-planned DAG structures: sometimes you need to update a job definition based on runtime information, for example by skipping a branch of your workflow.
-So we removed a key constraint that workflows be written explicitly as DAGs, fully embracing native Python control flow—if/else conditionals, while loops-everything that makes Python…Python.
+So we removed a key constraint that workflows be written explicitly as DAGs, fully embracing native Python control flow—if/else conditionals, while loops—everything that makes Python…*Python*.
 
 
-**2023-present:** With our release of Prefect 3.0 in 2024, we fully embraced these dynamic patterns by open-sourcing our events and automations backend, allowing users to natively represent event-driven workflows and gain additional observability into their execution.
+**2024:** With our release of Prefect 3.0 in 2024, we fully embraced these dynamic patterns by open-sourcing our events and automations backend, allowing users to natively represent event-driven workflows and gain additional observability into their execution.
 Prefect 3.0 also unlocked a leap forward in performance, improving the runtime overhead of Prefect by up to 90%.
 
 
 ## Join our community
 
-Join Prefect's vibrant [community of nearly 30,000 engineers](/contribute/index/) to learn with others and share your knowledge!
+Join Prefect's vibrant [Slack community](/contribute/index/) to learn with others and share your knowledge!


### PR DESCRIPTION
the em-dash error in the 2022 section caught my eye, also made couple other small improvements. 
In the raw markdown I cannot see the rendering of a normal dash vs. an em dash.  Might need some help from you @discdiver 

![Screenshot 2025-02-23 at 5 01 34 PM](https://github.com/user-attachments/assets/86ddf7f8-e76e-4e63-bb15-2721fad44e4d)
