### PR TITLE
[ui-v2] Fix types for `parameters` and `job_variables` on `DeploymentCreate`

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -15605,6 +15605,7 @@
                         "title": "Entrypoint"
                     },
                     "job_variables": {
+                        "additionalProperties": true,
                         "type": "object",
                         "title": "Job Variables",
                         "description": "Overrides for the flow's infrastructure configuration."

--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -15444,6 +15444,7 @@
                         "description": "The parameter schema of the flow, including defaults."
                     },
                     "parameters": {
+                        "additionalProperties": true,
                         "type": "object",
                         "title": "Parameters",
                         "description": "Parameters for flow runs scheduled by the deployment."

--- a/scripts/generate_oss_openapi_schema.py
+++ b/scripts/generate_oss_openapi_schema.py
@@ -1,8 +1,3 @@
-# /// script
-# dependencies = [
-#   "prefect @ file:${PROJECT_ROOT}/../",
-# ]
-# ///
 import json
 
 from prefect.server.api.server import create_api_app

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -197,6 +197,7 @@ class DeploymentCreate(ActionBaseModel):
     parameters: Dict[str, Any] = Field(
         default_factory=dict,
         description="Parameters for flow runs scheduled by the deployment.",
+        json_schema_extra={"additionalProperties": True},
     )
     tags: List[str] = Field(
         default_factory=list,

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -225,6 +225,7 @@ class DeploymentCreate(ActionBaseModel):
     job_variables: Dict[str, Any] = Field(
         default_factory=dict,
         description="Overrides for the flow's infrastructure configuration.",
+        json_schema_extra={"additionalProperties": True},
     )
 
     def check_valid_configuration(self, base_job_template: dict[str, Any]) -> None:

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -13,7 +13,7 @@
 		"format:check": "biome check",
 		"format": "biome check --write",
 		"preview": "vite preview",
-		"service-sync": "uv run --with-editable ../. ../scripts/generate_oss_openapi_schema.py && npx openapi-typescript oss_schema.json -o src/api/prefect.ts && rm oss_schema.json",
+		"service-sync": "uv run ../scripts/generate_oss_openapi_schema.py && npx openapi-typescript oss_schema.json -o src/api/prefect.ts && rm oss_schema.json",
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build",
 		"validate:types": "tsc -b --noEmit"

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -5346,7 +5346,9 @@ export interface components {
              * Job Variables
              * @description Overrides for the flow's infrastructure configuration.
              */
-            job_variables?: Record<string, never>;
+            job_variables?: {
+                [key: string]: unknown;
+            };
         };
         /**
          * DeploymentFilter

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -5308,7 +5308,9 @@ export interface components {
              * Parameters
              * @description Parameters for flow runs scheduled by the deployment.
              */
-            parameters?: Record<string, never>;
+            parameters?: {
+                [key: string]: unknown;
+            };
             /**
              * Tags
              * @description A list of deployment tags.

--- a/ui-v2/src/components/deployments/deployment-form/use-deployment-form.ts
+++ b/ui-v2/src/components/deployments/deployment-form/use-deployment-form.ts
@@ -163,10 +163,8 @@ export const useDeploymentForm = (
 						description,
 						enforce_parameter_schema,
 						flow_id: deployment.flow_id,
-						// @ts-expect-error Expecting TS error from poor openAPI typings
 						job_variables: jobVariablesPayload,
 						name,
-						// @ts-expect-error Expecting TS error from poor openAPI typings
 						parameters: parametersFormValues,
 						parameter_openapi_schema,
 						paused: deployment.paused,


### PR DESCRIPTION
# Description
Adds `additionalProperties: True` to both properties so that the generated typescript types are not `Record<string, never>`