### PR TITLE
feat: ensure ui files are writeable

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -250,8 +250,14 @@ def copy_directory(directory: str, path: str) -> None:
             if os.path.exists(destination):
                 shutil.rmtree(destination)
             shutil.copytree(source, destination, symlinks=True)
+            # ensure copied files are writeable
+            for root, dirs, files in os.walk(destination):
+                for f in files:
+                    os.chmod(os.path.join(root, f), 0o600)
         else:
             shutil.copy2(source, destination)
+            # Ensure copied file is writeable
+            os.chmod(destination, 0o600)
 
 
 async def custom_internal_exception_handler(


### PR DESCRIPTION
On startup prefect copies over files from the ui into the ui direcctory. If for any reason the ui files were not writeable, the whole setup will fail. This PR ensures that the copied files are writeable To give a bit more context, I am currently packaging Prefect for nixos. Nix having a little bit of a strict build system, makes sure that the built package has only read-only files. this is to ensure the build is deterministic.
I understand that this might appear as a detail related to nix build system only. I can patch the source when building the nix package, but I thought I would try to contribute the patch. No hard feelings if you are not interested in this patch. Thank you for developping prefect!

closes https://github.com/PrefectHQ/prefect/issues/17337

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
