### PR TITLE
[ui-v2] Ignore `node_modules` and `dist` from biome config

### DIFF
--- a/ui-v2/biome.json
+++ b/ui-v2/biome.json
@@ -8,6 +8,8 @@
 	"files": {
 		"ignoreUnknown": false,
 		"ignore": [
+			"node_modules",
+			"dist",
 			"src/api/prefect.ts",
 			"src/routeTree.gen.ts",
 			"package.json",
@@ -21,6 +23,8 @@
 	"organizeImports": {
 		"enabled": true,
 		"ignore": [
+			"node_modules",
+			"dist",
 			"src/api/prefect.ts",
 			"src/routeTree.gen.ts",
 			"package.json",


### PR DESCRIPTION
# Description
Noticed a warning about a large dist file. Which shouldn't be being formatted anyway. 