### PR TITLE
Includes `Deployment` versioning info in flow run execution event

### DIFF
--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -1102,12 +1102,23 @@ class DeploymentSchedule(ObjectBaseModel):
     )
 
 
+class VersionInfo(PrefectBaseModel, extra="allow"):
+    type: str = Field(default=..., description="The type of version info.")
+    version: str = Field(default=..., description="The version of the deployment.")
+
+
 class Deployment(ObjectBaseModel):
     """An ORM representation of deployment data."""
 
     name: Name = Field(default=..., description="The name of the deployment.")
     version: Optional[str] = Field(
         default=None, description="An optional version for the deployment."
+    )
+    version_id: Optional[UUID] = Field(
+        default=None, description="The ID of the current version of the deployment."
+    )
+    version_info: Optional[VersionInfo] = Field(
+        default=None, description="A description of this version of the deployment."
     )
     description: Optional[str] = Field(
         default=None, description="A description for the deployment."

--- a/src/prefect/client/schemas/responses.py
+++ b/src/prefect/client/schemas/responses.py
@@ -429,7 +429,7 @@ class DeploymentResponse(ObjectBaseModel):
         description="Current status of the deployment.",
     )
 
-    def as_related_resource(self, role: str) -> "RelatedResource":
+    def as_related_resource(self, role: str = "deployment") -> "RelatedResource":
         from prefect.events.schemas.events import RelatedResource
 
         labels = {

--- a/src/prefect/client/schemas/responses.py
+++ b/src/prefect/client/schemas/responses.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, ClassVar, Generic, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Optional, TypeVar, Union
 from uuid import UUID
 
 from pydantic import ConfigDict, Field
@@ -11,6 +11,9 @@ from prefect._internal.schemas.fields import CreatedBy, UpdatedBy
 from prefect.types import DateTime, KeyValueLabelsField
 from prefect.utilities.collections import AutoEnum
 from prefect.utilities.names import generate_slug
+
+if TYPE_CHECKING:
+    from prefect.events.schemas.events import RelatedResource
 
 T = TypeVar("T")
 
@@ -308,6 +311,12 @@ class DeploymentResponse(ObjectBaseModel):
     version: Optional[str] = Field(
         default=None, description="An optional version for the deployment."
     )
+    version_id: Optional[UUID] = Field(
+        default=None, description="The ID of the current version of the deployment."
+    )
+    version_info: Optional[objects.VersionInfo] = Field(
+        default=None, description="A description of this version of the deployment."
+    )
     description: Optional[str] = Field(
         default=None, description="A description for the deployment."
     )
@@ -419,6 +428,22 @@ class DeploymentResponse(ObjectBaseModel):
         default=None,
         description="Current status of the deployment.",
     )
+
+    def as_related_resource(self, role: str) -> "RelatedResource":
+        from prefect.events.schemas.events import RelatedResource
+
+        labels = {
+            "prefect.resource.id": f"prefect.deployment.{self.id}",
+            "prefect.resource.role": role,
+            "prefect.resource.name": self.name,
+        }
+
+        if self.version_id and self.version_info:
+            labels["prefect.deployment.version-id"] = str(self.version_id)
+            labels["prefect.deployment.version-type"] = self.version_info.type
+            labels["prefect.deployment.version"] = self.version_info.version
+
+        return RelatedResource(labels)
 
 
 class MinimalConcurrencyLimitResponse(PrefectBaseModel):

--- a/src/prefect/events/related.py
+++ b/src/prefect/events/related.py
@@ -44,21 +44,17 @@ def tags_as_related_resources(tags: Iterable[str]) -> List[RelatedResource]:
 
 
 def object_as_related_resource(kind: str, role: str, object: Any) -> RelatedResource:
+    if as_related_resource := getattr(object, "as_related_resource", None):
+        return as_related_resource(role=role)
+
     resource_id = f"prefect.{kind}.{object.id}"
