### PR TITLE
add `freeze` annotation

### DIFF
--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -384,8 +384,6 @@ class DeploymentUpdate(ActionBaseModel):
 
         parameters = self.parameters or {}
 
-        breakpoint()
-
         for key, value in parameters.items():
             if isinstance(value, freeze):
                 raw_value = value.unfreeze()

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Callable, Optional, Self, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
 from uuid import UUID, uuid4
 
 import jsonschema
 from pydantic import Field, field_validator, model_validator
+from typing_extensions import Self
 
 import prefect.client.schemas.objects as objects
 from prefect._internal.schemas.bases import ActionBaseModel

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -6,7 +6,6 @@ from uuid import UUID, uuid4
 
 import jsonschema
 from pydantic import Field, field_validator, model_validator
-from typing_extensions import Self
 
 import prefect.client.schemas.objects as objects
 from prefect._internal.schemas.bases import ActionBaseModel
@@ -45,7 +44,6 @@ from prefect.types import (
     PositiveInteger,
     StrictVariableValue,
 )
-from prefect.utilities.annotations import freeze
 from prefect.utilities.collections import listrepr
 from prefect.utilities.pydantic import get_class_fields_only
 
@@ -279,27 +277,6 @@ class DeploymentCreate(ActionBaseModel):
 
             jsonschema.validate(self.job_variables, variables_schema)
 
-    @model_validator(mode="after")
-    def validate_parameters(self) -> Self:
-        """Update the parameter schema to mark frozen parameters as readonly."""
-        if not self.parameters:
-            return self
-
-        for key, value in self.parameters.items():
-            if isinstance(value, freeze):
-                raw_value = value.unfreeze()
-                if (
-                    self.parameter_openapi_schema is not None
-                    and key in self.parameter_openapi_schema.get("properties", {})
-                ):
-                    self.parameter_openapi_schema["properties"][key]["readOnly"] = True
-                    self.parameter_openapi_schema["properties"][key]["enum"] = [
-                        raw_value
-                    ]
-                    self.parameters[key] = raw_value
-
-        return self
-
 
 class DeploymentUpdate(ActionBaseModel):
     """Data used by the Prefect REST API to update a deployment."""
@@ -373,27 +350,6 @@ class DeploymentUpdate(ActionBaseModel):
 
         if variables_schema is not None:
             jsonschema.validate(self.job_variables, variables_schema)
-
-    @model_validator(mode="after")
-    def validate_parameters(self) -> Self:
-        """Update the parameter schema to mark frozen parameters as readonly."""
-        if not self.parameters:
-            return self
-
-        for key, value in self.parameters.items():
-            if isinstance(value, freeze):
-                raw_value = value.unfreeze()
-                if (
-                    self.parameter_openapi_schema is not None
-                    and key in self.parameter_openapi_schema.get("properties", {})
-                ):
-                    self.parameter_openapi_schema["properties"][key]["readOnly"] = True
-                    self.parameter_openapi_schema["properties"][key]["enum"] = [
-                        raw_value
-                    ]
-                    self.parameters[key] = raw_value
-
-        return self
 
 
 class FlowRunUpdate(ActionBaseModel):

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -282,9 +282,7 @@ class DeploymentCreate(ActionBaseModel):
     @model_validator(mode="after")
     def validate_parameters(self) -> Self:
         """Update the parameter schema to mark frozen parameters as readonly."""
-        if not hasattr(self, "parameters") or not hasattr(
-            self, "parameter_openapi_schema"
-        ):
+        if not self.parameters:
             return self
 
         for key, value in self.parameters.items():
@@ -379,14 +377,10 @@ class DeploymentUpdate(ActionBaseModel):
     @model_validator(mode="after")
     def validate_parameters(self) -> Self:
         """Update the parameter schema to mark frozen parameters as readonly."""
-        if not hasattr(self, "parameters") or not hasattr(
-            self, "parameter_openapi_schema"
-        ):
+        if not self.parameters:
             return self
 
