### PR TITLE
Add logging of ECS task definition differences when equality comparison fails

### DIFF
--- a/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
+++ b/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
@@ -2342,3 +2342,66 @@ async def test_get_or_generate_family(
     task = describe_task(ecs_client, task_arn)
     task_definition = describe_task_definition(ecs_client, task)
     assert task_definition["family"] == family
+
+
+@pytest.mark.usefixtures("ecs_mocks")
+def test_task_definitions_equal_logs_differences(caplog):
+    """Test that we log the differences between task definitions when they don't match."""
+    # Create a worker instance to access the method
+    worker = ECSWorker()
+
+    # Create two slightly different task definitions
+    taskdef_1 = {
+        "containerDefinitions": [
+            {
+                "name": "prefect",
+                "image": "prefecthq/prefect:2-latest",
+                "cpu": 256,
+                "memory": 512,
+                "essential": True,
+            }
+        ],
+        "family": "test-family",
+        "networkMode": "bridge",
+    }
+
+    taskdef_2 = {
+        "containerDefinitions": [
+            {
+                "name": "prefect",
+                "image": "prefecthq/prefect:3-latest",  # Different image version
+                "cpu": 512,  # Different CPU
+                "memory": 512,
+                "essential": True,
+            }
+        ],
+        "family": "test-family",
+        "networkMode": "bridge",
+        "executionRoleArn": "test-role",  # Additional key
+    }
+
+    # Create a logger for testing
+    logger = logging.getLogger("prefect.workers.ecs")
+
+    # Set the log level to DEBUG to capture debug messages
+    with caplog.at_level(logging.DEBUG, logger="prefect.workers.ecs"):
+        # Call the method
+        result = worker._task_definitions_equal(taskdef_1, taskdef_2, logger)
+
+        # Assert the result is False
+        assert result is False
+
+        # Check that the differences were logged
+        assert (
+            "Keys only in retrieved task definition: {'executionRoleArn'}"
+            in caplog.text
+        )
+        assert "Value differs for key 'containerDefinitions'" in caplog.text
+
+        # The differences in the container definitions should be logged
+        assert "Generated:  " in caplog.text
+        assert "Retrieved: " in caplog.text
+        assert "prefecthq/prefect:2.0" in caplog.text
+        assert "prefecthq/prefect:2.1" in caplog.text
+        assert "cpu: 256" in caplog.text
+        assert "cpu: 512" in caplog.text


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
Several users are reporting that their ECS worker repeatedly registers new task definition revisions despite no changes to their deployment. It appears that the equality check used for task definition caching and matching the latest revision may be failing, so this adds debug logging to highlight differences between the generated and fetched task definitions at comparison time.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
