### PR TITLE
warn if `RunnerDeployment` with a `work_pool_name` given to `serve`

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -2162,6 +2162,11 @@ def serve(
 
     runner = Runner(pause_on_shutdown=pause_on_shutdown, limit=limit, **kwargs)
     for deployment in args:
+        if deployment.work_pool_name:
+            raise ValueError(
+                "Work pools are not necessary for served deployments, omit the "
+                "`work_pool_name` argument."
+            )
         runner.add_deployment(deployment)
 
     if print_starting_message:

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -2163,10 +2163,13 @@ def serve(
     runner = Runner(pause_on_shutdown=pause_on_shutdown, limit=limit, **kwargs)
     for deployment in args:
         if deployment.work_pool_name:
-            raise ValueError(
-                "Work pools are not necessary for served deployments, omit the "
-                "`work_pool_name` argument."
+            warnings.warn(
+                "Work pools are not necessary for served deployments - "
+                "the `work_pool_name` argument will be ignored. Omit the "
+                f"`work_pool_name` argument from `to_deployment` for {deployment.name!r}.",
+                UserWarning,
             )
+            deployment.work_pool_name = None
         runner.add_deployment(deployment)
 
     if print_starting_message:

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -191,7 +191,7 @@ def temp_storage() -> Generator[MockStorage, Any, None]:
 
 @pytest.fixture
 def in_temporary_runner_directory(tmp_path: Path):
-    with tmpchdir(tmp_path):
+    with tmpchdir(str(tmp_path)):
         yield
 
 
@@ -246,12 +246,14 @@ class TestInit:
 
 class TestServe:
     @pytest.fixture(autouse=True)
-    async def mock_runner_start(self, monkeypatch):
+    async def mock_runner_start(self, monkeypatch: pytest.MonkeyPatch):
         mock = AsyncMock()
         monkeypatch.setattr("prefect.runner.Runner.start", mock)
         return mock
 
-    def test_serve_prints_help_message_on_startup(self, capsys):
+    def test_serve_prints_help_message_on_startup(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
         serve(
             dummy_flow_1.to_deployment(__file__),
             dummy_flow_2.to_deployment(__file__),
@@ -271,7 +273,17 @@ class TestServe:
 
     is_python_38 = sys.version_info[:2] == (3, 8)
 
-    def test_serve_typed_container_inputs_flow(self, capsys):
+    def test_serve_raises_if_runner_deployment_sets_work_pool_name(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
+        with pytest.raises(
+            ValueError, match="Work pools are not necessary for served deployments"
+        ):
+            serve(dummy_flow_1.to_deployment(__file__, work_pool_name="foo"))
+
+    def test_serve_typed_container_inputs_flow(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
         if self.is_python_38:
 
             @flow
@@ -333,7 +345,7 @@ class TestServe:
 
         mock_runner_start.assert_awaited_once()
 
-    def test_log_level_lowercasing(self, monkeypatch):
+    def test_log_level_lowercasing(self, monkeypatch: pytest.MonkeyPatch):
         runner_mock = mock.MagicMock()
         log_level = "DEBUG"
 
@@ -353,7 +365,7 @@ class TestServe:
                     webserver_mock, host=mock.ANY, port=mock.ANY, log_level="debug"
                 )
 
-    def test_serve_in_async_context_raises_error(self, monkeypatch):
+    def test_serve_in_async_context_raises_error(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr(
             "asyncio.get_running_loop", lambda: asyncio.get_event_loop()
         )

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -276,8 +276,8 @@ class TestServe:
     def test_serve_raises_if_runner_deployment_sets_work_pool_name(
         self, capsys: pytest.CaptureFixture[str]
     ):
-        with pytest.raises(
-            ValueError, match="Work pools are not necessary for served deployments"
+        with pytest.warns(
+            UserWarning, match="Work pools are not necessary for served deployments"
         ):
             serve(dummy_flow_1.to_deployment(__file__, work_pool_name="foo"))
 
@@ -381,12 +381,14 @@ class TestServe:
 
 class TestAServe:
     @pytest.fixture(autouse=True)
-    async def mock_runner_start(self, monkeypatch):
+    async def mock_runner_start(self, monkeypatch: pytest.MonkeyPatch):
         mock = AsyncMock()
         monkeypatch.setattr("prefect.runner.Runner.start", mock)
         return mock
 
-    async def test_aserve_prints_help_message_on_startup(self, capsys):
+    async def test_aserve_prints_help_message_on_startup(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
         await aserve(
             await dummy_flow_1.to_deployment(__file__),
             await dummy_flow_2.to_deployment(__file__),
@@ -404,7 +406,9 @@ class TestAServe:
         assert "tired-flow/test_runner" in captured.out
         assert "$ prefect deployment run [DEPLOYMENT_NAME]" in captured.out
 
-    async def test_aserve_typed_container_inputs_flow(self, capsys):
+    async def test_aserve_typed_container_inputs_flow(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
         @flow
         def type_container_input_flow(arg1: List[str]) -> str:
             print(arg1)


### PR DESCRIPTION
motivated by the example in #17348 (not directly related to that issue)

in order to avoid 404ing later, we must explicitly set the `work_pool_name` to `None`