### PR TITLE
explicitly disallow async rollback hooks until supported

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -765,6 +765,11 @@ class Task(Generic[P, R]):
     def on_rollback(
         self, fn: Callable[["Transaction"], None]
     ) -> Callable[["Transaction"], None]:
+        if asyncio.iscoroutinefunction(fn):
+            raise ValueError(
+                "Asynchronous rollback hooks are not yet supported. Rollback hooks must be synchronous functions."
+            )
+
         self.on_rollback_hooks.append(fn)
         return fn
 

--- a/tests/test_task_engine.py
+++ b/tests/test_task_engine.py
@@ -3127,3 +3127,17 @@ class TestTransactionHooks:
         txn_flow(return_state=True)
         assert "Running commit hook 'commit'" in caplog.text
         assert "Commit hook 'commit' finished running successfully" in caplog.text
+
+    async def test_async_rollback_hooks_are_not_supported(self):
+        @task
+        def foo():
+            pass
+
+        with pytest.raises(
+            ValueError,
+            match="Asynchronous rollback hooks are not yet supported. Rollback hooks must be synchronous functions.",
+        ):
+
+            @foo.on_rollback
+            async def rollback(txn):
+                pass


### PR DESCRIPTION
related to https://github.com/PrefectHQ/prefect/issues/17637