-        parameters = self.parameters or {}
-
-        for key, value in parameters.items():
+        for key, value in self.parameters.items():
             if isinstance(value, freeze):
                 raw_value = value.unfreeze()
                 if (
@@ -397,9 +391,7 @@ class DeploymentUpdate(ActionBaseModel):
                     self.parameter_openapi_schema["properties"][key]["enum"] = [
                         raw_value
                     ]
-                    parameters[key] = raw_value
-
-        self.parameters = parameters
+                    self.parameters[key] = raw_value
 
         return self
 

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -288,15 +288,16 @@ class DeploymentCreate(ActionBaseModel):
 
         for key, value in self.parameters.items():
             if isinstance(value, freeze):
+                raw_value = value.unfreeze()
                 if (
                     self.parameter_openapi_schema is not None
                     and key in self.parameter_openapi_schema.get("properties", {})
                 ):
                     self.parameter_openapi_schema["properties"][key]["readOnly"] = True
                     self.parameter_openapi_schema["properties"][key]["enum"] = [
-                        value.unfreeze()
+                        raw_value
                     ]
-                    self.parameters[key] = value.unfreeze()
+                    self.parameters[key] = raw_value
 
         return self
 

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -355,7 +355,7 @@ class RunnerDeployment(BaseModel):
         update_payload = self.model_dump(
             mode="json",
             exclude_unset=True,
-            exclude={"storage", "name", "flow_name", "triggers"},
+            exclude={"storage", "name", "flow_name", "triggers", "parameters"},
         )
 
         if self.storage:
@@ -367,7 +367,9 @@ class RunnerDeployment(BaseModel):
         await client.update_deployment(
             deployment_id,
             deployment=DeploymentUpdate(
-                **update_payload, parameter_openapi_schema=parameter_openapi_schema
+                **update_payload,
+                parameter_openapi_schema=parameter_openapi_schema,
+                parameters=self.parameters,
             ),
         )
 

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -47,6 +47,7 @@ from pydantic import (
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn, track
 from rich.table import Table
+from typing_extensions import Self
 
 from prefect._experimental.sla.objects import SlaTypes
 from prefect._internal.compatibility.async_dispatch import async_dispatch
@@ -84,6 +85,7 @@ from prefect.settings import (
 )
 from prefect.types import ListOfNonEmptyStrings
 from prefect.types.entrypoint import EntrypointType
+from prefect.utilities.annotations import freeze
 from prefect.utilities.asyncutils import run_coro_as_sync, sync_compatible
 from prefect.utilities.callables import ParameterSchema, parameter_schema
 from prefect.utilities.collections import get_from_dict, isiterable
@@ -135,7 +137,9 @@ class RunnerDeployment(BaseModel):
         _sla: (Experimental) SLA configuration for the deployment. May be removed or modified at any time. Currently only supported on Prefect Cloud.
     """
 
-    model_config: ClassVar[ConfigDict] = ConfigDict(arbitrary_types_allowed=True)
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        arbitrary_types_allowed=True, validate_assignment=True
+    )
 
     name: str = Field(..., description="The name of the deployment.")
     flow_name: Optional[str] = Field(
@@ -250,14 +254,30 @@ class RunnerDeployment(BaseModel):
                 trigger.name = f"{self.name}__automation_{i}"
         return self
 
+    @model_validator(mode="after")
+    def validate_deployment_parameters(self) -> Self:
+        """Update the parameter schema to mark frozen parameters as readonly."""
+        if not self.parameters:
+            return self
+
+        for key, value in self.parameters.items():
+            if isinstance(value, freeze):
+                raw_value = value.unfreeze()
+                if key in self._parameter_openapi_schema.properties:
+                    self._parameter_openapi_schema.properties[key]["readOnly"] = True
+                    self._parameter_openapi_schema.properties[key]["enum"] = [raw_value]
+                    self.parameters[key] = raw_value
+
+        return self
+
     @model_validator(mode="before")
     @classmethod
-    def reconcile_paused(cls, values):
+    def reconcile_paused(cls, values: dict[str, Any]) -> dict[str, Any]:
         return reconcile_paused_deployment(values)
 
     @model_validator(mode="before")
     @classmethod
-    def reconcile_schedules(cls, values):
+    def reconcile_schedules(cls, values: dict[str, Any]) -> dict[str, Any]:
         return reconcile_schedules_runner(values)
 
     async def _create(
@@ -355,7 +375,7 @@ class RunnerDeployment(BaseModel):
         update_payload = self.model_dump(
             mode="json",
             exclude_unset=True,
-            exclude={"storage", "name", "flow_name", "triggers", "parameters"},
+            exclude={"storage", "name", "flow_name", "triggers"},
         )
 
         if self.storage:
@@ -369,7 +389,6 @@ class RunnerDeployment(BaseModel):
             deployment=DeploymentUpdate(
                 **update_payload,
                 parameter_openapi_schema=parameter_openapi_schema,
-                parameters=self.parameters,
             ),
         )
 

--- a/src/prefect/utilities/annotations.py
+++ b/src/prefect/utilities/annotations.py
@@ -108,3 +108,25 @@ class NotSet:
     """
     Singleton to distinguish `None` from a value that is not provided by the user.
     """
+
+
+class freeze(BaseAnnotation[T]):
+    """
+    Wrapper for parameters in deployments.
+
+    Indicates that this parameter should be frozen in the UI and not editable
+    when creating flow runs from this deployment.
+
+    Example:
+    ```python
+    @flow
+    def my_flow(customer_id: str):
+        # flow logic
+
+    deployment = my_flow.deploy(parameters={"customer_id": freeze("customer123")})
+    ```
+    """
+
+    def unfreeze(self) -> T:
+        """Return the unwrapped value."""
+        return self.unwrap()

--- a/src/prefect/utilities/annotations.py
+++ b/src/prefect/utilities/annotations.py
@@ -2,6 +2,7 @@ import warnings
 from operator import itemgetter
 from typing import Any, cast
 
+from pydantic_core import to_json
 from typing_extensions import Self, TypeVar
 
 T = TypeVar("T", infer_variance=True)
@@ -126,6 +127,13 @@ class freeze(BaseAnnotation[T]):
     deployment = my_flow.deploy(parameters={"customer_id": freeze("customer123")})
     ```
     """
+
+    def __new__(cls, value: T) -> Self:
+        try:
+            to_json(value)
+        except Exception:
+            raise ValueError("Value must be JSON serializable")
+        return super().__new__(cls, value)
 
     def unfreeze(self) -> T:
         """Return the unwrapped value."""

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -2533,7 +2533,7 @@ class TestRunnerDeployment:
             __file__,
             parameters={"value": freeze("test")},
         )
-        assert deployment_object.parameters == {"value": freeze("test")}
+        assert deployment_object.parameters == {"value": "test"}
         deployment_id = await deployment_object.apply()
 
         deployment = await prefect_client.read_deployment(deployment_id)
@@ -2560,7 +2560,7 @@ class TestRunnerDeployment:
             __file__,
             parameters={"number": freeze(42)},
         )
