### PR TITLE
Updates `ProcessWorker` to delegate flow run execution to a `Runner`

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -2353,7 +2353,9 @@ async def load_flow_from_flow_run(
         from prefect.deployments.steps.core import StepExecutionError, run_steps
 
         try:
-            output = await run_steps(deployment.pull_steps)
+            output = await run_steps(
+                deployment.pull_steps, print_function=run_logger.info
+            )
         except StepExecutionError as e:
             e = e.__cause__ or e
             run_logger.error(str(e))

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -559,6 +559,7 @@ class Runner:
         cwd: Path | None = None,
         env: dict[str, str | None] | None = None,
         task_status: anyio.abc.TaskStatus[int] | None = None,
+        stream_output: bool = True,
     ) -> anyio.abc.Process | None:
         """
         Executes a single flow run with the given ID.
@@ -589,6 +590,7 @@ class Runner:
                             command=command,
                             cwd=cwd,
                             env=env,
+                            stream_output=stream_output,
                         ),
                     )
                     if task_status:
@@ -762,6 +764,7 @@ class Runner:
         command: str | None = None,
         cwd: Path | None = None,
         env: dict[str, str | None] | None = None,
+        stream_output: bool = True,
     ) -> anyio.abc.Process:
         """
         Runs the given flow run in a subprocess.
@@ -831,7 +834,7 @@ class Runner:
 
         process = await run_process(
             command=runner_command,
-            stream_output=True,
+            stream_output=stream_output,
             task_status=task_status,
             task_status_handler=lambda process: process,
             env=env,
@@ -1374,6 +1377,7 @@ class Runner:
         command: str | None = None,
         cwd: Path | None = None,
         env: dict[str, str | None] | None = None,
+        stream_output: bool = True,
     ) -> Union[Optional[int], Exception]:
         run_logger = self._get_flow_run_logger(flow_run)
 
@@ -1385,6 +1389,7 @@ class Runner:
                 command=command,
                 cwd=cwd,
                 env=env,
+                stream_output=stream_output,
             )
             status_code = process.returncode
         except Exception as exc:
@@ -1638,8 +1643,6 @@ class Runner:
         if self.pause_on_shutdown:
             await self._pause_schedules()
         self.started = False
-
-        self._flow_run_process_map_lock = None
 
         for scope in self._scheduled_task_scopes:
             scope.cancel()

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -277,8 +277,8 @@ class DeploymentUpdate(ActionBaseModel):
     def remove_old_fields(cls, values: dict[str, Any]) -> dict[str, Any]:
         return remove_old_deployment_fields(values)
 
-    version: Optional[str] = Field(None)
-    description: Optional[str] = Field(None)
+    version: Optional[str] = Field(default=None)
+    description: Optional[str] = Field(default=None)
     paused: bool = Field(
         default=False, description="Whether or not the deployment is paused."
     )
@@ -305,28 +305,27 @@ class DeploymentUpdate(ActionBaseModel):
         description="A list of deployment tags.",
         examples=[["tag-1", "tag-2"]],
     )
-    work_queue_name: Optional[str] = Field(None)
+    work_queue_name: Optional[str] = Field(default=None)
     work_pool_name: Optional[str] = Field(
         default=None,
         description="The name of the deployment's work pool.",
         examples=["my-work-pool"],
     )
-    path: Optional[str] = Field(None)
+    path: Optional[str] = Field(default=None)
     job_variables: Optional[Dict[str, Any]] = Field(
         default=None,
         description="Overrides for the flow's infrastructure configuration.",
     )
-    pull_steps: Optional[List[dict[str, Any]]] = Field(None)
-    entrypoint: Optional[str] = Field(None)
-    storage_document_id: Optional[UUID] = Field(None)
-    infrastructure_document_id: Optional[UUID] = Field(None)
+    pull_steps: Optional[List[dict[str, Any]]] = Field(default=None)
+    entrypoint: Optional[str] = Field(default=None)
+    storage_document_id: Optional[UUID] = Field(default=None)
+    infrastructure_document_id: Optional[UUID] = Field(default=None)
     enforce_parameter_schema: Optional[bool] = Field(
         default=None,
         description=(
             "Whether or not the deployment should enforce the parameter schema."
         ),
     )
-    pull_steps: Optional[List[dict[str, Any]]] = Field(None)
     model_config: ClassVar[ConfigDict] = ConfigDict(populate_by_name=True)
 
     def check_valid_configuration(self, base_job_template: dict[str, Any]) -> None:

