### PR TITLE
Add virtualization to `RunLogs` component

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,21 +71,6 @@ repos:
               src/prefect/settings/models/.*|
               scripts/generate_settings_ref.py
           )$
-      - id: lint-ui-v2
-        name: Lint UI v2
-        language: system
-        entry: sh
-        args:
-          [
-            "-c",
-            ". $NVM_DIR/nvm.sh || true && cd ui-v2 && nvm use || true && npm i --no-upgrade --silent --no-progress && npm run lint-staged",
-          ]
-        files: |
-          (?x)^(
-              .pre-commit-config.yaml|
-              ui-v2/.*
-          )$
-        pass_filenames: false
       - id: format-ui-v2
         name: Format UI v2
         language: system

--- a/ui-v2/package-lock.json
+++ b/ui-v2/package-lock.json
@@ -38,6 +38,7 @@
 				"@tanstack/react-query-devtools": "^5.71.1",
 				"@tanstack/react-router": "^1.114.29",
 				"@tanstack/react-table": "^8.21.2",
+				"@tanstack/react-virtual": "^3.13.6",
 				"@tanstack/zod-adapter": "^1.114.29",
 				"@uiw/react-codemirror": "^4.23.10",
 				"class-variance-authority": "^0.7.1",
@@ -5261,6 +5262,22 @@
 				"react-dom": ">=16.8"
 			}
 		},
