### PR TITLE
Add UI-specific route for task run details

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -292,7 +292,7 @@
                           "v3/api-ref/rest-api/server/task-runs/set-task-run-state",
                           "v3/api-ref/rest-api/server/task-runs/read-dashboard-task-run-counts",
                           "v3/api-ref/rest-api/server/task-runs/read-task-run-counts-by-state",
-                          "v3/api-ref/rest-api/server/task-runs/read-task-run-1"
+                          "v3/api-ref/rest-api/server/task-runs/read-task-run-with-flow-run-name"
                         ]
                       },
                       {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -291,7 +291,8 @@
                           "v3/api-ref/rest-api/server/task-runs/paginate-task-runs",
                           "v3/api-ref/rest-api/server/task-runs/set-task-run-state",
                           "v3/api-ref/rest-api/server/task-runs/read-dashboard-task-run-counts",
-                          "v3/api-ref/rest-api/server/task-runs/read-task-run-counts-by-state"
+                          "v3/api-ref/rest-api/server/task-runs/read-task-run-counts-by-state",
+                          "v3/api-ref/rest-api/server/task-runs/read-task-run-1"
                         ]
                       },
                       {

--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -1625,7 +1625,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/TaskRun"
+                                    "$ref": "#/components/schemas/prefect__server__schemas__core__TaskRun"
                                 }
                             }
                         }
@@ -1736,7 +1736,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/TaskRun"
+                                    "$ref": "#/components/schemas/prefect__server__schemas__core__TaskRun"
                                 }
                             }
                         }
@@ -1946,7 +1946,7 @@
                                 "schema": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#/components/schemas/TaskRun"
+                                        "$ref": "#/components/schemas/prefect__server__schemas__core__TaskRun"
                                     },
                                     "title": "Response Read Task Runs Task Runs Filter Post"
                                 }
@@ -9529,6 +9529,62 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/CountByState"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/ui/task_runs/{id}": {
+            "get": {
+                "tags": [
+                    "Task Runs",
+                    "UI"
+                ],
+                "summary": "Read Task Run",
+                "description": "Get a task run by id.",
+                "operationId": "read_task_run_ui_task_runs__id__get",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The task run id",
+                            "title": "Id"
+                        },
+                        "description": "The task run id"
+                    },
+                    {
+                        "name": "x-prefect-api-version",
+                        "in": "header",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "title": "X-Prefect-Api-Version"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/prefect__server__schemas__ui__TaskRun"
                                 }
                             }
                         }
@@ -22864,317 +22920,6 @@
                 "title": "SuspendFlowRun",
                 "description": "Suspends a flow run associated with the trigger"
             },
-            "TaskRun": {
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Id"
-                    },
-                    "created": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Created"
-                    },
-                    "updated": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Updated"
-                    },
-                    "name": {
-                        "type": "string",
-                        "title": "Name",
-                        "examples": [
-                            "my-task-run"
-                        ]
-                    },
-                    "flow_run_id": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "uuid"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Flow Run Id",
-                        "description": "The flow run id of the task run."
-                    },
-                    "task_key": {
-                        "type": "string",
-                        "title": "Task Key",
-                        "description": "A unique identifier for the task being run."
-                    },
-                    "dynamic_key": {
-                        "type": "string",
-                        "title": "Dynamic Key",
-                        "description": "A dynamic key used to differentiate between multiple runs of the same task within the same flow run."
-                    },
-                    "cache_key": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Cache Key",
-                        "description": "An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run."
-                    },
-                    "cache_expiration": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Cache Expiration",
-                        "description": "Specifies when the cached state should expire."
-                    },
-                    "task_version": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Task Version",
-                        "description": "The version of the task being run."
-                    },
-                    "empirical_policy": {
-                        "$ref": "#/components/schemas/TaskRunPolicy"
-                    },
-                    "tags": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "title": "Tags",
-                        "description": "A list of tags for the task run.",
-                        "examples": [
-                            [
-                                "tag-1",
-                                "tag-2"
-                            ]
-                        ]
-                    },
-                    "labels": {
-                        "anyOf": [
-                            {
-                                "additionalProperties": {
-                                    "anyOf": [
-                                        {
-                                            "type": "boolean"
-                                        },
-                                        {
-                                            "type": "integer"
-                                        },
-                                        {
-                                            "type": "number"
-                                        },
-                                        {
-                                            "type": "string"
-                                        }
-                                    ]
-                                },
-                                "type": "object"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Labels",
-                        "description": "A dictionary of key-value labels. Values can be strings, numbers, or booleans.",
-                        "examples": [
-                            {
-                                "key": "value1",
-                                "key2": 42
-                            }
-                        ]
-                    },
-                    "state_id": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "uuid"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "State Id",
-                        "description": "The id of the current task run state."
-                    },
-                    "task_inputs": {
-                        "additionalProperties": {
-                            "items": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/components/schemas/TaskRunResult"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/Parameter"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/Constant"
-                                    }
-                                ]
-                            },
-                            "type": "array"
-                        },
-                        "type": "object",
-                        "title": "Task Inputs",
-                        "description": "Tracks the source of inputs to a task run. Used for internal bookkeeping."
-                    },
-                    "state_type": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/StateType"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "description": "The type of the current task run state."
-                    },
-                    "state_name": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "State Name",
-                        "description": "The name of the current task run state."
-                    },
-                    "run_count": {
-                        "type": "integer",
-                        "title": "Run Count",
-                        "description": "The number of times the task run has been executed.",
-                        "default": 0
-                    },
-                    "flow_run_run_count": {
-                        "type": "integer",
-                        "title": "Flow Run Run Count",
-                        "description": "If the parent flow has retried, this indicates the flow retry this run is associated with.",
-                        "default": 0
-                    },
-                    "expected_start_time": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Expected Start Time",
-                        "description": "The task run's expected start time."
-                    },
-                    "next_scheduled_start_time": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Next Scheduled Start Time",
-                        "description": "The next time the task run is scheduled to start."
-                    },
-                    "start_time": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Start Time",
-                        "description": "The actual start time."
-                    },
-                    "end_time": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "End Time",
-                        "description": "The actual end time."
-                    },
-                    "total_run_time": {
-                        "type": "number",
-                        "title": "Total Run Time",
-                        "description": "Total run time. If the task run was executed multiple times, the time of each run will be summed.",
-                        "default": 0.0
-                    },
-                    "estimated_run_time": {
-                        "type": "number",
-                        "title": "Estimated Run Time",
-                        "description": "A real-time estimate of total run time.",
-                        "default": 0.0
-                    },
-                    "estimated_start_time_delta": {
-                        "type": "number",
-                        "title": "Estimated Start Time Delta",
-                        "description": "The difference between actual and expected start time.",
-                        "default": 0.0
-                    },
-                    "state": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/State"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "description": "The current task run state."
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "task_key",
-                    "dynamic_key",
-                    "id",
-                    "created",
-                    "updated"
-                ],
-                "title": "TaskRun",
-                "description": "An ORM representation of task run data."
-            },
             "TaskRunCount": {
                 "additionalProperties": {
                     "type": "integer"
@@ -25873,6 +25618,639 @@
                 ],
                 "title": "WorkerStatus",
                 "description": "Enumeration of worker statuses."
+            },
+            "prefect__server__schemas__core__TaskRun": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "created": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Created"
+                    },
+                    "updated": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Updated"
+                    },
+                    "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "examples": [
+                            "my-task-run"
+                        ]
+                    },
+                    "flow_run_id": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flow Run Id",
+                        "description": "The flow run id of the task run."
+                    },
+                    "task_key": {
+                        "type": "string",
+                        "title": "Task Key",
+                        "description": "A unique identifier for the task being run."
+                    },
+                    "dynamic_key": {
+                        "type": "string",
+                        "title": "Dynamic Key",
+                        "description": "A dynamic key used to differentiate between multiple runs of the same task within the same flow run."
+                    },
+                    "cache_key": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cache Key",
+                        "description": "An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run."
+                    },
+                    "cache_expiration": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cache Expiration",
+                        "description": "Specifies when the cached state should expire."
+                    },
+                    "task_version": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Task Version",
+                        "description": "The version of the task being run."
+                    },
+                    "empirical_policy": {
+                        "$ref": "#/components/schemas/TaskRunPolicy"
+                    },
+                    "tags": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Tags",
+                        "description": "A list of tags for the task run.",
+                        "examples": [
+                            [
+                                "tag-1",
+                                "tag-2"
+                            ]
+                        ]
+                    },
+                    "labels": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Labels",
+                        "description": "A dictionary of key-value labels. Values can be strings, numbers, or booleans.",
+                        "examples": [
+                            {
+                                "key": "value1",
+                                "key2": 42
+                            }
+                        ]
+                    },
+                    "state_id": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "State Id",
+                        "description": "The id of the current task run state."
+                    },
+                    "task_inputs": {
+                        "additionalProperties": {
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/TaskRunResult"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Parameter"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Constant"
+                                    }
+                                ]
+                            },
+                            "type": "array"
+                        },
+                        "type": "object",
+                        "title": "Task Inputs",
+                        "description": "Tracks the source of inputs to a task run. Used for internal bookkeeping."
+                    },
+                    "state_type": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/StateType"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "The type of the current task run state."
+                    },
+                    "state_name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "State Name",
+                        "description": "The name of the current task run state."
+                    },
+                    "run_count": {
+                        "type": "integer",
+                        "title": "Run Count",
+                        "description": "The number of times the task run has been executed.",
+                        "default": 0
+                    },
+                    "flow_run_run_count": {
+                        "type": "integer",
+                        "title": "Flow Run Run Count",
+                        "description": "If the parent flow has retried, this indicates the flow retry this run is associated with.",
+                        "default": 0
+                    },
+                    "expected_start_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Expected Start Time",
+                        "description": "The task run's expected start time."
+                    },
+                    "next_scheduled_start_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Next Scheduled Start Time",
+                        "description": "The next time the task run is scheduled to start."
+                    },
+                    "start_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Start Time",
+                        "description": "The actual start time."
+                    },
+                    "end_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "End Time",
+                        "description": "The actual end time."
+                    },
+                    "total_run_time": {
+                        "type": "number",
+                        "title": "Total Run Time",
+                        "description": "Total run time. If the task run was executed multiple times, the time of each run will be summed.",
+                        "default": 0.0
+                    },
+                    "estimated_run_time": {
+                        "type": "number",
+                        "title": "Estimated Run Time",
+                        "description": "A real-time estimate of total run time.",
+                        "default": 0.0
+                    },
+                    "estimated_start_time_delta": {
+                        "type": "number",
+                        "title": "Estimated Start Time Delta",
+                        "description": "The difference between actual and expected start time.",
+                        "default": 0.0
+                    },
+                    "state": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/State"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "The current task run state."
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "task_key",
+                    "dynamic_key",
+                    "id",
+                    "created",
+                    "updated"
+                ],
+                "title": "TaskRun",
+                "description": "An ORM representation of task run data."
+            },
+            "prefect__server__schemas__ui__TaskRun": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "created": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Created"
+                    },
+                    "updated": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Updated"
+                    },
+                    "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "examples": [
+                            "my-task-run"
+                        ]
+                    },
+                    "flow_run_id": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flow Run Id",
+                        "description": "The flow run id of the task run."
+                    },
+                    "task_key": {
+                        "type": "string",
+                        "title": "Task Key",
+                        "description": "A unique identifier for the task being run."
+                    },
+                    "dynamic_key": {
+                        "type": "string",
+                        "title": "Dynamic Key",
+                        "description": "A dynamic key used to differentiate between multiple runs of the same task within the same flow run."
+                    },
+                    "cache_key": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cache Key",
+                        "description": "An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run."
+                    },
+                    "cache_expiration": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cache Expiration",
+                        "description": "Specifies when the cached state should expire."
+                    },
+                    "task_version": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Task Version",
+                        "description": "The version of the task being run."
+                    },
+                    "empirical_policy": {
+                        "$ref": "#/components/schemas/TaskRunPolicy"
+                    },
+                    "tags": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Tags",
+                        "description": "A list of tags for the task run.",
+                        "examples": [
+                            [
+                                "tag-1",
+                                "tag-2"
+                            ]
+                        ]
+                    },
+                    "labels": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Labels",
+                        "description": "A dictionary of key-value labels. Values can be strings, numbers, or booleans.",
+                        "examples": [
+                            {
+                                "key": "value1",
+                                "key2": 42
+                            }
+                        ]
+                    },
+                    "state_id": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "State Id",
+                        "description": "The id of the current task run state."
+                    },
+                    "task_inputs": {
+                        "additionalProperties": {
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/TaskRunResult"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Parameter"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Constant"
+                                    }
+                                ]
+                            },
+                            "type": "array"
+                        },
+                        "type": "object",
+                        "title": "Task Inputs",
+                        "description": "Tracks the source of inputs to a task run. Used for internal bookkeeping."
+                    },
+                    "state_type": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/StateType"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "The type of the current task run state."
+                    },
+                    "state_name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "State Name",
+                        "description": "The name of the current task run state."
+                    },
+                    "run_count": {
+                        "type": "integer",
+                        "title": "Run Count",
+                        "description": "The number of times the task run has been executed.",
+                        "default": 0
+                    },
+                    "flow_run_run_count": {
+                        "type": "integer",
+                        "title": "Flow Run Run Count",
+                        "description": "If the parent flow has retried, this indicates the flow retry this run is associated with.",
+                        "default": 0
+                    },
+                    "expected_start_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Expected Start Time",
+                        "description": "The task run's expected start time."
+                    },
+                    "next_scheduled_start_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Next Scheduled Start Time",
+                        "description": "The next time the task run is scheduled to start."
+                    },
+                    "start_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Start Time",
+                        "description": "The actual start time."
+                    },
+                    "end_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "End Time",
+                        "description": "The actual end time."
+                    },
+                    "total_run_time": {
+                        "type": "number",
+                        "title": "Total Run Time",
+                        "description": "Total run time. If the task run was executed multiple times, the time of each run will be summed.",
+                        "default": 0.0
+                    },
+                    "estimated_run_time": {
+                        "type": "number",
+                        "title": "Estimated Run Time",
+                        "description": "A real-time estimate of total run time.",
+                        "default": 0.0
+                    },
+                    "estimated_start_time_delta": {
+                        "type": "number",
+                        "title": "Estimated Start Time Delta",
+                        "description": "The difference between actual and expected start time.",
+                        "default": 0.0
+                    },
+                    "state": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/State"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "The current task run state."
+                    },
+                    "flow_run_name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flow Run Name"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "task_key",
+                    "dynamic_key",
+                    "id",
+                    "created",
+                    "updated"
+                ],
+                "title": "TaskRun",
+                "description": "A task run with additional details for display in the UI."
             }
         }
     }

