### PR TITLE
Fix dependency installation for flow submission

### DIFF
--- a/src/prefect/_experimental/bundles.py
+++ b/src/prefect/_experimental/bundles.py
@@ -145,20 +145,12 @@ def execute_bundle_in_subprocess(
 
     ctx = multiprocessing.get_context("spawn")
 
-    print("Checking for dependencies")
-    print("Dependencies: ", bundle.get("dependencies"))
     # Install dependencies if necessary
     if dependencies := bundle.get("dependencies"):
-        print("Installing dependencies")
-        print(
-            "Command: ", [uv.find_uv_bin(), "pip", "install", *dependencies.split("\n")]
-        )
         subprocess.check_call(
             [uv.find_uv_bin(), "pip", "install", *dependencies.split("\n")],
             # Copy the current environment to ensure we install into the correct venv
             env=os.environ,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
         )
 
     process = ctx.Process(

--- a/src/prefect/_experimental/bundles.py
+++ b/src/prefect/_experimental/bundles.py
@@ -145,10 +145,20 @@ def execute_bundle_in_subprocess(
 
     ctx = multiprocessing.get_context("spawn")
 
+    print("Checking for dependencies")
+    print("Dependencies: ", bundle.get("dependencies"))
     # Install dependencies if necessary
     if dependencies := bundle.get("dependencies"):
+        print("Installing dependencies")
+        print(
+            "Command: ", [uv.find_uv_bin(), "pip", "install", *dependencies.split("\n")]
+        )
         subprocess.check_call(
             [uv.find_uv_bin(), "pip", "install", *dependencies.split("\n")],
+            # Copy the current environment to ensure we install into the correct venv
+            env=os.environ,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
 
     process = ctx.Process(

--- a/tests/experimental/test_bundles.py
+++ b/tests/experimental/test_bundles.py
@@ -1,3 +1,4 @@
+import os
 import signal
 import subprocess
 import sys
@@ -76,7 +77,8 @@ class TestExecuteBundleInSubprocess:
                 "pip",
                 "install",
                 "the-whole-enchilada==0.5.3",
-            ]
+            ],
+            env=os.environ,
         )
 
         flow_run = await prefect_client.read_flow_run(flow_run.id)


### PR DESCRIPTION
I was running into issues with the `@kubernetes` decorator because `prefect-kubernetes` wasn't available during unpickling. Turns out `subprocess.check_call` won't propagate the current environment variables for you, so the dependencies scooped up using `uv pip freeze` were being installed in the wrong virtual environment. This PR fixes that and I've verified the fix by running it against this branch.
