### PR TITLE
Bump min prefect version in `prefect-aws`

### DIFF
--- a/src/integrations/prefect-aws/pyproject.toml
+++ b/src/integrations/prefect-aws/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "botocore>=1.27.53",
   "mypy_boto3_s3>=1.24.94",
   "mypy_boto3_secretsmanager>=1.26.49",
-  "prefect>=3.1.3",
+  "prefect>=3.2.13",
   "pyparsing>=3.1.1",
   "tenacity>=8.0.0",
 ]


### PR DESCRIPTION
`prefect-aws==0.5.7` released a change that uses `Worker.work_pool` property that is only available in `prefect>=3.2.13` 