--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -9552,9 +9552,9 @@
                     "Task Runs",
                     "UI"
                 ],
-                "summary": "Read Task Run",
+                "summary": "Read Task Run With Flow Run Name",
                 "description": "Get a task run by id.",
-                "operationId": "read_task_run_ui_task_runs__id__get",
+                "operationId": "read_task_run_with_flow_run_name_ui_task_runs__id__get",
                 "parameters": [
                     {
                         "name": "id",

--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -1625,7 +1625,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/prefect__server__schemas__core__TaskRun"
+                                    "$ref": "#/components/schemas/TaskRun"
                                 }
                             }
                         }
@@ -1736,7 +1736,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/prefect__server__schemas__core__TaskRun"
+                                    "$ref": "#/components/schemas/TaskRun"
                                 }
                             }
                         }
@@ -1946,7 +1946,7 @@
                                 "schema": {
                                     "type": "array",
                                     "items": {
-                                        "$ref": "#/components/schemas/prefect__server__schemas__core__TaskRun"
+                                        "$ref": "#/components/schemas/TaskRun"
                                     },
                                     "title": "Response Read Task Runs Task Runs Filter Post"
                                 }
@@ -9584,7 +9584,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/prefect__server__schemas__ui__TaskRun"
+                                    "$ref": "#/components/schemas/UITaskRun"
                                 }
                             }
                         }
@@ -22920,6 +22920,317 @@
                 "title": "SuspendFlowRun",
                 "description": "Suspends a flow run associated with the trigger"
             },
