### PR TITLE
respect default namespace for docker `prefect.yaml` steps

### DIFF
--- a/src/integrations/prefect-docker/prefect_docker/deployments/steps.py
+++ b/src/integrations/prefect-docker/prefect_docker/deployments/steps.py
@@ -28,25 +28,29 @@ import os
 import sys
 from functools import wraps
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Callable, List, Optional, ParamSpec, TypeVar
 
 import docker.errors
 from docker.models.images import Image
 from typing_extensions import TypedDict
 
 from prefect.logging.loggers import get_logger
+from prefect.settings import PREFECT_DEFAULT_DOCKER_BUILD_NAMESPACE
 from prefect.types import DateTime
 from prefect.utilities.dockerutils import (
     IMAGE_LABELS,
     BuildError,
     docker_client,
     get_prefect_image_name,
+    split_repository_path,
 )
 from prefect.utilities.slugify import slugify
 
+P = ParamSpec("P")
+T = TypeVar("T")
 logger = get_logger("prefect_docker.deployments.steps")
 
-STEP_OUTPUT_CACHE: Dict = {}
+STEP_OUTPUT_CACHE: dict[tuple[Any, ...], Any] = {}
 
 
 class BuildDockerImageResult(TypedDict):
@@ -85,7 +89,7 @@ class PushDockerImageResult(TypedDict):
     additional_tags: Optional[List[str]]
 
 
-def _make_hashable(obj):
+def _make_hashable(obj: Any) -> Any:
     if isinstance(obj, dict):
         return json.dumps(obj, sort_keys=True)
     elif isinstance(obj, list):
@@ -93,9 +97,9 @@ def _make_hashable(obj):
     return obj
 
 
