### PR TITLE
Add experimental bundle steps for Azure Blob Storage

### DIFF
--- a/src/integrations/prefect-azure/prefect_azure/credentials.py
+++ b/src/integrations/prefect-azure/prefect_azure/credentials.py
@@ -174,7 +174,7 @@ class AzureBlobStorageCredentials(Block):
         )
 
     @_raise_help_msg("blob_storage")
-    def get_blob_client(self, container, blob) -> "BlobClient":
+    def get_blob_client(self, container: str, blob: str) -> "BlobClient":
         """
         Returns an authenticated Blob client that can be used to
         download and upload blobs.
@@ -221,7 +221,7 @@ class AzureBlobStorageCredentials(Block):
         return blob_client
 
     @_raise_help_msg("blob_storage")
-    def get_container_client(self, container) -> "ContainerClient":
+    def get_container_client(self, container: str) -> "ContainerClient":
         """
         Returns an authenticated Container client that can be used to create clients
         for Azure services.

--- a/src/integrations/prefect-azure/prefect_azure/experimental/bundles/__init__.py
+++ b/src/integrations/prefect-azure/prefect_azure/experimental/bundles/__init__.py
@@ -1,0 +1,7 @@
+from .upload import upload_bundle_to_azure_blob_storage
+from .execute import execute_bundle_from_azure_blob_storage
+
+__all__ = [
+    "upload_bundle_to_azure_blob_storage",
+    "execute_bundle_from_azure_blob_storage",
+]

--- a/src/integrations/prefect-azure/prefect_azure/experimental/bundles/execute.py
+++ b/src/integrations/prefect-azure/prefect_azure/experimental/bundles/execute.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import cast
+
+import typer
+from pydantic_core import from_json
+
+import prefect.runner
+import prefect_azure.credentials
+
+logger = logging.getLogger("prefect_azure.experimental.bundles.execute")
+
+
+async def execute_bundle_from_azure_blob_storage(
+    container: str,
+    key: str,
+    azure_blob_storage_credentials_block_name: str,
+):
+    if azure_blob_storage_credentials_block_name:
+        logger.debug(
+            "Loading Azure credentials from block %s",
+            azure_blob_storage_credentials_block_name,
+        )
+        abs_credentials = cast(
+            prefect_azure.credentials.AzureBlobStorageCredentials,
+            await prefect_azure.credentials.AzureBlobStorageCredentials.load(
+                azure_blob_storage_credentials_block_name,
+                _sync=False,  # pyright: ignore[reportCallIssue] _sync is needed to prevent incidental async
+            ),
+        )
+    else:
+        logger.debug("Loading default Azure credentials")
+        abs_credentials = prefect_azure.credentials.AzureBlobStorageCredentials()
+
+    blob_client = abs_credentials.get_blob_client(container=container, blob=key)
+
+    try:
+        logger.debug(
+            "Downloading bundle from Azure Blob Storage container %s with key %s",
+            container,
+            key,
+        )
+        blob_obj = await blob_client.download_blob()
+        bundle = from_json(await blob_obj.content_as_bytes())
+
+        logger.debug("Executing bundle")
+        await prefect.runner.Runner().execute_bundle(bundle)
+    except Exception as e:
+        raise RuntimeError(f"Failed to download bundle from Azure Blob Storage: {e}")
+
+
+def _cli_wrapper(
+    container: str = typer.Option(
+        ...,
+        help="The name of the Azure Blob Storage container to download the bundle from.",
+    ),
+    key: str = typer.Option(
+        ...,
+        help="The key (path) to download the bundle from in the Azure Blob Storage container.",
+    ),
+    azure_blob_storage_credentials_block_name: str = typer.Option(
+        ...,
+        help="The name of the Azure Blob Storage credentials block to use for authentication. If not provided, the default credentials will be used.",
+    ),
+) -> None:
+    return asyncio.run(
+        execute_bundle_from_azure_blob_storage(
+            container, key, azure_blob_storage_credentials_block_name
+        )
+    )
+
+
+if __name__ == "__main__":
+    typer.run(_cli_wrapper)

