### PR TITLE
[Docs] Move Modal tutorial to the Dynamic infrastructure examples section

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -1438,6 +1438,10 @@
       "source": "/v3/manage/cloud/terraform-provider"
     },
     {
+      "destination": "/v3/deploy/infrastructure-examples/modal",
+      "source": "/v3/tutorials/modal"
+    },
+    {
       "destination": "/v3/api-ref/python",
       "source": "/latest/api-ref/prefect/:slug*"
     },

--- a/docs/v3/deploy/infrastructure-concepts/work-pools.mdx
+++ b/docs/v3/deploy/infrastructure-concepts/work-pools.mdx
@@ -168,7 +168,7 @@ The following work pool types are supported by Prefect:
     | Google Cloud Run - Push              | Execute flow runs within containers on Google Cloud Run. Requires a Google Cloud Platform account. Flow runs are pushed directly to your environment, without the need for a Prefect worker.  |
     | AWS Elastic Container Service - Push | Execute flow runs within containers on AWS ECS. Works with existing ECS clusters and serverless execution through AWS Fargate. Requires an AWS account. Flow runs are pushed directly to your environment, without the need for a Prefect worker.   |
     | Azure Container Instances - Push     | Execute flow runs within containers on Azure's Container Instances service. Requires an Azure account. Flow runs are pushed directly to your environment, without the need for a Prefect worker.    |
-    | Modal - Push                         | Execute flow runs on Modal. Requires a Modal account. Flow runs are pushed directly to your Modal workspace, without the need for a Prefect worker. Learn more [here](/v3/tutorials/modal)  |
+    | Modal - Push                         | Execute [flow runs on Modal](/v3/deploy/infrastructure-examples/modal). Requires a Modal account. Flow runs are pushed directly to your Modal workspace, without the need for a Prefect worker.  |
     | Coiled                               | Execute flow runs in the cloud platform of your choice with Coiled.  Makes it easy to run in your account without setting up Kubernetes or other cloud infrastructure.  | 
     | Prefect Managed                      | Execute flow runs within containers on Prefect managed infrastructure.                                                      |
   </Tab>

--- a/docs/v3/deploy/infrastructure-examples/modal.mdx
+++ b/docs/v3/deploy/infrastructure-examples/modal.mdx
@@ -1,5 +1,5 @@
 ---
-title: Schedule Prefect deployments to run on Modal
+title: Run flows on Modal
 description: Learn how to use Modal as a push work pool to schedule, run, and debug your Prefect flows
 ---
 

--- a/docs/v3/deploy/infrastructure-examples/serverless.mdx
+++ b/docs/v3/deploy/infrastructure-examples/serverless.mdx
@@ -149,8 +149,6 @@ To use automatic infrastructure provisioning, you need:
   </Tab>
   <Tab title="Modal">
 
-    See a fully runnable tutorial [here](/v3/tutorials/modal)
-
     Install `modal` by running:
 
     ```bash
@@ -162,6 +160,8 @@ To use automatic infrastructure provisioning, you need:
     ```bash
     modal token new
     ```
+
+    See [Run flows on Modal](/v3/deploy/infrastructure-examples/modal) for more details.
   </Tab>
   <Tab title="Coiled">
 

--- a/docs/v3/get-started/index.mdx
+++ b/docs/v3/get-started/index.mdx
@@ -54,9 +54,6 @@ Prefect is an open-source orchestration engine that turns your Python functions 
   <Card title="Send alerts on failure" icon="bell" href="/v3/tutorials/alerts">
     Set up an email alert to notify your teams about failures.
   </Card>
-  <Card title="Schedule deployments to run on Modal" icon="bell" href="/v3/tutorials/modal">
-     Use Modal as a push-pool to schedule, run, and debug your prefect flows
-  </Card>
 </CardGroup>
 
 ## Start building


### PR DESCRIPTION
Let's move the Modal tutorial to the same section as the other dynamic infra examples (for example, Coiled).

### Checklist

- [ ] ~This pull request references any related issue by including "closes `<link to issue>`"~
- [ ] ~If this pull request adds new functionality, it includes unit tests that cover the changes~
- [ ] ~If this pull request removes docs files, it includes redirect settings in `mint.json`.~
- [ ] ~If this pull request adds functions or classes, it includes helpful docstrings.~
