### PR TITLE
Update `DaskTaskRunner` to lazily load the Dask client

### DIFF
--- a/src/integrations/prefect-dask/prefect_dask/task_runners.py
+++ b/src/integrations/prefect-dask/prefect_dask/task_runners.py
@@ -304,11 +304,11 @@ class DaskTaskRunner(TaskRunner):
         """
         if isinstance(other, DaskTaskRunner):
             return (
-                bool(self.address == other.address)
-                and bool(self.cluster_class == other.cluster_class)
-                and bool(self.cluster_kwargs == other.cluster_kwargs)
-                and bool(self.adapt_kwargs == other.adapt_kwargs)
-                and bool(self.client_kwargs == other.client_kwargs)
+                self.address == other.address
+                and self.cluster_class == other.cluster_class
+                and self.cluster_kwargs == other.cluster_kwargs
+                and self.adapt_kwargs == other.adapt_kwargs
+                and self.client_kwargs == other.client_kwargs
             )
         else:
             return False

--- a/src/integrations/prefect-dask/prefect_dask/task_runners.py
+++ b/src/integrations/prefect-dask/prefect_dask/task_runners.py
@@ -71,13 +71,14 @@ Example:
     ```
 """
 
+from __future__ import annotations
+
 import asyncio
 from contextlib import ExitStack
 from typing import (
     Any,
     Callable,
     Coroutine,
-    Dict,
     Iterable,
     Optional,
     Set,
@@ -87,6 +88,8 @@ from typing import (
 )
 
 import distributed
+import distributed.deploy
+import distributed.deploy.cluster
 from typing_extensions import ParamSpec
 
 from prefect.client.schemas.objects import State, TaskRunInput
@@ -103,7 +106,7 @@ logger = get_logger(__name__)
 
 P = ParamSpec("P")
 T = TypeVar("T")
-F = TypeVar("F", bound=PrefectFuture)
+F = TypeVar("F", bound=PrefectFuture[Any])
 R = TypeVar("R")
 
 
@@ -222,15 +225,18 @@ class DaskTaskRunner(TaskRunner):
 
     def __init__(
         self,
-        cluster: Optional[distributed.deploy.Cluster] = None,
+        cluster: Optional[distributed.deploy.cluster.Cluster] = None,
         address: Optional[str] = None,
-        cluster_class: Union[str, Callable, None] = None,
-        cluster_kwargs: Optional[Dict] = None,
-        adapt_kwargs: Optional[Dict] = None,
-        client_kwargs: Optional[Dict] = None,
+        cluster_class: Union[
+            str, Callable[[], distributed.deploy.cluster.Cluster], None
+        ] = None,
+        cluster_kwargs: Optional[dict[str, Any]] = None,
+        adapt_kwargs: Optional[dict[str, Any]] = None,
+        client_kwargs: Optional[dict[str, Any]] = None,
         performance_report_path: Optional[str] = None,
     ):
         # Validate settings and infer defaults
+        resolved_cluster_class: distributed.deploy.cluster.Cluster | None = None
         if address:
             if cluster or cluster_class or cluster_kwargs or adapt_kwargs:
                 raise ValueError(
@@ -244,9 +250,11 @@ class DaskTaskRunner(TaskRunner):
                 )
         else:
             if isinstance(cluster_class, str):
-                cluster_class = from_qualified_name(cluster_class)
+                resolved_cluster_class = from_qualified_name(cluster_class)
+            elif isinstance(cluster_class, Callable):
+                resolved_cluster_class = cluster_class()
             else:
-                cluster_class = cluster_class
+                resolved_cluster_class = cluster_class
 
         # Create a copies of incoming kwargs since we may mutate them
         cluster_kwargs = cluster_kwargs.copy() if cluster_kwargs else {}
@@ -269,16 +277,22 @@ class DaskTaskRunner(TaskRunner):
             )
 
         # Store settings
