### PR TITLE
fix(flow-run): ensure state is consistent when cancelling

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -34,6 +34,7 @@ from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas.actions import WorkPoolCreate, WorkPoolUpdate
 from prefect.client.schemas.objects import (
     Integration,
+    State,
     StateType,
     WorkerMetadata,
     WorkPool,
@@ -51,7 +52,6 @@ from prefect.logging.loggers import (
     get_worker_logger,
 )
 from prefect.plugins import load_prefect_collections
-from prefect.server.schemas.states import State
 from prefect.settings import (
     PREFECT_API_URL,
     PREFECT_TEST_MODE,
@@ -61,6 +61,7 @@ from prefect.settings import (
     get_current_settings,
 )
 from prefect.states import (
+    Cancelled,
     Crashed,
     Pending,
     exception_to_failed_state,
@@ -1258,7 +1259,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             state = flow_run.state.model_copy(update=state_updates)
         else:
             # Unexpectedly when flow run does not have a state, create a new one
-            state: State = State(**state_updates)  # pyright: ignore[reportAssignmentType]
+            state: "State[R]" = Cancelled()
 
         await self.client.set_flow_run_state(flow_run.id, state, force=True)
 

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1258,7 +1258,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             state = flow_run.state.model_copy(update=state_updates)
         else:
             # Unexpectedly when flow run does not have a state, create a new one
-            state = State(**state_updates)
+            state: State = State(**state_updates)  # pyright: ignore[reportAssignmentType]
 
         await self.client.set_flow_run_state(flow_run.id, state, force=True)
 

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -34,7 +34,6 @@ from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas.actions import WorkPoolCreate, WorkPoolUpdate
 from prefect.client.schemas.objects import (
     Integration,
-    State,
     StateType,
     WorkerMetadata,
     WorkPool,

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1256,7 +1256,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
 
         if not flow_run.state:
             # BUG: ensure flow run has its state loaded
-            current_states: list[State[Any]] = await self.client.read_flow_run_states(
+            current_states: list[State] = await self.client.read_flow_run_states(
                 flow_run.id
             )
             # Set flow run's state with the latest one

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -51,7 +51,7 @@ from prefect.logging.loggers import (
     get_worker_logger,
 )
 from prefect.plugins import load_prefect_collections
-from prefect.server.database.orm_models import FlowRunState
+from prefect.server.schemas.states import State
 from prefect.settings import (
     PREFECT_API_URL,
     PREFECT_TEST_MODE,
@@ -1256,7 +1256,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
 
         if not flow_run.state:
             # BUG: ensure flow run has its state loaded
-            current_states: list[FlowRunState] = await self.client.read_flow_run_states(
+            current_states: list[State[Any]] = await self.client.read_flow_run_states(
                 flow_run.id
             )
             # Set flow run's state with the latest one

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1256,7 +1256,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
 
         if not flow_run.state:
             current_states: (
-                list[State] | list[State[Any]]
+                list[State] | list[State[Any]]  # pyright: ignore[reportAssignmentType]
             ) = await self.client.read_flow_run_states(flow_run.id)
             # Set flow run's state with the latest one
             # Don't need to make API call, because after executing this function,

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1259,7 +1259,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             state = flow_run.state.model_copy(update=state_updates)
         else:
             # Unexpectedly when flow run does not have a state, create a new one
-            state: "State[R]" = Cancelled()
+            state = Cancelled(**state_updates)
 
         await self.client.set_flow_run_state(flow_run.id, state, force=True)
 

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1255,10 +1255,9 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             assert flow_run.state
 
         if not flow_run.state:
-            # BUG: ensure flow run has its state loaded
-            current_states: list[State] = await self.client.read_flow_run_states(
-                flow_run.id
-            )
+            current_states: (
+                list[State] | list[State[Any]]
+            ) = await self.client.read_flow_run_states(flow_run.id)
             # Set flow run's state with the latest one
             # Don't need to make API call, because after executing this function,
             # the state will be finally CANCELLED

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1252,8 +1252,6 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         state_updates = state_updates or {}
         state_updates.setdefault("name", "Cancelled")
         state_updates.setdefault("type", StateType.CANCELLED)
-        if TYPE_CHECKING:
-            assert flow_run.state
 
         if flow_run.state:
             state = flow_run.state.model_copy(update=state_updates)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->
Closes #17536 

<!-- Include an overview of the proposed changes here -->
When workers try to submit a scheduled flow run if its corresponding deployment somehow got deleted, workers will mark the flow run as cancelled.

However, the current implementation is getting an error leading to failure in marking the flow run as canceled. This then leads to to crashed worker in an **infinite loop**.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