-def cacheable(func):
+def cacheable(func: Callable[P, T]) -> Callable[P, T]:
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         if ignore_cache := kwargs.pop("ignore_cache", False):
             logger.debug(f"Ignoring `@cacheable` decorator for {func.__name__}.")
         key = (
@@ -117,10 +121,10 @@ def cacheable(func):
 def build_docker_image(
     image_name: str,
     dockerfile: str = "Dockerfile",
-    tag: Optional[str] = None,
-    additional_tags: Optional[List[str]] = None,
+    tag: str | None = None,
+    additional_tags: list[str] | None = None,
     ignore_cache: bool = False,
-    **build_kwargs,
+    **build_kwargs: Any,
 ) -> BuildDockerImageResult:
     """
     Builds a Docker image for a Prefect deployment.
@@ -181,9 +185,17 @@ def build_docker_image(
                 platform: amd64
         ```
     """  # noqa
+
+    namespace, repository = split_repository_path(image_name)
+    if not namespace:
+        namespace = PREFECT_DEFAULT_DOCKER_BUILD_NAMESPACE.value()
+    # join the namespace and repository to create the full image name
+    # ignore namespace if it is None
+    image_name = "/".join(filter(None, [namespace, repository]))
+
     auto_build = dockerfile == "auto"
     if auto_build:
-        lines = []
+        lines: list[str] = []
         base_image = get_prefect_image_name()
         lines.append(f"FROM {base_image}")
         dir_name = os.path.basename(os.getcwd())
@@ -262,9 +274,9 @@ def build_docker_image(
 @cacheable
 def push_docker_image(
     image_name: str,
-    tag: Optional[str] = None,
-    credentials: Optional[Dict] = None,
-    additional_tags: Optional[List[str]] = None,
+    tag: str | None = None,
+    credentials: dict[str, Any] | None = None,
+    additional_tags: list[str] | None = None,
     ignore_cache: bool = False,
 ) -> PushDockerImageResult:
     """
@@ -319,6 +331,14 @@ def push_docker_image(
                 additional_tags: "{{ build-image.additional_tags }}"
         ```
     """  # noqa
+
+    namespace, repository = split_repository_path(image_name)
+    if not namespace:
+        namespace = PREFECT_DEFAULT_DOCKER_BUILD_NAMESPACE.value()
+    # join the namespace and repository to create the full image name
+    # ignore namespace if it is None
+    image_name = "/".join(filter(None, [namespace, repository]))
+
     with docker_client() as client:
         if credentials is not None:
             client.login(
@@ -331,7 +351,7 @@ def push_docker_image(
             client.api.push(repository=image_name, tag=tag, stream=True, decode=True)
         )
         additional_tags = additional_tags or []
-        for i, tag_ in enumerate(additional_tags):
+        for tag_ in additional_tags:
             event = list(
                 client.api.push(
                     repository=image_name, tag=tag_, stream=True, decode=True

--- a/src/integrations/prefect-docker/prefect_docker/deployments/steps.py
+++ b/src/integrations/prefect-docker/prefect_docker/deployments/steps.py
@@ -23,6 +23,8 @@ the build step for a specific deployment.
     ```
 """
 
+from __future__ import annotations
+
 import json
 import os
 import sys

--- a/src/integrations/prefect-docker/prefect_docker/deployments/steps.py
+++ b/src/integrations/prefect-docker/prefect_docker/deployments/steps.py
@@ -28,11 +28,11 @@ import os
 import sys
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, List, Optional, ParamSpec, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 
 import docker.errors
 from docker.models.images import Image
-from typing_extensions import TypedDict
+from typing_extensions import ParamSpec, TypedDict
 
 from prefect.logging.loggers import get_logger
 from prefect.settings import PREFECT_DEFAULT_DOCKER_BUILD_NAMESPACE

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -6009,7 +6009,7 @@ class TestDeploymentTrigger:
 
     class TestDeploymentTriggerPassedViaCLI:
         @pytest.mark.usefixtures("project_dir")
-        async def test_json_string_trigger(self, docker_work_pool):
+        async def test_json_string_trigger(self, docker_work_pool: WorkPool):
             client = AsyncMock()
             client.server_type = ServerType.CLOUD
 
@@ -6049,7 +6049,7 @@ class TestDeploymentTrigger:
                 assert triggers == expected_triggers
 
         @pytest.mark.usefixtures("project_dir")
-        async def test_json_file_trigger(self, docker_work_pool):
+        async def test_json_file_trigger(self, docker_work_pool: WorkPool):
             client = AsyncMock()
             client.server_type = ServerType.CLOUD
 
@@ -6090,7 +6090,7 @@ class TestDeploymentTrigger:
                 assert triggers == expected_triggers
 
         @pytest.mark.usefixtures("project_dir")
-        async def test_yaml_file_trigger(self, docker_work_pool):
+        async def test_yaml_file_trigger(self, docker_work_pool: WorkPool):
             client = AsyncMock()
             client.server_type = ServerType.CLOUD
 
@@ -6131,7 +6131,9 @@ class TestDeploymentTrigger:
                 assert triggers == expected_triggers
 
         @pytest.mark.usefixtures("project_dir")
-        async def test_nested_yaml_file_trigger(self, docker_work_pool, tmpdir):
+        async def test_nested_yaml_file_trigger(
+            self, docker_work_pool: WorkPool, tmpdir: Path
+        ):
             client = AsyncMock()
             client.server_type = ServerType.CLOUD
 
@@ -6171,7 +6173,7 @@ class TestDeploymentTrigger:
                 assert triggers == expected_triggers
 
         @pytest.mark.usefixtures("project_dir")
-        async def test_multiple_trigger_flags(self, docker_work_pool):
+        async def test_multiple_trigger_flags(self, docker_work_pool: WorkPool):
             client = AsyncMock()
             client.server_type = ServerType.CLOUD
 


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/17604

### copilot summary
focusing on type annotations, cache improvements, and the handling of Docker image namespaces. Additionally, new tests have been added to ensure these changes work as expected.

### Type Annotations and Cache Improvements:
* Added type annotations to functions and variables in `src/integrations/prefect-docker/prefect_docker/deployments/steps.py` to improve code clarity and type checking. [[1]](diffhunk://#diff-3f40bcfdb088269ff630005eab5d7b9f51ebf44937ac6317c65517c1b14b497fR26-R55) [[2]](diffhunk://#diff-3f40bcfdb088269ff630005eab5d7b9f51ebf44937ac6317c65517c1b14b497fL88-R104) [[3]](diffhunk://#diff-3f40bcfdb088269ff630005eab5d7b9f51ebf44937ac6317c65517c1b14b497fL120-R129)
* Updated `STEP_OUTPUT_CACHE` to use a more specific type annotation for better type safety.

### Docker Image Namespace Handling:
* Introduced logic to handle default Docker image namespaces using `PREFECT_DEFAULT_DOCKER_BUILD_NAMESPACE` in `build_docker_image` and `push_docker_image` functions. [[1]](diffhunk://#diff-3f40bcfdb088269ff630005eab5d7b9f51ebf44937ac6317c65517c1b14b497fR190-R200) [[2]](diffhunk://#diff-3f40bcfdb088269ff630005eab5d7b9f51ebf44937ac6317c65517c1b14b497fL265-R281) [[3]](diffhunk://#diff-3f40bcfdb088269ff630005eab5d7b9f51ebf44937ac6317c65517c1b14b497fR336-R343)
* Added new tests to verify that the default namespace is respected and that explicitly provided namespaces take precedence.

### Test Enhancements:
* Added type annotations to test functions in `tests/cli/test_deploy.py` for better type checking and readability. [[1]](diffhunk://#diff-270fd4ffbacb722e15faf790f524814042a724536fd43743c78f273660b36ff3L6012-R6012) [[2]](diffhunk://#diff-270fd4ffbacb722e15faf790f524814042a724536fd43743c78f273660b36ff3L6052-R6052) [[3]](diffhunk://#diff-270fd4ffbacb722e15faf790f524814042a724536fd43743c78f273660b36ff3L6093-R6093) [[4]](diffhunk://#diff-270fd4ffbacb722e15faf790f524814042a724536fd43743c78f273660b36ff3L6134-R6136) [[5]](diffhunk://#diff-270fd4ffbacb722e15faf790f524814042a724536fd43743c78f273660b36ff3L6174-R6176)