### PR TITLE
Improve ad-hoc infrastructure submission error handling

### DIFF
--- a/src/integrations/prefect-aws/prefect_aws/experimental/bundles/execute.py
+++ b/src/integrations/prefect-aws/prefect_aws/experimental/bundles/execute.py
@@ -106,7 +106,7 @@ def _execute_bundle_from_s3(
             aws_credentials_block_name=aws_credentials_block_name,
         )
     except Exception as e:
-        print(f"Failed to execute bundle: {e}", file=sys.stderr)
+        print(f"Bundle execution failed ({type(e).__name__}): {e}", file=sys.stderr)
         raise typer.Exit(code=1) from e
 
 

--- a/src/integrations/prefect-aws/prefect_aws/experimental/bundles/execute.py
+++ b/src/integrations/prefect-aws/prefect_aws/experimental/bundles/execute.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 from pathlib import Path
 from typing import Optional, TypedDict
@@ -98,11 +99,15 @@ def _execute_bundle_from_s3(
     key: str = typer.Option(...),
     aws_credentials_block_name: Optional[str] = typer.Option(None),
 ) -> None:
-    execute_bundle_from_s3(
-        bucket=bucket,
-        key=key,
-        aws_credentials_block_name=aws_credentials_block_name,
-    )
+    try:
+        execute_bundle_from_s3(
+            bucket=bucket,
+            key=key,
+            aws_credentials_block_name=aws_credentials_block_name,
+        )
+    except Exception as e:
+        print(f"Failed to execute bundle: {e}", file=sys.stderr)
+        raise typer.Exit(code=1) from e
 
 
 if __name__ == "__main__":

--- a/src/integrations/prefect-aws/prefect_aws/experimental/bundles/upload.py
+++ b/src/integrations/prefect-aws/prefect_aws/experimental/bundles/upload.py
@@ -85,12 +85,16 @@ def _upload_bundle_to_s3(
         else None
     )
 
-    return upload_bundle_to_s3(
-        local_filepath=local_filepath,
-        bucket=bucket,
-        key=key,
-        aws_credentials_block_name=block_name,
-    )
+    try:
+        return upload_bundle_to_s3(
+            local_filepath=local_filepath,
+            bucket=bucket,
+            key=key,
+            aws_credentials_block_name=block_name,
+        )
+    except Exception as e:
+        print(f"Failed to upload bundle: {e}")
+        raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":

--- a/src/integrations/prefect-aws/prefect_aws/experimental/bundles/upload.py
+++ b/src/integrations/prefect-aws/prefect_aws/experimental/bundles/upload.py
@@ -5,6 +5,7 @@ These steps allow uploading and downloading flow/task bundles to and from S3.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Optional, TypedDict
 
@@ -93,7 +94,8 @@ def _upload_bundle_to_s3(
             aws_credentials_block_name=block_name,
         )
     except Exception as e:
-        print(f"Failed to upload bundle: {e}")
+        print(type(e).__name__, file=sys.stderr)
+        print(f"Failed to upload bundle to S3: {e}", file=sys.stderr)
         raise typer.Exit(code=1)
 
 

--- a/src/integrations/prefect-aws/prefect_aws/experimental/bundles/upload.py
+++ b/src/integrations/prefect-aws/prefect_aws/experimental/bundles/upload.py
@@ -94,8 +94,9 @@ def _upload_bundle_to_s3(
             aws_credentials_block_name=block_name,
         )
     except Exception as e:
-        print(type(e).__name__, file=sys.stderr)
-        print(f"Failed to upload bundle to S3: {e}", file=sys.stderr)
+        print(
+            f"Failed to upload bundle to S3 ({type(e).__name__}): {e}", file=sys.stderr
+        )
         raise typer.Exit(code=1)
 
 

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/experimental/decorators.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/experimental/decorators.py
@@ -13,7 +13,7 @@ from typing import (
     overload,
 )
 
-from exceptiongroup import ExceptionGroup
+from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 from prefect_kubernetes.worker import KubernetesWorker
 from typing_extensions import Literal, ParamSpec
 
@@ -123,10 +123,11 @@ class InfrastructureBoundFlow(Flow[P, R]):
                         await future.wait_async()
                         return future.state
                     return await future.aresult()
