### PR TITLE
[UI v2] feat: Completes action items in deployments data table

### DIFF
--- a/ui-v2/src/components/deployments/data-table/cells.tsx
+++ b/ui-v2/src/components/deployments/data-table/cells.tsx
@@ -2,6 +2,7 @@ import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 
 import type { DeploymentWithFlow } from "@/api/deployments";
 import { buildFilterFlowRunsQuery } from "@/api/flow-runs";
+import { useQuickRun } from "@/components/deployments/use-quick-run";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,
@@ -14,29 +15,21 @@ import { Icon } from "@/components/ui/icons";
 import useDebounce from "@/hooks/use-debounce";
 import { useToast } from "@/hooks/use-toast";
 import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
 import type { CellContext } from "@tanstack/react-table";
 import { subSeconds } from "date-fns";
 import { secondsInWeek } from "date-fns/constants";
 import { useCallback, useState } from "react";
 
 type ActionsCellProps = CellContext<DeploymentWithFlow, unknown> & {
-	onQuickRun: (deployment: DeploymentWithFlow) => void;
-	onCustomRun: (deployment: DeploymentWithFlow) => void;
-	onEdit: (deployment: DeploymentWithFlow) => void;
 	onDelete: (deployment: DeploymentWithFlow) => void;
-	onDuplicate: (deployment: DeploymentWithFlow) => void;
 };
 
