### PR TITLE
update background tasks docs and add guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -131,7 +131,8 @@
               {
                 "group": "Static infrastructure examples",
                 "pages": [
-                  "v3/deploy/static-infrastructure-examples/docker"
+                  "v3/deploy/static-infrastructure-examples/docker",
+                  "v3/deploy/static-infrastructure-examples/background-tasks"
                 ]
               },
               "v3/deploy/daemonize-processes"

--- a/docs/v3/deploy/static-infrastructure-examples/background-tasks.mdx
+++ b/docs/v3/deploy/static-infrastructure-examples/background-tasks.mdx
@@ -6,7 +6,7 @@ description: Learn how to background heavy tasks from a web application to dedic
 This example demonstrates how to use [background tasks](/v3/develop/deferred-tasks) in the context of a web application using Prefect for task submission, execution, monitoring, and result storage. We'll build out an application using FastAPI to offer API endpoints to our clients, and task workers to execute the background tasks these endpoints defer.
 
 <Tip>
-Refer to the [examples repository](https://github.com/PrefectHQ/examples/pull/20) for the complete example's source code.
+Refer to the [examples repository](https://github.com/PrefectHQ/examples/tree/main/apps/background-tasks) for the complete example's source code.
 </Tip>
 
 This pattern is useful when you need to perform operations that are too long for a standard web request-response cycle, such as data processing, sending emails, or interacting with external APIs that might be slow.

--- a/docs/v3/deploy/static-infrastructure-examples/background-tasks.mdx
+++ b/docs/v3/deploy/static-infrastructure-examples/background-tasks.mdx
@@ -63,6 +63,7 @@ This example does **_not_** require:
 
 The core of the background processing is a Python function decorated with `@prefect.task`. This marks the function as a unit of work that Prefect can manage (e.g. observe, cache, retry, etc.)
 
+{/* pmd-metadata: notest */}
 ```python src/foo/task.py
 import inspect
 from typing import Any, Callable
@@ -121,6 +122,7 @@ Key details:
 
 The FastAPI application provides API endpoints to trigger the background task and check its status.
 
+{/* pmd-metadata: notest */}
 ```python src/foo/api.py
 import logging
 from uuid import UUID

--- a/docs/v3/deploy/static-infrastructure-examples/background-tasks.mdx
+++ b/docs/v3/deploy/static-infrastructure-examples/background-tasks.mdx
@@ -1,0 +1,455 @@
+---
+title: Deploy background tasks with Docker Compose
+description: Learn how to use Prefect to manage background tasks triggered from a web API
+---
+
+This example demonstrates how to run [background tasks](/v3/develop/deferred-tasks) triggered by a web application using Prefect for task submission, execution, and monitoring. We'll build a simple application using FastAPI to provide the API endpoints, and Prefect to handle the long-running background work.
+
+<Tip>
+Refer to [the complete example](https://github.com/PrefectHQ/examples/pull/20) for details on the application code.
+</Tip>
+
+This pattern is useful when you need to perform operations that are too long for a standard web request-response cycle, such as data processing, sending emails, or interacting with external APIs that might be slow.
+
+
+
+## Overview
+
+In this example, you will set up:
+
+- `@prefect.task` definitions representing the work you want to run in the background
+- A `fastapi` application providing API endpoints to:
+    - Receive task parameters via `POST` request and submit the task to Prefect with `.delay()`
+    - Allow polling for the task's status via a `GET` request using its `task_run_id`
+- A `compose.yaml` to manage lifecycles of the web app, Prefect server and task worker(s)
+
+<Note>
+This example does **_not_** require:
+- Prefect Cloud
+- creating a Prefect Deployment
+- creating a work pool
+</Note>
+
+## Useful things to remember
+
+- You can call any Python code from your task definitions (including other flows and tasks!)
+- Prefect [Results](/v3/concepts/caching.html) allow you to save/serialize the `return` value of your task definitions to your result storage (e.g. a local directory, S3, GCS, etc), enabling [caching](/v3/develop/task-caching) and [idempotency](/v3/develop/transactions).
+
+
+
+## Defining the background task
+
+The core of the background processing is a Python function decorated with `@prefect.task`. This marks the function as a unit of work that Prefect can manage (e.g. observe, cache, retry, etc.)
+
+```python src/foo/task.py
+import inspect
+from typing import Any, Callable
+
+import marvin
+
+from prefect import task
+from prefect.cache_policies import INPUTS, TASK_SOURCE
+from prefect.task_worker import serve
+
+
+def def _print_output(output: Any):
+    print(f"result type: {type(output)}")
+    print(f"result: {output!r}")
+
+
+@task(cache_policy=INPUTS + TASK_SOURCE)
+async def cast_data_to_type[T](
+    data: Any,
+    target: type[T],
+    instructions: str,
+    on_complete: Callable[[T], None] | None = _print_output,
+) -> T:
+    output = await marvin.cast_async(
+        data,
+        target=target,
+        instructions=instructions,
+    )
+
+    if on_complete:
+        if inspect.iscoroutinefunction(on_complete):
+            await on_complete(output)
+        else:
+            on_complete(output)
+
+    return output
+
+
+def main():
+    """main entrypoint for the task"""
+    serve(cast_data_to_type)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Key aspects:
+
+- `@task`: Decorator that registers the function with Prefect.
+- `cache_policy`: Optional caching based on `INPUTS` and `TASK_SOURCE`.
+- `serve(cast_data_to_type)`: This function starts a websocket client subscribed to newly `delay()`ed task runs.
+
+
+
+## Building the FastAPI application
+
+The FastAPI application provides API endpoints to trigger the background task and check its status.
+
+```python src/foo/api.py
+import logging
+from uuid import UUID
+
+from fastapi import Depends, FastAPI, Response
+from fastapi.responses import JSONResponse
+
+from foo._internal import get_form_data, get_task_result, StructuredOutputRequest
+from foo.task import cast_data_to_type
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI()
+
+
+@app.post("/tasks", status_code=202)
+async def submit_task(
+    form_data: StructuredOutputRequest = Depends(get_form_data),
+) -> JSONResponse:
+    """Submits the background task to Prefect.
+
+    Receives task parameters, calls `.delay()` on the Prefect task,
+    and returns the task run ID.
+    """
+    future = cast_data_to_type.delay(
+        form_data.payload,
+        target=form_data.target_type,
+        instructions=form_data.instructions,
+    )
+    logger.info(f"Submitted task run: {future.task_run_id}")
+    return {"task_run_id": str(future.task_run_id)}
+
+
+@app.get("/tasks/{task_run_id}/status")
+async def get_task_status_api(task_run_id: UUID) -> Response:
+    """Checks the status of a submitted task run.
+
+    Uses the helper function `get_task_result` which queries the Prefect API.
+    Returns the status and result/error message.
+    """
+    status, data = await get_task_result(task_run_id)
+
+    response_data = {"task_run_id": str(task_run_id), "status": status}
+    http_status_code = 200 # Default to 200 OK
+
+    if status == "completed":
+        response_data["result"] = data
+    elif status == "error":
+        response_data["message"] = data
+        # Optionally set a different HTTP status for errors
+
+    return JSONResponse(response_data, status_code=http_status_code)
+```
+<Accordion title="Checking Task Status with the Prefect Client">
+
+The `get_task_result` helper function (in `src/foo/_internal/_prefect.py`) uses the Prefect Python client to interact with the Prefect API:
+
+```python src/foo/_internal/_prefect.py
+from typing import Any, Literal, cast
+from uuid import UUID
+
+
+from prefect.client.orchestration import get_client
+from prefect.client.schemas.objects import TaskRun
+from prefect.logging import get_logger
+
+logger = get_logger(__name__)
+
+Status = Literal["completed", "pending", "error"]
+
+
+def _any_task_run_result(task_run: TaskRun) -> Any:
+    try:
+        return cast(Any, task_run.state.result(_sync=True))  # type: ignore
+    except Exception as e:
+        logger.warning(f"Could not retrieve result for task run {task_run.id}: {e}")
+        return None
+
+
+async def get_task_result(task_run_id: UUID) -> tuple[Status, Any]:
+    """Get task result or status.
+
+    Returns:
+        tuple: (status, data)
+            status: "completed", "pending", or "error"
+            data: the result if completed, error message if error, None if pending
+    """
+    try:
+        async with get_client() as client:
+            task_run = await client.read_task_run(task_run_id)
+            if not task_run.state:
+                return "pending", None
+
+            if task_run.state.is_completed():
+                try:
+                    result = _any_task_run_result(task_run)
+                    return "completed", result
+                except Exception as e:
+                    logger.warning(
+                        f"Could not retrieve result for completed task run {task_run_id}: {e}"
+                    )
+                    return "completed", "<Could not retrieve result>"
+
+            elif task_run.state.is_failed():
+                try:
+                    error_result = _any_task_run_result(task_run)
+                    error_message = (
+                        str(error_result)
+                        if error_result
+                        else "Task failed without specific error message."
+                    )
+                    return "error", error_message
+                except Exception as e:
+                    logger.warning(
+                        f"Could not retrieve error result for failed task run {task_run_id}: {e}"
+                    )
+                    return "error", "<Could not retrieve error message>"
+
+            else:
+                return "pending", None
+
+    except Exception as e:
+        logger.error(f"Error checking task status for {task_run_id}: {e}")
+        return "error", f"Failed to check task status: {str(e)}"
+```
+
+This function fetches the `TaskRun` object from the API and checks its `state` to determine if it's `Completed`, `Failed`, or still `Pending`/`Running`. If completed, it attempts to retrieve the result using `task_run.state.result()`. If failed, it tries to get the error message.
+
+
+</Accordion>
+## Building the Docker Image
+
+A multi-stage `Dockerfile` is used to create optimized images for each service (Prefect server, task worker, and web API). This approach helps keep image sizes small and separates build dependencies from runtime dependencies.
+
+```dockerfile Dockerfile
+# Stage 1: Base image with Python and uv
+FROM --platform=linux/amd64 ghcr.io/astral-sh/uv:python3.12-bookworm-slim as base
+
+WORKDIR /app
+
+# Set environment variables for uv
+ENV UV_SYSTEM_PYTHON=1
+ENV PATH="/root/.local/bin:$PATH"
+
+# Copy project definition and lock file
+COPY pyproject.toml uv.lock* ./
+
+# Install dependencies using uv, leveraging cache
+# Note: We install all dependencies needed for all stages here.
+# A more optimized approach might separate dependencies per stage.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system -r pyproject.toml
+
+# Copy the source code
+COPY src/ /app/src
+
+# --- Server Stage --- #
+FROM base as server
+
+# Expose the default Prefect server port
+EXPOSE 4200
+
+# Command to start the Prefect server
+CMD ["prefect", "server", "start"]
+
+# --- Task Worker Stage --- #
+FROM base as task
+
+# Command to start the task worker by running the task script
+# This script should call `prefect.task_worker.serve(...)`
+CMD ["python", "src/foo/task.py"]
+
+# --- API Stage --- #
+FROM base as api
+
+# Expose the default FastAPI port
+EXPOSE 8000
+
+# Command to start the FastAPI server using uvicorn
+# Ensure uvicorn is included in dependencies if using this command
+CMD ["uvicorn", "src.foo.api:app", "--host", "0.0.0.0", "--port", "8000"]
+
+```
+
+Key aspects of this `Dockerfile`:
+
+- **Base Stage (`base`)**: Sets up Python, `uv`, installs all dependencies from `pyproject.toml` into a base layer to leverage Docker caching, and copies the source code.
+- **Server Stage (`server`)**: Builds upon the `base` stage. Sets the default command (`CMD`) to start the Prefect server.
+- **Task Worker Stage (`task`)**: Builds upon the `base` stage. Sets the `CMD` to run the `src/foo/task.py` script, which is expected to contain the `serve()` call for the task(s).
+- **API Stage (`api`)**: Builds upon the `base` stage. Sets the `CMD` to start the FastAPI application using `uvicorn`.
+
+The `docker-compose.yaml` file then uses the `target` build argument to specify which of these final stages (`server`, `task`, `api`) to use for each service container.
+
+## Orchestrating with Docker Compose
+
+We use `docker-compose.yaml` to define and run the multi-container application, managing the lifecycles of the FastAPI web server, the Prefect API server, database and task worker(s).
+
+```yaml compose.yaml
+services:
+
+  prefect-server:
+    build:
+      context: .
+      target: server
+    ports:
+      - "4200:4200" # Expose Prefect UI/API
+    volumes:
+      - prefect-data:/root/.prefect # Persist Prefect DB
+    environment:
+      # Allow connections from other containers
+      PREFECT_SERVER_API_HOST: 0.0.0.0
+
+  task:
+    build:
+      context: .
+      target: task # Use the 'task' stage from Dockerfile
+    deploy:
+      replicas: 1 # task workers are safely horizontally scalable (think redis stream consumer groups)
+    volumes:
+      # Mount storage for results
+      - ./task-storage:/task-storage
+    depends_on:
+      # Wait for Prefect API to be available
+      prefect-server:
+        condition: service_started
+    environment:
+      # Point the worker to the Prefect API
+      PREFECT_API_URL: http://prefect-server:4200/api
+      # --- Prefect Configuration --- #
+      # Store results locally in the mounted volume
+      PREFECT_LOCAL_STORAGE_PATH: /task-storage
+      # Enable capturing print statements as logs
+      PREFECT_LOGGING_LOG_PRINTS: "true"
+      # Automatically persist results for tasks
+      PREFECT_RESULTS_PERSIST_BY_DEFAULT: "true"
+      # Disable Marvin's default print handler if needed
+      MARVIN_ENABLE_DEFAULT_PRINT_HANDLER: "false"
+      # Pass necessary secrets to the task environment
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+
+    develop:
+      # Optional: Watch for code changes for development
+      watch:
+        - action: sync
+          path: .
+          target: /app
+          ignore:
+            - .venv/
+            - task-storage/
+        - action: rebuild
+          path: uv.lock
+
+  api:
+    build:
+      context: .
+      target: api # Use the 'api' stage from Dockerfile
+    volumes:
+      - ./task-storage:/task-storage # Access task results if needed
+    ports:
+      - "8000:8000" # Expose the web API
+    depends_on:
+      task:
+        condition: service_started # Optional: wait for worker
+      prefect-server:
+        condition: service_started # Wait for Prefect API
+    environment:
+      # Point the API application to the Prefect API
+      PREFECT_API_URL: http://prefect-server:4200/api
+      # Allow API to potentially read results from same path
+      PREFECT_LOCAL_STORAGE_PATH: /task-storage
+    develop:
+      # Optional: Watch for code changes for development
+      watch:
+        - action: sync
+          path: .
+          target: /app
+          ignore:
+            - .venv/
+            - task-storage/
+        - action: rebuild
+          path: uv.lock
+
+volumes:
+  # Named volumes for data persistence
+  postgres_data: {} # Likely unused in this specific example
+  prefect-data: {}
+  task-storage: {}
+```
+
+<Accordion title="Key Service Configurations">
+
+- **`prefect-server`**: Runs the Prefect API server and UI.
+    - `build`: Uses a multi-stage `Dockerfile` (not shown here, but present in the example repo) targeting the `server` stage.
+    - `ports`: Exposes the Prefect API/UI on port `4200`.
+    - `volumes`: Uses a named volume `prefect-data` to persist the Prefect SQLite database (`/root/.prefect/prefect.db`) across container restarts.
+    - `PREFECT_SERVER_API_HOST=0.0.0.0`: Makes the API server listen on all interfaces within the Docker network, allowing the `task` and `api` services to connect.
+
+- **`task`**: Runs the Prefect task worker process (executing `python src/foo/task.py` which calls `serve`).
+    - `build`: Uses the `task` stage from the `Dockerfile`.
+    - `depends_on`: Ensures the `prefect-server` service is started before this service attempts to connect.
+    - `PREFECT_API_URL`: Crucial setting that tells the worker where to find the Prefect API to poll for submitted task runs.
+    - `PREFECT_LOCAL_STORAGE_PATH=/task-storage`: Configures the worker to store task run results in the `/task-storage` directory inside the container. This path is mounted to the host using the `task-storage` named volume via `volumes: - ./task-storage:/task-storage` (or just `task-storage:` if using a named volume without a host path binding).
+    - `PREFECT_RESULTS_PERSIST_BY_DEFAULT=true`: Tells Prefect tasks to automatically save their results using the configured storage (defined by `PREFECT_LOCAL_STORAGE_PATH` in this case).
+    - `PREFECT_LOGGING_LOG_PRINTS=true`: Configures the Prefect logger to capture output from `print()` statements within tasks.
+    - `OPENAI_API_KEY=${OPENAI_API_KEY}`: Passes secrets needed by the task code from the host environment (via a `.env` file loaded by Docker Compose) into the container's environment.
+
+- **`api`**: Runs the FastAPI web application.
+    - `build`: Uses the `api` stage from the `Dockerfile`.
+    - `depends_on`: Waits for the `prefect-server` (required for submitting tasks and checking status) and optionally the `task` worker.
+    - `PREFECT_API_URL`: Tells the FastAPI application where to send `.delay()` calls and status check requests.
+    - `PREFECT_LOCAL_STORAGE_PATH`: May be needed if the API itself needs to directly read result files (though typically fetching results via `task_run.state.result()` is preferred).
+
+- **`volumes`**: Defines named volumes (`prefect-data`, `task-storage`) to persist data generated by the containers.
+
+Environment variables (like `OPENAI_API_KEY`) are typically loaded by Docker Compose from a `.env` file in the project root.
+
+</Accordion>
+
+## Running this example
+
+1.  **Prerequisites:** Docker Desktop (or equivalent) with `docker compose` support.
+2.  **Get the Code:** Clone the [Prefect examples repository](https://github.com/PrefectHQ/examples) and navigate to the `apps/background-tasks` directory.
+3.  **Configure Secrets (if needed):** Create a `.env` file in the project root if your task requires secrets (like the `OPENAI_API_KEY` used in the example). Docker Compose automatically loads variables from this file.
+    ```dotenv .env
+    OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    ```
+4.  **Build and Run Services:**
+    ```bash
+    docker compose up --build --watch
+    ```
+    *   `--build`: Builds the container images if they don't exist or if the Dockerfile/context has changed.
+    *   `--watch`: Watches for changes in the project and rebuilds the containers as needed.
+    *   `--detach`: Runs the containers in detached mode (in the background).
+5.  **Access Services:**
+    - API Endpoint (for submitting tasks): `POST http://localhost:8000/tasks`
+    - API Endpoint (for checking status): `GET http://localhost:8000/tasks/{task_run_id}/status`
+    - Prefect UI (for observing task runs): [http://localhost:4200](http://localhost:4200)
+
+### Cleaning up
+
+```bash
+docker compose down
+```
+*   Use `docker compose down -v` to also remove the named volumes (`prefect-data`, `task-storage`) if you want a completely clean restart.
+
+## Next Steps
+
+This example provides a robust pattern for integrating Prefect-managed background tasks with any web API framework. You can:
+
+- Adapt the `@task` definition (`src/foo/task.py`) to perform your specific long-running work.
+- Modify the API endpoints (`src/foo/api.py`) to accept different inputs or return different responses.
+- Configure Prefect settings (environment variables in `compose.yaml`) further, for example, using different result storage or logging levels.
+- Deploy these services to cloud infrastructure using managed container services.

--- a/docs/v3/deploy/static-infrastructure-examples/background-tasks.mdx
+++ b/docs/v3/deploy/static-infrastructure-examples/background-tasks.mdx
@@ -1,12 +1,12 @@
 ---
-title: Deploy background tasks with Docker Compose
-description: Learn how to use Prefect to manage background tasks triggered from a web API
+title: Deploy a web application powered by background tasks
+description: Learn how to background heavy tasks from a web application to dedicated infrastructure.
 ---
 
-This example demonstrates how to run [background tasks](/v3/develop/deferred-tasks) triggered by a web application using Prefect for task submission, execution, and monitoring. We'll build a simple application using FastAPI to provide the API endpoints, and Prefect to handle the long-running background work.
+This example demonstrates how to leverage [background tasks](/v3/develop/deferred-tasks) in the context of a web application using Prefect for task submission, execution, monitoring, and result storage. We'll build out an application using FastAPI to offer API endpoints to our clients, and task workers to execute the background tasks these endpoints defer.
 
 <Tip>
-Refer to [the complete example](https://github.com/PrefectHQ/examples/pull/20) for details on the application code.
+Refer to the [examples repository](https://github.com/PrefectHQ/examples/pull/20) for the complete example's source code.
 </Tip>
 
 This pattern is useful when you need to perform operations that are too long for a standard web request-response cycle, such as data processing, sending emails, or interacting with external APIs that might be slow.
@@ -15,13 +15,36 @@ This pattern is useful when you need to perform operations that are too long for
 
 ## Overview
 
-In this example, you will set up:
+This example will build out:
 
 - `@prefect.task` definitions representing the work you want to run in the background
 - A `fastapi` application providing API endpoints to:
     - Receive task parameters via `POST` request and submit the task to Prefect with `.delay()`
     - Allow polling for the task's status via a `GET` request using its `task_run_id`
+- A `Dockerfile` to build a multi-stage image for the web app, Prefect server and task worker(s)
 - A `compose.yaml` to manage lifecycles of the web app, Prefect server and task worker(s)
+
+```bash
+├── Dockerfile
+├── README.md
+├── compose.yaml
+├── pyproject.toml
+├── src
+│   └── foo
+│       ├── __init__.py
+│       ├── _internal/*.py
+│       ├── api.py
+│       └── task.py
+```
+
+You can follow along by cloning the [examples repository](https://github.com/PrefectHQ/examples) or instead use [`uv`](https://docs.astral.sh/uv/getting-started/installation/) to bootstrap a your own new project:
+
+```bash
+uv init --lib foo
+uv add prefect marvin
+```
+
+This example application is structured as a library with a `src/foo` directory for portability and organization.
 
 <Note>
 This example does **_not_** require:
@@ -34,7 +57,6 @@ This example does **_not_** require:
 
 - You can call any Python code from your task definitions (including other flows and tasks!)
 - Prefect [Results](/v3/concepts/caching.html) allow you to save/serialize the `return` value of your task definitions to your result storage (e.g. a local directory, S3, GCS, etc), enabling [caching](/v3/develop/task-caching) and [idempotency](/v3/develop/transactions).
-
 
 
 ## Defining the background task
@@ -80,7 +102,6 @@ async def cast_data_to_type[T](
 
 
 def main():
-    """main entrypoint for the task"""
     serve(cast_data_to_type)
 
 
@@ -88,11 +109,11 @@ if __name__ == "__main__":
     main()
 ```
 
-Key aspects:
+Key details:
 
-- `@task`: Decorator that registers the function with Prefect.
-- `cache_policy`: Optional caching based on `INPUTS` and `TASK_SOURCE`.
-- `serve(cast_data_to_type)`: This function starts a websocket client subscribed to newly `delay()`ed task runs.
+- `@task`: Decorator to define our task we want to run in the background.
+- `cache_policy`: Caching based on `INPUTS` and `TASK_SOURCE`.
+- `serve(cast_data_to_type)`: This function starts a task worker subscribed to newly `delay()`ed task runs.
 
 
 
@@ -119,11 +140,7 @@ app = FastAPI()
 async def submit_task(
     form_data: StructuredOutputRequest = Depends(get_form_data),
 ) -> JSONResponse:
-    """Submits the background task to Prefect.
-
-    Receives task parameters, calls `.delay()` on the Prefect task,
-    and returns the task run ID.
-    """
+    """Submit a task to Prefect for background execution."""
     future = cast_data_to_type.delay(
         form_data.payload,
         target=form_data.target_type,
@@ -135,22 +152,17 @@ async def submit_task(
 
 @app.get("/tasks/{task_run_id}/status")
 async def get_task_status_api(task_run_id: UUID) -> Response:
-    """Checks the status of a submitted task run.
-
-    Uses the helper function `get_task_result` which queries the Prefect API.
-    Returns the status and result/error message.
-    """
+    """Checks the status of a submitted task run."""
     status, data = await get_task_result(task_run_id)
 
     response_data = {"task_run_id": str(task_run_id), "status": status}
-    http_status_code = 200 # Default to 200 OK
+    http_status_code = 200
 
     if status == "completed":
         response_data["result"] = data
     elif status == "error":
         response_data["message"] = data
         # Optionally set a different HTTP status for errors
-
     return JSONResponse(response_data, status_code=http_status_code)
 ```
 <Accordion title="Checking Task Status with the Prefect Client">
@@ -240,29 +252,20 @@ FROM --platform=linux/amd64 ghcr.io/astral-sh/uv:python3.12-bookworm-slim as bas
 
 WORKDIR /app
 
-# Set environment variables for uv
 ENV UV_SYSTEM_PYTHON=1
 ENV PATH="/root/.local/bin:$PATH"
 
-# Copy project definition and lock file
 COPY pyproject.toml uv.lock* ./
 
-# Install dependencies using uv, leveraging cache
 # Note: We install all dependencies needed for all stages here.
 # A more optimized approach might separate dependencies per stage.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system -r pyproject.toml
 
-# Copy the source code
 COPY src/ /app/src
 
-# --- Server Stage --- #
 FROM base as server
 
-# Expose the default Prefect server port
-EXPOSE 4200
-
-# Command to start the Prefect server
 CMD ["prefect", "server", "start"]
 
 # --- Task Worker Stage --- #
@@ -275,27 +278,25 @@ CMD ["python", "src/foo/task.py"]
 # --- API Stage --- #
 FROM base as api
 
-# Expose the default FastAPI port
-EXPOSE 8000
-
 # Command to start the FastAPI server using uvicorn
-# Ensure uvicorn is included in dependencies if using this command
 CMD ["uvicorn", "src.foo.api:app", "--host", "0.0.0.0", "--port", "8000"]
 
 ```
 
-Key aspects of this `Dockerfile`:
+<Accordion title="Dockerfile Key Details">
 
 - **Base Stage (`base`)**: Sets up Python, `uv`, installs all dependencies from `pyproject.toml` into a base layer to leverage Docker caching, and copies the source code.
 - **Server Stage (`server`)**: Builds upon the `base` stage. Sets the default command (`CMD`) to start the Prefect server.
 - **Task Worker Stage (`task`)**: Builds upon the `base` stage. Sets the `CMD` to run the `src/foo/task.py` script, which is expected to contain the `serve()` call for the task(s).
 - **API Stage (`api`)**: Builds upon the `base` stage. Sets the `CMD` to start the FastAPI application using `uvicorn`.
 
-The `docker-compose.yaml` file then uses the `target` build argument to specify which of these final stages (`server`, `task`, `api`) to use for each service container.
+The `compose.yaml` file then uses the `target` build argument to specify which of these final stages (`server`, `task`, `api`) to use for each service container.
 
-## Orchestrating with Docker Compose
+</Accordion>
 
-We use `docker-compose.yaml` to define and run the multi-container application, managing the lifecycles of the FastAPI web server, the Prefect API server, database and task worker(s).
+## Declaring the application services
+
+We use `compose.yaml` to define and run the multi-container application, managing the lifecycles of the FastAPI web server, the Prefect API server, database and task worker(s).
 
 ```yaml compose.yaml
 services:
@@ -305,43 +306,35 @@ services:
       context: .
       target: server
     ports:
-      - "4200:4200" # Expose Prefect UI/API
+      - "4200:4200"
     volumes:
       - prefect-data:/root/.prefect # Persist Prefect DB
     environment:
       # Allow connections from other containers
       PREFECT_SERVER_API_HOST: 0.0.0.0
-
+  # Task Worker
   task:
     build:
       context: .
-      target: task # Use the 'task' stage from Dockerfile
+      target:
     deploy:
       replicas: 1 # task workers are safely horizontally scalable (think redis stream consumer groups)
     volumes:
       # Mount storage for results
       - ./task-storage:/task-storage
     depends_on:
-      # Wait for Prefect API to be available
       prefect-server:
         condition: service_started
     environment:
-      # Point the worker to the Prefect API
       PREFECT_API_URL: http://prefect-server:4200/api
-      # --- Prefect Configuration --- #
-      # Store results locally in the mounted volume
       PREFECT_LOCAL_STORAGE_PATH: /task-storage
-      # Enable capturing print statements as logs
       PREFECT_LOGGING_LOG_PRINTS: "true"
-      # Automatically persist results for tasks
       PREFECT_RESULTS_PERSIST_BY_DEFAULT: "true"
-      # Disable Marvin's default print handler if needed
       MARVIN_ENABLE_DEFAULT_PRINT_HANDLER: "false"
-      # Pass necessary secrets to the task environment
       OPENAI_API_KEY: ${OPENAI_API_KEY}
 
     develop:
-      # Optional: Watch for code changes for development
+      # Optionally watch for code changes for development
       watch:
         - action: sync
           path: .
@@ -355,23 +348,22 @@ services:
   api:
     build:
       context: .
-      target: api # Use the 'api' stage from Dockerfile
+      target: api
     volumes:
-      - ./task-storage:/task-storage # Access task results if needed
+      # Mount storage for results
+      - ./task-storage:/task-storage
     ports:
-      - "8000:8000" # Expose the web API
+      - "8000:8000"
     depends_on:
       task:
-        condition: service_started # Optional: wait for worker
+        condition: service_started
       prefect-server:
-        condition: service_started # Wait for Prefect API
+        condition: service_started
     environment:
-      # Point the API application to the Prefect API
       PREFECT_API_URL: http://prefect-server:4200/api
-      # Allow API to potentially read results from same path
       PREFECT_LOCAL_STORAGE_PATH: /task-storage
     develop:
-      # Optional: Watch for code changes for development
+      # Optionally watch for code changes for development
       watch:
         - action: sync
           path: .
@@ -384,10 +376,13 @@ services:
 
 volumes:
   # Named volumes for data persistence
-  postgres_data: {} # Likely unused in this specific example
   prefect-data: {}
   task-storage: {}
 ```
+In a production use-case, you'd likely want to:
+- write a `Dockerfile` for each service
+- add a `postgres` service and [configure it as the Prefect database](/v3/manage/server/index#quickstart%3A-configure-a-postgresql-database-with-docker).
+- remove the hot-reloading configuration in the `develop` section
 
 <Accordion title="Key Service Configurations">
 
@@ -414,42 +409,44 @@ volumes:
 
 - **`volumes`**: Defines named volumes (`prefect-data`, `task-storage`) to persist data generated by the containers.
 
-Environment variables (like `OPENAI_API_KEY`) are typically loaded by Docker Compose from a `.env` file in the project root.
-
 </Accordion>
 
 ## Running this example
 
-1.  **Prerequisites:** Docker Desktop (or equivalent) with `docker compose` support.
-2.  **Get the Code:** Clone the [Prefect examples repository](https://github.com/PrefectHQ/examples) and navigate to the `apps/background-tasks` directory.
-3.  **Configure Secrets (if needed):** Create a `.env` file in the project root if your task requires secrets (like the `OPENAI_API_KEY` used in the example). Docker Compose automatically loads variables from this file.
-    ```dotenv .env
-    OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    ```
-4.  **Build and Run Services:**
+Assuming you have obtained the code (either by cloning the repository or using `uv init` as described previously) and are in the project directory:
+
+1.  **Prerequisites:** Ensure Docker Desktop (or equivalent) with `docker compose` support is running.
+
+2.  **Build and Run Services:** 
+    This example's task uses [marvin](https://github.com/PrefectHQ/marvin), which (by default) requires an OpenAI API key. Provide it as an environment variable when starting the services:
+
     ```bash
-    docker compose up --build --watch
+    OPENAI_API_KEY=<your-openai-api-key> docker compose up --build --watch
     ```
-    *   `--build`: Builds the container images if they don't exist or if the Dockerfile/context has changed.
-    *   `--watch`: Watches for changes in the project and rebuilds the containers as needed.
-    *   `--detach`: Runs the containers in detached mode (in the background).
-5.  **Access Services:**
-    - API Endpoint (for submitting tasks): `POST http://localhost:8000/tasks`
-    - API Endpoint (for checking status): `GET http://localhost:8000/tasks/{task_run_id}/status`
+    This command will:
+    *   `--build`: Build the container images if they don't exist or if the Dockerfile/context has changed.
+    *   `--watch`: Watch for changes in the project source code and automatically sync/rebuild services (useful for development).
+    *   Add `--detach` or `-d` to run the containers in the background.
+
+3.  **Access Services:**
+    - If you cloned the existing example, check out the basic [htmx](https://htmx.org/) UI at [http://localhost:8000](http://localhost:8000)
+    - FastAPI docs: [http://localhost:8000/docs](http://localhost:8000/docs)
     - Prefect UI (for observing task runs): [http://localhost:4200](http://localhost:4200)
 
 ### Cleaning up
 
 ```bash
 docker compose down
+
+# also remove the named volumes
+docker compose down -v
 ```
-*   Use `docker compose down -v` to also remove the named volumes (`prefect-data`, `task-storage`) if you want a completely clean restart.
 
 ## Next Steps
 
-This example provides a robust pattern for integrating Prefect-managed background tasks with any web API framework. You can:
+This example provides a repeatable pattern for integrating Prefect-managed background tasks with any python web application. You can:
 
-- Adapt the `@task` definition (`src/foo/task.py`) to perform your specific long-running work.
-- Modify the API endpoints (`src/foo/api.py`) to accept different inputs or return different responses.
+- Explore the [background tasks examples repository](https://github.com/PrefectHQ/prefect-background-task-examples) for more examples.
+- Adapt `src/**/*.py` to define and submit your specific web app and background tasks.
 - Configure Prefect settings (environment variables in `compose.yaml`) further, for example, using different result storage or logging levels.
 - Deploy these services to cloud infrastructure using managed container services.

--- a/docs/v3/deploy/static-infrastructure-examples/background-tasks.mdx
+++ b/docs/v3/deploy/static-infrastructure-examples/background-tasks.mdx
@@ -3,7 +3,7 @@ title: Deploy a web application powered by background tasks
 description: Learn how to background heavy tasks from a web application to dedicated infrastructure.
 ---
 
-This example demonstrates how to leverage [background tasks](/v3/develop/deferred-tasks) in the context of a web application using Prefect for task submission, execution, monitoring, and result storage. We'll build out an application using FastAPI to offer API endpoints to our clients, and task workers to execute the background tasks these endpoints defer.
+This example demonstrates how to use [background tasks](/v3/develop/deferred-tasks) in the context of a web application using Prefect for task submission, execution, monitoring, and result storage. We'll build out an application using FastAPI to offer API endpoints to our clients, and task workers to execute the background tasks these endpoints defer.
 
 <Tip>
 Refer to the [examples repository](https://github.com/PrefectHQ/examples/pull/20) for the complete example's source code.
@@ -287,7 +287,7 @@ CMD ["uvicorn", "src.foo.api:app", "--host", "0.0.0.0", "--port", "8000"]
 
 <Accordion title="Dockerfile Key Details">
 
-- **Base Stage (`base`)**: Sets up Python, `uv`, installs all dependencies from `pyproject.toml` into a base layer to leverage Docker caching, and copies the source code.
+- **Base Stage (`base`)**: Sets up Python, `uv`, installs all dependencies from `pyproject.toml` into a base layer to make use of Docker caching, and copies the source code.
 - **Server Stage (`server`)**: Builds upon the `base` stage. Sets the default command (`CMD`) to start the Prefect server.
 - **Task Worker Stage (`task`)**: Builds upon the `base` stage. Sets the `CMD` to run the `src/foo/task.py` script, which is expected to contain the `serve()` call for the task(s).
 - **API Stage (`api`)**: Builds upon the `base` stage. Sets the `CMD` to start the FastAPI application using `uvicorn`.

--- a/docs/v3/deploy/static-infrastructure-examples/background-tasks.mdx
+++ b/docs/v3/deploy/static-infrastructure-examples/background-tasks.mdx
@@ -65,45 +65,36 @@ The core of the background processing is a Python function decorated with `@pref
 
 {/* pmd-metadata: notest */}
 ```python src/foo/task.py
-import inspect
-from typing import Any, Callable
+from typing import Any, TypeVar
 
 import marvin
 
-from prefect import task
+from prefect import task, Task
 from prefect.cache_policies import INPUTS, TASK_SOURCE
+from prefect.states import State
 from prefect.task_worker import serve
+from prefect.client.schemas.objects import TaskRun
+
+T = TypeVar("T")
 
 
-def def _print_output(output: Any):
-    print(f"result type: {type(output)}")
-    print(f"result: {output!r}")
+def _print_output(task: Task, task_run: TaskRun, state: State[T]):
+    result = state.result()
+    print(f"result type: {type(result)}")
+    print(f"result: {result!r}")
 
 
-@task(cache_policy=INPUTS + TASK_SOURCE)
-async def cast_data_to_type[T](
-    data: Any,
-    target: type[T],
-    instructions: str,
-    on_complete: Callable[[T], None] | None = _print_output,
-) -> T:
-    output = await marvin.cast_async(
+@task(cache_policy=INPUTS + TASK_SOURCE, on_completion=[_print_output])
+async def create_structured_output(data: Any, target: type[T], instructions: str) -> T:
+    return await marvin.cast_async(
         data,
         target=target,
         instructions=instructions,
     )
 
-    if on_complete:
-        if inspect.iscoroutinefunction(on_complete):
-            await on_complete(output)
-        else:
-            on_complete(output)
-
-    return output
-
 
 def main():
-    serve(cast_data_to_type)
+    serve(create_structured_output)
 
 
 if __name__ == "__main__":
@@ -114,7 +105,7 @@ Key details:
 
 - `@task`: Decorator to define our task we want to run in the background.
 - `cache_policy`: Caching based on `INPUTS` and `TASK_SOURCE`.
-- `serve(cast_data_to_type)`: This function starts a task worker subscribed to newly `delay()`ed task runs.
+- `serve(create_structured_output)`: This function starts a task worker subscribed to newly `delay()`ed task runs.
 
 
 
@@ -131,7 +122,7 @@ from fastapi import Depends, FastAPI, Response
 from fastapi.responses import JSONResponse
 
 from foo._internal import get_form_data, get_task_result, StructuredOutputRequest
-from foo.task import cast_data_to_type
+from foo.task import create_structured_output
 
 logger = logging.getLogger(__name__)
 
@@ -143,7 +134,7 @@ async def submit_task(
     form_data: StructuredOutputRequest = Depends(get_form_data),
 ) -> JSONResponse:
     """Submit a task to Prefect for background execution."""
-    future = cast_data_to_type.delay(
+    future = create_structured_output.delay(
         form_data.payload,
         target=form_data.target_type,
         instructions=form_data.instructions,

--- a/docs/v3/develop/deferred-tasks.mdx
+++ b/docs/v3/develop/deferred-tasks.mdx
@@ -3,101 +3,65 @@ title: Run tasks in the background
 description: See examples of using Prefect tasks and the task worker.
 ---
 
-Prefect tasks help you quickly execute small, discrete units of work. _Deferred_ Prefect tasks run in a 
-background process using a Prefect task worker. Use deferred tasks to move work out of the foreground of your 
+Prefect [tasks](/v3/develop/write-tasks)  help you quickly execute small, discrete units of work. Tasks have a `delay` method that allows you to defer execution to a task worker somewhere else (a long-lived process / container). Use background tasks to move work out of the foreground of your 
 application and distribute concurrent execution across multiple processes or machines.
 
-For example, if you have a web application, deferred tasks allow you to offload processes such as sending emails, processing 
-images, or inserting data into a database.
+For example, imagine a web application that needs to trigger a task that will run longer than a desirable request-response cycle. You can defer tasks from your endpoint to independent, horizontally scalable task workers on separate infrastructure.
 
-## Using deferred tasks
+## Defining and running background tasks
 
-Prefect tasks are Python functions that can be run immediately or deferred for background execution.
-
-Define a task by adding the `@task` decorator to a Python function, and use the `delay` method to 
-run the task in the background.
-
-If you schedule the task for background execution, you can run a task worker in a separate process or container to execute 
-the task. This process is similar to a Celery worker or an arq worker.
-
-### Defining a task
-
-Add the `@task` decorator to a Python function to define a Prefect task:
+- Define a task by adding the `@task` decorator to a Python function (like any other Prefect task)
+- Use the `.delay()` method to background a run of this task
+- Use the `.serve()` method or `serve()` function to start a task worker and execute any waiting task runs
 
 ```python
 from prefect import task
 
 @task
-def my_background_task(name: str):
-    # Task logic here
-    print(f"Hello, {name}!")
+def add(a: int, b: int):
+    return a + b
+
+add.delay(1, 2) # background one task run
+add.delay(42, 100) # background another task run
+
+
+add.serve() # start a task worker and execute any waiting task runs
 ```
 
-### Calling tasks
+<Tip>
+`.delay()` has the same signature as the `@task` decorated function.
+</Tip>
 
-You can call a task to run it immediately, or you can defer the task by scheduling it for background execution with 
-`Task.delay`.
 
-<Note>
-You can submit tasks to a _task runner_ such as Ray or Dask within 
-a workflow, which in Prefect is called a _flow_. However, this guide focuses on deferring task execution outside of 
-workflows. For example, by calling `my_task.delay()` within a web application.
-</Note>
-
-However you run a task, Prefect uses your task configuration to manage and control task execution.
-The following example shows both methods of calling a task and using `delay`:
+To listen for multiple different background tasks at once, you can use the `serve()` function with a list of tasks:
 
 ```python
-# Import the previously-defined task
-from myproject.tasks import my_background_task
-
-# Run the task immediately
-my_background_task("Joaquim")
-
-# Schedule the task for execution outside of this process
-my_background_task.delay("Agrajag")
-```
-
-### Executing deferred tasks with a task worker
-
-To run tasks in a separate process or container, start a task worker.
-
-The task worker continually receives instructions to execute deferred tasks from Prefect's API, executes them, and 
-reports the results back to the API.
-
-<Note>
-Task workers only run deferred tasks, not tasks you call directly as normal Python functions.
-</Note>
-
-Run a task worker by passing tasks into the `prefect.task_worker.serve()` method:
-
-```python tasks.py
 from prefect import task
 from prefect.task_worker import serve
 
+@task(log_prints=True)
+def add(a: int, b: int):
+    print(f"{a} + {b} = {a + b}")
 
-@task
-def my_background_task(name: str):
-    # Task logic here
-    print(f"Hello, {name}!")
+@task(log_prints=True)
+def multiply(a: int, b: int):
+    print(f"{a} * {b} = {a * b}")
 
+A = [1, 2, 3]
+B = [4, 5, 6]
 
-if __name__ == "__main__":
-    # NOTE: The serve() function accepts multiple tasks. The Task worker 
-    # will listen for scheduled task runs for all tasks passed in.
-    serve(my_background_task)
+add.map(A, B, deferred=True) # background 3 task runs - i.e. zip(A, B)
+multiply.map(A, B, deferred=True) # background 3 task runs - i.e. zip(A, B)
+
+serve(add, multiply) # start a task worker listening for both `add` and `multiply`
 ```
 
-The task worker begins listening for scheduled tasks. If tasks were scheduled before the task worker started, 
-it will begin processing them.
+<Tip>
+`.map()` accepts `(list[P.args], list[P.kwargs])` for each task, and `deferred=True` to run the tasks in the background (instead of the current context's task runner)
+</Tip>
 
-You can also use the helper CLI command `prefect task serve` to start a task worker:
 
-```bash
-prefect task serve my_task.py:my_background_task
-```
-
-## Guided exploration of deferred tasks and task workers in Prefect
+<Accordion title="Beginner walkthrough of the Prefect background task examples repository">
 
 Here are some examples of using deferred tasks and task workers in Prefect.
 
@@ -313,3 +277,8 @@ This guide showed you how to send tasks to multiple Prefect task workers running
 This allows you to observe these tasks executing in parallel and very quickly with web sockets, with no polling required.
 
 See additional examples in the [deferred tasks GitHub repository](https://github.com/PrefectHQ/prefect-background-task-examples.git).
+</Accordion>
+
+## Next steps
+
+- Explore a [complete example of a FastAPI application that backgrounds tasks](/v3/deploy/static-infrastructure-examples/background-tasks)

--- a/docs/v3/develop/deferred-tasks.mdx
+++ b/docs/v3/develop/deferred-tasks.mdx
@@ -1,39 +1,94 @@
 ---
 title: Run tasks in the background
-description: See examples of using Prefect tasks and the task worker.
+description: Learn to defer task runs to task workers running in a separate process.
 ---
 
-Prefect [tasks](/v3/develop/write-tasks)  help you quickly execute small, discrete units of work. Tasks have a `delay` method that allows you to defer execution to a task worker somewhere else (a long-lived process / container). Use background tasks to move work out of the foreground of your 
-application and distribute concurrent execution across multiple processes or machines.
+## Introduction
+Prefect [tasks](/v3/develop/write-tasks) are atomic pieces of work that you might want to cache or retry. Tasks have `.submit()` and  `.map()` methods to [simplify concurrent execution](/v3/develop/task-runners) of a task in a given workflow.
 
-For example, imagine a web application that needs to trigger a task that will run longer than a desirable request-response cycle. You can defer tasks from your endpoint to independent, horizontally scalable task workers on separate infrastructure.
+<Warning>
+If you need your task results available to the calling context, you probably want to use Prefect's [task runners](/v3/develop/task-runners) via `.submit()` or `.map()` instead.
+</Warning>
 
-## Defining and running background tasks
+Sometimes your parent workflow doesn't need to resolve a task's result, it just needs the task to produce some side effect or save a result. In this case, the caller doesn't need to waste time blocking on the task's completion - instead, it can "background" that task run _somewhere else_.
 
-- Define a task by adding the `@task` decorator to a Python function (like any other Prefect task)
-- Use the `.delay()` method to background a run of this task
-- Use the `.serve()` method or `serve()` function to start a task worker and execute any waiting task runs
+
+Background tasks are built for this use case. They allow you to defer a task's execution to a [task worker](#task-workers) running in a separate process.
+
+<Note>
+Prefect background tasks can be used in place of tools like [Celery](https://docs.celeryq.dev/en/stable/getting-started/introduction.html) and [RabbitMQ](https://www.rabbitmq.com/).
+</Note>
+
+
+### Motivating example
+Background tasks are useful for dispatching heavy and/or blocking work from your application or workflow to task workers on static infrastructure that you can scale or manage independently.
+
+For example, imagine a web application that needs to trigger an agentic `while` loop for each request, which we encapsulate as a `@task`-decorated function named `run_agent_loop`. The task will likely run longer than an acceptable request-response cycle. You can `delay()` the expensive task from your endpoint to any task workers subscribed to `run_agent_loop`'s runs.
+
+
+### Define a background task
+Define a task by adding the `@task` decorator to a Python function (like any other Prefect task)
 
 ```python
 from prefect import task
 
-@task
+@task(log_prints=True)
 def add(a: int, b: int):
-    return a + b
+    print(f"{a} + {b} = {a + b}")
+```
+
+All task configuration options (e.g. `log_prints`, `retries`, `result_storage`) are supported.
+
+### Background task methods
+- Use the `.delay()` method to background a run of this task
+- Use the `.serve()` method or `serve()` function to start a task worker and execute any waiting task runs
+
+```python
+add.delay(1, 2) # background one task run
+add.delay(42, 100) # background another task run
+
+add.serve() # start a task worker and execute any waiting task runs
+```
+
+The `.serve()` method starts a task worker subscribed to that specific task's runs.
+
+<Accordion title="Complete example with output">
+
+```python
+from prefect import task
+
+@task(log_prints=True)
+def add(a: int, b: int):
+    print(f"{a} + {b} = {a + b}")
 
 add.delay(1, 2) # background one task run
 add.delay(42, 100) # background another task run
 
-
 add.serve() # start a task worker and execute any waiting task runs
 ```
+
+```python
+22:56:01.765 | INFO    | prefect.tasks - Created task run 'add'.
+22:56:02.010 | INFO    | prefect.tasks - Created task run 'add'.
+22:56:02.167 | INFO    | prefect.task_worker - Starting task worker...
+22:56:02.167 | INFO    | prefect.task_worker - Subscribing to runs of task(s): add
+22:56:02.428 | INFO    | prefect.task_worker - Received task run: 71d4716c-5a28-4518-8376-bfd810a88093 - add
+22:56:02.435 | INFO    | prefect.task_worker - Submitting task run 'add' to engine.
+22:56:02.476 | INFO    | prefect.task_worker - Received task run: 225f054d-4fe7-4ed9-9ba1-9ba995b74d0e - add
+22:56:02.481 | INFO    | prefect.task_worker - Submitting task run 'add' to engine.
+22:57:34.673 | INFO    | Task run 'add' - 1 + 2 = 3
+22:57:34.681 | INFO    | Task run 'add' - Finished in state Completed()
+22:57:34.697 | INFO    | Task run 'add' - 42 + 100 = 142
+22:57:34.700 | INFO    | Task run 'add' - Finished in state Completed()
+```
+</Accordion>
 
 <Tip>
 `.delay()` has the same signature as the `@task` decorated function.
 </Tip>
 
 
-To listen for multiple different background tasks at once, you can use the `serve()` function with a list of tasks:
+Subscribe to many background tasks at once by providing the `serve()` utility more than one task:
 
 ```python
 from prefect import task
@@ -55,230 +110,282 @@ multiply.map(A, B, deferred=True) # background 3 task runs - i.e. zip(A, B)
 
 serve(add, multiply) # start a task worker listening for both `add` and `multiply`
 ```
+<Accordion title="Output">
+
+
+```python
+22:27:09.590 | INFO    | prefect.tasks - Created task run 'add'.
+22:27:09.868 | INFO    | prefect.tasks - Created task run 'add'.
+22:27:10.114 | INFO    | prefect.tasks - Created task run 'add'.
+22:27:10.384 | INFO    | prefect.tasks - Created task run 'multiply'. 
+22:27:10.611 | INFO    | prefect.tasks - Created task run 'multiply'. 
+22:27:10.855 | INFO    | prefect.tasks - Created task run 'multiply'.
+22:27:10.870 | INFO    | prefect.task_worker - Starting task worker...
+22:27:10.871 | INFO    | prefect.task_worker - Subscribing to runs of task(s): add | multiply
+22:27:11.117 | INFO    | prefect.task_worker - Received task run: 0f955090-89ce-402a-a7bd-057c5cecb0ae - add
+22:27:11.124 | INFO    | prefect.task_worker - Submitting task run 'add' to engine.
+22:27:11.197 | INFO    | Task run 'add' - 1 + 4 = 5                                                                                      22:27:11.203 | INFO    | Task run 'add' - Finished in state Completed()
+22:27:11.681 | INFO    | prefect.task_worker - Received task run: 8969b4d1-b662-452e-95e3-7536cb9f6a0d - multiply
+22:27:11.688 | INFO    | prefect.task_worker - Submitting task run 'multiply' to engine.
+22:27:11.724 | INFO    | prefect.task_worker - Received task run: 0bf25ec4-cdae-44bd-a2b6-1fa9cdd2ba4e - add
+22:27:11.727 | INFO    | prefect.task_worker - Submitting task run 'add' to engine.
+22:27:11.784 | INFO    | prefect.task_worker - Received task run: 0502dd78-6afd-4d75-8ce4-eb45a2d004a9 - multiply
+22:27:11.789 | INFO    | prefect.task_worker - Submitting task run 'multiply' to engine.
+22:27:11.792 | INFO    | Task run 'multiply' - 1 * 4 = 4
+22:27:11.802 | INFO    | Task run 'multiply' - Finished in state Completed()
+22:27:11.831 | INFO    | prefect.task_worker - Received task run: 53b866c4-0bb3-4941-af2e-ce95f7302595 - multiply
+22:27:11.836 | INFO    | Task run 'add' - 2 + 5 = 7
+22:27:11.838 | INFO    | prefect.task_worker - Submitting task run 'multiply' to engine.
+22:27:11.847 | INFO    | Task run 'add' - Finished in state Completed()
+22:27:11.880 | INFO    | prefect.task_worker - Received task run: 6afc2483-6a6e-40cf-895a-b82a37bddd5a - add
+22:27:11.885 | INFO    | prefect.task_worker - Submitting task run 'add' to engine.
+22:27:11.916 | INFO    | Task run 'multiply' - 2 * 5 = 10
+22:27:11.926 | INFO    | Task run 'multiply' - Finished in state Completed()
+22:27:11.963 | INFO    | Task run 'multiply' - 3 * 6 = 18
+22:27:11.970 | INFO    | Task run 'multiply' - Finished in state Completed()
+22:27:11.989 | INFO    | Task run 'add' - 3 + 6 = 9
+22:27:11.993 | INFO    | Task run 'add' - Finished in state Completed()
+```
+
+
+</Accordion>
 
 <Tip>
-`.map()` accepts `(list[P.args], list[P.kwargs])` for each task, and `deferred=True` to run the tasks in the background (instead of the current context's task runner)
+`.map()` accepts `Iterable[P.args]`, `Iterable[P.kwargs]` or `unmapped` inputs as well as the `deferred: bool` argument to control whether the tasks are run in the background (instead of the current context's task runner)
 </Tip>
 
 
-<Accordion title="Beginner walkthrough of the Prefect background task examples repository">
+### Task workers
+Task workers are push-based consumers that subscribe to some set of tasks' runs. They can subscribe to many tasks, and be safely scaled horizontally (e.g. `replicas: 4`).
 
-Here are some examples of using deferred tasks and task workers in Prefect.
+They generally do not need to be interacted with by Prefect users. Instead, they are started and stopped implicitly when you call `.serve()` or `serve()`.
 
-You will:
+## Tour of the Prefect background task examples repository
 
-- run a Prefect task in the foreground by calling it
-- start a task worker and defer tasks so that they run in the background
-- create a basic FastAPI application that defers tasks when you hit an endpoint
-- use Docker in two examples that mimic real use cases
+The [prefect-background-task-examples](https://github.com/PrefectHQ/prefect-background-task-examples) repository contains reference implementations of applications leveraging background tasks.
 
-One example uses a FastAPI server with multiple microservices and simulates a new user signup workflow.
-The other example uses a Flask server with [Marvin](https://www.askmarvin.ai/) to ask questions of an LLM from the CLI 
-and get back answers.
-
-### Set up
+Examples are generally Docker Compose setups that can be run locally with `docker compose up`. However, as shown above, you can decouple the task submission and execution however you like.
 
 <summary>Expand</summary>
 
-#### Step 1: Activate a virtual environment
-
-This example uses [conda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html), 
-but any virtual environment manager will work.
-
-```bash
-conda deactivate
-conda create -n python-tasks python=3.12
-conda activate python-tasks
-```
-
-#### Step 2: Install Python dependencies
-
-```bash
-pip install -U prefect marvin fastapi==0.107
-```
-
-#### Step 3: Connect to Prefect Cloud or a self-hosted Prefect server
-
-Use either Prefect Cloud or a self-hosted Prefect server for these examples.
-
-You must have `PREFECT_API_URL` set to send tasks to task workers.
-
-If you're using a Prefect server with a SQLite backing database (the default database), 
-save this value to your active Prefect Profile with the following command:
-
-```bash
-prefect config set PREFECT_API_URL=http://127.0.0.1:4200/api
-```
-
-If using Prefect Cloud, set the `PREFECT_API_URL` value to the Prefect Cloud API URL and add your 
-[API key](https://docs.prefect.io/cloud/users/api-keys/).
-
-The examples that use docker (examples 4 and 5) use a Prefect server by default.
-You can switch to Prefect Cloud by changing the `PREFECT_API_URL` and adding a variable for your API key in the 
-`docker-compose.yaml`.
-Or use a Prefect server backed by a PostgreSQL database by setting the `PREFECT_API_DATABASE_CONNECTION_URL`.
-
-If using Prefect server instead of Prefect Cloud, start your server by running the following command:
-
-```bash
-prefect server start 
-```
-
-#### Step 4: Clone the repository (optional)
-
-Clone the repository to get the code files for the examples:
+### Step 0: Clone the repository
 
 ```bash
 git clone https://github.com/PrefectHQ/prefect-background-task-examples.git
-```
-
-Move into the directory:
-
-```bash
 cd prefect-background-task-examples
 ```
 
-### Example 1: Run a Prefect task in the foreground by calling it
+### Step 1: Setup python environment
 
-<summary>Expand</summary>
-
-Add the `@task` decorator to any Python function to define a Prefect task.
-
-#### Step 1: Create a file with a task-decorated function 
-
-Create a file and save the following code in it, or run the existing file in the 
-basic-examples directory.
-
-```python greeter.py
-from prefect import task 
-
-@task(log_prints=True)
-def greet(name: str = "Marvin"):
-    print(f"Hello, {name}!")
-
-if __name__ == "__main__":
-    greet()
-```
-
-#### Step 2: Run the script in the terminal
+This example uses [uv](https://docs.astral.sh/uv/), which is generally recommended for python dependency management.
 
 ```bash
-python greeter.py
+uv venv
 ```
 
-You should see the task run in the terminal. This task runs in the foreground, meaning it is not deferred.
+<CodeGroup>
 
-#### Optional
-
-You can see the task run in the UI.
-If you're using a self-hosted Prefect server instance, you can also see the task runs in the database.
-
-If you want to inspect the SQLite database, use your favorite interface.
-*DB Browser for SQLite* is explained below.
-
-Download it [here](https://sqlitebrowser.org/dl/), if needed. Install it and open it.
-
-Click *Connect*. Then navigate to your SQLite DB file. It's located in `~/.prefect` directory by default.
-
-Go to the `task_run` table to see all your task runs there.
-Scroll down to see your most recent task runs or filter for them.
-
-Hit the refresh button for updates, if needed.
-
-### Example 2: Start a task worker and run deferred tasks in the background
-
-To run tasks in a separate process or container, start a task worker, similar to how you would run a 
-Celery worker or an arq worker.
-The task worker continually receives scheduled tasks to execute from Prefect's API, executes them, and reports the 
-results back to the API.
-Run a task worker by passing tasks into the `prefect.task_worker.serve()` method.
-
-#### Step 1: Define the task and task worker in a file 
-
-```python task_worker.py
-from prefect import task
-from prefect.task_worker import serve
-
-
-@task
-def my_background_task(name: str):
-    print(f"Hello, {name}!")
-
-
-if __name__ == "__main__":
-    serve(my_background_task)
+```bash unix
+source .venv/bin/activate
 ```
 
-#### Step 2: Start the task worker by running the script in the terminal
+```bash windows
+.\.venv\Scripts\activate
+```
+
+</CodeGroup>
 
 ```bash
-python task_worker.py
+uv pip install -U prefect
 ```
 
-The task worker is waiting for runs of the `my_background_task` task.
+### Step 2: Connect to Prefect Cloud or a self-hosted Prefect server
 
-#### Step 3: Create a file and save the following code in it:
+Use either Prefect Cloud or a self-hosted Prefect server for these examples.
 
-{/* pmd-metadata: notest */}
-```python task_scheduler.py
-from task_worker import my_background_task
+You must have `PREFECT_API_URL` set to a Prefect server or Prefect Cloud API URL.
 
+<CodeGroup>
 
-if __name__ == "__main__":
-    my_background_task.delay("Agrajag")
+```bash oss server
+prefect config set PREFECT_API_URL=http://127.0.0.1:4200/api
 ```
 
-#### Step 4: Open another terminal and run the script
+```bash cloud
+prefect config set PREFECT_API_URL=https://api.prefect.cloud/api/accounts/{account_id}/workspaces/{workspace_id}
+```
+
+</CodeGroup>
+
+If using Prefect Cloud, [make sure your `PREFECT_API_URL` and `PREFECT_API_KEY` are set](https://docs.prefect.io/v3/manage/cloud/connect-to-cloud).
+
+Otherwise, start a Prefect server by running one of the following commands:
+```bash
+# blocks the current terminal session
+prefect server start
+
+# run in a detached container
+docker run -d -p 4200:4200 --name prefect-server prefecthq/prefect:3-latest prefect server start --host 0.0.0.0
+```
+
+### Step 3: Run the minimal local example
+In `minimal-local-setup` you'll find a minimal `fastapi` application using background tasks.
 
 ```bash
-python task_scheduler.py
+cd minimal-local-setup
 ```
 
-The code returns a "future" from the `delay` method. You can use this object to wait for the task to complete with 
-`wait()` and to retrieve its result with `result()`.
-You can also see the task run's UUID and other information about the task run.
+```
+├── README.md
+├── api.py
+├── requirements.txt
+├── tasks.py
+└── test
+```
 
-#### Step 5: See the task run in the UI
-
-Use the task run UUID to see the task run in the UI.
-The URL will look like this:
-
-`http://127.0.0.1:4200/task-runs/task-run/my_task_run_uuid_goes_here`
-
-Substitute your UUID at the end of the URL.
-
-#### Step 6: Use multiple task workers to run tasks in parallel
-
-Start another instance of the task worker. In another terminal run:
+There's a `test` script that starts an ephemeral web server and task worker, then sends a demo request and cleans up.
 
 ```bash
-python task_worker.py
+cat test
 ```
 
-#### Step 7: Send multiple tasks to the task worker
-
-Modify the `task_scheduler.py` file to send multiple tasks to the task worker with different inputs:
-
-{/* pmd-metadata: notest */}
-```python
-from task_worker import my_background_task
-
-if __name__ == "__main__":
-    my_background_task.delay("Ford")
-    my_background_task.delay("Prefect")
-    my_background_task.delay("Slartibartfast")
+If you're comfortable, permit and run the script.
+```bash
+chmod +x test
+./test
 ```
 
-Run the file to see the work get distributed across both task workers.
+<Accordion title="Output">
+```
+» ./test
+[+] Starting API server (background)... Logging to /tmp/api.log
+[+] Starting task worker (background)... Logging to /tmp/tasks.log
+[+] Submitting job via curl...
+    {"message":"submitted task run UUID('3d10165f-a15d-4440-abdb-75872ced6407')"}
+[*] Letting processes run for 3 seconds...
 
-#### Step 8: Shut down the task workers with *control* + *c*
+[!] Times up! Stopping processes...
 
-This guide showed you how to send tasks to multiple Prefect task workers running in the background.
-This allows you to observe these tasks executing in parallel and very quickly with web sockets, with no polling required.
+[>] Final API server log contents (/tmp/api.log):
+    23:58:22.224 | INFO    | prefect.tasks - Created task run 'some_work'. View it in the UI at 'http://127.0.0.1:4200/runs/task-run/3d10165f-a15d-4440-abdb-75872ced6407'
 
-See additional examples in the [deferred tasks GitHub repository](https://github.com/PrefectHQ/prefect-background-task-examples.git).
+[>] Final task worker log contents (/tmp/tasks.log):
+    23:58:21.152 | INFO    | prefect.task_worker - Starting task worker...
+    23:58:21.153 | INFO    | prefect.task_worker - Subscribing to runs of task(s): some_work
+    23:58:22.278 | INFO    | prefect.task_worker - Received task run: 3d10165f-a15d-4440-abdb-75872ced6407 - some_work
+    23:58:22.281 | INFO    | prefect.task_worker - Submitting task run 'some_work' to engine. View in the UI: http://127.0.0.1:4200/runs/task-run/3d10165f-a15d-4440-abdb-75872ced6407
+    23:58:22.314 | WARNING | prefect.client - Your Prefect server is running an older version of Prefect than your client which may result in unexpected behavior. Please upgrade your Prefect server from version 3.2.12 to version 3.3.4.dev1+9.g1cfffaaff or higher.
+    23:58:22.318 | INFO    | Task run 'some_work' - doing some work with some_input='dude i found the best cat meme'
+    23:58:22.323 | INFO    | Task run 'some_work' - Finished in state Completed()
+
+[*] Cleaning up background processes...
+[*] Cleanup complete.
+```
 </Accordion>
+
+Otherwise feel free to run the commands at your own pace in separate terminals.
+
+```bash
+# start the web server
+uv run --with-requirements requirements.txt uvicorn api:app --reload
+```
+
+```bash
+# start the task worker
+uv run --with-requirements requirements.txt tasks.py
+```
+
+<Warning>
+If you're already running a Prefect server, kill it for the following steps.
+
+For example, to kill the `prefect-server` container started in [Step 2](#step-2%3A-connect-to-prefect-cloud-or-a-self-hosted-prefect-server), run:
+```bash
+docker kill prefect-server
+```
+</Warning>
+
+### Step 4: Run the minimal docker compose example
+
+In `minimal-docker-compose` you'll find a minimal `fastapi` application defined in `main.py` with a `/POST /job` endpoint that calls `process_job.delay(**job_request)`.
+
+```bash
+cd minimal-docker-compose
+```
+
+```
+├── README.md
+├── _types.py
+├── compose.yaml
+├── main.py
+├── pyproject.toml
+└── tasks.py
+```
+
+Start the Docker Compose stack in detached mode:
+
+```bash
+docker compose up -d
+```
+
+
+Navigate to [http://localhost:8000/docs](http://localhost:8000/docs) and try out the `/POST /job` endpoint.
+
+Watch the logs:
+
+```bash
+docker compose logs -f
+```
+
+<Accordion title="Output">
+```
+prefect-db-1      |
+prefect-db-1      | PostgreSQL Database directory appears to contain a database; Skipping initialization
+prefect-db-1      |
+prefect-db-1      | 2025-04-09 05:26:17.416 UTC [1] LOG:  starting PostgreSQL 15.12 (Debian 15.12-1.pgdg120+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
+prefect-db-1      | 2025-04-09 05:26:17.416 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
+prefect-db-1      | 2025-04-09 05:26:17.416 UTC [1] LOG:  listening on IPv6 address "::", port 5432
+prefect-db-1      | 2025-04-09 05:26:17.418 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
+prefect-db-1      | 2025-04-09 05:26:17.421 UTC [30] LOG:  database system was shut down at 2025-04-09 05:26:14 UTC
+prefect-db-1      | 2025-04-09 05:26:17.424 UTC [1] LOG:  database system is ready to accept connections
+tasks-1           | 05:26:18.701 | INFO    | prefect.task_worker - Starting task worker...
+tasks-1           | 05:26:18.702 | INFO    | prefect.task_worker - Subscribing to runs of task(s): process_job
+api-1             | INFO:     Started server process [12]
+api-1             | INFO:     Waiting for application startup.
+api-1             | INFO:     Application startup complete.
+api-1             | INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
+prefect-server-1  |
+prefect-server-1  |  ___ ___ ___ ___ ___ ___ _____
+prefect-server-1  | | _ \ _ \ __| __| __/ __|_   _|
+prefect-server-1  | |  _/   / _|| _|| _| (__  | |
+prefect-server-1  | |_| |_|_\___|_| |___\___| |_|
+prefect-server-1  |
+prefect-server-1  | Configure Prefect to communicate with the server with:
+prefect-server-1  |
+prefect-server-1  |     prefect config set PREFECT_API_URL=http://0.0.0.0:4200/api
+prefect-server-1  |
+prefect-server-1  | View the API reference documentation at http://0.0.0.0:4200/docs
+prefect-server-1  |
+prefect-server-1  | Check out the dashboard at http://0.0.0.0:4200
+prefect-server-1  |
+prefect-server-1  |
+prefect-server-1  |
+api-1             | INFO:     172.18.0.1:55884 - "GET /docs HTTP/1.1" 200 OK
+api-1             | INFO:     172.18.0.1:55884 - "GET /openapi.json HTTP/1.1" 200 OK
+api-1             | 05:26:32.640 | INFO    | prefect.tasks - Created task run 'process_job'. View it in the UI at 'http://prefect-server:4200/runs/task-run/a291db65-4e23-489e-9d3e-e7585b69745d'
+api-1             | INFO:     172.18.0.1:63032 - "POST /job HTTP/1.1" 200 OK
+tasks-1           | 05:26:32.656 | INFO    | prefect.task_worker - Received task run: a291db65-4e23-489e-9d3e-e7585b69745d - process_job tasks-1           | 05:26:32.677 | INFO    | prefect.task_worker - Submitting task run 'process_job' to engine. View in the UI: http://prefect-server:4200/runs/task-run/a291db65-4e23-489e-9d3e-e7585b69745d
+tasks-1           | 05:26:32.782 | INFO    | Task run 'process_job' - Finished in state Completed()
+```
+
+
+
+</Accordion>
+
+### Step 5: Explore the rest of the examples
+Check out the rest of the examples in the repository, like [`fastapi-user-signups`](https://github.com/PrefectHQ/prefect-background-task-examples/tree/main/fastapi-user-signups) and [`chaos-duck`](https://github.com/PrefectHQ/prefect-background-task-examples/tree/main/chaos-duck).
+
 
 ## Next steps
 
+- Learn about [Results](/v3/develop/results) to enable task [caching](/v3/develop/task-caching) and [idempotency](/v3/develop/transactions).
 - Explore a [complete example of a FastAPI application that backgrounds tasks](/v3/deploy/static-infrastructure-examples/background-tasks)


### PR DESCRIPTION
revamps concept doc for background tasks and adds a static infra example guide based on https://github.com/PrefectHQ/examples/pull/20, which I should merge first so that I can link it from here (instead of the PR)

note i am intentionally using `marvin` as a means of illustrating
- dealing with dependencies in similar setups
- dealing with injecting an application critical env var (`OPENAI_API_KEY`)
