### PR TITLE
Add settings to control observer behavior

### DIFF
--- a/src/integrations/prefect-kubernetes/integration_tests/src/prefect_kubernetes_integration_tests/test_filtering.py
+++ b/src/integrations/prefect-kubernetes/integration_tests/src/prefect_kubernetes_integration_tests/test_filtering.py
@@ -1,0 +1,111 @@
+import asyncio
+import os
+import subprocess
+from typing import Any
+
+import anyio
+import pytest
+
+from prefect import get_client
+from prefect.states import StateType
+from prefect_kubernetes_integration_tests.utils import display, prefect_core
+
+DEFAULT_JOB_VARIABLES: dict[str, Any] = {
+    "image": "prefecthq/prefect:3.2.11-python3.12",
+}
+if os.environ.get("CI", False):
+    DEFAULT_JOB_VARIABLES["env"] = {"PREFECT_API_URL": "http://172.17.0.1:4200/api"}
+
+DEFAULT_PARAMETERS = {"n": 1}
+# Default source is a simple flow that sleeps
+DEFAULT_FLOW_SOURCE = "https://gist.github.com/772d095672484b76da40a4e6158187f0.git"
+DEFAULT_FLOW_ENTRYPOINT = "sleeping.py:sleepy"
+
+
+@pytest.mark.usefixtures("kind_cluster")
+async def test_filter_by_namespace(
+    work_pool_name: str, monkeypatch: pytest.MonkeyPatch
+):
+    """Test that the observer doesn't emit events for flow runs in namespaces that are not watched."""
+    monkeypatch.setenv(
+        "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES",
+        "other-namespace,yet-another-namespace",
+    )
+    flow_run = await prefect_core.create_flow_run(
+        source=DEFAULT_FLOW_SOURCE,
+        entrypoint=DEFAULT_FLOW_ENTRYPOINT,
+        name="filter-by-namespace",
+        work_pool_name=work_pool_name,
+        job_variables=DEFAULT_JOB_VARIABLES,
+        parameters=DEFAULT_PARAMETERS,
+    )
+
+    display.print_flow_run_created(flow_run)
+
+    with subprocess.Popen(
+        ["prefect", "worker", "start", "--pool", work_pool_name],
+    ) as worker_process:
+        try:
+            prefect_core.wait_for_flow_run_state(
+                flow_run.id, StateType.COMPLETED, timeout=30
+            )
+
+            async with get_client() as client:
+                updated_flow_run = await client.read_flow_run(flow_run.id)
+
+            display.print_flow_run_result(updated_flow_run)
+
+            # Collect events while worker is still running
+            events = []
+            with anyio.move_on_after(30):
+                while len(events) < 3:
+                    events = await prefect_core.read_pod_events_for_flow_run(
+                        flow_run.id
+                    )
+                    await asyncio.sleep(1)
+        finally:
+            worker_process.terminate()
+
+    events = await prefect_core.read_pod_events_for_flow_run(flow_run.id)
+    assert len(events) == 0, (
+        f"Expected 0 events, got {len(events)}: {[event.event for event in events]}"
+    )
+
+
+@pytest.mark.usefixtures("kind_cluster")
+async def test_filter_by_label(work_pool_name: str, monkeypatch: pytest.MonkeyPatch):
+    """Test that the observer doesn't emit events for flow runs that don't match the label filter."""
+    monkeypatch.setenv(
+        "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_ADDITIONAL_LABEL_FILTERS",
+        "prefect.io/deployment-id=not-real-deployment-id",
+    )
+    flow_run = await prefect_core.create_flow_run(
+        source=DEFAULT_FLOW_SOURCE,
+        entrypoint=DEFAULT_FLOW_ENTRYPOINT,
+        name="filter-by-label",
+        work_pool_name=work_pool_name,
+        job_variables=DEFAULT_JOB_VARIABLES,
+        parameters=DEFAULT_PARAMETERS,
+    )
+
+    display.print_flow_run_created(flow_run)
+
+    with subprocess.Popen(
+        ["prefect", "worker", "start", "--pool", work_pool_name],
+    ) as worker_process:
+        try:
+            prefect_core.wait_for_flow_run_state(
+                flow_run.id, StateType.COMPLETED, timeout=30
+            )
+
+            async with get_client() as client:
+                updated_flow_run = await client.read_flow_run(flow_run.id)
+
+            display.print_flow_run_result(updated_flow_run)
+        finally:
+            worker_process.terminate()
+
+    events = await prefect_core.read_pod_events_for_flow_run(flow_run.id)
+    assert len(events) == 0, (
+        f"Expected 0 events, got {len(events)}: {[event.event for event in events]}"
+    )

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py
@@ -28,18 +28,12 @@ logging.getLogger("kopf.objects").setLevel(logging.INFO)
 
 settings = KubernetesSettings()
 
