### PR TITLE
avoid inheriting `NullFilesystem` for transaction metadata storage

### DIFF
--- a/src/prefect/results.py
+++ b/src/prefect/results.py
@@ -410,8 +410,7 @@ class ResultStore(BaseModel):
             update["serializer"] = resolve_serializer(flow.result_serializer)
         if self.result_storage is None and update.get("result_storage") is None:
             update["result_storage"] = await aget_default_result_storage()
-        # Do not set metadata_storage to NullFileSystem, let it remain None
-        # so transaction idempotency works correctly
+        update["metadata_storage"] = NullFileSystem()
         return self.model_copy(update=update)
 
     @sync_compatible

--- a/src/prefect/transactions.py
+++ b/src/prefect/transactions.py
@@ -23,6 +23,7 @@ from prefect.exceptions import (
     MissingContextError,
     SerializationError,
 )
+from prefect.filesystems import NullFileSystem
 from prefect.logging.loggers import LoggingAdapter, get_logger, get_run_logger
 from prefect.results import (
     ResultRecord,
@@ -452,6 +453,10 @@ def transaction(
     # if there is no key, we won't persist a record
     if key and not store:
         store = get_result_store()
+
+    # Avoid inheriting a NullFileSystem for metadata_storage from a flow's result store
+    if store and isinstance(store.metadata_storage, NullFileSystem):
+        store = store.model_copy(update={"metadata_storage": None})
 
     try:
         _logger: Union[logging.Logger, LoggingAdapter] = logger or get_run_logger()


### PR DESCRIPTION
Fix flow transaction idempotency by replacing `NullFileSystem` with `None` in the `transaction` ctx manager. This ensures `transaction.is_committed()` correctly detects previously committed files, even when a flow's `ResultStore` uses `NullFileSystem` for metadata storage.