### PR TITLE
[UI v2] fix: Fixes Artifacts table hydration warnings

### DIFF
--- a/ui-v2/src/components/artifacts/artifact/artifact-detail-page.test.tsx
+++ b/ui-v2/src/components/artifacts/artifact/artifact-detail-page.test.tsx
@@ -6,7 +6,7 @@ import {
 	createRootRoute,
 	createRouter,
 } from "@tanstack/react-router";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { createWrapper } from "@tests/utils";
 import { describe, expect, it } from "vitest";
 import {
@@ -37,14 +37,11 @@ describe("ArtifactDetailPage", () => {
 			data: "# Title\n\nThis is a test markdown",
 		});
 
-		const { getByTestId } = render(
-			<ArtifactDetailPageRouter artifact={artifact} />,
-			{
-				wrapper: createWrapper(),
-			},
-		);
+		render(<ArtifactDetailPageRouter artifact={artifact} />, {
+			wrapper: createWrapper(),
+		});
 
-		expect(getByTestId("markdown-display")).toBeTruthy();
+		expect(screen.getByTestId("markdown-display")).toBeTruthy();
 	});
 
 	it("renders artifact detail for image", () => {
@@ -54,14 +51,11 @@ describe("ArtifactDetailPage", () => {
 			data: url,
 		});
 
-		const { getByTestId } = render(
-			<ArtifactDetailPageRouter artifact={artifact} />,
-			{
-				wrapper: createWrapper(),
-			},
-		);
+		render(<ArtifactDetailPageRouter artifact={artifact} />, {
+			wrapper: createWrapper(),
+		});
 
-		expect(getByTestId(url)).toBeTruthy();
+		expect(screen.getByTestId(url)).toBeTruthy();
 	});
 
 	it("renders artifact detail for progress", () => {
@@ -70,14 +64,11 @@ describe("ArtifactDetailPage", () => {
 			data: 50,
 		});
 
-		const { getByTestId } = render(
-			<ArtifactDetailPageRouter artifact={artifact} />,
-			{
-				wrapper: createWrapper(),
-			},
-		);
+		render(<ArtifactDetailPageRouter artifact={artifact} />, {
+			wrapper: createWrapper(),
+		});
 
-		expect(getByTestId("progress-display")).toBeTruthy();
+		expect(screen.getByTestId("progress-display")).toBeTruthy();
 	});
 
 	it("renders artifact detail for table with data", () => {
@@ -89,14 +80,11 @@ describe("ArtifactDetailPage", () => {
 			]),
 		});
 
-		const { getByTestId } = render(
-			<ArtifactDetailPageRouter artifact={artifact} />,
-			{
-				wrapper: createWrapper(),
-			},
-		);
+		render(<ArtifactDetailPageRouter artifact={artifact} />, {
+			wrapper: createWrapper(),
+		});
 
-		expect(getByTestId("table-display")).toBeTruthy();
+		expect(screen.getByTestId("table-display")).toBeTruthy();
 	});
 
 	it("renders artifact detail for link as markdown", () => {
@@ -105,13 +93,10 @@ describe("ArtifactDetailPage", () => {
 			data: "[test](https://example.com)",
 		});
 
-		const { getByTestId } = render(
-			<ArtifactDetailPageRouter artifact={artifact} />,
-			{
-				wrapper: createWrapper(),
-			},
-		);
+		render(<ArtifactDetailPageRouter artifact={artifact} />, {
+			wrapper: createWrapper(),
+		});
 
-		expect(getByTestId("markdown-display")).toBeTruthy();
+		expect(screen.getByTestId("markdown-display")).toBeTruthy();
 	});
 });

