### PR TITLE
Avoid clobbering dev venv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,10 +36,10 @@ repos:
 
   - repo: local
     hooks:
-      - id: generate-mintlify-openapi-docs
-        name: Generating OpenAPI docs for Mintlify
+      - id: run-all-generators
+        name: Running All Generators
         language: system
-        entry: uv run -p 3.9 --with 'pydantic>=2.9.0' ./scripts/generate_mintlify_openapi_docs.py
+        entry: uv run --isolated -p 3.9 --with 'pydantic>=2.9.0' ./scripts/run_precommit_generation_scripts.py
         pass_filenames: false
         files: |
           (?x)^(
@@ -47,29 +47,11 @@ repos:
               src/prefect/server/api/.*|
               src/prefect/server/schemas/.*|
               src/prefect/server/events/.*|
-              scripts/generate_mintlify_openapi_docs.py
-          )$
-      - id: generate-settings-schema
-        name: Generating Settings Schema
-        language: system
-        entry: uv run -p 3.9 --with 'pydantic>=2.9.0' ./scripts/generate_settings_schema.py
-        pass_filenames: false
-        files: |
-          (?x)^(
-              .pre-commit-config.yaml|
               src/prefect/settings/models/.*|
-              scripts/generate_settings_schema.py
-          )$
-      - id: generate-settings-ref
-        name: Generating Settings Reference
-        language: system
-        entry: uv run -p 3.9 --with 'pydantic>=2.9.0' ./scripts/generate_settings_ref.py
-        pass_filenames: false
-        files: |
-          (?x)^(
-              .pre-commit-config.yaml|
-              src/prefect/settings/models/.*|
-              scripts/generate_settings_ref.py
+              scripts/generate_mintlify_openapi_docs.py|
+              scripts/generate_settings_schema.py|
+              scripts/generate_settings_ref.py|
+              scripts/run_all_generators.py
           )$
       - id: check-ui-v2
         name: Check UI v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,8 +36,8 @@ repos:
 
   - repo: local
     hooks:
-      - id: run-all-generators
-        name: Running All Generators
+      - id: auto-generate-documentation
+        name: Auto-generating Documentation
         language: system
         entry: uv run --isolated -p 3.9 --with 'pydantic>=2.9.0' ./scripts/run_precommit_generation_scripts.py
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
               scripts/generate_mintlify_openapi_docs.py|
               scripts/generate_settings_schema.py|
               scripts/generate_settings_ref.py|
-              scripts/run_all_generators.py
+              scripts/run_precommit_generation_scripts.py
           )$
       - id: check-ui-v2
         name: Check UI v2

--- a/scripts/run_precommit_generation_scripts.py
+++ b/scripts/run_precommit_generation_scripts.py
@@ -1,0 +1,62 @@
+"""
+Script to run all "generation" scripts that require a python environment in sequence using
+the same environment. This avoids multiple virtual environment creations in pre-commit hooks.
+"""
+
+import importlib.util
+import sys
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+from types import ModuleType
+
+
+def import_script(script_path: Path) -> ModuleType:
+    """Import a Python file as a module."""
+    spec = importlib.util.spec_from_file_location("module.name", str(script_path))
+    if spec is None:
+        raise ImportError(f"Could not load spec for {script_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    if spec.loader is None:
+        raise ImportError(f"Could not load module for {script_path}")
+
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_generator(script_name: str) -> None:
+    print(f"Running {script_name}...")
+
+    script_path = Path(__file__).parent / script_name
+
+    original_argv = sys.argv.copy()
+
+    try:
+        sys.argv = [str(script_path)]
+
+        module = import_script(script_path)
+
+        if hasattr(module, "main"):
+            module.main()
+    finally:
+        sys.argv = original_argv
+
+    print(f"Completed {script_name}")
+
+
+def main() -> None:
+    with ProcessPoolExecutor() as executor:
+        executor.map(
+            run_generator,
+            [
+                "generate_mintlify_openapi_docs.py",
+                "generate_settings_schema.py",
+                "generate_settings_ref.py",
+            ],
+        )
+
+    print("All generators completed successfully!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_precommit_generation_scripts.py
+++ b/scripts/run_precommit_generation_scripts.py
@@ -4,7 +4,6 @@ the same environment. This avoids multiple virtual environment creations in pre-
 """
 
 import importlib.util
-import sys
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 from types import ModuleType
@@ -29,17 +28,11 @@ def run_generator(script_name: str) -> None:
 
     script_path = Path(__file__).parent / script_name
 
-    original_argv = sys.argv.copy()
+    module = import_script(script_path)
 
-    try:
-        sys.argv = [str(script_path)]
-
-        module = import_script(script_path)
-
-        if hasattr(module, "main"):
-            module.main()
-    finally:
-        sys.argv = original_argv
+    if not hasattr(module, "main"):
+        raise AttributeError(f"Script {script_name} does not have a main function")
+    module.main()
 
     print(f"Completed {script_name}")
 


### PR DESCRIPTION
the pre-commit was using `uv run -p 3.9 ...` for 3 consecutive pre-commit hooks, which would

- use the invoking user's venv iff it was a 3.9 venv
- otherwise destroy the existing venv and create a new 3.9 one

so if you had a 3.13 venv and then ran pre-commits, after running them you have 3.9

the solution here is `--isolated`, but doing that 3 times consecutively is annoyingly slow, so this PR consolidates the scripts (that use the same deps) into the same hook and makes sure it doesnt interact with the user's venv