--- a/src/integrations/prefect-azure/prefect_azure/experimental/bundles/upload.py
+++ b/src/integrations/prefect-azure/prefect_azure/experimental/bundles/upload.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import TypedDict, cast
+
+import typer
+
+import prefect_azure.credentials
+
+logger = logging.getLogger("prefect_azure.experimental.bundles.upload")
+
+
+class UploadBundleToAzureBlobStorageOutput(TypedDict):
+    container: str
+    key: str
+
+
+async def upload_bundle_to_azure_blob_storage(
+    local_filepath: Path,
+    container: str,
+    key: str,
+    azure_blob_storage_credentials_block_name: str,
+) -> UploadBundleToAzureBlobStorageOutput:
+    if not local_filepath.exists():
+        raise ValueError(f"Bundle file not found: {local_filepath}")
+
+    key = key or local_filepath.name
+
+    if azure_blob_storage_credentials_block_name:
+        logger.debug(
+            "Loading Azure credentials from block %s",
+            azure_blob_storage_credentials_block_name,
+        )
+        abs_credentials = cast(
+            prefect_azure.credentials.AzureBlobStorageCredentials,
+            await prefect_azure.credentials.AzureBlobStorageCredentials.load(
+                azure_blob_storage_credentials_block_name,
+                _sync=False,  # pyright: ignore[reportCallIssue] _sync is needed to prevent incidental async
+            ),
+        )
+    else:
+        logger.debug("Loading default Azure credentials")
+        abs_credentials = prefect_azure.credentials.AzureBlobStorageCredentials()
+
+    container_client = abs_credentials.get_container_client(container=container)
+
+    try:
+        logger.debug(
+            "Uploading bundle from path %s to Azure Blob Storage container %s with key %s",
+            local_filepath,
+            container,
+            key,
+        )
+        with open(local_filepath, "rb") as f:
+            await container_client.upload_blob(key, f)  # pyright: ignore[reportUnknownMemberType] Incomplete type hints
+    except Exception as e:
+        raise RuntimeError(f"Failed to upload bundle to Azure Blob Storage: {e}")
+
+    return {"container": container, "key": key}
+
+
+def _cli_wrapper(
+    local_filepath: Path = typer.Argument(
+        ..., help="The path to the bundle file to upload."
+    ),
+    container: str = typer.Option(
+        ...,
+        help="The name of the Azure Blob Storage container to upload the bundle to.",
+    ),
+    key: str = typer.Option(
+        ...,
+        help="The key (path) to upload the bundle to in the Azure Blob Storage container.",
+    ),
+    azure_blob_storage_credentials_block_name: str = typer.Option(
+        ...,
+        help="The name of the Azure Blob Storage credentials block to use for authentication. If not provided, the default credentials will be used.",
+    ),
+) -> UploadBundleToAzureBlobStorageOutput:
+    """
+    Uploads a bundle file to an Azure Blob Storage container.
+    """
+    return asyncio.run(
+        upload_bundle_to_azure_blob_storage(
+            local_filepath, container, key, azure_blob_storage_credentials_block_name
+        )
+    )
+
+
+if __name__ == "__main__":
+    typer.run(_cli_wrapper)

