### PR TITLE
Log ignored template variables when a task definition arn is supplied to the ECS worker

### DIFF
--- a/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
+++ b/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
@@ -761,7 +761,9 @@ class ECSWorker(BaseWorker):
             if configuration.task_definition:
                 logger.warning(
                     "Ignoring task definition in configuration since task definition"
-                    " ARN is provided on the task run request."
+                    " ARN is provided on the task run request. By default, this discards"
+                    " the following job variables: image, container_name, cpu, family, memory, and"
+                    " execution_role_arn."
                 )
 
         self._validate_task_definition(task_definition, configuration)

--- a/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
+++ b/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
@@ -68,6 +68,7 @@ from prefect.client.schemas.objects import FlowRun
 from prefect.client.utilities import inject_client
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.dockerutils import get_prefect_image_name
+from prefect.utilities.templating import find_placeholders
 from prefect.workers.base import (
     BaseJobConfiguration,
     BaseVariables,
@@ -98,7 +99,6 @@ ECS_POST_REGISTRATION_FIELDS = [
     "registeredBy",
     "deregisteredAt",
 ]
-
 
 DEFAULT_TASK_DEFINITION_TEMPLATE = """
 containerDefinitions:
@@ -759,11 +759,18 @@ class ECSWorker(BaseWorker):
                 logger, ecs_client, task_definition_arn
             )
             if configuration.task_definition:
+                template_with_placeholders = self.work_pool.base_job_template[
+                    "job_configuration"
+                ]["task_definition"]
+                placeholders = [
+                    placeholder.name
+                    for placeholder in find_placeholders(template_with_placeholders)
+                ]
+
                 logger.warning(
                     "Ignoring task definition in configuration since task definition"
-                    " ARN is provided on the task run request. By default, this discards"
-                    " the following job variables: image, container_name, cpu, family, memory, and"
-                    " execution_role_arn."
+                    " ARN is provided on the task run request. The following job variables"
+                    " will be ignored: " + ", ".join(placeholders)
                 )
 
         self._validate_task_definition(task_definition, configuration)

--- a/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
+++ b/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
@@ -769,8 +769,8 @@ class ECSWorker(BaseWorker):
 
                 logger.warning(
                     "Skipping task definition construction since a task definition"
-                    " ARN is provided on the task run request. The following job variable"
-                    " references in the task definition template will be ignored: "
+                    " ARN is provided. The following job variable references"
+                    " in the task definition template will be ignored: "
                     + ", ".join(placeholders)
                 )
 

--- a/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
+++ b/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
@@ -768,9 +768,10 @@ class ECSWorker(BaseWorker):
                 ]
 
                 logger.warning(
-                    "Ignoring task definition in configuration since task definition"
-                    " ARN is provided on the task run request. The following job variables"
-                    " will be ignored: " + ", ".join(placeholders)
+                    "Skipping task definition construction since a task definition"
+                    " ARN is provided on the task run request. The following job variable"
+                    " references in the task definition template will be ignored: "
+                    + ", ".join(placeholders)
                 )
 
         self._validate_task_definition(task_definition, configuration)

--- a/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
+++ b/src/integrations/prefect-aws/prefect_aws/workers/ecs_worker.py
@@ -769,10 +769,15 @@ class ECSWorker(BaseWorker):
 
                 logger.warning(
                     "Skipping task definition construction since a task definition"
-                    " ARN is provided. The following job variable references"
-                    " in the task definition template will be ignored: "
-                    + ", ".join(placeholders)
+                    " ARN is provided."
                 )
+
+                if placeholders:
+                    logger.warning(
+                        "The following job variable references"
+                        " in the task definition template will be ignored: "
+                        + ", ".join(placeholders)
+                    )
 
         self._validate_task_definition(task_definition, configuration)
 

--- a/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
+++ b/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
@@ -35,6 +35,7 @@ from pydantic import ValidationError
 from prefect.server.schemas.core import FlowRun
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from prefect.utilities.slugify import slugify
+from prefect.utilities.templating import find_placeholders
 
 TEST_TASK_DEFINITION_YAML = """
 containerDefinitions:
@@ -621,7 +622,9 @@ async def test_container_command(
 
 
 @pytest.mark.usefixtures("ecs_mocks")
-async def test_task_definition_arn(aws_credentials: AwsCredentials, flow_run: FlowRun):
+async def test_task_definition_arn(
+    aws_credentials: AwsCredentials, flow_run: FlowRun, caplog
+):
     session = aws_credentials.get_boto3_session()
     ecs_client = session.client("ecs")
 
@@ -636,7 +639,10 @@ async def test_task_definition_arn(aws_credentials: AwsCredentials, flow_run: Fl
     )
 
     async with ECSWorker(work_pool_name="test") as worker:
-        result = await run_then_stop_task(worker, configuration, flow_run)
+        with caplog.at_level(
+            logging.WARN, logger=worker.get_flow_run_logger(flow_run).name
+        ):
+            result = await run_then_stop_task(worker, configuration, flow_run)
 
     assert result.status_code == 0
     _, task_arn = parse_identifier(result.identifier)
@@ -645,6 +651,11 @@ async def test_task_definition_arn(aws_credentials: AwsCredentials, flow_run: Fl
     print(task)
     assert task["taskDefinitionArn"] == task_definition_arn, (
         "The task definition should be used without registering a new one"
+    )
+
+    assert (
+        "Skipping task definition construction since a task definition"
+        " ARN is provided." in caplog.text
     )
 
 
@@ -678,6 +689,13 @@ async def test_task_definition_arn_with_variables_that_are_ignored(
         with caplog.at_level(
             logging.WARN, logger=worker.get_flow_run_logger(flow_run).name
         ):
+            template_with_placeholders = worker.work_pool.base_job_template[
+                "job_configuration"
+            ]["task_definition"]
+            placeholders = [
+                placeholder.name
+                for placeholder in find_placeholders(template_with_placeholders)
+            ]
             result = await run_then_stop_task(worker, configuration, flow_run)
 
     assert result.status_code == 0
@@ -690,9 +708,16 @@ async def test_task_definition_arn_with_variables_that_are_ignored(
 
     assert (
         "Skipping task definition construction since a task definition"
-        " ARN is provided. The following job variable references"
+        " ARN is provided." in caplog.text
+    )
+
+    assert (
+        "The following job variable references"
         " in the task definition template will be ignored: " in caplog.text
     )
+
+    for key in overrides.keys():
+        assert key in caplog.text if key in placeholders else key not in caplog.text
 
 
 @pytest.mark.usefixtures("ecs_mocks")

--- a/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
+++ b/src/integrations/prefect-aws/tests/workers/test_ecs_worker.py
@@ -676,7 +676,7 @@ async def test_task_definition_arn_with_variables_that_are_ignored(
 
     async with ECSWorker(work_pool_name="test") as worker:
         with caplog.at_level(
-            logging.INFO, logger=worker.get_flow_run_logger(flow_run).name
+            logging.WARN, logger=worker.get_flow_run_logger(flow_run).name
         ):
             result = await run_then_stop_task(worker, configuration, flow_run)
 
@@ -688,13 +688,11 @@ async def test_task_definition_arn_with_variables_that_are_ignored(
         "A new task definition should not be registered"
     )
 
-    # TODO: Add logging for this case
-    # assert (
-    #     "Settings require changes to the linked task definition. "
-    #     "The settings will be ignored. "
-    #     "Enable DEBUG level logs to see the difference."
-    #     in caplog.text
-    # )
+    assert (
+        "Skipping task definition construction since a task definition"
+        " ARN is provided. The following job variable references"
+        " in the task definition template will be ignored: " in caplog.text
+    )
 
 
 @pytest.mark.usefixtures("ecs_mocks")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
When a task definition arn is included in an ECS work pool's job variables, any value that would be used to construct a task definition is ignored since a task definition doesn't need to be constructed. Updates a warning log that calls this out more explicitly.

Sample logs
```bash
19:02:28.089 | WARNING | prefect.flow_runs.worker - Skipping task definition construction since a task definition ARN is provided.
19:02:28.091 | WARNING | prefect.flow_runs.worker - The following job variable references in the task definition template will be ignored: cpu, execution_role_arn, memory, image, container_name, family
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
