### PR TITLE
docs: Nginx sample config + note about client API key/auth string precedence

### DIFF
--- a/docs/v3/develop/settings-and-profiles.mdx
+++ b/docs/v3/develop/settings-and-profiles.mdx
@@ -260,6 +260,10 @@ Self-hosted Prefect servers can be equipped with Basic Authentication through tw
 
 With these settings, the UI will prompt for the full authentication string `"admin:pass"` (no quotes) upon first load. It is recommended to store this information in a secure way, such as a Kubernetes Secret or in a private `.env` file.
 
+If both Prefect API key and Prefect API authentication string are set on the client, Prefect API key will be used. If you plan to use a
+self-hosted Prefect server, you may want to make sure a Prefect API key is not set in your Prefect profile or as
+an environment variable, otherwise authentication will fail (`HTTP 401 Unauthorized`).
+
 Example `.env` file:
 
 ```bash .env

--- a/docs/v3/develop/settings-and-profiles.mdx
+++ b/docs/v3/develop/settings-and-profiles.mdx
@@ -260,7 +260,7 @@ Self-hosted Prefect servers can be equipped with Basic Authentication through tw
 
 With these settings, the UI will prompt for the full authentication string `"admin:pass"` (no quotes) upon first load. It is recommended to store this information in a secure way, such as a Kubernetes Secret or in a private `.env` file.
 
-If both Prefect API key and Prefect API authentication string are set on the client, Prefect API key will be used. If you plan to use a
+If both `PREFECT_API_KEY` and `PREFECT_API_AUTH_STRING` are set on the client, `PREFECT_API_KEY` will take precedence. If you plan to use a
 self-hosted Prefect server, you may want to make sure a Prefect API key is not set in your Prefect profile or as
 an environment variable, otherwise authentication will fail (`HTTP 401 Unauthorized`).
 

--- a/docs/v3/develop/settings-and-profiles.mdx
+++ b/docs/v3/develop/settings-and-profiles.mdx
@@ -261,7 +261,7 @@ Self-hosted Prefect servers can be equipped with Basic Authentication through tw
 With these settings, the UI will prompt for the full authentication string `"admin:pass"` (no quotes) upon first load. It is recommended to store this information in a secure way, such as a Kubernetes Secret or in a private `.env` file.
 
 If both `PREFECT_API_KEY` and `PREFECT_API_AUTH_STRING` are set on the client, `PREFECT_API_KEY` will take precedence. If you plan to use a
-self-hosted Prefect server, you may want to make sure a Prefect API key is not set in your Prefect profile or as
+self-hosted Prefect server, you may want to make sure `PREFECT_API_KEY` is not set in your active profile or as
 an environment variable, otherwise authentication will fail (`HTTP 401 Unauthorized`).
 
 Example `.env` file:

--- a/docs/v3/manage/server/index.mdx
+++ b/docs/v3/manage/server/index.mdx
@@ -208,7 +208,7 @@ Disabling certificate validation is insecure and only suggested as an option for
 
 ### Reverse proxy
 
-Here is an example of basic Nginx configuration if you want to host a Prefect server behind a reverse proxy:
+Here is an example of basic [Nginx](https://nginx.org/) configuration if you want to host a Prefect server behind a reverse proxy:
 
 ```nginx
 server {

--- a/docs/v3/manage/server/index.mdx
+++ b/docs/v3/manage/server/index.mdx
@@ -206,6 +206,51 @@ If the certificate is not part of your system bundle, set the
 Disabling certificate validation is insecure and only suggested as an option for testing.
 </Warning>
 
+### Reverse proxy
+
+Here is an example of basic Nginx configuration if you want to host a Prefect server behind a reverse proxy:
+
+```nginx
+server {
+    listen 80;
+    listen [::]:80;
+    server_name prefect.example.com; # the domain name you set up to access your Prefect server from outside
+    location / {
+        return 301 https://$host$request_uri; # HTTP requests are forwarded to HTTPS
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name prefect.example.com; # the domain name you set up to access your Prefect server from outside
+
+    ssl_certificate /path/to/ssl/certificate.pem;
+    ssl_certificate_key /path/to/ssl/certificate_key.pem;
+
+    location /api { # API routes
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Real-IP $remote_addr;
+
+    proxy_set_header Upgrade $http_upgrade; # for websocket communication with prefect client
+    proxy_set_header Connection "upgrade"; # for websocket communication with prefect client
+
+    proxy_set_header Authorization $http_authorization; # for basic authentication
+    proxy_pass_header Authorization; # for basic authentication
+
+    proxy_pass  http://127.0.0.1:4200; # port is 4200 or value of Prefect server API port setting
+    }
+
+    location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_pass http://127.0.0.1:4200;  # port is 4200 or value of Prefect server API port setting
+    }
+}
+```
+
 ### Proxies
 
 Prefect supports communicating with proxies through environment variables.

--- a/docs/v3/manage/server/index.mdx
+++ b/docs/v3/manage/server/index.mdx
@@ -229,17 +229,19 @@ server {
     ssl_certificate_key /path/to/ssl/certificate_key.pem;
 
     location /api { # API routes
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
 
-    proxy_set_header Upgrade $http_upgrade; # for websocket communication with prefect client
-    proxy_set_header Connection "upgrade"; # for websocket communication with prefect client
+        # for websocket communication with prefect client
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
 
-    proxy_set_header Authorization $http_authorization; # for basic authentication
-    proxy_pass_header Authorization; # for basic authentication
+        # for basic authentication
+        proxy_set_header Authorization $http_authorization;
+        proxy_pass_header Authorization;
 
-    proxy_pass  http://127.0.0.1:4200; # port is 4200 or value of Prefect server API port setting
+        proxy_pass  http://127.0.0.1:4200; # port is 4200 or value of Prefect server API port setting
     }
 
     location / {


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

This PR adds

- a sample **tested** nginx configuration to self-host a Prefect server (see the [journey](https://github.com/ColinMaudry/prefect_ynh/issues/2) here)
- a note about how the Prefect API key setting takes precedence over the Prefect client authentication string when the Prefect client sets up the connection with the API

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - It's a small fix
