### PR TITLE
bump `prefect-kubernetes`'s dependency on `prefect`

### DIFF
--- a/src/integrations/prefect-kubernetes/pyproject.toml
+++ b/src/integrations/prefect-kubernetes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 dependencies = [
-    "prefect>=3.1.1",
+    "prefect>=3.2.8",
     "kubernetes-asyncio>=32.0.0",
     "tenacity>=8.2.3",
     "exceptiongroup",


### PR DESCRIPTION
```python
» uv run --with prefect==3.2.7 --with prefect-kubernetes python -c "import prefect_kubernetes"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/nate/Library/Caches/uv/archive-v0/nBzMLbYy8B3yWNDaG_Rwg/lib/python3.12/site-packages/prefect_kubernetes/__init__.py", line 8, in <module>
    from prefect_kubernetes.worker import KubernetesWorker  # noqa F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nate/Library/Caches/uv/archive-v0/nBzMLbYy8B3yWNDaG_Rwg/lib/python3.12/site-packages/prefect_kubernetes/worker.py", line 156, in <module>
    from prefect.futures import PrefectFlowRunFuture
ImportError: cannot import name 'PrefectFlowRunFuture' from 'prefect.futures' (/Users/nate/Library/Caches/uv/archive-v0/nBzMLbYy8B3yWNDaG_Rwg/lib/python3.12/site-packages/prefect/futures.py). Did you mean: 'PrefectWrappedFuture'?
```