--- a/src/integrations/prefect-azure/tests/experimental/bundles/test_execute.py
+++ b/src/integrations/prefect-azure/tests/experimental/bundles/test_execute.py
@@ -1,0 +1,133 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from azure.core.exceptions import ResourceNotFoundError
+from prefect_azure.credentials import AzureBlobStorageCredentials
+from prefect_azure.experimental.bundles.execute import (
+    execute_bundle_from_azure_blob_storage,
+)
+from pytest import MonkeyPatch
+
+
+@pytest.fixture
+def mock_blob_storage_credentials(monkeypatch: MonkeyPatch) -> MagicMock:
+    """Mock the AzureBlobStorageCredentials class."""
+    mock_credentials = MagicMock(
+        spec=AzureBlobStorageCredentials, name="mock-azure-blob-storage-credentials"
+    )
+    monkeypatch.setattr(
+        "prefect_azure.credentials.AzureBlobStorageCredentials",
+        mock_credentials,
+    )
+    mock_credentials.load = AsyncMock(return_value=mock_credentials.return_value)
+
+    return mock_credentials
+
+
+@pytest.fixture
+def mock_runner(monkeypatch: MonkeyPatch) -> MagicMock:
+    """Mock the prefect.runner.Runner class."""
+    mock_runner_instance = AsyncMock()
+    mock_runner_class = MagicMock(return_value=mock_runner_instance)
+    monkeypatch.setattr("prefect.runner.Runner", mock_runner_class)
+    return mock_runner_instance
+
+
+class TestExecuteBundleFromAzureBlobStorage:
+    """Tests for the execute_bundle_from_azure_blob_storage function."""
+
+    async def test_execute_bundle_with_credentials_block(
+        self, mock_blob_storage_credentials: MagicMock, mock_runner: MagicMock
+    ) -> None:
+        """Test executing a bundle using a credentials block."""
+        container = "test-container"
+        key = "test-key"
+        credentials_block_name = "test-credentials"
+        mock_bundle = {"test": "bundle"}
+
+        # Mock the blob client's download_blob method
+        mock_blob_client = (
+            mock_blob_storage_credentials.return_value.get_blob_client.return_value
+        )
+        mock_blob_obj = AsyncMock()
+        mock_blob_obj.content_as_bytes = AsyncMock(return_value=b'{"test": "bundle"}')
+        mock_blob_client.download_blob = AsyncMock(return_value=mock_blob_obj)
+
+        # Call the function
+        await execute_bundle_from_azure_blob_storage(
+            container=container,
+            key=key,
+            azure_blob_storage_credentials_block_name=credentials_block_name,
+        )
+
+        # Verify the credentials were loaded from the block
+        mock_blob_storage_credentials.load.assert_called_once_with(
+            credentials_block_name,
+            _sync=False,
+        )
+
+        # Verify the blob client was created with the correct container and key
+        mock_blob_storage_credentials.return_value.get_blob_client.assert_called_once_with(
+            container=container, blob=key
+        )
+
+        # Verify the blob was downloaded
+        mock_blob_client.download_blob.assert_called_once()
+
+        # Verify the bundle was executed
+        mock_runner.execute_bundle.assert_called_once()
+        call_args = mock_runner.execute_bundle.call_args[0]
+        assert call_args[0] == mock_bundle
+
+    async def test_execute_bundle_with_download_error(
+        self, mock_blob_storage_credentials: MagicMock
+    ) -> None:
+        """Test executing a bundle when the download fails."""
+        container = "test-container"
+        key = "test-key"
+        credentials_block_name = "test-credentials"
+        # Mock the blob client's download_blob method to raise an exception
+        mock_blob_client = (
+            mock_blob_storage_credentials.return_value.get_blob_client.return_value
+        )
+        mock_blob_client.download_blob.side_effect = ResourceNotFoundError(
+            "The specified blob does not exist"
+        )
+
+        # Call the function and expect a RuntimeError
+        with pytest.raises(
+            RuntimeError, match="Failed to download bundle from Azure Blob Storage"
+        ):
+            await execute_bundle_from_azure_blob_storage(
+                container=container,
+                key=key,
+                azure_blob_storage_credentials_block_name=credentials_block_name,
+            )
+
+    async def test_execute_bundle_with_execution_error(
+        self, mock_blob_storage_credentials: MagicMock, mock_runner: MagicMock
+    ) -> None:
+        """Test executing a bundle when the execution fails."""
+        container = "test-container"
+        key = "test-key"
+        credentials_block_name = "test-credentials"
+        # Mock the blob client's download_blob method
+        mock_blob_client = (
+            mock_blob_storage_credentials.return_value.get_blob_client.return_value
+        )
+        mock_blob_obj = AsyncMock()
+        mock_blob_obj.content_as_bytes = AsyncMock(return_value=b'{"test": "bundle"}')
+        mock_blob_client.download_blob = AsyncMock(return_value=mock_blob_obj)
+
+        # Mock the runner's execute_bundle method to raise an exception
+        mock_runner.execute_bundle.side_effect = Exception("Failed to execute bundle")
+
+        # Call the function and expect a RuntimeError
+        with pytest.raises(
+            RuntimeError, match="Failed to download bundle from Azure Blob Storage"
+        ):
+            await execute_bundle_from_azure_blob_storage(
+                container=container,
+                key=key,
+                azure_blob_storage_credentials_block_name=credentials_block_name,
+            )

