### PR TITLE
Add sigterm handling for `prefect flow-run execute`

### DIFF
--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -2,6 +2,8 @@
 Command line interface for working with flow runs
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import signal

--- a/src/prefect/cli/flow_run.py
+++ b/src/prefect/cli/flow_run.py
@@ -32,7 +32,6 @@ from prefect.logging import get_logger
 from prefect.runner import Runner
 from prefect.states import State
 from prefect.types._datetime import create_datetime_instance
-from prefect.utilities.asyncutils import run_coro_as_sync
 
 flow_run_app: PrefectTyper = PrefectTyper(
     name="flow-run", help="Interact with flow runs."
@@ -362,7 +361,7 @@ async def execute(
 
     def _handle_reschedule_sigterm(_signal: int, _frame: FrameType | None):
         logger.info("SIGTERM received, initiating graceful shutdown...")
-        run_coro_as_sync(runner.reschedule_current_flow_runs())
+        runner.reschedule_current_flow_runs()
         exit_with_success("Flow run successfully rescheduled.")
 
     # Set up signal handling to reschedule run on SIGTERM

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -973,11 +973,11 @@ class Runner:
                 )
                 try:
                     propose_state_sync(client, AwaitingRetry(), flow_run_id=flow_run.id)
-                    try:
-                        os.kill(process_info["pid"], signal.SIGTERM)
-                    except ProcessLookupError:
-                        pass
+                    os.kill(process_info["pid"], signal.SIGTERM)
                     run_logger.info("Rescheduled flow run for resubmission")
+                except ProcessLookupError:
+                    # Process may have already exited
+                    pass
                 except Abort as exc:
                     run_logger.info(
                         (

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -961,36 +961,39 @@ class Runner:
         Reschedules all flow runs that are currently running.
         """
         self._rescheduling = True
-        # Create a new sync client because this will often run in a separate thread
-        # as part of a signal handler.
-        with get_client(sync_client=True) as client:
-            self._logger.info("Rescheduling flow runs...")
-            for process_info in self._flow_run_process_map.values():
-                flow_run = process_info["flow_run"]
-                run_logger = self._get_flow_run_logger(flow_run)
-                run_logger.info(
-                    "Rescheduling flow run for resubmission in response to SIGTERM"
-                )
-                try:
-                    propose_state_sync(client, AwaitingRetry(), flow_run_id=flow_run.id)
-                    os.kill(process_info["pid"], signal.SIGTERM)
-                    run_logger.info("Rescheduled flow run for resubmission")
-                except ProcessLookupError:
-                    # Process may have already exited
-                    pass
-                except Abort as exc:
+        try:
+            # Create a new sync client because this will often run in a separate thread
+            # as part of a signal handler.
+            with get_client(sync_client=True) as client:
+                self._logger.info("Rescheduling flow runs...")
+                for process_info in self._flow_run_process_map.values():
+                    flow_run = process_info["flow_run"]
+                    run_logger = self._get_flow_run_logger(flow_run)
                     run_logger.info(
-                        (
-                            "Aborted submission of flow run. "
-                            f"Server sent an abort signal: {exc}"
-                        ),
+                        "Rescheduling flow run for resubmission in response to SIGTERM"
                     )
-                except Exception:
-                    run_logger.exception(
-                        "Failed to reschedule flow run",
-                    )
-
-        self._rescheduling = False
+                    try:
+                        propose_state_sync(
+                            client, AwaitingRetry(), flow_run_id=flow_run.id
+                        )
+                        os.kill(process_info["pid"], signal.SIGTERM)
+                        run_logger.info("Rescheduled flow run for resubmission")
+                    except ProcessLookupError:
+                        # Process may have already exited
+                        pass
+                    except Abort as exc:
+                        run_logger.info(
+                            (
+                                "Aborted submission of flow run. "
+                                f"Server sent an abort signal: {exc}"
+                            ),
+                        )
+                    except Exception:
+                        run_logger.exception(
+                            "Failed to reschedule flow run",
+                        )
+        finally:
+            self._rescheduling = False
 
     async def _pause_schedules(self):
         """

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -990,6 +990,8 @@ class Runner:
                         "Failed to reschedule flow run",
                     )
 
+        self._rescheduling = False
+
     async def _pause_schedules(self):
         """
         Pauses all deployment schedules.

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -981,7 +981,7 @@ class Runner:
                 except Abort as exc:
                     run_logger.info(
                         (
-                            f"Aborted submission of flow run. "
+                            "Aborted submission of flow run. "
                             f"Server sent an abort signal: {exc}"
                         ),
                     )

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import signal
 import subprocess

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -842,7 +842,9 @@ class TestSignalHandling:
         sigterm_handling: str | None,
     ):
         if sigterm_handling is not None:
-            monkeypatch.setenv("PREFECT_RUNNER_ON_SIGTERM", sigterm_handling)
+            monkeypatch.setenv(
+                "PREFECT_FLOW_RUN_EXECUTE_SIGTERM_BEHAVIOR", sigterm_handling
+            )
 
         # Create a flow run that will take a while to run
         deployment_id = await (await tired_flow.to_deployment(__file__)).apply()

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -879,7 +879,7 @@ class TestSignalHandling:
         popen.terminate()
 
         # Wait for the process to exit
-        return_code = await run_sync_in_worker_thread(popen.wait, timeout=10)
+        return_code = await run_sync_in_worker_thread(popen.wait, timeout=20)
 
         flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
         assert flow_run.state

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -1,6 +1,11 @@
+import os
+import signal
+import subprocess
+from time import sleep
 from typing import Any, Awaitable, Callable
 from uuid import UUID, uuid4
 
+import anyio
 import pytest
 
 import prefect.exceptions
@@ -10,6 +15,7 @@ from prefect.client.orchestration import PrefectClient, SyncPrefectClient
 from prefect.client.schemas.actions import LogCreate
 from prefect.client.schemas.objects import FlowRun
 from prefect.deployments.runner import RunnerDeployment
+from prefect.settings.context import get_current_settings
 from prefect.states import (
     AwaitingRetry,
     Cancelled,
@@ -37,6 +43,15 @@ def hello_flow():
 @flow(name="goodbye")
 def goodbye_flow():
     return "Goodbye"
+
+
+@flow()
+def tired_flow():
+    print("I am so tired...")
+
+    for _ in range(100):
+        print("zzzzz...")
+        sleep(5)
 
 
 async def assert_flow_run_is_deleted(prefect_client: PrefectClient, flow_run_id: UUID):
@@ -814,3 +829,66 @@ class TestFlowRunExecute:
 
         flow_run = await prefect_client.read_flow_run(flow_run.id)
         assert flow_run.state.is_completed()
+
+
+class TestSignalHandling:
+    @pytest.mark.parametrize("sigterm_handling", ["reschedule", None])
+    async def test_flow_run_execute_sigterm_handling(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        prefect_client: PrefectClient,
+        sigterm_handling: str | None,
+    ):
+        if sigterm_handling is not None:
+            monkeypatch.setenv("PREFECT_RUNNER_ON_SIGTERM", sigterm_handling)
+
+        # Create a flow run that will take a while to run
+        deployment_id = await (await tired_flow.to_deployment(__file__)).apply()
+
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        # Run the flow run in a new process with a Runner
+        popen = subprocess.Popen(
+            [
+                "prefect",
+                "flow-run",
+                "execute",
+                str(flow_run.id),
+            ],
+            env=get_current_settings().to_environment_variables(exclude_unset=True)
+            | os.environ,
+        )
+
+        assert popen.pid is not None
+
+        # Wait for the flow run to start
+        while True:
+            await anyio.sleep(0.5)
+            flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+            assert flow_run.state
+            if flow_run.state.is_running():
+                break
+
+        # Send the SIGTERM signal
+        popen.terminate()
+
+        # Wait for the process to exit
+        return_code = await run_sync_in_worker_thread(popen.wait, timeout=10)
+
+        flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+        assert flow_run.state
+
+        if sigterm_handling == "reschedule":
+            assert flow_run.state.is_scheduled(), (
+                "The flow run should have been rescheduled"
+            )
+            assert return_code == 0, "The process should have exited with a 0 exit code"
+        else:
+            assert flow_run.state.is_running(), (
+                "The flow run should be stuck in running"
+            )
+            assert return_code == -signal.SIGTERM.value, (
+                "The process should have exited with a SIGTERM exit code"
+            )

--- a/tests/cli/test_flow_run.py
+++ b/tests/cli/test_flow_run.py
@@ -879,7 +879,7 @@ class TestSignalHandling:
         popen.terminate()
 
         # Wait for the process to exit
-        return_code = await run_sync_in_worker_thread(popen.wait, timeout=20)
+        return_code = popen.wait(timeout=10)
 
         flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
         assert flow_run.state

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1331,7 +1331,7 @@ class TestRunner:
             if flow_run.state.is_running():
                 break
 
-        await runner.reschedule_current_flow_runs()
+        runner.reschedule_current_flow_runs()
 
         await execute_flow_run_task
 

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+import multiprocessing
 import os
 import re
 import signal
@@ -38,6 +39,7 @@ from prefect.client.schemas.objects import (
     WorkerStatus,
 )
 from prefect.client.schemas.schedules import CronSchedule, IntervalSchedule
+from prefect.context import SettingsContext, get_settings_context
 from prefect.deployments.runner import (
     DeploymentApplyError,
     EntrypointType,
@@ -63,8 +65,11 @@ from prefect.settings import (
     PREFECT_RUNNER_SERVER_ENABLE,
     temporary_settings,
 )
+from prefect.settings.context import get_current_settings
+from prefect.settings.models.root import Settings
 from prefect.states import Cancelling
 from prefect.testing.utilities import AsyncMock
+from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.dockerutils import parse_image_tag
 from prefect.utilities.filesystem import tmpchdir
 from prefect.utilities.slugify import slugify
@@ -3205,3 +3210,77 @@ class TestDockerImage:
     def test_no_default_registry_url_by_default(self):
         image = DockerImage(name="my-org/test-image")
         assert image.name == "my-org/test-image"
+
+
+def execute_flow_run(flow_run_id: str, env: dict[str, str]):
+    os.environ.update(env)
+    settings_context = get_settings_context()
+    # I've had to do this song and dance a couple of times now. Might be time to create a util.
+    with SettingsContext(
+        profile=settings_context.profile,
+        settings=Settings(),
+    ):
+        runner = Runner()
+        print("Starting flow run")
+        asyncio.run(runner.execute_flow_run(flow_run_id))
+
+
+class TestSignalHandling:
+    @pytest.mark.parametrize("sigterm_handling", ["reschedule", None])
+    async def test_flow_run_execute_sigterm_handling(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        prefect_client: PrefectClient,
+        sigterm_handling: str | None,
+    ):
+        if sigterm_handling is not None:
+            monkeypatch.setenv("PREFECT_RUNNER_ON_SIGTERM", sigterm_handling)
+
+        # Create a flow run that will take a while to run
+        deployment_id = await (await tired_flow.to_deployment(__file__)).apply()
+
+        flow_run = await prefect_client.create_flow_run_from_deployment(
+            deployment_id=deployment_id
+        )
+
+        # Run the flow run in a new process with a Runner
+        ctx = multiprocessing.get_context("spawn")
+        process = ctx.Process(
+            target=execute_flow_run,
+            args=(
+                flow_run.id,
+                get_current_settings().to_environment_variables(exclude_unset=True)
+                | os.environ,
+            ),
+        )
+        process.start()
+
+        # Wait for the flow run to start
+        while True:
+            await anyio.sleep(0.5)
+            flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+            assert flow_run.state
+            if flow_run.state.is_running():
+                break
+
+        # Send the SIGTERM signal
+        process.terminate()
+
+        # Wait for the process to exit
+        await run_sync_in_worker_thread(process.join, timeout=10)
+        assert not process.is_alive(), "The process should have exited"
+
+        flow_run = await prefect_client.read_flow_run(flow_run_id=flow_run.id)
+
+        if sigterm_handling == "reschedule":
+            assert flow_run.state.is_scheduled(), (
+                "The flow run should have been rescheduled"
+            )
+            assert process.exitcode == 0, (
+                "The process should have exited with a 0 exit code"
+            )
+        else:
+            assert flow_run.state.is_running(), (
+                "The flow run should be stuck in running"
+            )
+            assert process.exitcode == -signal.SIGTERM.value

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import datetime
 import multiprocessing


### PR DESCRIPTION
This PR adds the ability to reschedule flow runs when the `Runner` receives a SIGTERM. This should handle some cases where infrastructure providers will interrupt work while it's still running due to scale-down. 

This opt-in feature can be enabled by setting the environment variable `PREFECT_FLOW_RUN_EXECUTE_SIGTERM_BEHAVIOR` to `reschedule`. Note, this should NOT be used with a `backoffLimit` in Kubernetes (or equivalent in other infrastructure providers) as it will result in duplicate flow runs. It should be safe to use with the default Kubernetes work pool configuration where the `backoffLimit` defaults to `0`.