### PR TITLE
respect auth for websockets

### DIFF
--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -658,13 +658,13 @@ class PrefectEventSubscriber:
         except AssertionError as e:
             raise Exception(
                 "Unable to authenticate to the event stream. Please ensure the "
-                "provided api_key you are using is valid for this environment. "
+                "provided api_key or auth_token you are using is valid for this environment. "
                 f"Reason: {e.args[0]}"
             )
         except ConnectionClosedError as e:
             reason = getattr(e.rcvd, "reason", None)
             msg = "Unable to authenticate to the event stream. Please ensure the "
-            msg += "provided api_key you are using is valid for this environment. "
+            msg += "provided api_key or auth_token you are using is valid for this environment. "
             msg += f"Reason: {reason}" if reason else ""
             raise Exception(msg) from e
 

--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -39,6 +39,7 @@ import prefect.types._datetime
 from prefect.events import Event
 from prefect.logging import get_logger
 from prefect.settings import (
+    PREFECT_API_AUTH_STRING,
     PREFECT_API_KEY,
     PREFECT_API_SSL_CERT_FILE,
     PREFECT_API_TLS_INSECURE_SKIP_VERIFY,
@@ -367,7 +368,7 @@ class PrefectEventsClient(EventsClient):
         await self._connect.__aexit__(exc_type, exc_val, exc_tb)
         return await super().__aexit__(exc_type, exc_val, exc_tb)
 
-    def _log_debug(self, message: str, *args, **kwargs) -> None:
+    def _log_debug(self, message: str, *args: Any, **kwargs: Any) -> None:
         message = f"EventsClient(id={id(self)}): " + message
         logger.debug(message, *args, **kwargs)
 
@@ -592,7 +593,8 @@ class PrefectEventSubscriber:
             reconnection_attempts: When the client is disconnected, how many times
                 the client should attempt to reconnect
         """
-        self._api_key = None
+        self._api_key = PREFECT_API_AUTH_STRING.value()
+
         if not api_url:
             api_url = cast(str, PREFECT_API_URL.value())
 

--- a/src/prefect/server/utilities/subscriptions.py
+++ b/src/prefect/server/utilities/subscriptions.py
@@ -1,5 +1,6 @@
 import asyncio
 from asyncio import IncompleteReadError as IOError
+from logging import Logger
 from typing import Optional
 
 from fastapi import WebSocket
@@ -12,7 +13,7 @@ from prefect.settings import PREFECT_SERVER_API_AUTH_STRING
 
 NORMAL_DISCONNECT_EXCEPTIONS = (IOError, ConnectionClosed, WebSocketDisconnect)
 
-logger = get_logger("prefect.server.utilities.subscriptions")
+logger: Logger = get_logger("prefect.server.utilities.subscriptions")
 
 
 async def accept_prefect_socket(websocket: WebSocket) -> Optional[WebSocket]:
@@ -30,7 +31,6 @@ async def accept_prefect_socket(websocket: WebSocket) -> Optional[WebSocket]:
         # The protocol requires receiving an auth message for compatibility
         # with Prefect Cloud, even if server-side auth is not configured.
         message = await websocket.receive_json()
-        logger.debug(f"Received WebSocket message: {message}")
 
         auth_setting = PREFECT_SERVER_API_AUTH_STRING.value()
         logger.debug(

--- a/src/prefect/server/utilities/subscriptions.py
+++ b/src/prefect/server/utilities/subscriptions.py
@@ -9,7 +9,7 @@ from starlette.websockets import WebSocketDisconnect
 from websockets.exceptions import ConnectionClosed
 
 from prefect.logging import get_logger
-from prefect.settings import PREFECT_SERVER_API_AUTH_STRING
+from prefect.settings import get_current_settings
 
 NORMAL_DISCONNECT_EXCEPTIONS = (IOError, ConnectionClosed, WebSocketDisconnect)
 
@@ -32,7 +32,11 @@ async def accept_prefect_socket(websocket: WebSocket) -> Optional[WebSocket]:
         # with Prefect Cloud, even if server-side auth is not configured.
         message = await websocket.receive_json()
 
-        auth_setting = PREFECT_SERVER_API_AUTH_STRING.value()
+        auth_setting = (
+            auth_setting_secret.get_secret_value()
+            if (auth_setting_secret := get_current_settings().server.api.auth_string)
+            else None
+        )
         logger.debug(
             f"PREFECT_SERVER_API_AUTH_STRING setting: {'*' * len(auth_setting) if auth_setting else 'Not set'}"
         )


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/17687

Addresses an issue where `PREFECT_SERVER_API_AUTH_STRING` did not enforce authentication for the WebSocket event stream (`/events/out`). Clients (e.g., `prefect events stream`) could connect without a valid `PREFECT_API_AUTH_STRING`.

**notable changes**

1.  **Server (`accept_prefect_socket`):** Verifies the received WebSocket auth `token` against `PREFECT_SERVER_API_AUTH_STRING` (if set), rejecting invalid/missing tokens. Includes associated logging.
2.  **Client (`PrefectEventSubscriber`):** Reads `PREFECT_API_AUTH_STRING` and correctly sends it as the `token` for self-hosted connections.
3.  **Test (`test_events_subscriber_auth_string`):** Added test using the `puppeteer` fixture to verify client behavior (token sending) and simulated server rejection logic for matching, mismatching, and missing auth strings.

**test it out**

1.  `PREFECT_SERVER_API_AUTH_STRING="mysecret" prefect server start`
2.  In another terminal:
    *   `export PREFECT_API_AUTH_STRING="mysecret"; prefect events stream` -> **Connects.**
    *   `export PREFECT_API_AUTH_STRING="wrong"; prefect events stream` -> **Fails ("Invalid token").**
    *   `unset PREFECT_API_AUTH_STRING; prefect events stream` -> **Fails ("Auth required but no token provided").**
