### PR TITLE
chore(API docs): link to related docs pages

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -58,7 +58,7 @@
                     "Flows"
                 ],
                 "summary": "Create Flow",
-                "description": "Gracefully creates a new flow from the provided schema. If a flow with the\nsame name already exists, the existing flow is returned.\n\nFor more information, see [flows](https://docs.prefect.io/v3/develop/write-flows).",
+                "description": "Gracefully creates a new flow from the provided schema. If a flow with the\nsame name already exists, the existing flow is returned.\n\nFor more information, see https://docs.prefect.io/v3/develop/write-flows.",
                 "operationId": "create_flow_flows__post",
                 "parameters": [
                     {
@@ -483,7 +483,7 @@
                     "Flow Runs"
                 ],
                 "summary": "Create Flow Run",
-                "description": "Create a flow run. If a flow run with the same flow_id and\nidempotency key already exists, the existing flow run will be returned.\n\nIf no state is provided, the flow run will be created in a PENDING state.\n\nFor more information, see [flow runs](https://docs.prefect.io/v3/develop/write-flows).",
+                "description": "Create a flow run. If a flow run with the same flow_id and\nidempotency key already exists, the existing flow run will be returned.\n\nIf no state is provided, the flow run will be created in a PENDING state.\n\nFor more information, see https://docs.prefect.io/v3/develop/write-flows.",
                 "operationId": "create_flow_run_flow_runs__post",
                 "parameters": [
                     {
@@ -1593,7 +1593,7 @@
                     "Task Runs"
                 ],
                 "summary": "Create Task Run",
-                "description": "Create a task run. If a task run with the same flow_run_id,\ntask_key, and dynamic_key already exists, the existing task\nrun will be returned.\n\nIf no state is provided, the task run will be created in a PENDING state.\n\nFor more information, see [write and run tasks](https://docs.prefect.io/v3/develop/write-tasks).",
+                "description": "Create a task run. If a task run with the same flow_run_id,\ntask_key, and dynamic_key already exists, the existing task\nrun will be returned.\n\nIf no state is provided, the task run will be created in a PENDING state.\n\nFor more information, see https://docs.prefect.io/v3/develop/write-tasks.",
                 "operationId": "create_task_run_task_runs__post",
                 "parameters": [
                     {
@@ -2034,7 +2034,7 @@
                     "Flow Run States"
                 ],
                 "summary": "Read Flow Run State",
-                "description": "Get a flow run state by id.\n\nFor more information, see [write and run flows](https://docs.prefect.io/v3/develop/write-flows#final-state-determination).",
+                "description": "Get a flow run state by id.\n\nFor more information, see https://docs.prefect.io/v3/develop/write-flows#final-state-determination.",
                 "operationId": "read_flow_run_state_flow_run_states__id__get",
                 "parameters": [
                     {
@@ -2146,7 +2146,7 @@
                     "Task Run States"
                 ],
                 "summary": "Read Task Run State",
-                "description": "Get a task run state by id.\n\nFor more information, see [write and run tasks](https://docs.prefect.io/v3/develop/write-tasks).",
+                "description": "Get a task run state by id.\n\nFor more information, see https://docs.prefect.io/v3/develop/write-tasks.",
                 "operationId": "read_task_run_state_task_run_states__id__get",
                 "parameters": [
                     {
@@ -2258,7 +2258,7 @@
                     "Flow Run Notification Policies"
                 ],
                 "summary": "Create Flow Run Notification Policy",
-                "description": "Creates a new flow run notification policy.\n\nFor more information, see [trigger actions on events](https://docs.prefect.io/v3/automate/events/automations-triggers#sending-notifications-with-automations).",
+                "description": "Creates a new flow run notification policy.\n\nFor more information, see https://docs.prefect.io/v3/automate/events/automations-triggers#sending-notifications-with-automations.",
                 "operationId": "create_flow_run_notification_policy_flow_run_notification_policies__post",
                 "parameters": [
                     {
@@ -2524,7 +2524,7 @@
                     "Deployments"
                 ],
                 "summary": "Create Deployment",
-                "description": "Gracefully creates a new deployment from the provided schema. If a deployment with\nthe same name and flow_id already exists, the deployment is updated.\n\nIf the deployment has an active schedule, flow runs will be scheduled.\nWhen upserting, any scheduled runs from the existing deployment will be deleted.\n\nFor more information, see [deployments](https://docs.prefect.io/v3/deploy).",
+                "description": "Gracefully creates a new deployment from the provided schema. If a deployment with\nthe same name and flow_id already exists, the deployment is updated.\n\nIf the deployment has an active schedule, flow runs will be scheduled.\nWhen upserting, any scheduled runs from the existing deployment will be deleted.\n\nFor more information, see https://docs.prefect.io/v3/deploy.",
                 "operationId": "create_deployment_deployments__post",
                 "parameters": [
                     {
@@ -3775,7 +3775,7 @@
                     "Logs"
                 ],
                 "summary": "Create Logs",
-                "description": "Create new logs from the provided schema.\n\nFor more information, see [configure logging](https://docs.prefect.io/v3/develop/logging).",
+                "description": "Create new logs from the provided schema.\n\nFor more information, see https://docs.prefect.io/v3/develop/logging.",
                 "operationId": "create_logs_logs__post",
                 "parameters": [
                     {
@@ -3886,7 +3886,7 @@
                     "Concurrency Limits"
                 ],
                 "summary": "Create Concurrency Limit",
-                "description": "Create a task run concurrency limit.\n\nFor more information, see [manage concurrency](https://docs.prefect.io/v3/develop/task-run-limits).",
+                "description": "Create a task run concurrency limit.\n\nFor more information, see https://docs.prefect.io/v3/develop/task-run-limits.",
                 "operationId": "create_concurrency_limit_concurrency_limits__post",
                 "parameters": [
                     {
@@ -4369,7 +4369,7 @@
                     "Concurrency Limits V2"
                 ],
                 "summary": "Create Concurrency Limit V2",
-                "description": "Create a task run concurrency limit.\n\nFor more information, see [manage concurrency](https://docs.prefect.io/v3/develop/global-concurrency-limits).",
+                "description": "Create a task run concurrency limit.\n\nFor more information, see https://docs.prefect.io/v3/develop/global-concurrency-limits.",
                 "operationId": "create_concurrency_limit_v2_v2_concurrency_limits__post",
                 "parameters": [
                     {
@@ -4764,7 +4764,7 @@
                     "Block types"
                 ],
                 "summary": "Create Block Type",
-                "description": "Create a new block type.\n\nFor more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).",
+                "description": "Create a new block type.\n\nFor more information, see https://docs.prefect.io/v3/develop/blocks.",
                 "operationId": "create_block_type_block_types__post",
                 "parameters": [
                     {
@@ -5272,7 +5272,7 @@
                     "Block documents"
                 ],
                 "summary": "Create Block Document",
-                "description": "Create a new block document.\n\nFor more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).",
+                "description": "Create a new block document.\n\nFor more information, see https://docs.prefect.io/v3/develop/blocks.",
                 "operationId": "create_block_document_block_documents__post",
                 "parameters": [
                     {
@@ -5600,7 +5600,7 @@
                     "Work Pools"
                 ],
                 "summary": "Create Work Pool",
-                "description": "Creates a new work pool. If a work pool with the same\nname already exists, an error will be raised.\n\nFor more information, see [work pools](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools).",
+                "description": "Creates a new work pool. If a work pool with the same\nname already exists, an error will be raised.\n\nFor more information, see https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools.",
                 "operationId": "create_work_pool_work_pools__post",
                 "parameters": [
                     {
@@ -5983,7 +5983,7 @@
                     "Work Pools"
                 ],
                 "summary": "Create Work Queue",
-                "description": "Creates a new work pool queue. If a work pool queue with the same\nname already exists, an error will be raised.\n\nFor more information, see [work queues](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues).",
+                "description": "Creates a new work pool queue. If a work pool queue with the same\nname already exists, an error will be raised.\n\nFor more information, see https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues.",
                 "operationId": "create_work_queue_work_pools__work_pool_name__queues_post",
                 "parameters": [
                     {
@@ -6482,7 +6482,7 @@
                     "Task Workers"
                 ],
                 "summary": "Read Task Workers",
-                "description": "Read active task workers. Optionally filter by task keys.\n\nFor more information, see [run tasks in the background](https://docs.prefect.io/v3/develop/deferred-tasks).",
+                "description": "Read active task workers. Optionally filter by task keys.\n\nFor more information, see https://docs.prefect.io/v3/develop/deferred-tasks.",
                 "operationId": "read_task_workers_task_workers_filter_post",
                 "parameters": [
                     {
@@ -6538,7 +6538,7 @@
                     "Work Queues"
                 ],
                 "summary": "Create Work Queue",
-                "description": "Creates a new work queue.\n\nIf a work queue with the same name already exists, an error\nwill be raised.\n\nFor more information, see [work queues](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues).",
+                "description": "Creates a new work queue.\n\nIf a work queue with the same name already exists, an error\nwill be raised.\n\nFor more information, see https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues.",
                 "operationId": "create_work_queue_work_queues__post",
                 "parameters": [
                     {
@@ -7000,7 +7000,7 @@
                     "Artifacts"
                 ],
                 "summary": "Create Artifact",
-                "description": "Create an artifact.\n\nFor more information, see [create run artifacts](https://docs.prefect.io/v3/develop/artifacts).",
+                "description": "Create an artifact.\n\nFor more information, see https://docs.prefect.io/v3/develop/artifacts.",
                 "operationId": "create_artifact_artifacts__post",
                 "parameters": [
                     {
@@ -7482,7 +7482,7 @@
                     "Block schemas"
                 ],
                 "summary": "Create Block Schema",
-                "description": "Create a block schema.\n\nFor more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).",
+                "description": "Create a block schema.\n\nFor more information, see https://docs.prefect.io/v3/develop/blocks.",
                 "operationId": "create_block_schema_block_schemas__post",
                 "parameters": [
                     {
@@ -7763,7 +7763,7 @@
                     "Block capabilities"
                 ],
                 "summary": "Read Available Block Capabilities",
-                "description": "Get available block capabilities.\n\nFor more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).",
+                "description": "Get available block capabilities.\n\nFor more information, see https://docs.prefect.io/v3/develop/blocks.",
                 "operationId": "read_available_block_capabilities_block_capabilities__get",
                 "parameters": [
                     {
@@ -7863,7 +7863,7 @@
                     "Variables"
                 ],
                 "summary": "Create Variable",
-                "description": "Create a variable.\n\nFor more information, see [get and set variables](https://docs.prefect.io/v3/develop/variables).",
+                "description": "Create a variable.\n\nFor more information, see https://docs.prefect.io/v3/develop/variables.",
                 "operationId": "create_variable_variables__post",
                 "parameters": [
                     {
@@ -8367,7 +8367,7 @@
                     "Events"
                 ],
                 "summary": "Create Events",
-                "description": "Record a batch of Events.\n\nFor more information, see [track activity through events](https://docs.prefect.io/v3/automate/events/events).",
+                "description": "Record a batch of Events.\n\nFor more information, see https://docs.prefect.io/v3/automate/events/events.",
                 "operationId": "create_events_events_post",
                 "parameters": [
                     {
@@ -8586,7 +8586,7 @@
                     "Automations"
                 ],
                 "summary": "Create Automation",
-                "description": "Create an automation.\n\nFor more information, see [automate](https://docs.prefect.io/v3/automate).",
+                "description": "Create an automation.\n\nFor more information, see https://docs.prefect.io/v3/automate.",
                 "operationId": "create_automation_automations__post",
                 "parameters": [
                     {

--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -58,7 +58,7 @@
                     "Flows"
                 ],
                 "summary": "Create Flow",
-                "description": "Gracefully creates a new flow from the provided schema. If a flow with the\nsame name already exists, the existing flow is returned.\n\nFor more information, see [flows](/v3/develop/write-flows).",
+                "description": "Gracefully creates a new flow from the provided schema. If a flow with the\nsame name already exists, the existing flow is returned.\n\nFor more information, see [flows](https://docs.prefect.io/v3/develop/write-flows).",
                 "operationId": "create_flow_flows__post",
                 "parameters": [
                     {
@@ -483,7 +483,7 @@
                     "Flow Runs"
                 ],
                 "summary": "Create Flow Run",
-                "description": "Create a flow run. If a flow run with the same flow_id and\nidempotency key already exists, the existing flow run will be returned.\n\nIf no state is provided, the flow run will be created in a PENDING state.\n\nFor more information, see [flow runs](/v3/develop/write-flows).",
+                "description": "Create a flow run. If a flow run with the same flow_id and\nidempotency key already exists, the existing flow run will be returned.\n\nIf no state is provided, the flow run will be created in a PENDING state.\n\nFor more information, see [flow runs](https://docs.prefect.io/v3/develop/write-flows).",
                 "operationId": "create_flow_run_flow_runs__post",
                 "parameters": [
                     {
@@ -1593,7 +1593,7 @@
                     "Task Runs"
                 ],
                 "summary": "Create Task Run",
-                "description": "Create a task run. If a task run with the same flow_run_id,\ntask_key, and dynamic_key already exists, the existing task\nrun will be returned.\n\nIf no state is provided, the task run will be created in a PENDING state.\n\nFor more information, see [write and run tasks](/v3/develop/write-tasks).",
+                "description": "Create a task run. If a task run with the same flow_run_id,\ntask_key, and dynamic_key already exists, the existing task\nrun will be returned.\n\nIf no state is provided, the task run will be created in a PENDING state.\n\nFor more information, see [write and run tasks](https://docs.prefect.io/v3/develop/write-tasks).",
                 "operationId": "create_task_run_task_runs__post",
                 "parameters": [
                     {
@@ -2034,7 +2034,7 @@
                     "Flow Run States"
                 ],
                 "summary": "Read Flow Run State",
-                "description": "Get a flow run state by id.\n\nFor more information, see [write and run flows](/v3/develop/write-flows#final-state-determination).",
+                "description": "Get a flow run state by id.\n\nFor more information, see [write and run flows](https://docs.prefect.io/v3/develop/write-flows#final-state-determination).",
                 "operationId": "read_flow_run_state_flow_run_states__id__get",
                 "parameters": [
                     {
@@ -2146,7 +2146,7 @@
                     "Task Run States"
                 ],
                 "summary": "Read Task Run State",
-                "description": "Get a task run state by id.\n\nFor more information, see [write and run tasks](/v3/develop/write-tasks).",
+                "description": "Get a task run state by id.\n\nFor more information, see [write and run tasks](https://docs.prefect.io/v3/develop/write-tasks).",
                 "operationId": "read_task_run_state_task_run_states__id__get",
                 "parameters": [
                     {
@@ -2258,7 +2258,7 @@
                     "Flow Run Notification Policies"
                 ],
                 "summary": "Create Flow Run Notification Policy",
-                "description": "Creates a new flow run notification policy.\n\nFor more information, see [trigger actions on events](/v3/automate/events/automations-triggers#sending-notifications-with-automations).",
+                "description": "Creates a new flow run notification policy.\n\nFor more information, see [trigger actions on events](https://docs.prefect.io/v3/automate/events/automations-triggers#sending-notifications-with-automations).",
                 "operationId": "create_flow_run_notification_policy_flow_run_notification_policies__post",
                 "parameters": [
                     {
@@ -2524,7 +2524,7 @@
                     "Deployments"
                 ],
                 "summary": "Create Deployment",
-                "description": "Gracefully creates a new deployment from the provided schema. If a deployment with\nthe same name and flow_id already exists, the deployment is updated.\n\nIf the deployment has an active schedule, flow runs will be scheduled.\nWhen upserting, any scheduled runs from the existing deployment will be deleted.\n\nFor more information, see [deployments](/v3/deploy).",
+                "description": "Gracefully creates a new deployment from the provided schema. If a deployment with\nthe same name and flow_id already exists, the deployment is updated.\n\nIf the deployment has an active schedule, flow runs will be scheduled.\nWhen upserting, any scheduled runs from the existing deployment will be deleted.\n\nFor more information, see [deployments](https://docs.prefect.io/v3/deploy).",
                 "operationId": "create_deployment_deployments__post",
                 "parameters": [
                     {
@@ -3775,7 +3775,7 @@
                     "Logs"
                 ],
                 "summary": "Create Logs",
-                "description": "Create new logs from the provided schema.\n\nFor more information, see [configure logging](/v3/develop/logging).",
+                "description": "Create new logs from the provided schema.\n\nFor more information, see [configure logging](https://docs.prefect.io/v3/develop/logging).",
                 "operationId": "create_logs_logs__post",
                 "parameters": [
                     {
@@ -3886,7 +3886,7 @@
                     "Concurrency Limits"
                 ],
                 "summary": "Create Concurrency Limit",
-                "description": "Create a task run concurrency limit.\n\nFor more information, see [manage concurrency](/v3/develop/task-run-limits).",
+                "description": "Create a task run concurrency limit.\n\nFor more information, see [manage concurrency](https://docs.prefect.io/v3/develop/task-run-limits).",
                 "operationId": "create_concurrency_limit_concurrency_limits__post",
                 "parameters": [
                     {
@@ -4369,7 +4369,7 @@
                     "Concurrency Limits V2"
                 ],
                 "summary": "Create Concurrency Limit V2",
-                "description": "Create a task run concurrency limit.\n\nFor more information, see [manage concurrency](/v3/develop/global-concurrency-limits).",
+                "description": "Create a task run concurrency limit.\n\nFor more information, see [manage concurrency](https://docs.prefect.io/v3/develop/global-concurrency-limits).",
                 "operationId": "create_concurrency_limit_v2_v2_concurrency_limits__post",
                 "parameters": [
                     {
@@ -4764,7 +4764,7 @@
                     "Block types"
                 ],
                 "summary": "Create Block Type",
-                "description": "Create a new block type.\n\nFor more information, see [securely store typed configuration](/v3/develop/blocks).",
+                "description": "Create a new block type.\n\nFor more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).",
                 "operationId": "create_block_type_block_types__post",
                 "parameters": [
                     {
@@ -5272,7 +5272,7 @@
                     "Block documents"
                 ],
                 "summary": "Create Block Document",
-                "description": "Create a new block document.\n\nFor more information, see [securely store typed configuration](/v3/develop/blocks).",
+                "description": "Create a new block document.\n\nFor more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).",
                 "operationId": "create_block_document_block_documents__post",
                 "parameters": [
                     {
@@ -5600,7 +5600,7 @@
                     "Work Pools"
                 ],
                 "summary": "Create Work Pool",
-                "description": "Creates a new work pool. If a work pool with the same\nname already exists, an error will be raised.\n\nFor more information, see [work pools](/v3/deploy/infrastructure-concepts/work-pools).",
+                "description": "Creates a new work pool. If a work pool with the same\nname already exists, an error will be raised.\n\nFor more information, see [work pools](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools).",
                 "operationId": "create_work_pool_work_pools__post",
                 "parameters": [
                     {
@@ -5983,7 +5983,7 @@
                     "Work Pools"
                 ],
                 "summary": "Create Work Queue",
-                "description": "Creates a new work pool queue. If a work pool queue with the same\nname already exists, an error will be raised.\n\nFor more information, see [work queues](/v3/deploy/infrastructure-concepts/work-pools#work-queues).",
+                "description": "Creates a new work pool queue. If a work pool queue with the same\nname already exists, an error will be raised.\n\nFor more information, see [work queues](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues).",
                 "operationId": "create_work_queue_work_pools__work_pool_name__queues_post",
                 "parameters": [
                     {
@@ -6482,7 +6482,7 @@
                     "Task Workers"
                 ],
                 "summary": "Read Task Workers",
-                "description": "Read active task workers. Optionally filter by task keys.\n\nFor more information, see [run tasks in the background](/v3/develop/deferred-tasks).",
+                "description": "Read active task workers. Optionally filter by task keys.\n\nFor more information, see [run tasks in the background](https://docs.prefect.io/v3/develop/deferred-tasks).",
                 "operationId": "read_task_workers_task_workers_filter_post",
                 "parameters": [
                     {
@@ -6538,7 +6538,7 @@
                     "Work Queues"
                 ],
                 "summary": "Create Work Queue",
-                "description": "Creates a new work queue.\n\nIf a work queue with the same name already exists, an error\nwill be raised.\n\nFor more information, see [work queues](/v3/deploy/infrastructure-concepts/work-pools#work-queues).",
+                "description": "Creates a new work queue.\n\nIf a work queue with the same name already exists, an error\nwill be raised.\n\nFor more information, see [work queues](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues).",
                 "operationId": "create_work_queue_work_queues__post",
                 "parameters": [
                     {
@@ -7000,7 +7000,7 @@
                     "Artifacts"
                 ],
                 "summary": "Create Artifact",
-                "description": "Create an artifact.\n\nFor more information, see [create run artifacts](/v3/develop/artifacts).",
+                "description": "Create an artifact.\n\nFor more information, see [create run artifacts](https://docs.prefect.io/v3/develop/artifacts).",
                 "operationId": "create_artifact_artifacts__post",
                 "parameters": [
                     {
@@ -7482,7 +7482,7 @@
                     "Block schemas"
                 ],
                 "summary": "Create Block Schema",
-                "description": "Create a block schema.\n\nFor more information, see [securely store typed configuration](/v3/develop/blocks).",
+                "description": "Create a block schema.\n\nFor more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).",
                 "operationId": "create_block_schema_block_schemas__post",
                 "parameters": [
                     {
@@ -7763,7 +7763,7 @@
                     "Block capabilities"
                 ],
                 "summary": "Read Available Block Capabilities",
-                "description": "Get available block capabilities.\n\nFor more information, see [securely store typed configuration](/v3/develop/blocks).",
+                "description": "Get available block capabilities.\n\nFor more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).",
                 "operationId": "read_available_block_capabilities_block_capabilities__get",
                 "parameters": [
                     {
@@ -7863,7 +7863,7 @@
                     "Variables"
                 ],
                 "summary": "Create Variable",
-                "description": "Create a variable.\n\nFor more information, see [get and set variables](/v3/develop/variables).",
+                "description": "Create a variable.\n\nFor more information, see [get and set variables](https://docs.prefect.io/v3/develop/variables).",
                 "operationId": "create_variable_variables__post",
                 "parameters": [
                     {
@@ -8367,7 +8367,7 @@
                     "Events"
                 ],
                 "summary": "Create Events",
-                "description": "Record a batch of Events.\n\nFor more information, see [track activity through events](/v3/automate/events/events).",
+                "description": "Record a batch of Events.\n\nFor more information, see [track activity through events](https://docs.prefect.io/v3/automate/events/events).",
                 "operationId": "create_events_events_post",
                 "parameters": [
                     {
@@ -8586,7 +8586,7 @@
                     "Automations"
                 ],
                 "summary": "Create Automation",
-                "description": "Create an automation.\n\nFor more information, see [automate](/v3/automate).",
+                "description": "Create an automation.\n\nFor more information, see [automate](https://docs.prefect.io/v3/automate).",
                 "operationId": "create_automation_automations__post",
                 "parameters": [
                     {

--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -58,7 +58,7 @@
                     "Flows"
                 ],
                 "summary": "Create Flow",
-                "description": "Gracefully creates a new flow from the provided schema. If a flow with the\nsame name already exists, the existing flow is returned.",
+                "description": "Gracefully creates a new flow from the provided schema. If a flow with the\nsame name already exists, the existing flow is returned.\n\nFor more information, see [flows](/v3/develop/write-flows).",
                 "operationId": "create_flow_flows__post",
                 "parameters": [
                     {
@@ -483,7 +483,7 @@
                     "Flow Runs"
                 ],
                 "summary": "Create Flow Run",
-                "description": "Create a flow run. If a flow run with the same flow_id and\nidempotency key already exists, the existing flow run will be returned.\n\nIf no state is provided, the flow run will be created in a PENDING state.",
+                "description": "Create a flow run. If a flow run with the same flow_id and\nidempotency key already exists, the existing flow run will be returned.\n\nIf no state is provided, the flow run will be created in a PENDING state.\n\nFor more information, see [flow runs](/v3/develop/write-flows).",
                 "operationId": "create_flow_run_flow_runs__post",
                 "parameters": [
                     {
@@ -1593,7 +1593,7 @@
                     "Task Runs"
                 ],
                 "summary": "Create Task Run",
-                "description": "Create a task run. If a task run with the same flow_run_id,\ntask_key, and dynamic_key already exists, the existing task\nrun will be returned.\n\nIf no state is provided, the task run will be created in a PENDING state.",
+                "description": "Create a task run. If a task run with the same flow_run_id,\ntask_key, and dynamic_key already exists, the existing task\nrun will be returned.\n\nIf no state is provided, the task run will be created in a PENDING state.\n\nFor more information, see [write and run tasks](/v3/develop/write-tasks).",
                 "operationId": "create_task_run_task_runs__post",
                 "parameters": [
                     {
@@ -2034,7 +2034,7 @@
                     "Flow Run States"
                 ],
                 "summary": "Read Flow Run State",
-                "description": "Get a flow run state by id.",
+                "description": "Get a flow run state by id.\n\nFor more information, see [write and run flows](/v3/develop/write-flows#final-state-determination).",
                 "operationId": "read_flow_run_state_flow_run_states__id__get",
                 "parameters": [
                     {
@@ -2146,7 +2146,7 @@
                     "Task Run States"
                 ],
                 "summary": "Read Task Run State",
-                "description": "Get a task run state by id.",
+                "description": "Get a task run state by id.\n\nFor more information, see [write and run tasks](/v3/develop/write-tasks).",
                 "operationId": "read_task_run_state_task_run_states__id__get",
                 "parameters": [
                     {
@@ -2258,7 +2258,7 @@
                     "Flow Run Notification Policies"
                 ],
                 "summary": "Create Flow Run Notification Policy",
-                "description": "Creates a new flow run notification policy.",
+                "description": "Creates a new flow run notification policy.\n\nFor more information, see [trigger actions on events](/v3/automate/events/automations-triggers#sending-notifications-with-automations).",
                 "operationId": "create_flow_run_notification_policy_flow_run_notification_policies__post",
                 "parameters": [
                     {
@@ -2524,7 +2524,7 @@
                     "Deployments"
                 ],
                 "summary": "Create Deployment",
-                "description": "Gracefully creates a new deployment from the provided schema. If a deployment with\nthe same name and flow_id already exists, the deployment is updated.\n\nIf the deployment has an active schedule, flow runs will be scheduled.\nWhen upserting, any scheduled runs from the existing deployment will be deleted.",
+                "description": "Gracefully creates a new deployment from the provided schema. If a deployment with\nthe same name and flow_id already exists, the deployment is updated.\n\nIf the deployment has an active schedule, flow runs will be scheduled.\nWhen upserting, any scheduled runs from the existing deployment will be deleted.\n\nFor more information, see [deployments](/v3/deploy).",
                 "operationId": "create_deployment_deployments__post",
                 "parameters": [
                     {
@@ -3775,7 +3775,7 @@
                     "Logs"
                 ],
                 "summary": "Create Logs",
-                "description": "Create new logs from the provided schema.",
+                "description": "Create new logs from the provided schema.\n\nFor more information, see [configure logging](/v3/develop/logging).",
                 "operationId": "create_logs_logs__post",
                 "parameters": [
                     {
@@ -3886,6 +3886,7 @@
                     "Concurrency Limits"
                 ],
                 "summary": "Create Concurrency Limit",
+                "description": "Create a task run concurrency limit.\n\nFor more information, see [manage concurrency](/v3/develop/task-run-limits).",
                 "operationId": "create_concurrency_limit_concurrency_limits__post",
                 "parameters": [
                     {
@@ -4368,6 +4369,7 @@
                     "Concurrency Limits V2"
                 ],
                 "summary": "Create Concurrency Limit V2",
+                "description": "Create a task run concurrency limit.\n\nFor more information, see [manage concurrency](/v3/develop/global-concurrency-limits).",
                 "operationId": "create_concurrency_limit_v2_v2_concurrency_limits__post",
                 "parameters": [
                     {
@@ -4762,7 +4764,7 @@
                     "Block types"
                 ],
                 "summary": "Create Block Type",
-                "description": "Create a new block type",
+                "description": "Create a new block type.\n\nFor more information, see [securely store typed configuration](/v3/develop/blocks).",
                 "operationId": "create_block_type_block_types__post",
                 "parameters": [
                     {
@@ -5270,7 +5272,7 @@
                     "Block documents"
                 ],
                 "summary": "Create Block Document",
-                "description": "Create a new block document.",
+                "description": "Create a new block document.\n\nFor more information, see [securely store typed configuration](/v3/develop/blocks).",
                 "operationId": "create_block_document_block_documents__post",
                 "parameters": [
                     {
@@ -5598,7 +5600,7 @@
                     "Work Pools"
                 ],
                 "summary": "Create Work Pool",
-                "description": "Creates a new work pool. If a work pool with the same\nname already exists, an error will be raised.",
+                "description": "Creates a new work pool. If a work pool with the same\nname already exists, an error will be raised.\n\nFor more information, see [work pools](/v3/deploy/infrastructure-concepts/work-pools).",
                 "operationId": "create_work_pool_work_pools__post",
                 "parameters": [
                     {
@@ -5981,7 +5983,7 @@
                     "Work Pools"
                 ],
                 "summary": "Create Work Queue",
-                "description": "Creates a new work pool queue. If a work pool queue with the same\nname already exists, an error will be raised.",
+                "description": "Creates a new work pool queue. If a work pool queue with the same\nname already exists, an error will be raised.\n\nFor more information, see [work queues](/v3/deploy/infrastructure-concepts/work-pools#work-queues).",
                 "operationId": "create_work_queue_work_pools__work_pool_name__queues_post",
                 "parameters": [
                     {
@@ -6480,7 +6482,7 @@
                     "Task Workers"
                 ],
                 "summary": "Read Task Workers",
-                "description": "Read active task workers. Optionally filter by task keys.",
+                "description": "Read active task workers. Optionally filter by task keys.\n\nFor more information, see [run tasks in the background](/v3/develop/deferred-tasks).",
                 "operationId": "read_task_workers_task_workers_filter_post",
                 "parameters": [
                     {
@@ -6536,7 +6538,7 @@
                     "Work Queues"
                 ],
                 "summary": "Create Work Queue",
-                "description": "Creates a new work queue.\n\nIf a work queue with the same name already exists, an error\nwill be raised.",
+                "description": "Creates a new work queue.\n\nIf a work queue with the same name already exists, an error\nwill be raised.\n\nFor more information, see [work queues](/v3/deploy/infrastructure-concepts/work-pools#work-queues).",
                 "operationId": "create_work_queue_work_queues__post",
                 "parameters": [
                     {
@@ -6998,6 +7000,7 @@
                     "Artifacts"
                 ],
                 "summary": "Create Artifact",
+                "description": "Create an artifact.\n\nFor more information, see [create run artifacts](/v3/develop/artifacts).",
                 "operationId": "create_artifact_artifacts__post",
                 "parameters": [
                     {
@@ -7479,6 +7482,7 @@
                     "Block schemas"
                 ],
                 "summary": "Create Block Schema",
+                "description": "Create a block schema.\n\nFor more information, see [securely store typed configuration](/v3/develop/blocks).",
                 "operationId": "create_block_schema_block_schemas__post",
                 "parameters": [
                     {
@@ -7759,6 +7763,7 @@
                     "Block capabilities"
                 ],
                 "summary": "Read Available Block Capabilities",
+                "description": "Get available block capabilities.\n\nFor more information, see [securely store typed configuration](/v3/develop/blocks).",
                 "operationId": "read_available_block_capabilities_block_capabilities__get",
                 "parameters": [
                     {
@@ -7858,6 +7863,7 @@
                     "Variables"
                 ],
                 "summary": "Create Variable",
+                "description": "Create a variable.\n\nFor more information, see [get and set variables](/v3/develop/variables).",
                 "operationId": "create_variable_variables__post",
                 "parameters": [
                     {
@@ -8361,7 +8367,7 @@
                     "Events"
                 ],
                 "summary": "Create Events",
-                "description": "Record a batch of Events",
+                "description": "Record a batch of Events.\n\nFor more information, see [track activity through events](/v3/automate/events/events).",
                 "operationId": "create_events_events_post",
                 "parameters": [
                     {
@@ -8580,6 +8586,7 @@
                     "Automations"
                 ],
                 "summary": "Create Automation",
+                "description": "Create an automation.\n\nFor more information, see [automate](/v3/automate).",
                 "operationId": "create_automation_automations__post",
                 "parameters": [
                     {

--- a/src/prefect/server/api/artifacts.py
+++ b/src/prefect/server/api/artifacts.py
@@ -26,6 +26,11 @@ async def create_artifact(
     response: Response,
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> core.Artifact:
+    """
+    Create an artifact.
+
+    For more information, see [create run artifacts](/v3/develop/artifacts).
+    """
     artifact = core.Artifact(**artifact.model_dump())
 
     right_now = now("UTC")

--- a/src/prefect/server/api/artifacts.py
+++ b/src/prefect/server/api/artifacts.py
@@ -29,7 +29,7 @@ async def create_artifact(
     """
     Create an artifact.
 
-    For more information, see [create run artifacts](https://docs.prefect.io/v3/develop/artifacts).
+    For more information, see https://docs.prefect.io/v3/develop/artifacts.
     """
     artifact = core.Artifact(**artifact.model_dump())
 

--- a/src/prefect/server/api/artifacts.py
+++ b/src/prefect/server/api/artifacts.py
@@ -29,7 +29,7 @@ async def create_artifact(
     """
     Create an artifact.
 
-    For more information, see [create run artifacts](/v3/develop/artifacts).
+    For more information, see [create run artifacts](https://docs.prefect.io/v3/develop/artifacts).
     """
     artifact = core.Artifact(**artifact.model_dump())
 

--- a/src/prefect/server/api/automations.py
+++ b/src/prefect/server/api/automations.py
@@ -42,7 +42,7 @@ async def create_automation(
     """
     Create an automation.
 
-    For more information, see [automate](https://docs.prefect.io/v3/automate).
+    For more information, see https://docs.prefect.io/v3/automate.
     """
     # reset any client-provided IDs on the provided triggers
     automation.trigger.reset_ids()

--- a/src/prefect/server/api/automations.py
+++ b/src/prefect/server/api/automations.py
@@ -42,7 +42,7 @@ async def create_automation(
     """
     Create an automation.
 
-    For more information, see [automate](/v3/automate).
+    For more information, see [automate](https://docs.prefect.io/v3/automate).
     """
     # reset any client-provided IDs on the provided triggers
     automation.trigger.reset_ids()

--- a/src/prefect/server/api/automations.py
+++ b/src/prefect/server/api/automations.py
@@ -39,6 +39,11 @@ async def create_automation(
     automation: AutomationCreate,
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> Automation:
+    """
+    Create an automation.
+
+    For more information, see [automate](/v3/automate).
+    """
     # reset any client-provided IDs on the provided triggers
     automation.trigger.reset_ids()
 

--- a/src/prefect/server/api/block_capabilities.py
+++ b/src/prefect/server/api/block_capabilities.py
@@ -22,7 +22,7 @@ async def read_available_block_capabilities(
     """
     Get available block capabilities.
 
-    For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
+    For more information, see https://docs.prefect.io/v3/develop/blocks.
     """
     async with db.session_context() as session:
         return await models.block_schemas.read_available_block_capabilities(

--- a/src/prefect/server/api/block_capabilities.py
+++ b/src/prefect/server/api/block_capabilities.py
@@ -22,7 +22,7 @@ async def read_available_block_capabilities(
     """
     Get available block capabilities.
 
-    For more information, see [securely store typed configuration](/v3/develop/blocks).
+    For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
     """
     async with db.session_context() as session:
         return await models.block_schemas.read_available_block_capabilities(

--- a/src/prefect/server/api/block_capabilities.py
+++ b/src/prefect/server/api/block_capabilities.py
@@ -19,6 +19,11 @@ router: PrefectRouter = PrefectRouter(
 async def read_available_block_capabilities(
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> List[str]:
+    """
+    Get available block capabilities.
+
+    For more information, see [securely store typed configuration](/v3/develop/blocks).
+    """
     async with db.session_context() as session:
         return await models.block_schemas.read_available_block_capabilities(
             session=session

--- a/src/prefect/server/api/block_documents.py
+++ b/src/prefect/server/api/block_documents.py
@@ -25,7 +25,7 @@ async def create_block_document(
     """
     Create a new block document.
 
-    For more information, see [securely store typed configuration](/v3/develop/blocks).
+    For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
     """
     async with db.session_context(begin_transaction=True) as session:
         if block_document.name is not None:

--- a/src/prefect/server/api/block_documents.py
+++ b/src/prefect/server/api/block_documents.py
@@ -24,6 +24,8 @@ async def create_block_document(
 ) -> schemas.core.BlockDocument:
     """
     Create a new block document.
+
+    For more information, see [securely store typed configuration](/v3/develop/blocks).
     """
     async with db.session_context(begin_transaction=True) as session:
         if block_document.name is not None:

--- a/src/prefect/server/api/block_documents.py
+++ b/src/prefect/server/api/block_documents.py
@@ -25,7 +25,7 @@ async def create_block_document(
     """
     Create a new block document.
 
-    For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
+    For more information, see https://docs.prefect.io/v3/develop/blocks.
     """
     async with db.session_context(begin_transaction=True) as session:
         if block_document.name is not None:

--- a/src/prefect/server/api/block_schemas.py
+++ b/src/prefect/server/api/block_schemas.py
@@ -33,7 +33,7 @@ async def create_block_schema(
     """
     Create a block schema.
 
-    For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
+    For more information, see https://docs.prefect.io/v3/develop/blocks.
     """
     from prefect.blocks.core import Block
 

--- a/src/prefect/server/api/block_schemas.py
+++ b/src/prefect/server/api/block_schemas.py
@@ -30,6 +30,11 @@ async def create_block_schema(
     response: Response,
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> schemas.core.BlockSchema:
+    """
+    Create a block schema.
+
+    For more information, see [securely store typed configuration](/v3/develop/blocks).
+    """
     from prefect.blocks.core import Block
 
     async with db.session_context(begin_transaction=True) as session:

--- a/src/prefect/server/api/block_schemas.py
+++ b/src/prefect/server/api/block_schemas.py
@@ -33,7 +33,7 @@ async def create_block_schema(
     """
     Create a block schema.
 
-    For more information, see [securely store typed configuration](/v3/develop/blocks).
+    For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
     """
     from prefect.blocks.core import Block
 

--- a/src/prefect/server/api/block_types.py
+++ b/src/prefect/server/api/block_types.py
@@ -21,7 +21,7 @@ async def create_block_type(
     """
     Create a new block type.
 
-    For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
+    For more information, see https://docs.prefect.io/v3/develop/blocks.
     """
     # API-created blocks cannot start with the word "Prefect"
     # as it is reserved for system use

--- a/src/prefect/server/api/block_types.py
+++ b/src/prefect/server/api/block_types.py
@@ -21,7 +21,7 @@ async def create_block_type(
     """
     Create a new block type.
 
-    For more information, see [securely store typed configuration](/v3/develop/blocks).
+    For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
     """
     # API-created blocks cannot start with the word "Prefect"
     # as it is reserved for system use

--- a/src/prefect/server/api/block_types.py
+++ b/src/prefect/server/api/block_types.py
@@ -19,7 +19,9 @@ async def create_block_type(
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> schemas.core.BlockType:
     """
-    Create a new block type
+    Create a new block type.
+
+    For more information, see [securely store typed configuration](/v3/develop/blocks).
     """
     # API-created blocks cannot start with the word "Prefect"
     # as it is reserved for system use

--- a/src/prefect/server/api/concurrency_limits.py
+++ b/src/prefect/server/api/concurrency_limits.py
@@ -28,6 +28,11 @@ async def create_concurrency_limit(
     response: Response,
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> schemas.core.ConcurrencyLimit:
+    """
+    Create a task run concurrency limit.
+
+    For more information, see [manage concurrency](/v3/develop/task-run-limits).
+    """
     # hydrate the input model into a full model
     concurrency_limit_model = schemas.core.ConcurrencyLimit(
         **concurrency_limit.model_dump()

--- a/src/prefect/server/api/concurrency_limits.py
+++ b/src/prefect/server/api/concurrency_limits.py
@@ -31,7 +31,7 @@ async def create_concurrency_limit(
     """
     Create a task run concurrency limit.
 
-    For more information, see [manage concurrency](https://docs.prefect.io/v3/develop/task-run-limits).
+    For more information, see https://docs.prefect.io/v3/develop/task-run-limits.
     """
     # hydrate the input model into a full model
     concurrency_limit_model = schemas.core.ConcurrencyLimit(

--- a/src/prefect/server/api/concurrency_limits.py
+++ b/src/prefect/server/api/concurrency_limits.py
@@ -31,7 +31,7 @@ async def create_concurrency_limit(
     """
     Create a task run concurrency limit.
 
-    For more information, see [manage concurrency](/v3/develop/task-run-limits).
+    For more information, see [manage concurrency](https://docs.prefect.io/v3/develop/task-run-limits).
     """
     # hydrate the input model into a full model
     concurrency_limit_model = schemas.core.ConcurrencyLimit(

--- a/src/prefect/server/api/concurrency_limits_v2.py
+++ b/src/prefect/server/api/concurrency_limits_v2.py
@@ -21,6 +21,11 @@ async def create_concurrency_limit_v2(
     concurrency_limit: actions.ConcurrencyLimitV2Create,
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> schemas.core.ConcurrencyLimitV2:
+    """
+    Create a task run concurrency limit.
+
+    For more information, see [manage concurrency](/v3/develop/global-concurrency-limits).
+    """
     async with db.session_context(begin_transaction=True) as session:
         model = await models.concurrency_limits_v2.create_concurrency_limit(
             session=session, concurrency_limit=concurrency_limit

--- a/src/prefect/server/api/concurrency_limits_v2.py
+++ b/src/prefect/server/api/concurrency_limits_v2.py
@@ -24,7 +24,7 @@ async def create_concurrency_limit_v2(
     """
     Create a task run concurrency limit.
 
-    For more information, see [manage concurrency](https://docs.prefect.io/v3/develop/global-concurrency-limits).
+    For more information, see https://docs.prefect.io/v3/develop/global-concurrency-limits.
     """
     async with db.session_context(begin_transaction=True) as session:
         model = await models.concurrency_limits_v2.create_concurrency_limit(

--- a/src/prefect/server/api/concurrency_limits_v2.py
+++ b/src/prefect/server/api/concurrency_limits_v2.py
@@ -24,7 +24,7 @@ async def create_concurrency_limit_v2(
     """
     Create a task run concurrency limit.
 
-    For more information, see [manage concurrency](/v3/develop/global-concurrency-limits).
+    For more information, see [manage concurrency](https://docs.prefect.io/v3/develop/global-concurrency-limits).
     """
     async with db.session_context(begin_transaction=True) as session:
         model = await models.concurrency_limits_v2.create_concurrency_limit(

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -68,6 +68,8 @@ async def create_deployment(
 
     If the deployment has an active schedule, flow runs will be scheduled.
     When upserting, any scheduled runs from the existing deployment will be deleted.
+
+    For more information, see [deployments](/v3/deploy).
     """
 
     data = deployment.model_dump(exclude_unset=True)

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -69,7 +69,7 @@ async def create_deployment(
     If the deployment has an active schedule, flow runs will be scheduled.
     When upserting, any scheduled runs from the existing deployment will be deleted.
 
-    For more information, see [deployments](https://docs.prefect.io/v3/deploy).
+    For more information, see https://docs.prefect.io/v3/deploy.
     """
 
     data = deployment.model_dump(exclude_unset=True)

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -69,7 +69,7 @@ async def create_deployment(
     If the deployment has an active schedule, flow runs will be scheduled.
     When upserting, any scheduled runs from the existing deployment will be deleted.
 
-    For more information, see [deployments](/v3/deploy).
+    For more information, see [deployments](https://docs.prefect.io/v3/deploy).
     """
 
     data = deployment.model_dump(exclude_unset=True)

--- a/src/prefect/server/api/events.py
+++ b/src/prefect/server/api/events.py
@@ -48,7 +48,11 @@ async def create_events(
     events: List[Event],
     ephemeral_request: bool = Depends(is_ephemeral_request),
 ) -> None:
-    """Record a batch of Events"""
+    """
+    Record a batch of Events.
+
+    For more information, see [track activity through events](/v3/automate/events/events).
+    """
     if ephemeral_request:
         await EventsPipeline().process_events(events)
     else:

--- a/src/prefect/server/api/events.py
+++ b/src/prefect/server/api/events.py
@@ -51,7 +51,7 @@ async def create_events(
     """
     Record a batch of Events.
 
-    For more information, see [track activity through events](/v3/automate/events/events).
+    For more information, see [track activity through events](https://docs.prefect.io/v3/automate/events/events).
     """
     if ephemeral_request:
         await EventsPipeline().process_events(events)

--- a/src/prefect/server/api/events.py
+++ b/src/prefect/server/api/events.py
@@ -51,7 +51,7 @@ async def create_events(
     """
     Record a batch of Events.
 
-    For more information, see [track activity through events](https://docs.prefect.io/v3/automate/events/events).
+    For more information, see https://docs.prefect.io/v3/automate/events/events.
     """
     if ephemeral_request:
         await EventsPipeline().process_events(events)

--- a/src/prefect/server/api/flow_run_notification_policies.py
+++ b/src/prefect/server/api/flow_run_notification_policies.py
@@ -26,7 +26,7 @@ async def create_flow_run_notification_policy(
     """
     Creates a new flow run notification policy.
 
-    For more information, see [trigger actions on events](https://docs.prefect.io/v3/automate/events/automations-triggers#sending-notifications-with-automations).
+    For more information, see https://docs.prefect.io/v3/automate/events/automations-triggers#sending-notifications-with-automations.
     """
     async with db.session_context(begin_transaction=True) as session:
         return await models.flow_run_notification_policies.create_flow_run_notification_policy(

--- a/src/prefect/server/api/flow_run_notification_policies.py
+++ b/src/prefect/server/api/flow_run_notification_policies.py
@@ -26,7 +26,7 @@ async def create_flow_run_notification_policy(
     """
     Creates a new flow run notification policy.
 
-    For more information, see [trigger actions on events](/v3/automate/events/automations-triggers#sending-notifications-with-automations).
+    For more information, see [trigger actions on events](https://docs.prefect.io/v3/automate/events/automations-triggers#sending-notifications-with-automations).
     """
     async with db.session_context(begin_transaction=True) as session:
         return await models.flow_run_notification_policies.create_flow_run_notification_policy(

--- a/src/prefect/server/api/flow_run_notification_policies.py
+++ b/src/prefect/server/api/flow_run_notification_policies.py
@@ -25,6 +25,8 @@ async def create_flow_run_notification_policy(
 ) -> schemas.core.FlowRunNotificationPolicy:
     """
     Creates a new flow run notification policy.
+
+    For more information, see [trigger actions on events](/v3/automate/events/automations-triggers#sending-notifications-with-automations).
     """
     async with db.session_context(begin_transaction=True) as session:
         return await models.flow_run_notification_policies.create_flow_run_notification_policy(

--- a/src/prefect/server/api/flow_run_states.py
+++ b/src/prefect/server/api/flow_run_states.py
@@ -27,7 +27,7 @@ async def read_flow_run_state(
     """
     Get a flow run state by id.
 
-    For more information, see [write and run flows](https://docs.prefect.io/v3/develop/write-flows#final-state-determination).
+    For more information, see https://docs.prefect.io/v3/develop/write-flows#final-state-determination.
     """
     async with db.session_context() as session:
         flow_run_state = await models.flow_run_states.read_flow_run_state(

--- a/src/prefect/server/api/flow_run_states.py
+++ b/src/prefect/server/api/flow_run_states.py
@@ -27,7 +27,7 @@ async def read_flow_run_state(
     """
     Get a flow run state by id.
 
-    For more information, see [write and run flows](/v3/develop/write-flows#final-state-determination).
+    For more information, see [write and run flows](https://docs.prefect.io/v3/develop/write-flows#final-state-determination).
     """
     async with db.session_context() as session:
         flow_run_state = await models.flow_run_states.read_flow_run_state(

--- a/src/prefect/server/api/flow_run_states.py
+++ b/src/prefect/server/api/flow_run_states.py
@@ -26,6 +26,8 @@ async def read_flow_run_state(
 ) -> schemas.states.State:
     """
     Get a flow run state by id.
+
+    For more information, see [write and run flows](/v3/develop/write-flows#final-state-determination).
     """
     async with db.session_context() as session:
         flow_run_state = await models.flow_run_states.read_flow_run_state(

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -75,7 +75,7 @@ async def create_flow_run(
 
     If no state is provided, the flow run will be created in a PENDING state.
 
-    For more information, see [flow runs](https://docs.prefect.io/v3/develop/write-flows).
+    For more information, see https://docs.prefect.io/v3/develop/write-flows.
     """
     # hydrate the input model into a full flow run / state model
     flow_run_object = schemas.core.FlowRun(

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -75,7 +75,7 @@ async def create_flow_run(
 
     If no state is provided, the flow run will be created in a PENDING state.
 
-    For more information, see [flow runs](/v3/develop/write-flows).
+    For more information, see [flow runs](https://docs.prefect.io/v3/develop/write-flows).
     """
     # hydrate the input model into a full flow run / state model
     flow_run_object = schemas.core.FlowRun(

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -74,6 +74,8 @@ async def create_flow_run(
     idempotency key already exists, the existing flow run will be returned.
 
     If no state is provided, the flow run will be created in a PENDING state.
+
+    For more information, see [flow runs](/v3/develop/write-flows).
     """
     # hydrate the input model into a full flow run / state model
     flow_run_object = schemas.core.FlowRun(

--- a/src/prefect/server/api/flows.py
+++ b/src/prefect/server/api/flows.py
@@ -28,7 +28,7 @@ async def create_flow(
     """Gracefully creates a new flow from the provided schema. If a flow with the
     same name already exists, the existing flow is returned.
 
-    For more information, see [flows](/v3/develop/write-flows).
+    For more information, see [flows](https://docs.prefect.io/v3/develop/write-flows).
     """
     # hydrate the input model into a full flow model
     flow = schemas.core.Flow(**flow.model_dump())

--- a/src/prefect/server/api/flows.py
+++ b/src/prefect/server/api/flows.py
@@ -27,6 +27,8 @@ async def create_flow(
 ) -> schemas.core.Flow:
     """Gracefully creates a new flow from the provided schema. If a flow with the
     same name already exists, the existing flow is returned.
+
+    For more information, see [flows](/v3/develop/write-flows).
     """
     # hydrate the input model into a full flow model
     flow = schemas.core.Flow(**flow.model_dump())

--- a/src/prefect/server/api/flows.py
+++ b/src/prefect/server/api/flows.py
@@ -28,7 +28,7 @@ async def create_flow(
     """Gracefully creates a new flow from the provided schema. If a flow with the
     same name already exists, the existing flow is returned.
 
-    For more information, see [flows](https://docs.prefect.io/v3/develop/write-flows).
+    For more information, see https://docs.prefect.io/v3/develop/write-flows.
     """
     # hydrate the input model into a full flow model
     flow = schemas.core.Flow(**flow.model_dump())

--- a/src/prefect/server/api/logs.py
+++ b/src/prefect/server/api/logs.py
@@ -23,7 +23,7 @@ async def create_logs(
     """
     Create new logs from the provided schema.
 
-    For more information, see [configure logging](/v3/develop/logging).
+    For more information, see [configure logging](https://docs.prefect.io/v3/develop/logging).
     """
     for batch in models.logs.split_logs_into_batches(logs):
         async with db.session_context(begin_transaction=True) as session:

--- a/src/prefect/server/api/logs.py
+++ b/src/prefect/server/api/logs.py
@@ -20,7 +20,11 @@ async def create_logs(
     logs: List[schemas.actions.LogCreate],
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> None:
-    """Create new logs from the provided schema."""
+    """
+    Create new logs from the provided schema.
+
+    For more information, see [configure logging](/v3/develop/logging).
+    """
     for batch in models.logs.split_logs_into_batches(logs):
         async with db.session_context(begin_transaction=True) as session:
             await models.logs.create_logs(session=session, logs=batch)

--- a/src/prefect/server/api/logs.py
+++ b/src/prefect/server/api/logs.py
@@ -23,7 +23,7 @@ async def create_logs(
     """
     Create new logs from the provided schema.
 
-    For more information, see [configure logging](https://docs.prefect.io/v3/develop/logging).
+    For more information, see https://docs.prefect.io/v3/develop/logging.
     """
     for batch in models.logs.split_logs_into_batches(logs):
         async with db.session_context(begin_transaction=True) as session:

--- a/src/prefect/server/api/task_run_states.py
+++ b/src/prefect/server/api/task_run_states.py
@@ -27,7 +27,7 @@ async def read_task_run_state(
     """
     Get a task run state by id.
 
-    For more information, see [write and run tasks](/v3/develop/write-tasks).
+    For more information, see [write and run tasks](https://docs.prefect.io/v3/develop/write-tasks).
     """
     async with db.session_context() as session:
         task_run_state = await models.task_run_states.read_task_run_state(

--- a/src/prefect/server/api/task_run_states.py
+++ b/src/prefect/server/api/task_run_states.py
@@ -26,6 +26,8 @@ async def read_task_run_state(
 ) -> schemas.states.State:
     """
     Get a task run state by id.
+
+    For more information, see [write and run tasks](/v3/develop/write-tasks).
     """
     async with db.session_context() as session:
         task_run_state = await models.task_run_states.read_task_run_state(

--- a/src/prefect/server/api/task_run_states.py
+++ b/src/prefect/server/api/task_run_states.py
@@ -27,7 +27,7 @@ async def read_task_run_state(
     """
     Get a task run state by id.
 
-    For more information, see [write and run tasks](https://docs.prefect.io/v3/develop/write-tasks).
+    For more information, see https://docs.prefect.io/v3/develop/write-tasks.
     """
     async with db.session_context() as session:
         task_run_state = await models.task_run_states.read_task_run_state(

--- a/src/prefect/server/api/task_runs.py
+++ b/src/prefect/server/api/task_runs.py
@@ -58,7 +58,7 @@ async def create_task_run(
 
     If no state is provided, the task run will be created in a PENDING state.
 
-    For more information, see [write and run tasks](https://docs.prefect.io/v3/develop/write-tasks).
+    For more information, see https://docs.prefect.io/v3/develop/write-tasks.
     """
     # hydrate the input model into a full task run / state model
     task_run_dict = task_run.model_dump()

--- a/src/prefect/server/api/task_runs.py
+++ b/src/prefect/server/api/task_runs.py
@@ -57,6 +57,8 @@ async def create_task_run(
     run will be returned.
 
     If no state is provided, the task run will be created in a PENDING state.
+
+    For more information, see [write and run tasks](/v3/develop/write-tasks).
     """
     # hydrate the input model into a full task run / state model
     task_run_dict = task_run.model_dump()

--- a/src/prefect/server/api/task_runs.py
+++ b/src/prefect/server/api/task_runs.py
@@ -58,7 +58,7 @@ async def create_task_run(
 
     If no state is provided, the task run will be created in a PENDING state.
 
-    For more information, see [write and run tasks](/v3/develop/write-tasks).
+    For more information, see [write and run tasks](https://docs.prefect.io/v3/develop/write-tasks).
     """
     # hydrate the input model into a full task run / state model
     task_run_dict = task_run.model_dump()

--- a/src/prefect/server/api/task_workers.py
+++ b/src/prefect/server/api/task_workers.py
@@ -23,7 +23,7 @@ async def read_task_workers(
     """
     Read active task workers. Optionally filter by task keys.
 
-    For more information, see [run tasks in the background](https://docs.prefect.io/v3/develop/deferred-tasks).
+    For more information, see https://docs.prefect.io/v3/develop/deferred-tasks.
     """
 
     if task_worker_filter and task_worker_filter.task_keys:

--- a/src/prefect/server/api/task_workers.py
+++ b/src/prefect/server/api/task_workers.py
@@ -23,7 +23,7 @@ async def read_task_workers(
     """
     Read active task workers. Optionally filter by task keys.
 
-    For more information, see [run tasks in the background](/v3/develop/deferred-tasks).
+    For more information, see [run tasks in the background](https://docs.prefect.io/v3/develop/deferred-tasks).
     """
 
     if task_worker_filter and task_worker_filter.task_keys:

--- a/src/prefect/server/api/task_workers.py
+++ b/src/prefect/server/api/task_workers.py
@@ -20,7 +20,11 @@ async def read_task_workers(
         default=None, description="The task worker filter", embed=True
     ),
 ) -> List[TaskWorkerResponse]:
-    """Read active task workers. Optionally filter by task keys."""
+    """
+    Read active task workers. Optionally filter by task keys.
+
+    For more information, see [run tasks in the background](/v3/develop/deferred-tasks).
+    """
 
     if task_worker_filter and task_worker_filter.task_keys:
         return await models.task_workers.get_workers_for_task_keys(

--- a/src/prefect/server/api/variables.py
+++ b/src/prefect/server/api/variables.py
@@ -60,7 +60,7 @@ async def create_variable(
     """
     Create a variable.
 
-    For more information, see [get and set variables](/v3/develop/variables).
+    For more information, see [get and set variables](https://docs.prefect.io/v3/develop/variables).
     """
     async with db.session_context(begin_transaction=True) as session:
         try:

--- a/src/prefect/server/api/variables.py
+++ b/src/prefect/server/api/variables.py
@@ -57,6 +57,11 @@ async def create_variable(
     variable: actions.VariableCreate,
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> core.Variable:
+    """
+    Create a variable.
+
+    For more information, see [get and set variables](/v3/develop/variables).
+    """
     async with db.session_context(begin_transaction=True) as session:
         try:
             model = await models.variables.create_variable(

--- a/src/prefect/server/api/variables.py
+++ b/src/prefect/server/api/variables.py
@@ -60,7 +60,7 @@ async def create_variable(
     """
     Create a variable.
 
-    For more information, see [get and set variables](https://docs.prefect.io/v3/develop/variables).
+    For more information, see https://docs.prefect.io/v3/develop/variables.
     """
     async with db.session_context(begin_transaction=True) as session:
         try:

--- a/src/prefect/server/api/work_queues.py
+++ b/src/prefect/server/api/work_queues.py
@@ -46,7 +46,7 @@ async def create_work_queue(
     If a work queue with the same name already exists, an error
     will be raised.
 
-    For more information, see [work queues](/v3/deploy/infrastructure-concepts/work-pools#work-queues).
+    For more information, see [work queues](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues).
     """
 
     try:

--- a/src/prefect/server/api/work_queues.py
+++ b/src/prefect/server/api/work_queues.py
@@ -46,7 +46,7 @@ async def create_work_queue(
     If a work queue with the same name already exists, an error
     will be raised.
 
-    For more information, see [work queues](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues).
+    For more information, see https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues.
     """
 
     try:

--- a/src/prefect/server/api/work_queues.py
+++ b/src/prefect/server/api/work_queues.py
@@ -45,6 +45,8 @@ async def create_work_queue(
 
     If a work queue with the same name already exists, an error
     will be raised.
+
+    For more information, see [work queues](/v3/deploy/infrastructure-concepts/work-pools#work-queues).
     """
 
     try:

--- a/src/prefect/server/api/workers.py
+++ b/src/prefect/server/api/workers.py
@@ -162,7 +162,7 @@ async def create_work_pool(
     Creates a new work pool. If a work pool with the same
     name already exists, an error will be raised.
 
-    For more information, see [work pools](/v3/deploy/infrastructure-concepts/work-pools).
+    For more information, see [work pools](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools).
     """
     if work_pool.name.lower().startswith("prefect"):
         raise HTTPException(
@@ -411,7 +411,7 @@ async def create_work_queue(
     Creates a new work pool queue. If a work pool queue with the same
     name already exists, an error will be raised.
 
-    For more information, see [work queues](/v3/deploy/infrastructure-concepts/work-pools#work-queues).
+    For more information, see [work queues](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues).
     """
 
     try:

--- a/src/prefect/server/api/workers.py
+++ b/src/prefect/server/api/workers.py
@@ -162,7 +162,7 @@ async def create_work_pool(
     Creates a new work pool. If a work pool with the same
     name already exists, an error will be raised.
 
-    For more information, see [work pools](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools).
+    For more information, see https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools.
     """
     if work_pool.name.lower().startswith("prefect"):
         raise HTTPException(
@@ -411,7 +411,7 @@ async def create_work_queue(
     Creates a new work pool queue. If a work pool queue with the same
     name already exists, an error will be raised.
 
-    For more information, see [work queues](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues).
+    For more information, see https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues.
     """
 
     try:

--- a/src/prefect/server/api/workers.py
+++ b/src/prefect/server/api/workers.py
@@ -161,6 +161,8 @@ async def create_work_pool(
     """
     Creates a new work pool. If a work pool with the same
     name already exists, an error will be raised.
+
+    For more information, see [work pools](/v3/deploy/infrastructure-concepts/work-pools).
     """
     if work_pool.name.lower().startswith("prefect"):
         raise HTTPException(
@@ -408,6 +410,8 @@ async def create_work_queue(
     """
     Creates a new work pool queue. If a work pool queue with the same
     name already exists, an error will be raised.
+
+    For more information, see [work queues](/v3/deploy/infrastructure-concepts/work-pools#work-queues).
     """
 
     try:

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -51,6 +51,8 @@ export interface paths {
          * Create Flow
          * @description Gracefully creates a new flow from the provided schema. If a flow with the
          *     same name already exists, the existing flow is returned.
+         *
+         *     For more information, see [flows](/v3/develop/write-flows).
          */
         post: operations["create_flow_flows__post"];
         delete?: never;
@@ -182,6 +184,8 @@ export interface paths {
          *     idempotency key already exists, the existing flow run will be returned.
          *
          *     If no state is provided, the flow run will be created in a PENDING state.
+         *
+         *     For more information, see [flow runs](/v3/develop/write-flows).
          */
         post: operations["create_flow_run_flow_runs__post"];
         delete?: never;
@@ -518,6 +522,8 @@ export interface paths {
          *     run will be returned.
          *
          *     If no state is provided, the task run will be created in a PENDING state.
+         *
+         *     For more information, see [write and run tasks](/v3/develop/write-tasks).
          */
         post: operations["create_task_run_task_runs__post"];
         delete?: never;
@@ -644,6 +650,8 @@ export interface paths {
         /**
          * Read Flow Run State
          * @description Get a flow run state by id.
+         *
+         *     For more information, see [write and run flows](/v3/develop/write-flows#final-state-determination).
          */
         get: operations["read_flow_run_state_flow_run_states__id__get"];
         put?: never;
@@ -684,6 +692,8 @@ export interface paths {
         /**
          * Read Task Run State
          * @description Get a task run state by id.
+         *
+         *     For more information, see [write and run tasks](/v3/develop/write-tasks).
          */
         get: operations["read_task_run_state_task_run_states__id__get"];
         put?: never;
@@ -726,6 +736,8 @@ export interface paths {
         /**
          * Create Flow Run Notification Policy
          * @description Creates a new flow run notification policy.
+         *
+         *     For more information, see [trigger actions on events](/v3/automate/events/automations-triggers#sending-notifications-with-automations).
          */
         post: operations["create_flow_run_notification_policy_flow_run_notification_policies__post"];
         delete?: never;
@@ -798,6 +810,8 @@ export interface paths {
          *
          *     If the deployment has an active schedule, flow runs will be scheduled.
          *     When upserting, any scheduled runs from the existing deployment will be deleted.
+         *
+         *     For more information, see [deployments](/v3/deploy).
          */
         post: operations["create_deployment_deployments__post"];
         delete?: never;
@@ -1169,6 +1183,8 @@ export interface paths {
         /**
          * Create Logs
          * @description Create new logs from the provided schema.
+         *
+         *     For more information, see [configure logging](/v3/develop/logging).
          */
         post: operations["create_logs_logs__post"];
         delete?: never;
@@ -1206,7 +1222,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Create Concurrency Limit */
+        /**
+         * Create Concurrency Limit
+         * @description Create a task run concurrency limit.
+         *
+         *     For more information, see [manage concurrency](/v3/develop/task-run-limits).
+         */
         post: operations["create_concurrency_limit_concurrency_limits__post"];
         delete?: never;
         options?: never;
@@ -1345,7 +1366,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Create Concurrency Limit V2 */
+        /**
+         * Create Concurrency Limit V2
+         * @description Create a task run concurrency limit.
+         *
+         *     For more information, see [manage concurrency](/v3/develop/global-concurrency-limits).
+         */
         post: operations["create_concurrency_limit_v2_v2_concurrency_limits__post"];
         delete?: never;
         options?: never;
@@ -1434,7 +1460,9 @@ export interface paths {
         put?: never;
         /**
          * Create Block Type
-         * @description Create a new block type
+         * @description Create a new block type.
+         *
+         *     For more information, see [securely store typed configuration](/v3/develop/blocks).
          */
         post: operations["create_block_type_block_types__post"];
         delete?: never;
@@ -1571,6 +1599,8 @@ export interface paths {
         /**
          * Create Block Document
          * @description Create a new block document.
+         *
+         *     For more information, see [securely store typed configuration](/v3/develop/blocks).
          */
         post: operations["create_block_document_block_documents__post"];
         delete?: never;
@@ -1651,6 +1681,8 @@ export interface paths {
          * Create Work Pool
          * @description Creates a new work pool. If a work pool with the same
          *     name already exists, an error will be raised.
+         *
+         *     For more information, see [work pools](/v3/deploy/infrastructure-concepts/work-pools).
          */
         post: operations["create_work_pool_work_pools__post"];
         delete?: never;
@@ -1760,6 +1792,8 @@ export interface paths {
          * Create Work Queue
          * @description Creates a new work pool queue. If a work pool queue with the same
          *     name already exists, an error will be raised.
+         *
+         *     For more information, see [work queues](/v3/deploy/infrastructure-concepts/work-pools#work-queues).
          */
         post: operations["create_work_queue_work_pools__work_pool_name__queues_post"];
         delete?: never;
@@ -1885,6 +1919,8 @@ export interface paths {
         /**
          * Read Task Workers
          * @description Read active task workers. Optionally filter by task keys.
+         *
+         *     For more information, see [run tasks in the background](/v3/develop/deferred-tasks).
          */
         post: operations["read_task_workers_task_workers_filter_post"];
         delete?: never;
@@ -1908,6 +1944,8 @@ export interface paths {
          *
          *     If a work queue with the same name already exists, an error
          *     will be raised.
+         *
+         *     For more information, see [work queues](/v3/deploy/infrastructure-concepts/work-pools#work-queues).
          */
         post: operations["create_work_queue_work_queues__post"];
         delete?: never;
@@ -2033,7 +2071,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Create Artifact */
+        /**
+         * Create Artifact
+         * @description Create an artifact.
+         *
+         *     For more information, see [create run artifacts](/v3/develop/artifacts).
+         */
         post: operations["create_artifact_artifacts__post"];
         delete?: never;
         options?: never;
@@ -2178,7 +2221,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Create Block Schema */
+        /**
+         * Create Block Schema
+         * @description Create a block schema.
+         *
+         *     For more information, see [securely store typed configuration](/v3/develop/blocks).
+         */
         post: operations["create_block_schema_block_schemas__post"];
         delete?: never;
         options?: never;
@@ -2254,7 +2302,12 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Read Available Block Capabilities */
+        /**
+         * Read Available Block Capabilities
+         * @description Get available block capabilities.
+         *
+         *     For more information, see [securely store typed configuration](/v3/develop/blocks).
+         */
         get: operations["read_available_block_capabilities_block_capabilities__get"];
         put?: never;
         post?: never;
@@ -2293,7 +2346,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Create Variable */
+        /**
+         * Create Variable
+         * @description Create a variable.
+         *
+         *     For more information, see [get and set variables](/v3/develop/variables).
+         */
         post: operations["create_variable_variables__post"];
         delete?: never;
         options?: never;
@@ -2404,7 +2462,9 @@ export interface paths {
         put?: never;
         /**
          * Create Events
-         * @description Record a batch of Events
+         * @description Record a batch of Events.
+         *
+         *     For more information, see [track activity through events](/v3/automate/events/events).
          */
         post: operations["create_events_events_post"];
         delete?: never;
@@ -2487,7 +2547,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Create Automation */
+        /**
+         * Create Automation
+         * @description Create an automation.
+         *
+         *     For more information, see [automate](/v3/automate).
+         */
         post: operations["create_automation_automations__post"];
         delete?: never;
         options?: never;

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -52,7 +52,7 @@ export interface paths {
          * @description Gracefully creates a new flow from the provided schema. If a flow with the
          *     same name already exists, the existing flow is returned.
          *
-         *     For more information, see [flows](https://docs.prefect.io/v3/develop/write-flows).
+         *     For more information, see https://docs.prefect.io/v3/develop/write-flows.
          */
         post: operations["create_flow_flows__post"];
         delete?: never;
@@ -185,7 +185,7 @@ export interface paths {
          *
          *     If no state is provided, the flow run will be created in a PENDING state.
          *
-         *     For more information, see [flow runs](https://docs.prefect.io/v3/develop/write-flows).
+         *     For more information, see https://docs.prefect.io/v3/develop/write-flows.
          */
         post: operations["create_flow_run_flow_runs__post"];
         delete?: never;
@@ -523,7 +523,7 @@ export interface paths {
          *
          *     If no state is provided, the task run will be created in a PENDING state.
          *
-         *     For more information, see [write and run tasks](https://docs.prefect.io/v3/develop/write-tasks).
+         *     For more information, see https://docs.prefect.io/v3/develop/write-tasks.
          */
         post: operations["create_task_run_task_runs__post"];
         delete?: never;
@@ -651,7 +651,7 @@ export interface paths {
          * Read Flow Run State
          * @description Get a flow run state by id.
          *
-         *     For more information, see [write and run flows](https://docs.prefect.io/v3/develop/write-flows#final-state-determination).
+         *     For more information, see https://docs.prefect.io/v3/develop/write-flows#final-state-determination.
          */
         get: operations["read_flow_run_state_flow_run_states__id__get"];
         put?: never;
@@ -693,7 +693,7 @@ export interface paths {
          * Read Task Run State
          * @description Get a task run state by id.
          *
-         *     For more information, see [write and run tasks](https://docs.prefect.io/v3/develop/write-tasks).
+         *     For more information, see https://docs.prefect.io/v3/develop/write-tasks.
          */
         get: operations["read_task_run_state_task_run_states__id__get"];
         put?: never;
@@ -737,7 +737,7 @@ export interface paths {
          * Create Flow Run Notification Policy
          * @description Creates a new flow run notification policy.
          *
-         *     For more information, see [trigger actions on events](https://docs.prefect.io/v3/automate/events/automations-triggers#sending-notifications-with-automations).
+         *     For more information, see https://docs.prefect.io/v3/automate/events/automations-triggers#sending-notifications-with-automations.
          */
         post: operations["create_flow_run_notification_policy_flow_run_notification_policies__post"];
         delete?: never;
@@ -811,7 +811,7 @@ export interface paths {
          *     If the deployment has an active schedule, flow runs will be scheduled.
          *     When upserting, any scheduled runs from the existing deployment will be deleted.
          *
-         *     For more information, see [deployments](https://docs.prefect.io/v3/deploy).
+         *     For more information, see https://docs.prefect.io/v3/deploy.
          */
         post: operations["create_deployment_deployments__post"];
         delete?: never;
@@ -1184,7 +1184,7 @@ export interface paths {
          * Create Logs
          * @description Create new logs from the provided schema.
          *
-         *     For more information, see [configure logging](https://docs.prefect.io/v3/develop/logging).
+         *     For more information, see https://docs.prefect.io/v3/develop/logging.
          */
         post: operations["create_logs_logs__post"];
         delete?: never;
@@ -1226,7 +1226,7 @@ export interface paths {
          * Create Concurrency Limit
          * @description Create a task run concurrency limit.
          *
-         *     For more information, see [manage concurrency](https://docs.prefect.io/v3/develop/task-run-limits).
+         *     For more information, see https://docs.prefect.io/v3/develop/task-run-limits.
          */
         post: operations["create_concurrency_limit_concurrency_limits__post"];
         delete?: never;
@@ -1370,7 +1370,7 @@ export interface paths {
          * Create Concurrency Limit V2
          * @description Create a task run concurrency limit.
          *
-         *     For more information, see [manage concurrency](https://docs.prefect.io/v3/develop/global-concurrency-limits).
+         *     For more information, see https://docs.prefect.io/v3/develop/global-concurrency-limits.
          */
         post: operations["create_concurrency_limit_v2_v2_concurrency_limits__post"];
         delete?: never;
@@ -1462,7 +1462,7 @@ export interface paths {
          * Create Block Type
          * @description Create a new block type.
          *
-         *     For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
+         *     For more information, see https://docs.prefect.io/v3/develop/blocks.
          */
         post: operations["create_block_type_block_types__post"];
         delete?: never;
@@ -1600,7 +1600,7 @@ export interface paths {
          * Create Block Document
          * @description Create a new block document.
          *
-         *     For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
+         *     For more information, see https://docs.prefect.io/v3/develop/blocks.
          */
         post: operations["create_block_document_block_documents__post"];
         delete?: never;
@@ -1682,7 +1682,7 @@ export interface paths {
          * @description Creates a new work pool. If a work pool with the same
          *     name already exists, an error will be raised.
          *
-         *     For more information, see [work pools](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools).
+         *     For more information, see https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools.
          */
         post: operations["create_work_pool_work_pools__post"];
         delete?: never;
@@ -1793,7 +1793,7 @@ export interface paths {
          * @description Creates a new work pool queue. If a work pool queue with the same
          *     name already exists, an error will be raised.
          *
-         *     For more information, see [work queues](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues).
+         *     For more information, see https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues.
          */
         post: operations["create_work_queue_work_pools__work_pool_name__queues_post"];
         delete?: never;
@@ -1920,7 +1920,7 @@ export interface paths {
          * Read Task Workers
          * @description Read active task workers. Optionally filter by task keys.
          *
-         *     For more information, see [run tasks in the background](https://docs.prefect.io/v3/develop/deferred-tasks).
+         *     For more information, see https://docs.prefect.io/v3/develop/deferred-tasks.
          */
         post: operations["read_task_workers_task_workers_filter_post"];
         delete?: never;
@@ -1945,7 +1945,7 @@ export interface paths {
          *     If a work queue with the same name already exists, an error
          *     will be raised.
          *
-         *     For more information, see [work queues](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues).
+         *     For more information, see https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues.
          */
         post: operations["create_work_queue_work_queues__post"];
         delete?: never;
@@ -2075,7 +2075,7 @@ export interface paths {
          * Create Artifact
          * @description Create an artifact.
          *
-         *     For more information, see [create run artifacts](https://docs.prefect.io/v3/develop/artifacts).
+         *     For more information, see https://docs.prefect.io/v3/develop/artifacts.
          */
         post: operations["create_artifact_artifacts__post"];
         delete?: never;
@@ -2225,7 +2225,7 @@ export interface paths {
          * Create Block Schema
          * @description Create a block schema.
          *
-         *     For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
+         *     For more information, see https://docs.prefect.io/v3/develop/blocks.
          */
         post: operations["create_block_schema_block_schemas__post"];
         delete?: never;
@@ -2306,7 +2306,7 @@ export interface paths {
          * Read Available Block Capabilities
          * @description Get available block capabilities.
          *
-         *     For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
+         *     For more information, see https://docs.prefect.io/v3/develop/blocks.
          */
         get: operations["read_available_block_capabilities_block_capabilities__get"];
         put?: never;
@@ -2350,7 +2350,7 @@ export interface paths {
          * Create Variable
          * @description Create a variable.
          *
-         *     For more information, see [get and set variables](https://docs.prefect.io/v3/develop/variables).
+         *     For more information, see https://docs.prefect.io/v3/develop/variables.
          */
         post: operations["create_variable_variables__post"];
         delete?: never;
@@ -2464,7 +2464,7 @@ export interface paths {
          * Create Events
          * @description Record a batch of Events.
          *
-         *     For more information, see [track activity through events](https://docs.prefect.io/v3/automate/events/events).
+         *     For more information, see https://docs.prefect.io/v3/automate/events/events.
          */
         post: operations["create_events_events_post"];
         delete?: never;
@@ -2551,7 +2551,7 @@ export interface paths {
          * Create Automation
          * @description Create an automation.
          *
-         *     For more information, see [automate](https://docs.prefect.io/v3/automate).
+         *     For more information, see https://docs.prefect.io/v3/automate.
          */
         post: operations["create_automation_automations__post"];
         delete?: never;

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -52,7 +52,7 @@ export interface paths {
          * @description Gracefully creates a new flow from the provided schema. If a flow with the
          *     same name already exists, the existing flow is returned.
          *
-         *     For more information, see [flows](/v3/develop/write-flows).
+         *     For more information, see [flows](https://docs.prefect.io/v3/develop/write-flows).
          */
         post: operations["create_flow_flows__post"];
         delete?: never;
@@ -185,7 +185,7 @@ export interface paths {
          *
          *     If no state is provided, the flow run will be created in a PENDING state.
          *
-         *     For more information, see [flow runs](/v3/develop/write-flows).
+         *     For more information, see [flow runs](https://docs.prefect.io/v3/develop/write-flows).
          */
         post: operations["create_flow_run_flow_runs__post"];
         delete?: never;
@@ -523,7 +523,7 @@ export interface paths {
          *
          *     If no state is provided, the task run will be created in a PENDING state.
          *
-         *     For more information, see [write and run tasks](/v3/develop/write-tasks).
+         *     For more information, see [write and run tasks](https://docs.prefect.io/v3/develop/write-tasks).
          */
         post: operations["create_task_run_task_runs__post"];
         delete?: never;
@@ -651,7 +651,7 @@ export interface paths {
          * Read Flow Run State
          * @description Get a flow run state by id.
          *
-         *     For more information, see [write and run flows](/v3/develop/write-flows#final-state-determination).
+         *     For more information, see [write and run flows](https://docs.prefect.io/v3/develop/write-flows#final-state-determination).
          */
         get: operations["read_flow_run_state_flow_run_states__id__get"];
         put?: never;
@@ -693,7 +693,7 @@ export interface paths {
          * Read Task Run State
          * @description Get a task run state by id.
          *
-         *     For more information, see [write and run tasks](/v3/develop/write-tasks).
+         *     For more information, see [write and run tasks](https://docs.prefect.io/v3/develop/write-tasks).
          */
         get: operations["read_task_run_state_task_run_states__id__get"];
         put?: never;
@@ -737,7 +737,7 @@ export interface paths {
          * Create Flow Run Notification Policy
          * @description Creates a new flow run notification policy.
          *
-         *     For more information, see [trigger actions on events](/v3/automate/events/automations-triggers#sending-notifications-with-automations).
+         *     For more information, see [trigger actions on events](https://docs.prefect.io/v3/automate/events/automations-triggers#sending-notifications-with-automations).
          */
         post: operations["create_flow_run_notification_policy_flow_run_notification_policies__post"];
         delete?: never;
@@ -811,7 +811,7 @@ export interface paths {
          *     If the deployment has an active schedule, flow runs will be scheduled.
          *     When upserting, any scheduled runs from the existing deployment will be deleted.
          *
-         *     For more information, see [deployments](/v3/deploy).
+         *     For more information, see [deployments](https://docs.prefect.io/v3/deploy).
          */
         post: operations["create_deployment_deployments__post"];
         delete?: never;
@@ -1184,7 +1184,7 @@ export interface paths {
          * Create Logs
          * @description Create new logs from the provided schema.
          *
-         *     For more information, see [configure logging](/v3/develop/logging).
+         *     For more information, see [configure logging](https://docs.prefect.io/v3/develop/logging).
          */
         post: operations["create_logs_logs__post"];
         delete?: never;
@@ -1226,7 +1226,7 @@ export interface paths {
          * Create Concurrency Limit
          * @description Create a task run concurrency limit.
          *
-         *     For more information, see [manage concurrency](/v3/develop/task-run-limits).
+         *     For more information, see [manage concurrency](https://docs.prefect.io/v3/develop/task-run-limits).
          */
         post: operations["create_concurrency_limit_concurrency_limits__post"];
         delete?: never;
@@ -1370,7 +1370,7 @@ export interface paths {
          * Create Concurrency Limit V2
          * @description Create a task run concurrency limit.
          *
-         *     For more information, see [manage concurrency](/v3/develop/global-concurrency-limits).
+         *     For more information, see [manage concurrency](https://docs.prefect.io/v3/develop/global-concurrency-limits).
          */
         post: operations["create_concurrency_limit_v2_v2_concurrency_limits__post"];
         delete?: never;
@@ -1462,7 +1462,7 @@ export interface paths {
          * Create Block Type
          * @description Create a new block type.
          *
-         *     For more information, see [securely store typed configuration](/v3/develop/blocks).
+         *     For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
          */
         post: operations["create_block_type_block_types__post"];
         delete?: never;
@@ -1600,7 +1600,7 @@ export interface paths {
          * Create Block Document
          * @description Create a new block document.
          *
-         *     For more information, see [securely store typed configuration](/v3/develop/blocks).
+         *     For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
          */
         post: operations["create_block_document_block_documents__post"];
         delete?: never;
@@ -1682,7 +1682,7 @@ export interface paths {
          * @description Creates a new work pool. If a work pool with the same
          *     name already exists, an error will be raised.
          *
-         *     For more information, see [work pools](/v3/deploy/infrastructure-concepts/work-pools).
+         *     For more information, see [work pools](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools).
          */
         post: operations["create_work_pool_work_pools__post"];
         delete?: never;
@@ -1793,7 +1793,7 @@ export interface paths {
          * @description Creates a new work pool queue. If a work pool queue with the same
          *     name already exists, an error will be raised.
          *
-         *     For more information, see [work queues](/v3/deploy/infrastructure-concepts/work-pools#work-queues).
+         *     For more information, see [work queues](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues).
          */
         post: operations["create_work_queue_work_pools__work_pool_name__queues_post"];
         delete?: never;
@@ -1920,7 +1920,7 @@ export interface paths {
          * Read Task Workers
          * @description Read active task workers. Optionally filter by task keys.
          *
-         *     For more information, see [run tasks in the background](/v3/develop/deferred-tasks).
+         *     For more information, see [run tasks in the background](https://docs.prefect.io/v3/develop/deferred-tasks).
          */
         post: operations["read_task_workers_task_workers_filter_post"];
         delete?: never;
@@ -1945,7 +1945,7 @@ export interface paths {
          *     If a work queue with the same name already exists, an error
          *     will be raised.
          *
-         *     For more information, see [work queues](/v3/deploy/infrastructure-concepts/work-pools#work-queues).
+         *     For more information, see [work queues](https://docs.prefect.io/v3/deploy/infrastructure-concepts/work-pools#work-queues).
          */
         post: operations["create_work_queue_work_queues__post"];
         delete?: never;
@@ -2075,7 +2075,7 @@ export interface paths {
          * Create Artifact
          * @description Create an artifact.
          *
-         *     For more information, see [create run artifacts](/v3/develop/artifacts).
+         *     For more information, see [create run artifacts](https://docs.prefect.io/v3/develop/artifacts).
          */
         post: operations["create_artifact_artifacts__post"];
         delete?: never;
@@ -2225,7 +2225,7 @@ export interface paths {
          * Create Block Schema
          * @description Create a block schema.
          *
-         *     For more information, see [securely store typed configuration](/v3/develop/blocks).
+         *     For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
          */
         post: operations["create_block_schema_block_schemas__post"];
         delete?: never;
@@ -2306,7 +2306,7 @@ export interface paths {
          * Read Available Block Capabilities
          * @description Get available block capabilities.
          *
-         *     For more information, see [securely store typed configuration](/v3/develop/blocks).
+         *     For more information, see [securely store typed configuration](https://docs.prefect.io/v3/develop/blocks).
          */
         get: operations["read_available_block_capabilities_block_capabilities__get"];
         put?: never;
@@ -2350,7 +2350,7 @@ export interface paths {
          * Create Variable
          * @description Create a variable.
          *
-         *     For more information, see [get and set variables](/v3/develop/variables).
+         *     For more information, see [get and set variables](https://docs.prefect.io/v3/develop/variables).
          */
         post: operations["create_variable_variables__post"];
         delete?: never;
@@ -2464,7 +2464,7 @@ export interface paths {
          * Create Events
          * @description Record a batch of Events.
          *
-         *     For more information, see [track activity through events](/v3/automate/events/events).
+         *     For more information, see [track activity through events](https://docs.prefect.io/v3/automate/events/events).
          */
         post: operations["create_events_events_post"];
         delete?: never;
@@ -2551,7 +2551,7 @@ export interface paths {
          * Create Automation
          * @description Create an automation.
          *
-         *     For more information, see [automate](/v3/automate).
+         *     For more information, see [automate](https://docs.prefect.io/v3/automate).
          */
         post: operations["create_automation_automations__post"];
         delete?: never;


### PR DESCRIPTION
Links from the API docs to the related documentation pages. This helps identify which features each API route represents.

Related to https://linear.app/prefect/issue/PLA-987/add-links-to-documentation-from-the-oss-api-docs

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
