### PR TITLE
Include timezone in default `since` value for flow run graph v2 endpoint

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -947,7 +947,7 @@
                             "type": "string",
                             "format": "date-time",
                             "description": "Only include runs that start or end after this time.",
-                            "default": "0001-01-01T00:00:00",
+                            "default": "0001-01-01T00:00:00+00:00",
                             "title": "Since"
                         },
                         "description": "Only include runs that start or end after this time."

--- a/src/prefect/server/api/flow_runs.py
+++ b/src/prefect/server/api/flow_runs.py
@@ -48,7 +48,7 @@ from prefect.server.schemas.responses import (
 )
 from prefect.server.utilities.server import PrefectRouter
 from prefect.types import DateTime
-from prefect.types._datetime import now
+from prefect.types._datetime import earliest_possible_datetime, now
 from prefect.utilities import schema_tools
 
 if TYPE_CHECKING:
@@ -353,7 +353,7 @@ async def read_flow_run_graph_v1(
 async def read_flow_run_graph_v2(
     flow_run_id: UUID = Path(..., description="The flow run id", alias="id"),
     since: datetime.datetime = Query(
-        default=jsonable_encoder(datetime.datetime.min),
+        default=jsonable_encoder(earliest_possible_datetime()),
         description="Only include runs that start or end after this time.",
     ),
     db: PrefectDBInterface = Depends(provide_database_interface),


### PR DESCRIPTION
Closes https://github.com/PrefectHQ/prefect/issues/17729