--- a/src/integrations/prefect-azure/tests/experimental/bundles/test_upload.py
+++ b/src/integrations/prefect-azure/tests/experimental/bundles/test_upload.py
@@ -1,0 +1,149 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from azure.core.exceptions import ResourceExistsError
+from prefect_azure.credentials import AzureBlobStorageCredentials
+from prefect_azure.experimental.bundles.upload import (
+    upload_bundle_to_azure_blob_storage,
+)
+from pytest import MonkeyPatch
+
+
+@pytest.fixture
+def tmp_bundle_file(tmp_path: Path) -> Path:
+    bundle_file = tmp_path / "test_bundle.zip"
+    bundle_file.write_bytes(b"test bundle content")
+    return bundle_file
+
+
+@pytest.fixture
+def mock_blob_storage_credentials(monkeypatch: MonkeyPatch) -> MagicMock:
+    """Mock the AzureBlobStorageCredentials class."""
+    mock_credentials = MagicMock(
+        spec=AzureBlobStorageCredentials, name="mock-azure-blob-storage-credentials"
+    )
+    monkeypatch.setattr(
+        "prefect_azure.credentials.AzureBlobStorageCredentials",
+        mock_credentials,
+    )
+    mock_credentials.load = AsyncMock(return_value=mock_credentials.return_value)
+
+    return mock_credentials
+
+
+class TestUploadBundleToAzureBlobStorage:
+    """Tests for the upload_bundle_to_azure_blob_storage function."""
+
+    async def test_upload_bundle_with_credentials_block(
+        self, tmp_bundle_file: Path, mock_blob_storage_credentials: MagicMock
+    ) -> None:
+        """Test uploading a bundle using a credentials block."""
+        container = "test-container"
+        key = "test-key"
+        credentials_block_name = "test-credentials"
+
+        # Mock the container client's upload_blob method
+        mock_container_client = (
+            mock_blob_storage_credentials.return_value.get_container_client.return_value
+        )
+        mock_container_client.upload_blob = AsyncMock()
+
+        # Call the function
+        result = await upload_bundle_to_azure_blob_storage(
+            local_filepath=tmp_bundle_file,
+            container=container,
+            key=key,
+            azure_blob_storage_credentials_block_name=credentials_block_name,
+        )
+
+        # Verify the result
+        assert result == {"container": container, "key": key}
+
+        # Verify the credentials were loaded from the block
+        mock_blob_storage_credentials.load.assert_called_once_with(
+            credentials_block_name,
+            _sync=False,
+        )
+
+        # Verify the container client was created with the correct container
+        mock_blob_storage_credentials.return_value.get_container_client.assert_called_once_with(
+            container=container
+        )
+
+        # Verify the blob was uploaded
+        mock_container_client.upload_blob.assert_called_once()
+
+    async def test_upload_bundle_with_nonexistent_file(self, tmp_path: Path) -> None:
+        """Test uploading a bundle with a nonexistent file."""
+        nonexistent_file = tmp_path / "nonexistent.zip"
+        container = "test-container"
+        key = "test-key"
+        credentials_block_name = "test-credentials"
+
+        # Call the function and expect a ValueError
+        with pytest.raises(
+            ValueError, match=f"Bundle file not found: {nonexistent_file}"
+        ):
+            await upload_bundle_to_azure_blob_storage(
+                local_filepath=nonexistent_file,
+                container=container,
+                key=key,
+                azure_blob_storage_credentials_block_name=credentials_block_name,
+            )
+
+    async def test_upload_bundle_with_upload_error(
+        self, tmp_bundle_file: Path, mock_blob_storage_credentials: MagicMock
+    ) -> None:
+        """Test uploading a bundle when the upload fails."""
+        container = "test-container"
+        key = "test-key"
+        credentials_block_name = "test-credentials"
+
+        # Mock the container client's upload_blob method to raise an exception
+        mock_container_client = (
+            mock_blob_storage_credentials.return_value.get_container_client.return_value
+        )
+        mock_container_client.upload_blob.side_effect = ResourceExistsError(
+            "Blob already exists"
+        )
+
+        # Call the function and expect a RuntimeError
+        with pytest.raises(
+            RuntimeError, match="Failed to upload bundle to Azure Blob Storage"
+        ):
+            await upload_bundle_to_azure_blob_storage(
+                local_filepath=tmp_bundle_file,
+                container=container,
+                key=key,
+                azure_blob_storage_credentials_block_name=credentials_block_name,
+            )
+
+    async def test_upload_bundle_with_empty_key(
+        self, tmp_bundle_file: Path, mock_blob_storage_credentials: MagicMock
+    ) -> None:
+        """Test uploading a bundle with an empty key (should use the filename)."""
+        container = "test-container"
+        key = ""  # Empty key
+        credentials_block_name = "test-credentials"
+        # Mock the container client's upload_blob method
+        mock_container_client = (
+            mock_blob_storage_credentials.return_value.get_container_client.return_value
+        )
+        mock_container_client.upload_blob = AsyncMock()
+
+        # Call the function
+        result = await upload_bundle_to_azure_blob_storage(
+            local_filepath=tmp_bundle_file,
+            container=container,
+            key=key,
+            azure_blob_storage_credentials_block_name=credentials_block_name,
+        )
+
+        # Verify the result uses the filename as the key
+        assert result == {"container": container, "key": tmp_bundle_file.name}
+
+        # Verify the blob was uploaded with the filename as the key
+        mock_container_client.upload_blob.assert_called_once()
+        call_args = mock_container_client.upload_blob.call_args[0]
+        assert call_args[0] == tmp_bundle_file.name


### PR DESCRIPTION
Adds bundle upload and execution steps for Azure blob storage. Similar to the S3 versions, these can be executed via a CLI command and will be used in work pool storage configuration. One unique aspect of these steps is that they require a credentials block name since Azure always requires an account URL.

Related to https://github.com/PrefectHQ/prefect/issues/17194