### PR TITLE
Only log at INFO level for final state

### DIFF
--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -1279,7 +1279,11 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
                 except Exception:
                     # regular exceptions are caught and re-raised to the user
                     raise
-                except (Abort, Pause):
+                except (Abort, Pause) as exc:
+                    if getattr(exc, "state", None):
+                        # we set attribute explicitly because
+                        # internals will have already called the state change API
+                        self.flow_run.state = exc.state
                     raise
                 except GeneratorExit:
                     # Do not capture generator exits as crashes

--- a/src/prefect/flow_runs.py
+++ b/src/prefect/flow_runs.py
@@ -454,7 +454,7 @@ async def suspend_flow_run(
 
     if suspending_current_flow_run:
         # Exit this process so the run can be resubmitted later
-        raise Pause()
+        raise Pause(state=state)
 
 
 @sync_compatible


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/17264

The log _itself_ is pure INFO, regardless of the state that the run is ending it; whether or not a problem occurred should be logged accordingly at other places of the engine.