+            "TaskRun": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "created": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Created"
+                    },
+                    "updated": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Updated"
+                    },
+                    "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "examples": [
+                            "my-task-run"
+                        ]
+                    },
+                    "flow_run_id": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flow Run Id",
+                        "description": "The flow run id of the task run."
+                    },
+                    "task_key": {
+                        "type": "string",
+                        "title": "Task Key",
+                        "description": "A unique identifier for the task being run."
+                    },
+                    "dynamic_key": {
+                        "type": "string",
+                        "title": "Dynamic Key",
+                        "description": "A dynamic key used to differentiate between multiple runs of the same task within the same flow run."
+                    },
+                    "cache_key": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cache Key",
+                        "description": "An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run."
+                    },
+                    "cache_expiration": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cache Expiration",
+                        "description": "Specifies when the cached state should expire."
+                    },
+                    "task_version": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Task Version",
+                        "description": "The version of the task being run."
+                    },
+                    "empirical_policy": {
+                        "$ref": "#/components/schemas/TaskRunPolicy"
+                    },
+                    "tags": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Tags",
+                        "description": "A list of tags for the task run.",
+                        "examples": [
+                            [
+                                "tag-1",
+                                "tag-2"
+                            ]
+                        ]
+                    },
+                    "labels": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Labels",
+                        "description": "A dictionary of key-value labels. Values can be strings, numbers, or booleans.",
+                        "examples": [
+                            {
+                                "key": "value1",
+                                "key2": 42
+                            }
+                        ]
+                    },
+                    "state_id": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "State Id",
+                        "description": "The id of the current task run state."
+                    },
+                    "task_inputs": {
+                        "additionalProperties": {
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/TaskRunResult"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Parameter"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Constant"
+                                    }
+                                ]
+                            },
+                            "type": "array"
+                        },
+                        "type": "object",
+                        "title": "Task Inputs",
+                        "description": "Tracks the source of inputs to a task run. Used for internal bookkeeping."
+                    },
+                    "state_type": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/StateType"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "The type of the current task run state."
+                    },
+                    "state_name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "State Name",
+                        "description": "The name of the current task run state."
+                    },
+                    "run_count": {
+                        "type": "integer",
+                        "title": "Run Count",
+                        "description": "The number of times the task run has been executed.",
+                        "default": 0
+                    },
+                    "flow_run_run_count": {
+                        "type": "integer",
+                        "title": "Flow Run Run Count",
+                        "description": "If the parent flow has retried, this indicates the flow retry this run is associated with.",
+                        "default": 0
+                    },
+                    "expected_start_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Expected Start Time",
+                        "description": "The task run's expected start time."
+                    },
+                    "next_scheduled_start_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Next Scheduled Start Time",
+                        "description": "The next time the task run is scheduled to start."
+                    },
+                    "start_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Start Time",
+                        "description": "The actual start time."
+                    },
+                    "end_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "End Time",
+                        "description": "The actual end time."
+                    },
+                    "total_run_time": {
+                        "type": "number",
+                        "title": "Total Run Time",
+                        "description": "Total run time. If the task run was executed multiple times, the time of each run will be summed.",
+                        "default": 0.0
+                    },
+                    "estimated_run_time": {
+                        "type": "number",
+                        "title": "Estimated Run Time",
+                        "description": "A real-time estimate of total run time.",
+                        "default": 0.0
+                    },
+                    "estimated_start_time_delta": {
+                        "type": "number",
+                        "title": "Estimated Start Time Delta",
+                        "description": "The difference between actual and expected start time.",
+                        "default": 0.0
+                    },
+                    "state": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/State"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "The current task run state."
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "task_key",
+                    "dynamic_key",
+                    "id",
+                    "created",
+                    "updated"
+                ],
+                "title": "TaskRun",
+                "description": "An ORM representation of task run data."
+            },
             "TaskRunCount": {
                 "additionalProperties": {
                     "type": "integer"
@@ -23893,6 +24204,328 @@
                     "second"
                 ],
                 "title": "TimeUnit"
+            },
+            "UITaskRun": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "created": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Created"
+                    },
+                    "updated": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Updated"
+                    },
+                    "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "examples": [
+                            "my-task-run"
+                        ]
+                    },
+                    "flow_run_id": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flow Run Id",
+                        "description": "The flow run id of the task run."
+                    },
+                    "task_key": {
+                        "type": "string",
+                        "title": "Task Key",
+                        "description": "A unique identifier for the task being run."
+                    },
+                    "dynamic_key": {
+                        "type": "string",
+                        "title": "Dynamic Key",
+                        "description": "A dynamic key used to differentiate between multiple runs of the same task within the same flow run."
+                    },
+                    "cache_key": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cache Key",
+                        "description": "An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run."
+                    },
+                    "cache_expiration": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cache Expiration",
+                        "description": "Specifies when the cached state should expire."
+                    },
+                    "task_version": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Task Version",
+                        "description": "The version of the task being run."
+                    },
+                    "empirical_policy": {
+                        "$ref": "#/components/schemas/TaskRunPolicy"
+                    },
+                    "tags": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Tags",
+                        "description": "A list of tags for the task run.",
+                        "examples": [
+                            [
+                                "tag-1",
+                                "tag-2"
+                            ]
+                        ]
+                    },
+                    "labels": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Labels",
+                        "description": "A dictionary of key-value labels. Values can be strings, numbers, or booleans.",
+                        "examples": [
+                            {
+                                "key": "value1",
+                                "key2": 42
+                            }
+                        ]
+                    },
+                    "state_id": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "State Id",
+                        "description": "The id of the current task run state."
+                    },
+                    "task_inputs": {
+                        "additionalProperties": {
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/TaskRunResult"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Parameter"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Constant"
+                                    }
+                                ]
+                            },
+                            "type": "array"
+                        },
+                        "type": "object",
+                        "title": "Task Inputs",
+                        "description": "Tracks the source of inputs to a task run. Used for internal bookkeeping."
+                    },
+                    "state_type": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/StateType"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "The type of the current task run state."
+                    },
+                    "state_name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "State Name",
+                        "description": "The name of the current task run state."
+                    },
+                    "run_count": {
+                        "type": "integer",
+                        "title": "Run Count",
+                        "description": "The number of times the task run has been executed.",
+                        "default": 0
+                    },
+                    "flow_run_run_count": {
+                        "type": "integer",
+                        "title": "Flow Run Run Count",
+                        "description": "If the parent flow has retried, this indicates the flow retry this run is associated with.",
+                        "default": 0
+                    },
+                    "expected_start_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Expected Start Time",
+                        "description": "The task run's expected start time."
+                    },
+                    "next_scheduled_start_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Next Scheduled Start Time",
+                        "description": "The next time the task run is scheduled to start."
+                    },
+                    "start_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Start Time",
+                        "description": "The actual start time."
+                    },
+                    "end_time": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "End Time",
+                        "description": "The actual end time."
+                    },
+                    "total_run_time": {
+                        "type": "number",
+                        "title": "Total Run Time",
+                        "description": "Total run time. If the task run was executed multiple times, the time of each run will be summed.",
+                        "default": 0.0
+                    },
+                    "estimated_run_time": {
+                        "type": "number",
+                        "title": "Estimated Run Time",
+                        "description": "A real-time estimate of total run time.",
+                        "default": 0.0
+                    },
+                    "estimated_start_time_delta": {
+                        "type": "number",
+                        "title": "Estimated Start Time Delta",
+                        "description": "The difference between actual and expected start time.",
+                        "default": 0.0
+                    },
+                    "state": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/State"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "The current task run state."
+                    },
+                    "flow_run_name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Flow Run Name"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "task_key",
+                    "dynamic_key",
+                    "id",
+                    "created",
+                    "updated"
+                ],
+                "title": "UITaskRun",
+                "description": "A task run with additional details for display in the UI."
             },
             "UpdatedBy": {
                 "properties": {
@@ -25618,639 +26251,6 @@
                 ],
                 "title": "WorkerStatus",
                 "description": "Enumeration of worker statuses."
-            },
-            "prefect__server__schemas__core__TaskRun": {
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Id"
-                    },
-                    "created": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Created"
-                    },
-                    "updated": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Updated"
-                    },
-                    "name": {
-                        "type": "string",
-                        "title": "Name",
-                        "examples": [
-                            "my-task-run"
-                        ]
-                    },
-                    "flow_run_id": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "uuid"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Flow Run Id",
-                        "description": "The flow run id of the task run."
-                    },
-                    "task_key": {
-                        "type": "string",
-                        "title": "Task Key",
-                        "description": "A unique identifier for the task being run."
-                    },
-                    "dynamic_key": {
-                        "type": "string",
-                        "title": "Dynamic Key",
-                        "description": "A dynamic key used to differentiate between multiple runs of the same task within the same flow run."
-                    },
-                    "cache_key": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Cache Key",
-                        "description": "An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run."
-                    },
-                    "cache_expiration": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Cache Expiration",
-                        "description": "Specifies when the cached state should expire."
-                    },
-                    "task_version": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Task Version",
-                        "description": "The version of the task being run."
-                    },
-                    "empirical_policy": {
-                        "$ref": "#/components/schemas/TaskRunPolicy"
-                    },
-                    "tags": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "title": "Tags",
-                        "description": "A list of tags for the task run.",
-                        "examples": [
-                            [
-                                "tag-1",
-                                "tag-2"
-                            ]
-                        ]
-                    },
-                    "labels": {
-                        "anyOf": [
-                            {
-                                "additionalProperties": {
-                                    "anyOf": [
-                                        {
-                                            "type": "boolean"
-                                        },
-                                        {
-                                            "type": "integer"
-                                        },
-                                        {
-                                            "type": "number"
-                                        },
-                                        {
-                                            "type": "string"
-                                        }
-                                    ]
-                                },
-                                "type": "object"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Labels",
-                        "description": "A dictionary of key-value labels. Values can be strings, numbers, or booleans.",
-                        "examples": [
-                            {
-                                "key": "value1",
-                                "key2": 42
-                            }
-                        ]
-                    },
-                    "state_id": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "uuid"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "State Id",
-                        "description": "The id of the current task run state."
-                    },
-                    "task_inputs": {
-                        "additionalProperties": {
-                            "items": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/components/schemas/TaskRunResult"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/Parameter"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/Constant"
-                                    }
-                                ]
-                            },
-                            "type": "array"
-                        },
-                        "type": "object",
-                        "title": "Task Inputs",
-                        "description": "Tracks the source of inputs to a task run. Used for internal bookkeeping."
-                    },
-                    "state_type": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/StateType"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "description": "The type of the current task run state."
-                    },
-                    "state_name": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "State Name",
-                        "description": "The name of the current task run state."
-                    },
-                    "run_count": {
-                        "type": "integer",
-                        "title": "Run Count",
-                        "description": "The number of times the task run has been executed.",
-                        "default": 0
-                    },
-                    "flow_run_run_count": {
-                        "type": "integer",
-                        "title": "Flow Run Run Count",
-                        "description": "If the parent flow has retried, this indicates the flow retry this run is associated with.",
-                        "default": 0
-                    },
-                    "expected_start_time": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Expected Start Time",
-                        "description": "The task run's expected start time."
-                    },
-                    "next_scheduled_start_time": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Next Scheduled Start Time",
-                        "description": "The next time the task run is scheduled to start."
-                    },
-                    "start_time": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Start Time",
-                        "description": "The actual start time."
-                    },
-                    "end_time": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "End Time",
-                        "description": "The actual end time."
-                    },
-                    "total_run_time": {
-                        "type": "number",
-                        "title": "Total Run Time",
-                        "description": "Total run time. If the task run was executed multiple times, the time of each run will be summed.",
-                        "default": 0.0
-                    },
-                    "estimated_run_time": {
-                        "type": "number",
-                        "title": "Estimated Run Time",
-                        "description": "A real-time estimate of total run time.",
-                        "default": 0.0
-                    },
-                    "estimated_start_time_delta": {
-                        "type": "number",
-                        "title": "Estimated Start Time Delta",
-                        "description": "The difference between actual and expected start time.",
-                        "default": 0.0
-                    },
-                    "state": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/State"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "description": "The current task run state."
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "task_key",
-                    "dynamic_key",
-                    "id",
-                    "created",
-                    "updated"
-                ],
-                "title": "TaskRun",
-                "description": "An ORM representation of task run data."
-            },
-            "prefect__server__schemas__ui__TaskRun": {
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Id"
-                    },
-                    "created": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Created"
-                    },
-                    "updated": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Updated"
-                    },
-                    "name": {
-                        "type": "string",
-                        "title": "Name",
-                        "examples": [
-                            "my-task-run"
-                        ]
-                    },
-                    "flow_run_id": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "uuid"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Flow Run Id",
-                        "description": "The flow run id of the task run."
-                    },
-                    "task_key": {
-                        "type": "string",
-                        "title": "Task Key",
-                        "description": "A unique identifier for the task being run."
-                    },
-                    "dynamic_key": {
-                        "type": "string",
-                        "title": "Dynamic Key",
-                        "description": "A dynamic key used to differentiate between multiple runs of the same task within the same flow run."
-                    },
-                    "cache_key": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Cache Key",
-                        "description": "An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run."
-                    },
-                    "cache_expiration": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Cache Expiration",
-                        "description": "Specifies when the cached state should expire."
-                    },
-                    "task_version": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Task Version",
-                        "description": "The version of the task being run."
-                    },
-                    "empirical_policy": {
-                        "$ref": "#/components/schemas/TaskRunPolicy"
-                    },
-                    "tags": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "title": "Tags",
-                        "description": "A list of tags for the task run.",
-                        "examples": [
-                            [
-                                "tag-1",
-                                "tag-2"
-                            ]
-                        ]
-                    },
-                    "labels": {
-                        "anyOf": [
-                            {
-                                "additionalProperties": {
-                                    "anyOf": [
-                                        {
-                                            "type": "boolean"
-                                        },
-                                        {
-                                            "type": "integer"
-                                        },
-                                        {
-                                            "type": "number"
-                                        },
-                                        {
-                                            "type": "string"
-                                        }
-                                    ]
-                                },
-                                "type": "object"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Labels",
-                        "description": "A dictionary of key-value labels. Values can be strings, numbers, or booleans.",
-                        "examples": [
-                            {
-                                "key": "value1",
-                                "key2": 42
-                            }
-                        ]
-                    },
-                    "state_id": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "uuid"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "State Id",
-                        "description": "The id of the current task run state."
-                    },
-                    "task_inputs": {
-                        "additionalProperties": {
-                            "items": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/components/schemas/TaskRunResult"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/Parameter"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/Constant"
-                                    }
-                                ]
-                            },
-                            "type": "array"
-                        },
-                        "type": "object",
-                        "title": "Task Inputs",
-                        "description": "Tracks the source of inputs to a task run. Used for internal bookkeeping."
-                    },
-                    "state_type": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/StateType"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "description": "The type of the current task run state."
-                    },
-                    "state_name": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "State Name",
-                        "description": "The name of the current task run state."
-                    },
-                    "run_count": {
-                        "type": "integer",
-                        "title": "Run Count",
-                        "description": "The number of times the task run has been executed.",
-                        "default": 0
-                    },
-                    "flow_run_run_count": {
-                        "type": "integer",
-                        "title": "Flow Run Run Count",
-                        "description": "If the parent flow has retried, this indicates the flow retry this run is associated with.",
-                        "default": 0
-                    },
-                    "expected_start_time": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Expected Start Time",
-                        "description": "The task run's expected start time."
-                    },
-                    "next_scheduled_start_time": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Next Scheduled Start Time",
-                        "description": "The next time the task run is scheduled to start."
-                    },
-                    "start_time": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Start Time",
-                        "description": "The actual start time."
-                    },
-                    "end_time": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "End Time",
-                        "description": "The actual end time."
-                    },
-                    "total_run_time": {
-                        "type": "number",
-                        "title": "Total Run Time",
-                        "description": "Total run time. If the task run was executed multiple times, the time of each run will be summed.",
-                        "default": 0.0
-                    },
-                    "estimated_run_time": {
-                        "type": "number",
-                        "title": "Estimated Run Time",
-                        "description": "A real-time estimate of total run time.",
-                        "default": 0.0
-                    },
-                    "estimated_start_time_delta": {
-                        "type": "number",
-                        "title": "Estimated Start Time Delta",
-                        "description": "The difference between actual and expected start time.",
-                        "default": 0.0
-                    },
-                    "state": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/State"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "description": "The current task run state."
-                    },
-                    "flow_run_name": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Flow Run Name"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "task_key",
-                    "dynamic_key",
-                    "id",
-                    "created",
-                    "updated"
-                ],
-                "title": "TaskRun",
-                "description": "A task run with additional details for display in the UI."
             }
         }
     }

