### PR TITLE
avoid unexpected pre-commit diffs from local to CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
       - id: generate-mintlify-openapi-docs
         name: Generating OpenAPI docs for Mintlify
         language: system
-        entry: uv run --with 'pydantic>=2.9.0' ./scripts/generate_mintlify_openapi_docs.py
+        entry: uv run -p 3.9 --with 'pydantic>=2.9.0' ./scripts/generate_mintlify_openapi_docs.py
         pass_filenames: false
         files: |
           (?x)^(
@@ -52,7 +52,7 @@ repos:
       - id: generate-settings-schema
         name: Generating Settings Schema
         language: system
-        entry: uv run --with 'pydantic>=2.9.0' ./scripts/generate_settings_schema.py
+        entry: uv run -p 3.9 --with 'pydantic>=2.9.0' ./scripts/generate_settings_schema.py
         pass_filenames: false
         files: |
           (?x)^(
@@ -63,7 +63,7 @@ repos:
       - id: generate-settings-ref
         name: Generating Settings Reference
         language: system
-        entry: uv run --with 'pydantic>=2.9.0' ./scripts/generate_settings_ref.py
+        entry: uv run -p 3.9 --with 'pydantic>=2.9.0' ./scripts/generate_settings_ref.py
         pass_filenames: false
         files: |
           (?x)^(


### PR DESCRIPTION
if you run the pre-commits locally with 3.12 for example, it will pass and then fail in CI