### PR TITLE
update `self.model_fields` -> `type(self).model_fields`

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -947,7 +947,7 @@
                             "type": "string",
                             "format": "date-time",
                             "description": "Only include runs that start or end after this time.",
-                            "default": "0001-01-01T00:00:00+00:00",
+                            "default": "0001-01-01T00:00:00",
                             "title": "Since"
                         },
                         "description": "Only include runs that start or end after this time."

--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -947,7 +947,7 @@
                             "type": "string",
                             "format": "date-time",
                             "description": "Only include runs that start or end after this time.",
-                            "default": "0001-01-01T00:00:00",
+                            "default": "0001-01-01T00:00:00+00:00",
                             "title": "Since"
                         },
                         "description": "Only include runs that start or end after this time."

--- a/src/integrations/prefect-dbt/prefect_dbt/cli/configs/base.py
+++ b/src/integrations/prefect-dbt/prefect_dbt/cli/configs/base.py
@@ -100,7 +100,7 @@ class DbtConfigs(Block, abc.ABC):
         Returns:
             A configs JSON.
         """
-        return self._populate_configs_json({}, self.model_fields, model=self)
+        return self._populate_configs_json({}, type(self).model_fields, model=self)
 
 
 class BaseTargetConfigs(DbtConfigs, abc.ABC):

--- a/src/prefect/_internal/schemas/bases.py
+++ b/src/prefect/_internal/schemas/bases.py
@@ -64,7 +64,7 @@ class PrefectBaseModel(BaseModel):
 
     def __rich_repr__(self) -> RichReprResult:
         # Display all of the fields in the model if they differ from the default value
-        for name, field in self.model_fields.items():
+        for name, field in type(self).model_fields.items():
             value = getattr(self, name)
 
             # Simplify the display of some common fields
@@ -90,7 +90,9 @@ class PrefectBaseModel(BaseModel):
         """
         return self.model_copy(
             update={
-                field: self.model_fields[field].get_default(call_default_factory=True)
+                field: type(self)
+                .model_fields[field]
+                .get_default(call_default_factory=True)
                 for field in self._reset_fields
             }
         )

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -371,7 +371,7 @@ class Block(BaseModel, ABC):
                         visit_fn=partial(handle_secret_render, context=ctx),
                         return_data=True,
                     )
-                    for field_name in self.model_fields
+                    for field_name in type(self).model_fields
                 }
             )
         if extra_fields := {

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -414,7 +414,7 @@ class State(ObjectBaseModel, Generic[R]):
         database again. The 'timestamp' is reset using the default factory.
         """
         update = {
-            "timestamp": self.model_fields["timestamp"].get_default(),
+            "timestamp": type(self).model_fields["timestamp"].get_default(),
             **(update or {}),
         }
         return super().model_copy(update=update, deep=deep)

--- a/src/prefect/events/filters.py
+++ b/src/prefect/events/filters.py
@@ -45,7 +45,7 @@ class EventDataFilter(PrefectBaseModel, extra="forbid"):  # type: ignore[call-ar
     def get_filters(self) -> list["EventDataFilter"]:
         filters: list["EventDataFilter"] = [
             filter
-            for filter in [getattr(self, name) for name in self.model_fields]
+            for filter in [getattr(self, name) for name in type(self).model_fields]
             if isinstance(filter, EventDataFilter)
         ]
         return filters

--- a/src/prefect/server/events/filters.py
+++ b/src/prefect/server/events/filters.py
@@ -85,7 +85,7 @@ class EventDataFilter(PrefectBaseModel, extra="forbid"):
     def get_filters(self) -> List["EventDataFilter"]:
         filters: List[EventDataFilter] = [
             filter
-            for filter in [getattr(self, name) for name in self.model_fields]
+            for filter in [getattr(self, name) for name in type(self).model_fields]
             if isinstance(filter, EventDataFilter)
         ]
         for filter in filters:

--- a/src/prefect/server/utilities/schemas/bases.py
+++ b/src/prefect/server/utilities/schemas/bases.py
@@ -90,7 +90,7 @@ class PrefectBaseModel(BaseModel):
 
     def __rich_repr__(self) -> "RichReprResult":
         # Display all of the fields in the model if they differ from the default value
-        for name, field in self.model_fields.items():
+        for name, field in type(self).model_fields.items():
             value = getattr(self, name)
 
             # Simplify the display of some common fields
@@ -114,7 +114,9 @@ class PrefectBaseModel(BaseModel):
         """
         return self.model_copy(
             update={
-                field: self.model_fields[field].get_default(call_default_factory=True)
+                field: type(self)
+                .model_fields[field]
+                .get_default(call_default_factory=True)
                 for field in self._reset_fields
             }
         )

--- a/src/prefect/settings/base.py
+++ b/src/prefect/settings/base.py
@@ -101,7 +101,7 @@ class PrefectBaseSettings(BaseSettings):
             context={"include_secrets": include_secrets},
         )
         env_variables: dict[str, str] = {}
-        for key in self.model_fields.keys():
+        for key in type(self).model_fields.keys():
             if isinstance(child_settings := getattr(self, key), PrefectBaseSettings):
                 child_env = child_settings.to_environment_variables(
                     exclude_unset=exclude_unset,
@@ -110,7 +110,7 @@ class PrefectBaseSettings(BaseSettings):
                 )
                 env_variables.update(child_env)
             elif (value := env.get(key)) is not None:
-                validation_alias = self.model_fields[key].validation_alias
+                validation_alias = type(self).model_fields[key].validation_alias
                 if include_aliases and validation_alias is not None:
                     if isinstance(validation_alias, AliasChoices):
                         for alias in validation_alias.choices:
@@ -136,7 +136,7 @@ class PrefectBaseSettings(BaseSettings):
     ) -> Any:
         jsonable_self = handler(self)
         # iterate over fields to ensure child models that have been updated are also included
-        for key in self.model_fields.keys():
+        for key in type(self).model_fields.keys():
             if info.exclude and key in info.exclude:
                 continue
             if info.include and key not in info.include:


### PR DESCRIPTION
pydantic 2.11 started throwing all these deprecation warnings about `self.model_fields`