### PR TITLE
Update `uv.lock` and use `--locked` for all workflows

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -42,7 +42,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Install the project
-        run:  uv sync --group benchmark --compile-bytecode
+        run:  uv sync --group benchmark --compile-bytecode --locked
 
       - name: Prepare benchmark comparisons
         # Note: We use a "cache" instead of artifacts because artifacts are not available

--- a/.github/workflows/codspeed-benchmarks.yaml
+++ b/.github/workflows/codspeed-benchmarks.yaml
@@ -43,7 +43,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
           
       - name: Install the project
-        run:  uv sync --group benchmark --compile-bytecode
+        run:  uv sync --group benchmark --compile-bytecode --locked
 
       - name: Start server
         run: |

--- a/.github/workflows/markdown-tests.yaml
+++ b/.github/workflows/markdown-tests.yaml
@@ -74,7 +74,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Install packages
-        run: uv sync --group markdown-docs
+        run: uv sync --group markdown-docs --locked
 
       - name: Start server
         run: |

--- a/.github/workflows/proxy-test.yaml
+++ b/.github/workflows/proxy-test.yaml
@@ -66,7 +66,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Install Dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run Proxy Tests
         env:

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install python packages
         run: |
-          uv sync --only-dev --frozen
+          uv sync --only-dev --locked
 
       - name: Build UI
         run: |

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -115,7 +115,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Install packages
-        run: uv sync --frozen
+        run: uv sync --locked
 
       - name: Start database container
         if: ${{ startsWith(matrix.database, 'postgres') }}
@@ -248,7 +248,7 @@ jobs:
           docker run --rm prefecthq/prefect-dev:${{ steps.get_image_tag.outputs.image_tag }} prefect version
 
       - name: Install packages
-        run: uv sync --frozen
+        run: uv sync --locked
 
       - name: Start database container
         if: ${{ startsWith(matrix.database, 'postgres') }}
@@ -333,7 +333,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Install packages
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run tests
         run: |

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -42,7 +42,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Install the project
-        run: uv sync --compile-bytecode --no-editable
+        run: uv sync --compile-bytecode --no-editable --locked
 
       - name: Setup NodeJS
         uses: actions/setup-node@v4
@@ -74,7 +74,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       
       - name: Install the project
-        run: uv sync --compile-bytecode --no-editable --group type-checking --no-dev
+        run: uv sync --compile-bytecode --no-editable --group type-checking --no-dev --locked
 
       - name: Run type completeness check
         run: >-

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -3629,7 +3630,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.4.1,<7.0.0" },
     { name = "readchar", specifier = ">=4.0.0,<5.0.0" },
     { name = "rfc3339-validator", specifier = ">=0.1.4,<0.2.0" },
-    { name = "rich", specifier = ">=11.0,<14.0" },
+    { name = "rich", specifier = ">=11.0,<15.0" },
     { name = "ruamel-yaml", specifier = ">=0.17.0" },
     { name = "sniffio", specifier = ">=1.3.0,<2.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0,<3.0.0" },
@@ -3642,6 +3643,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=13.0,<16.0" },
     { name = "whenever", marker = "python_full_version >= '3.13'", specifier = ">=0.7.3,<0.8.0" },
 ]
+provides-extras = ["aws", "azure", "bitbucket", "dask", "databricks", "dbt", "docker", "email", "gcp", "github", "gitlab", "kubernetes", "otel", "ray", "redis", "shell", "slack", "snowflake", "sqlalchemy"]
 
 [package.metadata.requires-dev]
 benchmark = [
@@ -3793,6 +3795,7 @@ requires-dist = [
     { name = "prefect-docker", directory = "src/integrations/prefect-docker" },
     { name = "setuptools" },
 ]
+provides-extras = ["blob-storage", "cosmos-db", "ml-datastore", "all-extras"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3940,6 +3943,7 @@ requires-dist = [
     { name = "prefect-sqlalchemy", marker = "extra == 'postgres'", directory = "src/integrations/prefect-sqlalchemy" },
     { name = "sgqlc", specifier = ">=16.0.0" },
 ]
+provides-extras = ["snowflake", "bigquery", "postgres", "all-extras"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4057,6 +4061,7 @@ requires-dist = [
     { name = "python-slugify", specifier = ">=8.0.0" },
     { name = "tenacity", specifier = ">=8.0.0" },
 ]
+provides-extras = ["cloud-storage", "bigquery", "secret-manager", "aiplatform", "all-extras"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This PR updates `uv.lock` to fix an error seen [during release](https://github.com/PrefectHQ/prefect/actions/runs/14174764761/job/39706861201) and updates `uv sync` calls to use `--locked` to catch issues like this earlier.