-        self.address = address
-        self.cluster_class = cluster_class
-        self.cluster_kwargs = cluster_kwargs
-        self.adapt_kwargs = adapt_kwargs
-        self.client_kwargs = client_kwargs
-        self.performance_report_path = performance_report_path
+        self.address: str | None = address
+        self.cluster_class: (
+            str | Callable[[], distributed.deploy.cluster.Cluster] | None
+        ) = cluster_class
+
+        self.resolved_cluster_class: distributed.deploy.cluster.Cluster | None = (
+            resolved_cluster_class
+        )
+        self.cluster_kwargs: dict[str, Any] = cluster_kwargs
+        self.adapt_kwargs: dict[str, Any] = adapt_kwargs
+        self.client_kwargs: dict[str, Any] = client_kwargs
+        self.performance_report_path: str | None = performance_report_path
 
         # Runtime attributes
-        self._client: PrefectDaskClient = None
-        self._cluster: "distributed.deploy.Cluster" = cluster
+        self._client: PrefectDaskClient | None = None
+        self._cluster: distributed.deploy.cluster.Cluster | None = cluster
 
         self._exit_stack = ExitStack()
 
@@ -290,14 +304,82 @@ class DaskTaskRunner(TaskRunner):
         """
         if isinstance(other, DaskTaskRunner):
             return (
-                self.address == other.address
-                and self.cluster_class == other.cluster_class
-                and self.cluster_kwargs == other.cluster_kwargs
-                and self.adapt_kwargs == other.adapt_kwargs
-                and self.client_kwargs == other.client_kwargs
+                bool(self.address == other.address)
+                and bool(self.cluster_class == other.cluster_class)
+                and bool(self.cluster_kwargs == other.cluster_kwargs)
+                and bool(self.adapt_kwargs == other.adapt_kwargs)
+                and bool(self.client_kwargs == other.client_kwargs)
             )
         else:
             return False
+
+    @property
+    def client(self) -> PrefectDaskClient:
+        """
+        Get the Dask client for the task runner.
+
+        The client is created on first access. If a remote cluster is not
+        provided, the client will attempt to create/connect to a local cluster.
+        """
+        if not self._client:
+            in_dask = False
+            try:
+                client = distributed.get_client()
+                if client.cluster is not None:
+                    self._cluster = client.cluster
+                elif client.scheduler is not None:
+                    self.address = client.scheduler.address
+                else:
+                    raise RuntimeError("No global client found and no address provided")
+                in_dask = True
+            except ValueError:
+                pass
+
+            if self._cluster:
+                self.logger.info(f"Connecting to existing Dask cluster {self._cluster}")
+                self._connect_to = self._cluster
+                if self.adapt_kwargs:
+                    self._cluster.adapt(**self.adapt_kwargs)
+            elif self.address:
+                self.logger.info(
+                    f"Connecting to an existing Dask cluster at {self.address}"
+                )
+                self._connect_to = self.address
+            else:
+                self.cluster_class = self.cluster_class or distributed.LocalCluster
+
+                self.logger.info(
+                    f"Creating a new Dask cluster with "
+                    f"`{to_qualified_name(self.cluster_class)}`"
+                )
+                self._connect_to = self._cluster = self._exit_stack.enter_context(
+                    self.cluster_class(**self.cluster_kwargs)
+                )
+
+                if self.adapt_kwargs:
+                    maybe_coro = self._cluster.adapt(**self.adapt_kwargs)
+                    if asyncio.iscoroutine(maybe_coro):
+                        run_coro_as_sync(maybe_coro)
+
+            self._client = self._exit_stack.enter_context(
+                PrefectDaskClient(self._connect_to, **self.client_kwargs)
+            )
+
+            if self.performance_report_path:
+                # Register our client as current so that it's found by distributed.get_client()
+                self._exit_stack.enter_context(
+                    distributed.Client.as_current(self._client)
+                )
+                self._exit_stack.enter_context(
+                    distributed.performance_report(self.performance_report_path)
+                )
+
+            if self._client.dashboard_link and not in_dask:
+                self.logger.info(
+                    f"The Dask dashboard is available at {self._client.dashboard_link}",
+                )
+
+        return self._client
 
     def duplicate(self):
         """