+		"node_modules/@tanstack/react-virtual": {
+			"version": "3.13.6",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.6.tgz",
+			"integrity": "sha512-WT7nWs8ximoQ0CDx/ngoFP7HbQF9Q2wQe4nh2NB+u2486eX3nZRE40P9g6ccCVq7ZfTSH5gFOuCoVH5DLNS/aA==",
+			"dependencies": {
+				"@tanstack/virtual-core": "3.13.6"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
 		"node_modules/@tanstack/router-core": {
 			"version": "1.114.29",
 			"resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.114.29.tgz",
@@ -5475,6 +5492,15 @@
 			"engines": {
 				"node": ">=12"
 			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/virtual-core": {
+			"version": "3.13.6",
+			"resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.6.tgz",
+			"integrity": "sha512-cnQUeWnhNP8tJ4WsGcYiX24Gjkc9ALstLbHcBj1t3E7EimN6n6kHH+DPV4PpDnuw00NApQp+ViojMj1GRdwYQg==",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/tannerlinsley"

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -49,6 +49,7 @@
 		"@tanstack/react-query-devtools": "^5.71.1",
 		"@tanstack/react-router": "^1.114.29",
 		"@tanstack/react-table": "^8.21.2",
+		"@tanstack/react-virtual": "^3.13.6",
 		"@tanstack/zod-adapter": "^1.114.29",
 		"@uiw/react-codemirror": "^4.23.10",
 		"class-variance-authority": "^0.7.1",

--- a/ui-v2/src/api/logs/index.ts
+++ b/ui-v2/src/api/logs/index.ts
@@ -1,5 +1,5 @@
 import type { components } from "@/api/prefect";
-import { queryOptions } from "@tanstack/react-query";
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { getQueryService } from "../service";
 
 type LogsFilter = components["schemas"]["Body_read_logs_logs_filter_post"];
@@ -21,6 +21,9 @@ export const queryKeyFactory = {
 	all: () => ["logs"] as const,
 	lists: () => [...queryKeyFactory.all(), "list"] as const,
 	list: (filter: LogsFilter) => [...queryKeyFactory.lists(), filter] as const,
+	infiniteLists: () => [...queryKeyFactory.lists(), "infinite"] as const,
+	infiniteList: (filter: Omit<LogsFilter, "offset">) =>
+		[...queryKeyFactory.infiniteLists(), filter] as const,
 };
 
 /**
@@ -54,5 +57,25 @@ export const buildFilterLogsQuery = (filter: LogsFilter) =>
 				body: filter,
 			});
 			return res.data ?? [];
+		},
+	});
+
+export const buildInfiniteFilterLogsQuery = (
+	filter: Omit<LogsFilter, "offset">,
+) =>
+	infiniteQueryOptions({
+		queryKey: queryKeyFactory.infiniteList(filter),
+		queryFn: async ({ pageParam = { offset: 0 } }) => {
+			const res = await getQueryService().POST("/logs/filter", {
+				body: { ...filter, offset: pageParam.offset },
+			});
+			return res.data ?? [];
+		},
+		initialPageParam: { offset: 0 },
+		getNextPageParam: (lastPage, pages) => {
+			if (lastPage.length === 0) {
+				return;
+			}
+			return { offset: pages.reduce((sum, page) => sum + page.length, 0) };
 		},
 	});

--- a/ui-v2/src/components/task-runs/task-run-logs/index.tsx
+++ b/ui-v2/src/components/task-runs/task-run-logs/index.tsx
@@ -1,4 +1,4 @@
-import { buildFilterLogsQuery } from "@/api/logs";
+import { buildInfiniteFilterLogsQuery } from "@/api/logs";
 import type { components } from "@/api/prefect";
 import { RunLogs } from "@/components/ui/run-logs";
 import {
@@ -8,8 +8,8 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
 
 type TaskRunLogsProps = {
 	taskRun: components["schemas"]["TaskRun"];
@@ -21,25 +21,29 @@ export const TaskRunLogs = ({ taskRun }: TaskRunLogsProps) => {
 		"TIMESTAMP_ASC" | "TIMESTAMP_DESC"
 	>("TIMESTAMP_ASC");
 
-	const { data: logs } = useSuspenseQuery(
-		buildFilterLogsQuery({
-			limit: 200,
-			offset: 0,
-			sort: sortOrder,
-			logs: {
-				operator: "and_",
-				level: {
-					ge_: levelFilter,
+	const queryOptions = useMemo(
+		() =>
+			buildInfiniteFilterLogsQuery({
+				limit: 50,
+				sort: sortOrder,
+				logs: {
+					operator: "and_",
+					level: { ge_: levelFilter },
+					task_run_id: { any_: [taskRun.id] },
 				},
-				task_run_id: {
-					any_: [taskRun.id],
-				},
-			},
-		}),
+			}),
+		[levelFilter, sortOrder, taskRun.id],
 	);
 
+	const {
+		data: logs,
+		hasNextPage,
+		fetchNextPage,
+		isFetchingNextPage,
+	} = useSuspenseInfiniteQuery(queryOptions);
+	const noLogs = logs.pages.length === 1 && logs.pages[0].length === 0;
 	let message = "This run did not produce any logs.";
-	if (logs.length === 0) {
+	if (noLogs) {
 		if (levelFilter > 0) {
 			message = "No logs match your filter criteria";
 		} else if (
@@ -49,8 +53,6 @@ export const TaskRunLogs = ({ taskRun }: TaskRunLogsProps) => {
 			message = "Run has not yet started. Check back soon for logs.";
 		} else if (taskRun.state_type === "RUNNING") {
 			message = "Waiting for logs...";
-		} else {
-			message = "This run did not produce any logs.";
 		}
 	}
 
@@ -63,12 +65,22 @@ export const TaskRunLogs = ({ taskRun }: TaskRunLogsProps) => {
 				/>
 				<LogSortOrder sortOrder={sortOrder} setSortOrder={setSortOrder} />
 			</div>
-			{logs.length === 0 ? (
+			{noLogs ? (
 				<div className="flex flex-col gap-2 text-center bg-gray-100 p-2 rounded-md">
 					<span className="text-gray-500">{message}</span>
 				</div>
 			) : (
-				<RunLogs taskRun={taskRun} logs={logs} />
+				<RunLogs
+					taskRun={taskRun}
+					logs={logs.pages.flat()}
+					onBottomReached={() => {
+						if (hasNextPage && !isFetchingNextPage) {
+							fetchNextPage().catch((error) => {
+								console.error(error);
+							});
+						}
+					}}
+				/>
 			)}
 		</div>
 	);

--- a/ui-v2/src/components/task-runs/task-run-logs/task-run-logs.stories.tsx
+++ b/ui-v2/src/components/task-runs/task-run-logs/task-run-logs.stories.tsx
@@ -8,6 +8,7 @@ import { TaskRunLogs } from ".";
 
 const MOCK_TASK_RUN_WITH_LOGS = createFakeTaskRun();
 const MOCK_TASK_RUN_WITHOUT_LOGS = createFakeTaskRun();
+const MOCK_TASK_RUN_WITH_INFINITE_LOGS = createFakeTaskRun();
 // Create a range of logs with different levels
 const ALL_MOCK_LOGS = [
 	createFakeLog({
@@ -104,5 +105,25 @@ export const NoLogs: Story = {
 	},
 	args: {
 		taskRun: MOCK_TASK_RUN_WITHOUT_LOGS,
+	},
+};
+
+export const Infinite: Story = {
+	args: {
+		taskRun: MOCK_TASK_RUN_WITH_INFINITE_LOGS,
+	},
+	parameters: {
+		msw: {
+			handlers: [
+				http.post(buildApiUrl("/logs/filter"), async ({ request }) => {
+					const body = (await request.json()) as LogsFilterBody;
+					return HttpResponse.json(
+						Array.from({ length: body.limit as number }, createFakeLog).sort(
+							(a, b) => a.timestamp.localeCompare(b.timestamp),
+						),
+					);
+				}),
+			],
+		},
 	},
 };

--- a/ui-v2/src/components/task-runs/task-run-logs/task-run-logs.test.tsx
+++ b/ui-v2/src/components/task-runs/task-run-logs/task-run-logs.test.tsx
@@ -5,7 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { buildApiUrl, createWrapper, server } from "@tests/utils";
 import { mockPointerEvents } from "@tests/utils/browser";
 import { http, HttpResponse } from "msw";
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { TaskRunLogs } from ".";
 
 const MOCK_LOGS = [

--- a/ui-v2/src/components/task-runs/task-run-logs/task-run-logs.test.tsx
+++ b/ui-v2/src/components/task-runs/task-run-logs/task-run-logs.test.tsx
@@ -5,7 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { buildApiUrl, createWrapper, server } from "@tests/utils";
 import { mockPointerEvents } from "@tests/utils/browser";
 import { http, HttpResponse } from "msw";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { TaskRunLogs } from ".";
 
 const MOCK_LOGS = [
@@ -21,15 +21,34 @@ const MOCK_LOGS = [
 type LogsFilterBody = components["schemas"]["Body_read_logs_logs_filter_post"];
 
 describe("TaskRunLogs", () => {
-	beforeAll(mockPointerEvents);
-	it("displays logs with default filter (all levels)", async () => {
+	beforeEach(() => {
+		mockPointerEvents();
 		// Setup mock API response
 		server.use(
-			http.post(buildApiUrl("/logs/filter"), () => {
-				return HttpResponse.json(MOCK_LOGS);
+			http.post(buildApiUrl("/logs/filter"), async ({ request }) => {
+				const body = (await request.json()) as LogsFilterBody;
+
+				let filteredLogs = [...MOCK_LOGS];
+
+				// Filter logs by level if specified
+				const minLevel = body.logs?.level?.ge_;
+				if (typeof minLevel === "number") {
+					filteredLogs = filteredLogs.filter((log) => log.level >= minLevel);
+				}
+
+				// Sort logs based on the sort parameter
+				if (body.sort === "TIMESTAMP_DESC") {
+					filteredLogs = filteredLogs.reverse();
+				}
+
+				if (body.offset) {
+					filteredLogs = filteredLogs.slice(body.offset);
+				}
+				return HttpResponse.json(filteredLogs);
 			}),
 		);
-
+	});
+	it("displays logs with default filter (all levels)", async () => {
 		// Render component
 		const taskRun = createFakeTaskRun();
 		render(<TaskRunLogs taskRun={taskRun} />, {
@@ -51,17 +70,6 @@ describe("TaskRunLogs", () => {
 	it("filters logs by level", async () => {
 		const user = userEvent.setup();
 
-		// Setup mock API response for filtered logs
-		server.use(
-			http.post(buildApiUrl("/logs/filter"), async ({ request }) => {
-				const body = (await request.json()) as LogsFilterBody;
-				const minLevel = body.logs?.level?.ge_ ?? 0;
-
-				const filteredLogs = MOCK_LOGS.filter((log) => log.level >= minLevel);
-				return HttpResponse.json(filteredLogs);
-			}),
-		);
-
 		// Render component
 		const taskRun = createFakeTaskRun();
 		render(<TaskRunLogs taskRun={taskRun} />, {
@@ -69,7 +77,9 @@ describe("TaskRunLogs", () => {
 		});
 
 		await waitFor(() => {
-			expect(screen.getByText("Critical error in task")).toBeInTheDocument();
+			expect(
+				screen.getByRole("combobox", { name: /log level filter/i }),
+			).toBeInTheDocument();
 		});
 
 		// Change filter to "Error and above"
@@ -218,7 +228,9 @@ describe("TaskRunLogs", () => {
 		});
 
 		await waitFor(() => {
-			expect(screen.getByText("Critical error in task")).toBeInTheDocument();
+			expect(
+				screen.getByRole("combobox", { name: /log sort order/i }),
+			).toBeInTheDocument();
 		});
 
 		// Change sort order to newest first

--- a/ui-v2/src/components/ui/run-logs/index.tsx
+++ b/ui-v2/src/components/ui/run-logs/index.tsx
@@ -1,15 +1,52 @@
 import type { components } from "@/api/prefect";
 import { Badge } from "@/components/ui/badge";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { cva } from "class-variance-authority";
 import { isSameDay } from "date-fns";
 import { format } from "date-fns-tz";
+import { useEffect, useRef } from "react";
 
 type RunLogsProps = {
 	logs: components["schemas"]["Log"][];
 	taskRun?: components["schemas"]["TaskRun"];
+	bottomReached: () => void;
 };
 
-export const RunLogs = ({ logs, taskRun }: RunLogsProps) => {
+/**
+ * Displays logs from a run in a virtualized list.
+ *
+ * @param logs - Array of log entries to display
+ * @param taskRun - Optional task run information to display with logs
+ * @param bottomReached - Callback function triggered when the user scrolls to the bottom of the logs
+ *
+ */
+export const RunLogs = ({ logs, taskRun, bottomReached }: RunLogsProps) => {
+	const parentRef = useRef<HTMLDivElement>(null);
+	const virtualizer = useVirtualizer({
+		count: logs.length,
+		getScrollElement: () => parentRef.current,
+		estimateSize: () => 75,
+	});
+
+	const virtualItems = virtualizer.getVirtualItems();
+
+	/**
+	 * This effect detects when the user has scrolled to the bottom of the logs.
+	 * It works by checking if the last visible virtual item is also the last item in the logs array.
+	 * When this condition is met, it calls the bottomReached callback to potentially load more logs.
+	 */
+	useEffect(() => {
+		const [lastItem] = [...virtualItems].reverse();
+
+		if (!lastItem) {
+			return;
+		}
+
+		if (lastItem.index >= logs.length - 1) {
+			bottomReached();
+		}
+	}, [logs.length, virtualItems, bottomReached]);
+
 	const showDivider = (index: number): boolean => {
 		if (index === 0) {
 			return true;
@@ -28,15 +65,44 @@ export const RunLogs = ({ logs, taskRun }: RunLogsProps) => {
 			</div>
 		);
 	}
+
 	return (
-		<ol className="flex flex-col gap-4 bg-gray-100 p-2 rounded-md font-mono">
-			{logs.map((log, index) => (
-				<li key={log.id}>
-					{showDivider(index) && <LogDivider date={new Date(log.timestamp)} />}
-					<RunLogRow key={log.id} log={log} taskRunName={taskRun?.name} />
-				</li>
-			))}
-		</ol>
+		<div
+			ref={parentRef}
+			className="bg-gray-100 rounded-md font-mono w-full h-full overflow-y-auto p-4"
+			role="log"
+		>
+			<ol
+				className="relative w-full"
+				style={{
+					height: `${virtualizer.getTotalSize()}px`,
+				}}
+			>
+				{virtualItems.map((virtualRow) => {
+					const log = logs[virtualRow.index];
+					const shouldShowDivider = showDivider(virtualRow.index);
+
+					return (
+						<li
+							key={log.id}
+							style={{
+								position: "absolute",
+								top: 0,
+								left: 0,
+								width: "100%",
+								height: `${virtualRow.size}px`,
+								transform: `translateY(${virtualRow.start}px)`,
+							}}
+						>
+							{shouldShowDivider && (
+								<LogDivider date={new Date(log.timestamp)} />
+							)}
+							<RunLogRow log={log} taskRunName={taskRun?.name} />
+						</li>
+					);
+				})}
+			</ol>
+		</div>
 	);
 };
 

--- a/ui-v2/src/components/ui/run-logs/index.tsx
+++ b/ui-v2/src/components/ui/run-logs/index.tsx
@@ -9,7 +9,7 @@ import { useEffect, useRef } from "react";
 type RunLogsProps = {
 	logs: components["schemas"]["Log"][];
 	taskRun?: components["schemas"]["TaskRun"];
-	bottomReached: () => void;
+	onBottomReached: () => void;
 };
 
 /**
@@ -17,10 +17,10 @@ type RunLogsProps = {
  *
  * @param logs - Array of log entries to display
  * @param taskRun - Optional task run information to display with logs
- * @param bottomReached - Callback function triggered when the user scrolls to the bottom of the logs
+ * @param onBottomReached - Callback function triggered when the user scrolls to the bottom of the logs
  *
  */
-export const RunLogs = ({ logs, taskRun, bottomReached }: RunLogsProps) => {
+export const RunLogs = ({ logs, taskRun, onBottomReached }: RunLogsProps) => {
 	const parentRef = useRef<HTMLDivElement>(null);
 	const virtualizer = useVirtualizer({
 		count: logs.length,
@@ -43,9 +43,9 @@ export const RunLogs = ({ logs, taskRun, bottomReached }: RunLogsProps) => {
 		}
 
 		if (lastItem.index >= logs.length - 1) {
-			bottomReached();
+			onBottomReached();
 		}
-	}, [logs.length, virtualItems, bottomReached]);
+	}, [logs.length, virtualItems, onBottomReached]);
 
 	const showDivider = (index: number): boolean => {
 		if (index === 0) {

--- a/ui-v2/src/components/ui/run-logs/run-logs.stories.tsx
+++ b/ui-v2/src/components/ui/run-logs/run-logs.stories.tsx
@@ -1,17 +1,16 @@
 import { createFakeLog, createFakeTaskRun } from "@/mocks";
 import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+
 import { RunLogs } from ".";
 
 export default {
 	title: "UI/RunLogs",
 	component: (args) => (
-		<div>
+		<div className="w-screen h-screen">
 			<RunLogs {...args} />
 		</div>
 	),
-	parameters: {
-		layout: "centered",
-	},
 } satisfies Meta<typeof RunLogs>;
 
 type Story = StoryObj<typeof RunLogs>;
@@ -19,10 +18,11 @@ type Story = StoryObj<typeof RunLogs>;
 export const logs: Story = {
 	name: "RunLogs",
 	args: {
-		logs: Array.from({ length: 7 }, () => createFakeLog()).sort((a, b) =>
+		logs: Array.from({ length: 100 }, () => createFakeLog()).sort((a, b) =>
 			a.timestamp.localeCompare(b.timestamp),
 		),
 		taskRun: createFakeTaskRun(),
+		bottomReached: fn(),
 	},
 };
 
@@ -30,5 +30,6 @@ export const noLogs: Story = {
 	args: {
 		logs: [],
 		taskRun: createFakeTaskRun(),
+		bottomReached: fn(),
 	},
 };

--- a/ui-v2/src/components/ui/run-logs/run-logs.stories.tsx
+++ b/ui-v2/src/components/ui/run-logs/run-logs.stories.tsx
@@ -22,7 +22,7 @@ export const logs: Story = {
 			a.timestamp.localeCompare(b.timestamp),
 		),
 		taskRun: createFakeTaskRun(),
-		bottomReached: fn(),
+		onBottomReached: fn(),
 	},
 };
 
@@ -30,6 +30,6 @@ export const noLogs: Story = {
 	args: {
 		logs: [],
 		taskRun: createFakeTaskRun(),
-		bottomReached: fn(),
+		onBottomReached: fn(),
 	},
 };

--- a/ui-v2/src/components/ui/run-logs/run-logs.test.tsx
+++ b/ui-v2/src/components/ui/run-logs/run-logs.test.tsx
@@ -1,5 +1,5 @@
-import { render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { RunLogs } from ".";
 
 import { createFakeLog, createFakeTaskRun } from "@/mocks";
@@ -14,26 +14,35 @@ describe("RunLogs", () => {
 			createFakeLog({ level: 10 }),
 			createFakeLog({ level: 0 }),
 		];
-		const screen = render(<RunLogs logs={logs} />);
+		const mockBottomReached = vi.fn();
+		const screen = render(
+			<RunLogs logs={logs} bottomReached={mockBottomReached} />,
+		);
 
 		expect(screen.getByText("CRITICAL")).toBeVisible();
 		expect(screen.getByText("ERROR")).toBeVisible();
 		expect(screen.getByText("WARNING")).toBeVisible();
 		expect(screen.getByText("INFO")).toBeVisible();
 		expect(screen.getByText("DEBUG")).toBeVisible();
+
+		// Scroll to the bottom to see the last log
+		fireEvent.scroll(screen.getByRole("log"), { target: { scrollTop: 500 } });
 		expect(screen.getByText("CUSTOM")).toBeVisible();
+
+		// Check that bottomReached is called
+		expect(mockBottomReached).toHaveBeenCalled();
 	});
 
 	it("should display a log message", () => {
 		const log = createFakeLog({ message: "Hello, world!" });
-		const screen = render(<RunLogs logs={[log]} />);
+		const screen = render(<RunLogs logs={[log]} bottomReached={vi.fn()} />);
 
 		expect(screen.getByText("Hello, world!")).toBeVisible();
 	});
 
 	it("should display a log day and time", () => {
 		const log = createFakeLog({ timestamp: "2021-01-01T00:00:00.000Z" });
-		const screen = render(<RunLogs logs={[log]} />);
+		const screen = render(<RunLogs logs={[log]} bottomReached={vi.fn()} />);
 
 		expect(screen.getByText("Jan 1, 2021")).toBeVisible();
 		expect(screen.getByText("12:00:00 AM")).toBeVisible();
@@ -46,7 +55,9 @@ describe("RunLogs", () => {
 		const taskRun = createFakeTaskRun({
 			name: "test_task",
 		});
-		const screen = render(<RunLogs logs={[log]} taskRun={taskRun} />);
+		const screen = render(
+			<RunLogs logs={[log]} taskRun={taskRun} bottomReached={vi.fn()} />,
+		);
 
 		expect(screen.getByText("test_task")).toBeVisible();
 		expect(screen.getByText("prefect.test_logger")).toBeVisible();
@@ -55,7 +66,9 @@ describe("RunLogs", () => {
 	it("should show multiple day dividers when there are logs from different days", () => {
 		const log1 = createFakeLog({ timestamp: "2021-01-01T00:00:00.000Z" });
 		const log2 = createFakeLog({ timestamp: "2021-01-02T00:00:00.000Z" });
-		const screen = render(<RunLogs logs={[log1, log2]} />);
+		const screen = render(
+			<RunLogs logs={[log1, log2]} bottomReached={vi.fn()} />,
+		);
 
 		expect(screen.getByText("Jan 1, 2021")).toBeVisible();
 		expect(screen.getByText("Jan 2, 2021")).toBeVisible();

--- a/ui-v2/src/components/ui/run-logs/run-logs.test.tsx
+++ b/ui-v2/src/components/ui/run-logs/run-logs.test.tsx
@@ -16,7 +16,7 @@ describe("RunLogs", () => {
 		];
 		const mockBottomReached = vi.fn();
 		const screen = render(
-			<RunLogs logs={logs} bottomReached={mockBottomReached} />,
+			<RunLogs logs={logs} onBottomReached={mockBottomReached} />,
 		);
 
 		expect(screen.getByText("CRITICAL")).toBeVisible();
@@ -29,20 +29,20 @@ describe("RunLogs", () => {
 		fireEvent.scroll(screen.getByRole("log"), { target: { scrollTop: 500 } });
 		expect(screen.getByText("CUSTOM")).toBeVisible();
 
-		// Check that bottomReached is called
+		// Check that onBottomReached is called
 		expect(mockBottomReached).toHaveBeenCalled();
 	});
 
 	it("should display a log message", () => {
 		const log = createFakeLog({ message: "Hello, world!" });
-		const screen = render(<RunLogs logs={[log]} bottomReached={vi.fn()} />);
+		const screen = render(<RunLogs logs={[log]} onBottomReached={vi.fn()} />);
 
 		expect(screen.getByText("Hello, world!")).toBeVisible();
 	});
 
 	it("should display a log day and time", () => {
 		const log = createFakeLog({ timestamp: "2021-01-01T00:00:00.000Z" });
-		const screen = render(<RunLogs logs={[log]} bottomReached={vi.fn()} />);
+		const screen = render(<RunLogs logs={[log]} onBottomReached={vi.fn()} />);
 
 		expect(screen.getByText("Jan 1, 2021")).toBeVisible();
 		expect(screen.getByText("12:00:00 AM")).toBeVisible();
@@ -56,7 +56,7 @@ describe("RunLogs", () => {
 			name: "test_task",
 		});
 		const screen = render(
-			<RunLogs logs={[log]} taskRun={taskRun} bottomReached={vi.fn()} />,
+			<RunLogs logs={[log]} taskRun={taskRun} onBottomReached={vi.fn()} />,
 		);
 
 		expect(screen.getByText("test_task")).toBeVisible();
@@ -67,7 +67,7 @@ describe("RunLogs", () => {
 		const log1 = createFakeLog({ timestamp: "2021-01-01T00:00:00.000Z" });
 		const log2 = createFakeLog({ timestamp: "2021-01-02T00:00:00.000Z" });
 		const screen = render(
-			<RunLogs logs={[log1, log2]} bottomReached={vi.fn()} />,
+			<RunLogs logs={[log1, log2]} onBottomReached={vi.fn()} />,
 		);
 
 		expect(screen.getByText("Jan 1, 2021")).toBeVisible();


### PR DESCRIPTION
This PR adds virtualization to the `RunsLogs` component via [`@tanstack/react-virtual`](http://tanstack.com/virtual/latest/docs/introduction), which ensures responsible memory usage for runs with lots of flow. I also added an `onBottomReached` callback for `RunLogs` which is used to query for more logs if they are available.

I removed the UI lint pre-commit hook because it's just too darn slow. We'll still lint in CI, but commits should be faster now.