### PR TITLE
Allow Kubernetes integration tests to run in parallel

### DIFF
--- a/.github/workflows/k8s-integration-tests.yaml
+++ b/.github/workflows/k8s-integration-tests.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Run integration tests
         run: |
           cd src/integrations/prefect-kubernetes/integration_tests
-          uv run pytest -n auto --max-workers 6
+          uv run pytest -n auto --maxprocesses 6
         env:
           PREFECT_API_URL: http://127.0.0.1:4200/api
 

--- a/.github/workflows/k8s-integration-tests.yaml
+++ b/.github/workflows/k8s-integration-tests.yaml
@@ -17,35 +17,34 @@ jobs:
     name: Run Kubernetes Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
-      
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           python-version: "3.12"
           cache-dependency-glob: "src/integrations/prefect-kubernetes/integration_tests/pyproject.toml"
-      
 
       - name: Install dependencies
         run: cd src/integrations/prefect-kubernetes/integration_tests && uv sync --active
-      
+
       - name: Set up Kind cluster
         uses: helm/kind-action@v1.8.0
         with:
           cluster_name: prefect-test
-      
+
       - name: Install kubectl
         uses: azure/setup-kubectl@v4
         with:
-          version: 'latest'
-      
+          version: "latest"
+
       - name: Install krew
         run: |
           (
@@ -71,15 +70,13 @@ jobs:
           prefect server start --analytics-off --host 0.0.0.0 2>&1 > server.log &
           python ./scripts/wait-for-server.py
 
-      
       - name: Run integration tests
         run: |
           cd src/integrations/prefect-kubernetes/integration_tests
-          uv run pytest -s
+          uv run pytest -n auto --max-workers 6
         env:
           PREFECT_API_URL: http://127.0.0.1:4200/api
 
-      
       - name: Delete Kind cluster
         if: always()
         run: |

--- a/src/integrations/prefect-kubernetes/integration_tests/pyproject.toml
+++ b/src/integrations/prefect-kubernetes/integration_tests/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "kubernetes",
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+    "pytest-xdist",
 ]
 
 [build-system]
@@ -22,6 +23,7 @@ prefect-kubernetes = { workspace = true }
 run-integration-tests = "prefect_kubernetes_integration_tests.scenarios.run:main"
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 testpaths = ["src/prefect_kubernetes_integration_tests"]
 python_files = ["test_*.py"]
 addopts = "-v -ra"

--- a/src/integrations/prefect-kubernetes/integration_tests/src/prefect_kubernetes_integration_tests/utils/prefect_core.py
+++ b/src/integrations/prefect-kubernetes/integration_tests/src/prefect_kubernetes_integration_tests/utils/prefect_core.py
@@ -19,24 +19,11 @@ async def create_flow_run(
     source: str,
     entrypoint: str,
     name: str,
-    work_pool_name: str = "k8s-test",
+    work_pool_name: str,
     job_variables: dict[str, Any] | None = None,
     parameters: dict[str, Any] | None = None,
 ) -> FlowRun:
     """Create a flow run from a remote source."""
-    # Create work pool if it doesn't exist
-    subprocess.check_call(
-        [
-            "prefect",
-            "work-pool",
-            "create",
-            work_pool_name,
-            "--type",
-            "kubernetes",
-            "--overwrite",
-        ]
-    )
-
     remote_flow = await flow.from_source(source=source, entrypoint=entrypoint)
     deployment_id = await remote_flow.deploy(
         name=name,


### PR DESCRIPTION
Updates Kubernetes integration test to run in parallel. To support parallel execution, each xdist worker will use its own work pool.