-
-    labels = {
-        "prefect.resource.id": resource_id,
-        "prefect.resource.role": role,
-        "prefect.resource.name": object.name,
-    }
-
-    if role == "deployment":
-        from prefect.client.schemas.responses import DeploymentResponse
-
-        if isinstance(object, DeploymentResponse):
-            return object.as_related_resource("deployment")
-
-    return RelatedResource(labels)
+    return RelatedResource(
+        {
+            "prefect.resource.id": resource_id,
+            "prefect.resource.role": role,
+            "prefect.resource.name": object.name,
+        }
+    )
 
 
 async def related_resources_from_run_context(

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -1158,7 +1158,7 @@ class Runner:
 
         flow, deployment = await self._get_flow_and_deployment(flow_run)
         if deployment:
-            related.append(deployment.as_related_resource("deployment"))
+            related.append(deployment.as_related_resource())
             tags.extend(deployment.tags)
         if flow:
             related.append(
@@ -1203,7 +1203,7 @@ class Runner:
         related: list[RelatedResource] = []
         tags: list[str] = []
         if deployment:
-            related.append(deployment.as_related_resource("deployment"))
+            related.append(deployment.as_related_resource())
             tags.extend(deployment.tags)
         if flow:
             related.append(

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -1158,15 +1158,7 @@ class Runner:
 
         flow, deployment = await self._get_flow_and_deployment(flow_run)
         if deployment:
-            related.append(
-                RelatedResource(
-                    {
-                        "prefect.resource.id": f"prefect.deployment.{deployment.id}",
-                        "prefect.resource.role": "deployment",
-                        "prefect.resource.name": deployment.name,
-                    }
-                )
-            )
+            related.append(deployment.as_related_resource("deployment"))
             tags.extend(deployment.tags)
         if flow:
             related.append(
@@ -1211,15 +1203,7 @@ class Runner:
         related: list[RelatedResource] = []
         tags: list[str] = []
         if deployment:
-            related.append(
-                RelatedResource(
-                    {
-                        "prefect.resource.id": f"prefect.deployment.{deployment.id}",
-                        "prefect.resource.role": "deployment",
-                        "prefect.resource.name": deployment.name,
-                    }
-                )
-            )
+            related.append(deployment.as_related_resource("deployment"))
             tags.extend(deployment.tags)
         if flow:
             related.append(

--- a/tests/events/client/instrumentation/test_events_workers_instrumentation.py
+++ b/tests/events/client/instrumentation/test_events_workers_instrumentation.py
@@ -1,9 +1,13 @@
+from unittest import mock
+
 import pytest
 
 from prefect import __version__
 from prefect.client.orchestration import PrefectClient
+from prefect.client.schemas.objects import VersionInfo
 from prefect.events.clients import AssertingEventsClient
 from prefect.events.worker import EventsWorker
+from prefect.server.database import orm_models
 from prefect.states import Scheduled
 from prefect.testing.cli import invoke_and_assert
 from prefect.testing.utilities import AsyncMock
@@ -194,6 +198,76 @@ async def test_worker_emits_executed_event(
     ]
 
     assert executed_events[0].follows == submitted_events[0].id
+
+
+async def test_worker_event_includes_deployment_version(
+    asserting_events_worker: EventsWorker,
+    reset_worker_events,
+    prefect_client: PrefectClient,
+    worker_deployment_wq1: orm_models.Deployment,
+    work_pool: orm_models.WorkPool,
+):
+    await prefect_client.create_flow_run_from_deployment(
+        worker_deployment_wq1.id,
+        state=Scheduled(scheduled_time=now("UTC")),
+        tags=["flow-run-one"],
+    )
+
+    worker_result = BaseWorkerResult(status_code=1, identifier="process123")
+    run_flow_fn = AsyncMock(return_value=worker_result)
+
+    # mock the client to return a DeploymentResponse with a version_id and version_info,
+    # which would be the case if the deployment was created Prefect Cloud experimental
+    # deployment versioning support.
+    server_deployment = await prefect_client.read_deployment(worker_deployment_wq1.id)
+    server_deployment.version_id = "aaaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    server_deployment.version_info = VersionInfo(
+        type="githubulous", version="1.2.3.4.5.6"
+    )
+
+    with mock.patch(
+        "prefect.client.orchestration.PrefectClient.read_deployment",
+        return_value=server_deployment,
+    ):
+        async with WorkerEventsTestImpl(work_pool_name=work_pool.name) as worker:
+            worker._work_pool = work_pool
+            worker.run = run_flow_fn
+            await worker.get_and_submit_flow_runs()
+
+    await asserting_events_worker.drain()
+
+    assert isinstance(asserting_events_worker._client, AssertingEventsClient)
+
+    # When a worker submits a flow-run, it monitors that flow run until it's complete.
+    # When it's complete, it fires a second 'submitted' event, which
+    # is covered by the test_worker_emits_submitted_event below.
+    assert len(asserting_events_worker._client.events) == 2
+
+    events = list(
+        filter(
+            lambda e: (
+                e.event == "prefect.worker.submitted-flow-run"
+                or e.event == "prefect.worker.executed-flow-run"
+            ),
+            asserting_events_worker._client.events,
+        )
+    )
+    # We can just spot-check one of the events here
+    event = events[0]
+
+    deployment = event.resource_in_role["deployment"]
+    assert (
+        deployment["prefect.resource.id"]
+        == f"prefect.deployment.{worker_deployment_wq1.id}"
+    )
+    assert deployment["prefect.resource.role"] == "deployment"
+    assert deployment["prefect.resource.name"] == worker_deployment_wq1.name
+    assert (
+        deployment["prefect.deployment.version-id"]
+        == "aaaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    )
+    assert deployment["prefect.deployment.version-type"] == "githubulous"
+    assert deployment["prefect.deployment.version"] == "1.2.3.4.5.6"
 
 
 @pytest.mark.usefixtures("use_hosted_api_server")

--- a/tests/runner/test_runner.py
+++ b/tests/runner/test_runner.py
@@ -35,6 +35,7 @@ from prefect.client.schemas.objects import (
     FlowRun,
     State,
     StateType,
+    VersionInfo,
     Worker,
     WorkerStatus,
 )
@@ -49,6 +50,7 @@ from prefect.docker.docker_image import DockerImage
 from prefect.events.clients import AssertingEventsClient
 from prefect.events.schemas.automations import Posture
 from prefect.events.schemas.deployment_triggers import DeploymentEventTrigger
+from prefect.events.schemas.events import Event
 from prefect.events.worker import EventsWorker
 from prefect.flows import Flow
 from prefect.logging.loggers import flow_run_logger
@@ -841,6 +843,59 @@ class TestRunner:
 
         # We should get at least 5 heartbeats since the flow should take about 5 seconds to run
         assert len(heartbeat_events) > 5
+
+    async def test_runner_heartbeats_include_deployment_version(
+        self,
+        prefect_client: PrefectClient,
+        asserting_events_worker: EventsWorker,
+    ):
+        runner = Runner(heartbeat_seconds=30)
+
+        await runner.add_deployment(await dummy_flow_1.to_deployment(__file__))
+
+        # mock the client to return a DeploymentResponse with a version_id and
+        # version_info, which would be the case if the deployment was created Prefect
+        # Cloud experimental deployment versioning support.
+        deployment = await prefect_client.read_deployment_by_name(
+            name="dummy-flow-1/test_runner"
+        )
+        deployment.version_id = uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        deployment.version_info = VersionInfo(
+            type="githubulous",
+            version="1.2.3.4.5.6",
+        )
+
+        with mock.patch(
+            "prefect.client.orchestration.PrefectClient.read_deployment"
+        ) as mock_read_deployment:
+            mock_read_deployment.return_value = deployment
+
+            await prefect_client.create_flow_run_from_deployment(
+                deployment_id=deployment.id
+            )
+            await runner.start(run_once=True)
+
+            await asserting_events_worker.drain()
+
+        heartbeat_events: list[Event] = list(
+            filter(
+                lambda e: e.event == "prefect.flow-run.heartbeat",
+                asserting_events_worker._client.events,
+            )
+        )
+        assert len(heartbeat_events) == 1
+
+        heartbeat = heartbeat_events[0]
+
+        resource = heartbeat.resource_in_role["deployment"]
+
+        assert resource["prefect.resource.id"] == f"prefect.deployment.{deployment.id}"
+        assert (
+            resource["prefect.deployment.version-id"]
+            == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        )
+        assert resource["prefect.deployment.version-type"] == "githubulous"
+        assert resource["prefect.deployment.version"] == "1.2.3.4.5.6"
 
     @pytest.mark.usefixtures("use_hosted_api_server")
     async def test_runner_runs_on_cancellation_hooks_for_remotely_stored_flows(


### PR DESCRIPTION
If the server provides the new versioning fields on `Deployment`, use
them when emitting events in the context of a flow run or runner.

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
