### PR TITLE
Add Prefect labels to flow run pods

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -389,6 +389,7 @@ class KubernetesWorkerJobConfiguration(BaseJobConfiguration):
         self._populate_image_if_not_present()
         self._populate_command_if_not_present()
         self._populate_generate_name_if_not_present()
+        self._propagate_labels_to_pod()
 
     def _populate_env_in_manifest(self):
         """
@@ -511,6 +512,18 @@ class KubernetesWorkerJobConfiguration(BaseJobConfiguration):
             if not generate_name:
                 generate_name = "prefect-job"
             self.job_manifest["metadata"]["generateName"] = f"{generate_name}-"
+
+    def _propagate_labels_to_pod(self):
+        """Propagates Prefect-specific labels to the pod in the job manifest."""
+        current_pod_metadata = self.job_manifest["spec"]["template"].get("metadata", {})
+        current_pod_labels = current_pod_metadata.get("labels", {})
+        all_labels = {**current_pod_labels, **self.labels}
+
+        current_pod_metadata["labels"] = {
+            _slugify_label_key(k): _slugify_label_value(v)
+            for k, v in all_labels.items()
+        }
+        self.job_manifest["spec"]["template"]["metadata"] = current_pod_metadata
 
 
 class KubernetesWorkerVariables(BaseVariables):

--- a/src/integrations/prefect-kubernetes/tests/test_worker.py
+++ b/src/integrations/prefect-kubernetes/tests/test_worker.py
@@ -296,6 +296,19 @@ from_template_and_values_cases = [
                 "spec": {
                     "backoffLimit": 0,
                     "template": {
+                        "metadata": {
+                            "labels": {
+                                "prefect.io/flow-run-id": str(flow_run.id),
+                                "prefect.io/flow-run-name": flow_run.name,
+                                "prefect.io/version": _slugify_label_value(
+                                    prefect.__version__.split("+")[0]
+                                ),
+                                "prefect.io/deployment-id": str(deployment.id),
+                                "prefect.io/deployment-name": deployment.name,
+                                "prefect.io/flow-id": str(flow.id),
+                                "prefect.io/flow-name": flow.name,
+                            },
+                        },
                         "spec": {
                             "parallelism": 1,
                             "completions": 1,
@@ -326,7 +339,7 @@ from_template_and_values_cases = [
                                     ],
                                 }
                             ],
-                        }
+                        },
                     },
                 },
             },
@@ -581,6 +594,19 @@ from_template_and_values_cases = [
                 "spec": {
                     "backoffLimit": 0,
                     "template": {
+                        "metadata": {
+                            "labels": {
+                                "prefect.io/flow-run-id": str(flow_run.id),
+                                "prefect.io/flow-run-name": flow_run.name,
+                                "prefect.io/version": _slugify_label_value(
+                                    prefect.__version__.split("+")[0]
+                                ),
+                                "prefect.io/deployment-id": str(deployment.id),
+                                "prefect.io/deployment-name": deployment.name,
+                                "prefect.io/flow-id": str(flow.id),
+                                "prefect.io/flow-name": flow.name,
+                            },
+                        },
                         "spec": {
                             "parallelism": 1,
                             "completions": 1,
@@ -620,7 +646,7 @@ from_template_and_values_cases = [
                                     ],
                                 }
                             ],
-                        }
+                        },
                     },
                 },
             },
@@ -742,6 +768,20 @@ from_template_and_values_cases = [
                     "backoffLimit": 0,
                     "ttlSecondsAfterFinished": 60,
                     "template": {
+                        "metadata": {
+                            "labels": {
+                                "prefect.io/flow-run-id": str(flow_run.id),
+                                "prefect.io/flow-run-name": flow_run.name,
+                                "prefect.io/version": _slugify_label_value(
+                                    prefect.__version__.split("+")[0]
+                                ),
+                                "prefect.io/deployment-id": str(deployment.id),
+                                "prefect.io/deployment-name": deployment.name,
+                                "prefect.io/flow-id": str(flow.id),
+                                "prefect.io/flow-name": flow.name,
+                                "test_label": "test-label",
+                            },
+                        },
                         "spec": {
                             "parallelism": 1,
                             "completions": 1,
@@ -773,7 +813,7 @@ from_template_and_values_cases = [
                                     "args": ["echo", "hello"],
                                 }
                             ],
-                        }
+                        },
                     },
                 },
             },
@@ -797,6 +837,12 @@ from_template_and_values_cases = [
                     "kind": "Job",
                     "spec": {
                         "template": {
+                            "metadata": {
+                                "other_metadata": "other-metadata",
+                                "labels": {
+                                    "label_from_template": "label-from-template",
+                                },
+                            },
                             "spec": {
                                 "parallelism": 1,
                                 "completions": 1,
@@ -813,7 +859,7 @@ from_template_and_values_cases = [
                                         },
                                     }
                                 ],
-                            }
+                            },
                         }
                     },
                 },
@@ -951,6 +997,12 @@ from_template_and_values_cases = [
                 "kind": "Job",
                 "spec": {
                     "template": {
+                        "metadata": {
+                            "other_metadata": "other-metadata",
+                            "labels": {
+                                "label_from_template": "label-from-template",
+                            },
+                        },
                         "spec": {
                             "parallelism": 1,
                             "completions": 1,
@@ -971,7 +1023,7 @@ from_template_and_values_cases = [
                                     },
                                 },
                             ],
-                        }
+                        },
                     }
                 },
             },
@@ -1020,6 +1072,22 @@ from_template_and_values_cases = [
                 },
                 "spec": {
                     "template": {
+                        "metadata": {
+                            "other_metadata": "other-metadata",
+                            "labels": {
+                                "prefect.io/flow-run-id": str(flow_run.id),
+                                "prefect.io/flow-run-name": flow_run.name,
+                                "prefect.io/version": _slugify_label_value(
+                                    prefect.__version__.split("+")[0]
+                                ),
+                                "prefect.io/deployment-id": str(deployment.id),
+                                "prefect.io/deployment-name": deployment.name,
+                                "prefect.io/flow-id": str(flow.id),
+                                "prefect.io/flow-name": flow.name,
+                                "test_label": "test-label",
+                                "label_from_template": "label-from-template",
+                            },
+                        },
                         "spec": {
                             "parallelism": 1,
                             "completions": 1,
@@ -1058,7 +1126,7 @@ from_template_and_values_cases = [
                                     },
                                 }
                             ],
-                        }
+                        },
                     }
                 },
             },


### PR DESCRIPTION
This PR adds Prefect labels to job pods created for flow runs. This allows us to efficiently watch pods by querying for pods with the `prefect.io/flow-run-id` label.