### PR TITLE
docs(prefect-ray): `.wait()` needed

### DIFF
--- a/docs/integrations/prefect-ray/index.mdx
+++ b/docs/integrations/prefect-ray/index.mdx
@@ -53,7 +53,7 @@ def shout(number):
 @flow(task_runner=RayTaskRunner)
 def count_to(highest_number):
     for number in range(highest_number):
-        shout.submit(number)
+        shout.submit(number).wait()
 
 if __name__ == "__main__":
     count_to(10)
@@ -155,7 +155,7 @@ def say_hello(name: str) -> None:
 )
 def greetings(names: List[str]) -> None:
     for name in names:
-        say_hello.submit(name)
+        say_hello.submit(name).wait()
 
 
 if __name__ == "__main__":
@@ -199,7 +199,7 @@ def process(x):
 def my_flow():
     # equivalent to setting @ray.remote(num_cpus=4, num_gpus=2)
     with remote_options(num_cpus=4, num_gpus=2):
-        process.submit(42)
+        process.submit(42).wait()
 ```
 
 ## Resources


### PR DESCRIPTION
Using the example verbatim from the current docs results in a bunch (10, to be exact)
```
WARNING | Flow run 'denim-labrador' - A future was garbage collected before it resolved. Please call `.wait()` or `.result()` on futures to ensure they resolve.
```
see:
<img width="920" alt="SCR-20250404-nuhs-4" src="https://github.com/user-attachments/assets/c7861cbb-ea37-4cb4-8f52-d841e9168440" />