-# Convert list of "key=value" label filters into a dictionary
-additional_label_filters: dict[str, str] = {}
-for label in settings.observer.additional_label_filters:
-    key, value = label.split("=")
-    additional_label_filters[key] = value
-
 
 @kopf.on.event(
     "pods",
     labels={
         "prefect.io/flow-run-id": kopf.PRESENT,
-        **additional_label_filters,
+        **settings.observer.additional_label_filters,
     },
 )  # type: ignore
 async def _replicate_pod_event(  # pyright: ignore[reportUnusedFunction]
@@ -166,7 +160,7 @@ async def _get_k8s_jobs(
     "jobs",
     labels={
         "prefect.io/flow-run-id": kopf.PRESENT,
-        **additional_label_filters,
+        **settings.observer.additional_label_filters,
     },
 )  # type: ignore
 async def _mark_flow_run_as_crashed(  # pyright: ignore[reportUnusedFunction]

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/settings.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/settings.py
@@ -5,6 +5,24 @@ from pydantic import AliasChoices, AliasPath, Field
 from prefect.settings.base import PrefectBaseSettings, build_settings_config
 
 
+class KubernetesObserverSettings(PrefectBaseSettings):
+    model_config = build_settings_config(("integrations", "kubernetes", "observer"))
+
+    namespaces: list[str] = Field(
+        default_factory=list,
+        description="The namespaces to watch for Prefect-submitted Kubernetes "
+        "jobs and pods. If not provided, the watch will be cluster-wide.",
+    )
+
+    additional_label_filters: list[str] = Field(
+        default_factory=list,
+        description="Additional label filters to apply to the watch for "
+        "Prefect-submitted Kubernetes jobs and pods. If not provided, the watch will "
+        "include all pods and jobs with the `prefect.io/flow-run-id` label. Labels "
+        "should be provided in the format `key=value`.",
+    )
+
+
 class KubernetesWorkerSettings(PrefectBaseSettings):
     model_config = build_settings_config(("integrations", "kubernetes", "worker"))
 

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/settings.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/settings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 from typing import Annotated, Optional, Union
 

--- a/src/integrations/prefect-kubernetes/tests/test_settings.py
+++ b/src/integrations/prefect-kubernetes/tests/test_settings.py
@@ -1,10 +1,13 @@
+import json
 import os
+from pathlib import Path
 
+import pytest
 import toml
 from prefect_kubernetes.settings import KubernetesSettings
 
 
-def test_set_values_via_environment_variables(monkeypatch):
+def test_set_values_via_environment_variables(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(
         "PREFECT_INTEGRATIONS_KUBERNETES_WORKER_API_KEY_SECRET_NAME", "test-secret"
     )
@@ -26,7 +29,7 @@ def test_set_values_via_environment_variables(monkeypatch):
     assert settings.cluster_uid == "test-cluster-uid"
 
 
-def test_set_values_via_dot_env_file(tmp_path):
+def test_set_values_via_dot_env_file(tmp_path: Path):
     dot_env_path = tmp_path / ".env"
     with open(dot_env_path, "w") as f:
         f.write(
@@ -49,7 +52,7 @@ def test_set_values_via_dot_env_file(tmp_path):
     assert settings.cluster_uid == "test-cluster-uid"
 
 
-def test_set_values_via_prefect_toml_file(tmp_path):
+def test_set_values_via_prefect_toml_file(tmp_path: Path):
     toml_path = tmp_path / "prefect.toml"
     toml_data = {
         "integrations": {
@@ -78,7 +81,7 @@ def test_set_values_via_prefect_toml_file(tmp_path):
     assert settings.cluster_uid == "test-cluster-uid"
 
 
-def test_set_values_via_pyproject_toml_file(tmp_path):
+def test_set_values_via_pyproject_toml_file(tmp_path: Path):
     pyproject_toml_path = tmp_path / "pyproject.toml"
     pyproject_toml_data = {
         "tool": {
@@ -109,3 +112,40 @@ def test_set_values_via_pyproject_toml_file(tmp_path):
     assert settings.worker.create_secret_for_api_key is True
     assert settings.worker.add_tcp_keepalive is False
     assert settings.cluster_uid == "test-cluster-uid"
+
+
+class TestObserverSettings:
+    @pytest.mark.parametrize(
+        "env_var_value",
+        [
+            "key1=value1,key2=value2",
+            json.dumps({"key1": "value1", "key2": "value2"}),
+        ],
+    )
+    def test_additional_label_filters(
+        self, monkeypatch: pytest.MonkeyPatch, env_var_value: str
+    ):
+        monkeypatch.setenv(
+            "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_ADDITIONAL_LABEL_FILTERS",
+            env_var_value,
+        )
+        settings = KubernetesSettings()
+        assert settings.observer.additional_label_filters == {
+            "key1": "value1",
+            "key2": "value2",
+        }
+
+    @pytest.mark.parametrize(
+        "env_var_value",
+        [
+            "namespace1,namespace2",
+            json.dumps(["namespace1", "namespace2"]),
+        ],
+    )
+    def test_namespaces(self, monkeypatch: pytest.MonkeyPatch, env_var_value: str):
+        monkeypatch.setenv(
+            "PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES",
+            env_var_value,
+        )
+        settings = KubernetesSettings()
+        assert settings.observer.namespaces == {"namespace1", "namespace2"}

--- a/src/integrations/prefect-kubernetes/tests/test_worker.py
+++ b/src/integrations/prefect-kubernetes/tests/test_worker.py
@@ -5,6 +5,7 @@ import sys
 import uuid
 from contextlib import asynccontextmanager
 from time import monotonic
+from typing import Any
 from unittest import mock
 from unittest.mock import ANY, AsyncMock, MagicMock
 
@@ -43,6 +44,7 @@ from prefect.settings import (
     get_current_settings,
     temporary_settings,
 )
+from prefect.types._datetime import DateTime
 from prefect.utilities.dockerutils import get_prefect_image_name
 
 FAKE_CLUSTER = "fake-cluster"


### PR DESCRIPTION
Add a `KubernetesObserverSettings` object to allow configuration of the namespaces the observer watches and additional labels to filter on.

The namespaces the observer watches can be set with the `PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES` environment variable like this:
```bash
export PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_NAMESPACES="default,another-one"
```
and additional labels to filter on can be set like this:
```bash
export PREFECT_INTEGRATIONS_KUBERNETES_OBSERVER_ADDITIONAL_LABEL_FILTERS="prefect.io/deployment-id=not-a-real-deployment-id,prefect.io/deployment-id=also-not-a-real-deployment-id"
```

Both these settings can be used to assign observers to specific domains if multiple observers are running in the same cluster.