### PR TITLE
Remove custom CancelledError

### DIFF
--- a/src/prefect/_internal/concurrency/threads.py
+++ b/src/prefect/_internal/concurrency/threads.py
@@ -16,7 +16,6 @@ from typing_extensions import TypeVar
 
 from prefect._internal.concurrency import logger
 from prefect._internal.concurrency.calls import Call, Portal
-from prefect._internal.concurrency.cancellation import CancelledError
 from prefect._internal.concurrency.event_loop import get_running_loop
 from prefect._internal.concurrency.primitives import Event
 
@@ -95,7 +94,7 @@ class WorkerThread(Portal):
         """
         try:
             self._run_until_shutdown()
-        except CancelledError:
+        except asyncio.CancelledError:
             logger.exception("%s was cancelled", self.name)
         except BaseException:
             # Log exceptions that crash the thread

--- a/src/prefect/concurrency/v1/services.py
+++ b/src/prefect/concurrency/v1/services.py
@@ -53,6 +53,7 @@ class ConcurrencySlotAcquisitionService(
                     retry_after = exc.response.headers.get("Retry-After")
                     if retry_after:
                         retry_after = float(retry_after)
+                        print(f"sleeping for {retry_after}")
                         await asyncio.sleep(retry_after)
                     else:
                         # We received a 423 but no Retry-After header. This

--- a/tests/_internal/concurrency/test_api.py
+++ b/tests/_internal/concurrency/test_api.py
@@ -6,7 +6,6 @@ import time
 import pytest
 
 from prefect._internal.concurrency.api import create_call, from_async, from_sync
-from prefect._internal.concurrency.cancellation import CancelledError
 from prefect._internal.concurrency.threads import wait_for_global_loop_exit
 
 
@@ -102,7 +101,7 @@ def test_from_sync_wait_for_call_in_new_thread_captures_context_variables(get):
 
 
 async def test_from_async_wait_for_call_in_loop_thread_timeout():
-    with pytest.raises(CancelledError):
+    with pytest.raises(asyncio.CancelledError):
         await from_async.wait_for_call_in_loop_thread(
             create_call(asyncio.sleep, 1),
             timeout=0.1,
@@ -112,7 +111,7 @@ async def test_from_async_wait_for_call_in_loop_thread_timeout():
 
 
 def test_from_sync_wait_for_call_in_loop_thread_timeout():
-    with pytest.raises(CancelledError):
+    with pytest.raises(asyncio.CancelledError):
         # In this test, there is a slight race condition where the waiting can reach
         # the timeout before the call does resulting in an error during `wait_for...`
         # or the call can encounter the timeout and return before the waiting times out
@@ -127,7 +126,7 @@ def test_from_sync_wait_for_call_in_loop_thread_timeout():
 
 
 async def test_from_async_wait_for_call_in_new_thread_timeout():
-    with pytest.raises(CancelledError):
+    with pytest.raises(asyncio.CancelledError):
         await from_async.wait_for_call_in_new_thread(
             create_call(sleep_repeatedly, 1),
             timeout=0.1,
@@ -135,7 +134,7 @@ async def test_from_async_wait_for_call_in_new_thread_timeout():
 
 
 def test_from_sync_wait_for_call_in_new_thread_timeout():
-    with pytest.raises(CancelledError):
+    with pytest.raises(asyncio.CancelledError):
         from_sync.wait_for_call_in_new_thread(
             create_call(sleep_repeatedly, 1),
             timeout=0.1,

--- a/tests/_internal/concurrency/test_calls.py
+++ b/tests/_internal/concurrency/test_calls.py
@@ -4,7 +4,6 @@ import time
 import pytest
 
 from prefect._internal.concurrency.calls import Call
-from prefect._internal.concurrency.cancellation import CancelledError
 
 
 def identity(x):
@@ -77,7 +76,7 @@ def test_call_timeout(fn):
     call = Call.new(fn, 2)
     call.set_timeout(1)
     call.run()
-    with pytest.raises(CancelledError):
+    with pytest.raises(asyncio.CancelledError):
         call.result()
     assert call.cancelled()
 
@@ -86,6 +85,6 @@ def test_call_future_cancelled():
     call = Call.new(identity, 2)
     call.future.cancel()
     call.run()
-    with pytest.raises(CancelledError):
+    with pytest.raises(asyncio.CancelledError):
         call.result()
     assert call.cancelled()

--- a/tests/_internal/concurrency/test_waiters.py
+++ b/tests/_internal/concurrency/test_waiters.py
@@ -5,7 +5,6 @@ import time
 import pytest
 
 from prefect._internal.concurrency.calls import Call
-from prefect._internal.concurrency.cancellation import CancelledError
 from prefect._internal.concurrency.threads import WorkerThread
 from prefect._internal.concurrency.waiters import (
     AsyncWaiter,
@@ -123,7 +122,7 @@ def test_sync_waiter_timeout_in_worker_thread():
     waiter.wait()
     t1 = time.time()
 
-    with pytest.raises(CancelledError):
+    with pytest.raises(asyncio.CancelledError):
         call.result()
 
     assert t1 - t0 < 2
@@ -160,10 +159,10 @@ def test_sync_waiter_timeout_in_main_thread():
         waiter.wait()
         t1 = time.time()
 
-    with pytest.raises(CancelledError):
+    with pytest.raises(asyncio.CancelledError):
         call.result()
 
-    with pytest.raises(CancelledError):
+    with pytest.raises(asyncio.CancelledError):
         # This call had no timeout attached so it just gets cancelled
         waiting_callback.result()
 
@@ -192,7 +191,7 @@ async def test_async_waiter_timeout_in_worker_thread():
     assert t1 - t0 < 1
 
     # The call has a cancelled error
-    with pytest.raises(CancelledError):
+    with pytest.raises(asyncio.CancelledError):
         call.result()
 
     assert call.cancelled()
@@ -223,10 +222,10 @@ async def test_async_waiter_timeout_in_main_thread():
         await waiter.wait()
         t1 = time.time()
 
-    with pytest.raises(CancelledError):
+    with pytest.raises(asyncio.CancelledError):
         call.result()
 
-    with pytest.raises(CancelledError):
+    with pytest.raises(asyncio.CancelledError):
         waiting_callback.result()
 
     assert t1 - t0 < 2
@@ -257,7 +256,7 @@ async def test_async_waiter_timeout_in_worker_thread_mixed_sleeps():
 
         assert t1 - t0 < 1
 
-    with pytest.raises(CancelledError):
+    with pytest.raises(asyncio.CancelledError):
         call.result()
 
     assert call.cancelled()


### PR DESCRIPTION
There were comments about this "needing" to be a `BaseException` but tests appear to pass when I remove our custom class in favor of the underlying `asyncio.CancelledError`. 

Having this class around had potentially unexpected side effects as [this comment suggests](https://github.com/PrefectHQ/prefect/issues/16746#issuecomment-2771762184) so this PR proposes to remove it entirely.

Closes https://github.com/PrefectHQ/prefect/issues/16746