### PR TITLE
Persist work pool and job variables for submitted ad-hoc flow runs

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -18599,6 +18599,42 @@
                         "title": "Idempotency Key",
                         "description": "An optional idempotency key. If a flow run with the same idempotency key has already been created, the existing flow run will be returned."
                     },
+                    "work_pool_name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Work Pool Name",
+                        "description": "The name of the work pool to run the flow run in."
+                    },
+                    "work_queue_name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Work Queue Name",
+                        "description": "The name of the work queue to place the flow run in."
+                    },
+                    "job_variables": {
+                        "anyOf": [
+                            {
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Job Variables",
+                        "description": "The job variables to use when setting up flow run infrastructure."
+                    },
                     "deployment_id": {
                         "anyOf": [
                             {

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -108,6 +108,7 @@ import enum
 import json
 import logging
 import shlex
+import subprocess
 import tempfile
 import uuid
 import warnings
@@ -812,16 +813,16 @@ class KubernetesWorker(
         with tempfile.TemporaryDirectory() as temp_dir:
             await (
                 anyio.Path(temp_dir)
-                .joinpath(str(flow_run.id))
+                .joinpath(bundle_key)
                 .write_bytes(json.dumps(bundle).encode("utf-8"))
             )
 
             try:
                 await anyio.run_process(
-                    upload_command + [str(flow_run.id)],
+                    upload_command + [bundle_key],
                     cwd=temp_dir,
                 )
-            except Exception as e:
+            except subprocess.CalledProcessError as e:
                 self._logger.error(
                     "Failed to upload bundle: %s", e.stderr.decode("utf-8")
                 )

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -109,6 +109,7 @@ import json
 import logging
 import shlex
 import tempfile
+import uuid
 import warnings
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -757,15 +758,6 @@ class KubernetesWorker(
         if TYPE_CHECKING:
             assert self._client is not None
             assert self._work_pool is not None
-        flow_run = await self._client.create_flow_run(
-            flow, parameters=parameters, state=Pending()
-        )
-        if task_status is not None:
-            # Emit the flow run object to .submit to allow it to return a future as soon as possible
-            task_status.started(flow_run)
-        # Avoid an API call to get the flow
-        api_flow = APIFlow(id=flow_run.flow_id, name=flow.name, labels={})
-        logger = self.get_flow_run_logger(flow_run)
 
         # TODO: Migrate steps to their own attributes on work pool when hardening this design
         upload_step = json.loads(
@@ -783,10 +775,24 @@ class KubernetesWorker(
             )
         )
 
-        upload_command = convert_step_to_command(upload_step, str(flow_run.id))
-        execute_command = convert_step_to_command(execute_step, str(flow_run.id))
+        bundle_key = str(uuid.uuid4())
+        upload_command = convert_step_to_command(upload_step, bundle_key)
+        execute_command = convert_step_to_command(execute_step, bundle_key)
 
         job_variables = (job_variables or {}) | {"command": " ".join(execute_command)}
+        flow_run = await self._client.create_flow_run(
+            flow,
+            parameters=parameters,
+            state=Pending(),
+            job_variables=job_variables,
+            work_pool_name=self._work_pool.name,
+        )
+        if task_status is not None:
+            # Emit the flow run object to .submit to allow it to return a future as soon as possible
+            task_status.started(flow_run)
+        # Avoid an API call to get the flow
+        api_flow = APIFlow(id=flow_run.flow_id, name=flow.name, labels={})
+        logger = self.get_flow_run_logger(flow_run)
 
         configuration = await self.job_configuration.from_template_and_values(
             base_job_template=self._work_pool.base_job_template,

--- a/src/integrations/prefect-kubernetes/tests/test_worker.py
+++ b/src/integrations/prefect-kubernetes/tests/test_worker.py
@@ -3324,6 +3324,12 @@ class TestKubernetesWorker:
                 cwd=ANY,
             )
 
+            async with prefect.get_client() as client:
+                flow_run = await client.read_flow_run(future.flow_run_id)
+                assert flow_run.work_pool_name == work_pool.name
+                assert flow_run.work_queue_name == "default"
+                assert flow_run.job_variables == {"command": " ".join(expected_command)}
+
         async def test_submit_adhoc_run_failed_submission(
             self,
             mock_batch_client,

--- a/src/prefect/client/orchestration/_flow_runs/client.py
+++ b/src/prefect/client/orchestration/_flow_runs/client.py
@@ -46,6 +46,9 @@ class FlowRunClient(BaseClient):
         tags: "Iterable[str] | None" = None,
         parent_task_run_id: "UUID | None" = None,
         state: "State[R] | None" = None,
+        work_pool_name: str | None = None,
+        work_queue_name: str | None = None,
+        job_variables: dict[str, Any] | None = None,
     ) -> "FlowRun":
         """
         Create a flow run for a flow.
@@ -59,7 +62,10 @@ class FlowRunClient(BaseClient):
             parent_task_run_id: if a subflow run is being created, the placeholder task
                 run identifier in the parent flow
             state: The initial state for the run. If not provided, defaults to
-                `Scheduled` for now. Should always be a `Scheduled` type.
+                `Pending`.
+            work_pool_name: The name of the work pool to run the flow run in.
+            work_queue_name: The name of the work queue to place the flow run in.
+            job_variables: The job variables to use when setting up flow run infrastructure.
 
         Raises:
             httpx.RequestError: if the Prefect API does not successfully create a run for any reason
@@ -98,6 +104,9 @@ class FlowRunClient(BaseClient):
                 retries=flow.retries,
                 retry_delay=int(flow.retry_delay_seconds or 0),
             ),
+            work_pool_name=work_pool_name,
+            work_queue_name=work_queue_name,
+            job_variables=job_variables,
         )
 
         flow_run_create_json = flow_run_create.model_dump(mode="json")
@@ -480,6 +489,9 @@ class FlowRunAsyncClient(BaseAsyncClient):
         tags: "Iterable[str] | None" = None,
         parent_task_run_id: "UUID | None" = None,
         state: "State[R] | None" = None,
+        work_pool_name: str | None = None,
+        work_queue_name: str | None = None,
+        job_variables: dict[str, Any] | None = None,
     ) -> "FlowRun":
         """
         Create a flow run for a flow.
@@ -493,7 +505,10 @@ class FlowRunAsyncClient(BaseAsyncClient):
             parent_task_run_id: if a subflow run is being created, the placeholder task
                 run identifier in the parent flow
             state: The initial state for the run. If not provided, defaults to
-                `Scheduled` for now. Should always be a `Scheduled` type.
+                `Pending`.
+            work_pool_name: The name of the work pool to run the flow run in.
+            work_queue_name: The name of the work queue to place the flow run in.
+            job_variables: The job variables to use when setting up flow run infrastructure.
 
         Raises:
             httpx.RequestError: if the Prefect API does not successfully create a run for any reason
@@ -532,6 +547,9 @@ class FlowRunAsyncClient(BaseAsyncClient):
                 retries=flow.retries,
                 retry_delay=int(flow.retry_delay_seconds or 0),
             ),
+            work_pool_name=work_pool_name,
+            work_queue_name=work_queue_name,
+            job_variables=job_variables,
         )
 
         flow_run_create_json = flow_run_create.model_dump(mode="json")

--- a/src/prefect/client/orchestration/_flow_runs/client.py
+++ b/src/prefect/client/orchestration/_flow_runs/client.py
@@ -104,10 +104,14 @@ class FlowRunClient(BaseClient):
                 retries=flow.retries,
                 retry_delay=int(flow.retry_delay_seconds or 0),
             ),
-            work_pool_name=work_pool_name,
-            work_queue_name=work_queue_name,
-            job_variables=job_variables,
         )
+
+        if work_pool_name is not None:
+            flow_run_create.work_pool_name = work_pool_name
+        if work_queue_name is not None:
+            flow_run_create.work_queue_name = work_queue_name
+        if job_variables is not None:
+            flow_run_create.job_variables = job_variables
 
         flow_run_create_json = flow_run_create.model_dump(mode="json")
         response = self.request("POST", "/flow_runs/", json=flow_run_create_json)

--- a/src/prefect/client/orchestration/_flow_runs/client.py
+++ b/src/prefect/client/orchestration/_flow_runs/client.py
@@ -113,7 +113,9 @@ class FlowRunClient(BaseClient):
         if job_variables is not None:
             flow_run_create.job_variables = job_variables
 
-        flow_run_create_json = flow_run_create.model_dump(mode="json")
+        flow_run_create_json = flow_run_create.model_dump(
+            mode="json", exclude_unset=True
+        )
         response = self.request("POST", "/flow_runs/", json=flow_run_create_json)
 
         flow_run = FlowRun.model_validate(response.json())
@@ -551,12 +553,18 @@ class FlowRunAsyncClient(BaseAsyncClient):
                 retries=flow.retries,
                 retry_delay=int(flow.retry_delay_seconds or 0),
             ),
-            work_pool_name=work_pool_name,
-            work_queue_name=work_queue_name,
-            job_variables=job_variables,
         )
 
-        flow_run_create_json = flow_run_create.model_dump(mode="json")
+        if work_pool_name is not None:
+            flow_run_create.work_pool_name = work_pool_name
+        if work_queue_name is not None:
+            flow_run_create.work_queue_name = work_queue_name
+        if job_variables is not None:
+            flow_run_create.job_variables = job_variables
+
+        flow_run_create_json = flow_run_create.model_dump(
+            mode="json", exclude_unset=True
+        )
         response = await self.request("POST", "/flow_runs/", json=flow_run_create_json)
 
         flow_run = FlowRun.model_validate(response.json())

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -443,6 +443,9 @@ class FlowRunCreate(ActionBaseModel):
     idempotency_key: Optional[str] = Field(default=None)
 
     labels: KeyValueLabelsField = Field(default_factory=dict)
+    work_pool_name: Optional[str] = Field(default=None)
+    work_queue_name: Optional[str] = Field(default=None)
+    job_variables: Optional[dict[str, Any]] = Field(default=None)
 
 
 class DeploymentFlowRunCreate(ActionBaseModel):

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -560,6 +560,18 @@ class FlowRunCreate(ActionBaseModel):
             " has already been created, the existing flow run will be returned."
         ),
     )
