### PR TITLE
fix broken link in docs for settings ref

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -94,8 +94,7 @@
               {
                 "group": "Manage settings",
                 "pages": [
-                  "v3/develop/settings-and-profiles",
-                  "v3/develop/settings-ref"
+                  "v3/develop/settings-and-profiles"
                 ]
               },
               "v3/develop/interact-with-api",
@@ -214,6 +213,7 @@
             "pages": [
               "v3/api-ref/index",
               "v3/api-ref/python/index",
+              "v3/api-ref/settings-ref",
               {
                 "group": "REST API",
                 "pages": [
@@ -1475,6 +1475,10 @@
     {
       "source": "/2/:slug*",
       "destination": "/v2/:slug*"
+    },
+    {
+      "destination": "/v3/api-ref/settings-ref",
+      "source": "/v3/develop/settings-ref"
     }
   ]
 }


### PR DESCRIPTION
Reintroduces `settings-ref` location change from #17590 - the change in #17591 reverted the location and was causing redirects to the documentation's intro page.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
