### PR TITLE
Respect custom cert files in events client

### DIFF
--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -125,13 +125,13 @@ class WebsocketProxyConnect(connect):
         self._host = host
         self._port = port
 
-        if PREFECT_API_TLS_INSECURE_SKIP_VERIFY or u.scheme == "ws":
+        if PREFECT_API_TLS_INSECURE_SKIP_VERIFY and u.scheme == "wss":
             # Create an unverified context for insecure connections
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
             self._kwargs.setdefault("ssl", ctx)
-        else:
+        elif u.scheme == "wss":
             cert_file = PREFECT_API_SSL_CERT_FILE.value()
             if not cert_file:
                 cert_file = certifi.where()

--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -125,7 +125,7 @@ class WebsocketProxyConnect(connect):
         self._host = host
         self._port = port
 
-        if PREFECT_API_TLS_INSECURE_SKIP_VERIFY:
+        if PREFECT_API_TLS_INSECURE_SKIP_VERIFY or u.scheme == "ws":
             # Create an unverified context for insecure connections
             ctx = ssl.create_default_context()
             ctx.check_hostname = False

--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -137,7 +137,7 @@ class WebsocketProxyConnect(connect):
                 cert_file = certifi.where()
             # Create a verified context with the certificate file
             ctx = ssl.create_default_context(cafile=cert_file)
-            self._kwargs.setdefault("verify", ctx)
+            self._kwargs.setdefault("ssl", ctx)
 
     async def _proxy_connect(self: Self) -> ClientConnection:
         if self._proxy:

--- a/tests/events/client/test_events_client.py
+++ b/tests/events/client/test_events_client.py
@@ -66,7 +66,13 @@ def test_errors_when_missing_api_url_and_ephemeral_disabled():
 async def test_prefect_api_tls_insecure_skip_verify_setting_set_to_true(
     monkeypatch: pytest.MonkeyPatch, ephemeral_settings: None
 ):
-    with temporary_settings(updates={PREFECT_API_TLS_INSECURE_SKIP_VERIFY: True}):
+    with temporary_settings(
+        updates={
+            PREFECT_API_TLS_INSECURE_SKIP_VERIFY: True,
+            PREFECT_API_URL: "https://my-self-hosted-thing",
+            PREFECT_SERVER_ALLOW_EPHEMERAL_MODE: False,
+        }
+    ):
         client = get_events_client()
 
     ssl_ctx = client._connect._kwargs["ssl"]


### PR DESCRIPTION
It looks like our events client didn't respect the `PREFECT_API_SSL_CERT_FILE` setting, so this PR adds in the necessary logic