+    work_pool_name: Optional[str] = Field(
+        default=None,
+        description="The name of the work pool to run the flow run in.",
+    )
+    work_queue_name: Optional[str] = Field(
+        default=None,
+        description="The name of the work queue to place the flow run in.",
+    )
+    job_variables: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="The job variables to use when setting up flow run infrastructure.",
+    )
 
     # DEPRECATED
 

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -6583,6 +6583,21 @@ export interface components {
              */
             idempotency_key?: string | null;
             /**
+             * Work Pool Name
+             * @description The name of the work pool to run the flow run in.
+             */
+            work_pool_name?: string | null;
+            /**
+             * Work Queue Name
+             * @description The name of the work queue to place the flow run in.
+             */
+            work_queue_name?: string | null;
+            /**
+             * Job Variables
+             * @description The job variables to use when setting up flow run infrastructure.
+             */
+            job_variables?: Record<string, never> | null;
+            /**
              * Deployment Id
              * @deprecated
              * @description DEPRECATED: The id of the deployment associated with this flow run, if available.


### PR DESCRIPTION
This PR adds work_pool_name, work_queue_name, and job_variables fields to the create flow run endpoint.

The client is also updated to use the API updates when submitting ad-hoc flow run to remote infrastructure via a worker. The worker will use the base job template from an existing work pool when spinning up infra, so defining the work pool/queue will mark those flow runs as having run in that work pool. The job variables will store the custom command necessary to execute the submitted flow runs. Neither change is strictly necessary, but they enable infrastructure-level retries for submitted flow runs.

Related to #17194 