### PR TITLE
Update `Cron` `day_or` default to match `croniter` default

### DIFF
--- a/src/prefect/schedules.py
+++ b/src/prefect/schedules.py
@@ -47,7 +47,7 @@ class Schedule:
     anchor_date: datetime.datetime = dataclasses.field(
         default_factory=partial(datetime.datetime.now, tz=datetime.timezone.utc)
     )
-    day_or: bool = False
+    day_or: bool = True
     active: bool = True
     parameters: dict[str, Any] = dataclasses.field(default_factory=dict)
     slug: str | None = None
@@ -73,7 +73,7 @@ def Cron(
     cron: str,
     /,
     timezone: str | None = None,
-    day_or: bool = False,
+    day_or: bool = True,
     active: bool = True,
     parameters: dict[str, Any] | None = None,
     slug: str | None = None,

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -28,7 +28,7 @@ class TestSchedule:
         assert schedule.rrule is None
         assert schedule.timezone is None
         assert isinstance(schedule.anchor_date, datetime.datetime)
-        assert schedule.day_or is False
+        assert schedule.day_or is True
         assert schedule.active is True
         assert schedule.parameters == {}
 
@@ -38,7 +38,7 @@ class TestCronSchedule:
         schedule = Cron("0 0 * * *")
         assert schedule.cron == "0 0 * * *"
         assert schedule.timezone is None
-        assert schedule.day_or is False
+        assert schedule.day_or is True
         assert schedule.active is True
         assert schedule.parameters == {}
 
@@ -47,13 +47,13 @@ class TestCronSchedule:
         schedule = Cron(
             "0 0 * * *",
             timezone="America/New_York",
-            day_or=True,
+            day_or=False,
             active=False,
             parameters=params,
         )
         assert schedule.cron == "0 0 * * *"
         assert schedule.timezone == "America/New_York"
-        assert schedule.day_or is True
+        assert schedule.day_or is False
         assert schedule.active is False
         assert schedule.parameters == params
 


### PR DESCRIPTION
This update also matches the default for other schedule models and matches the docstrings in `prefect.schedules`.

Closes https://github.com/PrefectHQ/prefect/issues/17672