### PR TITLE
Add logic to handle cancel_scope None

### DIFF
--- a/src/prefect/_internal/concurrency/calls.py
+++ b/src/prefect/_internal/concurrency/calls.py
@@ -374,6 +374,11 @@ class Call(Generic[T]):
 
         except CancelledError:
             # Report cancellation
+            # in rare cases, enforce_sync_deadline raises CancelledError
+            # prior to yielding
+            if cancel_scope is None:
+                self.future.cancel()
+                return None
             if TYPE_CHECKING:
                 assert cancel_scope is not None
             if cancel_scope.timedout():

--- a/src/prefect/_internal/concurrency/calls.py
+++ b/src/prefect/_internal/concurrency/calls.py
@@ -379,8 +379,6 @@ class Call(Generic[T]):
             if cancel_scope is None:
                 self.future.cancel()
                 return None
-            if TYPE_CHECKING:
-                assert cancel_scope is not None
             if cancel_scope.timedout():
                 setattr(self.future, "_timed_out", True)
                 self.future.cancel()


### PR DESCRIPTION
It seems that in rare circumstances we trigger an unhandled edge case (at least in tests, example [here](https://github.com/PrefectHQ/prefect/actions/runs/14145853194/job/39633057783?pr=17644)).

In an effort to hopefully make tests more resilient, this PR adds handling for this edge case.