### PR TITLE
bump `typing-extensions` lower bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
     "ruamel.yaml>=0.17.0",
     "sniffio>=1.3.0,<2.0.0",
     "toml>=0.10.0",
-    "typing_extensions>=4.5.0,<5.0.0",
+    "typing_extensions>=4.10.0,<5.0.0",
     "ujson>=5.8.0,<6.0.0",
     "uvicorn>=0.14.0,!=0.29.0",
     "websockets>=13.0,<16.0",


### PR DESCRIPTION
closes #17579 

see https://github.com/python/typing_extensions/releases/tag/4.10.0