### PR TITLE
Add `.submit` method to `BaseWorker`

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/worker.py
@@ -737,6 +737,7 @@ class KubernetesWorker(
 
             return KubernetesWorkerResult(identifier=pid, status_code=status_code)
 
+    # TODO: Remove this once `.submit` is available on the `BaseWorker` class in a published release
     async def submit(
         self,
         flow: "Flow[..., R]",
@@ -773,6 +774,7 @@ class KubernetesWorker(
         )
         return PrefectFlowRunFuture(flow_run_id=flow_run.id)
 
+    # TODO: Remove this once `.submit` is available on the `BaseWorker` class in a published release
     async def _submit_adhoc_run(
         self,
         flow: "Flow[..., R]",


### PR DESCRIPTION
Adding the `.submit` method to `BaseWorker` class will allow all workers to offer ad-hoc flow submission. Once this change is released, the `.submit` method can be removed from the `KubernetesWorker`.

Related to https://github.com/PrefectHQ/prefect/issues/17194
