### PR TITLE
show correct url upon `prefect server start`

### DIFF
--- a/tests/cli/test_start_server.py
+++ b/tests/cli/test_start_server.py
@@ -106,6 +106,15 @@ async def start_server_process() -> AsyncIterator[Process]:
 
 
 class TestBackgroundServer:
+    @pytest.fixture(autouse=True)
+    def temporary_profiles_path(self, tmp_path: Path):
+        path = tmp_path / "profiles.toml"
+        with temporary_settings({PREFECT_PROFILES_PATH: path}):
+            save_profiles(
+                profiles=ProfilesCollection(profiles=[get_settings_context().profile])
+            )
+            yield path
+
     def test_start_and_stop_background_server(self, unused_tcp_port: int):
         invoke_and_assert(
             command=[


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/17456

```python
» prefect config set PREFECT_API_URL=https://tunnel.mydomain.dev/api
Set 'PREFECT_API_URL' to 'https://tunnel.mydomain.dev/api'.
Updated profile 'local'.

» prefect server start

 ___ ___ ___ ___ ___ ___ _____
| _ \ _ \ __| __| __/ __|_   _|
|  _/   / _|| _|| _| (__  | |
|_| |_|_\___|_| |___\___| |_|

Configure Prefect to communicate with the server with:

    prefect config set PREFECT_API_URL=https://tunnel.mydomain.dev/api

View the API reference documentation at https://tunnel.mydomain.dev/docs

Check out the dashboard at https://tunnel.mydomain.dev
```