### PR TITLE
docs(gcp): fix google cloud run worker guide link

### DIFF
--- a/docs/integrations/prefect-gcp/index.mdx
+++ b/docs/integrations/prefect-gcp/index.mdx
@@ -181,7 +181,7 @@ Run flows on [Google Cloud Run](https://cloud.google.com/run) or [Vertex AI](htt
 
 Prefect Cloud offers [Google Cloud Run push work pools](/v3/deploy/infrastructure-examples/serverless). Push work pools submit runs directly to Google Cloud Run, instead of requiring a worker to actively poll for flow runs to execute.
 
-See the [Google Cloud Run Worker Guide](integrations/prefect-gcp/gcp-worker-guide/) for a walkthrough of using Google Cloud Run in a hybrid work pool.
+See the [Google Cloud Run Worker Guide](/integrations/prefect-gcp/gcp-worker-guide) for a walkthrough of using Google Cloud Run in a hybrid work pool.
 
 
 ## Examples


### PR DESCRIPTION
fixes a redirect to the getting started guide happening due to a faulty link

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