-        assert deployment_object.parameters == {"number": freeze(42)}
+        assert deployment_object.parameters == {"number": 42}
 
         deployment_id = await deployment_object.apply()
 

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -68,6 +68,7 @@ from prefect.settings import (
 from prefect.states import Cancelling
 from prefect.testing.utilities import AsyncMock
 from prefect.utilities import processutils
+from prefect.utilities.annotations import freeze
 from prefect.utilities.dockerutils import parse_image_tag
 from prefect.utilities.filesystem import tmpchdir
 from prefect.utilities.slugify import slugify
@@ -2518,6 +2519,65 @@ class TestRunnerDeployment:
             dummy_flow_1, name="flow-from-my.python.module"
         )
         assert deployment2.name == "flow-from-my.python.module"
+
+    async def test_from_flow_with_frozen_parameters(
+        self, prefect_client: PrefectClient
+    ):
+        """Test that frozen parameters are properly handled in deployment creation."""
+
+        @flow
+        def dummy_flow_4(value: Any): ...
+
+        deployment_object = RunnerDeployment.from_flow(
+            dummy_flow_4,
+            __file__,
+            parameters={"value": freeze("test")},
+        )
+        assert deployment_object.parameters == {"value": freeze("test")}
+        deployment_id = await deployment_object.apply()
+
+        deployment = await prefect_client.read_deployment(deployment_id)
+
+        assert deployment.parameters == {"value": "test"}
+        assert (
+            deployment.parameter_openapi_schema["properties"]["value"]["readOnly"]
+            is True
+        )
+        assert deployment.parameter_openapi_schema["properties"]["value"]["enum"] == [
+            "test"
+        ]
+
+    async def test_from_flow_with_frozen_parameters_preserves_type(
+        self, prefect_client: PrefectClient
+    ):
+        """Test that frozen parameters preserve their type information."""
+
+        @flow
+        def dummy_flow_5(number: int): ...
+
+        deployment_object = RunnerDeployment.from_flow(
+            dummy_flow_5,
+            __file__,
+            parameters={"number": freeze(42)},
+        )
+        assert deployment_object.parameters == {"number": freeze(42)}
+
+        deployment_id = await deployment_object.apply()
+
+        deployment = await prefect_client.read_deployment(deployment_id)
+
+        assert deployment.parameters == {"number": 42}
+        assert (
+            deployment.parameter_openapi_schema["properties"]["number"]["type"]
+            == "integer"
+        )
+        assert (
+            deployment.parameter_openapi_schema["properties"]["number"]["readOnly"]
+            is True
+        )
+        assert deployment.parameter_openapi_schema["properties"]["number"]["enum"] == [
+            42
+        ]
 
 
 class TestServer:

