### PR TITLE
Cancel runs if the deployment was deleted

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -945,15 +945,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             )
 
         try:
-            deployment = await self._client.read_deployment(flow_run.deployment_id)
-            if deployment.storage_document_id:
-                self._logger.error(
-                    f"Flow run {flow_run.id!r} was created from deployment"
-                    f" {deployment.name!r} which is configured with a storage block."
-                    " Please use an agent to execute this flow run."
-                )
-                self._submitting_flow_run_ids.remove(flow_run.id)
-                return
+            await self._client.read_deployment(flow_run.deployment_id)
         except ObjectNotFound:
             self._logger.exception(
                 f"Deployment {flow_run.deployment_id} no longer exists. "

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -933,40 +933,40 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             )
         )
 
-    async def _check_flow_run(self, flow_run: "FlowRun") -> None:
-        """
-        Performs a check on a submitted flow run to warn the user if the flow run
-        was created from a deployment with a storage block.
-        """
-        if flow_run.deployment_id:
-            assert self._client and self._client._started, (
-                "Client must be started to check flow run deployment."
-            )
-            deployment = await self._client.read_deployment(flow_run.deployment_id)
-            if deployment.storage_document_id:
-                raise ValueError(
-                    f"Flow run {flow_run.id!r} was created from deployment"
-                    f" {deployment.name!r} which is configured with a storage block."
-                    " Please use an agent to execute this flow run."
-                )
-
     async def _submit_run(self, flow_run: "FlowRun") -> None:
         """
         Submits a given flow run for execution by the worker.
         """
         run_logger = self.get_flow_run_logger(flow_run)
 
+        if flow_run.deployment_id:
+            assert self._client and self._client._started, (
+                "Client must be started to check flow run deployment."
+            )
+
         try:
-            await self._check_flow_run(flow_run)
-        except (ValueError, ObjectNotFound):
+            deployment = await self._client.read_deployment(flow_run.deployment_id)
+            if deployment.storage_document_id:
+                self._logger.error(
+                    f"Flow run {flow_run.id!r} was created from deployment"
+                    f" {deployment.name!r} which is configured with a storage block."
+                    " Please use an agent to execute this flow run."
+                )
+            self._submitting_flow_run_ids.remove(flow_run.id)
+            return
+        except ObjectNotFound:
             self._logger.exception(
-                (
-                    "Flow run %s did not pass checks and will not be submitted for"
-                    " execution"
-                ),
-                flow_run.id,
+                f"Deployment {flow_run.deployment_id} no longer exists. "
+                f"Flow run {flow_run.id} will not be submitted for"
+                " execution"
             )
             self._submitting_flow_run_ids.remove(flow_run.id)
+            self._mark_flow_run_as_cancelled(
+                flow_run,
+                state_updates=dict(
+                    message=f"Deployment {flow_run.deployment_id} no longer exists, cancelled run."
+                ),
+            )
             return
 
         ready_to_submit = await self._propose_pending_state(flow_run)

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -961,7 +961,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
                 " execution"
             )
             self._submitting_flow_run_ids.remove(flow_run.id)
-            self._mark_flow_run_as_cancelled(
+            await self._mark_flow_run_as_cancelled(
                 flow_run,
                 state_updates=dict(
                     message=f"Deployment {flow_run.deployment_id} no longer exists, cancelled run."

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -952,8 +952,8 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
                     f" {deployment.name!r} which is configured with a storage block."
                     " Please use an agent to execute this flow run."
                 )
-            self._submitting_flow_run_ids.remove(flow_run.id)
-            return
+                self._submitting_flow_run_ids.remove(flow_run.id)
+                return
         except ObjectNotFound:
             self._logger.exception(
                 f"Deployment {flow_run.deployment_id} no longer exists. "

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -525,37 +525,6 @@ async def test_worker_calls_run_with_expected_arguments(
     }
 
 
-async def test_worker_warns_when_running_a_flow_run_with_a_storage_block(
-    prefect_client: PrefectClient, deployment, work_pool, caplog
-):
-    @flow
-    def test_flow():
-        pass
-
-    def create_run_with_deployment(state):
-        return prefect_client.create_flow_run_from_deployment(
-            deployment.id, state=state
-        )
-
-    flow_run = await create_run_with_deployment(
-        Scheduled(scheduled_time=pendulum.now("utc").add(seconds=5))
-    )
-
-    async with WorkerTestImpl(work_pool_name=work_pool.name) as worker:
-        worker._work_pool = work_pool
-        await worker.get_and_submit_flow_runs()
-
-    assert (
-        f"Flow run {flow_run.id!r} was created from deployment"
-        f" {deployment.name!r} which is configured with a storage block. Please use an"
-        + " agent to execute this flow run."
-        in caplog.text
-    )
-
-    flow_run = await prefect_client.read_flow_run(flow_run.id)
-    assert flow_run.state_name == "Scheduled"
-
-
 async def test_worker_creates_only_one_client_context(
     prefect_client, worker_deployment_wq1, work_pool, monkeypatch, caplog
 ):


### PR DESCRIPTION
I also removed a method from the worker - I personally find the pattern of encapsulating every possible mini-subroutine as a function increases complexity of a codebase.

Closes https://github.com/PrefectHQ/prefect/issues/16213