### PR TITLE
chore(docs): remove Helm reference on ECS page

### DIFF
--- a/docs/integrations/prefect-aws/ecs_guide.mdx
+++ b/docs/integrations/prefect-aws/ecs_guide.mdx
@@ -84,11 +84,8 @@ If you specify a task definition [ARN (Amazon Resource Name)](https://docs.aws.a
 You can use either EC2 or Fargate as the capacity provider. Fargate simplifies initiation, but lengthens infrastructure setup time for each flow run. Using EC2 for the ECS cluster can reduce setup time. In this example, we will show how to use Fargate.
 
 import { TF } from "/snippets/resource-management/terraform.mdx"
-import { HELM } from "/snippets/resource-management/helm.mdx"
 import { workers } from "/snippets/resource-management/vars.mdx"
 import { work_pools } from "/snippets/resource-management/vars.mdx"
-
-<HELM name="Prefect workers" href={workers.helm} />
 
 <TF name="work pools" href={work_pools.tf} />
 


### PR DESCRIPTION
Helm isn't relevant in the ECS guide, because the workers will be created using the AWS CLI instead of the Helm `prefect-worker` chart, which is used in Kubernetes.

We'll expand on this with an ECS Terraform example as part of:
- https://github.com/PrefectHQ/examples/issues/11
- https://linear.app/prefect/issue/PLA-1072

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
