### PR TITLE
Check if status.container_status[0] is not None

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -1205,9 +1205,9 @@ class KubernetesWorker(
             )
             most_recent_pod = pods.items[0] if pods.items else None
             first_container_status = (
-                getattr(most_recent_pod, "status", None) and
-                getattr(most_recent_pod.status, "container_statuses", None) and
-                most_recent_pod.status.container_statuses[0]
+                getattr(most_recent_pod, "status", None)
+                and getattr(most_recent_pod.status, "container_statuses", None)
+                and most_recent_pod.status.container_statuses[0]
             )
 
         if not first_container_status:

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -1205,9 +1205,9 @@ class KubernetesWorker(
             )
             most_recent_pod = pods.items[0] if pods.items else None
             first_container_status = (
+                getattr(most_recent_pod, "status", None) and
+                getattr(most_recent_pod.status, "container_statuses", None) and
                 most_recent_pod.status.container_statuses[0]
-                if most_recent_pod
-                else None
             )
 
         if not first_container_status:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

We are seeing this issue in production:
```
19:51:49.451 | INFO    | prefect.flow_runs.worker - Job 'testing-pool-94wq5': Pod 'testing-pool-94wq5-n8mbn' has started.
19:51:49.452 | INFO    | prefect.flow_runs.worker - Job 'testing-pool-94wq5': Pod has status 'Pending'.
19:51:49.458 | INFO    | prefect.flow_runs.worker - Job 'testing-pool-94wq5': Pod 'testing-pool-94wq5-n8mbn' has started.
19:51:49.459 | INFO    | prefect.flow_runs.worker - Job 'testing-pool-94wq5': Pod has status 'Failed'.
19:51:50.458 | ERROR   | prefect.flow_runs.worker - Job 'testing-pool-94wq5': Job reached backoff limit.
19:51:50.467 | ERROR   | prefect.flow_runs.worker - An error occurred while monitoring flow run '29ed2ed6-6c92-4c9c-95af-1eba0a35c5c8'. The flow run will not be marked as failed, but an issue may have occurred.
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/prefect/workers/base.py", line 1011, in _submit_run_and_capture_errors
    result = await self.run(
             ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/prefect_kubernetes/worker.py", line 619, in run
    status_code = await self._watch_job(
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/prefect_kubernetes/worker.py", line 1054, in _watch_job
    most_recent_pod.status.container_statuses[0]
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
TypeError: 'NoneType' object is not subscriptable
```

On https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Pod.md and https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1PodStatus.md it is stated that these attributes are optional, so we should handle this.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
