### PR TITLE
Convert strings to timezone-aware datetimes in the flow run graph API

### DIFF
--- a/src/prefect/server/models/flow_runs.py
+++ b/src/prefect/server/models/flow_runs.py
@@ -607,6 +607,9 @@ async def read_flow_run_graph(
 ) -> Graph:
     """Given a flow run, return the graph of it's task and subflow runs. If a `since`
     datetime is provided, only return items that may have changed since that time."""
+    if isinstance(since, str):
+        since = DateTime.fromisoformat(since)
+
     return await db.queries.flow_run_graph_v2(
         session=session,
         flow_run_id=flow_run_id,

--- a/tests/server/orchestration/api/test_flow_run_graph_v2.py
+++ b/tests/server/orchestration/api/test_flow_run_graph_v2.py
@@ -168,6 +168,22 @@ async def test_reading_graph_for_flow_run_with_no_tasks(
     assert_graph_is_connected(graph)
 
 
+async def test_reading_graph_for_flow_run_with_string_since_field(
+    session: AsyncSession,
+    flow_run,  # db.FlowRun,
+):
+    graph = await read_flow_run_graph(
+        session=session,
+        flow_run_id=flow_run.id,
+        since="0001-01-01T00:00:00+00:00",
+    )
+
+    assert graph.start_time == flow_run.start_time
+    assert graph.end_time == flow_run.end_time
+    assert graph.root_node_ids == []
+    assert graph.nodes == []
+
+
 @pytest.fixture
 async def flat_tasks(
     db: PrefectDBInterface,


### PR DESCRIPTION
I ran into this when trying to reproduce another issue - it seems like something changed in the UI that began sending naive strings instead of timezone-aware strings? Either way this makes the known problematic endpoint more robust to inputs.

Closes #16487
Closes https://github.com/PrefectHQ/prefect/issues/17225