### PR TITLE
deprecate runner webserver machinery

### DIFF
--- a/src/prefect/runner/server.py
+++ b/src/prefect/runner/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Coroutine, Hashable, Optional
 
 import uvicorn
@@ -8,6 +9,7 @@ from fastapi import APIRouter, FastAPI, HTTPException, status
 from fastapi.responses import JSONResponse
 from typing_extensions import Literal
 
+from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect._internal.schemas.validators import validate_values_conform_to_schema
 from prefect.client.orchestration import get_client
 from prefect.exceptions import MissingFlowError, ScriptError
@@ -252,6 +254,11 @@ def _build_generic_endpoint_for_flows(
     return _create_flow_run_for_flow_from_fqn
 
 
+@deprecated_callable(
+    start_date=datetime(2025, 4, 1),
+    end_date=datetime(2025, 10, 1),
+    help="Use background tasks (https://docs.prefect.io/v3/develop/deferred-tasks) or `run_deployment` and `.serve` instead of submitting runs to the Runner webserver.",
+)
 async def build_server(runner: "Runner") -> FastAPI:
     """
     Build a FastAPI server for a runner.
@@ -296,6 +303,11 @@ async def build_server(runner: "Runner") -> FastAPI:
     return webserver
 
 
+@deprecated_callable(
+    start_date=datetime(2025, 4, 1),
+    end_date=datetime(2025, 10, 1),
+    help="Use background tasks (https://docs.prefect.io/v3/develop/deferred-tasks) or `run_deployment` and `.serve` instead of submitting runs to the Runner webserver.",
+)
 def start_webserver(runner: "Runner", log_level: str | None = None) -> None:
     """
     Run a FastAPI server for a runner.

--- a/src/prefect/runner/submit.py
+++ b/src/prefect/runner/submit.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import asyncio
 import inspect
 import uuid
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Union, overload
 
 import anyio
 import httpx
 from typing_extensions import Literal, TypeAlias
 
+from prefect._internal.compatibility.deprecated import deprecated_callable
 from prefect.client.orchestration import get_client
 from prefect.client.schemas.filters import (
     FlowRunFilter,
@@ -119,6 +121,12 @@ def submit_to_runner(
 ) -> list[FlowRun]: ...
 
 
+@deprecated_callable(
+    start_date=datetime(2025, 4, 1),
+    end_date=datetime(2025, 10, 1),
+    help="Submitting flow runs via the Runner webserver is deprecated and will be removed in a future release. "
+    " Use background tasks or `run_deployment` and `.serve` instead.",
+)
 @sync_compatible
 async def submit_to_runner(
     prefect_callable: Flow[Any, Any],
@@ -192,7 +200,7 @@ async def wait_for_submitted_runs(
     task_run_filter: TaskRunFilter | None = None,
     timeout: float | None = None,
     poll_interval: float = 3.0,
-):
+) -> uuid.UUID | None:
     """
     Wait for completion of any provided flow runs (eventually task runs), as well as subflow runs
     of the current flow run (if called from within a flow run and subflow runs exist).

--- a/src/prefect/runner/submit.py
+++ b/src/prefect/runner/submit.py
@@ -124,8 +124,7 @@ def submit_to_runner(
 @deprecated_callable(
     start_date=datetime(2025, 4, 1),
     end_date=datetime(2025, 10, 1),
-    help="Submitting flow runs via the Runner webserver is deprecated and will be removed in a future release. "
-    " Use background tasks or `run_deployment` and `.serve` instead.",
+    help="Use background tasks (https://docs.prefect.io/v3/develop/deferred-tasks) or `run_deployment` and `.serve` instead of submitting runs to the Runner webserver.",
 )
 @sync_compatible
 async def submit_to_runner(
@@ -194,6 +193,11 @@ async def submit_to_runner(
     return submitted_runs
 
 
+@deprecated_callable(
+    start_date=datetime(2025, 4, 1),
+    end_date=datetime(2025, 10, 1),
+    help="Use background tasks (https://docs.prefect.io/v3/develop/deferred-tasks) or `run_deployment` and `.serve` instead of submitting runs to the Runner webserver.",
+)
 @sync_compatible
 async def wait_for_submitted_runs(
     flow_run_filter: FlowRunFilter | None = None,

--- a/tests/runner/test_submit.py
+++ b/tests/runner/test_submit.py
@@ -1,11 +1,13 @@
 import uuid
-from typing import Dict, List, Union
+import warnings
+from typing import Any, Callable, Generator, Union
 from unittest import mock
 
 import httpx
 import pytest
 
 from prefect import flow
+from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
 from prefect.client.schemas.objects import FlowRun
 from prefect.runner import submit_to_runner
 from prefect.settings import (
@@ -16,17 +18,17 @@ from prefect.states import Running
 
 
 @flow
-def identity(whatever):
+def identity(whatever: Any):
     return whatever
 
 
 @flow
-async def async_identity(whatever):
+async def async_identity(whatever: Any):
     return whatever
 
 
 @flow
-def super_identity(*args, **kwargs):
+def super_identity(*args: Any, **kwargs: Any):
     return args, kwargs
 
 
@@ -36,8 +38,8 @@ def independent():
 
 
 @pytest.fixture
-def mock_webserver(monkeypatch):
-    async def mock_submit_flow_to_runner(_, parameters, *__):
+def mock_webserver(monkeypatch: pytest.MonkeyPatch):
+    async def mock_submit_flow_to_runner(_: Any, parameters: Any, *__: Any) -> FlowRun:
         return FlowRun(flow_id=uuid.uuid4(), state=Running(), parameters=parameters)
 
     monkeypatch.setattr(
@@ -46,8 +48,8 @@ def mock_webserver(monkeypatch):
 
 
 @pytest.fixture
-def mock_webserver_not_running(monkeypatch):
-    async def mock_submit_flow_to_runner(*_, **__):
+def mock_webserver_not_running(monkeypatch: pytest.MonkeyPatch):
+    async def mock_submit_flow_to_runner(*_: Any, **__: Any):
         raise httpx.ConnectError("Mocked connection error")
 
     monkeypatch.setattr(
@@ -56,29 +58,35 @@ def mock_webserver_not_running(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def runner_settings():
-    with temporary_settings(
-        {
-            PREFECT_RUNNER_SERVER_ENABLE: True,
-        }
-    ):
+def runner_settings() -> Generator[None, None, None]:
+    with temporary_settings({PREFECT_RUNNER_SERVER_ENABLE: True}):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def suppress_deprecation_warning() -> Generator[None, None, None]:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=PrefectDeprecationWarning)
         yield
 
 
 @pytest.mark.parametrize("prefect_callable", [identity, async_identity])
-def test_submit_to_runner_happy_path_sync_context(mock_webserver, prefect_callable):
+@pytest.mark.usefixtures("mock_webserver")
+def test_submit_to_runner_happy_path_sync_context(prefect_callable: Callable[..., Any]):
     @flow
-    def test_flow():
+    def test_flow() -> FlowRun:
         return submit_to_runner(prefect_callable, {"whatever": 42})
 
     flow_run = test_flow()
+    assert flow_run.state is not None
     assert flow_run.state.is_running()
     assert flow_run.parameters == {"whatever": 42}
 
 
 @pytest.mark.parametrize("prefect_callable", [identity, async_identity])
+@pytest.mark.usefixtures("mock_webserver")
 async def test_submit_to_runner_happy_path_async_context(
-    mock_webserver, prefect_callable
+    prefect_callable: Callable[..., Any],
 ):
     flow_run = await submit_to_runner(prefect_callable, {"whatever": 42})
 
@@ -96,14 +104,16 @@ async def test_submit_to_runner_raises_if_not_prefect_callable():
         await submit_to_runner(lambda: None)
 
 
-async def test_submission_with_optional_parameters(mock_webserver):
+@pytest.mark.usefixtures("mock_webserver")
+async def test_submission_with_optional_parameters():
     flow_run = await submit_to_runner(independent)
 
     assert flow_run.state.is_running()
     assert flow_run.parameters == {}
 
 
-async def test_submission_raises_if_webserver_not_running(mock_webserver_not_running):
+@pytest.mark.usefixtures("mock_webserver_not_running")
+async def test_submission_raises_if_webserver_not_running():
     with temporary_settings({PREFECT_RUNNER_SERVER_ENABLE: False}):
         with pytest.raises(
             (httpx.ConnectTimeout, RuntimeError),
@@ -113,10 +123,11 @@ async def test_submission_raises_if_webserver_not_running(mock_webserver_not_run
 
 
 @pytest.mark.parametrize("input_", [[{"input": 1}, {"input": 2}], {"input": 3}])
+@pytest.mark.usefixtures("mock_webserver")
 async def test_return_for_submissions_matches_input(
-    mock_webserver, input_: Union[List[Dict], Dict]
+    input_: Union[list[dict[str, Any]], dict[str, Any]],
 ):
-    def _flow_run_generator(*_, **__):
+    def _flow_run_generator(*_: Any, **__: Any) -> FlowRun:
         return FlowRun(flow_id=uuid.uuid4())
 
     with mock.patch(
@@ -166,10 +177,13 @@ async def test_return_for_submissions_matches_input(
         [{"1": {2: {3: {4: None}}}}],
     ],
 )
-async def test_types_in_submission(mock_webserver, input_: Union[List[Dict], Dict]):
+@pytest.mark.usefixtures("mock_webserver")
+async def test_types_in_submission(
+    input_: Union[list[dict[str, Any]], dict[str, Any]],
+):
     results = await submit_to_runner(super_identity, input_)
 
-    if isinstance(input_, List):
+    if isinstance(input_, list):
         assert len(results) == len(input_)
         for r in results:
             assert isinstance(r, FlowRun)

--- a/tests/runner/test_webserver.py
+++ b/tests/runner/test_webserver.py
@@ -1,5 +1,6 @@
 import uuid
-from typing import Callable, List
+import warnings
+from typing import Callable, Generator, List
 from unittest import mock
 
 import pydantic
@@ -7,6 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from prefect import flow
+from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
 from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas.objects import FlowRun
 from prefect.runner import Runner
@@ -51,6 +53,13 @@ def tmp_runner_settings():
             PREFECT_RUNNER_SERVER_PORT: 0,
         }
     ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def suppress_deprecation_warnings() -> Generator[None, None, None]:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=PrefectDeprecationWarning)
         yield
 
 


### PR DESCRIPTION
related to https://github.com/PrefectHQ/prefect/issues/15733

these were (unfortunately) added to the public API because experimental flags were removed. the outcomes are better reached via background tasks or using `run_deployment` in conjunction with `.serve` / `.deploy`

In addition, there are security issues with the runner webserver, as anyone with network access could bypass RBAC and create runs.

all "public" methods in the following modules will be slated for removal in October 2025:
- `prefect.runner.submit`
- `prefect.runner.server`


---

> "I was using the runner webserver, what should I use instead?"

- background tasks
  - [docs](https://docs.prefect.io/v3/develop/deferred-tasks)
  - [example](https://github.com/PrefectHQ/examples/tree/main/apps/background-tasks)
- `serve` many flows and use `run_deployment` to invoke one from another