--- a/src/prefect/telemetry/instrumentation.py
+++ b/src/prefect/telemetry/instrumentation.py
@@ -95,7 +95,7 @@ def _setup_meter_provider(
     resource: Resource, headers: dict[str, str], telemetry_url: str
 ) -> MeterProvider:
     metric_reader = PeriodicExportingMetricReader(
-        OTLPMetricExporter(
+        OTLPMetricExporter(  # pyright: ignore[reportArgumentType] `preferred_temporality` and `preferred_aggregation` default to `None`, but otel's typing doesn't include it
             endpoint=_url_join(telemetry_url, "v1/metrics"),
             headers=headers,
         )
@@ -109,7 +109,7 @@ def _setup_meter_provider(
 def _setup_logger_provider(
     resource: Resource, headers: dict[str, str], telemetry_url: str
 ) -> LoggerProvider:
-    logger_provider = LoggerProvider(resource=resource)
+    logger_provider = LoggerProvider(resource=resource)  # pyright: ignore[reportArgumentType] `multi_log_record_processor` defaults to `None` but otel's typing doesn't include it
     queueing_log_exporter = QueueingLogExporter.instance(
         _url_join(telemetry_url, "v1/logs"), tuple(headers.items())
     )

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1085,7 +1085,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         self,
         flow_run: "FlowRun",
         deployment: Optional["DeploymentResponse"] = None,
-    ) -> BaseJobConfiguration:
+    ) -> C:
         deployment = (
             deployment
             if deployment

--- a/src/prefect/workers/process.py
+++ b/src/prefect/workers/process.py
@@ -223,6 +223,7 @@ class ProcessWorker(
             command=configuration.command,
             cwd=configuration.working_dir,
             env=configuration.env,
+            stream_output=configuration.stream_output,
             task_status=task_status,
         )
 

--- a/src/prefect/workers/process.py
+++ b/src/prefect/workers/process.py
@@ -17,12 +17,10 @@ checkout out the [Prefect docs](/concepts/work-pools/).
 from __future__ import annotations
 
 import os
-import socket
-import sys
 import threading
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import anyio
 import anyio.abc
@@ -44,20 +42,6 @@ from prefect.workers.base import (
 if TYPE_CHECKING:
     from prefect.client.schemas.objects import Flow
     from prefect.client.schemas.responses import DeploymentResponse
-
-if sys.platform == "win32":
-    # exit code indicating that the process was terminated by Ctrl+C or Ctrl+Break
-    STATUS_CONTROL_C_EXIT = 0xC000013A
-
-
-def _infrastructure_pid_from_process(process: anyio.abc.Process) -> str:
-    hostname = socket.gethostname()
-    return f"{hostname}:{process.pid}"
-
-
-def _parse_infrastructure_pid(infrastructure_pid: str) -> Tuple[str, int]:
-    hostname, pid = infrastructure_pid.split(":")
-    return hostname, int(pid)
 
 
 class ProcessJobConfiguration(BaseJobConfiguration):
@@ -86,7 +70,8 @@ class ProcessJobConfiguration(BaseJobConfiguration):
             else self.command
         )
 
-    def _base_flow_run_command(self) -> str:
+    @staticmethod
+    def _base_flow_run_command() -> str:
         """
         Override the base flow run command because enhanced cancellation doesn't
         work with the process worker.

--- a/src/prefect/workers/process.py
+++ b/src/prefect/workers/process.py
@@ -16,17 +16,13 @@ checkout out the [Prefect docs](/concepts/work-pools/).
 
 from __future__ import annotations
 
-import contextlib
 import os
-import signal
 import socket
-import subprocess
 import sys
-import tempfile
 import threading
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple
 
 import anyio
 import anyio.abc
@@ -34,26 +30,9 @@ from pydantic import Field, field_validator
 
 from prefect._internal.schemas.validators import validate_working_dir
 from prefect.client.schemas import FlowRun
-from prefect.client.schemas.filters import (
-    FlowRunFilter,
-    FlowRunFilterId,
-    FlowRunFilterState,
-    FlowRunFilterStateName,
-    FlowRunFilterStateType,
-    WorkPoolFilter,
-    WorkPoolFilterName,
-    WorkQueueFilter,
-    WorkQueueFilterName,
-)
-from prefect.client.schemas.objects import StateType
-from prefect.events.utilities import emit_event
-from prefect.exceptions import (
-    InfrastructureNotAvailable,
-    InfrastructureNotFound,
-    ObjectNotFound,
-)
+from prefect.runner.runner import Runner
 from prefect.settings import PREFECT_WORKER_QUERY_SECONDS
-from prefect.utilities.processutils import get_sys_executable, run_process
+from prefect.utilities.processutils import get_sys_executable
 from prefect.utilities.services import critical_service_loop
 from prefect.workers.base import (
     BaseJobConfiguration,
@@ -205,16 +184,6 @@ class ProcessWorker(
                             backoff=4,
                         )
                     )
-                    loops_task_group.start_soon(
-                        partial(
-                            critical_service_loop,
-                            workload=self.check_for_cancelled_flow_runs,
-                            interval=PREFECT_WORKER_QUERY_SECONDS.value() * 2,
-                            run_once=run_once,
-                            jitter_range=0.3,
-                            backoff=4,
-                        )
-                    )
 
                     self._started_event = await self._emit_worker_started_event()
 
@@ -249,279 +218,27 @@ class ProcessWorker(
         configuration: ProcessJobConfiguration,
         task_status: Optional[anyio.abc.TaskStatus[int]] = None,
     ) -> ProcessWorkerResult:
-        command = configuration.command
-        if not command:
-            command = f"{get_sys_executable()} -m prefect.engine"
-
-        flow_run_logger = self.get_flow_run_logger(flow_run)
-
-        # We must add creationflags to a dict so it is only passed as a function
-        # parameter on Windows, because the presence of creationflags causes
-        # errors on Unix even if set to None
-        kwargs: Dict[str, object] = {}
-        if sys.platform == "win32":
-            kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
-
-        flow_run_logger.info("Opening process...")
-
-        working_dir_ctx = (
-            tempfile.TemporaryDirectory(suffix="prefect")
-            if not configuration.working_dir
-            else contextlib.nullcontext(configuration.working_dir)
+        process = await self._runner.execute_flow_run(
+            flow_run_id=flow_run.id,
+            command=configuration.command,
+            cwd=configuration.working_dir,
+            env=configuration.env,
+            task_status=task_status,
         )
-        with working_dir_ctx as working_dir:
-            flow_run_logger.debug(
-                f"Process running command: {command} in {working_dir}"
-            )
-            process = await run_process(
-                command.split(" "),
-                stream_output=configuration.stream_output,
-                task_status=task_status,
-                task_status_handler=_infrastructure_pid_from_process,
-                cwd=working_dir,
-                env=configuration.env,
-                **kwargs,
-            )
 
-        # Use the pid for display if no name was given
-        display_name = f" {process.pid}"
-
-        if process.returncode:
-            help_message = None
-            if process.returncode == -9:
-                help_message = (
-                    "This indicates that the process exited due to a SIGKILL signal. "
-                    "Typically, this is either caused by manual cancellation or "
-                    "high memory usage causing the operating system to "
-                    "terminate the process."
-                )
-            if process.returncode == -15:
-                help_message = (
-                    "This indicates that the process exited due to a SIGTERM signal. "
-                    "Typically, this is caused by manual cancellation."
-                )
-            elif process.returncode == 247:
-                help_message = (
-                    "This indicates that the process was terminated due to high "
-                    "memory usage."
-                )
-            elif (
-                sys.platform == "win32" and process.returncode == STATUS_CONTROL_C_EXIT
-            ):
-                help_message = (
-                    "Process was terminated due to a Ctrl+C or Ctrl+Break signal. "
-                    "Typically, this is caused by manual cancellation."
-                )
-
-            flow_run_logger.error(
-                f"Process{display_name} exited with status code: {process.returncode}"
-                + (f"; {help_message}" if help_message else "")
-            )
-        else:
-            flow_run_logger.info(f"Process{display_name} exited cleanly.")
+        if process is None or process.returncode is None:
+            raise RuntimeError("Failed to start flow run process.")
 
         return ProcessWorkerResult(
             status_code=process.returncode, identifier=str(process.pid)
         )
 
-    async def kill_process(
-        self,
-        infrastructure_pid: str,
-        grace_seconds: int = 30,
-    ) -> None:
-        hostname, pid = _parse_infrastructure_pid(infrastructure_pid)
-
-        if hostname != socket.gethostname():
-            raise InfrastructureNotAvailable(
-                f"Unable to kill process {pid!r}: The process is running on a different"
-                f" host {hostname!r}."
-            )
-
-        # In a non-windows environment first send a SIGTERM, then, after
-        # `grace_seconds` seconds have passed subsequent send SIGKILL. In
-        # Windows we use CTRL_BREAK_EVENT as SIGTERM is useless:
-        # https://bugs.python.org/issue26350
-        if sys.platform == "win32":
-            try:
-                os.kill(pid, signal.CTRL_BREAK_EVENT)
-            except (ProcessLookupError, WindowsError):
-                raise InfrastructureNotFound(
-                    f"Unable to kill process {pid!r}: The process was not found."
-                )
-        else:
-            try:
-                os.kill(pid, signal.SIGTERM)
-            except ProcessLookupError:
-                raise InfrastructureNotFound(
-                    f"Unable to kill process {pid!r}: The process was not found."
-                )
-
-            # Throttle how often we check if the process is still alive to keep
-            # from making too many system calls in a short period of time.
-            check_interval = max(grace_seconds / 10, 1)
-
-            with anyio.move_on_after(grace_seconds):
-                while True:
-                    await anyio.sleep(check_interval)
-
-                    # Detect if the process is still alive. If not do an early
-                    # return as the process respected the SIGTERM from above.
-                    try:
-                        os.kill(pid, 0)
-                    except ProcessLookupError:
-                        return
-
-            try:
-                os.kill(pid, signal.SIGKILL)
-            except OSError:
-                # We shouldn't ever end up here, but it's possible that the
-                # process ended right after the check above.
-                return
-
-    async def check_for_cancelled_flow_runs(self) -> list["FlowRun"]:
-        if not self.is_setup:
-            raise RuntimeError(
-                "Worker is not set up. Please make sure you are running this worker "
-                "as an async context manager."
-            )
-
-        self._logger.debug("Checking for cancelled flow runs...")
-
-        work_queue_filter = (
-            WorkQueueFilter(name=WorkQueueFilterName(any_=list(self._work_queues)))
-            if self._work_queues
-            else None
+    async def __aenter__(self) -> ProcessWorker:
+        await super().__aenter__()
+        self._runner = await self._exit_stack.enter_async_context(
+            Runner(pause_on_shutdown=False)
         )
+        return self
 
-        named_cancelling_flow_runs = await self._client.read_flow_runs(
-            flow_run_filter=FlowRunFilter(
-                state=FlowRunFilterState(
-                    type=FlowRunFilterStateType(any_=[StateType.CANCELLED]),
-                    name=FlowRunFilterStateName(any_=["Cancelling"]),
-                ),
-                # Avoid duplicate cancellation calls
-                id=FlowRunFilterId(not_any_=list(self._cancelling_flow_run_ids)),
-            ),
-            work_pool_filter=WorkPoolFilter(
-                name=WorkPoolFilterName(any_=[self._work_pool_name])
-            ),
-            work_queue_filter=work_queue_filter,
-        )
-
-        typed_cancelling_flow_runs = await self._client.read_flow_runs(
-            flow_run_filter=FlowRunFilter(
-                state=FlowRunFilterState(
-                    type=FlowRunFilterStateType(any_=[StateType.CANCELLING]),
-                ),
-                # Avoid duplicate cancellation calls
-                id=FlowRunFilterId(not_any_=list(self._cancelling_flow_run_ids)),
-            ),
-            work_pool_filter=WorkPoolFilter(
-                name=WorkPoolFilterName(any_=[self._work_pool_name])
-            ),
-            work_queue_filter=work_queue_filter,
-        )
-
-        cancelling_flow_runs = named_cancelling_flow_runs + typed_cancelling_flow_runs
-
-        if cancelling_flow_runs:
-            self._logger.info(
-                f"Found {len(cancelling_flow_runs)} flow runs awaiting cancellation."
-            )
-
-        for flow_run in cancelling_flow_runs:
-            self._cancelling_flow_run_ids.add(flow_run.id)
-            self._runs_task_group.start_soon(self.cancel_run, flow_run)
-
-        return cancelling_flow_runs
-
-    async def cancel_run(self, flow_run: "FlowRun") -> None:
-        run_logger = self.get_flow_run_logger(flow_run)
-
-        try:
-            configuration = await self._get_configuration(flow_run)
-        except ObjectNotFound:
-            self._logger.warning(
-                f"Flow run {flow_run.id!r} cannot be cancelled by this worker:"
-                f" associated deployment {flow_run.deployment_id!r} does not exist."
-            )
-            await self._mark_flow_run_as_cancelled(
-                flow_run,
-                state_updates={
-                    "message": (
-                        "This flow run is missing infrastructure configuration information"
-                        " and cancellation cannot be guaranteed."
-                    )
-                },
-            )
-            return
-        else:
-            if configuration.is_using_a_runner:
-                self._logger.info(
-                    f"Skipping cancellation because flow run {str(flow_run.id)!r} is"
-                    " using enhanced cancellation. A dedicated runner will handle"
-                    " cancellation."
-                )
-                return
-
-        if not flow_run.infrastructure_pid:
-            run_logger.error(
-                f"Flow run '{flow_run.id}' does not have an infrastructure pid"
-                " attached. Cancellation cannot be guaranteed."
-            )
-            await self._mark_flow_run_as_cancelled(
-                flow_run,
-                state_updates={
-                    "message": (
-                        "This flow run is missing infrastructure tracking information"
-                        " and cancellation cannot be guaranteed."
-                    )
-                },
-            )
-            return
-
-        try:
-            await self.kill_process(
-                infrastructure_pid=flow_run.infrastructure_pid,
-            )
-        except NotImplementedError:
-            self._logger.error(
-                f"Worker type {self.type!r} does not support killing created "
-                "infrastructure. Cancellation cannot be guaranteed."
-            )
-        except InfrastructureNotFound as exc:
-            self._logger.warning(f"{exc} Marking flow run as cancelled.")
-            await self._mark_flow_run_as_cancelled(flow_run)
-        except InfrastructureNotAvailable as exc:
-            self._logger.warning(f"{exc} Flow run cannot be cancelled by this worker.")
-        except Exception:
-            run_logger.exception(
-                "Encountered exception while killing infrastructure for flow run "
-                f"'{flow_run.id}'. Flow run may not be cancelled."
-            )
-            # We will try again on generic exceptions
-            self._cancelling_flow_run_ids.remove(flow_run.id)
-            return
-        else:
-            self._emit_flow_run_cancelled_event(
-                flow_run=flow_run, configuration=configuration
-            )
-            await self._mark_flow_run_as_cancelled(flow_run)
-            run_logger.info(f"Cancelled flow run '{flow_run.id}'!")
-
-    def _emit_flow_run_cancelled_event(
-        self, flow_run: "FlowRun", configuration: BaseJobConfiguration
-    ):
-        related = self._event_related_resources(configuration=configuration)
-
-        for resource in related:
-            if resource.role == "flow-run":
-                resource["prefect.infrastructure.identifier"] = str(
-                    flow_run.infrastructure_pid
-                )
-
-        emit_event(
-            event="prefect.worker.cancelled-flow-run",
-            resource=self._event_resource(),
-            related=related,
-        )
+    async def __aexit__(self, *exc_info: Any) -> None:
+        await super().__aexit__(*exc_info)

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -7,12 +7,13 @@ import subprocess
 import sys
 import tempfile
 import time
+import uuid
 import warnings
 from itertools import combinations
 from pathlib import Path
 from textwrap import dedent
 from time import sleep
-from typing import Any, Generator, List, Union
+from typing import TYPE_CHECKING, Any, Coroutine, Generator, List, Union
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -113,6 +114,31 @@ def tired_flow():
     for _ in range(100):
         print("zzzzz...")
         sleep(5)
+
+
+@pytest.fixture
+def patch_run_process(monkeypatch: pytest.MonkeyPatch):
+    def patch_run_process(returncode: int = 0, pid: int = 1000):
+        mock_run_process = AsyncMock()
+        mock_process = MagicMock()
+        mock_process.returncode = returncode
+        mock_process.pid = pid
+        mock_run_process.return_value = mock_process
+
+        async def side_effect(
+            *args: Any,
+            **kwargs: Any,
+        ):
+            kwargs["task_status"].started(mock_process)
+            return MagicMock(returncode=returncode, pid=pid)
+
+        mock_run_process.side_effect = side_effect
+
+        monkeypatch.setattr(prefect.runner.runner, "run_process", mock_run_process)
+
+        return mock_run_process
+
+    return patch_run_process
 
 
 class MockStorage:
@@ -832,7 +858,7 @@ class TestRunner:
         assert flow_run.state.is_cancelled()
         assert "This flow was cancelled!" not in caplog.text
         assert (
-            "Runner cannot retrieve flow to execute cancellation hooks for flow run"
+            "Runner failed to retrieve flow to execute on_cancellation hooks for flow run"
             in caplog.text
         )
 
@@ -1136,6 +1162,117 @@ class TestRunner:
             runner.stopping = True
             runner._cancelling_flow_run_ids.add(flow_run.id)
             await runner._cancel_run(flow_run)
+
+    @pytest.mark.parametrize(
+        "exit_code,help_message",
+        [
+            (-9, "This indicates that the process exited due to a SIGKILL signal"),
+            (
+                247,
+                "This indicates that the process was terminated due to high memory usage.",
+            ),
+        ],
+    )
+    async def test_runner_logs_exit_code_help_message(
+        self,
+        exit_code: int,
+        help_message: str,
+        caplog: pytest.LogCaptureFixture,
+        patch_run_process: MagicMock,
+        prefect_client: PrefectClient,
+    ):
+        flow_id = await prefect_client.create_flow(
+            flow=dummy_flow_1,
+        )
+        deployment_id = await prefect_client.create_deployment(
+            flow_id=flow_id,
+            name=f"test-runner-deployment-{uuid.uuid4()}",
+            path=str(
+                prefect.__development_base_path__
+                / "tests"
+                / "test-projects"
+                / "import-project"
+            ),
+            entrypoint="my_module/flow.py:test_flow",
+        )
+
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id,
+        )
+
+        patch_run_process(returncode=exit_code)
+        async with Runner() as runner:
+            result = await runner.execute_flow_run(
+                flow_run_id=flow_run.id,
+            )
+
+        assert result
+        assert result.returncode == exit_code
+
+        record = next(r for r in caplog.records if help_message in r.message)
+        if exit_code == -9:
+            assert record.levelname == "INFO"
+        else:
+            assert record.levelname == "ERROR"
+
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="subprocess.CREATE_NEW_PROCESS_GROUP is only defined in Windows",
+    )
+    async def test_windows_process_worker_run_sets_process_group_creation_flag(
+        self,
+        patch_run_process: MagicMock,
+        prefect_client: PrefectClient,
+    ):
+        mock = patch_run_process()
+
+        deployment = await dummy_flow_1.ato_deployment(__file__)
+        deployment_id_coro = deployment.apply()
+        if TYPE_CHECKING:
+            assert isinstance(deployment_id_coro, Coroutine)
+        deployment_id = await deployment_id_coro
+
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        async with Runner() as runner:
+            await runner.execute_flow_run(
+                flow_run_id=flow_run.id,
+            )
+
+        mock.assert_awaited_once()
+        (_, kwargs) = mock.call_args
+        assert kwargs.get("creationflags") == mock.CREATE_NEW_PROCESS_GROUP
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason=(
+            "The asyncio.open_process_*.creationflags argument is only supported on Windows"
+        ),
+    )
+    async def test_unix_process_worker_run_does_not_set_creation_flag(
+        self, patch_run_process: MagicMock, prefect_client: PrefectClient
+    ):
+        mock = patch_run_process()
+        deployment = await dummy_flow_1.ato_deployment(__file__)
+        deployment_id_coro = deployment.apply()
+        if TYPE_CHECKING:
+            assert isinstance(deployment_id_coro, Coroutine)
+        deployment_id = await deployment_id_coro
+
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        async with Runner() as runner:
+            await runner.execute_flow_run(
+                flow_run_id=flow_run.id,
+            )
+
+        mock.assert_awaited_once()
+        (_, kwargs) = mock.call_args
+        assert kwargs.get("creationflags") is None
 
     class TestRunnerBundleExecution:
         @pytest.fixture(autouse=True)

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1180,7 +1180,11 @@ class TestRunner:
         caplog: pytest.LogCaptureFixture,
         patch_run_process: MagicMock,
         prefect_client: PrefectClient,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ):
+        # Change directory to avoid polluting the working directory
+        monkeypatch.chdir(str(tmp_path))
         flow_id = await prefect_client.create_flow(
             flow=dummy_flow_1,
         )


### PR DESCRIPTION
This PR updates the `ProcessWorker` to use a `Runner` for flow run execution. This brings the `ProcessWorker` in line with other worker types and allows the `ProcessWorker` to adopt some of the `Runner` enhancements like flow run heartbeats and improved `on_cancellation` and `on_crashed` hook running.

The `ProcessWorker` using a `Runner` also allows the `Runner` to handle cancellation, so the cancellation code and accompanying tests have been removed as part of this PR.

Closes https://github.com/PrefectHQ/prefect/issues/17259
Closes https://github.com/PrefectHQ/prefect/issues/16515
Closes https://github.com/PrefectHQ/prefect/issues/16436