### PR TITLE
[UI v2] fix: Fixed navigation upon deletions

### DIFF
--- a/ui-v2/src/components/automations/use-delete-automation-confirmation-dialog.ts
+++ b/ui-v2/src/components/automations/use-delete-automation-confirmation-dialog.ts
@@ -1,12 +1,10 @@
 import { type Automation, useDeleteAutomation } from "@/api/automations";
 import { useDeleteConfirmationDialog } from "@/components/ui/delete-confirmation-dialog";
-import { getRouteApi } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 
-const routeApi = getRouteApi("/concurrency-limits/");
-
 export const useDeleteAutomationConfirmationDialog = () => {
-	const navigate = routeApi.useNavigate();
+	const navigate = useNavigate();
 	const [dialogState, confirmDelete] = useDeleteConfirmationDialog();
 
 	const { deleteAutomation } = useDeleteAutomation();
@@ -34,6 +32,7 @@ export const useDeleteAutomationConfirmationDialog = () => {
 					onError: (error) => {
 						const message =
 							error.message || "Unknown error while deleting automation.";
+						toast.error(message);
 						console.error(message);
 					},
 				});

--- a/ui-v2/src/components/blocks/blocks-row-count/blocks-row-count.test.tsx
+++ b/ui-v2/src/components/blocks/blocks-row-count/blocks-row-count.test.tsx
@@ -1,29 +1,38 @@
 import { Toaster } from "@/components/ui/sonner";
+import { QueryClient } from "@tanstack/react-query";
+import {
+	RouterProvider,
+	createMemoryHistory,
+	createRootRoute,
+	createRouter,
+} from "@tanstack/react-router";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createWrapper } from "@tests/utils";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { BlocksRowCount } from "./blocks-row-count";
+import { describe, expect, it, vi } from "vitest";
+import { BlocksRowCount, type BlocksRowCountProps } from "./blocks-row-count";
 
-describe("BlocksRowCount", () => {
-	beforeEach(() => {
-		// Mocks away getRouteApi dependency in `useDeleteDeploymentConfirmationDialog`
-		// @ts-expect-error Ignoring error until @tanstack/react-router has better testing documentation. Ref: https://vitest.dev/api/vi.html#vi-mock
-		vi.mock(import("@tanstack/react-router"), async (importOriginal) => {
-			const mod = await importOriginal();
-			return {
-				...mod,
-				getRouteApi: () => ({
-					useNavigate: vi.fn,
-				}),
-			};
-		});
+// Wraps component in test with a Tanstack router provider
+const BlocksRowCountRouter = (props: BlocksRowCountProps) => {
+	const rootRoute = createRootRoute({
+		component: () => <BlocksRowCount {...props} />,
 	});
 
+	const router = createRouter({
+		routeTree: rootRoute,
+		history: createMemoryHistory({
+			initialEntries: ["/"],
+		}),
+		context: { queryClient: new QueryClient() },
+	});
+	return <RouterProvider router={router} />;
+};
+
+describe("BlocksRowCount", () => {
 	it("renders total count when there is no selected values", () => {
 		// ------------ Setup
 		render(
-			<BlocksRowCount
+			<BlocksRowCountRouter
 				count={101}
 				setRowSelection={vi.fn()}
 				rowSelection={{}}
@@ -41,7 +50,7 @@ describe("BlocksRowCount", () => {
 		render(
 			<>
 				<Toaster />
-				<BlocksRowCount
+				<BlocksRowCountRouter
 					count={1}
 					setRowSelection={mockSetRowSelection}
 					rowSelection={{ "1": true, "2": true }}

--- a/ui-v2/src/components/blocks/use-delete-block-document-confirmation-dialog.ts
+++ b/ui-v2/src/components/blocks/use-delete-block-document-confirmation-dialog.ts
@@ -3,13 +3,11 @@ import {
 	useDeleteBlockDocument,
 } from "@/api/block-documents";
 import { useDeleteConfirmationDialog } from "@/components/ui/delete-confirmation-dialog";
-import { getRouteApi } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 
-const routeApi = getRouteApi("/blocks/");
-
 export const useDeleteBlockDocumentConfirmationDialog = () => {
-	const navigate = routeApi.useNavigate();
+	const navigate = useNavigate();
 	const [dialogState, confirmDelete] = useDeleteConfirmationDialog();
 
 	const { deleteBlockDocument, mutateAsync } = useDeleteBlockDocument();

--- a/ui-v2/src/components/concurrency/task-run-concurrency-limits/task-run-concurrency-limit-page/task-run-concurrency-limit-dialog.tsx
+++ b/ui-v2/src/components/concurrency/task-run-concurrency-limits/task-run-concurrency-limit-page/task-run-concurrency-limit-dialog.tsx
@@ -1,11 +1,9 @@
 import type { TaskRunConcurrencyLimit } from "@/api/task-run-concurrency-limits";
 import { TaskRunConcurrencyLimitsDeleteDialog } from "@/components/concurrency/task-run-concurrency-limits/task-run-concurrency-limits-delete-dialog";
 import { TaskRunConcurrencyLimitsResetDialog } from "@/components/concurrency/task-run-concurrency-limits/task-run-concurrency-limits-reset-dialog";
-import { getRouteApi } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 
 export type Dialogs = null | "delete" | "reset";
-
-const routeApi = getRouteApi("/concurrency-limits/");
 
 type TaskRunConcurrencyLimitDialogProps = {
 	data: TaskRunConcurrencyLimit;
@@ -20,7 +18,7 @@ export const TaskRunConcurrencyLimitDialog = ({
 	onCloseDialog,
 	onOpenChange,
 }: TaskRunConcurrencyLimitDialogProps) => {
-	const navigate = routeApi.useNavigate();
+	const navigate = useNavigate();
 
 	const handleDelete = () => {
 		onCloseDialog();

--- a/ui-v2/src/components/deployments/use-delete-deployment-confirmation-dialog.ts
+++ b/ui-v2/src/components/deployments/use-delete-deployment-confirmation-dialog.ts
@@ -1,12 +1,10 @@
 import { type Deployment, useDeleteDeployment } from "@/api/deployments";
 import { useDeleteConfirmationDialog } from "@/components/ui/delete-confirmation-dialog";
-import { getRouteApi } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 
-const routeApi = getRouteApi("/deployments/");
-
 export const useDeleteDeploymentConfirmationDialog = () => {
-	const navigate = routeApi.useNavigate();
+	const navigate = useNavigate();
 	const [dialogState, confirmDelete] = useDeleteConfirmationDialog();
 
 	const { deleteDeployment } = useDeleteDeployment();


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
At some point `getRouteApi` was updated to work with a route that is relative to the path being passed.
This broke the `useNavigate` mechanism because these re-usable hooks are referencing an incorrect relative path.

Update `useNavigate` to **not** use `getRouteApi`, and default to use absolute pathing

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
