### PR TITLE
allow configuring `RecentDeploymentScheduler` loop interval

### DIFF
--- a/docs/v3/api-ref/settings-ref.mdx
+++ b/docs/v3/api-ref/settings-ref.mdx
@@ -1939,6 +1939,20 @@ Whether or not to start the scheduler service in the server application.
 **Supported environment variables**:
 `PREFECT_SERVER_SERVICES_SCHEDULER_INSERT_BATCH_SIZE`, `PREFECT_API_SERVICES_SCHEDULER_INSERT_BATCH_SIZE`
 
+### `recent_deployments_loop_seconds`
+
+        The number of seconds the recent deployments scheduler will wait between checking for recently updated deployments. Defaults to `5`.
+        
+
+**Type**: `number`
+
+**Default**: `5`
+
+**TOML dotted key path**: `server.services.scheduler.recent_deployments_loop_seconds`
+
+**Supported environment variables**:
+`PREFECT_SERVER_SERVICES_SCHEDULER_RECENT_DEPLOYMENTS_LOOP_SECONDS`
+
 ---
 ## ServerServicesSettings
 Settings for controlling server services

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -1715,6 +1715,15 @@
                     ],
                     "title": "Insert Batch Size",
                     "type": "integer"
+                },
+                "recent_deployments_loop_seconds": {
+                    "default": 5,
+                    "description": "\n        The number of seconds the recent deployments scheduler will wait between checking for recently updated deployments. Defaults to `5`.\n        ",
+                    "supported_environment_variables": [
+                        "PREFECT_SERVER_SERVICES_SCHEDULER_RECENT_DEPLOYMENTS_LOOP_SECONDS"
+                    ],
+                    "title": "Recent Deployments Loop Seconds",
+                    "type": "number"
                 }
             },
             "title": "ServerServicesSchedulerSettings",

--- a/src/prefect/server/services/scheduler.py
+++ b/src/prefect/server/services/scheduler.py
@@ -316,11 +316,20 @@ class RecentDeploymentsScheduler(Scheduler):
     """
 
     # this scheduler runs on a tight loop
-    loop_seconds: float = 5
+    loop_seconds: float
 
     @classmethod
     def service_settings(cls) -> ServicesBaseSetting:
         return get_current_settings().server.services.scheduler
+
+    def __init__(self, loop_seconds: float | None = None, **kwargs: Any):
+        super().__init__(
+            loop_seconds=(
+                loop_seconds
+                or get_current_settings().server.services.scheduler.recent_deployments_loop_seconds
+            ),
+            **kwargs,
+        )
 
     @db_injector
     def _get_select_deployments_to_schedule_query(

--- a/src/prefect/settings/models/server/services.py
+++ b/src/prefect/settings/models/server/services.py
@@ -385,6 +385,13 @@ class ServerServicesSchedulerSettings(ServicesBaseSetting):
         ),
     )
 
+    recent_deployments_loop_seconds: float = Field(
+        default=5,
+        description="""
+        The number of seconds the recent deployments scheduler will wait between checking for recently updated deployments. Defaults to `5`.
+        """,
+    )
+
 
 class ServerServicesPauseExpirationsSettings(ServicesBaseSetting):
     """

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -401,6 +401,9 @@ SUPPORTED_SETTINGS = {
     "PREFECT_SERVER_SERVICES_SCHEDULER_MAX_SCHEDULED_TIME": {
         "test_value": timedelta(hours=10)
     },
+    "PREFECT_SERVER_SERVICES_SCHEDULER_RECENT_DEPLOYMENTS_LOOP_SECONDS": {
+        "test_value": 5.0
+    },
     "PREFECT_SERVER_SERVICES_SCHEDULER_MIN_RUNS": {"test_value": 10},
     "PREFECT_SERVER_SERVICES_SCHEDULER_MIN_SCHEDULED_TIME": {
         "test_value": timedelta(minutes=10)


### PR DESCRIPTION
closes #17696 

Here we add a specific setting for `RecentDeploymentsScheduler`'s loop interval while recognizing that both this and the PREFECT_LOGGING_* settings that don't necessarily need to be defined on the settings object, and rather can be derived from existing loop services and the `logging.yml` file respectively.

so we could potentially refactor (many) existing explicit loop service interval settings to be dynamic while remaining first class settings