### PR TITLE
Remove `react-code-blocks` dependency

### DIFF
--- a/ui-v2/package-lock.json
+++ b/ui-v2/package-lock.json
@@ -55,7 +55,6 @@
 				"next-themes": "^0.4.6",
 				"openapi-fetch": "^0.13.5",
 				"react": "19.1.0",
-				"react-code-blocks": "^0.1.6",
 				"react-day-picker": "^9.6.5",
 				"react-dom": "19.1.0",
 				"react-hook-form": "^7.55.0",
@@ -956,24 +955,6 @@
 			"resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
 			"integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==",
 			"license": "MIT"
-		},
-		"node_modules/@emotion/is-prop-valid": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
-			"integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
-			"dependencies": {
-				"@emotion/memoize": "^0.8.1"
-			}
-		},
-		"node_modules/@emotion/memoize": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-			"integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
-		},
-		"node_modules/@emotion/unitless": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-			"integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.25.1",
@@ -5922,11 +5903,6 @@
 			"integrity": "sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==",
 			"dev": true
 		},
-		"node_modules/@types/stylis": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
-			"integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw=="
-		},
 		"node_modules/@types/tough-cookie": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -7013,14 +6989,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/camelize": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-			"integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/caniuse-lite": {
 			"version": "1.0.30001700",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
@@ -7389,24 +7357,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/css-color-keywords": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-			"integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/css-to-react-native": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
-			"integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-			"dependencies": {
-				"camelize": "^1.0.0",
-				"css-color-keywords": "^1.0.0",
-				"postcss-value-parser": "^4.0.2"
 			}
 		},
 		"node_modules/css.escape": {
@@ -8837,18 +8787,6 @@
 				"reusify": "^1.0.4"
 			}
 		},
-		"node_modules/fault": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
-			"integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
-			"dependencies": {
-				"format": "^0.2.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -8951,14 +8889,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/format": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-			"integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
-			"engines": {
-				"node": ">=0.4.x"
 			}
 		},
 		"node_modules/fsevents": {
@@ -9325,15 +9255,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/hast-util-parse-selector": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
-			"integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/hast-util-to-jsx-runtime": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.2.tgz",
@@ -9372,83 +9293,11 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/hastscript": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
-			"integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
-			"dependencies": {
-				"@types/hast": "^2.0.0",
-				"comma-separated-tokens": "^1.0.0",
-				"hast-util-parse-selector": "^2.0.0",
-				"property-information": "^5.0.0",
-				"space-separated-tokens": "^1.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/hastscript/node_modules/@types/hast": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
-			"integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
-			"dependencies": {
-				"@types/unist": "^2"
-			}
-		},
-		"node_modules/hastscript/node_modules/@types/unist": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
-		},
-		"node_modules/hastscript/node_modules/comma-separated-tokens": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-			"integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/hastscript/node_modules/property-information": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
-			"integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
-			"dependencies": {
-				"xtend": "^4.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/hastscript/node_modules/space-separated-tokens": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-			"integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/headers-polyfill": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
 			"integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
 			"dev": true
-		},
-		"node_modules/highlight.js": {
-			"version": "10.7.3",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/highlightjs-vue": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
-			"integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA=="
 		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "4.0.0",
@@ -10674,19 +10523,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lowlight": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
-			"integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
-			"dependencies": {
-				"fault": "^1.0.0",
-				"highlight.js": "~10.7.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -11767,6 +11603,7 @@
 			"version": "3.3.8",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
 			"integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -12180,7 +12017,8 @@
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -12686,11 +12524,6 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
-		"node_modules/postcss-value-parser": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
-		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -12756,14 +12589,6 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true
-		},
-		"node_modules/prismjs": {
-			"version": "1.29.0",
-			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-			"integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/process": {
 			"version": "0.11.10",
@@ -12858,23 +12683,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/react-code-blocks": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/react-code-blocks/-/react-code-blocks-0.1.6.tgz",
-			"integrity": "sha512-ENNuxG07yO+OuX1ChRje3ieefPRz6yrIpHmebQlaFQgzcAHbUfVeTINpOpoI9bSRSObeYo/OdHsporeToZ7fcg==",
-			"dependencies": {
-				"@babel/runtime": "^7.10.4",
-				"react-syntax-highlighter": "^15.5.0",
-				"styled-components": "^6.1.0",
-				"tslib": "^2.6.0"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependencies": {
-				"react": ">=16"
 			}
 		},
 		"node_modules/react-day-picker": {
@@ -13118,22 +12926,6 @@
 				}
 			}
 		},
