### PR TITLE
Add task inputs display to task run details page

### DIFF
--- a/ui-v2/src/components/task-runs/task-run-details-page/index.tsx
+++ b/ui-v2/src/components/task-runs/task-run-details-page/index.tsx
@@ -10,6 +10,7 @@ import {
 	BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import { Icon } from "@/components/ui/icons";
+import { JsonInput } from "@/components/ui/json-input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StateBadge } from "@/components/ui/state-badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -63,7 +64,7 @@ export const TaskRunDetailsPage = ({
 						</Suspense>
 					}
 					artifactsContent={<div>🚧🚧 Pardon our dust! 🚧🚧</div>}
-					taskInputsContent={<div>🚧🚧 Pardon our dust! 🚧🚧</div>}
+					taskInputsContent={<TaskInputs taskRun={taskRun} />}
 					detailsContent={<TaskRunDetails taskRun={taskRun} />}
 				/>
 				<div className="hidden lg:block">
@@ -186,5 +187,11 @@ const LogsSkeleton = () => {
 			</div>
 			<Skeleton className="h-32" />
 		</div>
+	);
+};
+
+const TaskInputs = ({ taskRun }: { taskRun: TaskRun }) => {
+	return (
+		<JsonInput value={JSON.stringify(taskRun.task_inputs, null, 2)} disabled />
 	);
 };

--- a/ui-v2/src/components/task-runs/task-run-details-page/task-run-details-page.test.tsx
+++ b/ui-v2/src/components/task-runs/task-run-details-page/task-run-details-page.test.tsx
@@ -1,4 +1,5 @@
 import { createFakeState, createFakeTaskRun } from "@/mocks";
+import "@/mocks/mock-json-input";
 import { QueryClient } from "@tanstack/react-query";
 import {
 	RouterProvider,
@@ -6,7 +7,7 @@ import {
 	createRouter,
 } from "@tanstack/react-router";
 import { createRootRoute } from "@tanstack/react-router";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { buildApiUrl, createWrapper, server } from "@tests/utils";
 import { http, HttpResponse } from "msw";
@@ -100,5 +101,19 @@ describe("TaskRunDetailsPage", () => {
 
 		await user.click(screen.getByRole("tab", { name: "Details" }));
 		expect(mockOnTabChange).toHaveBeenCalledWith("Details");
+	});
+
+	it("displays the task run inputs", async () => {
+		renderTaskRunDetailsPage({ tab: "TaskInputs" });
+
+		await waitFor(() => {
+			expect(screen.getByText("test-task")).toBeInTheDocument();
+		});
+
+		const tabPanel = screen.getByRole("tabpanel", { name: "Task Inputs" });
+
+		await waitFor(() => {
+			expect(within(tabPanel).getByText(/"name": \[\]/)).toBeInTheDocument();
+		});
 	});
 });

--- a/ui-v2/src/components/task-runs/task-run-details-page/task-run-details-page.test.tsx
+++ b/ui-v2/src/components/task-runs/task-run-details-page/task-run-details-page.test.tsx
@@ -123,10 +123,11 @@ describe("TaskRunDetailsPage", () => {
 
 	it("displays the task run inputs", async () => {
 		renderTaskRunDetailsPage({ tab: "TaskInputs" });
-      
-    await waitFor(() => {
+
+		await waitFor(() => {
 			expect(screen.getByText("test-task")).toBeInTheDocument();
 		});
+	});
 
 	it("copies task run ID to clipboard and shows success toast", async () => {
 		const [screen] = renderTaskRunDetailsPage();
@@ -141,6 +142,7 @@ describe("TaskRunDetailsPage", () => {
 
 		await waitFor(() => {
 			expect(within(tabPanel).getByText(/"name": \[\]/)).toBeInTheDocument();
+		});
 
 		// Open the dropdown menu
 		const moreButton = screen.getByRole("button", { expanded: false });

--- a/ui-v2/src/components/task-runs/task-run-details-page/task-run-details-page.test.tsx
+++ b/ui-v2/src/components/task-runs/task-run-details-page/task-run-details-page.test.tsx
@@ -127,6 +127,12 @@ describe("TaskRunDetailsPage", () => {
 		await waitFor(() => {
 			expect(screen.getByText("test-task")).toBeInTheDocument();
 		});
+
+		const tabPanel = screen.getByRole("tabpanel", { name: "Task Inputs" });
+
+		await waitFor(() => {
+			expect(within(tabPanel).getByText(/"name": \[\]/)).toBeInTheDocument();
+		});
 	});
 
 	it("copies task run ID to clipboard and shows success toast", async () => {
@@ -136,12 +142,6 @@ describe("TaskRunDetailsPage", () => {
 		// Wait for the task run data to be loaded
 		await waitFor(() => {
 			expect(screen.getByText("test-task")).toBeInTheDocument();
-		});
-
-		const tabPanel = screen.getByRole("tabpanel", { name: "Task Inputs" });
-
-		await waitFor(() => {
-			expect(within(tabPanel).getByText(/"name": \[\]/)).toBeInTheDocument();
 		});
 
 		// Open the dropdown menu

--- a/ui-v2/src/mocks/mock-json-input.tsx
+++ b/ui-v2/src/mocks/mock-json-input.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { vi } from "vitest";
 
 //  Mock out JsonInput because the underlying CodeMirror editor
-//  relies on browser APIs that are not available in JSDOM.
+// relies on browser APIs that are not available in JSDOM.
 // TODO: Ensure input into JsonInput is covered by Playwright tests.
 export const MockJsonInput = React.forwardRef<
 	HTMLTextAreaElement,
@@ -27,8 +27,4 @@ MockJsonInput.displayName = "MockJsonInput";
 
 vi.mock("@/components/ui/json-input", () => ({
 	JsonInput: MockJsonInput,
-}));
-
-vi.mock("@/hooks/use-debounce", () => ({
-	default: (v: unknown) => v,
 }));

--- a/ui-v2/src/mocks/mock-use-debounce.ts
+++ b/ui-v2/src/mocks/mock-use-debounce.ts
@@ -1,0 +1,5 @@
+import { vi } from "vitest";
+
+vi.mock("@/hooks/use-debounce", () => ({
+	default: (v: unknown) => v,
+}));

--- a/ui-v2/tests/variables/variables.test.tsx
+++ b/ui-v2/tests/variables/variables.test.tsx
@@ -1,6 +1,6 @@
-import "./mocks";
 import { Toaster } from "@/components/ui/sonner";
 import { VariablesDataTable } from "@/components/variables/data-table";
+import "@/mocks/mock-json-input";
 import { router } from "@/router";
 import { RouterProvider } from "@tanstack/react-router";
 import {


### PR DESCRIPTION
I also moved the `JsonInput` and `use-debounce` mocks for easier reuse.

![Screenshot 2025-04-07 at 11 43 49 AM](https://github.com/user-attachments/assets/b50594d7-44db-40b4-86ba-570d443fb8c3)

