### PR TITLE
Don't pop the loader module

### DIFF
--- a/flows/multiprocessing_flow.py
+++ b/flows/multiprocessing_flow.py
@@ -1,0 +1,55 @@
+"""
+Regression test for https://github.com/PrefectHQ/prefect/issues/9329#issuecomment-2423021074
+"""
+
+import multiprocessing as mp
+import signal
+import tempfile
+from datetime import timedelta
+from pathlib import Path
+
+from prefect import flow, get_client
+from prefect.client.schemas.filters import DeploymentFilter, DeploymentFilterTags
+from prefect.settings import PREFECT_RUNNER_POLL_FREQUENCY, temporary_settings
+
+
+def read_flow_runs(tags):
+    with get_client(sync_client=True) as client:
+        return client.read_flow_runs(deployment_filter=DeploymentFilter(tags=DeploymentFilterTags(all_=tags)))
+
+
+def _task(i):
+    pass
+
+
+@flow
+def main():
+    with mp.Pool(5) as pool:
+        pool.map(_task, range(5))
+
+
+def _handler(signum, frame):
+    raise KeyboardInterrupt("Simulating user interruption")
+
+
+if __name__ == "__main__":
+    TIMEOUT: int = 15
+    INTERVAL_SECONDS: int = 3
+    TAGS = ["unique", "integration"]
+
+    signal.signal(signal.SIGALRM, _handler)
+    signal.alarm(TIMEOUT)
+
+    with temporary_settings({PREFECT_RUNNER_POLL_FREQUENCY: 1}):
+        try:
+            main.serve(name="mp-integration", interval=timedelta(seconds=INTERVAL_SECONDS), tags=TAGS)
+        except KeyboardInterrupt as e:
+            print(str(e))
+        finally:
+            signal.alarm(0)
+
+    runs = read_flow_runs(TAGS)
+    assert len(runs) >= 1
+    assert [run.state.is_completed() for run in runs]
+
+    print("Successfully ran a multiprocessing flow")

--- a/flows/multiprocessing_flow.py
+++ b/flows/multiprocessing_flow.py
@@ -4,9 +4,7 @@ Regression test for https://github.com/PrefectHQ/prefect/issues/9329#issuecommen
 
 import multiprocessing as mp
 import signal
-import tempfile
 from datetime import timedelta
-from pathlib import Path
 
 from prefect import flow, get_client
 from prefect.client.schemas.filters import DeploymentFilter, DeploymentFilterTags
@@ -15,7 +13,9 @@ from prefect.settings import PREFECT_RUNNER_POLL_FREQUENCY, temporary_settings
 
 def read_flow_runs(tags):
     with get_client(sync_client=True) as client:
-        return client.read_flow_runs(deployment_filter=DeploymentFilter(tags=DeploymentFilterTags(all_=tags)))
+        return client.read_flow_runs(
+            deployment_filter=DeploymentFilter(tags=DeploymentFilterTags(all_=tags))
+        )
 
 
 def _task(i):
@@ -42,7 +42,11 @@ if __name__ == "__main__":
 
     with temporary_settings({PREFECT_RUNNER_POLL_FREQUENCY: 1}):
         try:
-            main.serve(name="mp-integration", interval=timedelta(seconds=INTERVAL_SECONDS), tags=TAGS)
+            main.serve(
+                name="mp-integration",
+                interval=timedelta(seconds=INTERVAL_SECONDS),
+                tags=TAGS,
+            )
         except KeyboardInterrupt as e:
             print(str(e))
         finally:

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -673,19 +673,8 @@ class RunnerDeployment(BaseModel):
                 if not flow_file:
                     if not mod_name:
                         raise ValueError(no_file_location_error)
-                    try:
-                        module = importlib.import_module(mod_name)
-                        flow_file = getattr(module, "__file__", None)
-                    except ModuleNotFoundError as exc:
-                        # 16458 adds an identifier to the module name, so checking
-                        # for "__prefect_loader__" (2 underscores) will not match
-                        if "__prefect_loader_" in str(exc):
-                            raise ValueError(
-                                "Cannot create a RunnerDeployment from a flow that has been"
-                                " loaded from an entrypoint. To deploy a flow via"
-                                " entrypoint, use RunnerDeployment.from_entrypoint instead."
-                            )
-                        raise ValueError(no_file_location_error)
+                    module = importlib.import_module(mod_name)
+                    flow_file = getattr(module, "__file__", None)
                     if not flow_file:
                         raise ValueError(no_file_location_error)
 

