### PR TITLE
Remove code past its marked deprecation date

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -12592,7 +12592,7 @@
                     "create_if_missing": {
                         "type": "boolean",
                         "title": "Create If Missing",
-                        "default": true
+                        "deprecated": true
                     }
                 },
                 "type": "object",
@@ -12635,7 +12635,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Create If Missing"
+                        "title": "Create If Missing",
+                        "deprecated": true
                     }
                 },
                 "type": "object",

--- a/src/integrations/prefect-aws/prefect_aws/deployments/steps.py
+++ b/src/integrations/prefect-aws/prefect_aws/deployments/steps.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 
 from typing_extensions import TypedDict
 
-from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect.utilities.filesystem import filter_files, relative_path_to_current_platform
 from prefect_aws.s3 import get_s3_client
 
@@ -24,11 +23,6 @@ class PushToS3Output(TypedDict):
     folder: str
 
 
-@deprecated_callable(start_date="Jun 2023", help="Use `PushToS3Output` instead.")
-class PushProjectToS3Output(PushToS3Output):
-    """Deprecated. Use `PushToS3Output` instead."""
-
-
 class PullFromS3Output(TypedDict):
     """
     The output of the `pull_from_s3` step.
@@ -37,17 +31,6 @@ class PullFromS3Output(TypedDict):
     bucket: str
     folder: str
     directory: str
-
-
-@deprecated_callable(start_date="Jun 2023", help="Use `PullFromS3Output` instead.")
-class PullProjectFromS3Output(PullFromS3Output):
-    """Deprecated. Use `PullFromS3Output` instead.."""
-
-
-@deprecated_callable(start_date="Jun 2023", help="Use `push_to_s3` instead.")
-def push_project_to_s3(*args: Any, **kwargs: Any):
-    """Deprecated. Use `push_to_s3` instead."""
-    push_to_s3(*args, **kwargs)
 
 
 def push_to_s3(
@@ -122,12 +105,6 @@ def push_to_s3(
         "bucket": bucket,
         "folder": folder,
     }
-
-
-@deprecated_callable(start_date="Jun 2023", help="Use `pull_from_s3` instead.")
-def pull_project_from_s3(*args: Any, **kwargs: Any):
-    """Deprecated. Use `pull_from_s3` instead."""
-    pull_from_s3(*args, **kwargs)
 
 
 def pull_from_s3(

--- a/src/integrations/prefect-dask/prefect_dask/task_runners.py
+++ b/src/integrations/prefect-dask/prefect_dask/task_runners.py
@@ -140,14 +140,7 @@ class PrefectDaskFuture(PrefectWrappedFuture[R, distributed.Future]):
             else:
                 return future_result
 
-        _result = self._final_state.result(
-            raise_on_failure=raise_on_failure, fetch=True
-        )
-        # state.result is a `sync_compatible` function that may or may not return an awaitable
-        # depending on whether the parent frame is sync or not
-        if asyncio.iscoroutine(_result):
-            _result = run_coro_as_sync(_result)
-        return _result
+        return self._final_state.result(raise_on_failure=raise_on_failure, _sync=True)
 
     def __del__(self):
         if self._final_state or self._wrapped_future.done():

--- a/src/integrations/prefect-gcp/prefect_gcp/deployments/steps.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/deployments/steps.py
@@ -10,7 +10,6 @@ from google.cloud.storage import Client as StorageClient
 from google.oauth2.service_account import Credentials
 from typing_extensions import TypedDict
 
-from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect.utilities.filesystem import filter_files, relative_path_to_current_platform
 
 
@@ -23,11 +22,6 @@ class PushToGcsOutput(TypedDict):
     folder: str
 
 
-@deprecated_callable(start_date="Jun 2023", help="Use `PushToGcsOutput` instead.")
-class PushProjectToGcsOutput(PushToGcsOutput):
-    """Deprecated. Use `PushToGcsOutput` instead."""
-
-
 class PullFromGcsOutput(TypedDict):
     """
     The output of the `pull_from_gcs` step.
@@ -36,11 +30,6 @@ class PullFromGcsOutput(TypedDict):
     bucket: str
     folder: str
     directory: str
-
-
-@deprecated_callable(start_date="Jun 2023", help="Use `PullFromGcsOutput` instead.")
-class PullProjectFromGcsOutput(PullFromGcsOutput):
-    """Deprecated. Use `PullFromGcsOutput` instead."""
 
 
 def push_to_gcs(
@@ -148,20 +137,12 @@ def push_to_gcs(
     }
 
 
-@deprecated_callable(start_date="Jun 2023", help="Use `push_to_gcs` instead.")
-def push_project_to_gcs(*args, **kwargs) -> PushToGcsOutput:
-    """
-    Deprecated. Use `push_to_gcs` instead.
-    """
-    return push_to_gcs(*args, **kwargs)
-
-
 def pull_from_gcs(
     bucket: str,
     folder: str,
     project: Optional[str] = None,
     credentials: Optional[Dict] = None,
-) -> PullProjectFromGcsOutput:
+) -> PullFromGcsOutput:
     """
     Pulls the contents of a project from an GCS bucket to the current working directory.
 
@@ -249,11 +230,3 @@ def pull_from_gcs(
         "folder": folder,
         "directory": str(local_path),
     }
-
-
-@deprecated_callable(start_date="Jun 2023", help="Use `pull_from_gcs` instead.")
-def pull_project_from_gcs(*args, **kwargs) -> PullProjectFromGcsOutput:
-    """
-    Deprecated. Use `pull_from_gcs` instead.
-    """
-    return pull_from_gcs(*args, **kwargs)

--- a/src/integrations/prefect-ray/prefect_ray/task_runners.py
+++ b/src/integrations/prefect-ray/prefect_ray/task_runners.py
@@ -143,9 +143,7 @@ class PrefectRayFuture(PrefectWrappedFuture[R, "ray.ObjectRef"]):
             else:
                 return object_ref_result
 
-        _result = self._final_state.result(
-            raise_on_failure=raise_on_failure, fetch=True
-        )
+        _result = self._final_state.result(raise_on_failure=raise_on_failure)
         # state.result is a `sync_compatible` function that may or may not return an awaitable
         # depending on whether the parent frame is sync or not
         if asyncio.iscoroutine(_result):

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -23,9 +23,6 @@ from yaml.error import YAMLError
 
 import prefect
 from prefect._experimental.sla.objects import SlaTypes
-from prefect._internal.compatibility.deprecated import (
-    generate_deprecation_message,
-)
 from prefect.blocks.system import Secret
 from prefect.cli._prompts import (
     confirm,
@@ -304,12 +301,6 @@ async def deploy(
             "It will be created if it doesn't already exist. Defaults to `None`."
         ),
     ),
-    variables: List[str] = typer.Option(
-        None,
-        "-v",
-        "--variable",
-        help=("DEPRECATED: Please use --jv/--job-variable for similar functionality "),
-    ),
     job_variables: List[str] = typer.Option(
         None,
         "-jv",
@@ -403,24 +394,8 @@ async def deploy(
 
     Should be run from a project root directory.
     """
