### PR TITLE
Ensure base `prefect.yaml` template is included in built package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ prefect.yaml
 
 # Deployment recipes
 !src/prefect/deployments/recipes/*/**
+!src/prefect/deployments/templates/prefect.yaml
 
 # For development doc server if link
 libcairo.2.dylib


### PR DESCRIPTION
There's a `prefect.yaml` file in `.gitignore` which causes the base `prefect.yaml` to not be included in the sdist. This PR explicitly includes the base `prefect.yaml` to make sure it's included in the sdist and wheel.

Closes https://github.com/PrefectHQ/prefect/issues/17377