--- a/src/prefect/deployments/runner.py
+++ b/src/prefect/deployments/runner.py
@@ -673,8 +673,11 @@ class RunnerDeployment(BaseModel):
                 if not flow_file:
                     if not mod_name:
                         raise ValueError(no_file_location_error)
-                    module = importlib.import_module(mod_name)
-                    flow_file = getattr(module, "__file__", None)
+                    try:
+                        module = importlib.import_module(mod_name)
+                        flow_file = getattr(module, "__file__", None)
+                    except ModuleNotFoundError:
+                        raise ValueError(no_file_location_error)
                     if not flow_file:
                         raise ValueError(no_file_location_error)
 

--- a/src/prefect/utilities/importtools.py
+++ b/src/prefect/utilities/importtools.py
@@ -95,6 +95,10 @@ def load_script_as_module(path: str) -> ModuleType:
 
     module_name = os.path.splitext(Path(path).name)[0]
 
+    # fall back in case of filenames with the same names as modules
+    if module_name in sys.modules:
+        module_name = f"__prefect_loader_{id(path)}__"
+
     spec = importlib.util.spec_from_file_location(
         module_name,
         path,

--- a/src/prefect/utilities/importtools.py
+++ b/src/prefect/utilities/importtools.py
@@ -93,8 +93,7 @@ def load_script_as_module(path: str) -> ModuleType:
     parent_path = str(Path(path).resolve().parent)
     working_directory = os.getcwd()
 
-    # Generate unique module name for thread safety
-    module_name = f"__prefect_loader_{id(path)}__"
+    module_name = os.path.splitext(Path(path).name)[0]
 
     spec = importlib.util.spec_from_file_location(
         module_name,
@@ -112,15 +111,9 @@ def load_script_as_module(path: str) -> ModuleType:
         with _get_sys_path_lock():
             sys.path.insert(0, working_directory)
             sys.path.insert(0, parent_path)
-            try:
-                spec.loader.exec_module(module)
-            finally:
-                sys.path.remove(parent_path)
-                sys.path.remove(working_directory)
+            spec.loader.exec_module(module)
     except Exception as exc:
         raise ScriptError(user_exc=exc, path=path) from exc
-    finally:
-        sys.modules.pop(module_name)
 
     return module
 

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -51,7 +51,7 @@ from prefect.events.clients import AssertingEventsClient
 from prefect.events.schemas.automations import Posture
 from prefect.events.schemas.deployment_triggers import DeploymentEventTrigger
 from prefect.events.worker import EventsWorker
-from prefect.flows import Flow, load_flow_from_entrypoint
+from prefect.flows import Flow
 from prefect.logging.loggers import flow_run_logger
 from prefect.runner.runner import Runner
 from prefect.runner.server import perform_health_check, start_webserver
@@ -1942,18 +1942,6 @@ class TestRunnerDeployment:
 
         assert deployment.version == "test"
         assert deployment.description == "I'm just here for tests"
-
-    def test_from_flow_raises_when_using_flow_loaded_from_entrypoint(self):
-        da_flow = load_flow_from_entrypoint("tests/runner/test_runner.py:dummy_flow_1")
-
-        with pytest.raises(
-            ValueError,
-            match=(
-                "Cannot create a RunnerDeployment from a flow that has been loaded from"
-                " an entrypoint"
-            ),
-        ):
-            RunnerDeployment.from_flow(da_flow, __file__)
 
     def test_from_flow_raises_on_interactively_defined_flow(self):
         @flow


### PR DESCRIPTION
This PR attempts to close various issues related to the `__prefect_loader_` module mechanic by not using random module names but instead using the file name itself, while also preserving the `sys.path` and `sys.module` manipulations. This ensures that these paths and objects loaded from the file can be more robustly pickled and unpickled.

Closes https://github.com/PrefectHQ/prefect/issues/9329 
Closes https://github.com/PrefectHQ/prefect/issues/5984
Closes https://github.com/PrefectHQ/prefect/issues/17150
Closes https://github.com/PrefectHQ/prefect/issues/9542
Closes https://github.com/PrefectHQ/prefect/issues/6762
Closes https://github.com/PrefectHQ/prefect/issues/17449

I am not sure if I am backtracking on other issues with this change, so want to be mindful of looking into that before we merge - the main avenue would be my removal of the path and module clean up steps.