### PR TITLE
Adds checks for events in eviction tests and and handling for race condition

### DIFF
--- a/src/integrations/prefect-kubernetes/integration_tests/src/prefect_kubernetes_integration_tests/utils/k8s.py
+++ b/src/integrations/prefect-kubernetes/integration_tests/src/prefect_kubernetes_integration_tests/utils/k8s.py
@@ -91,8 +91,8 @@ def get_job_name(flow_run_name: str, timeout: int = 60) -> str:
     )
 
 
-def wait_for_pod(job_name: str, timeout: int = 60) -> str:
-    """Wait for a pod matching the job name to be running."""
+def wait_for_pod(job_name: str, phase: str = "Running", timeout: int = 60) -> str:
+    """Wait for a pod matching the job name to be in a given phase."""
     v1 = init_k8s_client()
     start_time = time.time()
 
@@ -112,8 +112,8 @@ def wait_for_pod(job_name: str, timeout: int = 60) -> str:
                 )
 
                 for pod in sorted_pods:
-                    if pod.status.phase == "Running":
-                        console.log(f"[green]Found running pod: {pod.metadata.name}")
+                    if pod.status.phase == phase:
+                        console.log(f"[green]Found pod: {pod.metadata.name}")
                         return pod.metadata.name
 
             except client.ApiException as e:


### PR DESCRIPTION
This PR adds additional event checks to ensure the operator correctly emits events in eviction scenarios.

This PR also adds handling for a race condition where the worker might mark a flow run as crashed if the pod disappears too soon. To handle that, the worker will check if the flow run has been rescheduled before saying that it should be marked as crashed. This fixes a flake we've been seeing in the integration tests.