--- a/ui-v2/src/components/artifacts/artifact/detail-table.tsx
+++ b/ui-v2/src/components/artifacts/artifact/detail-table.tsx
@@ -1,6 +1,7 @@
 import { SearchInput } from "@/components/ui/input";
 import {
 	Table,
+	TableBody,
 	TableCell,
 	TableHead,
 	TableHeader,
@@ -39,23 +40,27 @@ export const DetailTable = ({ tableData }: DetailTableProps) => {
 			<div className="rounded-md border">
 				<Table>
 					<TableHeader className="bg-gray-100">
-						{headers.map((header, index) => {
+						<TableRow>
+							{headers.map((header, index) => {
+								return (
+									<TableHead key={index} className="py-2 text-black">
+										{header}
+									</TableHead>
+								);
+							})}
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{filteredTable.map((row, index) => {
 							return (
-								<TableHead key={index} className="py-2 text-black">
-									{header}
-								</TableHead>
+								<TableRow key={index}>
+									{headers.map((header, index) => {
+										return <TableCell key={index}>{row[header]}</TableCell>;
+									})}
+								</TableRow>
 							);
 						})}
-					</TableHeader>
-					{filteredTable.map((row, index) => {
-						return (
-							<TableRow key={index}>
-								{headers.map((header, index) => {
-									return <TableCell key={index}>{row[header]}</TableCell>;
-								})}
-							</TableRow>
-						);
-					})}
+					</TableBody>
 				</Table>
 			</div>
 		</div>


### PR DESCRIPTION
This PR adds the correct table components for the artifact table component. This PR also updates the test to use `screen` queries instead of render based on the updated [docs](https://testing-library.com/docs/queries/about/)

Was getting an error in tests and console saying:
```
stderr | src/components/artifacts/artifact/artifact-detail-page.test.tsx > ArtifactDetailPage > renders artifact detail for table with data
In HTML, <th> cannot be a child of <thead>.
This will cause a hydration error.

  ...
    <SafeFragment fallback={null}>
      <SafeFragment getResetKey={function getResetKey} errorComponent={function ErrorComponent} ...>
        <SafeFragment fallback={function fallback}>
          <MatchInnerImpl matchId="__root__">
            <component>
              <ArtifactDetailPage artifact={{id:"3cf11a...", ...}}>
                <div>
                  <ArtifactDetailHeader>
                  <DetailTable tableData={"[{\"key\..."}>
                    <div data-testid="table-display" className="mt-4">
                      <div>
                      <div className="rounded-md...">
                        <Table>
                          <div data-slot="table-cont..." className="relative w...">
                            <table data-slot="table" className="w-full cap...">
                              <TableHeader className="bg-gray-100">
>                               <thead data-slot="table-header" className={"[&_tr]:border-b bg-gray-100"}>
                                  <TableHead className="py-2 text-...">
>                                   <th
>                                     data-slot="table-head"
>                                     className={"h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:h..."}
>                                   >
                                  ...
                              ...
                  ...

In HTML, <tr> cannot be a child of <table>. Add a <tbody>, <thead> or <tfoot> to your code to match the DOM tree generated by the browser.
This will cause a hydration error.

  ...
    <CatchBoundaryImpl getResetKey={function getResetKey} onCatch={function onCatch}>
      <MatchImpl matchId="__root__">
        <SafeFragment fallback={null}>
          <SafeFragment getResetKey={function getResetKey} errorComponent={function ErrorComponent} ...>
            <SafeFragment fallback={function fallback}>
              <MatchInnerImpl matchId="__root__">
                <component>
                  <ArtifactDetailPage artifact={{id:"3cf11a...", ...}}>
                    <div>
                      <ArtifactDetailHeader>
                      <DetailTable tableData={"[{\"key\..."}>
                        <div data-testid="table-display" className="mt-4">
                          <div>
                          <div className="rounded-md...">
                            <Table>
                              <div data-slot="table-cont..." className="relative w...">
>                               <table data-slot="table" className="w-full caption-bottom text-sm">
                                  <TableHeader>
                                  <TableRow>
>                                   <tr
>                                     data-slot="table-row"
>                                     className="hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-..."
>                                   >
                                  ...
                      ...
```
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
