### PR TITLE
[UI v2] feat: Adds deployment duplicate page

### DIFF
--- a/ui-v2/src/api/deployments/index.ts
+++ b/ui-v2/src/api/deployments/index.ts
@@ -199,6 +199,47 @@ export const buildDeploymentDetailsQuery = (id: string) =>
 // ----------------------------
 
 /**
+ * Hook for creating a deployment
+ *
+ * @returns Mutation object for creating a deployment with loading/error states and trigger function
+ *
+ * @example
+ * ```ts
+ * const { createDeployment } = useCreateDeployment();
+ *
+ * // Create a deployment
+ * createDeployment('deployment-id', {
+ *   onSuccess: () => {
+ *     // Handle successful creation
+ *     console.log('Deployment created successfully');
+ *   },
+ *   onError: (error) => {
+ *     // Handle error
+ *     console.error('Failed to create deployment:', error);
+ *   }
+ * });
+ * ```
+ */
+export const useCreateDeployment = () => {
+	const queryClient = useQueryClient();
+	const { mutate: createDeployment, ...rest } = useMutation({
+		mutationFn: async (body: components["schemas"]["DeploymentCreate"]) => {
+			const res = await getQueryService().POST("/deployments/", { body });
+			if (!res.data) {
+				throw new Error("'data' expected");
+			}
+			return res.data;
+		},
+		onSettled: async () => {
+			return await queryClient.invalidateQueries({
+				queryKey: queryKeyFactory.lists(),
+			});
+		},
+	});
+	return { createDeployment, ...rest };
+};
+
+/**
  * Hook for updating a deployment
  *
  * @returns Mutation object for updating a deployment with loading/error states and trigger function

--- a/ui-v2/src/components/deployments/deployment-form/deployment-form.stories.tsx
+++ b/ui-v2/src/components/deployments/deployment-form/deployment-form.stories.tsx
@@ -37,6 +37,9 @@ const meta = {
 				http.patch(buildApiUrl("/deployments/id"), () => {
 					return HttpResponse.json(createFakeDeployment());
 				}),
+				http.post(buildApiUrl("/deployments"), () => {
+					return HttpResponse.json(createFakeDeployment());
+				}),
 			],
 		},
 	},
@@ -44,6 +47,12 @@ const meta = {
 
 export default meta;
 
-export const story: StoryObj = {
-	name: "DeploymentForm",
+type Story = StoryObj<typeof DeploymentForm>;
+
+export const Edit: Story = {
+	args: { mode: "edit" },
+};
+
+export const Duplicate: Story = {
+	args: { mode: "duplicate" },
 };

--- a/ui-v2/src/components/deployments/deployment-form/deployment-form.tsx
+++ b/ui-v2/src/components/deployments/deployment-form/deployment-form.tsx
@@ -10,8 +10,8 @@ import {
 	FormLabel,
 	FormMessage,
 } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
 import { JsonInput } from "@/components/ui/json-input";
-import { Label } from "@/components/ui/label";
 import { MarkdownInput } from "@/components/ui/markdown-input";
 import { Switch } from "@/components/ui/switch";
 import { TagsInput } from "@/components/ui/tags-input";
@@ -24,16 +24,17 @@ import { useDeploymentForm } from "./use-deployment-form";
 
 type DeploymentFormProps = {
 	deployment: Deployment;
+	mode: "edit" | "duplicate";
 };
 
-export const DeploymentForm = ({ deployment }: DeploymentFormProps) => {
+export const DeploymentForm = ({ deployment, mode }: DeploymentFormProps) => {
 	const {
 		form,
 		onSave,
 		parameterFormErrors,
 		setParametersFormValues,
 		parametersFormValues,
-	} = useDeploymentForm(deployment);
+	} = useDeploymentForm(deployment, { mode });
 	const watchPoolName = form.watch("work_pool_name");
 	const parametersOpenAPISchema = form.getValues("parameter_openapi_schema");
 
@@ -47,10 +48,23 @@ export const DeploymentForm = ({ deployment }: DeploymentFormProps) => {
 
 				<Typography variant="h3">General</Typography>
 
-				<Label>Name</Label>
-				<Typography className="text-muted-foreground">
-					{deployment.name}
-				</Typography>
+				<FormField
+					control={form.control}
+					name="name"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>Name</FormLabel>
+							<FormControl>
+								<Input
+									{...field}
+									value={field.value}
+									disabled={mode === "edit"}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
 
 				<FormField
 					control={form.control}

--- a/ui-v2/src/components/deployments/deployment-form/index.ts
+++ b/ui-v2/src/components/deployments/deployment-form/index.ts
@@ -1,0 +1,1 @@
+export { DeploymentForm } from "./deployment-form";

--- a/ui-v2/src/components/deployments/deployment-parameters-table/deployment-parameters-table.tsx
+++ b/ui-v2/src/components/deployments/deployment-parameters-table/deployment-parameters-table.tsx
@@ -47,8 +47,12 @@ const useDeploymentParametersToTable = (
 	deployment: Deployment,
 ): Array<ParametersTableColumns> =>
 	useMemo(() => {
+		if (!deployment.parameter_openapi_schema) {
+			return [];
+		}
+
 		const parameterOpenApiSchema = deployment.parameter_openapi_schema
-			?.properties as Record<string, ParameterOpenApiSchema>;
+			.properties as Record<string, ParameterOpenApiSchema>;
 		const parameters = deployment.parameters as Record<string, unknown>;
 		return Object.keys(parameterOpenApiSchema)
 			.sort((a, b) => {

--- a/ui-v2/src/routes/deployments/deployment_.$id.duplicate.tsx
+++ b/ui-v2/src/routes/deployments/deployment_.$id.duplicate.tsx
@@ -1,9 +1,18 @@
+import { buildDeploymentDetailsQuery } from "@/api/deployments";
+import { DeploymentForm } from "@/components/deployments/deployment-form";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/deployments/deployment_/$id/duplicate")({
 	component: RouteComponent,
+	loader: ({ params, context: { queryClient } }) =>
+		queryClient.ensureQueryData(buildDeploymentDetailsQuery(params.id)),
+	wrapInSuspense: true,
 });
 
 function RouteComponent() {
-	return "🚧🚧 Pardon our dust! 🚧🚧";
+	const { id } = Route.useParams();
+	const { data } = useSuspenseQuery(buildDeploymentDetailsQuery(id));
+
+	return <DeploymentForm deployment={data} mode="duplicate" />;
 }

--- a/ui-v2/src/routes/deployments/deployment_.$id.edit.tsx
+++ b/ui-v2/src/routes/deployments/deployment_.$id.edit.tsx
@@ -1,20 +1,18 @@
 import { buildDeploymentDetailsQuery } from "@/api/deployments";
-import { DeploymentForm } from "@/components/deployments/deployment-form/deployment-form";
+import { DeploymentForm } from "@/components/deployments/deployment-form";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/deployments/deployment_/$id/edit")({
 	component: RouteComponent,
-	loader: async ({ params, context: { queryClient } }) =>
+	loader: ({ params, context: { queryClient } }) =>
 		queryClient.ensureQueryData(buildDeploymentDetailsQuery(params.id)),
 	wrapInSuspense: true,
 });
 
 function RouteComponent() {
 	const { id } = Route.useParams();
-	const { data: deployment } = useSuspenseQuery(
-		buildDeploymentDetailsQuery(id),
-	);
+	const { data } = useSuspenseQuery(buildDeploymentDetailsQuery(id));
 
-	return <DeploymentForm deployment={deployment} />;
+	return <DeploymentForm deployment={data} mode="edit" />;
 }


### PR DESCRIPTION
Adds deployment duplicate page

1. Adds create deployment API
2. Updates `DeploymentForm` and `useDeploymentForm` to include a `duplicate` mode.
3. Update name field to be a form field, but disabled if it is in `edit` mode
4. Updates `useDeploymentForm` to support editing or duplicating a deployment


https://github.com/user-attachments/assets/399e5ff8-5904-4f71-a682-6391bd27eae6


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
