### PR TITLE
Add handling for extra install in `prefect.deployments.flow_runs`

### DIFF
--- a/src/prefect/deployments/flow_runs.py
+++ b/src/prefect/deployments/flow_runs.py
@@ -4,7 +4,6 @@ from uuid import UUID
 
 import anyio
 from opentelemetry import trace
-from opentelemetry.instrumentation.utils import is_instrumentation_enabled
 
 import prefect
 from prefect._result_records import ResultRecordMetadata
@@ -18,6 +17,14 @@ from prefect.telemetry.run_telemetry import LABELS_TRACEPARENT_KEY, RunTelemetry
 from prefect.types._datetime import now
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.slugify import slugify
+
+try:
+    from opentelemetry.instrumentation.utils import is_instrumentation_enabled
+except (ImportError, ModuleNotFoundError):
+
+    def is_instrumentation_enabled() -> bool:
+        return False
+
 
 if TYPE_CHECKING:
     from prefect.client.orchestration import PrefectClient

--- a/src/prefect/deployments/flow_runs.py
+++ b/src/prefect/deployments/flow_runs.py
@@ -18,11 +18,13 @@ from prefect.types._datetime import now
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.slugify import slugify
 
-try:
-    from opentelemetry.instrumentation.utils import is_instrumentation_enabled
-except (ImportError, ModuleNotFoundError):
 
-    def is_instrumentation_enabled() -> bool:
+def is_instrumentation_enabled() -> bool:
+    try:
+        from opentelemetry.instrumentation.utils import is_instrumentation_enabled
+
+        return is_instrumentation_enabled()
+    except (ImportError, ModuleNotFoundError):
         return False
 
 

--- a/src/prefect/deployments/flow_runs.py
+++ b/src/prefect/deployments/flow_runs.py
@@ -19,7 +19,7 @@ from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.slugify import slugify
 
 
-def is_instrumentation_enabled() -> bool:
+def _is_instrumentation_enabled() -> bool:
     try:
         from opentelemetry.instrumentation.utils import is_instrumentation_enabled
 
@@ -173,7 +173,7 @@ async def run_deployment(
 
     if flow_run_ctx and flow_run_ctx.flow_run:
         traceparent = flow_run_ctx.flow_run.labels.get(LABELS_TRACEPARENT_KEY)
-    elif is_instrumentation_enabled():
+    elif _is_instrumentation_enabled():
         traceparent = RunTelemetry.traceparent_from_span(span=trace.get_current_span())
     else:
         traceparent = None


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/17391

Verified locally:
```python
~/d/P/prefect ❯❯❯ python                             (.venv) fix-over-eager-import ✭ ✱ ◼
Python 3.12.5 (main, Aug 14 2024, 04:32:18) [Clang 18.1.8 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from opentelemetry.instrumentation.utils import is_instrumentation_enabled
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'opentelemetry.instrumentation'
>>> from prefect.deployments.flow_runs import run_deployment
>>>
```