### PR TITLE
Fix readiness_result type to match expected Process type

### DIFF
--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -1363,7 +1363,9 @@ class Runner:
         ready_to_submit = await self._propose_pending_state(flow_run)
 
         if ready_to_submit:
-            readiness_result = await self._runs_task_group.start(
+            readiness_result: (
+                anyio.abc.Process | Exception
+            ) = await self._runs_task_group.start(
                 partial(
                     self._submit_run_and_capture_errors,
                     flow_run=flow_run,
@@ -1374,7 +1376,7 @@ class Runner:
             if readiness_result and not isinstance(readiness_result, Exception):
                 async with self._flow_run_process_map_lock:
                     self._flow_run_process_map[flow_run.id] = ProcessMapEntry(
-                        pid=readiness_result, flow_run=flow_run
+                        pid=readiness_result.pid, flow_run=flow_run
                     )
             # Heartbeats are opt-in and only emitted if a heartbeat frequency is set
             if self.heartbeat_seconds is not None:


### PR DESCRIPTION
According to the implementation of self._runs_task_group.start the return type might be an `anyio.abc.Process` or an `Exception`, as defined in [execute_flow_run](https://github.com/PrefectHQ/prefect/blob/990e781d79dd40250b7324619186988c39b546b9/src/prefect/runner/runner.py#L591), closes #17621

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [X] If this pull request adds new functionality, it includes unit tests that cover the changes
- [X] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [X] If this pull request adds functions or classes, it includes helpful docstrings.
