### PR TITLE
Add debugging variables to Vertex AI Worker

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -192,8 +192,8 @@ class VertexAIWorkerVariables(BaseVariables):
         ),
         examples=[True],
     )
-    enable_dashboard_access: Optional[bool] = Field(
-        default=None,
+    enable_dashboard_access: bool = Field(
+        default=False,
         title="Enable Dashboard Access",
         description=(
             "Whether you want Vertex AI to enable access to the customized dashboard in training "

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -196,10 +196,10 @@ class VertexAIWorkerVariables(BaseVariables):
         default=False,
         title="Enable Dashboard Access",
         description=(
-            "Whether you want Vertex AI to enable access to the customized dashboard in training "
-            "chief container. If set to true, you can access the dashboard at the URIs given by "
-            "CustomJob.web_access_uris or Trial.web_access_uris (within HyperparameterTuningJob.trials). "
-            "See: https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.CustomJobSpec"
+            "Whether you want Vertex AI to enable access to the customized dashboard in the training chief container. If set to true, you can access the dashboard "
+            "in the Cloud Console UI. Inspect the Vertex AI in the Cloud Console UI, go to Training and then Custom Jobs. Click on the name of your "
+            "custom training job. On the page for your job, click `Launch web terminal` for `workerpool0-0:` + `port number` for dashboard access. "
+            "See https://cloud.google.com/vertex-ai/docs/training/monitor-debug-interactive-shell#get-uri"
         ),
         examples=[True],
     )

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -188,7 +188,7 @@ class VertexAIWorkerVariables(BaseVariables):
         title="Enable Web Access",
         description=(
             "Whether you want Vertex AI to enable `interactive shell access` "
-            "See: https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.CustomJobSpec"
+            "See https://cloud.google.com/vertex-ai/docs/training/monitor-debug-interactive-shell for how to access your job via interactive console when running."
         ),
         examples=[True],
     )

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -140,15 +140,6 @@ class VertexAIWorkerVariables(BaseVariables):
         title="Maximum Run Time (Hours)",
         description="The maximum job running time, in hours",
     )
-    persistent_resource_id: Optional[str] = Field(
-        default=None,
-        title="Persistent Resource ID",
-        description="The ID of the PersistentResource in the same Project and Location "
-        "which to run if this is specified, the job will be run on existing machines "
-        "held by the PersistentResource instead of on-demand short-live machines. "
-        "See: https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.CustomJobSpec",
-        examples="PERSISTENT_RESOURCE_ID",
-    )
     network: Optional[str] = Field(
         default=None,
         title="Network",

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -196,10 +196,8 @@ class VertexAIWorkerVariables(BaseVariables):
         default=False,
         title="Enable Dashboard Access",
         description=(
-            "Whether you want Vertex AI to enable access to the customized dashboard in the training chief container. If set to true, you can access the dashboard "
-            "in the Cloud Console UI. Inspect the Vertex AI in the Cloud Console UI, go to Training and then Custom Jobs. Click on the name of your "
-            "custom training job. On the page for your job, click `Launch web terminal` for `workerpool0-0:` + `port number` for dashboard access. "
-            "See https://cloud.google.com/vertex-ai/docs/training/monitor-debug-interactive-shell#get-uri"
+            "Whether to enable access to the customized dashboard in the training chief container. " 
+            "See https://cloud.google.com/vertex-ai/docs/training/monitor-debug-interactive-shell#get-uri for access instructions."
         ),
         examples=[True],
     )

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -183,8 +183,8 @@ class VertexAIWorkerVariables(BaseVariables):
             "and required if a service account cannot be detected in GCP credentials."
         ),
     )
-    enable_web_access: Optional[bool] = Field(
-        default=None,
+    enable_web_access: bool = Field(
+        default=False,
         title="Enable Web Access",
         description=(
             "Whether you want Vertex AI to enable `interactive shell access` "

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -55,8 +55,6 @@ try:
     )
     from google.cloud.aiplatform_v1.types.job_state import JobState
     from google.cloud.aiplatform_v1.types.machine_resources import DiskSpec, MachineSpec
-
-    # from google.protobuf.duration_pb2 import Duration # Remove unused import
     from tenacity import AsyncRetrying, stop_after_attempt, wait_fixed, wait_random
 except ModuleNotFoundError:
     pass

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -196,7 +196,7 @@ class VertexAIWorkerVariables(BaseVariables):
         default=False,
         title="Enable Dashboard Access",
         description=(
-            "Whether to enable access to the customized dashboard in the training chief container. " 
+            "Whether to enable access to the customized dashboard in the training chief container. "
             "See https://cloud.google.com/vertex-ai/docs/training/monitor-debug-interactive-shell#get-uri for access instructions."
         ),
         examples=[True],

--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -170,7 +170,7 @@ class VertexAIWorkerVariables(BaseVariables):
             "See REST: https://cloud.google.com/vertex-ai/docs/reference/rest/v1/CustomJobSpec#Scheduling"
         ),
         examples=[
-            {"scheduling": {"strategy": "FLEX_START", "max_wait_duration": "1800s"}},
+            {"scheduling": {"strategy": "FLEX_START", "max_wait_duration": "1800s"}}
         ],
     )
     service_account_name: Optional[str] = Field(


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
Adding two variables to the Vertex AI Worker:  `enable_web_access` and `enable_dashboard_access` which are useful for debugging jobs, these parameters are available today in Vertex AI [CustomJobSpec](https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform_v1.types.CustomJobSpec) and closing the loop on [issue #5495](https://github.com/PrefectHQ/prefect/issues/5495). In addition, cleaned up the scheduling parameters logic to make it more readable.

The `VertexAIWorker` in `vertex.py` already allows [passing additional arguments into CustomJobSpec](https://github.com/PrefectHQ/prefect/blob/af502b4497663b65418e2891ea3baf384c338c73/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py#L520) in the provided job_spec, if they should explicitly defined as variables will create separate PR's for those.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue by including "closes `<link to issue>`"(https://github.com/PrefectHQ/prefect/issues/new/choose) first.
  - closes [#5495](https://github.com/PrefectHQ/prefect/issues/5495)
- [X] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
