### PR TITLE
docs(ray): update ray url

### DIFF
--- a/docs/integrations/prefect-ray/index.mdx
+++ b/docs/integrations/prefect-ray/index.mdx
@@ -90,7 +90,7 @@ def my_flow():
     ...
 ```
 
-This flow uses the `RayTaskRunner` configured to access an existing Ray instance at `ray://192.0.2.255:8786`.
+This flow uses the `RayTaskRunner` configured to access an existing Ray instance at `ray://<head_node_host>:10001`.
 
 ```python
 from prefect import flow
@@ -98,7 +98,7 @@ from prefect_ray.task_runners import RayTaskRunner
 
 @flow(
     task_runner=RayTaskRunner(
-        address="ray://192.0.2.255:8786",
+        address="ray://<head_node_host>:10001",
         init_kwargs={"runtime_env": {"pip": ["prefect-ray"]}},
     )
 )

--- a/src/integrations/prefect-ray/prefect_ray/task_runners.py
+++ b/src/integrations/prefect-ray/prefect_ray/task_runners.py
@@ -206,7 +206,7 @@ class RayTaskRunner(TaskRunner[PrefectRayFuture[R]]):
         ```
         Connecting to an existing ray instance:
         ```python
-        RayTaskRunner(address="ray://192.0.2.255:8786")
+        RayTaskRunner(address="ray://<head_node_host>:10001")
         ```
     """
 


### PR DESCRIPTION
Just a small change, update Ray URL based on Ray document https://docs.ray.io/en/latest/ray-core/configure.html#head-node

![image](https://github.com/user-attachments/assets/bce37e75-eacc-40f3-8270-07ef3857c4ca)

[Daft document](https://www.getdaft.io/projects/docs/en/stable/integrations/ray/?h=ray#ray-client) is also using `ray://<head_node_host>:10001` which I think makes sense to use for Prefect as well. 😃