### PR TITLE
Add GCS bundle upload and execute steps

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/deployments/steps.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/deployments/steps.py
@@ -3,12 +3,11 @@ Prefect deployment steps for code storage in and retrieval from Google Cloud Sto
 """
 
 from pathlib import Path, PurePosixPath
-from typing import Dict, Optional
+from typing import Dict, Optional, TypedDict
 
 import google.auth
 from google.cloud.storage import Client as StorageClient
 from google.oauth2.service_account import Credentials
-from typing_extensions import TypedDict
 
 from prefect.utilities.filesystem import filter_files, relative_path_to_current_platform
 

--- a/src/integrations/prefect-gcp/prefect_gcp/experimental/bundles/__init__.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/experimental/bundles/__init__.py
@@ -1,0 +1,4 @@
+from .upload import upload_bundle_to_gcs
+from .execute import execute_bundle_from_gcs
+
+__all__ = ["upload_bundle_to_gcs", "execute_bundle_from_gcs"]

--- a/src/integrations/prefect-gcp/prefect_gcp/experimental/bundles/execute.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/experimental/bundles/execute.py
@@ -1,0 +1,67 @@
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Optional, cast
+
+import typer
+from pydantic_core import from_json
+
+import prefect.runner
+import prefect_gcp.credentials
+from prefect.utilities.asyncutils import run_coro_as_sync
+
+logger = logging.getLogger("prefect_gcp.experimental.bundles.execute")
+
+
+def execute_bundle_from_gcs(
+    bucket: str,
+    key: str,
+    gcp_credentials_block_name: Optional[str] = None,
+) -> None:
+    if isinstance(gcp_credentials_block_name, str):
+        logger.debug(
+            "Loading GCP credentials from block %s", gcp_credentials_block_name
+        )
+        gcp_credentials = cast(
+            prefect_gcp.credentials.GcpCredentials,
+            prefect_gcp.credentials.GcpCredentials.load(
+                gcp_credentials_block_name,
+                _sync=True,  # pyright: ignore[reportCallIssue] _sync is needed to prevent incidental async
+            ),
+        )
+    else:
+        logger.debug("Loading default GCP credentials")
+        gcp_credentials = prefect_gcp.credentials.GcpCredentials()
+
+    gcs_client = gcp_credentials.get_cloud_storage_client()
+
+    with tempfile.TemporaryDirectory(prefix="prefect-bundle-") as tmp_dir:
+        local_path = Path(tmp_dir) / os.path.basename(key)
+
+        try:
+            logger.debug(
+                "Downloading bundle from GCS bucket %s with key %s to local path %s",
+                bucket,
+                key,
+                local_path,
+            )
+            gcs_client.bucket(bucket).blob(key).download_to_file(str(local_path))  # pyright: ignore[reportUnknownMemberType] Incomplete type hints
+            bundle = from_json(local_path.read_bytes())
+
+            logger.debug("Executing bundle")
+            run_coro_as_sync(prefect.runner.Runner().execute_bundle(bundle))
+        except Exception as e:
+            raise RuntimeError(f"Failed to download bundle from GCS: {e}")
+
+
+def _cli_wrapper(
+    bucket: str = typer.Option(...),
+    key: str = typer.Option(...),
+    gcp_credentials_block_name: Optional[str] = typer.Option(None),
+) -> None:
+    execute_bundle_from_gcs(bucket, key, gcp_credentials_block_name)
+
+
+if __name__ == "__main__":
+    typer.run(_cli_wrapper)

--- a/src/integrations/prefect-gcp/prefect_gcp/experimental/bundles/upload.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/experimental/bundles/upload.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional, TypedDict, cast
+
+import typer
+
+import prefect_gcp.credentials
+
+logger = logging.getLogger("prefect_gcp.experimental.bundles.upload")
+
+
+class UploadBundleToGcsOutput(TypedDict):
+    """
+    The output of the `upload_bundle_to_gcs` step.
+    """
+
+    bucket: str
+    key: str
+
+
+def upload_bundle_to_gcs(
+    local_filepath: Path,
+    bucket: str,
+    key: str,
+    gcp_credentials_block_name: str | None = None,
+) -> UploadBundleToGcsOutput:
+    """
+    Uploads a bundle file to a GCS bucket.
+
+    Args:
+        local_filepath: The path to the bundle file to upload.
+        bucket: The name of the GCS bucket to upload the bundle to.
+        key: The key (path) to upload the bundle to in the GCS bucket.
+        gcp_credentials_block_name: The name of the GCP credentials block to use.
+
+    Returns:
+        A dictionary containing the bucket and key of the uploaded bundle.
+    """
+    if not local_filepath.exists():
+        raise ValueError(f"Bundle file not found: {local_filepath}")
+
+    key = key or local_filepath.name
+
+    if gcp_credentials_block_name:
+        logger.debug(
+            "Loading GCP credentials from block %s", gcp_credentials_block_name
+        )
+        gcp_credentials = cast(
+            prefect_gcp.credentials.GcpCredentials,
+            prefect_gcp.credentials.GcpCredentials.load(
+                gcp_credentials_block_name,
+                _sync=True,  # pyright: ignore[reportCallIssue] _sync is needed to prevent incidental async
+            ),
+        )
+    else:
+        logger.debug("Loading default GCP credentials")
+        gcp_credentials = prefect_gcp.credentials.GcpCredentials()
+
+    gcs_client = gcp_credentials.get_cloud_storage_client()
+
+    try:
+        logger.debug(
+            "Uploading bundle from path %s to GCS bucket %s with key %s",
+            local_filepath,
+            bucket,
+            key,
+        )
+        gcs_client.bucket(bucket).blob(key).upload_from_file(local_filepath)  # pyright: ignore[reportUnknownMemberType] Incomplete type hints
+    except Exception as e:
+        raise RuntimeError(f"Failed to upload bundle to GCS: {e}")
+
+    return {"bucket": bucket, "key": key}
+
+
+def _cli_wrapper(
+    local_filepath: Path = typer.Argument(
+        ..., help="The path to the bundle file to upload."
+    ),
+    bucket: str = typer.Option(
+        ..., help="The name of the GCS bucket to upload the bundle to."
+    ),
+    key: str = typer.Option(
+        ..., help="The key (path) to upload the bundle to in the GCS bucket."
+    ),
+    gcp_credentials_block_name: Optional[str] = typer.Option(
+        None,
+        help="The name of the GCP credentials block to use for authentication. If not provided, the default credentials will be used.",
+    ),
+) -> UploadBundleToGcsOutput:
+    """
+    Uploads a bundle file to a GCS bucket.
+    """
+    return upload_bundle_to_gcs(local_filepath, bucket, key, gcp_credentials_block_name)
+
+
+if __name__ == "__main__":
+    typer.run(_cli_wrapper)

--- a/src/integrations/prefect-gcp/tests/conftest.py
+++ b/src/integrations/prefect-gcp/tests/conftest.py
@@ -32,7 +32,7 @@ def google_auth(monkeypatch):
     )
     google_auth_mock.default.side_effect = lambda *args, **kwargs: (
         default_credentials_mock,
-        None,
+        "my_project",
     )
     monkeypatch.setattr("google.auth", google_auth_mock)
     return google_auth_mock
@@ -70,8 +70,9 @@ class Blob:
         Path(filename).write_text("abcdef")
 
 
-class CloudStorageClient:
-    def __init__(self, credentials=None, project=None):
+class CloudStorageClient(MagicMock):
+    def __init__(self, credentials=None, project=None, *args, **kwargs):
+        super().__init__()
         self.credentials = credentials
         self.project = project
 
@@ -315,11 +316,10 @@ def service_account_info_json(monkeypatch):
 
 @pytest.fixture
 def gcp_credentials(
-    monkeypatch,
-    google_auth,
-    mock_credentials,
-    job_service_client,
-    job_service_async_client,
+    google_auth: MagicMock,
+    mock_credentials: MagicMock,
+    job_service_client: MagicMock,
+    job_service_async_client: MagicMock,
 ):
     gcp_credentials_mock = MagicMock(spec=GcpCredentials)
     gcp_credentials_mock.service_account_info = None

--- a/src/integrations/prefect-gcp/tests/experimental/bundles/test_execute.py
+++ b/src/integrations/prefect-gcp/tests/experimental/bundles/test_execute.py
@@ -1,0 +1,167 @@
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from prefect_gcp.experimental.bundles.execute import execute_bundle_from_gcs
+from pydantic_core import to_json
+
+from prefect.runner import Runner
+
+
+@pytest.fixture
+def mock_bundle_data() -> dict[str, Any]:
+    return {
+        "context": "foo",
+        "serialize_function": "bar",
+        "flow_run": {"name": "buzz", "id": "123"},
+    }
+
+
+def test_execute_bundle_from_gcs_success(
+    gcp_credentials: MagicMock,
+    mock_bundle_data: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Mock the GcpCredentials.load method
+    monkeypatch.setattr(
+        "prefect_gcp.credentials.GcpCredentials.load",
+        MagicMock(return_value=gcp_credentials),
+    )
+
+    # Mock the Runner and its execute_bundle method
+    mock_runner = MagicMock(spec=Runner)
+    monkeypatch.setattr("prefect.runner.Runner", MagicMock(return_value=mock_runner))
+
+    # Call the function
+    bucket = "test-bucket"
+    key = "test-key.json"
+
+    def mock_download_to_file(path: str) -> None:
+        Path(path).write_bytes(to_json(mock_bundle_data))
+
+    # wow, i love mocking so much
+    gcp_credentials.get_cloud_storage_client.return_value.bucket.return_value.blob.return_value.download_to_file.side_effect = mock_download_to_file
+
+    execute_bundle_from_gcs(
+        bucket=bucket,
+        key=key,
+        gcp_credentials_block_name="test-credentials",
+    )
+
+    # Verify the GCS client was called correctly
+    gcs_client = gcp_credentials.get_cloud_storage_client()
+    gcs_client.bucket.assert_called_once_with(bucket)
+    gcs_client.bucket(bucket).blob.assert_called_once_with(key)
+    gcs_client.bucket(bucket).blob(key).download_to_file.assert_called_once()
+
+    # Verify the Runner was called correctly
+    mock_runner.execute_bundle.assert_called_once_with(mock_bundle_data)
+
+
+def test_execute_bundle_from_gcs_with_default_credentials(
+    gcp_credentials: MagicMock,
+    mock_bundle_data: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Mock the GcpCredentials constructor
+    monkeypatch.setattr(
+        "prefect_gcp.credentials.GcpCredentials",
+        MagicMock(return_value=gcp_credentials),
+    )
+
+    # Mock the Runner and its execute_bundle method
+    mock_runner = MagicMock(spec=Runner)
+    monkeypatch.setattr("prefect.runner.Runner", MagicMock(return_value=mock_runner))
+
+    # Call the function
+    bucket = "test-bucket"
+    key = "test-key.json"
+
+    def mock_download_to_file(path: str) -> None:
+        Path(path).write_bytes(to_json(mock_bundle_data))
+
+    # Set up the mock for download_to_file
+    gcp_credentials.get_cloud_storage_client.return_value.bucket.return_value.blob.return_value.download_to_file.side_effect = mock_download_to_file
+
+    execute_bundle_from_gcs(
+        bucket=bucket,
+        key=key,
+    )
+
+    # Verify the GCS client was called correctly
+    gcs_client = gcp_credentials.get_cloud_storage_client()
+    gcs_client.bucket.assert_called_once_with(bucket)
+    gcs_client.bucket(bucket).blob.assert_called_once_with(key)
+    gcs_client.bucket(bucket).blob(key).download_to_file.assert_called_once()
+
+    # Verify the Runner was called correctly
+    mock_runner.execute_bundle.assert_called_once_with(mock_bundle_data)
+
+
+def test_execute_bundle_from_gcs_download_failure(
+    gcp_credentials: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Mock the GcpCredentials.load method
+    monkeypatch.setattr(
+        "prefect_gcp.credentials.GcpCredentials.load",
+        MagicMock(return_value=gcp_credentials),
+    )
+
+    # Call the function
+    bucket = "test-bucket"
+    key = "test-key.json"
+
+    # Mock the GCS client to raise an exception
+    gcs_client = gcp_credentials.get_cloud_storage_client()
+    gcs_client.bucket(bucket).blob(key).download_to_file.side_effect = Exception(
+        "Download failed"
+    )
+
+    # Call the function and expect it to raise a RuntimeError
+    with pytest.raises(
+        RuntimeError, match="Failed to download bundle from GCS: Download failed"
+    ):
+        execute_bundle_from_gcs(
+            bucket=bucket,
+            key=key,
+            gcp_credentials_block_name="test-credentials",
+        )
+
+
+def test_execute_bundle_from_gcs_execution_failure(
+    gcp_credentials: MagicMock,
+    mock_bundle_data: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Mock the GcpCredentials.load method
+    monkeypatch.setattr(
+        "prefect_gcp.credentials.GcpCredentials.load",
+        MagicMock(return_value=gcp_credentials),
+    )
+
+    # Mock the Runner and its execute_bundle method to raise an exception
+    mock_runner = MagicMock(spec=Runner)
+    mock_runner.execute_bundle.side_effect = Exception("Execution failed")
+    monkeypatch.setattr("prefect.runner.Runner", MagicMock(return_value=mock_runner))
+
+    # Call the function
+    bucket = "test-bucket"
+    key = "test-key.json"
+
+    def mock_download_to_file(path: str) -> None:
+        Path(path).write_bytes(to_json(mock_bundle_data))
+
+    # Set up the mock for download_to_file
+    gcp_credentials.get_cloud_storage_client.return_value.bucket.return_value.blob.return_value.download_to_file.side_effect = mock_download_to_file
+
+    # Call the function and expect it to raise a RuntimeError
+    with pytest.raises(
+        RuntimeError, match="Failed to download bundle from GCS: Execution failed"
+    ):
+        execute_bundle_from_gcs(
+            bucket=bucket,
+            key=key,
+            gcp_credentials_block_name="test-credentials",
+        )

--- a/src/integrations/prefect-gcp/tests/experimental/bundles/test_upload.py
+++ b/src/integrations/prefect-gcp/tests/experimental/bundles/test_upload.py
@@ -1,0 +1,144 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from prefect_gcp.credentials import GcpCredentials
+from prefect_gcp.experimental.bundles.upload import upload_bundle_to_gcs
+
+
+@pytest.fixture
+def mock_bundle_file(tmp_path: Path) -> Path:
+    bundle_file = tmp_path / "test_bundle.tar.gz"
+    bundle_file.write_text("test bundle content")
+    return Path(bundle_file)
+
+
+def test_upload_bundle_to_gcs_success(
+    gcp_credentials: GcpCredentials,
+    mock_bundle_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "prefect_gcp.credentials.GcpCredentials.load",
+        MagicMock(return_value=gcp_credentials),
+    )
+    bucket = "test-bucket"
+    key = "test-key.json"
+
+    result = upload_bundle_to_gcs(
+        local_filepath=mock_bundle_file,
+        bucket=bucket,
+        key=key,
+        gcp_credentials_block_name="test-credentials",
+    )
+
+    assert result == {"bucket": bucket, "key": key}
+
+    # Verify the GCS client was called correctly
+    gcs_client = gcp_credentials.get_cloud_storage_client()
+    gcs_client.bucket.assert_called_once_with(bucket)
+    gcs_client.bucket(bucket).blob.assert_called_once_with(key)
+    gcs_client.bucket(bucket).blob(key).upload_from_file.assert_called_once_with(
+        mock_bundle_file
+    )
+
+
+def test_upload_bundle_to_gcs_with_default_key(
+    gcp_credentials: GcpCredentials,
+    mock_bundle_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "prefect_gcp.credentials.GcpCredentials.load",
+        MagicMock(return_value=gcp_credentials),
+    )
+    bucket = "test-bucket"
+
+    result = upload_bundle_to_gcs(
+        local_filepath=mock_bundle_file,
+        bucket=bucket,
+        key="",
+        gcp_credentials_block_name="test-credentials",
+    )
+
+    assert result == {"bucket": bucket, "key": mock_bundle_file.name}
+
+    # Verify the GCS client was called with the default key
+    gcs_client = gcp_credentials.get_cloud_storage_client()
+    gcs_client.bucket(bucket).blob.assert_called_once_with(mock_bundle_file.name)
+
+
+def test_upload_bundle_to_gcs_with_default_credentials(
+    gcp_credentials: GcpCredentials,
+    mock_bundle_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "prefect_gcp.credentials.GcpCredentials",
+        MagicMock(return_value=gcp_credentials),
+    )
+    bucket = "test-bucket"
+    key = "test-key.tar.gz"
+
+    result = upload_bundle_to_gcs(
+        local_filepath=mock_bundle_file,
+        bucket=bucket,
+        key=key,
+    )
+
+    assert result == {"bucket": bucket, "key": key}
+
+    # Verify the GCS client was called correctly
+    gcs_client = gcp_credentials.get_cloud_storage_client()
+    gcs_client.bucket(bucket).blob(key).upload_from_file.assert_called_once_with(
+        mock_bundle_file
+    )
+
+
+def test_upload_bundle_to_gcs_file_not_found(
+    gcp_credentials: GcpCredentials, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "prefect_gcp.credentials.GcpCredentials.load",
+        MagicMock(return_value=gcp_credentials),
+    )
+    non_existent_file = Path("/non/existent/file.tar.gz")
+    bucket = "test-bucket"
+    key = "test-key.tar.gz"
+
+    with pytest.raises(ValueError, match=f"Bundle file not found: {non_existent_file}"):
+        upload_bundle_to_gcs(
+            local_filepath=non_existent_file,
+            bucket=bucket,
+            key=key,
+            gcp_credentials_block_name="test-credentials",
+        )
+
+
+def test_upload_bundle_to_gcs_upload_failure(
+    gcp_credentials: GcpCredentials,
+    mock_bundle_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "prefect_gcp.credentials.GcpCredentials.load",
+        MagicMock(return_value=gcp_credentials),
+    )
+    bucket = "test-bucket"
+    key = "test-key.tar.gz"
+
+    # Mock the upload to raise an exception
+    gcs_client = gcp_credentials.get_cloud_storage_client()
+    gcs_client.bucket(bucket).blob(key).upload_from_file.side_effect = Exception(
+        "Upload failed"
+    )
+
+    with pytest.raises(
+        RuntimeError, match="Failed to upload bundle to GCS: Upload failed"
+    ):
+        upload_bundle_to_gcs(
+            local_filepath=mock_bundle_file,
+            bucket=bucket,
+            key=key,
+            gcp_credentials_block_name="test-credentials",
+        )


### PR DESCRIPTION
Adds bundle upload and execution steps for Google Cloud Storage. Similar to the S3 versions, these can be executed via a CLI command and will be used in work pool storage configuration.

Related to https://github.com/PrefectHQ/prefect/issues/17194