-    if variables is not None:
-        app.console.print(
-            generate_deprecation_message(
-                name="The `--variable` flag",
-                start_date="Mar 2024",
-                help=(
-                    "Please use the `--job-variable foo=bar` argument instead: `prefect"
-                    " deploy --job-variable`."
-                ),
-            ),
-            style="yellow",
-        )
-
-    if variables is None:
-        variables = list()
     if job_variables is None:
         job_variables = list()
-    job_variables.extend(variables)
 
     concurrency_limit_config = (
         None

--- a/src/prefect/client/orchestration/_concurrency_limits/client.py
+++ b/src/prefect/client/orchestration/_concurrency_limits/client.py
@@ -244,7 +244,6 @@ class ConcurrencyLimitClient(BaseClient):
         names: list[str],
         slots: int,
         mode: str,
-        create_if_missing: bool | None = None,
     ) -> "Response":
         return self.request(
             "POST",
@@ -253,7 +252,6 @@ class ConcurrencyLimitClient(BaseClient):
                 "names": names,
                 "slots": slots,
                 "mode": mode,
-                "create_if_missing": create_if_missing if create_if_missing else False,
             },
         )
 
@@ -614,7 +612,6 @@ class ConcurrencyLimitAsyncClient(BaseAsyncClient):
         names: list[str],
         slots: int,
         mode: str,
-        create_if_missing: bool | None = None,
     ) -> "Response":
         return await self.request(
             "POST",
@@ -623,7 +620,6 @@ class ConcurrencyLimitAsyncClient(BaseAsyncClient):
                 "names": names,
                 "slots": slots,
                 "mode": mode,
-                "create_if_missing": create_if_missing if create_if_missing else False,
             },
         )
 

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -32,6 +32,7 @@ from pydantic import (
 )
 from typing_extensions import Literal, Self, TypeVar
 
+from prefect._internal.compatibility.async_dispatch import async_dispatch
 from prefect._internal.compatibility.migration import getattr_migration
 from prefect._internal.schemas.bases import ObjectBaseModel, PrefectBaseModel
 from prefect._internal.schemas.fields import CreatedBy, UpdatedBy
@@ -60,6 +61,7 @@ from prefect.types import (
     StrictVariableValue,
 )
 from prefect.types._datetime import DateTime
+from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.collections import AutoEnum, listrepr, visit_collection
 from prefect.utilities.names import generate_slug
 from prefect.utilities.pydantic import handle_secret_render
@@ -211,27 +213,65 @@ class State(ObjectBaseModel, Generic[R]):
     ] = Field(default=None)
 
     @overload