-            except ExceptionGroup as exc:
+            except (ExceptionGroup, BaseExceptionGroup) as exc:
+                # For less verbose tracebacks
                 exceptions = exc.exceptions
                 if len(exceptions) == 1:
-                    raise exceptions[0]
+                    raise exceptions[0] from None
                 else:
                     raise
 

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -772,7 +772,9 @@ class KubernetesWorker(
 
         bundle_key = str(uuid.uuid4())
         upload_command = convert_step_to_command(
-            self._work_pool.storage_configuration.bundle_upload_step, bundle_key
+            self._work_pool.storage_configuration.bundle_upload_step,
+            bundle_key,
+            quiet=True,
         )
         execute_command = convert_step_to_command(
             self._work_pool.storage_configuration.bundle_execution_step, bundle_key
@@ -824,7 +826,7 @@ class KubernetesWorker(
                     cwd=temp_dir,
                 )
             except subprocess.CalledProcessError as e:
-                raise RuntimeError(e.stdout.decode("utf-8")) from e
+                raise RuntimeError(e.stderr.decode("utf-8")) from e
 
         logger.debug("Successfully uploaded execution bundle")
 

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -821,10 +821,9 @@ class KubernetesWorker(
                     cwd=temp_dir,
                 )
             except subprocess.CalledProcessError as e:
-                self._logger.error(
-                    "Failed to upload bundle: %s", e.stderr.decode("utf-8")
-                )
-                raise e
+                raise RuntimeError(
+                    f"Failed to upload bundle: {e.stderr.decode('utf-8')}"
+                ) from e
 
         logger.debug("Successfully uploaded execution bundle")
 

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -807,7 +807,6 @@ class KubernetesWorker(
 
         bundle = create_bundle_for_flow_run(flow=flow, flow_run=flow_run)
 
-        logger.debug("Uploading execution bundle")
         with tempfile.TemporaryDirectory() as temp_dir:
             await (
                 anyio.Path(temp_dir)
@@ -816,14 +815,16 @@ class KubernetesWorker(
             )
 
             try:
+                full_command = upload_command + [bundle_key]
+                logger.debug(
+                    "Uploading execution bundle with command: %s", full_command
+                )
                 await anyio.run_process(
-                    upload_command + [bundle_key],
+                    full_command,
                     cwd=temp_dir,
                 )
             except subprocess.CalledProcessError as e:
-                raise RuntimeError(
-                    f"Failed to upload bundle: {e.stderr.decode('utf-8')}"
-                ) from e
+                raise RuntimeError(e.stdout.decode("utf-8")) from e
 
         logger.debug("Successfully uploaded execution bundle")
 

--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -730,6 +730,7 @@ class KubernetesWorker(
         )
         if self._runs_task_group is None:
             raise RuntimeError("Worker not properly initialized")
+
         flow_run = await self._runs_task_group.start(
             partial(
                 self._submit_adhoc_run,
@@ -764,7 +765,9 @@ class KubernetesWorker(
             or self._work_pool.storage_configuration.bundle_execution_step is None
         ):
             raise RuntimeError(
-                f"Storage is not configured for work pool {self._work_pool.name!r}. Please configure storage for the work pool by running `prefect work-pool storage configure`."
+                f"Storage is not configured for work pool {self._work_pool.name!r}. "
+                "Please configure storage for the work pool by running `prefect "
+                "work-pool storage configure`."
             )
 
         bundle_key = str(uuid.uuid4())

--- a/src/integrations/prefect-kubernetes/tests/experimental/test_decorator.py
+++ b/src/integrations/prefect-kubernetes/tests/experimental/test_decorator.py
@@ -1,19 +1,22 @@
+import uuid
 from typing import Generator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from prefect_kubernetes.experimental.decorators import kubernetes
 from prefect_kubernetes.worker import KubernetesWorker
 
-from prefect import State, flow
+import prefect
+from prefect.client.schemas.actions import WorkPoolCreate
+from prefect.client.schemas.objects import WorkPool, WorkPoolStorageConfiguration
 from prefect.futures import PrefectFuture
 
 
 @pytest.fixture
-def mock_submit() -> Generator[AsyncMock, None, None]:
+def mock_submit(monkeypatch: pytest.MonkeyPatch) -> Generator[AsyncMock, None, None]:
     """Create a mock for the KubernetesWorker.submit method"""
     # Create a mock state
-    mock_state = MagicMock(spec=State)
+    mock_state = MagicMock(spec=prefect.State)
     mock_state.is_completed.return_value = True
     mock_state.message = "Success"
 
@@ -25,18 +28,66 @@ def mock_submit() -> Generator[AsyncMock, None, None]:
 
     mock = AsyncMock(return_value=mock_future)
 
-    patcher = patch.object(KubernetesWorker, "submit", mock)
-    patcher.start()
+    monkeypatch.setattr(KubernetesWorker, "submit", mock)
     yield mock
-    patcher.stop()
+
+
+@pytest.fixture
+async def work_pool_without_storage_configuration():
+    async with prefect.get_client() as client:
+        work_pool = await client.create_work_pool(
+            WorkPoolCreate(
+                name=f"test-{uuid.uuid4()}",
+                base_job_template=KubernetesWorker.get_default_base_job_template(),
+            )
+        )
+        try:
+            yield work_pool
+        finally:
+            await client.delete_work_pool(work_pool.name)
+
+
+@pytest.fixture
+async def work_pool_with_storage_configuration():
+    UPLOAD_STEP = {
+        "prefect_mock.experimental.bundles.upload": {
+            "requires": "prefect-mock==0.5.5",
+            "bucket": "test-bucket",
+            "credentials_block_name": "my-creds",
+        }
+    }
+
+    EXECUTE_STEP = {
+        "prefect_mock.experimental.bundles.execute": {
+            "requires": "prefect-mock==0.5.5",
+            "bucket": "test-bucket",
+            "credentials_block_name": "my-creds",
+        }
+    }
+
+    async with prefect.get_client() as client:
+        work_pool = await client.create_work_pool(
+            WorkPoolCreate(
+                name=f"test-{uuid.uuid4()}",
+                base_job_template=KubernetesWorker.get_default_base_job_template(),
+                storage_configuration=WorkPoolStorageConfiguration(
+                    bundle_execution_step=EXECUTE_STEP,
+                    bundle_upload_step=UPLOAD_STEP,
+                ),
+            )
+        )
+        try:
+            yield work_pool
+        finally:
+            await client.delete_work_pool(work_pool.name)
 
 
 def test_kubernetes_decorator_sync_flow(mock_submit: AsyncMock) -> None:
     """Test that a synchronous flow is correctly decorated and executed"""
 
     @kubernetes(work_pool="test-pool", memory="2Gi")
-    @flow
-    def sync_test_flow(param1, param2="default"):
+    @prefect.flow
+    def sync_test_flow(param1: str, param2: str = "default") -> str:
         return f"{param1}-{param2}"
 
     result = sync_test_flow("test")
@@ -52,8 +103,8 @@ async def test_kubernetes_decorator_async_flow(mock_submit: AsyncMock) -> None:
     """Test that an asynchronous flow is correctly decorated and executed"""
 
     @kubernetes(work_pool="test-pool", cpu="1")
-    @flow
-    async def async_test_flow(param1):
+    @prefect.flow
+    async def async_test_flow(param1: str) -> str:
         return f"async-{param1}"
 
     result = await async_test_flow("test")
@@ -70,7 +121,7 @@ def test_kubernetes_decorator_return_state() -> None:
     """Test that return_state=True returns the state instead of the result"""
 
     @kubernetes(work_pool="test-pool")
-    @flow
+    @prefect.flow
     def test_flow():
         return "completed"
 
@@ -84,7 +135,7 @@ def test_kubernetes_decorator_return_state() -> None:
 def test_kubernetes_decorator_preserves_flow_attributes() -> None:
     """Test that the decorator preserves the original flow's attributes"""
 
-    @flow(name="custom-flow-name", description="Custom description")
+    @prefect.flow(name="custom-flow-name", description="Custom description")
     def original_flow():
         return "test"
 
@@ -104,7 +155,7 @@ def test_submit_method_receives_work_pool_name(mock_submit: AsyncMock) -> None:
     """Test that the correct work pool name is passed to submit"""
 
     @kubernetes(work_pool="specific-pool")
-    @flow
+    @prefect.flow
     def test_flow():
         return "test"
 
@@ -115,3 +166,21 @@ def test_submit_method_receives_work_pool_name(mock_submit: AsyncMock) -> None:
     assert "flow" in kwargs
     assert "parameters" in kwargs
     assert "job_variables" in kwargs
+
+
+def test_runtime_error_when_work_pool_is_missing_storage_configuration(
+    work_pool_without_storage_configuration: WorkPool,
+) -> None:
+    """Test that a runtime error is raised when the work pool is missing a storage configuration"""
+
+    @kubernetes(work_pool=work_pool_without_storage_configuration.name)
+    @prefect.flow
+    def test_flow():
+        return "test"
+
+    with pytest.raises(
+        RuntimeError,
+        match=f"Storage is not configured for work pool {work_pool_without_storage_configuration.name!r}. "
+        "Please configure storage for the work pool by running `prefect work-pool storage configure`.",
+    ):
+        test_flow()

--- a/src/integrations/prefect-kubernetes/tests/test_worker.py
+++ b/src/integrations/prefect-kubernetes/tests/test_worker.py
@@ -3305,6 +3305,7 @@ class TestKubernetesWorker:
             expected_upload_command = [
                 "uv",
                 "run",
+                "--quiet",
                 "--with",
                 "prefect-mock==0.5.5",
                 "--python",

--- a/src/prefect/_experimental/bundles.py
+++ b/src/prefect/_experimental/bundles.py
@@ -174,7 +174,7 @@ def execute_bundle_in_subprocess(
 
 
 def convert_step_to_command(
-    step: dict[str, Any], key: str, quiet: bool = True
+    step: dict[str, Any], key: str, quiet: bool = False
 ) -> list[str]:
     """
     Converts a bundle upload or execution step to a command.
@@ -182,6 +182,7 @@ def convert_step_to_command(
     Args:
         step: The step to convert.
         key: The key to use for the remote file when downloading or uploading.
+        quiet: Whether to suppress `uv` output from the command.
 
     Returns:
         A list of strings representing the command to run the step.

--- a/src/prefect/_experimental/bundles.py
+++ b/src/prefect/_experimental/bundles.py
@@ -173,7 +173,9 @@ def execute_bundle_in_subprocess(
     return process
 
 
-def convert_step_to_command(step: dict[str, Any], key: str) -> list[str]:
+def convert_step_to_command(
+    step: dict[str, Any], key: str, quiet: bool = True
+) -> list[str]:
     """
     Converts a bundle upload or execution step to a command.
 
@@ -186,6 +188,9 @@ def convert_step_to_command(step: dict[str, Any], key: str) -> list[str]:
     """
     # Start with uv run
     command = ["uv", "run"]
+
+    if quiet:
+        command.append("--quiet")
 
     step_keys = list(step.keys())
 

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -723,14 +723,7 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             except Exception:
                 self._logger.exception("Failed to emit worker stopped event")
 
-        # try:
-        #     await self._exit_stack.__aexit__(*exc_info)
-        # except Exception:
-        #     # We log quietly here to avoid anyio wrapping errors in an exception group
-        #     self._logger.debug("Error tearing down worker", exc_info=True)
-
         await self._exit_stack.__aexit__(*exc_info)
-
         self._runs_task_group = None
         self._client = None
 

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -723,7 +723,14 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
             except Exception:
                 self._logger.exception("Failed to emit worker stopped event")
 
+        # try:
+        #     await self._exit_stack.__aexit__(*exc_info)
+        # except Exception:
+        #     # We log quietly here to avoid anyio wrapping errors in an exception group
+        #     self._logger.debug("Error tearing down worker", exc_info=True)
+
         await self._exit_stack.__aexit__(*exc_info)
+
         self._runs_task_group = None
         self._client = None
 


### PR DESCRIPTION
This PR improves the error messages produced when an ad-hoc flow submitted to remote infrastructure fails. The main improvements come from:
- Ensuring exceptions don't get wrapped in an exception group by `anyio`
- Updating bundle steps to print nice error messages to `stderr` on failure

With this PR, you'll get an error message like this is the bundle upload to S3 fails:
`
RuntimeError: Failed to upload bundle to S3 (S3UploadFailedError): Failed to upload 013aa438-9aa5-4a55-a6d5-eedef0eebbf2 to storage-blocks-test-bucket/013aa438-9aa5-4a55-a6d5-eedef0eebbf2: An error occurred (InvalidToken) when calling the PutObject operation: The provided token is malformed or otherwise invalid.
`

Related to #17194 