### PR TITLE
Fixes class instance tasks and flows when called directly on a class

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -382,10 +382,11 @@ class Task(Generic[P, R]):
 
         if isinstance(fn, classmethod):
             fn = cast(Callable[P, R], fn.__func__)
+            self._isclassmethod = True
 
         if isinstance(fn, staticmethod):
             fn = cast(Callable[P, R], fn.__func__)
-            setattr(fn, "__prefect_static__", True)
+            self._isstaticmethod = True
 
         if not callable(fn):
             raise TypeError("'fn' must be callable")
@@ -547,11 +548,11 @@ class Task(Generic[P, R]):
 
     @property
     def isclassmethod(self) -> bool:
-        return hasattr(self.fn, "__prefect_cls__")
+        return getattr(self, "_isclassmethod", False)
 
     @property
     def isstaticmethod(self) -> bool:
-        return getattr(self.fn, "__prefect_static__", False)
+        return getattr(self, "_isstaticmethod", False)
 
     def __get__(self, instance: Any, owner: Any) -> "Task[P, R]":
         """
@@ -559,22 +560,20 @@ class Task(Generic[P, R]):
         When an instance method is loaded, this method is called with the "self" instance as
         an argument. We return a copy of the task with that instance bound to the task's function.
         """
-
-        if self.isstaticmethod:
-            return self
-
         # wrapped function is a classmethod
-        if not instance:
+        if self.isclassmethod:
             bound_task = copy(self)
             setattr(bound_task.fn, "__prefect_cls__", owner)
             return bound_task
 
         # if the task is being accessed on an instance, bind the instance to the __prefect_self__ attribute
         # of the task's function. This will allow it to be automatically added to the task's parameters
-        else:
+        if instance:
             bound_task = copy(self)
             bound_task.fn.__prefect_self__ = instance  # type: ignore[attr-defined]
             return bound_task
+
+        return self
 
     def with_options(
         self,

--- a/src/prefect/utilities/callables.py
+++ b/src/prefect/utilities/callables.py
@@ -63,7 +63,7 @@ def get_call_parameters(
     """
     if hasattr(fn, "__prefect_self__"):
         call_args = (getattr(fn, "__prefect_self__"), *call_args)
-    if hasattr(fn, "__prefect_cls__"):
+    elif hasattr(fn, "__prefect_cls__"):
         call_args = (getattr(fn, "__prefect_cls__"), *call_args)
 
     try:

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -904,6 +904,23 @@ class TestFlowCall:
         assert isinstance(Foo(x=10).instance_method, Flow)
 
     @pytest.mark.parametrize("T", [BaseFoo, BaseFooModel])
+    def test_flow_supports_instance_methods_called_with_instance(self, T):
+        """
+        Regression test for https://github.com/PrefectHQ/prefect/issues/17649
+        """
+
+        class Foo(T):
+            @flow
+            def instance_method(self):
+                return self.x
+
+        f = Foo(x=1)
+        # call like a class method with provided instance
+        assert Foo.instance_method(f) == 1
+        # call as instance method to ensure there was no class binding in above call
+        assert f.instance_method() == 1
+
+    @pytest.mark.parametrize("T", [BaseFoo, BaseFooModel])
     def test_flow_supports_class_methods(self, T):
         class Foo(T):
             def __init__(self, x):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -402,7 +402,7 @@ class TestTaskCall:
         x: int
 
     class BaseFoo:
-        def __init__(self, x):
+        def __init__(self, x: int):
             self.x = x
 
     @pytest.mark.parametrize("T", [BaseFoo, BaseFooModel])
@@ -418,6 +418,23 @@ class TestTaskCall:
         assert f.instance_method() == 1
 
         assert isinstance(Foo(x=10).instance_method, Task)
+
+    @pytest.mark.parametrize("T", [BaseFoo, BaseFooModel])
+    def test_task_supports_instance_methods_called_with_instance(self, T):
+        """
+        Regression test for https://github.com/PrefectHQ/prefect/issues/17649
+        """
+
+        class Foo(T):
+            @task
+            def instance_method(self):
+                return self.x
+
+        f = Foo(x=1)
+        # call like a class method with provided instance
+        assert Foo.instance_method(f) == 1
+        # call as instance method to ensure there was no class binding in above call
+        assert f.instance_method() == 1
 
     @pytest.mark.parametrize("T", [BaseFoo, BaseFooModel])
     def test_task_supports_class_methods(self, T):


### PR DESCRIPTION
This PR fixes the case when instance methods decorated with `@task` or `@flow` are called directly on a class with a provided instance like so:
```python
from prefect import task

class Foo:
    def __init__(self, x):
         self.x = x

    @flow
    def instance_method(self):
         return self.x


foo = Foo(1)
assert Foo.instance_method(foo) == 1
```

Previously, it was possible that both `__prefect_self__` and `__prefect_cls__` were erroneously bound. The fix adds more explicit tracking for when a decorated function is a `classmethod` and ensures that a decorated function can only be treated as a class method or an instance method.

Closes https://github.com/PrefectHQ/prefect/issues/17649