### PR TITLE
add overloads for `run_task`

### DIFF
--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -24,6 +24,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    overload,
 )
 from uuid import UUID
 
@@ -1525,6 +1526,32 @@ async def run_generator_task_async(
     # async generators can't return, but we can raise failures here
     if engine.state.is_failed():
         await engine.result()
+
+
+@overload
+def run_task(
+    task: "Task[P, R]",
+    task_run_id: Optional[UUID] = None,
+    task_run: Optional[TaskRun] = None,
+    parameters: Optional[dict[str, Any]] = None,
+    wait_for: Optional["OneOrManyFutureOrResult[Any]"] = None,
+    return_type: Literal["state"] = "state",
+    dependencies: Optional[dict[str, set[TaskRunInput]]] = None,
+    context: Optional[dict[str, Any]] = None,
+) -> State[R]: ...
+
+
+@overload
+def run_task(
+    task: "Task[P, R]",
+    task_run_id: Optional[UUID] = None,
+    task_run: Optional[TaskRun] = None,
+    parameters: Optional[dict[str, Any]] = None,
+    wait_for: Optional["OneOrManyFutureOrResult[Any]"] = None,
+    return_type: Literal["result"] = "result",
+    dependencies: Optional[dict[str, set[TaskRunInput]]] = None,
+    context: Optional[dict[str, Any]] = None,
+) -> R: ...
 
 
 def run_task(

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1426,6 +1426,8 @@ class Task(Generic[P, R]):
         else:
             return futures
 
+    # Background task methods
+
     def apply_async(
         self,
         args: Optional[tuple[Any, ...]] = None,


### PR DESCRIPTION
in preparation for solving #17388

`wait_for` is going to be tricky because we can't put it in the signature of anything that takes `P.args` and `P.kwargs` without it breaking type safety in the same way `submit` and `map` are currently broken