### PR TITLE
Remove extra example from Vertex AI worker

### DIFF
--- a/.github/workflows/markdown-tests.yaml
+++ b/.github/workflows/markdown-tests.yaml
@@ -55,7 +55,7 @@ jobs:
 
       fail-fast: true
 
-    timeout-minutes: 15
+    timeout-minutes: 10
 
     steps:
       - name: Display current test matrix

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -169,13 +169,7 @@ class VertexAIWorkerVariables(BaseVariables):
             "See REST: https://cloud.google.com/vertex-ai/docs/reference/rest/v1/CustomJobSpec#Scheduling"
         ),
         examples=[
-            {"scheduling": {"strategy": "FLEX_START", "max_wait_duration": "1800s"}},
-            {
-                "scheduling": {
-                    "strategy": Scheduling.Strategy.FLEX_START,
-                    "max_wait_duration": "1800s",
-                }
-            },
+            {"scheduling": {"strategy": "FLEX_START", "max_wait_duration": "1800s"}}
         ],
     )
     service_account_name: Optional[str] = Field(


### PR DESCRIPTION
This appears to be the source of the markdown test failures on `main`. Removing this example because `google-cloud-aiplatform` isn't guaranteed to be installed with a `prefect-gcp` installation.