### PR TITLE
fix(templating): deserialize block as dictionary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prefect"
-dynamic = ["version"]
+version = "3.2.9-dev"
 description = "Workflow orchestration and management."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/prefect/utilities/templating.py
+++ b/src/prefect/utilities/templating.py
@@ -13,6 +13,7 @@ from typing import (
     cast,
     overload,
 )
+import json
 
 from prefect.client.utilities import inject_client
 from prefect.logging.loggers import get_logger
@@ -360,6 +361,13 @@ async def resolve_block_document_references(
 
             # resolving keypath/block attributes
             if value_keypath:
+                try:  # try to parse the data as json
+                    data = json.loads(data)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Cannot parse block document data as JSON, use as is."
+                    )
+
                 from_dict: Any = get_from_dict(data, value_keypath[0], default=NotSet)
                 if from_dict is NotSet:
                     raise ValueError(

--- a/tests/utilities/test_templating.py
+++ b/tests/utilities/test_templating.py
@@ -1,5 +1,6 @@
 import uuid
 from typing import Any, Dict
+import logging
 
 import pytest
 
@@ -265,6 +266,22 @@ class TestApplyValues:
         apply_values(template, values={}, warn_on_notset=True)
         assert (
             "Value for placeholder 'name' not found in provided values." in caplog.text
+        )
+
+    def test_apply_values_with_invalid_json_string(self, caplog):
+        # Test that a warning is logged when trying to parse invalid JSON
+        template = "{{ prefect.variables.invalid_json }}"
+        values = {"prefect.variables.invalid_json": "{not valid json}"}
+
+        with caplog.at_level(logging.WARNING):
+            result = apply_values(template, values)
+
+        # Verify the result is the string as-is since it couldn't be parsed as JSON
+        assert result == "{not valid json}"
+        # Verify a warning was logged
+        assert any(
+            "Failed to parse value as JSON" in record.message
+            for record in caplog.records
         )
 
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
When resolving templated YAML, Prefect deserializes them as strings. This behavior is not correct for all cases, especially when extracting a key-value pair from a dictionary.

This PR adds an option to resolve it.

Closes #17492 

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
