### PR TITLE
Fix `mark_flow_run_as_cancelled` in worker still gets error

### DIFF
--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1250,12 +1250,13 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
     ) -> None:
         state_updates = state_updates or {}
         state_updates.setdefault("name", "Cancelled")
-        state_updates.setdefault("type", StateType.CANCELLED)
 
         if flow_run.state:
+            state_updates.setdefault("type", StateType.CANCELLED)
             state = flow_run.state.model_copy(update=state_updates)
         else:
             # Unexpectedly when flow run does not have a state, create a new one
+            # does not need to explicitly set the type
             state = Cancelled(**state_updates)
 
         await self.client.set_flow_run_state(flow_run.id, state, force=True)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->
Fixes #17627 

<!-- Include an overview of the proposed changes here -->
The issue is occurring in the way kwargs are being passed.

1. In `mark_flow_run_as_cancelled()`, we set `state_updates.setdefault("type", StateType.CANCELLED)`
2. Then we call `Cancelled(**state_updates)`
3. Inside `Cancelled()`, we call `_traced(cls, type=StateType.CANCELLED, **kwargs)`
4. The problem is that `kwargs` already contains "type" from `state_updates`, and we're also explicitly passing `type=StateType.CANCELLED`

This causes a duplicate key situation. When Python expands `**kwargs` in the function call, it would result in something like:

```python
_traced(cls, type=StateType.CANCELLED, type=state_updates["type"], ...)
```

Having the type parameter twice is causing the `KeyError`.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