--- a/tests/utilities/test_annotations.py
+++ b/tests/utilities/test_annotations.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import httpx
 import pytest
+from pydantic import TypeAdapter
 
 from prefect.utilities.annotations import freeze, unmapped
 
@@ -51,3 +52,23 @@ class TestFreeze:
         """Test that freeze rejects non-JSON serializable types."""
         with pytest.raises(ValueError, match="Value must be JSON serializable"):
             freeze(value)
+
+    @pytest.mark.parametrize(
+        "value,expected_type",
+        [
+            ("test", str),
+            (42, int),
+            (3.14, float),
+            (True, bool),
+            (None, type(None)),
+        ],
+        ids=["str", "int", "float", "bool", "none"],
+    )
+    def test_frozen_parameters_are_serialized_as_json(
+        self, value: Any, expected_type: type
+    ):
+        frozen = freeze(value)
+        # assert it works even if we don't parameterize the expected type
+        assert TypeAdapter(freeze).dump_python(frozen) == value
+        # assert it works if we do parameterize the expected type
+        assert TypeAdapter(freeze[expected_type]).dump_python(frozen) == value

--- a/tests/utilities/test_annotations.py
+++ b/tests/utilities/test_annotations.py
@@ -1,6 +1,6 @@
 import random
 
-from prefect.utilities.annotations import unmapped
+from prefect.utilities.annotations import freeze, unmapped
 
 
 class TestUnmapped:
@@ -9,3 +9,8 @@ class TestUnmapped:
 
         for _ in range(10):
             assert thing[random.randint(0, 100)] == "hello"
+
+
+class TestFreeze:
+    def test_round_trip(self):
+        assert freeze("hello").unfreeze() == "hello"

--- a/tests/utilities/test_annotations.py
+++ b/tests/utilities/test_annotations.py
@@ -1,4 +1,8 @@
 import random
+from typing import Any
+
+import httpx
+import pytest
 
 from prefect.utilities.annotations import freeze, unmapped
 
@@ -12,5 +16,38 @@ class TestUnmapped:
 
 
 class TestFreeze:
-    def test_round_trip(self):
-        assert freeze("hello").unfreeze() == "hello"
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "hello",
+            42,
+            3.14,
+            True,
+            None,
+            ["a", 1, True],
+            {"some", "set"},
+            {
+                "string": "value",
+                "number": 42,
+                "list": [1, "two", 3.0],
+                "nested": {"a": [True, None]},
+            },
+        ],
+        ids=["str", "int", "float", "bool", "none", "list", "set", "nested_dict"],
+    )
+    def test_round_trip(self, value: Any):
+        assert freeze(value).unfreeze() == value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            httpx.AsyncClient(),
+            lambda: None,
+            type("foo", (object,), {}),
+        ],
+        ids=["httpx_client", "lambda", "type"],
+    )
+    def test_non_json_serializable_raises(self, value: Any):
+        """Test that freeze rejects non-JSON serializable types."""
+        with pytest.raises(ValueError, match="Value must be JSON serializable"):
+            freeze(value)


### PR DESCRIPTION
closes #11073

this PR adds a `freeze` annotation type as described in the linked PR. adding a parameterized type (e.g. `freeze[str]`) is not necessary

```python
from prefect import flow
from prefect.utilities.annotations import freeze


@flow(log_prints=True)
def test_freeze(value: str) -> str:
    print(f"value: {value}, type: {type(value)}")
    assert isinstance(value, str)
    return value


if __name__ == "__main__":
    test_freeze.serve(parameters={"value": freeze[str]("test")})
```
![image](https://github.com/user-attachments/assets/a16250fe-089a-4b55-92c8-81f37ebfc212)

![image](https://github.com/user-attachments/assets/25df647a-b12d-41d2-8ef0-6f81a23089eb)