@@ -316,26 +398,26 @@ class DaskTaskRunner(TaskRunner):
     def submit(
         self,
         task: "Task[P, Coroutine[Any, Any, R]]",
-        parameters: Dict[str, Any],
-        wait_for: Optional[Iterable[PrefectDaskFuture[R]]] = None,
-        dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
+        parameters: dict[str, Any],
+        wait_for: Iterable[PrefectDaskFuture[R]] | None = None,
+        dependencies: dict[str, Set[TaskRunInput]] | None = None,
     ) -> PrefectDaskFuture[R]: ...
 
     @overload
     def submit(
         self,
         task: "Task[Any, R]",
-        parameters: Dict[str, Any],
-        wait_for: Optional[Iterable[PrefectDaskFuture[R]]] = None,
-        dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
+        parameters: dict[str, Any],
+        wait_for: Iterable[PrefectDaskFuture[R]] | None = None,
+        dependencies: dict[str, Set[TaskRunInput]] | None = None,
     ) -> PrefectDaskFuture[R]: ...
 
     def submit(
         self,
         task: "Union[Task[P, R], Task[P, Coroutine[Any, Any, R]]]",
-        parameters: Dict[str, Any],
-        wait_for: Optional[Iterable[PrefectDaskFuture[R]]] = None,
-        dependencies: Optional[Dict[str, Set[TaskRunInput]]] = None,
+        parameters: dict[str, Any],
+        wait_for: Iterable[PrefectDaskFuture[R]] | None = None,
+        dependencies: dict[str, Set[TaskRunInput]] | None = None,
     ) -> PrefectDaskFuture[R]:
         if not self._started:
             raise RuntimeError(
@@ -346,7 +428,7 @@ class DaskTaskRunner(TaskRunner):
         parameters = self._optimize_futures(parameters)
         wait_for = self._optimize_futures(wait_for) if wait_for else None
 
-        future = self._client.submit(
+        future = self.client.submit(
             task,
             parameters=parameters,
             wait_for=wait_for,
@@ -361,32 +443,30 @@ class DaskTaskRunner(TaskRunner):
     def map(
         self,
         task: "Task[P, Coroutine[Any, Any, R]]",
-        parameters: Dict[str, Any],
-        wait_for: Optional[Iterable[PrefectFuture]] = None,
+        parameters: dict[str, Any],
+        wait_for: Iterable[PrefectFuture[Any]] | None = None,
     ) -> PrefectFutureList[PrefectDaskFuture[R]]: ...
 
     @overload
     def map(
         self,
-        task: "Task[Any, R]",
-        parameters: Dict[str, Any],
-        wait_for: Optional[Iterable[PrefectFuture]] = None,
+        task: "Task[P, R]",
+        parameters: dict[str, Any],
+        wait_for: Iterable[PrefectFuture[Any]] | None = None,
     ) -> PrefectFutureList[PrefectDaskFuture[R]]: ...
 
     def map(
         self,
-        task: "Task",
-        parameters: Dict[str, Any],
-        wait_for: Optional[Iterable[PrefectFuture]] = None,
+        task: "Task[P, R]",
+        parameters: dict[str, Any],
+        wait_for: Iterable[PrefectFuture[Any]] | None = None,
     ):
         return super().map(task, parameters, wait_for)
 
-    def _optimize_futures(self, expr):
-        def visit_fn(expr):
+    def _optimize_futures(self, expr: PrefectDaskFuture[Any] | Any) -> Any:
+        def visit_fn(expr: Any) -> Any:
             if isinstance(expr, PrefectDaskFuture):
-                dask_future = expr.wrapped_future
-                if dask_future is not None:
-                    return dask_future
+                return expr.wrapped_future
             # Fallback to return the expression unaltered
             return expr
 
@@ -394,70 +474,13 @@ class DaskTaskRunner(TaskRunner):
 
     def __enter__(self):
         """
-        Start the task runner and prep for context exit.
-        - Creates a cluster if an external address is not set.
-        - Creates a client to connect to the cluster.
+        Start the task runner and create an exit stack to manage shutdown.
         """
-        in_dask = False
-        try:
-            client = distributed.get_client()
-            if client.cluster is not None:
-                self._cluster = client.cluster
-            elif client.scheduler is not None:
-                self.address = client.scheduler.address
-            else:
-                raise RuntimeError("No global client found and no address provided")
-            in_dask = True
-        except ValueError:
-            pass
-
         super().__enter__()
-        exit_stack = self._exit_stack.__enter__()
-
-        if self._cluster:
-            self.logger.info(f"Connecting to existing Dask cluster {self._cluster}")
-            self._connect_to = self._cluster
-            if self.adapt_kwargs:
-                self._cluster.adapt(**self.adapt_kwargs)
-        elif self.address:
-            self.logger.info(
-                f"Connecting to an existing Dask cluster at {self.address}"
-            )
-            self._connect_to = self.address
-        else:
-            self.cluster_class = self.cluster_class or distributed.LocalCluster
-
-            self.logger.info(
-                f"Creating a new Dask cluster with "
-                f"`{to_qualified_name(self.cluster_class)}`"
-            )
-            self._connect_to = self._cluster = exit_stack.enter_context(
-                self.cluster_class(**self.cluster_kwargs)
-            )
-
-            if self.adapt_kwargs:
-                maybe_coro = self._cluster.adapt(**self.adapt_kwargs)
-                if asyncio.iscoroutine(maybe_coro):
-                    run_coro_as_sync(maybe_coro)
-
-        self._client = exit_stack.enter_context(
-            PrefectDaskClient(self._connect_to, **self.client_kwargs)
-        )
-
-        if self.performance_report_path:
-            # Register our client as current so that it's found by distributed.get_client()
-            exit_stack.enter_context(distributed.Client.as_current(self._client))
-            exit_stack.enter_context(
-                distributed.performance_report(self.performance_report_path)
-            )
-
-        if self._client.dashboard_link and not in_dask:
-            self.logger.info(
-                f"The Dask dashboard is available at {self._client.dashboard_link}",
-            )
+        self._exit_stack.__enter__()
 
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any) -> None:
         self._exit_stack.__exit__(*args)
         super().__exit__(*args)

--- a/src/integrations/prefect-dask/pyproject.toml
+++ b/src/integrations/prefect-dask/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "prefect-dask"
 dependencies = [
-  "prefect>=3.0.0",
+  "prefect>=3.3.0",
   # don't allow versions from 2023.3.2 to 2023.5 (inclusive) due to issue with
   # get_client starting in 2023.3.2 (fixed in 2023.6.0)
   # https://github.com/dask/distributed/issues/7763

--- a/src/integrations/prefect-dask/tests/test_task_runners.py
+++ b/src/integrations/prefect-dask/tests/test_task_runners.py
@@ -344,6 +344,7 @@ class TestDaskTaskRunner:
                 adapt_kwargs={"minimum": 1, "maximum": 1},
             )
             with task_runner:
+                task_runner.client  # trigger client creation
                 assert task_runner._cluster._adapt_called
 
     def test_warns_if_future_garbage_collection_before_resolving(self, caplog):


### PR DESCRIPTION
This PR adds a `client` property to `DaskTaskRunner` that will perform any necessary connection logic when called for the first time. This will prevent unnecessary creation of Dask clients for tasks submitted to a Dask cluster.

Closes https://github.com/PrefectHQ/prefect/issues/17618