### PR TITLE
Update `ruff` settings in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,9 +287,11 @@ ignore_errors = true
 
 [tool.ruff]
 src = ["src"]
+
+[tool.ruff.lint]
 extend-select = ["I"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402", "F401", "I"]
 "main.py" = ["E402", "F401", "I"]
 "src/prefect/utilities/compat.py" = ["F401", "I"]
@@ -297,9 +299,8 @@ extend-select = ["I"]
 "src/prefect/runtime/*" = ["F822"]
 "src/prefect/server/database/migrations/**/*" = ["E501"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-third-party = []
-
 
 [tool.codespell]
 skip = [


### PR DESCRIPTION
This PR updates the `ruff` settings in `pyproject.toml` based on this warning that I've been seeing locally:

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'extend-select' -> 'lint.extend-select'
  - 'isort' -> 'lint.isort'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
```
