### PR TITLE
fix link to archived repo

### DIFF
--- a/docs/v3/develop/blocks.mdx
+++ b/docs/v3/develop/blocks.mdx
@@ -353,7 +353,7 @@ Available metadata fields include:
 ### Update custom `Block` types
 
 Here's an example of how to add a `bucket_folder` field to your custom `S3Bucket` block; it represents the default path to 
-read and write objects from (this field exists on [our implementation](https://github.com/PrefectHQ/prefect-aws/blob/main/prefect_aws/s3.py#L292)).
+read and write objects from (this field exists on [our implementation](https://github.com/PrefectHQ/prefect/blob/main/src/integrations/prefect-aws/prefect_aws/s3.py)).
 
 Add the new field to the class definition:
 


### PR DESCRIPTION
custom blocks page was linking to `prefecthq/prefect-aws` which is archived