### PR TITLE
Includes more (and more current) files in the nightly release detection

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -38,7 +38,7 @@ jobs:
         id: check_changes
         run: |
           latest_tag=${{ steps.get_latest_tag.outputs.latest_tag }}
-          if git diff --exit-code $latest_tag HEAD -- '*.py' setup.py requirements.txt requirements-client.txt ui; then
+          if git diff --exit-code $latest_tag HEAD -- '*.py' pyproject.toml Dockerfile client/pyproject.toml client/build_client.sh client/Dockerfile ui; then
             echo "SHOULD_CREATE_RELEASE=false" >> $GITHUB_OUTPUT
             echo "No changes in .py files or dependencies since the latest tag."
           else


### PR DESCRIPTION
The nightly release was only considering .py files and a handful of
project files, but it should also include the `Dockerfile`s and
`pyproject.toml`s of the main and client builds.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
