### PR TITLE
[UI v2] feat: Adds BlockDocumentActionMenu component

### DIFF
--- a/ui-v2/src/components/blocks/block-document-action-menu/block-document-action-menu.stories.tsx
+++ b/ui-v2/src/components/blocks/block-document-action-menu/block-document-action-menu.stories.tsx
@@ -1,0 +1,19 @@
+import { createFakeBlockDocument } from "@/mocks";
+import { routerDecorator, toastDecorator } from "@/storybook/utils";
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+import { BlockDocumentActionMenu } from "./block-document-action-menu";
+
+const meta = {
+	title: "Components/Blocks/BlockDocumentActionMenu",
+	component: BlockDocumentActionMenu,
+	decorators: [toastDecorator, routerDecorator],
+	args: {
+		blockDocument: createFakeBlockDocument(),
+		onDelete: fn(),
+	},
+} satisfies Meta<typeof BlockDocumentActionMenu>;
+
+export default meta;
+
+export const story: StoryObj = { name: "BlockDocumentActionMenu" };

--- a/ui-v2/src/components/blocks/block-document-action-menu/block-document-action-menu.test.tsx
+++ b/ui-v2/src/components/blocks/block-document-action-menu/block-document-action-menu.test.tsx
@@ -1,0 +1,107 @@
+import { Toaster } from "@/components/ui/sonner";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { createFakeBlockDocument } from "@/mocks";
+import { QueryClient } from "@tanstack/react-query";
+import {
+	RouterProvider,
+	createMemoryHistory,
+	createRootRoute,
+	createRouter,
+} from "@tanstack/react-router";
+import {
+	BlockDocumentActionMenu,
+	type BlockDocumentActionMenuProps,
+} from "./block-document-action-menu";
+
+describe("BlockDocumentActionMenu", () => {
+	// Wraps component in test with a Tanstack router provider
+	const BlockDocumentActionMenuRouter = (
+		props: BlockDocumentActionMenuProps,
+	) => {
+		const rootRoute = createRootRoute({
+			component: () => <BlockDocumentActionMenu {...props} />,
+		});
+
+		const router = createRouter({
+			routeTree: rootRoute,
+			history: createMemoryHistory({
+				initialEntries: ["/"],
+			}),
+			context: { queryClient: new QueryClient() },
+		});
+		return <RouterProvider router={router} />;
+	};
+
+	it("copies the block document name", async () => {
+		// ------------ Setup
+		const user = userEvent.setup();
+		const mockBlockDocument = createFakeBlockDocument({
+			name: "my-block-document",
+		});
+		render(
+			<>
+				<Toaster />
+				<BlockDocumentActionMenuRouter
+					blockDocument={mockBlockDocument}
+					onDelete={vi.fn()}
+				/>
+			</>,
+		);
+		// ------------ Act
+		await user.click(
+			screen.getByRole("button", { name: /open menu/i, hidden: true }),
+		);
+		await user.click(screen.getByRole("menuitem", { name: "Copy Name" }));
+
+		// ------------ Assert
+		await waitFor(() => {
+			expect(screen.getByText("Copied to clipboard!")).toBeVisible();
+		});
+	});
+
+	it("calls delete option ", async () => {
+		// ------------ Setup
+		const user = userEvent.setup();
+		const mockOnDeleteFn = vi.fn();
+
+		render(
+			<BlockDocumentActionMenuRouter
+				blockDocument={createFakeBlockDocument()}
+				onDelete={mockOnDeleteFn}
+			/>,
+		);
+
+		// ------------ Act
+		await user.click(
+			screen.getByRole("button", { name: /open menu/i, hidden: true }),
+		);
+		await user.click(screen.getByRole("menuitem", { name: /delete/i }));
+
+		// ------------ Assert
+		expect(mockOnDeleteFn).toHaveBeenCalledOnce();
+	});
+
+	it("edit option is visible", async () => {
+		const user = userEvent.setup();
+
+		// ------------ Setup
+		render(
+			<BlockDocumentActionMenuRouter
+				blockDocument={createFakeBlockDocument()}
+				onDelete={vi.fn()}
+			/>,
+		);
+
+		// ------------ Act
+		await user.click(
+			screen.getByRole("button", { name: /open menu/i, hidden: true }),
+		);
+
+		// ------------ Assert
+		expect(screen.getByRole("menuitem", { name: /edit/i })).toBeVisible();
+	});
+});

--- a/ui-v2/src/components/blocks/block-document-action-menu/block-document-action-menu.tsx
+++ b/ui-v2/src/components/blocks/block-document-action-menu/block-document-action-menu.tsx
@@ -1,0 +1,52 @@
+import { BlockDocument } from "@/api/block-documents";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Icon } from "@/components/ui/icons";
+import { Link } from "@tanstack/react-router";
+import { toast } from "sonner";
+
+export type BlockDocumentActionMenuProps = {
+	blockDocument: BlockDocument;
+	onDelete: () => void;
+};
+
+export const BlockDocumentActionMenu = ({
+	blockDocument,
+	onDelete,
+}: BlockDocumentActionMenuProps) => {
+	const handleCopyName = (_name: string) => {
+		void navigator.clipboard.writeText(_name);
+		toast.success("Copied to clipboard!");
+	};
+
+	const { id, name } = blockDocument;
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button variant="outline" className="size-8 p-0">
+					<span className="sr-only">Open menu</span>
+					<Icon id="MoreVertical" className="size-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuLabel>Actions</DropdownMenuLabel>
+				{name && (
+					<DropdownMenuItem onClick={() => handleCopyName(name)}>
+						Copy Name
+					</DropdownMenuItem>
+				)}
+				<Link to="/blocks/block/$id" params={{ id }}>
+					<DropdownMenuItem>Edit</DropdownMenuItem>
+				</Link>
+				<DropdownMenuItem onClick={onDelete}>Delete</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+};

--- a/ui-v2/src/components/blocks/block-document-action-menu/index.ts
+++ b/ui-v2/src/components/blocks/block-document-action-menu/index.ts
@@ -1,0 +1,1 @@
+export { BlockDocumentActionMenu } from "./block-document-action-menu";


### PR DESCRIPTION
Adds BlockDocumentActionMenu component.
This component is used for the `/blocks` and `/blocks/block/$id` routes

https://github.com/user-attachments/assets/19f7ea42-581b-4316-a4d6-dcff18478888


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
