### PR TITLE
chore: tool.versioningit.default-version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,9 @@ benchmark = ["pytest-benchmark>=5.1.0", "pytest-codspeed>=2.2.1"]
 [tool.hatch.version]
 source = "versioningit"
 
+[tool.versioningit]
+default-version = "0.0.0"
+
 [tool.versioningit.vcs]
 match = ["[0-9]*.[0-9]*.[0-9]*", "[0-9]*.[0-9]*.[0-9]*.dev[0-9]*"]
 default-tag = "0.0.0"


### PR DESCRIPTION
Some deployment platforms like Railway won't copy `.git` folder within build context, hence it is impossible for `versioningit` to determine a version without first fetching the repo's tags

```
RuntimeError: Error getting the version from source `versioningit`: NotSdistError: /opt/prefect does not contain a PKG-INFO file

versioningit could not find a version for the project in /opt/prefect!

You may be installing from a shallow clone, in which case you need to unshallow it first.

Alternatively, you may be installing from a Git archive, which is not supported by default.  Install from a git+https://... URL instead.
```


More context in this [Discord thread](https://discord.com/channels/713503345364697088/1359959718386339840/1359959718386339840)