### PR TITLE
Allow specifying the key for an existing Kubernetes worker API key secret

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/settings.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/settings.py
@@ -13,6 +13,11 @@ class KubernetesWorkerSettings(PrefectBaseSettings):
         description="The name of the secret the worker's API key is stored in.",
     )
 
+    api_key_secret_key: Optional[str] = Field(
+        default=None,
+        description="The key of the secret the worker's API key is stored in.",
+    )
+
     create_secret_for_api_key: bool = Field(
         default=False,
         description="If `True`, the worker will create a secret in the same namespace as created Kubernetes jobs to store the Prefect API key.",

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -839,6 +839,7 @@ class KubernetesWorker(
         configuration: KubernetesWorkerJobConfiguration,
         client: "ApiClient",
         secret_name: Optional[str] = None,
+        secret_key: Optional[str] = None,
     ):
         """Replaces the PREFECT_API_KEY environment variable with a Kubernetes secret"""
         manifest_env = configuration.job_manifest["spec"]["template"]["spec"][
@@ -867,9 +868,11 @@ class KubernetesWorker(
                 configuration
             )
         if secret_name:
+            if not secret_key:
+                secret_key = "value"
             new_api_env_entry = {
                 "name": "PREFECT_API_KEY",
-                "valueFrom": {"secretKeyRef": {"name": secret_name, "key": "value"}},
+                "valueFrom": {"secretKeyRef": {"name": secret_name, "key": secret_key}},
             }
             manifest_env = [
                 entry if entry.get("name") != "PREFECT_API_KEY" else new_api_env_entry
@@ -900,6 +903,7 @@ class KubernetesWorker(
                 configuration=configuration,
                 client=client,
                 secret_name=settings.worker.api_key_secret_name,
+                secret_key=settings.worker.api_key_secret_key,
             )
         elif settings.worker.create_secret_for_api_key:
             await self._replace_api_key_with_secret(


### PR DESCRIPTION
I'm looking to incorporate the ability to give a secret for the Kubernetes worker to pass down to created jobs into the Kubernetes worker Helm chart, but the value for the secret is currently hard coded. This PR adds a setting to allow customization of the key within the secret for the API key.

Related to https://github.com/PrefectHQ/prefect/issues/17093