-export const ActionsCell = ({
-	row,
-	onQuickRun,
-	onCustomRun,
-	onEdit,
-	onDelete,
-	onDuplicate,
-}: ActionsCellProps) => {
+export const ActionsCell = ({ row, onDelete }: ActionsCellProps) => {
 	const id = row.original.id;
 	const { toast } = useToast();
+	const { onQuickRun, isPending } = useQuickRun();
+
 	if (!id) return null;
 
 	return (
@@ -50,30 +43,35 @@ export const ActionsCell = ({
 				</DropdownMenuTrigger>
 				<DropdownMenuContent align="end">
 					<DropdownMenuLabel>Actions</DropdownMenuLabel>
-					<DropdownMenuItem onClick={() => onQuickRun(row.original)}>
+					<DropdownMenuItem disabled={isPending} onClick={() => onQuickRun(id)}>
 						Quick Run
 					</DropdownMenuItem>
-					<DropdownMenuItem onClick={() => onCustomRun(row.original)}>
-						Custom Run
+					<DropdownMenuItem>
+						<Link to="/deployments/deployment/$id/run" params={{ id }}>
+							Custom Run
+						</Link>
 					</DropdownMenuItem>
+
 					<DropdownMenuItem
 						onClick={() => {
 							void navigator.clipboard.writeText(id);
-							toast({
-								title: "ID copied",
-							});
+							toast({ title: "ID copied" });
 						}}
 					>
 						Copy ID
 					</DropdownMenuItem>
-					<DropdownMenuItem onClick={() => onEdit(row.original)}>
-						Edit
+					<DropdownMenuItem>
+						<Link to="/deployments/deployment/$id/edit" params={{ id }}>
+							Edit
+						</Link>
 					</DropdownMenuItem>
 					<DropdownMenuItem onClick={() => onDelete(row.original)}>
 						Delete
 					</DropdownMenuItem>
-					<DropdownMenuItem onClick={() => onDuplicate(row.original)}>
-						Duplicate
+					<DropdownMenuItem>
+						<Link to="/deployments/deployment/$id/duplicate" params={{ id }}>
+							Duplicate
+						</Link>
 					</DropdownMenuItem>
 				</DropdownMenuContent>
 			</DropdownMenu>

--- a/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
+++ b/ui-v2/src/components/deployments/data-table/data-table.stories.tsx
@@ -56,10 +56,6 @@ export const Default: StoryObj<StoryArgs> = {
 	args: {
 		numberOfDeployments: 10,
 		onPaginationChange: fn(),
-		onQuickRun: fn(),
-		onCustomRun: fn(),
-		onEdit: fn(),
-		onDuplicate: fn(),
 	},
 	render: (
 		args: Omit<

--- a/ui-v2/src/components/deployments/data-table/index.tsx
+++ b/ui-v2/src/components/deployments/data-table/index.tsx
@@ -42,26 +42,14 @@ export type DeploymentsDataTableProps = {
 	onPaginationChange: (pagination: PaginationState) => void;
 	onSortChange: (sort: components["schemas"]["DeploymentSort"]) => void;
 	onColumnFiltersChange: (columnFilters: ColumnFiltersState) => void;
-	onQuickRun: (deployment: DeploymentWithFlow) => void;
-	onCustomRun: (deployment: DeploymentWithFlow) => void;
-	onEdit: (deployment: DeploymentWithFlow) => void;
-	onDuplicate: (deployment: DeploymentWithFlow) => void;
 };
 
 const columnHelper = createColumnHelper<DeploymentWithFlow>();
 
 const createColumns = ({
-	onQuickRun,
-	onCustomRun,
-	onEdit,
 	onDelete,
-	onDuplicate,
 }: {
-	onQuickRun: (deployment: DeploymentWithFlow) => void;
-	onCustomRun: (deployment: DeploymentWithFlow) => void;
-	onEdit: (deployment: DeploymentWithFlow) => void;
 	onDelete: (deployment: DeploymentWithFlow) => void;
-	onDuplicate: (deployment: DeploymentWithFlow) => void;
 }) => [
 	columnHelper.display({
 		id: "name",
@@ -132,16 +120,7 @@ const createColumns = ({
 	}),
 	columnHelper.display({
 		id: "actions",
-		cell: (props) => (
-			<ActionsCell
-				{...props}
-				onQuickRun={onQuickRun}
-				onCustomRun={onCustomRun}
-				onEdit={onEdit}
-				onDelete={onDelete}
-				onDuplicate={onDuplicate}
-			/>
-		),
+		cell: (props) => <ActionsCell {...props} onDelete={onDelete} />,
 	}),
 ];
 
@@ -155,10 +134,6 @@ export const DeploymentsDataTable = ({
 	onPaginationChange,
 	onSortChange,
 	onColumnFiltersChange,
-	onQuickRun,
-	onCustomRun,
-	onEdit,
-	onDuplicate,
 }: DeploymentsDataTableProps) => {
 	const [deleteConfirmationDialogState, confirmDelete] =
 		useDeleteDeploymentConfirmationDialog();
@@ -209,16 +184,12 @@ export const DeploymentsDataTable = ({
 	const table = useReactTable({
 		data: deployments,
 		columns: createColumns({
-			onQuickRun,
-			onCustomRun,
-			onEdit,
 			onDelete: (deployment) => {
 				const name = deployment.flow?.name
 					? `${deployment.flow?.name}/${deployment.name}`
 					: deployment.name;
 				confirmDelete({ ...deployment, name });
 			},
-			onDuplicate,
 		}),
 		getCoreRowModel: getCoreRowModel(),
 		pageCount,

--- a/ui-v2/src/components/deployments/run-flow-button/run-flow-button.tsx
+++ b/ui-v2/src/components/deployments/run-flow-button/run-flow-button.tsx
@@ -1,5 +1,5 @@
 import { Deployment } from "@/api/deployments";
-import { useDeploymentCreateFlowRun } from "@/api/flow-runs";
+import { useQuickRun } from "@/components/deployments/use-quick-run";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,
@@ -9,59 +9,14 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Icon } from "@/components/ui/icons";
-import { useToast } from "@/hooks/use-toast";
 import { Link } from "@tanstack/react-router";
-
-const DEPLOYMENT_QUICK_RUN_PAYLOAD = {
-	state: {
-		type: "SCHEDULED",
-		message: "Run from the Prefect UI with defaults",
-		state_details: {
-			deferred: false,
-			untrackable_result: false,
-			pause_reschedule: false,
-		},
-	},
-} as const;
 
 export type RunFlowButtonProps = {
 	deployment: Deployment;
 };
 
 export const RunFlowButton = ({ deployment }: RunFlowButtonProps) => {
-	const { toast } = useToast();
-	const { createDeploymentFlowRun, isPending } = useDeploymentCreateFlowRun();
-
-	const handleClickQuickRun = (id: string) => {
-		createDeploymentFlowRun(
-			{
-				id,
-				...DEPLOYMENT_QUICK_RUN_PAYLOAD,
-			},
-			{
-				onSuccess: (res) => {
-					toast({
-						action: (
-							<Link to="/runs/flow-run/$id" params={{ id: res.id }}>
-								<Button size="sm">View run</Button>
-							</Link>
-						),
-						description: (
-							<p>
-								<span className="font-bold">{res.name}</span> scheduled to start{" "}
-								<span className="font-bold">now</span>
-							</p>
-						),
-					});
-				},
-				onError: (error) => {
-					const message =
-						error.message || "Unknown error while creating flow run.";
-					console.error(message);
-				},
-			},
-		);
-	};
+	const { onQuickRun, isPending } = useQuickRun();
 
 	return (
 		<DropdownMenu>
@@ -72,7 +27,7 @@ export const RunFlowButton = ({ deployment }: RunFlowButtonProps) => {
 			</DropdownMenuTrigger>
 			<DropdownMenuContent>
 				<DropdownMenuGroup>
-					<DropdownMenuItem onClick={() => handleClickQuickRun(deployment.id)}>
+					<DropdownMenuItem onClick={() => onQuickRun(deployment.id)}>
 						Quick run
 					</DropdownMenuItem>
 					<Link

--- a/ui-v2/src/components/deployments/use-quick-run.tsx
+++ b/ui-v2/src/components/deployments/use-quick-run.tsx
@@ -1,0 +1,56 @@
+import { useDeploymentCreateFlowRun } from "@/api/flow-runs";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/hooks/use-toast";
+import { Link } from "@tanstack/react-router";
+
+const DEPLOYMENT_QUICK_RUN_PAYLOAD = {
+	state: {
+		type: "SCHEDULED",
+		message: "Run from the Prefect UI with defaults",
+		state_details: {
+			deferred: false,
+			untrackable_result: false,
+			pause_reschedule: false,
+		},
+	},
+} as const;
+
+/**
+ *
+ * @returns a function that handles the mutation and UX when a deployment creates a quick run
+ */
+export const useQuickRun = () => {
+	const { createDeploymentFlowRun, isPending } = useDeploymentCreateFlowRun();
+	const onQuickRun = (id: string) => {
+		createDeploymentFlowRun(
+			{
+				id,
+				...DEPLOYMENT_QUICK_RUN_PAYLOAD,
+			},
+			{
+				onSuccess: (res) => {
+					toast({
+						action: (
+							<Link to="/runs/flow-run/$id" params={{ id: res.id }}>
+								<Button size="sm">View run</Button>
+							</Link>
+						),
+						description: (
+							<p>
+								<span className="font-bold">{res.name}</span> scheduled to start{" "}
+								<span className="font-bold">now</span>
+							</p>
+						),
+					});
+				},
+				onError: (error) => {
+					const message =
+						error.message || "Unknown error while creating flow run.";
+					console.error(message);
+				},
+			},
+		);
+	};
+
+	return { onQuickRun, isPending };
+};

--- a/ui-v2/src/routes/deployments/index.tsx
+++ b/ui-v2/src/routes/deployments/index.tsx
@@ -260,11 +260,6 @@ function RouteComponent() {
 					onPaginationChange={onPaginationChange}
 					onSortChange={onSortChange}
 					onColumnFiltersChange={onColumnFiltersChange}
-					// TODO: Replace console.log with actual handlers for deployment actions
-					onQuickRun={(deployment) => console.log(deployment)}
-					onCustomRun={(deployment) => console.log(deployment)}
-					onEdit={(deployment) => console.log(deployment)}
-					onDuplicate={(deployment) => console.log(deployment)}
 				/>
 			)}
 		</div>


### PR DESCRIPTION
1. Consolidates the ability to create a quick run through a re-usable hook
2. Updates `edit`, `duplicate`, and `custom run` options to be links instead.


https://github.com/user-attachments/assets/8d056c5f-42c6-4876-80e3-c5f247f45f2f

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.


Relates to https://github.com/PrefectHQ/prefect/issues/15512