### PR TITLE
Fix `serve` deployment name truncation

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1046,7 +1046,7 @@ class Flow(Generic[P, R]):
         if not name:
             name = self.name
         else:
-            # Only strip extension if it looks like a file path
+            # Only strip extension if it is a file path
             if (p := Path(name)).is_file():
                 name = p.stem
 

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -1046,10 +1046,9 @@ class Flow(Generic[P, R]):
         if not name:
             name = self.name
         else:
-            # Handling for my_flow.serve(__file__)
-            # Will set name to name of file where my_flow.serve() without the extension
-            # Non filepath strings will pass through unchanged
-            name = Path(name).stem
+            # Only strip extension if it looks like a file path
+            if (p := Path(name)).is_file():
+                name = p.stem
 
         runner = Runner(name=name, pause_on_shutdown=pause_on_shutdown, limit=limit)
         deployment_id = runner.add_flow(

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -4492,6 +4492,25 @@ class TestFlowServe:
             name="test", pause_on_shutdown=ANY, limit=limit
         )
 
+    def test_serve_does_not_strip_non_file_path_names(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """this is a regression test for https://github.com/PrefectHQ/prefect/issues/17446
+
+        Test that names like semantic version numbers in deployment names are preserved."""
+
+        captured_name = None
+
+        def mock_add_flow(*args, name=None, **kwargs):
+            nonlocal captured_name
+            captured_name = name
+            return uuid.uuid4()
+
+        monkeypatch.setattr("prefect.runner.Runner.add_flow", mock_add_flow)
+
+        self.flow.serve("etl-0.0.5")
+        assert captured_name == "etl-0.0.5"
+
 
 class MockStorage:
     """

--- a/uv.lock
+++ b/uv.lock
@@ -4059,7 +4059,7 @@ dependencies = [
 requires-dist = [
     { name = "exceptiongroup" },
     { name = "kubernetes-asyncio", specifier = ">=32.0.0" },
-    { name = "prefect", directory = "." },
+    { name = "prefect", editable = "." },
     { name = "pyopenssl", specifier = ">=24.1.0" },
     { name = "tenacity", specifier = ">=8.2.3" },
 ]


### PR DESCRIPTION
closes #17446 

fixes condition that was too broadly treating strings containing dots (like semantic versions) as file extensions and stripping them