### PR TITLE
Adds new setting `PREFECT_TASKS_DEFAULT_NO_CACHE` to not cache by default

### DIFF
--- a/docs/v3/develop/settings-ref.mdx
+++ b/docs/v3/develop/settings-ref.mdx
@@ -2376,6 +2376,18 @@ If `True`, enables a refresh of cached results: re-executing the task will refre
 **Supported environment variables**:
 `PREFECT_TASKS_REFRESH_CACHE`
 
+### `default_no_cache`
+If `True`, sets the default cache policy on all tasks to `NO_CACHE`.
+
+**Type**: `boolean`
+
+**Default**: `False`
+
+**TOML dotted key path**: `tasks.default_no_cache`
+
+**Supported environment variables**:
+`PREFECT_TASKS_DEFAULT_NO_CACHE`
+
 ### `default_retries`
 This value sets the default number of retries for all tasks.
 

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -2142,6 +2142,15 @@
                     "title": "Refresh Cache",
                     "type": "boolean"
                 },
+                "default_no_cache": {
+                    "default": false,
+                    "description": "If `True`, sets the default cache policy on all tasks to `NO_CACHE`.",
+                    "supported_environment_variables": [
+                        "PREFECT_TASKS_DEFAULT_NO_CACHE"
+                    ],
+                    "title": "Default No Cache",
+                    "type": "boolean"
+                },
                 "default_retries": {
                     "default": 0,
                     "description": "This value sets the default number of retries for all tasks.",

--- a/src/prefect/settings/models/tasks.py
+++ b/src/prefect/settings/models/tasks.py
@@ -57,6 +57,11 @@ class TasksSettings(PrefectBaseSettings):
         description="If `True`, enables a refresh of cached results: re-executing the task will refresh the cached results.",
     )
 
+    default_no_cache: bool = Field(
+        default=False,
+        description="If `True`, sets the default cache policy on all tasks to `NO_CACHE`.",
+    )
+
     default_retries: int = Field(
         default=0,
         ge=0,

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -463,7 +463,7 @@ class Task(Generic[P, R]):
                 )
         elif cache_policy is NotSet and result_storage_key is None:
             self.cache_policy = DEFAULT
-        elif result_storage_key:
+        elif cache_policy != NO_CACHE and result_storage_key:
             # TODO: handle this situation with double storage
             self.cache_policy = None
         else:

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -422,6 +422,11 @@ class Task(Generic[P, R]):
 
         self.task_key: str = _generate_task_key(self.fn)
 
+        # determine cache and result configuration
+        settings = get_current_settings()
+        if settings.tasks.default_no_cache and cache_policy is NotSet:
+            cache_policy = NO_CACHE
+
         if cache_policy is not NotSet and cache_key_fn is not None:
             logger.warning(
                 f"Both `cache_policy` and `cache_key_fn` are set on task {self}. `cache_key_fn` will be used."
@@ -468,7 +473,6 @@ class Task(Generic[P, R]):
         # TODO: We can instantiate a `TaskRunPolicy` and add Pydantic bound checks to
         #       validate that the user passes positive numbers here
 
-        settings = get_current_settings()
         self.retries: int = (
             retries if retries is not None else settings.tasks.default_retries
         )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -423,6 +423,7 @@ SUPPORTED_SETTINGS = {
     "PREFECT_SILENCE_API_URL_MISCONFIGURATION": {"test_value": True},
     "PREFECT_SQLALCHEMY_MAX_OVERFLOW": {"test_value": 10, "legacy": True},
     "PREFECT_SQLALCHEMY_POOL_SIZE": {"test_value": 10, "legacy": True},
+    "PREFECT_TASKS_DEFAULT_NO_CACHE": {"test_value": True},
     "PREFECT_TASKS_DEFAULT_PERSIST_RESULT": {"test_value": True},
     "PREFECT_TASKS_DEFAULT_RETRIES": {"test_value": 10},
     "PREFECT_TASKS_DEFAULT_RETRY_DELAY_SECONDS": {"test_value": 10},

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1882,6 +1882,14 @@ class TestTaskCaching:
 
         assert foo.cache_policy == NO_CACHE
 
+        with temporary_settings({PREFECT_TASKS_DEFAULT_NO_CACHE: True}):
+
+            @task(result_storage_key="foo-bar")
+            def zig(x):
+                return x
+
+        assert zig.cache_policy == NO_CACHE
+
     @pytest.mark.parametrize("cache_policy", [NO_CACHE, None])
     async def test_does_not_warn_went_false_persist_result_and_none_cache_policy(
         self, caplog, cache_policy

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -53,6 +53,7 @@ from prefect.settings import (
     PREFECT_DEBUG_MODE,
     PREFECT_LOCAL_STORAGE_PATH,
     PREFECT_TASK_DEFAULT_RETRIES,
+    PREFECT_TASKS_DEFAULT_NO_CACHE,
     PREFECT_TASKS_REFRESH_CACHE,
     PREFECT_UI_URL,
     temporary_settings,
@@ -1848,6 +1849,38 @@ class TestTaskCaching:
         assert (
             "Ignoring `cache_policy` because `persist_result` is False" in caplog.text
         )
+
+    async def test_no_cache_can_be_configured_as_default(self):
+        with temporary_settings({PREFECT_TASKS_DEFAULT_NO_CACHE: True}):
+
+            @task
+            def foo(x):
+                return x
+
+        assert foo.cache_policy == NO_CACHE
+
+    async def test_no_cache_default_can_be_overrided(self):
+        with temporary_settings({PREFECT_TASKS_DEFAULT_NO_CACHE: True}):
+
+            @task(cache_policy=DEFAULT)
+            def foo(x):
+                return x
+
+            @task(cache_key_fn=lambda **kwargs: "")
+            def bar(x):
+                return x
+
+        assert foo.cache_policy == DEFAULT
+        assert bar.cache_policy != NO_CACHE
+
+    async def test_no_cache_default_is_respected_even_with_result_persistence(self):
+        with temporary_settings({PREFECT_TASKS_DEFAULT_NO_CACHE: True}):
+
+            @task(persist_result=True)
+            def foo(x):
+                return x
+
+        assert foo.cache_policy == NO_CACHE
 
     @pytest.mark.parametrize("cache_policy", [NO_CACHE, None])
     async def test_does_not_warn_went_false_persist_result_and_none_cache_policy(


### PR DESCRIPTION
Adds a new setting that, when enabled, will set the default cache policy on tasks to `NO_CACHE`. Note that this _can_ be overwritten by explicitly providing a cache policy or cache key function so this is **not** equivalent to a full disabling of caching behavior.

Closes https://github.com/PrefectHQ/prefect/issues/17369