### PR TITLE
Add global concurrency id to the create and update route for deployments

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -15228,6 +15228,19 @@
                         ],
                         "description": "The deployment's concurrency options."
                     },
+                    "global_concurrency_limit_id": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Global Concurrency Limit Id",
+                        "description": "The ID of the global concurrency limit to apply to the deployment."
+                    },
                     "enforce_parameter_schema": {
                         "type": "boolean",
                         "title": "Enforce Parameter Schema",
@@ -16616,6 +16629,19 @@
                             }
                         ],
                         "description": "The deployment's concurrency options."
+                    },
+                    "global_concurrency_limit_id": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Global Concurrency Limit Id",
+                        "description": "The ID of the global concurrency limit to apply to the deployment."
                     },
                     "parameters": {
                         "anyOf": [

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -103,7 +103,9 @@ async def create_deployment(
             exclude_unset=True,
         )
 
-        requested_concurrency_limit = deployment_dict.pop("global_concurrency_limit_id")
+        requested_concurrency_limit = deployment_dict.pop(
+            "global_concurrency_limit_id", "unset"
+        )
         if requested_concurrency_limit != "unset":
             if requested_concurrency_limit:
                 concurrency_limit = (

--- a/src/prefect/server/api/deployments.py
+++ b/src/prefect/server/api/deployments.py
@@ -98,9 +98,29 @@ async def create_deployment(
             )
 
         # hydrate the input model into a full model
-        deployment_dict = deployment.model_dump(
-            exclude={"work_pool_name"}, exclude_unset=True
+        deployment_dict: dict = deployment.model_dump(
+            exclude={"work_pool_name"},
+            exclude_unset=True,
         )
+
+        requested_concurrency_limit = deployment_dict.pop("global_concurrency_limit_id")
+        if requested_concurrency_limit != "unset":
+            if requested_concurrency_limit:
+                concurrency_limit = (
+                    await models.concurrency_limits_v2.read_concurrency_limit(
+                        session=session,
+                        concurrency_limit_id=requested_concurrency_limit,
+                    )
+                )
+
+                if not concurrency_limit:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail="Concurrency limit not found",
+                    )
+
+            deployment_dict["concurrency_limit_id"] = requested_concurrency_limit
+
         if deployment.work_pool_name and deployment.work_queue_name:
             # If a specific pool name/queue name combination was provided, get the
             # ID for that work pool queue.
@@ -300,8 +320,24 @@ async def update_deployment(
                     detail="Invalid schema: Unable to validate schema with circular references.",
                 )
 
+        if deployment.global_concurrency_limit_id:
+            concurrency_limit = (
+                await models.concurrency_limits_v2.read_concurrency_limit(
+                    session=session,
+                    concurrency_limit_id=deployment.global_concurrency_limit_id,
+                )
+            )
+
+            if not concurrency_limit:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Concurrency limit not found",
+                )
+
         result = await models.deployments.update_deployment(
-            session=session, deployment_id=deployment_id, deployment=deployment
+            session=session,
+            deployment_id=deployment_id,
+            deployment=deployment,
         )
 
         for schedule in schedules_to_patch:

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -107,6 +107,11 @@ async def create_deployment(
 
     requested_concurrency_limit = insert_values.pop("concurrency_limit", "unset")
 
+    if requested_concurrency_limit != "unset" and deployment.concurrency_limit_id:
+        raise ValueError(
+            "Cannot provide both concurrency_limit and concurrency_limit_id"
+        )
+
     # The job_variables field in client and server schemas is named
     # infra_overrides in the database.
     job_variables = insert_values.pop("job_variables", None)
@@ -229,6 +234,21 @@ async def update_deployment(
     )
 
     requested_concurrency_limit_update = update_data.pop("concurrency_limit", "unset")
+
+    requested_global_concurrency_limit_update = update_data.pop(
+        "global_concurrency_limit_id", "unset"
+    )
+
+    if requested_global_concurrency_limit_update != "unset":
+        update_data["concurrency_limit_id"] = requested_global_concurrency_limit_update
+
+    if (
+        requested_global_concurrency_limit_update != "unset"
+        and requested_concurrency_limit_update != "unset"
+    ):
+        raise ValueError(
+            "Cannot provide both concurrency_limit and concurrency_limit_id"
+        )
 
     # The job_variables field in client and server schemas is named
     # infra_overrides in the database.

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -105,13 +105,6 @@ async def create_deployment(
         exclude_unset=True, exclude={"schedules"}
     )
 
-    requested_concurrency_limit = insert_values.pop("concurrency_limit", "unset")
-
-    if requested_concurrency_limit != "unset" and deployment.concurrency_limit_id:
-        raise ValueError(
-            "Cannot provide both concurrency_limit and concurrency_limit_id"
-        )
-
     # The job_variables field in client and server schemas is named
     # infra_overrides in the database.
     job_variables = insert_values.pop("job_variables", None)
@@ -184,6 +177,7 @@ async def create_deployment(
             ],
         )
 
+    requested_concurrency_limit = insert_values.pop("concurrency_limit", "unset")
     if requested_concurrency_limit != "unset":
         await _create_or_update_deployment_concurrency_limit(
             db, session, deployment_id, deployment.concurrency_limit
@@ -233,22 +227,11 @@ async def update_deployment(
         exclude={"work_pool_name"},
     )
 
-    requested_concurrency_limit_update = update_data.pop("concurrency_limit", "unset")
-
     requested_global_concurrency_limit_update = update_data.pop(
         "global_concurrency_limit_id", "unset"
     )
-
     if requested_global_concurrency_limit_update != "unset":
         update_data["concurrency_limit_id"] = requested_global_concurrency_limit_update
-
-    if (
-        requested_global_concurrency_limit_update != "unset"
-        and requested_concurrency_limit_update != "unset"
-    ):
-        raise ValueError(
-            "Cannot provide both concurrency_limit and concurrency_limit_id"
-        )
 
     # The job_variables field in client and server schemas is named
     # infra_overrides in the database.
@@ -322,6 +305,7 @@ async def update_deployment(
             ],
         )
 
+    requested_concurrency_limit_update = update_data.pop("concurrency_limit", "unset")
     if requested_concurrency_limit_update != "unset":
         await _create_or_update_deployment_concurrency_limit(
             db, session, deployment_id, deployment.concurrency_limit

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -105,6 +105,8 @@ async def create_deployment(
         exclude_unset=True, exclude={"schedules"}
     )
 
+    requested_concurrency_limit = insert_values.pop("concurrency_limit", "unset")
+
     # The job_variables field in client and server schemas is named
     # infra_overrides in the database.
     job_variables = insert_values.pop("job_variables", None)
@@ -177,7 +179,6 @@ async def create_deployment(
             ],
         )
 
-    requested_concurrency_limit = insert_values.pop("concurrency_limit", "unset")
     if requested_concurrency_limit != "unset":
         await _create_or_update_deployment_concurrency_limit(
             db, session, deployment_id, deployment.concurrency_limit
@@ -230,6 +231,8 @@ async def update_deployment(
     requested_global_concurrency_limit_update = update_data.pop(
         "global_concurrency_limit_id", "unset"
     )
+    requested_concurrency_limit_update = update_data.pop("concurrency_limit", "unset")
+
     if requested_global_concurrency_limit_update != "unset":
         update_data["concurrency_limit_id"] = requested_global_concurrency_limit_update
 
@@ -305,7 +308,6 @@ async def update_deployment(
             ],
         )
 
-    requested_concurrency_limit_update = update_data.pop("concurrency_limit", "unset")
     if requested_concurrency_limit_update != "unset":
         await _create_or_update_deployment_concurrency_limit(
             db, session, deployment_id, deployment.concurrency_limit

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -274,6 +274,17 @@ class DeploymentCreate(ActionBaseModel):
         )
         return values
 
+    @model_validator(mode="before")
+    def _validate_concurrency_limits(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Validate that a deployment does not have both a concurrency limit and global concurrency limit."""
+        if values.get("concurrency_limit") and values.get(
+            "global_concurrency_limit_id"
+        ):
+            raise ValueError(
+                "A deployment cannot have both a concurrency limit and a global concurrency limit."
+            )
+        return values
+
 
 class DeploymentUpdate(ActionBaseModel):
     """Data used by the Prefect REST API to update a deployment."""
@@ -364,6 +375,17 @@ class DeploymentUpdate(ActionBaseModel):
             if errors:
                 for error in errors:
                     raise error
+
+    @model_validator(mode="before")
+    def _validate_concurrency_limits(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Validate that a deployment does not have both a concurrency limit and global concurrency limit."""
+        if values.get("concurrency_limit") and values.get(
+            "global_concurrency_limit_id"
+        ):
+            raise ValueError(
+                "A deployment cannot have both a concurrency limit and a global concurrency limit."
+            )
+        return values
 
 
 class FlowRunUpdate(ActionBaseModel):

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -183,6 +183,10 @@ class DeploymentCreate(ActionBaseModel):
     concurrency_options: Optional[schemas.core.ConcurrencyOptions] = Field(
         default=None, description="The deployment's concurrency options."
     )
+    global_concurrency_limit_id: Optional[UUID] = Field(
+        default=None,
+        description="The ID of the global concurrency limit to apply to the deployment.",
+    )
     enforce_parameter_schema: bool = Field(
         default=True,
         description=(
@@ -293,6 +297,10 @@ class DeploymentUpdate(ActionBaseModel):
     )
     concurrency_options: Optional[schemas.core.ConcurrencyOptions] = Field(
         default=None, description="The deployment's concurrency options."
+    )
+    global_concurrency_limit_id: Optional[UUID] = Field(
+        default=None,
+        description="The ID of the global concurrency limit to apply to the deployment.",
     )
     parameters: Optional[Dict[str, Any]] = Field(
         default=None,

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -597,6 +597,10 @@ class Deployment(ORMBaseModel):
     concurrency_limit: Optional[NonNegativeInteger] = Field(
         default=None, description="The concurrency limit for the deployment."
     )
+    concurrency_limit_id: Optional[UUID] = Field(
+        default=None,
+        description="The concurrency limit id associated with the deployment.",
+    )
     concurrency_options: Optional[ConcurrencyOptions] = Field(
         default=None, description="The concurrency options for the deployment."
     )

--- a/tests/server/models/test_deployments.py
+++ b/tests/server/models/test_deployments.py
@@ -300,32 +300,6 @@ class TestCreateDeployment:
                 ),
             )
 
-    async def test_create_deployment_raises_error_with_both_concurrency_limit_and_id(
-        self, session: AsyncSession, flow: orm_models.Flow
-    ):
-        # Create a global concurrency limit first
-        global_limit = await models.concurrency_limits_v2.create_concurrency_limit(
-            session=session,
-            concurrency_limit=schemas.core.ConcurrencyLimitV2(
-                name="test-limit",
-                limit=3,
-            ),
-        )
-
-        with pytest.raises(
-            ValueError,
-            match="Cannot provide both concurrency_limit and concurrency_limit_id",
-        ):
-            await models.deployments.create_deployment(
-                session=session,
-                deployment=schemas.core.Deployment(
-                    name="My Deployment",
-                    flow_id=flow.id,
-                    concurrency_limit=2,
-                    concurrency_limit_id=global_limit.id,
-                ),
-            )
-
     async def test_create_deployment_retains_concurrency_limit_if_not_provided_on_upsert(
         self,
         session: AsyncSession,
@@ -1467,32 +1441,6 @@ class TestUpdateDeployment:
 
         assert deployment.concurrency_limit_id is None
         assert deployment.global_concurrency_limit is None
-
-    async def test_update_deployment_raises_when_both_concurrency_id_and_limit_provided(
-        self,
-        session,
-        deployment,
-    ):
-        concurrency_limit = await models.concurrency_limits_v2.create_concurrency_limit(
-            session=session,
-            concurrency_limit=schemas.core.ConcurrencyLimitV2(
-                name="test-limit",
-                limit=5,
-            ),
-        )
-
-        with pytest.raises(
-            ValueError,
-            match="Cannot provide both concurrency_limit and concurrency_limit_id",
-        ):
-            await models.deployments.update_deployment(
-                session=session,
-                deployment_id=deployment.id,
-                deployment=schemas.actions.DeploymentUpdate(
-                    global_concurrency_limit_id=concurrency_limit.id,
-                    concurrency_limit=5,
-                ),
-            )
 
     async def test_update_deployment_deletes_autoscheduled_flow_runs_in_scheduled(
         self,

--- a/tests/server/models/test_deployments.py
+++ b/tests/server/models/test_deployments.py
@@ -261,6 +261,71 @@ class TestCreateDeployment:
         assert deployment.global_concurrency_limit is not None
         assert deployment.global_concurrency_limit.limit == 2
 
+    async def test_create_deployment_with_global_concurrency_limit_id(
+        self, session: AsyncSession, flow: orm_models.Flow
+    ):
+        # Create a global concurrency limit first
+        global_limit = await models.concurrency_limits_v2.create_concurrency_limit(
+            session=session,
+            concurrency_limit=schemas.core.ConcurrencyLimitV2(
+                name="test-limit",
+                limit=3,
+            ),
+        )
+
+        deployment = await models.deployments.create_deployment(
+            session=session,
+            deployment=schemas.core.Deployment(
+                name="My Deployment",
+                flow_id=flow.id,
+                concurrency_limit_id=global_limit.id,
+            ),
+        )
+        assert deployment is not None
+        assert deployment.concurrency_limit_id == global_limit.id
+        assert deployment.global_concurrency_limit.id == global_limit.id
+        assert deployment.global_concurrency_limit.limit == 3
+
+    async def test_create_deployment_with_nonexistent_concurrency_limit_id(
+        self, session: AsyncSession, flow: orm_models.Flow
+    ):
+        nonexistent_id = uuid4()
+        with pytest.raises(sa.exc.IntegrityError):
+            await models.deployments.create_deployment(
+                session=session,
+                deployment=schemas.core.Deployment(
+                    name="My Deployment",
+                    flow_id=flow.id,
+                    concurrency_limit_id=nonexistent_id,
+                ),
+            )
+
+    async def test_create_deployment_raises_error_with_both_concurrency_limit_and_id(
+        self, session: AsyncSession, flow: orm_models.Flow
+    ):
+        # Create a global concurrency limit first
+        global_limit = await models.concurrency_limits_v2.create_concurrency_limit(
+            session=session,
+            concurrency_limit=schemas.core.ConcurrencyLimitV2(
+                name="test-limit",
+                limit=3,
+            ),
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="Cannot provide both concurrency_limit and concurrency_limit_id",
+        ):
+            await models.deployments.create_deployment(
+                session=session,
+                deployment=schemas.core.Deployment(
+                    name="My Deployment",
+                    flow_id=flow.id,
+                    concurrency_limit=2,
+                    concurrency_limit_id=global_limit.id,
+                ),
+            )
+
     async def test_create_deployment_retains_concurrency_limit_if_not_provided_on_upsert(
         self,
         session: AsyncSession,
@@ -1335,6 +1400,99 @@ class TestUpdateDeployment:
         assert updated_deployment._concurrency_limit == 42
         assert updated_deployment.global_concurrency_limit.limit == 42
         assert updated_deployment.concurrency_options.collision_strategy == "CANCEL_NEW"
+
+    async def test_update_deployment_with_global_concurrency_limit_id(
+        self,
+        session,
+        deployment,
+    ):
+        # Create a concurrency limit
+        concurrency_limit = await models.concurrency_limits_v2.create_concurrency_limit(
+            session=session,
+            concurrency_limit=schemas.core.ConcurrencyLimitV2(
+                name="test-limit",
+                limit=5,
+            ),
+        )
+
+        # Update deployment with concurrency limit ID
+        await models.deployments.update_deployment(
+            session=session,
+            deployment_id=deployment.id,
+            deployment=schemas.actions.DeploymentUpdate(
+                global_concurrency_limit_id=concurrency_limit.id,
+            ),
+        )
+        await session.commit()
+        await session.refresh(deployment)
+
+        assert deployment.concurrency_limit_id == concurrency_limit.id
+        assert deployment.global_concurrency_limit.id == concurrency_limit.id
+        assert deployment.global_concurrency_limit.limit == 5
+
+    async def test_update_deployment_with_none_global_concurrency_limit_id(
+        self,
+        session,
+        deployment,
+    ):
+        # First set a concurrency limit
+        concurrency_limit = await models.concurrency_limits_v2.create_concurrency_limit(
+            session=session,
+            concurrency_limit=schemas.core.ConcurrencyLimitV2(
+                name="test-limit",
+                limit=5,
+            ),
+        )
+
+        await models.deployments.update_deployment(
+            session=session,
+            deployment_id=deployment.id,
+            deployment=schemas.actions.DeploymentUpdate(
+                global_concurrency_limit_id=concurrency_limit.id,
+            ),
+        )
+        await session.commit()
+        await session.refresh(deployment)
+
+        # Then remove it by setting to None
+        await models.deployments.update_deployment(
+            session=session,
+            deployment_id=deployment.id,
+            deployment=schemas.actions.DeploymentUpdate(
+                global_concurrency_limit_id=None,
+            ),
+        )
+        await session.commit()
+        await session.refresh(deployment)
+
+        assert deployment.concurrency_limit_id is None
+        assert deployment.global_concurrency_limit is None
+
+    async def test_update_deployment_raises_when_both_concurrency_id_and_limit_provided(
+        self,
+        session,
+        deployment,
+    ):
+        concurrency_limit = await models.concurrency_limits_v2.create_concurrency_limit(
+            session=session,
+            concurrency_limit=schemas.core.ConcurrencyLimitV2(
+                name="test-limit",
+                limit=5,
+            ),
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="Cannot provide both concurrency_limit and concurrency_limit_id",
+        ):
+            await models.deployments.update_deployment(
+                session=session,
+                deployment_id=deployment.id,
+                deployment=schemas.actions.DeploymentUpdate(
+                    global_concurrency_limit_id=concurrency_limit.id,
+                    concurrency_limit=5,
+                ),
+            )
 
     async def test_update_deployment_deletes_autoscheduled_flow_runs_in_scheduled(
         self,

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -5374,6 +5374,11 @@ export interface components {
             /** @description The deployment's concurrency options. */
             concurrency_options?: components["schemas"]["ConcurrencyOptions"] | null;
             /**
+             * Global Concurrency Limit Id
+             * @description The ID of the global concurrency limit to apply to the deployment.
+             */
+            global_concurrency_limit_id?: string | null;
+            /**
              * Enforce Parameter Schema
              * @description Whether or not the deployment should enforce the parameter schema.
              * @default true
@@ -5934,6 +5939,11 @@ export interface components {
             concurrency_limit?: number | null;
             /** @description The deployment's concurrency options. */
             concurrency_options?: components["schemas"]["ConcurrencyOptions"] | null;
+            /**
+             * Global Concurrency Limit Id
+             * @description The ID of the global concurrency limit to apply to the deployment.
+             */
+            global_concurrency_limit_id?: string | null;
             /**
              * Parameters
              * @description Parameters for flow runs scheduled by the deployment.

--- a/ui-v2/src/components/deployments/deployment-form/deployment-form.tsx
+++ b/ui-v2/src/components/deployments/deployment-form/deployment-form.tsx
@@ -1,4 +1,5 @@
 import type { Deployment } from "@/api/deployments";
+import { GlobalConcurrencyLimitSelect } from "@/components/global-concurrency-limit/global-concurrency-limit-select";
 import { SchemaForm } from "@/components/schemas";
 import type { PrefectSchemaObject } from "@/components/schemas";
 import { Button } from "@/components/ui/button";
@@ -160,6 +161,24 @@ export const DeploymentForm = ({ deployment, mode }: DeploymentFormProps) => {
 								<LimitCollissionStrategySelect
 									value={field.value}
 									onValueChange={field.onChange}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<FormField
+					control={form.control}
+					name="global_concurrency_limit_id"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>Global concurrency limit</FormLabel>
+							<FormControl>
+								<GlobalConcurrencyLimitSelect
+									presetOptions={[{ label: "None", value: "" }]}
+									onSelect={field.onChange}
+									selected={field.value}
 								/>
 							</FormControl>
 							<FormMessage />

--- a/ui-v2/src/components/deployments/deployment-form/deployment-form.tsx
+++ b/ui-v2/src/components/deployments/deployment-form/deployment-form.tsx
@@ -176,7 +176,7 @@ export const DeploymentForm = ({ deployment, mode }: DeploymentFormProps) => {
 							<FormLabel>Global concurrency limit</FormLabel>
 							<FormControl>
 								<GlobalConcurrencyLimitSelect
-									presetOptions={[{ label: "None", value: "" }]}
+									presetOptions={[{ label: "None", value: null }]}
 									onSelect={field.onChange}
 									selected={field.value}
 								/>

--- a/ui-v2/src/components/deployments/deployment-form/use-deployment-form.ts
+++ b/ui-v2/src/components/deployments/deployment-form/use-deployment-form.ts
@@ -55,6 +55,7 @@ const createFormSchema = (
 			.optional()
 			.nullable()
 			.readonly(),
+		global_concurrency_limit_id: z.string().uuid().optional().nullable(),
 	});
 
 export type DeploymentFormSchema = z.infer<ReturnType<typeof createFormSchema>>;
@@ -65,6 +66,7 @@ const DEFAULT_VALUES: DeploymentFormSchema = {
 	tags: [],
 	job_variables: "",
 	enforce_parameter_schema: true,
+	global_concurrency_limit_id: null,
 };
 
 export const useDeploymentForm = (
@@ -98,6 +100,7 @@ export const useDeploymentForm = (
 			parameter_openapi_schema,
 			enforce_parameter_schema,
 			job_variables,
+			global_concurrency_limit,
 		} = deployment;
 
 		// nb: parameter form state and validation is handled separately using SchemaForm
@@ -115,6 +118,7 @@ export const useDeploymentForm = (
 			parameter_openapi_schema,
 			enforce_parameter_schema,
 			job_variables: job_variables ? JSON.stringify(job_variables) : "",
+			global_concurrency_limit_id: global_concurrency_limit?.id,
 		});
 	}, [form, deployment, setParametersFormValues]);
 
@@ -129,6 +133,7 @@ export const useDeploymentForm = (
 			enforce_parameter_schema,
 			concurrency_options,
 			parameter_openapi_schema,
+			global_concurrency_limit_id,
 		} = values;
 
 		const jobVariablesPayload = job_variables
@@ -172,6 +177,7 @@ export const useDeploymentForm = (
 						work_pool_name: work_pool_name || null,
 						// If value is "", set as null
 						work_queue_name: work_queue_name || null,
+						global_concurrency_limit_id,
 					},
 					{
 						onSuccess: ({ id }) => {
@@ -205,6 +211,7 @@ export const useDeploymentForm = (
 						work_pool_name: work_pool_name || null,
 						// If value is "", set as null
 						work_queue_name: work_queue_name || null,
+						global_concurrency_limit_id,
 					},
 					{
 						onSuccess: () => {

--- a/ui-v2/src/components/global-concurrency-limit/global-concurrency-limit-select/global-concurrency-limit-select.tsx
+++ b/ui-v2/src/components/global-concurrency-limit/global-concurrency-limit-select/global-concurrency-limit-select.tsx
@@ -96,7 +96,7 @@ const GlobalConcurrencyLimitSelectImplementation = ({
 									setSearch("");
 								}}
 								//nb: Stringifies label so that UX has a hoverable state
-								value={String(option.label || null)}
+								value={String(option.label)}
 							>
 								{option.label}
 							</ComboboxCommandItem>

--- a/ui-v2/src/components/global-concurrency-limit/global-concurrency-limit-select/global-concurrency-limit-select.tsx
+++ b/ui-v2/src/components/global-concurrency-limit/global-concurrency-limit-select/global-concurrency-limit-select.tsx
@@ -1,0 +1,122 @@
+import { buildListGlobalConcurrencyLimitsQuery } from "@/api/global-concurrency-limits";
+
+import {
+	Combobox,
+	ComboboxCommandEmtpy,
+	ComboboxCommandGroup,
+	ComboboxCommandInput,
+	ComboboxCommandItem,
+	ComboboxCommandList,
+	ComboboxContent,
+	ComboboxTrigger,
+} from "@/components/ui/combobox";
+
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense, useDeferredValue, useMemo, useState } from "react";
+
+type PresetOption = {
+	label: string;
+	value: string | null | undefined;
+};
+
+type GlobalConcurrencyLimitSelectProps = {
+	presetOptions?: Array<PresetOption>;
+	selected: string | undefined | null;
+	onSelect: (name: string | undefined | null) => void;
+};
+
+export const GlobalConcurrencyLimitSelect = ({
+	presetOptions = [],
+	selected,
+	onSelect,
+}: GlobalConcurrencyLimitSelectProps) => {
+	return (
+		<Suspense>
+			<GlobalConcurrencyLimitSelectImplementation
+				presetOptions={presetOptions}
+				selected={selected}
+				onSelect={onSelect}
+			/>
+		</Suspense>
+	);
+};
+
+const GlobalConcurrencyLimitSelectImplementation = ({
+	presetOptions = [],
+	selected,
+	onSelect,
+}: GlobalConcurrencyLimitSelectProps) => {
+	const [search, setSearch] = useState("");
+	const { data } = useSuspenseQuery(buildListGlobalConcurrencyLimitsQuery());
+
+	const deferredSearch = useDeferredValue(search);
+	const filteredData = useMemo(() => {
+		return data.filter((globalConcurrencyLimit) =>
+			globalConcurrencyLimit.name
+				.toLowerCase()
+				.includes(deferredSearch.toLowerCase()),
+		);
+	}, [data, deferredSearch]);
+
+	const filteredPresetOptions = useMemo(() => {
+		return presetOptions.filter((option) =>
+			option.label.toLowerCase().includes(deferredSearch.toLowerCase()),
+		);
+	}, [deferredSearch, presetOptions]);
+
+	return (
+		<Combobox>
+			<ComboboxTrigger
+				selected={Boolean(selected)}
+				aria-label="Select a global concurrency limit"
+			>
+				{
+					data.find(
+						(globalConcurrencyLimit) => globalConcurrencyLimit.id === selected,
+					)?.name
+				}
+			</ComboboxTrigger>
+			<ComboboxContent>
+				<ComboboxCommandInput
+					value={search}
+					onValueChange={setSearch}
+					placeholder="Search for a global concurrency limit..."
+				/>
+				<ComboboxCommandEmtpy>
+					No global concurrency limit found
+				</ComboboxCommandEmtpy>
+				<ComboboxCommandList>
+					<ComboboxCommandGroup>
+						{filteredPresetOptions.map((option) => (
+							<ComboboxCommandItem
+								key={option.label}
+								selected={selected === option.value}
+								onSelect={() => {
+									onSelect(option.value || null);
+									setSearch("");
+								}}
+								//nb: Stringifies label so that UX has a hoverable state
+								value={String(option.label || null)}
+							>
+								{option.label}
+							</ComboboxCommandItem>
+						))}
+						{filteredData.map((globalConcurrencyLimit) => (
+							<ComboboxCommandItem
+								key={globalConcurrencyLimit.id}
+								selected={selected === globalConcurrencyLimit.name}
+								onSelect={(value) => {
+									onSelect(value);
+									setSearch("");
+								}}
+								value={globalConcurrencyLimit.id}
+							>
+								{globalConcurrencyLimit.name}
+							</ComboboxCommandItem>
+						))}
+					</ComboboxCommandGroup>
+				</ComboboxCommandList>
+			</ComboboxContent>
+		</Combobox>
+	);
+};

--- a/ui-v2/src/components/global-concurrency-limit/global-concurrency-limit-select/global-concurrency-limit-select.tsx
+++ b/ui-v2/src/components/global-concurrency-limit/global-concurrency-limit-select/global-concurrency-limit-select.tsx
@@ -92,7 +92,7 @@ const GlobalConcurrencyLimitSelectImplementation = ({
 								key={option.label}
 								selected={selected === option.value}
 								onSelect={() => {
-									onSelect(option.value || null);
+									onSelect(option.value);
 									setSearch("");
 								}}
 								//nb: Stringifies label so that UX has a hoverable state

--- a/ui-v2/src/components/global-concurrency-limit/global-concurrency-limit-select/index.ts
+++ b/ui-v2/src/components/global-concurrency-limit/global-concurrency-limit-select/index.ts
@@ -1,0 +1,1 @@
+export { GlobalConcurrencyLimitSelect } from "./global-concurrency-limit-select";


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

This PR adds the `global_concurrency_limit_id` to the create and update route for deployments so that new and existing deployments can take advantage of the functionality to limit their work. 

closes #17803

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [x] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