-		"node_modules/react-syntax-highlighter": {
-			"version": "15.6.1",
-			"resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.6.1.tgz",
-			"integrity": "sha512-OqJ2/vL7lEeV5zTJyG7kmARppUjiB9h9udl4qHQjjgEos66z00Ia0OckwYfRxCSFrW8RJIBnsBwQsHZbVPspqg==",
-			"dependencies": {
-				"@babel/runtime": "^7.3.1",
-				"highlight.js": "^10.4.1",
-				"highlightjs-vue": "^1.0.0",
-				"lowlight": "^1.17.0",
-				"prismjs": "^1.27.0",
-				"refractor": "^3.6.0"
-			},
-			"peerDependencies": {
-				"react": ">= 0.14.0"
-			}
-		},
 		"node_modules/react-transition-group": {
 			"version": "4.4.5",
 			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -13247,112 +13039,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/refractor": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
-			"integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
-			"dependencies": {
-				"hastscript": "^6.0.0",
-				"parse-entities": "^2.0.0",
-				"prismjs": "~1.27.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/refractor/node_modules/character-entities": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/refractor/node_modules/character-entities-legacy": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-			"integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/refractor/node_modules/character-reference-invalid": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/refractor/node_modules/is-alphabetical": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/refractor/node_modules/is-alphanumerical": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-			"integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-			"dependencies": {
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/refractor/node_modules/is-decimal": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/refractor/node_modules/is-hexadecimal": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/refractor/node_modules/parse-entities": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
-			"integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-			"dependencies": {
-				"character-entities": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"character-reference-invalid": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/refractor/node_modules/prismjs": {
-			"version": "1.27.0",
-			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-			"integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/regenerator-runtime": {
@@ -13742,11 +13428,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/shallowequal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
-		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -13890,6 +13571,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -14207,70 +13889,6 @@
 			"dependencies": {
 				"inline-style-parser": "0.2.4"
 			}
-		},
-		"node_modules/styled-components": {
-			"version": "6.1.15",
-			"resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.15.tgz",
-			"integrity": "sha512-PpOTEztW87Ua2xbmLa7yssjNyUF9vE7wdldRfn1I2E6RTkqknkBYpj771OxM/xrvRGinLy2oysa7GOd7NcZZIA==",
-			"dependencies": {
-				"@emotion/is-prop-valid": "1.2.2",
-				"@emotion/unitless": "0.8.1",
-				"@types/stylis": "4.2.5",
-				"css-to-react-native": "3.2.0",
-				"csstype": "3.1.3",
-				"postcss": "8.4.49",
-				"shallowequal": "1.1.0",
-				"stylis": "4.3.2",
-				"tslib": "2.6.2"
-			},
-			"engines": {
-				"node": ">= 16"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/styled-components"
-			},
-			"peerDependencies": {
-				"react": ">= 16.8.0",
-				"react-dom": ">= 16.8.0"
-			}
-		},
-		"node_modules/styled-components/node_modules/postcss": {
-			"version": "8.4.49",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-			"integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/postcss/"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/postcss"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"dependencies": {
-				"nanoid": "^3.3.7",
-				"picocolors": "^1.1.1",
-				"source-map-js": "^1.2.1"
-			},
-			"engines": {
-				"node": "^10 || ^12 || >=14"
-			}
-		},
-		"node_modules/styled-components/node_modules/tslib": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-		},
-		"node_modules/stylis": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
-			"integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg=="
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -15559,14 +15177,6 @@
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
-		},
-		"node_modules/xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"engines": {
-				"node": ">=0.4"
-			}
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -66,7 +66,6 @@
 		"next-themes": "^0.4.6",
 		"openapi-fetch": "^0.13.5",
 		"react": "19.1.0",
-		"react-code-blocks": "^0.1.6",
 		"react-day-picker": "^9.6.5",
 		"react-dom": "19.1.0",
 		"react-hook-form": "^7.55.0",

--- a/ui-v2/src/components/artifacts/artifact/artifact-raw-data-display.stories.tsx
+++ b/ui-v2/src/components/artifacts/artifact/artifact-raw-data-display.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ArtifactDataDisplay } from "./artifact-raw-data-display";
+
+const meta: Meta<typeof ArtifactDataDisplay> = {
+	title: "Components/Artifacts/ArtifactDataDisplay",
+	component: ArtifactDataDisplay,
+};
+
+export default meta;
+type Story = StoryObj<typeof ArtifactDataDisplay>;
+
+const mockArtifact = {
+	data: JSON.stringify(
+		{
+			sample: "data",
+			nested: {
+				value: 123,
+				array: [1, 2, 3],
+			},
+		},
+		null,
+		2,
+	),
+	// Add other required properties from ArtifactWithFlowRunAndTaskRun
+	id: "test-artifact-id",
+	key: "test-artifact",
+	type: "json",
+	created: new Date().toISOString(),
+	updated: new Date().toISOString(),
+	flow_run_id: "test-flow-run-id",
+	task_run_id: "test-task-run-id",
+};
+
+export const Default: Story = {
+	args: {
+		artifact: mockArtifact,
+	},
+};
+
+export const LongData: Story = {
+	args: {
+		artifact: {
+			...mockArtifact,
+			data: JSON.stringify(
+				{
+					longArray: Array.from({ length: 100 }, (_, i) => ({
+						id: i,
+						value: `Item ${i}`,
+						timestamp: new Date().toISOString(),
+					})),
+				},
+				null,
+				2,
+			),
+		},
+	},
+};

