### PR TITLE
temporarily allow `str` or `datetime` for `generate_deprecation_message`

### DIFF
--- a/client/client_flow.py
+++ b/client/client_flow.py
@@ -1,3 +1,4 @@
+import prefect.main  # noqa: F401
 from prefect import flow, task
 from prefect.concurrency import asyncio, services, sync  # noqa: F401
 

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "cachetools>=5.3,<6.0",
     "cloudpickle>=2.0,<4.0",
     "coolname>=1.0.4,<3.0.0",
+    "dateparser>=1.1.1,<2.0.0",
     "exceptiongroup>=1.0.0",
     "fastapi>=0.111.0,<1.0.0",
     "fsspec>=2022.5.0",

--- a/src/prefect/_internal/compatibility/deprecated.py
+++ b/src/prefect/_internal/compatibility/deprecated.py
@@ -34,6 +34,8 @@ R = TypeVar("R", infer_variance=True)
 M = TypeVar("M", bound=BaseModel)
 T = TypeVar("T")
 
+# Note: A datetime is strongly preferred over a string, but a string is acceptable for
+# backwards compatibility until support is dropped from dateparser in Python 3.15.
 _AcceptableDate: TypeAlias = Optional[Union[datetime.datetime, str]]
 
 DEPRECATED_WARNING = (

--- a/src/prefect/_internal/compatibility/deprecated.py
+++ b/src/prefect/_internal/compatibility/deprecated.py
@@ -10,6 +10,8 @@ will be calculated 6 months later. Start and end dates are always in the format 
 e.g. Jan 2023.
 """
 
+from __future__ import annotations
+
 import datetime
 import functools
 import sys
@@ -32,7 +34,7 @@ R = TypeVar("R", infer_variance=True)
 M = TypeVar("M", bound=BaseModel)
 T = TypeVar("T")
 
-_AcceptableDate = datetime.datetime | str
+_AcceptableDate: TypeAlias = Optional[Union[datetime.datetime, str]]
 
 DEPRECATED_WARNING = (
     "{name} has been deprecated{when}. It will not be available in new releases after {end_date}."

--- a/src/prefect/_internal/compatibility/deprecated.py
+++ b/src/prefect/_internal/compatibility/deprecated.py
@@ -18,6 +18,7 @@ import sys
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
+import dateparser
 from pydantic import BaseModel
 from typing_extensions import ParamSpec, TypeAlias, TypeVar
 
@@ -59,16 +60,11 @@ class PrefectDeprecationWarning(DeprecationWarning):
 def _coerce_datetime(
     dt: Optional[_AcceptableDate],
 ) -> Optional[datetime.datetime]:
-    import dateparser
-
-    if dt is None:
-        return None
-    elif isinstance(dt, str):
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            return dateparser.parse(dt)
-    else:
+    if dt is None or isinstance(dt, datetime.datetime):
         return dt
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        return dateparser.parse(dt)
 
 
 def generate_deprecation_message(

--- a/src/prefect/types/_datetime.py
+++ b/src/prefect/types/_datetime.py
@@ -130,7 +130,7 @@ def end_of_period(dt: datetime.datetime, period: str) -> datetime.datetime:
         ValueError: If an invalid unit is specified.
     """
     if sys.version_info >= (3, 13):
-        from whenever import Weekday, ZonedDateTime
+        from whenever import TimeDelta, Weekday, ZonedDateTime
 
         if not isinstance(dt.tzinfo, ZoneInfo):
             zdt = ZonedDateTime.from_py_datetime(
@@ -150,8 +150,8 @@ def end_of_period(dt: datetime.datetime, period: str) -> datetime.datetime:
             days_till_end_of_week: int = (
                 Weekday.SUNDAY.value - zdt.date().day_of_week().value
             )
+            zdt = zdt + TimeDelta(days=days_till_end_of_week)
             zdt = zdt.replace(
-                day=zdt.day + days_till_end_of_week,
                 hour=23,
                 minute=59,
                 second=59,

--- a/src/prefect/types/_datetime.py
+++ b/src/prefect/types/_datetime.py
@@ -130,7 +130,7 @@ def end_of_period(dt: datetime.datetime, period: str) -> datetime.datetime:
         ValueError: If an invalid unit is specified.
     """
     if sys.version_info >= (3, 13):
-        from whenever import TimeDelta, Weekday, ZonedDateTime
+        from whenever import Weekday, ZonedDateTime, days
 
         if not isinstance(dt.tzinfo, ZoneInfo):
             zdt = ZonedDateTime.from_py_datetime(
@@ -150,7 +150,7 @@ def end_of_period(dt: datetime.datetime, period: str) -> datetime.datetime:
             days_till_end_of_week: int = (
                 Weekday.SUNDAY.value - zdt.date().day_of_week().value
             )
-            zdt = zdt + TimeDelta(days=days_till_end_of_week)
+            zdt = zdt + days(days_till_end_of_week)
             zdt = zdt.replace(
                 hour=23,
                 minute=59,

--- a/tests/_internal/compatibility/test_deprecated.py
+++ b/tests/_internal/compatibility/test_deprecated.py
@@ -37,6 +37,9 @@ def test_generate_deprecation_message_when():
     )
 
 
+@pytest.mark.xfail(
+    reason="we are temporarily allowing this, so it will not raise the expected exception"
+)
 def test_generate_deprecation_message_invalid_start_date():
     with pytest.raises(ValueError, match="Must provide start_date as a datetime"):
         generate_deprecation_message("test name", start_date="Jan 2022")
@@ -49,6 +52,9 @@ def test_generate_deprecation_message_end_date():
     )
 
 
+@pytest.mark.xfail(
+    reason="we are temporarily allowing this, so it will not raise the expected exception"
+)
 def test_generate_deprecation_message_invalid_end_date():
     with pytest.raises(ValueError, match="Must provide end_date as a datetime"):
         generate_deprecation_message("test name", end_date="Dec 2023")
@@ -199,3 +205,21 @@ def test_deprecated_class():
     ):
         obj = MyClass()
         assert isinstance(obj, MyClass)
+
+
+def test_generate_deprecation_message_with_str_start_date():
+    assert (
+        generate_deprecation_message(
+            "test name", start_date="Jan 2022", help="test help"
+        )
+        == "test name has been deprecated. It will not be available in new releases after Jul 2022."
+        " test help"
+    )
+
+
+def test_generate_deprecation_message_with_str_end_date():
+    assert (
+        generate_deprecation_message("test name", end_date="Dec 2023", help="test help")
+        == "test name has been deprecated. It will not be available in new releases after Dec 2023."
+        " test help"
+    )


### PR DESCRIPTION
this behavior from `dateparser` that we support will be removed in python 3.15 according to the warning I suppress here