### PR TITLE
fix: ui files permissions for self-hosted

### DIFF
--- a/src/prefect/server/api/server.py
+++ b/src/prefect/server/api/server.py
@@ -253,11 +253,11 @@ def copy_directory(directory: str, path: str) -> None:
             # ensure copied files are writeable
             for root, dirs, files in os.walk(destination):
                 for f in files:
-                    os.chmod(os.path.join(root, f), 0o600)
+                    os.chmod(os.path.join(root, f), 0o700)
         else:
             shutil.copy2(source, destination)
             # Ensure copied file is writeable
-            os.chmod(destination, 0o600)
+            os.chmod(destination, 0o700)
 
 
 async def custom_internal_exception_handler(


### PR DESCRIPTION
The self hosted version requires ui files copied over to be writeable not only readable, this was a small omission in changing the file permissions in the original PR. The writeable comes from the use of rmtree.

small omission in the original PR https://github.com/PrefectHQ/prefect/pull/17336

closes #17645 

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
