### PR TITLE
fix kubernetes job variables merge logic

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -375,6 +375,14 @@ class KubernetesWorkerJobConfiguration(BaseJobConfiguration):
 
         Ensures that necessary values are present in the job manifest and that the
         job manifest is valid.
+
+        Args:
+            flow_run: The flow run to prepare the job configuration for
+            deployment: The deployment associated with the flow run used for
+                preparation.
+            flow: The flow associated with the flow run used for preparation.
+            work_pool: The work pool associated with the flow run used for preparation.
+            worker_name: The name of the worker used for preparation.
         """
         original_env_list = None
         if isinstance(self.env, list):


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/17406

opted for handling this in the k8s worker directly instead of the base worker because this seems specific to the k8s worker

---
while mulling over https://github.com/PrefectHQ/prefect/pull/17512#discussion_r2001882300, I'm thinking that there might be some `RootModel`-ish stuff we want to do on `BaseJobConfiguration` to standardize initialization, validation and mutation of `self.env` since it would be on every subclass, but in the interest of this fix I think that could be in another PR.