### PR TITLE
[Docs] Remove dangling tutorial references

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -79,9 +79,7 @@
           "pages": [
             "v3/tutorials/platform",
             "v3/tutorials/debug",
-            "v3/tutorials/alerts",
-            "v3/tutorials/modal",
-            "v3/tutorials/server-and-worker"
+            "v3/tutorials/alerts"
           ]
         }
       ],

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -1453,6 +1453,10 @@
       "source": "/v3/tutorials/modal"
     },
     {
+      "destination": "/v3/manage/server/examples/helm",
+      "source": "/v3/tutorials/server-and-worker"
+    },
+    {
       "destination": "/v3/api-ref/python",
       "source": "/latest/api-ref/prefect/:slug*"
     },


### PR DESCRIPTION
I forgot to remove the old entries in the tutorials section, and I missed a redirect for the Helm tutorial too. This fixes both issues.

### Checklist

- [ ] ~This pull request references any related issue by including "closes `<link to issue>`"~
- [ ] ~If this pull request adds new functionality, it includes unit tests that cover the changes~
- [ ] ~If this pull request removes docs files, it includes redirect settings in `mint.json`.~
- [ ] ~If this pull request adds functions or classes, it includes helpful docstrings.~
