### PR TITLE
fix: cli login command in modal docs

### DIFF
--- a/docs/v3/deploy/infrastructure-examples/modal.mdx
+++ b/docs/v3/deploy/infrastructure-examples/modal.mdx
@@ -183,7 +183,7 @@ def main(name: str = "world", goodbye: bool = False):
 First, authenticate to Prefect Cloud.
 
 ```bash
-uv run prefect auth login
+uv run prefect cloud login
 ```
 
 You'll need a Personal Access Token (PAT) for authentication.


### PR DESCRIPTION
not sure if this was always here or was changed at some point but it should be `prefect cloud login`