--- a/docs/v3/api-ref/rest-api/server/task-runs/read-task-run-1.mdx
+++ b/docs/v3/api-ref/rest-api/server/task-runs/read-task-run-1.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /api/ui/task_runs/{id}
+---

--- a/docs/v3/api-ref/rest-api/server/task-runs/read-task-run-with-flow-run-name.mdx
+++ b/docs/v3/api-ref/rest-api/server/task-runs/read-task-run-with-flow-run-name.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /api/ui/task_runs/{id}
+---

--- a/src/prefect/server/api/ui/task_runs.py
+++ b/src/prefect/server/api/ui/task_runs.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional
+from uuid import UUID
 
 import sqlalchemy as sa
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Path, status
 from pydantic import Field, model_serializer
 
 import prefect.server.schemas as schemas
@@ -173,3 +174,29 @@ async def read_task_run_counts_by_state(
             task_run_filter=task_runs,
             deployment_filter=deployments,
         )
+
+
+@router.get("/{id}")
+async def read_task_run(
+    task_run_id: UUID = Path(..., description="The task run id", alias="id"),
+    db: PrefectDBInterface = Depends(provide_database_interface),
+) -> schemas.ui.TaskRun:
+    """
+    Get a task run by id.
+    """
+    async with db.session_context() as session:
+        task_run = await models.task_runs.read_task_run(
+            session=session, task_run_id=task_run_id
+        )
+
+        if not task_run:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Task not found")
+
+        if task_run.flow_run_id is not None:
+            flow_run = await models.flow_runs.read_flow_run(
+                session=session, flow_run_id=task_run.flow_run_id
+            )
+            if flow_run:
+                setattr(task_run, "flow_run_name", flow_run.name)
+
+    return schemas.ui.TaskRun.model_validate(task_run)