-    async def result(
+    async def aresult(
         self: "State[R]",
         raise_on_failure: Literal[True] = ...,
         retry_result_failure: bool = ...,
     ) -> R: ...
 
     @overload
-    async def result(
+    async def aresult(
         self: "State[R]",
         raise_on_failure: Literal[False] = False,
         retry_result_failure: bool = ...,
     ) -> Union[R, Exception]: ...
 
     @overload
-    async def result(
+    async def aresult(
         self: "State[R]",
         raise_on_failure: bool = ...,
         retry_result_failure: bool = ...,
     ) -> Union[R, Exception]: ...
 
-    async def result(
+    async def aresult(
+        self,
+        raise_on_failure: bool = True,
+        retry_result_failure: bool = True,
+    ) -> Union[R, Exception]:
+        """
+        Retrieve the result attached to this state.
+        """
+        from prefect.states import get_state_result
+
+        return await get_state_result(
+            self,
+            raise_on_failure=raise_on_failure,
+            retry_result_failure=retry_result_failure,
+        )
+
+    @overload
+    def result(
+        self: "State[R]",
+        raise_on_failure: Literal[True] = ...,
+        retry_result_failure: bool = ...,
+    ) -> R: ...
+
+    @overload
+    def result(
+        self: "State[R]",
+        raise_on_failure: Literal[False] = False,
+        retry_result_failure: bool = ...,
+    ) -> Union[R, Exception]: ...
+
+    @overload
+    def result(
+        self: "State[R]",
+        raise_on_failure: bool = ...,
+        retry_result_failure: bool = ...,
+    ) -> Union[R, Exception]: ...
+
+    @async_dispatch(aresult)
+    def result(
         self,
         raise_on_failure: bool = True,
         retry_result_failure: bool = True,
@@ -305,10 +345,12 @@ class State(ObjectBaseModel, Generic[R]):
         """
         from prefect.states import get_state_result
 
-        return await get_state_result(
-            self,
-            raise_on_failure=raise_on_failure,
-            retry_result_failure=retry_result_failure,
+        return run_coro_as_sync(
+            get_state_result(
+                self,
+                raise_on_failure=raise_on_failure,
+                retry_result_failure=retry_result_failure,
+            )
         )
 
     @model_validator(mode="after")

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -32,7 +32,6 @@ from pydantic import (
 )
 from typing_extensions import Literal, Self, TypeVar
 
-from prefect._internal.compatibility import deprecated
 from prefect._internal.compatibility.migration import getattr_migration
 from prefect._internal.schemas.bases import ObjectBaseModel, PrefectBaseModel
 from prefect._internal.schemas.fields import CreatedBy, UpdatedBy
@@ -212,40 +211,29 @@ class State(ObjectBaseModel, Generic[R]):
     ] = Field(default=None)
 
     @overload
-    def result(
+    async def result(
         self: "State[R]",
         raise_on_failure: Literal[True] = ...,
-        fetch: bool = ...,
         retry_result_failure: bool = ...,
     ) -> R: ...
 
     @overload
-    def result(
+    async def result(
         self: "State[R]",
         raise_on_failure: Literal[False] = False,
-        fetch: bool = ...,
         retry_result_failure: bool = ...,
     ) -> Union[R, Exception]: ...
 
     @overload
-    def result(
+    async def result(
         self: "State[R]",
         raise_on_failure: bool = ...,
-        fetch: bool = ...,
         retry_result_failure: bool = ...,
     ) -> Union[R, Exception]: ...
 
-    @deprecated.deprecated_parameter(
-        "fetch",
-        when=lambda fetch: fetch is not True,
-        start_date="Oct 2024",
-        end_date="Jan 2025",
-        help="Please ensure you are awaiting the call to `result()` when calling in an async context.",
-    )
-    def result(
+    async def result(
         self,
         raise_on_failure: bool = True,
-        fetch: bool = True,
         retry_result_failure: bool = True,
     ) -> Union[R, Exception]:
         """
@@ -317,10 +305,9 @@ class State(ObjectBaseModel, Generic[R]):
         """
         from prefect.states import get_state_result
 
-        return get_state_result(
+        return await get_state_result(
             self,
             raise_on_failure=raise_on_failure,
-            fetch=fetch,
             retry_result_failure=retry_result_failure,
         )
 

--- a/src/prefect/concurrency/_asyncio.py
+++ b/src/prefect/concurrency/_asyncio.py
@@ -3,7 +3,6 @@ from typing import Literal, Optional
 
 import httpx
 
-from prefect._internal.compatibility.deprecated import deprecated_parameter
 from prefect.client.orchestration import get_client
 from prefect.client.schemas.responses import MinimalConcurrencyLimitResponse
 from prefect.logging.loggers import get_run_logger
@@ -19,26 +18,16 @@ class AcquireConcurrencySlotTimeoutError(TimeoutError):
     """Raised when acquiring a concurrency slot times out."""
 
 
-@deprecated_parameter(
-    name="create_if_missing",
-    start_date="Sep 2024",
-    end_date="Oct 2024",
-    when=lambda x: x is not None,
-    help="Limits must be explicitly created before acquiring concurrency slots; see `strict` if you want to enforce this behavior.",
-)
 async def aacquire_concurrency_slots(
     names: list[str],
     slots: int,
     mode: Literal["concurrency", "rate_limit"] = "concurrency",
     timeout_seconds: Optional[float] = None,
-    create_if_missing: Optional[bool] = None,
     max_retries: Optional[int] = None,
     strict: bool = False,
 ) -> list[MinimalConcurrencyLimitResponse]:
     service = ConcurrencySlotAcquisitionService.instance(frozenset(names))
-    future = service.send(
-        (slots, mode, timeout_seconds, create_if_missing, max_retries)
-    )
+    future = service.send((slots, mode, timeout_seconds, max_retries))
     try:
         response = await asyncio.wrap_future(future)
     except TimeoutError as timeout:

--- a/src/prefect/concurrency/asyncio.py
+++ b/src/prefect/concurrency/asyncio.py
@@ -24,7 +24,6 @@ async def concurrency(
     occupy: int = 1,
     timeout_seconds: Optional[float] = None,
     max_retries: Optional[int] = None,
-    create_if_missing: Optional[bool] = None,
     strict: bool = False,
 ) -> AsyncGenerator[None, None]:
     """A context manager that acquires and releases concurrency slots from the
@@ -66,7 +65,6 @@ async def concurrency(
         names,
         occupy,
         timeout_seconds=timeout_seconds,
-        create_if_missing=create_if_missing,
         max_retries=max_retries,
         strict=strict,
     )
@@ -97,7 +95,6 @@ async def rate_limit(
     names: Union[str, list[str]],
     occupy: int = 1,
     timeout_seconds: Optional[float] = None,
-    create_if_missing: Optional[bool] = None,
     strict: bool = False,
 ) -> None:
     """Block execution until an `occupy` number of slots of the concurrency
@@ -126,7 +123,6 @@ async def rate_limit(
         occupy,
         mode="rate_limit",
         timeout_seconds=timeout_seconds,
-        create_if_missing=create_if_missing,
         strict=strict,
     )
     emit_concurrency_acquisition_events(limits, occupy)

--- a/src/prefect/concurrency/services.py
+++ b/src/prefect/concurrency/services.py
@@ -15,7 +15,7 @@ from prefect.utilities.timeout import timeout_async
 if TYPE_CHECKING:
     from prefect.client.orchestration import PrefectClient
 
-_Item: TypeAlias = tuple[int, str, Optional[float], Optional[bool], Optional[int]]
+_Item: TypeAlias = tuple[int, str, Optional[float], Optional[int]]
 
 
 class ConcurrencySlotAcquisitionService(
@@ -37,7 +37,6 @@ class ConcurrencySlotAcquisitionService(
         slots: int,
         mode: str,
         timeout_seconds: Optional[float] = None,
-        create_if_missing: Optional[bool] = None,
         max_retries: Optional[int] = None,
     ) -> httpx.Response:
         with timeout_async(seconds=timeout_seconds):
@@ -47,7 +46,6 @@ class ConcurrencySlotAcquisitionService(
                         names=self.concurrency_limit_names,
                         slots=slots,
                         mode=mode,
-                        create_if_missing=create_if_missing,
                     )
                 except httpx.HTTPStatusError as exc:
                     if not exc.response.status_code == status.HTTP_423_LOCKED:

--- a/src/prefect/concurrency/sync.py
+++ b/src/prefect/concurrency/sync.py
@@ -34,13 +34,12 @@ def _acquire_concurrency_slots(
     slots: int,
     mode: Literal["concurrency", "rate_limit"] = "concurrency",
     timeout_seconds: Optional[float] = None,
-    create_if_missing: Optional[bool] = None,
     max_retries: Optional[int] = None,
     strict: bool = False,
 ) -> list[MinimalConcurrencyLimitResponse]:
     result = run_coro_as_sync(
         aacquire_concurrency_slots(
-            names, slots, mode, timeout_seconds, create_if_missing, max_retries, strict
+            names, slots, mode, timeout_seconds, max_retries, strict
         )
     )
     return result
@@ -53,7 +52,6 @@ def concurrency(
     timeout_seconds: Optional[float] = None,
     max_retries: Optional[int] = None,
     strict: bool = False,
-    create_if_missing: Optional[bool] = None,
 ) -> Generator[None, None, None]:
     """A context manager that acquires and releases concurrency slots from the
     given concurrency limits.
@@ -94,7 +92,6 @@ def concurrency(
         names,
         occupy,
         timeout_seconds=timeout_seconds,
-        create_if_missing=create_if_missing,
         strict=strict,
         max_retries=max_retries,
     )
@@ -113,7 +110,6 @@ def rate_limit(
     names: Union[str, list[str]],
     occupy: int = 1,
     timeout_seconds: Optional[float] = None,
-    create_if_missing: Optional[bool] = None,
     strict: bool = False,
 ) -> None:
     """Block execution until an `occupy` number of slots of the concurrency
@@ -142,7 +138,6 @@ def rate_limit(
         occupy,
         mode="rate_limit",
         timeout_seconds=timeout_seconds,
-        create_if_missing=create_if_missing,
         strict=strict,
     )
     emit_concurrency_acquisition_events(limits, occupy)

--- a/src/prefect/flow_engine.py
+++ b/src/prefect/flow_engine.py
@@ -355,11 +355,7 @@ class FlowRunEngine(BaseFlowRunEngine[P, R]):
         # the State was Prefect-created.
         # TODO: Remove the need to get the result from a State except in cases where the return value
         # is a State object.
-        _result = self.state.result(raise_on_failure=raise_on_failure, fetch=True)  # type: ignore
-        # state.result is a `sync_compatible` function that may or may not return an awaitable
-        # depending on whether the parent frame is sync or not
-        if asyncio.iscoroutine(_result):
-            _result = run_coro_as_sync(_result)
+        _result = self.state.result(raise_on_failure=raise_on_failure, _sync=True)  # type: ignore
         return _result
 
     def handle_success(self, result: R) -> R:
@@ -924,12 +920,7 @@ class AsyncFlowRunEngine(BaseFlowRunEngine[P, R]):
         # the State was Prefect-created.
         # TODO: Remove the need to get the result from a State except in cases where the return value
         # is a State object.
-        _result = self.state.result(raise_on_failure=raise_on_failure, fetch=True)  # type: ignore
-        # state.result is a `sync_compatible` function that may or may not return an awaitable
-        # depending on whether the parent frame is sync or not
-        if asyncio.iscoroutine(_result):
-            _result = await _result
-        return _result
+        return await self.state.aresult(raise_on_failure=raise_on_failure)  # type: ignore
 
     async def handle_success(self, result: R) -> R:
         result_store = getattr(FlowRunContext.get(), "result_store", None)

--- a/src/prefect/states.py
+++ b/src/prefect/states.py
@@ -5,7 +5,6 @@ import datetime
 import sys
 import traceback
 import uuid
-import warnings
 from collections import Counter
 from types import GeneratorType, TracebackType
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Type
@@ -15,7 +14,6 @@ import httpx
 from opentelemetry import propagate
 from typing_extensions import TypeGuard
 
-from prefect._internal.compatibility import deprecated
 from prefect.client.schemas.objects import State, StateDetails, StateType
 from prefect.exceptions import (
     CancelledRun,
@@ -30,7 +28,7 @@ from prefect.exceptions import (
 from prefect.logging.loggers import get_logger, get_run_logger
 from prefect.types._datetime import DateTime, Duration, now
 from prefect.utilities.annotations import BaseAnnotation
-from prefect.utilities.asyncutils import in_async_main_thread, sync_compatible
+from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.collections import ensure_iterable
 
 if TYPE_CHECKING:
@@ -73,17 +71,9 @@ def to_state_create(state: State) -> "StateCreate":
     )
 
 
-@deprecated.deprecated_parameter(
-    "fetch",
-    when=lambda fetch: fetch is not True,
-    start_date="Oct 2024",
-    end_date="Jan 2025",
-    help="Please ensure you are awaiting the call to `result()` when calling in an async context.",
-)
-def get_state_result(
+async def get_state_result(
     state: "State[R]",
     raise_on_failure: bool = True,
-    fetch: bool = True,
     retry_result_failure: bool = True,
 ) -> "R":
     """
@@ -92,25 +82,11 @@ def get_state_result(
     See `State.result()`
     """
 
-    if not fetch and in_async_main_thread():
-        warnings.warn(
-            (
-                "State.result() was called from an async context but not awaited. "
-                "This method will be updated to return a coroutine by default in "
-                "the future. Pass `fetch=True` and `await` the call to get rid of "
-                "this warning."
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        return state.data
-    else:
-        return _get_state_result(
-            state,
-            raise_on_failure=raise_on_failure,
-            retry_result_failure=retry_result_failure,
-        )
+    return await _get_state_result(
+        state,
+        raise_on_failure=raise_on_failure,
+        retry_result_failure=retry_result_failure,
+    )
 
 
 RESULT_READ_MAXIMUM_ATTEMPTS = 10
@@ -155,7 +131,6 @@ async def _get_state_result_data_with_retries(
             await asyncio.sleep(RESULT_READ_RETRY_DELAY)
 
 
-@sync_compatible
 async def _get_state_result(
     state: "State[R]", raise_on_failure: bool, retry_result_failure: bool = True
 ) -> "R":

--- a/src/prefect/utilities/dockerutils.py
+++ b/src/prefect/utilities/dockerutils.py
@@ -57,7 +57,11 @@ def get_prefect_image_name(
     is_prod_build = parsed_version.local is None
     try:
         # Try to get the short SHA from git because it can add additional characters to avoid ambiguity
-        short_sha = subprocess.check_output(["git", "rev-parse", "--short=7", "HEAD"])
+        short_sha = (
+            subprocess.check_output(["git", "rev-parse", "--short=7", "HEAD"])
+            .decode("utf-8")
+            .strip()
+        )
     except Exception:
         # If git is not available, fallback to the first 7 characters of the full revision ID
         short_sha = prefect.__version_info__["full-revisionid"][:7]

--- a/src/prefect/utilities/dockerutils.py
+++ b/src/prefect/utilities/dockerutils.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import shutil
+import subprocess
 import sys
 import warnings
 from collections.abc import Generator, Iterable, Iterator
@@ -54,10 +55,14 @@ def get_prefect_image_name(
     """
     parsed_version = Version(prefect_version or prefect.__version__)
     is_prod_build = parsed_version.local is None
+    try:
+        # Try to get the short SHA from git because it can add additional characters to avoid ambiguity
+        short_sha = subprocess.check_output(["git", "rev-parse", "--short=7", "HEAD"])
+    except Exception:
+        # If git is not available, fallback to the first 7 characters of the full revision ID
+        short_sha = prefect.__version_info__["full-revisionid"][:7]
     prefect_version = (
-        parsed_version.base_version
-        if is_prod_build
-        else "sha-" + prefect.__version_info__["full-revisionid"][:7]
+        parsed_version.base_version if is_prod_build else f"sha-{short_sha}"
     )
 
     python_version = python_version or python_version_minor()

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -221,9 +221,9 @@ async def resolve_inputs(
         finished_states = [state for state in states if state.is_final()]
 
         state_results = [
-            state.result(raise_on_failure=False, fetch=True)
-            for state in finished_states
+            state.aresult(raise_on_failure=False) for state in finished_states
         ]
+        state_results = await asyncio.gather(*state_results)
 
         for state, result in zip(finished_states, state_results):
             result_by_state[state] = result
@@ -749,7 +749,7 @@ def resolve_to_final_result(expr: Any, context: dict[str, Any]) -> Any:
             " 'COMPLETED' state."
         )
 
-    result = state.result(raise_on_failure=False, fetch=True)
+    result = state.result(raise_on_failure=False, _sync=True)
     if asyncio.iscoroutine(result):
         result = run_coro_as_sync(result)
 

--- a/src/prefect/utilities/engine.py
+++ b/src/prefect/utilities/engine.py
@@ -50,7 +50,6 @@ from prefect.settings import PREFECT_LOGGING_LOG_PRINTS
 from prefect.states import State
 from prefect.tasks import Task
 from prefect.utilities.annotations import allow_failure, quote
-from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.collections import StopVisiting, visit_collection
 from prefect.utilities.text import truncated_to
 
@@ -749,9 +748,7 @@ def resolve_to_final_result(expr: Any, context: dict[str, Any]) -> Any:
             " 'COMPLETED' state."
         )
 
-    result = state.result(raise_on_failure=False, _sync=True)
-    if asyncio.iscoroutine(result):
-        result = run_coro_as_sync(result)
+    result: Any = state.result(raise_on_failure=False, _sync=True)  # pyright: ignore[reportCallIssue] _sync messes up type inference and can be removed once async_dispatch is removed
 
     if state.state_details.traceparent:
         parameter_context = propagate.extract(

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -277,7 +277,7 @@ class TestProjectDeploy:
             invoke_and_assert,
             command=(
                 "deploy ./flows/hello.py:my_flow -n test-name -p test-pool --version"
-                " 1.0.0 -v env=prod -t foo-bar"
+                " 1.0.0 -jv env=prod -t foo-bar"
             ),
             expected_code=0,
             expected_output_contains=[
@@ -463,7 +463,7 @@ class TestProjectDeploy:
                 invoke_and_assert,
                 command=(
                     "deploy ./flows/hello.py:my_flow -n test-name --version"
-                    " 1.0.0 -v env=prod -t foo-bar"
+                    " 1.0.0 -jv env=prod -t foo-bar"
                 ),
                 expected_code=0,
                 expected_output_contains=[
@@ -492,7 +492,7 @@ class TestProjectDeploy:
             invoke_and_assert,
             command=(
                 "deploy ./flows/hello.py:my_flow -n test-name -p test-pool --version"
-                " 1.0.0 -v env=prod -t foo-bar --enforce-parameter-schema"
+                " 1.0.0 -jv env=prod -t foo-bar --enforce-parameter-schema"
             ),
         )
         assert result.exit_code == 0
@@ -517,7 +517,7 @@ class TestProjectDeploy:
             invoke_and_assert,
             command=(
                 "deploy ./flows/hello.py:my_flow -n test-name -p"
-                f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
+                f" {work_pool.name} --version 1.0.0 -jv env=prod -t foo-bar"
             ),
             expected_code=0,
             expected_output_contains=[
@@ -548,7 +548,7 @@ class TestProjectDeploy:
             invoke_and_assert,
             command=(
                 "deploy ./flows/hello.py:my_flow -n test-name -p"
-                f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
+                f" {work_pool.name} --version 1.0.0 -jv env=prod -t foo-bar"
                 " --interval 60"
             ),
             user_input=(
@@ -689,7 +689,7 @@ class TestProjectDeploy:
                 invoke_and_assert,
                 command=(
                     "deploy ./flows/hello.py:my_flow -n test-name -p"
-                    f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
+                    f" {work_pool.name} --version 1.0.0 -jv env=prod -t foo-bar"
                     " --interval 60"
                 ),
                 expected_code=0,
@@ -717,7 +717,7 @@ class TestProjectDeploy:
                 invoke_and_assert,
                 command=(
                     "deploy ./flows/hello.py:my_flow -n test-name -p"
-                    f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
+                    f" {work_pool.name} --version 1.0.0 -jv env=prod -t foo-bar"
                     " --interval 60"
                 ),
                 # User rejects pulling from the remote repo and rejects saving the
@@ -749,7 +749,7 @@ class TestProjectDeploy:
                 invoke_and_assert,
                 command=(
                     "deploy ./flows/hello.py:my_flow -n test-name -p"
-                    f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
+                    f" {work_pool.name} --version 1.0.0 -jv env=prod -t foo-bar"
                     " --interval 60"
                 ),
                 expected_code=0,
@@ -813,7 +813,7 @@ class TestProjectDeploy:
                 invoke_and_assert,
                 command=(
                     "deploy ./flows/hello.py:my_flow -n test-name -p"
-                    f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
+                    f" {work_pool.name} --version 1.0.0 -jv env=prod -t foo-bar"
                     " --interval 60"
                 ),
                 expected_code=0,
@@ -879,7 +879,7 @@ class TestProjectDeploy:
                 invoke_and_assert,
                 command=(
                     "deploy ./flows/hello.py:my_flow -n test-name -p"
-                    f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
+                    f" {work_pool.name} --version 1.0.0 -jv env=prod -t foo-bar"
                     " --interval 60"
                 ),
                 expected_code=0,
@@ -953,7 +953,7 @@ class TestProjectDeploy:
                 invoke_and_assert,
                 command=(
                     "deploy ./flows/hello.py:my_flow -n test-name -p"
-                    f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
+                    f" {work_pool.name} --version 1.0.0 -jv env=prod -t foo-bar"
                     " --interval 60"
                 ),
                 expected_code=0,
@@ -1105,7 +1105,7 @@ class TestProjectDeploy:
                 invoke_and_assert,
                 command=(
                     "deploy ./flows/hello.py:my_flow -n test-name -p"
-                    f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
+                    f" {work_pool.name} --version 1.0.0 -jv env=prod -t foo-bar"
                     " --interval 60"
                 ),
                 expected_code=0,
@@ -1189,7 +1189,7 @@ class TestProjectDeploy:
                 invoke_and_assert,
                 command=(
                     "deploy ./flows/hello.py:my_flow -n test-name -p"
-                    f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
+                    f" {work_pool.name} --version 1.0.0 -jv env=prod -t foo-bar"
                     " --interval 60"
                 ),
                 expected_code=0,
@@ -1289,7 +1289,7 @@ class TestProjectDeploy:
                 invoke_and_assert,
                 command=(
                     "deploy ./flows/hello.py:my_flow -n test-name -p"
-                    f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
+                    f" {work_pool.name} --version 1.0.0 -jv env=prod -t foo-bar"
                     " --interval 60"
                 ),
                 expected_code=0,
@@ -1388,7 +1388,7 @@ class TestProjectDeploy:
                 invoke_and_assert,
                 command=(
                     "deploy ./flows/hello.py:my_flow -n test-name -p"
-                    f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
+                    f" {work_pool.name} --version 1.0.0 -jv env=prod -t foo-bar"
                     " --interval 60"
                 ),
                 expected_code=1,
@@ -3875,7 +3875,7 @@ class TestMultiDeploy:
             invoke_and_assert,
             command=(
                 "deploy ./flows/hello.py:my_flow -n test-name -p"
-                f" {work_pool.name} --version 1.0.0 -v env=prod -t foo-bar"
+                f" {work_pool.name} --version 1.0.0 -jv env=prod -t foo-bar"
             ),
             expected_code=0,
             expected_output_contains=[
@@ -5827,7 +5827,7 @@ class TestDeploymentTrigger:
                 invoke_and_assert,
                 command=(
                     "deploy ./flows/hello.py:my_flow -n test-name -p test-pool --version"
-                    " 1.0.0 -v env=prod -t foo-bar"
+                    " 1.0.0 -jv env=prod -t foo-bar"
                     f" --trigger '{json.dumps(trigger_spec)}'"
                 ),
                 expected_code=0,
@@ -6889,7 +6889,7 @@ class TestDeployInfraOverrides:
             invoke_and_assert,
             command=(
                 "deploy ./flows/hello.py:my_flow -n test-name -p test-pool --version"
-                " 1.0.0 -v env=prod -t foo-bar --job-variable"
+                " 1.0.0 -jv env=prod -t foo-bar --job-variable"
                 ' \'{"resources":{"limits":{"cpu": 1}}}\''
             ),
             expected_code=0,
@@ -6916,7 +6916,7 @@ class TestDeployInfraOverrides:
             invoke_and_assert,
             command=(
                 "deploy ./flows/hello.py:my_flow -n test-name -p test-pool --version"
-                " 1.0.0 -v env=prod -t foo-bar --job-variable 'my-variable'"
+                " 1.0.0 -jv env=prod -t foo-bar --job-variable 'my-variable'"
             ),
             expected_code=1,
             expected_output_contains=[
@@ -6929,7 +6929,7 @@ class TestDeployInfraOverrides:
             invoke_and_assert,
             command=(
                 "deploy ./flows/hello.py:my_flow -n test-name -p test-pool --version"
-                " 1.0.0 -v env=prod -t foo-bar --job-variable ['my-variable']"
+                " 1.0.0 -jv env=prod -t foo-bar --job-variable ['my-variable']"
             ),
             expected_code=1,
             expected_output_contains=[
@@ -6942,7 +6942,7 @@ class TestDeployInfraOverrides:
             invoke_and_assert,
             command=(
                 "deploy ./flows/hello.py:my_flow -n test-name -p test-pool --version"
-                " 1.0.0 -v env=prod -t foo-bar --job-variable "
+                " 1.0.0 -jv env=prod -t foo-bar --job-variable "
                 ' \'{"resources":{"limits":{"cpu"}\''
             ),
             expected_code=1,

--- a/tests/concurrency/test_acquire_concurrency_slots.py
+++ b/tests/concurrency/test_acquire_concurrency_slots.py
@@ -28,7 +28,6 @@ async def test_calls_increment_client_method():
             names=["test-1", "test-2"],
             slots=1,
             mode="concurrency",
-            create_if_missing=None,
         )
 
 

--- a/tests/concurrency/test_concurrency_slot_acquisition_service.py
+++ b/tests/concurrency/test_concurrency_slot_acquisition_service.py
@@ -41,7 +41,7 @@ async def test_returns_successful_response(mocked_client):
     expected_mode = "concurrency"
 
     service = ConcurrencySlotAcquisitionService.instance(frozenset(expected_names))
-    future = service.send((expected_slots, expected_mode, None, True, None))
+    future = service.send((expected_slots, expected_mode, None, None))
     await service.drain()
     returned_response = await asyncio.wrap_future(future)
     assert returned_response == response
@@ -50,7 +50,6 @@ async def test_returns_successful_response(mocked_client):
         names=expected_names,
         slots=expected_slots,
         mode=expected_mode,
-        create_if_missing=True,
     )
 
 
@@ -70,7 +69,7 @@ async def test_retries_failed_call_respects_retry_after_header(mocked_client):
     service = ConcurrencySlotAcquisitionService.instance(frozenset(limit_names))
 
     with mock.patch("asyncio.sleep") as sleep:
-        future = service.send((1, "concurrency", None, True, None))
+        future = service.send((1, "concurrency", None, None))
         await service.drain()
         returned_response = await asyncio.wrap_future(future)
 
@@ -94,7 +93,7 @@ async def test_failed_call_status_code_not_retryable_returns_exception(mocked_cl
     limit_names = sorted(["api", "database"])
     service = ConcurrencySlotAcquisitionService.instance(frozenset(limit_names))
 
-    future = service.send((1, "concurrency", None, True, None))
+    future = service.send((1, "concurrency", None, None))
     await service.drain()
     exception = await asyncio.wrap_future(future)
 
@@ -109,7 +108,7 @@ async def test_basic_exception_returns_exception(mocked_client):
     limit_names = sorted(["api", "database"])
     service = ConcurrencySlotAcquisitionService.instance(frozenset(limit_names))
 
-    future = service.send((1, "concurrency", None, True, None))
+    future = service.send((1, "concurrency", None, None))
     await service.drain()
 
     with pytest.raises(Exception) as info:

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -41,7 +41,6 @@ def test_concurrency_orchestrates_api(concurrency_limit: ConcurrencyLimitV2):
                 ["test"],
                 1,
                 timeout_seconds=None,
-                create_if_missing=None,
                 max_retries=None,
                 strict=False,
             )
@@ -273,7 +272,6 @@ def test_rate_limit_orchestrates_api(concurrency_limit_with_decay: ConcurrencyLi
                 1,
                 mode="rate_limit",
                 timeout_seconds=None,
-                create_if_missing=None,
                 strict=False,
             )
 

--- a/tests/concurrency/v1/test_increment_concurrency_limits.py
+++ b/tests/concurrency/v1/test_increment_concurrency_limits.py
@@ -32,7 +32,6 @@ async def test_calls_increment_client_method():
             names=["test-1", "test-2"],
             slots=1,
             mode="concurrency",
-            create_if_missing=None,
         )
 
 

--- a/tests/results/test_result_fetch.py
+++ b/tests/results/test_result_fetch.py
@@ -67,7 +67,7 @@ async def test_async_result_returns_coroutine_with_opt_in():
         return 1
 
     state = await foo(return_state=True)
-    coro = state.result(fetch=True)
+    coro = await state.aresult()
     assert await coro == 1
 
 

--- a/tests/results/test_result_fetch.py
+++ b/tests/results/test_result_fetch.py
@@ -61,14 +61,13 @@ async def test_async_result_warnings_are_not_raised_by_engine():
     assert await my_flow() == 6
 
 
-async def test_async_result_returns_coroutine_with_opt_in():
+async def test_aresult():
     @flow
     async def foo():
         return 1
 
     state = await foo(return_state=True)
-    coro = await state.aresult()
-    assert await coro == 1
+    assert await state.aresult() == 1
 
 
 async def test_async_result_returns_coroutine_with_setting():

--- a/tests/server/models/test_concurrency_limits_v2.py
+++ b/tests/server/models/test_concurrency_limits_v2.py
@@ -12,7 +12,7 @@ from prefect.server.models.concurrency_limits_v2 import (
     MINIMUM_OCCUPANCY_SECONDS_PER_SLOT,
     bulk_decrement_active_slots,
     bulk_increment_active_slots,
-    bulk_read_or_create_concurrency_limits,
+    bulk_read_concurrency_limits,
     bulk_update_denied_slots,
     create_concurrency_limit,
     delete_concurrency_limit,
@@ -340,9 +340,7 @@ async def test_delete_concurrency_limit_by_name(
     )
 
 
-async def test_bulk_read_or_create_concurrency_limits_with_deprecated_flag(
-    session: AsyncSession, ignore_prefect_deprecation_warnings
-):
+async def test_bulk_read_concurrency_limits_with_deprecated_flag(session: AsyncSession):
     names = ["Chase", "Marshall", "Skye", "Rubble", "Zuma", "Rocky", "Everest"]
 
     pre_existing = names[:3]
@@ -352,9 +350,7 @@ async def test_bulk_read_or_create_concurrency_limits_with_deprecated_flag(
             session=session, concurrency_limit=ConcurrencyLimitV2(name=name, limit=1)
         )
 
-    limits = await bulk_read_or_create_concurrency_limits(
-        session=session, names=names, create_if_missing=True
-    )
+    limits = await bulk_read_concurrency_limits(session=session, names=names)
 
     assert set(names) == {limit.name for limit in limits}
 
@@ -366,7 +362,7 @@ async def test_bulk_read_or_create_concurrency_limits_with_deprecated_flag(
             assert limit.limit == 1
 
 
-async def test_bulk_read_or_create_concurrency_limits_default(session: AsyncSession):
+async def test_bulk_read_concurrency_limits_default(session: AsyncSession):
     names = ["Chase", "Marshall", "Skye", "Rubble", "Zuma", "Rocky", "Everest"]
 
     pre_existing = names[:3]
@@ -376,7 +372,7 @@ async def test_bulk_read_or_create_concurrency_limits_default(session: AsyncSess
             session=session, concurrency_limit=ConcurrencyLimitV2(name=name, limit=1)
         )
 
-    limits = await bulk_read_or_create_concurrency_limits(session=session, names=names)
+    limits = await bulk_read_concurrency_limits(session=session, names=names)
 
     assert set(pre_existing) == {limit.name for limit in limits}
     assert all(limit.active for limit in limits)

--- a/tests/server/models/test_concurrency_limits_v2.py
+++ b/tests/server/models/test_concurrency_limits_v2.py
@@ -340,28 +340,6 @@ async def test_delete_concurrency_limit_by_name(
     )
 
 
-async def test_bulk_read_concurrency_limits_with_deprecated_flag(session: AsyncSession):
-    names = ["Chase", "Marshall", "Skye", "Rubble", "Zuma", "Rocky", "Everest"]
-
-    pre_existing = names[:3]
-
-    for name in pre_existing:
-        await create_concurrency_limit(
-            session=session, concurrency_limit=ConcurrencyLimitV2(name=name, limit=1)
-        )
-
-    limits = await bulk_read_concurrency_limits(session=session, names=names)
-
-    assert set(names) == {limit.name for limit in limits}
-
-    for limit in limits:
-        if limit.name in pre_existing:
-            assert limit.active
-        else:
-            assert not limit.active
-            assert limit.limit == 1
-
-
 async def test_bulk_read_concurrency_limits_default(session: AsyncSession):
     names = ["Chase", "Marshall", "Skye", "Rubble", "Zuma", "Rocky", "Everest"]
 

--- a/tests/server/orchestration/api/test_concurrency_limits_v2.py
+++ b/tests/server/orchestration/api/test_concurrency_limits_v2.py
@@ -455,35 +455,6 @@ async def test_increment_concurrency_limit_rate_limit_mode(
     assert refreshed_limit.active_slots == 1
 
 
-async def test_increment_concurrency_limit_rate_limit_mode_implicitly_created_limit(
-    client: AsyncClient,
-    session: AsyncSession,
-    ignore_prefect_deprecation_warnings,
-):
-    # DEPRECATED BEHAVIOR
-    response = await client.post(
-        "/v2/concurrency_limits/increment",
-        json={
-            "names": ["implicitly_created_limit"],
-            "slots": 1,
-            "mode": "rate_limit",
-            "create_if_missing": True,
-        },
-    )
-
-    # The limit should have been created as inactive this will bypass the
-    # validation of `slot_decay_per_second` being non-zero as the limit is
-    # effectively ignored resulting in a 200 response.
-    assert response.status_code == 200
-
-    refreshed_limit = await read_concurrency_limit(
-        session=session, name="implicitly_created_limit"
-    )
-    assert refreshed_limit
-    assert not bool(refreshed_limit.active)
-    assert refreshed_limit.active_slots == 0  # Inactive limits are not incremented
-
-
 async def test_increment_concurrency_limit_rate_limit_mode_doesnt_create_by_default(
     client: AsyncClient,
     session: AsyncSession,

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -3975,9 +3975,9 @@ export interface components {
             occupancy_seconds?: number | null;
             /**
              * Create If Missing
-             * @default true
+             * @deprecated
              */
-            create_if_missing: boolean;
+            create_if_missing?: boolean;
         };
         /** Body_bulk_increment_active_slots_v2_concurrency_limits_increment_post */
         Body_bulk_increment_active_slots_v2_concurrency_limits_increment_post: {
@@ -3991,7 +3991,10 @@ export interface components {
              * @enum {string}
              */
             mode: "concurrency" | "rate_limit";
-            /** Create If Missing */
+            /**
+             * Create If Missing
+             * @deprecated
+             */
             create_if_missing?: boolean | null;
         };
         /** Body_clear_database_admin_database_clear_post */


### PR DESCRIPTION
In preparation for the upcoming 3.3.0 release this PR removes

- The `fetch` parameter from `State.result`. To maintain similar behavior, a `State.aresult` method has been added and `State.result` has been decorated with `@async_compatible`.
- The `create_if_missing` parameter from `concurrency` and `aconcurrency`. The corresponding field in the concurrency v2 API is still present but deprecated and will not be respected.
- The `-v/--variable` flag from the `prefect deploy` CLI.
- Several old deployment step names and types from `prefect-aws` and `prefect-gcp`.