--- a/ui-v2/src/components/artifacts/artifact/artifact-raw-data-display.test.tsx
+++ b/ui-v2/src/components/artifacts/artifact/artifact-raw-data-display.test.tsx
@@ -10,16 +10,14 @@ describe("ArtifactDataDisplay", () => {
 			data: "test-data",
 		});
 
-		const { getByText, queryByText, getByTestId } = render(
-			<ArtifactDataDisplay artifact={artifact} />,
-		);
+		const { getByTestId } = render(<ArtifactDataDisplay artifact={artifact} />);
 
-		expect(queryByText("test-data")).toBeFalsy();
+		expect(getByTestId("raw-data-display")).not.toBeVisible();
 
 		const toggleButton = getByTestId("show-raw-data-button");
 
 		fireEvent.click(toggleButton);
 
-		expect(getByText("test-data")).toBeTruthy();
+		expect(getByTestId("raw-data-display")).toBeVisible();
 	});
 });

--- a/ui-v2/src/components/artifacts/artifact/artifact-raw-data-display.tsx
+++ b/ui-v2/src/components/artifacts/artifact/artifact-raw-data-display.tsx
@@ -1,7 +1,9 @@
 import type { ArtifactWithFlowRunAndTaskRun } from "@/api/artifacts";
 import { Button } from "@/components/ui/button";
-import { useState } from "react";
-import { CopyBlock, nord } from "react-code-blocks";
+import { Icon } from "@/components/ui/icons";
+import { EditorView, useCodeMirror } from "@uiw/react-codemirror";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 
 type ArtifactDataDisplayProps = {
 	artifact: ArtifactWithFlowRunAndTaskRun;
@@ -14,25 +16,63 @@ export const ArtifactDataDisplay = ({ artifact }: ArtifactDataDisplayProps) => {
 		setShowData((val) => !val);
 	};
 
+	const editor = useRef<HTMLDivElement | null>(null);
+	const basicSetup = {
+		highlightActiveLine: false,
+		foldGutter: false,
+		highlightActiveLineGutter: false,
+	};
+	const { setContainer } = useCodeMirror({
+		container: editor.current,
+		extensions: [EditorView.lineWrapping],
+		value: String(artifact.data),
+		indentWithTab: false,
+		editable: true,
+		basicSetup,
+	});
+
+	useEffect(() => {
+		if (editor.current) {
+			setContainer(editor.current);
+		}
+	}, [setContainer]);
+
+	const handleCopy = (_value: string) => {
+		toast.success("Copied to clipboard");
+		void navigator.clipboard.writeText(_value);
+	};
+
 	return (
-		<div className="mt-4 flex flex-col justify-center items-center">
+		<div className="flex flex-col justify-center items-center">
 			<Button
 				data-testid="show-raw-data-button"
 				variant={"outline"}
 				onClick={toggleShowData}
+				className="my-4"
 			>
 				{showData ? "Hide" : "Show"} Raw Data
 			</Button>
-			{showData && (
-				<div className="mt-4 max-w-5xl overflow-x-scroll">
-					<CopyBlock
-						text={artifact.data as string}
-						language="text"
-						theme={nord}
-						showLineNumbers
-					/>
-				</div>
-			)}
+
+			<div
+				className="rounded-md border shadow-xs focus-within:outline-hidden focus-within:ring-1 focus-within:ring-ring relative"
+				style={{
+					display: showData ? "block" : "none",
+				}}
+				ref={(node) => {
+					editor.current = node;
+				}}
+				data-testid="raw-data-display"
+			>
+				<Button
+					onClick={() => handleCopy(artifact.data as string)}
+					variant="ghost"
+					size="icon"
+					className="absolute top-0 right-0 z-10"
+					aria-label="copy"
+				>
+					<Icon id="Copy" className="size-2" />
+				</Button>
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
Removes `react-code-blocks` and replaces its use with Code Mirror to resolve this security issue: https://github.com/PrefectHQ/prefect/security/dependabot/94.