--- a/src/prefect/server/api/ui/task_runs.py
+++ b/src/prefect/server/api/ui/task_runs.py
@@ -185,18 +185,11 @@ async def read_task_run(
     Get a task run by id.
     """
     async with db.session_context() as session:
-        task_run = await models.task_runs.read_task_run(
+        task_run = await models.task_runs.read_task_run_with_flow_run_name(
             session=session, task_run_id=task_run_id
         )
 
-        if not task_run:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Task not found")
-
-        if task_run.flow_run_id is not None:
-            flow_run = await models.flow_runs.read_flow_run(
-                session=session, flow_run_id=task_run.flow_run_id
-            )
-            if flow_run:
-                setattr(task_run, "flow_run_name", flow_run.name)
+    if not task_run:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Task not found")
 
     return schemas.ui.TaskRun.model_validate(task_run)

--- a/src/prefect/server/api/ui/task_runs.py
+++ b/src/prefect/server/api/ui/task_runs.py
@@ -180,7 +180,7 @@ async def read_task_run_counts_by_state(
 async def read_task_run(
     task_run_id: UUID = Path(..., description="The task run id", alias="id"),
     db: PrefectDBInterface = Depends(provide_database_interface),
-) -> schemas.ui.TaskRun:
+) -> schemas.ui.UITaskRun:
     """
     Get a task run by id.
     """
@@ -192,4 +192,4 @@ async def read_task_run(
     if not task_run:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Task not found")
 
-    return schemas.ui.TaskRun.model_validate(task_run)
+    return schemas.ui.UITaskRun.model_validate(task_run)

--- a/src/prefect/server/api/ui/task_runs.py
+++ b/src/prefect/server/api/ui/task_runs.py
@@ -177,7 +177,7 @@ async def read_task_run_counts_by_state(
 
 
 @router.get("/{id}")
-async def read_task_run(
+async def read_task_run_with_flow_run_name(
     task_run_id: UUID = Path(..., description="The task run id", alias="id"),
     db: PrefectDBInterface = Depends(provide_database_interface),
 ) -> schemas.ui.UITaskRun:

--- a/src/prefect/server/schemas/__init__.py
+++ b/src/prefect/server/schemas/__init__.py
@@ -8,6 +8,7 @@ from . import (
     responses,
     actions,
     internal,
+    ui,
 )  # noqa
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "states",
     "statuses",
     "internal",
+    "ui",
 ]

--- a/src/prefect/server/schemas/ui.py
+++ b/src/prefect/server/schemas/ui.py
@@ -5,7 +5,7 @@ from typing import Optional
 from prefect.server.schemas.core import TaskRun as CoreTaskRun
 
 
-class TaskRun(CoreTaskRun):
+class UITaskRun(CoreTaskRun):
     """A task run with additional details for display in the UI."""
 
     flow_run_name: Optional[str] = None

--- a/src/prefect/server/schemas/ui.py
+++ b/src/prefect/server/schemas/ui.py
@@ -1,9 +1,11 @@
 """Schemas for UI endpoints."""
 
+from typing import Optional
+
 from prefect.server.schemas.core import TaskRun as CoreTaskRun
 
 
 class TaskRun(CoreTaskRun):
     """A task run with additional details for display in the UI."""
 
-    flow_run_name: str | None = None
+    flow_run_name: Optional[str] = None

--- a/src/prefect/server/schemas/ui.py
+++ b/src/prefect/server/schemas/ui.py
@@ -1,0 +1,9 @@
+"""Schemas for UI endpoints."""
+
+from prefect.server.schemas.core import TaskRun as CoreTaskRun
+
+
+class TaskRun(CoreTaskRun):
+    """A task run with additional details for display in the UI."""
+
+    flow_run_name: str | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,7 @@ EXCLUDE_FROM_CLEAR_DB_AUTO_MARK = [
     "tests/_internal",
     "tests/server/orchestration/test_rules.py",
     "tests/test_flows.py",
+    "tests/server/orchestration/api/ui/test_task_runs.py",
 ]
 
 

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -154,19 +154,19 @@ async def register_block_types(session):
 
 
 @pytest.fixture
-async def flow(session):
+async def flow(session: AsyncSession):
     model = await models.flows.create_flow(
-        session=session, flow=schemas.actions.FlowCreate(name="my-flow")
+        session=session, flow=schemas.core.Flow(name=f"my-flow-{uuid.uuid4()}")
     )
     await session.commit()
     return model
 
 
 @pytest.fixture
-async def flow_run(session, flow):
+async def flow_run(session: AsyncSession, flow: orm_models.Flow):
     model = await models.flow_runs.create_flow_run(
         session=session,
-        flow_run=schemas.actions.FlowRunCreate(flow_id=flow.id, flow_version="0.1"),
+        flow_run=schemas.core.FlowRun(flow_id=flow.id, flow_version="0.1"),
     )
     await session.commit()
     return model
@@ -322,6 +322,16 @@ async def task_run(session, flow_run):
         task_run=schemas.actions.TaskRunCreate(
             flow_run_id=flow_run.id, task_key="my-key", dynamic_key="0"
         ),
+    )
+    await session.commit()
+    return model
+
+
+@pytest.fixture
+async def task_run_without_flow_run(session: AsyncSession):
+    model = await models.task_runs.create_task_run(
+        session=session,
+        task_run=schemas.core.TaskRun(task_key="my-key", dynamic_key="0"),
     )
     await session.commit()
     return model

--- a/tests/server/orchestration/api/test_artifacts.py
+++ b/tests/server/orchestration/api/test_artifacts.py
@@ -2,9 +2,11 @@ from uuid import uuid4
 
 import pydantic
 import pytest
+from httpx import AsyncClient
 from starlette import status
 
 from prefect.server import models, schemas
+from prefect.server.database.orm_models import Deployment, Flow
 from prefect.server.schemas import actions
 from prefect.types._datetime import now
 from prefect.utilities.pydantic import parse_obj_as
@@ -81,8 +83,8 @@ async def artifacts(flow_run, task_run, client):
 
 
 @pytest.fixture
-async def flow_artifacts(client, deployment):
-    flow_data = {"name": "my-flow"}
+async def flow_artifacts(client: AsyncClient, flow: Flow, deployment: Deployment):
+    flow_data = {"name": flow.name}
     response = await client.post("/flows/", json=flow_data)
 
     flow = response.json()

--- a/tests/server/orchestration/api/ui/test_task_runs.py
+++ b/tests/server/orchestration/api/ui/test_task_runs.py
@@ -1,12 +1,16 @@
 from datetime import datetime, timedelta, timezone
-from typing import Tuple, cast
+from typing import cast
+from uuid import uuid4
 
 import pytest
+from fastapi import status
 from httpx import AsyncClient
+from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from prefect.server import models
 from prefect.server.api.ui.task_runs import TaskRunCount
+from prefect.server.database import orm_models
 from prefect.server.schemas import core, filters, states
 from prefect.types import DateTime
 
@@ -17,12 +21,14 @@ class TestReadDashboardTaskRunCounts:
         return "/ui/task_runs/dashboard/counts"
 
     @pytest.fixture
-    def time_window(self) -> Tuple[DateTime, DateTime]:
-        now = cast(DateTime, datetime(2023, 6, 1, 18, tzinfo=timezone.utc))
+    def time_window(self) -> tuple[datetime, datetime]:
+        now = datetime(2023, 6, 1, 18, tzinfo=timezone.utc)
         return (now, now - timedelta(hours=8))
 
     @pytest.fixture
-    def task_run_filter(self, time_window) -> filters.TaskRunFilter:
+    def task_run_filter(
+        self, time_window: tuple[DateTime, DateTime]
+    ) -> filters.TaskRunFilter:
         now, eight_hours_ago = time_window
         return filters.TaskRunFilter(
             start_time=filters.TaskRunFilterStartTime(
@@ -34,8 +40,8 @@ class TestReadDashboardTaskRunCounts:
     async def create_task_runs(
         self,
         session: AsyncSession,
-        flow_run,
-        time_window,
+        flow_run: orm_models.FlowRun,
+        time_window: tuple[DateTime, DateTime],
     ):
         now, eight_hours_ago = time_window
         runs_to_create = 100
@@ -92,12 +98,12 @@ class TestReadDashboardTaskRunCounts:
             TaskRunCount(completed=0, failed=0) for _ in range(len(counts))
         ]
 
+    @pytest.mark.usefixtures("create_task_runs")
     async def test_returns_completed_and_failed_counts(
         self,
         url: str,
         task_run_filter: filters.TaskRunFilter,
         client: AsyncClient,
-        create_task_runs,
     ):
         response = await client.post(
             url, json={"task_runs": task_run_filter.model_dump(mode="json")}
@@ -139,8 +145,10 @@ class TestReadTaskRunCountsByState:
     async def create_flow_runs(
         self,
         session: AsyncSession,
-        flow,
+        flow: orm_models.Flow,
     ):
+        await session.execute(delete(orm_models.FlowRun))
+
         run_1 = await models.flow_runs.create_flow_run(
             session=session,
             flow_run=core.FlowRun(
@@ -167,15 +175,17 @@ class TestReadTaskRunCountsByState:
 
         await session.commit()
 
-        return [run_1, run_2, run_3]
+        yield [run_1, run_2, run_3]
 
     @pytest.fixture
     async def create_task_runs(
         self,
         session: AsyncSession,
-        flow_run,
-        create_flow_runs,
+        flow_run: orm_models.FlowRun,
+        create_flow_runs: list[orm_models.FlowRun],
     ):
+        await session.execute(delete(orm_models.TaskRun))
+
         task_runs_per_flow_run = 27
         now = cast(DateTime, datetime(2023, 6, 1, 18, tzinfo=timezone.utc))
 
@@ -215,8 +225,8 @@ class TestReadTaskRunCountsByState:
                     session=session,
                     task_run=core.TaskRun(
                         flow_run_id=flow_run.id,
-                        task_key=f"task-{i}",
-                        dynamic_key=str(i),
+                        task_key=f"task-{i}-{uuid4()}",
+                        dynamic_key=str(uuid4()),
                         state_type=state_type,
                         state_name=state_name,
                         start_time=now,
@@ -225,6 +235,8 @@ class TestReadTaskRunCountsByState:
                 )
 
         await session.commit()
+
+        yield
 
     async def test_returns_all_state_types(
         self,
@@ -242,7 +254,12 @@ class TestReadTaskRunCountsByState:
         self,
         url: str,
         client: AsyncClient,
+        session: AsyncSession,
     ):
+        # ensure there are no task runs in the database
+        await session.execute(delete(orm_models.TaskRun))
+        await session.commit()
+
         response = await client.post(url)
         assert response.status_code == 200
 
@@ -259,11 +276,11 @@ class TestReadTaskRunCountsByState:
             "SCHEDULED": 0,
         }
 
+    @pytest.mark.usefixtures("create_task_runs")
     async def test_returns_counts(
         self,
         url: str,
         client: AsyncClient,
-        create_task_runs,
     ):
         response = await client.post(url)
         assert response.status_code == 200
@@ -282,11 +299,11 @@ class TestReadTaskRunCountsByState:
             "SCHEDULED": 3 * 3,
         }
 
+    @pytest.mark.usefixtures("create_task_runs")
     async def test_returns_counts_with_filter(
         self,
         url: str,
         client: AsyncClient,
-        create_task_runs,
     ):
         response = await client.post(
             url,
@@ -316,3 +333,32 @@ class TestReadTaskRunCountsByState:
             "CANCELLING": 1,
             "SCHEDULED": 3,
         }
+
+
+class TestReadTaskRun:
+    async def test_read_task_run(
+        self,
+        flow_run: orm_models.FlowRun,
+        task_run: orm_models.TaskRun,
+        client: AsyncClient,
+    ):
+        response = await client.get(f"/ui/task_runs/{task_run.id}")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["id"] == str(task_run.id)
+        assert response.json()["flow_run_id"] == str(flow_run.id)
+        assert response.json()["flow_run_name"] == flow_run.name
+
+    async def test_read_task_without_flow_run(
+        self, task_run_without_flow_run: orm_models.TaskRun, client: AsyncClient
+    ):
+        response = await client.get(f"/ui/task_runs/{task_run_without_flow_run.id}")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["id"] == str(task_run_without_flow_run.id)
+        assert response.json()["flow_run_id"] is None
+        assert response.json()["flow_run_name"] is None
+
+    async def test_read_task_run_returns_404_if_does_not_exist(
+        self, client: AsyncClient
+    ):
+        response = await client.get(f"/ui/task_runs/{uuid4()}")
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/server/orchestration/test_flow_run_instrumentation_policies.py
+++ b/tests/server/orchestration/test_flow_run_instrumentation_policies.py
@@ -98,7 +98,7 @@ async def test_instrumenting_a_flow_run_state_change(
             {
                 "prefect.resource.id": f"prefect.flow.{flow.id}",
                 "prefect.resource.role": "flow",
-                "prefect.resource.name": "my-flow",
+                "prefect.resource.name": flow.name,
             }
         )
     ]
@@ -417,7 +417,7 @@ async def test_instrumenting_a_deployed_flow_run_state_change(
             {
                 "prefect.resource.id": f"prefect.flow.{flow.id}",
                 "prefect.resource.role": "flow",
-                "prefect.resource.name": "my-flow",
+                "prefect.resource.name": flow.name,
             }
         ),
         RelatedResource.model_validate(

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -2813,6 +2813,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/ui/task_runs/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Read Task Run
+         * @description Get a task run by id.
+         */
+        get: operations["read_task_run_ui_task_runs__id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/settings": {
         parameters: {
             query?: never;
@@ -8629,137 +8649,6 @@ export interface components {
              */
             type: "suspend-flow-run";
         };
-        /**
-         * TaskRun
-         * @description An ORM representation of task run data.
-         */
-        TaskRun: {
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
-            /** Created */
-            created: string | null;
-            /** Updated */
-            updated: string | null;
-            /** Name */
-            name?: string;
-            /**
-             * Flow Run Id
-             * @description The flow run id of the task run.
-             */
-            flow_run_id?: string | null;
-            /**
-             * Task Key
-             * @description A unique identifier for the task being run.
-             */
-            task_key: string;
-            /**
-             * Dynamic Key
-             * @description A dynamic key used to differentiate between multiple runs of the same task within the same flow run.
-             */
-            dynamic_key: string;
-            /**
-             * Cache Key
-             * @description An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run.
-             */
-            cache_key?: string | null;
-            /**
-             * Cache Expiration
-             * @description Specifies when the cached state should expire.
-             */
-            cache_expiration?: string | null;
-            /**
-             * Task Version
-             * @description The version of the task being run.
-             */
-            task_version?: string | null;
-            empirical_policy?: components["schemas"]["TaskRunPolicy"];
-            /**
-             * Tags
-             * @description A list of tags for the task run.
-             */
-            tags?: string[];
-            /**
-             * Labels
-             * @description A dictionary of key-value labels. Values can be strings, numbers, or booleans.
-             */
-            labels?: {
-                [key: string]: boolean | number | string;
-            } | null;
-            /**
-             * State Id
-             * @description The id of the current task run state.
-             */
-            state_id?: string | null;
-            /**
-             * Task Inputs
-             * @description Tracks the source of inputs to a task run. Used for internal bookkeeping.
-             */
-            task_inputs?: {
-                [key: string]: (components["schemas"]["TaskRunResult"] | components["schemas"]["Parameter"] | components["schemas"]["Constant"])[];
-            };
-            /** @description The type of the current task run state. */
-            state_type?: components["schemas"]["StateType"] | null;
-            /**
-             * State Name
-             * @description The name of the current task run state.
-             */
-            state_name?: string | null;
-            /**
-             * Run Count
-             * @description The number of times the task run has been executed.
-             * @default 0
-             */
-            run_count: number;
-            /**
-             * Flow Run Run Count
-             * @description If the parent flow has retried, this indicates the flow retry this run is associated with.
-             * @default 0
-             */
-            flow_run_run_count: number;
-            /**
-             * Expected Start Time
-             * @description The task run's expected start time.
-             */
-            expected_start_time?: string | null;
-            /**
-             * Next Scheduled Start Time
-             * @description The next time the task run is scheduled to start.
-             */
-            next_scheduled_start_time?: string | null;
-            /**
-             * Start Time
-             * @description The actual start time.
-             */
-            start_time?: string | null;
-            /**
-             * End Time
-             * @description The actual end time.
-             */
-            end_time?: string | null;
-            /**
-             * Total Run Time
-             * @description Total run time. If the task run was executed multiple times, the time of each run will be summed.
-             * @default 0
-             */
-            total_run_time: number;
-            /**
-             * Estimated Run Time
-             * @description A real-time estimate of total run time.
-             * @default 0
-             */
-            estimated_run_time: number;
-            /**
-             * Estimated Start Time Delta
-             * @description The difference between actual and expected start time.
-             * @default 0
-             */
-            estimated_start_time_delta: number;
-            /** @description The current task run state. */
-            state?: components["schemas"]["State"] | null;
-        };
         TaskRunCount: {
             [key: string]: number;
         };
@@ -9920,6 +9809,270 @@ export interface components {
          * @enum {string}
          */
         WorkerStatus: "ONLINE" | "OFFLINE";
+        /**
+         * TaskRun
+         * @description An ORM representation of task run data.
+         */
+        prefect__server__schemas__core__TaskRun: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Created */
+            created: string | null;
+            /** Updated */
+            updated: string | null;
+            /** Name */
+            name?: string;
+            /**
+             * Flow Run Id
+             * @description The flow run id of the task run.
+             */
+            flow_run_id?: string | null;
+            /**
+             * Task Key
+             * @description A unique identifier for the task being run.
+             */
+            task_key: string;
+            /**
+             * Dynamic Key
+             * @description A dynamic key used to differentiate between multiple runs of the same task within the same flow run.
+             */
+            dynamic_key: string;
+            /**
+             * Cache Key
+             * @description An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run.
+             */
+            cache_key?: string | null;
+            /**
+             * Cache Expiration
+             * @description Specifies when the cached state should expire.
+             */
+            cache_expiration?: string | null;
+            /**
+             * Task Version
+             * @description The version of the task being run.
+             */
+            task_version?: string | null;
+            empirical_policy?: components["schemas"]["TaskRunPolicy"];
+            /**
+             * Tags
+             * @description A list of tags for the task run.
+             */
+            tags?: string[];
+            /**
+             * Labels
+             * @description A dictionary of key-value labels. Values can be strings, numbers, or booleans.
+             */
+            labels?: {
+                [key: string]: boolean | number | string;
+            } | null;
+            /**
+             * State Id
+             * @description The id of the current task run state.
+             */
+            state_id?: string | null;
+            /**
+             * Task Inputs
+             * @description Tracks the source of inputs to a task run. Used for internal bookkeeping.
+             */
+            task_inputs?: {
+                [key: string]: (components["schemas"]["TaskRunResult"] | components["schemas"]["Parameter"] | components["schemas"]["Constant"])[];
+            };
+            /** @description The type of the current task run state. */
+            state_type?: components["schemas"]["StateType"] | null;
+            /**
+             * State Name
+             * @description The name of the current task run state.
+             */
+            state_name?: string | null;
+            /**
+             * Run Count
+             * @description The number of times the task run has been executed.
+             * @default 0
+             */
+            run_count: number;
+            /**
+             * Flow Run Run Count
+             * @description If the parent flow has retried, this indicates the flow retry this run is associated with.
+             * @default 0
+             */
+            flow_run_run_count: number;
+            /**
+             * Expected Start Time
+             * @description The task run's expected start time.
+             */
+            expected_start_time?: string | null;
+            /**
+             * Next Scheduled Start Time
+             * @description The next time the task run is scheduled to start.
+             */
+            next_scheduled_start_time?: string | null;
+            /**
+             * Start Time
+             * @description The actual start time.
+             */
+            start_time?: string | null;
+            /**
+             * End Time
+             * @description The actual end time.
+             */
+            end_time?: string | null;
+            /**
+             * Total Run Time
+             * @description Total run time. If the task run was executed multiple times, the time of each run will be summed.
+             * @default 0
+             */
+            total_run_time: number;
+            /**
+             * Estimated Run Time
+             * @description A real-time estimate of total run time.
+             * @default 0
+             */
+            estimated_run_time: number;
+            /**
+             * Estimated Start Time Delta
+             * @description The difference between actual and expected start time.
+             * @default 0
+             */
+            estimated_start_time_delta: number;
+            /** @description The current task run state. */
+            state?: components["schemas"]["State"] | null;
+        };
+        /**
+         * TaskRun
+         * @description A task run with additional details for display in the UI.
+         */
+        prefect__server__schemas__ui__TaskRun: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Created */
+            created: string | null;
+            /** Updated */
+            updated: string | null;
+            /** Name */
+            name?: string;
+            /**
+             * Flow Run Id
+             * @description The flow run id of the task run.
+             */
+            flow_run_id?: string | null;
+            /**
+             * Task Key
+             * @description A unique identifier for the task being run.
+             */
+            task_key: string;
+            /**
+             * Dynamic Key
+             * @description A dynamic key used to differentiate between multiple runs of the same task within the same flow run.
+             */
+            dynamic_key: string;
+            /**
+             * Cache Key
+             * @description An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run.
+             */
+            cache_key?: string | null;
+            /**
+             * Cache Expiration
+             * @description Specifies when the cached state should expire.
+             */
+            cache_expiration?: string | null;
+            /**
+             * Task Version
+             * @description The version of the task being run.
+             */
+            task_version?: string | null;
+            empirical_policy?: components["schemas"]["TaskRunPolicy"];
+            /**
+             * Tags
+             * @description A list of tags for the task run.
+             */
+            tags?: string[];
+            /**
+             * Labels
+             * @description A dictionary of key-value labels. Values can be strings, numbers, or booleans.
+             */
+            labels?: {
+                [key: string]: boolean | number | string;
+            } | null;
+            /**
+             * State Id
+             * @description The id of the current task run state.
+             */
+            state_id?: string | null;
+            /**
+             * Task Inputs
+             * @description Tracks the source of inputs to a task run. Used for internal bookkeeping.
+             */
+            task_inputs?: {
+                [key: string]: (components["schemas"]["TaskRunResult"] | components["schemas"]["Parameter"] | components["schemas"]["Constant"])[];
+            };
+            /** @description The type of the current task run state. */
+            state_type?: components["schemas"]["StateType"] | null;
+            /**
+             * State Name
+             * @description The name of the current task run state.
+             */
+            state_name?: string | null;
+            /**
+             * Run Count
+             * @description The number of times the task run has been executed.
+             * @default 0
+             */
+            run_count: number;
+            /**
+             * Flow Run Run Count
+             * @description If the parent flow has retried, this indicates the flow retry this run is associated with.
+             * @default 0
+             */
+            flow_run_run_count: number;
+            /**
+             * Expected Start Time
+             * @description The task run's expected start time.
+             */
+            expected_start_time?: string | null;
+            /**
+             * Next Scheduled Start Time
+             * @description The next time the task run is scheduled to start.
+             */
+            next_scheduled_start_time?: string | null;
+            /**
+             * Start Time
+             * @description The actual start time.
+             */
+            start_time?: string | null;
+            /**
+             * End Time
+             * @description The actual end time.
+             */
+            end_time?: string | null;
+            /**
+             * Total Run Time
+             * @description Total run time. If the task run was executed multiple times, the time of each run will be summed.
+             * @default 0
+             */
+            total_run_time: number;
+            /**
+             * Estimated Run Time
+             * @description A real-time estimate of total run time.
+             * @default 0
+             */
+            estimated_run_time: number;
+            /**
+             * Estimated Start Time Delta
+             * @description The difference between actual and expected start time.
+             * @default 0
+             */
+            estimated_start_time_delta: number;
+            /** @description The current task run state. */
+            state?: components["schemas"]["State"] | null;
+            /** Flow Run Name */
+            flow_run_name?: string | null;
+        };
     };
     responses: never;
     parameters: never;
@@ -10943,7 +11096,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["TaskRun"];
+                    "application/json": components["schemas"]["prefect__server__schemas__core__TaskRun"];
                 };
             };
             /** @description Validation Error */
@@ -10977,7 +11130,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["TaskRun"];
+                    "application/json": components["schemas"]["prefect__server__schemas__core__TaskRun"];
                 };
             };
             /** @description Validation Error */
@@ -11150,7 +11303,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["TaskRun"][];
+                    "application/json": components["schemas"]["prefect__server__schemas__core__TaskRun"][];
                 };
             };
             /** @description Validation Error */
@@ -15912,6 +16065,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CountByState"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    read_task_run_ui_task_runs__id__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-prefect-api-version"?: string;
+            };
+            path: {
+                /** @description The task run id */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["prefect__server__schemas__ui__TaskRun"];
                 };
             };
             /** @description Validation Error */

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -2821,10 +2821,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Read Task Run
+         * Read Task Run With Flow Run Name
          * @description Get a task run by id.
          */
-        get: operations["read_task_run_ui_task_runs__id__get"];
+        get: operations["read_task_run_with_flow_run_name_ui_task_runs__id__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -16078,7 +16078,7 @@ export interface operations {
             };
         };
     };
-    read_task_run_ui_task_runs__id__get: {
+    read_task_run_with_flow_run_name_ui_task_runs__id__get: {
         parameters: {
             query?: never;
             header?: {

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -8649,6 +8649,137 @@ export interface components {
              */
             type: "suspend-flow-run";
         };
+        /**
+         * TaskRun
+         * @description An ORM representation of task run data.
+         */
+        TaskRun: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Created */
+            created: string | null;
+            /** Updated */
+            updated: string | null;
+            /** Name */
+            name?: string;
+            /**
+             * Flow Run Id
+             * @description The flow run id of the task run.
+             */
+            flow_run_id?: string | null;
+            /**
+             * Task Key
+             * @description A unique identifier for the task being run.
+             */
+            task_key: string;
+            /**
+             * Dynamic Key
+             * @description A dynamic key used to differentiate between multiple runs of the same task within the same flow run.
+             */
+            dynamic_key: string;
+            /**
+             * Cache Key
+             * @description An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run.
+             */
+            cache_key?: string | null;
+            /**
+             * Cache Expiration
+             * @description Specifies when the cached state should expire.
+             */
+            cache_expiration?: string | null;
+            /**
+             * Task Version
+             * @description The version of the task being run.
+             */
+            task_version?: string | null;
+            empirical_policy?: components["schemas"]["TaskRunPolicy"];
+            /**
+             * Tags
+             * @description A list of tags for the task run.
+             */
+            tags?: string[];
+            /**
+             * Labels
+             * @description A dictionary of key-value labels. Values can be strings, numbers, or booleans.
+             */
+            labels?: {
+                [key: string]: boolean | number | string;
+            } | null;
+            /**
+             * State Id
+             * @description The id of the current task run state.
+             */
+            state_id?: string | null;
+            /**
+             * Task Inputs
+             * @description Tracks the source of inputs to a task run. Used for internal bookkeeping.
+             */
+            task_inputs?: {
+                [key: string]: (components["schemas"]["TaskRunResult"] | components["schemas"]["Parameter"] | components["schemas"]["Constant"])[];
+            };
+            /** @description The type of the current task run state. */
+            state_type?: components["schemas"]["StateType"] | null;
+            /**
+             * State Name
+             * @description The name of the current task run state.
+             */
+            state_name?: string | null;
+            /**
+             * Run Count
+             * @description The number of times the task run has been executed.
+             * @default 0
+             */
+            run_count: number;
+            /**
+             * Flow Run Run Count
+             * @description If the parent flow has retried, this indicates the flow retry this run is associated with.
+             * @default 0
+             */
+            flow_run_run_count: number;
+            /**
+             * Expected Start Time
+             * @description The task run's expected start time.
+             */
+            expected_start_time?: string | null;
+            /**
+             * Next Scheduled Start Time
+             * @description The next time the task run is scheduled to start.
+             */
+            next_scheduled_start_time?: string | null;
+            /**
+             * Start Time
+             * @description The actual start time.
+             */
+            start_time?: string | null;
+            /**
+             * End Time
+             * @description The actual end time.
+             */
+            end_time?: string | null;
+            /**
+             * Total Run Time
+             * @description Total run time. If the task run was executed multiple times, the time of each run will be summed.
+             * @default 0
+             */
+            total_run_time: number;
+            /**
+             * Estimated Run Time
+             * @description A real-time estimate of total run time.
+             * @default 0
+             */
+            estimated_run_time: number;
+            /**
+             * Estimated Start Time Delta
+             * @description The difference between actual and expected start time.
+             * @default 0
+             */
+            estimated_start_time_delta: number;
+            /** @description The current task run state. */
+            state?: components["schemas"]["State"] | null;
+        };
         TaskRunCount: {
             [key: string]: number;
         };
@@ -9067,6 +9198,139 @@ export interface components {
          * @enum {string}
          */
         TimeUnit: "week" | "day" | "hour" | "minute" | "second";
+        /**
+         * UITaskRun
+         * @description A task run with additional details for display in the UI.
+         */
+        UITaskRun: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Created */
+            created: string | null;
+            /** Updated */
+            updated: string | null;
+            /** Name */
+            name?: string;
+            /**
+             * Flow Run Id
+             * @description The flow run id of the task run.
+             */
+            flow_run_id?: string | null;
+            /**
+             * Task Key
+             * @description A unique identifier for the task being run.
+             */
+            task_key: string;
+            /**
+             * Dynamic Key
+             * @description A dynamic key used to differentiate between multiple runs of the same task within the same flow run.
+             */
+            dynamic_key: string;
+            /**
+             * Cache Key
+             * @description An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run.
+             */
+            cache_key?: string | null;
+            /**
+             * Cache Expiration
+             * @description Specifies when the cached state should expire.
+             */
+            cache_expiration?: string | null;
+            /**
+             * Task Version
+             * @description The version of the task being run.
+             */
+            task_version?: string | null;
+            empirical_policy?: components["schemas"]["TaskRunPolicy"];
+            /**
+             * Tags
+             * @description A list of tags for the task run.
+             */
+            tags?: string[];
+            /**
+             * Labels
+             * @description A dictionary of key-value labels. Values can be strings, numbers, or booleans.
+             */
+            labels?: {
+                [key: string]: boolean | number | string;
+            } | null;
+            /**
+             * State Id
+             * @description The id of the current task run state.
+             */
+            state_id?: string | null;
+            /**
+             * Task Inputs
+             * @description Tracks the source of inputs to a task run. Used for internal bookkeeping.
+             */
+            task_inputs?: {
+                [key: string]: (components["schemas"]["TaskRunResult"] | components["schemas"]["Parameter"] | components["schemas"]["Constant"])[];
+            };
+            /** @description The type of the current task run state. */
+            state_type?: components["schemas"]["StateType"] | null;
+            /**
+             * State Name
+             * @description The name of the current task run state.
+             */
+            state_name?: string | null;
+            /**
+             * Run Count
+             * @description The number of times the task run has been executed.
+             * @default 0
+             */
+            run_count: number;
+            /**
+             * Flow Run Run Count
+             * @description If the parent flow has retried, this indicates the flow retry this run is associated with.
+             * @default 0
+             */
+            flow_run_run_count: number;
+            /**
+             * Expected Start Time
+             * @description The task run's expected start time.
+             */
+            expected_start_time?: string | null;
+            /**
+             * Next Scheduled Start Time
+             * @description The next time the task run is scheduled to start.
+             */
+            next_scheduled_start_time?: string | null;
+            /**
+             * Start Time
+             * @description The actual start time.
+             */
+            start_time?: string | null;
+            /**
+             * End Time
+             * @description The actual end time.
+             */
+            end_time?: string | null;
+            /**
+             * Total Run Time
+             * @description Total run time. If the task run was executed multiple times, the time of each run will be summed.
+             * @default 0
+             */
+            total_run_time: number;
+            /**
+             * Estimated Run Time
+             * @description A real-time estimate of total run time.
+             * @default 0
+             */
+            estimated_run_time: number;
+            /**
+             * Estimated Start Time Delta
+             * @description The difference between actual and expected start time.
+             * @default 0
+             */
+            estimated_start_time_delta: number;
+            /** @description The current task run state. */
+            state?: components["schemas"]["State"] | null;
+            /** Flow Run Name */
+            flow_run_name?: string | null;
+        };
         /** UpdatedBy */
         UpdatedBy: {
             /**
@@ -9809,270 +10073,6 @@ export interface components {
          * @enum {string}
          */
         WorkerStatus: "ONLINE" | "OFFLINE";
-        /**
-         * TaskRun
-         * @description An ORM representation of task run data.
-         */
-        prefect__server__schemas__core__TaskRun: {
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
-            /** Created */
-            created: string | null;
-            /** Updated */
-            updated: string | null;
-            /** Name */
-            name?: string;
-            /**
-             * Flow Run Id
-             * @description The flow run id of the task run.
-             */
-            flow_run_id?: string | null;
-            /**
-             * Task Key
-             * @description A unique identifier for the task being run.
-             */
-            task_key: string;
-            /**
-             * Dynamic Key
-             * @description A dynamic key used to differentiate between multiple runs of the same task within the same flow run.
-             */
-            dynamic_key: string;
-            /**
-             * Cache Key
-             * @description An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run.
-             */
-            cache_key?: string | null;
-            /**
-             * Cache Expiration
-             * @description Specifies when the cached state should expire.
-             */
-            cache_expiration?: string | null;
-            /**
-             * Task Version
-             * @description The version of the task being run.
-             */
-            task_version?: string | null;
-            empirical_policy?: components["schemas"]["TaskRunPolicy"];
-            /**
-             * Tags
-             * @description A list of tags for the task run.
-             */
-            tags?: string[];
-            /**
-             * Labels
-             * @description A dictionary of key-value labels. Values can be strings, numbers, or booleans.
-             */
-            labels?: {
-                [key: string]: boolean | number | string;
-            } | null;
-            /**
-             * State Id
-             * @description The id of the current task run state.
-             */
-            state_id?: string | null;
-            /**
-             * Task Inputs
-             * @description Tracks the source of inputs to a task run. Used for internal bookkeeping.
-             */
-            task_inputs?: {
-                [key: string]: (components["schemas"]["TaskRunResult"] | components["schemas"]["Parameter"] | components["schemas"]["Constant"])[];
-            };
-            /** @description The type of the current task run state. */
-            state_type?: components["schemas"]["StateType"] | null;
-            /**
-             * State Name
-             * @description The name of the current task run state.
-             */
-            state_name?: string | null;
-            /**
-             * Run Count
-             * @description The number of times the task run has been executed.
-             * @default 0
-             */
-            run_count: number;
-            /**
-             * Flow Run Run Count
-             * @description If the parent flow has retried, this indicates the flow retry this run is associated with.
-             * @default 0
-             */
-            flow_run_run_count: number;
-            /**
-             * Expected Start Time
-             * @description The task run's expected start time.
-             */
-            expected_start_time?: string | null;
-            /**
-             * Next Scheduled Start Time
-             * @description The next time the task run is scheduled to start.
-             */
-            next_scheduled_start_time?: string | null;
-            /**
-             * Start Time
-             * @description The actual start time.
-             */
-            start_time?: string | null;
-            /**
-             * End Time
-             * @description The actual end time.
-             */
-            end_time?: string | null;
-            /**
-             * Total Run Time
-             * @description Total run time. If the task run was executed multiple times, the time of each run will be summed.
-             * @default 0
-             */
-            total_run_time: number;
-            /**
-             * Estimated Run Time
-             * @description A real-time estimate of total run time.
-             * @default 0
-             */
-            estimated_run_time: number;
-            /**
-             * Estimated Start Time Delta
-             * @description The difference between actual and expected start time.
-             * @default 0
-             */
-            estimated_start_time_delta: number;
-            /** @description The current task run state. */
-            state?: components["schemas"]["State"] | null;
-        };
-        /**
-         * TaskRun
-         * @description A task run with additional details for display in the UI.
-         */
-        prefect__server__schemas__ui__TaskRun: {
-            /**
-             * Id
-             * Format: uuid
-             */
-            id: string;
-            /** Created */
-            created: string | null;
-            /** Updated */
-            updated: string | null;
-            /** Name */
-            name?: string;
-            /**
-             * Flow Run Id
-             * @description The flow run id of the task run.
-             */
-            flow_run_id?: string | null;
-            /**
-             * Task Key
-             * @description A unique identifier for the task being run.
-             */
-            task_key: string;
-            /**
-             * Dynamic Key
-             * @description A dynamic key used to differentiate between multiple runs of the same task within the same flow run.
-             */
-            dynamic_key: string;
-            /**
-             * Cache Key
-             * @description An optional cache key. If a COMPLETED state associated with this cache key is found, the cached COMPLETED state will be used instead of executing the task run.
-             */
-            cache_key?: string | null;
-            /**
-             * Cache Expiration
-             * @description Specifies when the cached state should expire.
-             */
-            cache_expiration?: string | null;
-            /**
-             * Task Version
-             * @description The version of the task being run.
-             */
-            task_version?: string | null;
-            empirical_policy?: components["schemas"]["TaskRunPolicy"];
-            /**
-             * Tags
-             * @description A list of tags for the task run.
-             */
-            tags?: string[];
-            /**
-             * Labels
-             * @description A dictionary of key-value labels. Values can be strings, numbers, or booleans.
-             */
-            labels?: {
-                [key: string]: boolean | number | string;
-            } | null;
-            /**
-             * State Id
-             * @description The id of the current task run state.
-             */
-            state_id?: string | null;
-            /**
-             * Task Inputs
-             * @description Tracks the source of inputs to a task run. Used for internal bookkeeping.
-             */
-            task_inputs?: {
-                [key: string]: (components["schemas"]["TaskRunResult"] | components["schemas"]["Parameter"] | components["schemas"]["Constant"])[];
-            };
-            /** @description The type of the current task run state. */
-            state_type?: components["schemas"]["StateType"] | null;
-            /**
-             * State Name
-             * @description The name of the current task run state.
-             */
-            state_name?: string | null;
-            /**
-             * Run Count
-             * @description The number of times the task run has been executed.
-             * @default 0
-             */
-            run_count: number;
-            /**
-             * Flow Run Run Count
-             * @description If the parent flow has retried, this indicates the flow retry this run is associated with.
-             * @default 0
-             */
-            flow_run_run_count: number;
-            /**
-             * Expected Start Time
-             * @description The task run's expected start time.
-             */
-            expected_start_time?: string | null;
-            /**
-             * Next Scheduled Start Time
-             * @description The next time the task run is scheduled to start.
-             */
-            next_scheduled_start_time?: string | null;
-            /**
-             * Start Time
-             * @description The actual start time.
-             */
-            start_time?: string | null;
-            /**
-             * End Time
-             * @description The actual end time.
-             */
-            end_time?: string | null;
-            /**
-             * Total Run Time
-             * @description Total run time. If the task run was executed multiple times, the time of each run will be summed.
-             * @default 0
-             */
-            total_run_time: number;
-            /**
-             * Estimated Run Time
-             * @description A real-time estimate of total run time.
-             * @default 0
-             */
-            estimated_run_time: number;
-            /**
-             * Estimated Start Time Delta
-             * @description The difference between actual and expected start time.
-             * @default 0
-             */
-            estimated_start_time_delta: number;
-            /** @description The current task run state. */
-            state?: components["schemas"]["State"] | null;
-            /** Flow Run Name */
-            flow_run_name?: string | null;
-        };
     };
     responses: never;
     parameters: never;
@@ -11096,7 +11096,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["prefect__server__schemas__core__TaskRun"];
+                    "application/json": components["schemas"]["TaskRun"];
                 };
             };
             /** @description Validation Error */
@@ -11130,7 +11130,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["prefect__server__schemas__core__TaskRun"];
+                    "application/json": components["schemas"]["TaskRun"];
                 };
             };
             /** @description Validation Error */
@@ -11303,7 +11303,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["prefect__server__schemas__core__TaskRun"][];
+                    "application/json": components["schemas"]["TaskRun"][];
                 };
             };
             /** @description Validation Error */
@@ -16098,7 +16098,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["prefect__server__schemas__ui__TaskRun"];
+                    "application/json": components["schemas"]["UITaskRun"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
Adds a `/ui/task_runs/$id` route to include the name of the corresponding flow run when retrieving details about a task run. This will reduce the number of calls the UI needs to make when displaying task run details.