### PR TITLE
fix: Pass DOCKER_CLIENT_TIMEOUT to the worker docker client

### DIFF
--- a/src/integrations/prefect-docker/prefect_docker/worker.py
+++ b/src/integrations/prefect-docker/prefect_docker/worker.py
@@ -29,6 +29,7 @@ import docker
 import docker.errors
 import packaging.version
 from docker import DockerClient
+from docker.constants import DEFAULT_TIMEOUT_SECONDS as DEFAULT_DOCKER_TIMEOUT_SECONDS
 from docker.models.containers import Container
 from pydantic import Field
 from slugify import slugify
@@ -446,8 +447,10 @@ class DockerWorker(BaseWorker):
                     message="distutils Version classes are deprecated.*",
                     category=DeprecationWarning,
                 )
-
-                docker_client = docker.from_env()
+                timeout = os.environ.get(
+                    "DOCKER_CLIENT_TIMEOUT", DEFAULT_DOCKER_TIMEOUT_SECONDS
+                )
+                docker_client = docker.from_env(timeout=timeout)
 
         except docker.errors.DockerException as exc:
             raise RuntimeError("Could not connect to Docker.") from exc

--- a/src/integrations/prefect-docker/prefect_docker/worker.py
+++ b/src/integrations/prefect-docker/prefect_docker/worker.py
@@ -447,8 +447,10 @@ class DockerWorker(BaseWorker):
                     message="distutils Version classes are deprecated.*",
                     category=DeprecationWarning,
                 )
-                timeout = os.environ.get(
-                    "DOCKER_CLIENT_TIMEOUT", DEFAULT_DOCKER_TIMEOUT_SECONDS
+                timeout = int(
+                    os.environ.get(
+                        "DOCKER_CLIENT_TIMEOUT", DEFAULT_DOCKER_TIMEOUT_SECONDS
+                    )
                 )
                 docker_client = docker.from_env(timeout=timeout)
 

--- a/src/integrations/prefect-docker/tests/test_worker.py
+++ b/src/integrations/prefect-docker/tests/test_worker.py
@@ -1,4 +1,5 @@
 import copy
+import os
 import uuid
 from unittest.mock import MagicMock, call, patch
 
@@ -1209,3 +1210,29 @@ async def test_emits_event_container_creation_failure(
             resource=worker_resource,
             related=worker._event_related_resources(),
         )
+
+
+@patch("docker.from_env")
+async def test_docker_client_default_timeout_configuration(
+    mocked_from_env: MagicMock,
+) -> None:
+    """Validate we can pass a timeout via environment variables to the underlying docker client."""
+
+    async with DockerWorker(work_pool_name="test") as worker:
+        _ = worker._get_client()
+
+        default_timeout_duration = 60
+        mocked_from_env.assert_called_once_with(timeout=default_timeout_duration)
+
+
+@patch.dict(os.environ, {"DOCKER_CLIENT_TIMEOUT": "30"})
+@patch("docker.from_env")
+async def test_docker_client_overwrite_timeout_configuration(
+    mocked_from_env: MagicMock,
+) -> None:
+    """Validate we can pass a timeout via environment variables to the underlying docker client."""
+
+    async with DockerWorker(work_pool_name="test") as worker:
+        _ = worker._get_client()
+
+        mocked_from_env.assert_called_once_with(timeout=30)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

We are running prefect open source, executing a growing number of containers on a Linux host.
We started occasionally seeing the create_container() command timing out with the python docker clients default timeout of 60 seconds.
While this is it's own problem which we are tackling, short term we did not find any way of bumping the timeout within docker or prefect.

This PR adds basic integration to allow controlling the timeout via the standard `DOCKER_CLIENT_TIMEOUT` variable.

closes https://github.com/PrefectHQ/prefect/issues/17553

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- ~~[ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.~~
- ~~[ ] If this pull request adds functions or classes, it includes helpful docstrings.~~
