### PR TITLE
Add `InfrastructureBoundFlow` class and `bind_flow_to_infrastructure` function

### DIFF
--- a/src/integrations/prefect-kubernetes/prefect_kubernetes/experimental/decorators.py
+++ b/src/integrations/prefect-kubernetes/prefect_kubernetes/experimental/decorators.py
@@ -27,6 +27,8 @@ R = TypeVar("R")
 T = TypeVar("T")
 
 
+# TODO: Remove this class once a version of Prefect is released that has the
+# InfrastructureBoundFlow class.
 class InfrastructureBoundFlow(Flow[P, R]):
     def __init__(
         self,

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -636,7 +636,12 @@ class Runner:
 
                     return process
 
-    async def execute_bundle(self, bundle: SerializedBundle) -> None:
+    async def execute_bundle(
+        self,
+        bundle: SerializedBundle,
+        cwd: Path | str | None = None,
+        env: dict[str, str | None] | None = None,
+    ) -> None:
         """
         Executes a bundle in a subprocess.
         """
@@ -651,7 +656,7 @@ class Runner:
             if not self._acquire_limit_slot(flow_run.id):
                 return
 
-            process = execute_bundle_in_subprocess(bundle)
+            process = execute_bundle_in_subprocess(bundle, cwd=cwd, env=env)
 
             if process.pid is None:
                 # This shouldn't happen because `execute_bundle_in_subprocess` starts the process

--- a/tests/test_infrastructure_bound_flow.py
+++ b/tests/test_infrastructure_bound_flow.py
@@ -1,0 +1,206 @@
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+
+from prefect.client.orchestration import PrefectClient
+from prefect.client.schemas.actions import WorkPoolCreate
+from prefect.client.schemas.objects import FlowRun, State, WorkPool
+from prefect.filesystems import LocalFileSystem
+from prefect.flows import (
+    Flow,
+    InfrastructureBoundFlow,
+    bind_flow_to_infrastructure,
+    flow,
+)
+from prefect.serializers import JSONSerializer
+from prefect.task_runners import ThreadPoolTaskRunner
+from prefect.workers.process import ProcessWorker
+
+
+class TestInfrastructureBoundFlow:
+    @pytest.fixture
+    async def work_pool(self, prefect_client: PrefectClient):
+        return await prefect_client.create_work_pool(
+            WorkPoolCreate(
+                name=f"submission-work-pool-{uuid.uuid4()}",
+                type="process",
+                base_job_template=ProcessWorker.get_default_base_job_template(),
+            )
+        )
+
+    @pytest.fixture
+    def result_storage(self, tmp_path: Path):
+        result_storage = LocalFileSystem(basepath=str(tmp_path / "result_storage"))
+        result_storage.save(str(uuid.uuid4()))
+        return result_storage
+
+    def test_bind_flow_to_infrastructure(
+        self, work_pool: WorkPool, result_storage: LocalFileSystem
+    ):
+        @flow(
+            name="chicago-style",
+            version="test",
+            flow_run_name="test-run",
+            retries=3,
+            retry_delay_seconds=1,
+            description="A flow with everything on it",
+            timeout_seconds=100,
+            validate_parameters=False,
+            persist_result=True,
+            result_storage=result_storage,
+            result_serializer=JSONSerializer(),
+            cache_result_in_memory=False,
+            log_prints=True,
+        )
+        def dragged_through_the_garden():
+            return "The works"
+
+        @dragged_through_the_garden.on_completion
+        def on_completion(flow: Flow[[], str], flow_run: FlowRun, state: State):  # pyright: ignore[reportUnusedFunction]
+            print(f"Flow run {flow_run.id} completed with state {state}")
+
+        @dragged_through_the_garden.on_failure
+        def on_failure(flow: Flow[[], str], flow_run: FlowRun, state: State):  # pyright: ignore[reportUnusedFunction]
+            print(f"Flow run {flow_run.id} failed with state {state}")
+
+        @dragged_through_the_garden.on_cancellation
+        def on_cancellation(flow: Flow[[], str], flow_run: FlowRun, state: State):  # pyright: ignore[reportUnusedFunction]
+            print(f"Flow run {flow_run.id} cancelled with state {state}")
+
+        @dragged_through_the_garden.on_crashed
+        def on_crashed(flow: Flow[[], str], flow_run: FlowRun, state: State):  # pyright: ignore[reportUnusedFunction]
+            print(f"Flow run {flow_run.id} crashed with state {state}")
+
+        @dragged_through_the_garden.on_running
+        def on_running(flow: Flow[[], str], flow_run: FlowRun, state: State):  # pyright: ignore[reportUnusedFunction]
+            print(f"Flow run {flow_run.id} is running with state {state}")
+
+        infrastructure_bound_flow = bind_flow_to_infrastructure(
+            flow=dragged_through_the_garden,
+            work_pool=work_pool.name,
+            worker_cls=ProcessWorker,
+            job_variables={"key": "value"},
+        )
+
+        assert isinstance(infrastructure_bound_flow, InfrastructureBoundFlow)
+        assert infrastructure_bound_flow.work_pool == work_pool.name
+        assert infrastructure_bound_flow.job_variables == {"key": "value"}
+        assert infrastructure_bound_flow.worker_cls == ProcessWorker
+
+        # check that all flow attributes are copied over
+        assert infrastructure_bound_flow.name == "chicago-style"
+        assert infrastructure_bound_flow.version == "test"
+        assert infrastructure_bound_flow.flow_run_name == "test-run"
+        assert infrastructure_bound_flow.retries == 3
+        assert infrastructure_bound_flow.retry_delay_seconds == 1
+        assert infrastructure_bound_flow.description == "A flow with everything on it"
+        assert infrastructure_bound_flow.result_storage == result_storage
+        assert infrastructure_bound_flow.result_serializer == JSONSerializer()
+        assert infrastructure_bound_flow.cache_result_in_memory is False
+        assert infrastructure_bound_flow.log_prints is True
+        assert infrastructure_bound_flow.timeout_seconds == 100
+        assert infrastructure_bound_flow.should_validate_parameters is False
+        assert infrastructure_bound_flow.persist_result is True
+        assert infrastructure_bound_flow.on_completion_hooks == [on_completion]
+        assert infrastructure_bound_flow.on_failure_hooks == [on_failure]
+        assert infrastructure_bound_flow.on_cancellation_hooks == [on_cancellation]
+        assert infrastructure_bound_flow.on_crashed_hooks == [on_crashed]
+        assert infrastructure_bound_flow.on_running_hooks == [on_running]
+        assert (
+            infrastructure_bound_flow.task_runner
+            == ThreadPoolTaskRunner()  # this one is implicit
+        )
+
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
+    def test_basic_call(self, work_pool: WorkPool, result_storage: LocalFileSystem):
+        @flow(
+            result_storage=result_storage,
+        )
+        def hello_world():
+            return "Hello, world!"
+
+        infrastructure_bound_flow = bind_flow_to_infrastructure(
+            flow=hello_world, work_pool=work_pool.name, worker_cls=ProcessWorker
+        )
+
+        assert infrastructure_bound_flow() == "Hello, world!"
+
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
+    async def test_async_call(
+        self, work_pool: WorkPool, result_storage: LocalFileSystem
+    ):
+        @flow(
+            result_storage=result_storage,
+        )
+        async def hello_world():
+            return "Hello, world!"
+
+        infrastructure_bound_flow = bind_flow_to_infrastructure(
+            flow=hello_world, work_pool=work_pool.name, worker_cls=ProcessWorker
+        )
+
+        assert await infrastructure_bound_flow() == "Hello, world!"
+
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
+    def test_call_with_parameters(
+        self, work_pool: WorkPool, result_storage: LocalFileSystem
+    ):
+        @flow(
+            result_storage=result_storage,
+        )
+        def hello_world(name: str):
+            return f"Hello, {name}!"
+
+        infrastructure_bound_flow = bind_flow_to_infrastructure(
+            flow=hello_world, work_pool=work_pool.name, worker_cls=ProcessWorker
+        )
+
+        assert infrastructure_bound_flow("friend") == "Hello, friend!"
+
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
+    def test_call_with_job_variables(
+        self, work_pool: WorkPool, result_storage: LocalFileSystem, tmp_path: Path
+    ):
+        @flow(
+            result_storage=result_storage,
+        )
+        def tell_me_your_cwd_and_env():
+            return {
+                "cwd": os.getcwd(),
+                "env": os.environ.get("TEST_ENV_VAR"),
+            }
+
+        infrastructure_bound_flow = bind_flow_to_infrastructure(
+            flow=tell_me_your_cwd_and_env,
+            work_pool=work_pool.name,
+            worker_cls=ProcessWorker,
+            job_variables={
+                "working_dir": str(tmp_path),
+                "env": {"TEST_ENV_VAR": "TEST_VALUE"},
+            },
+        )
+
+        assert infrastructure_bound_flow() == {
+            "cwd": str(tmp_path),
+            "env": "TEST_VALUE",
+        }
+
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
+    def test_call_with_return_state(
+        self, work_pool: WorkPool, result_storage: LocalFileSystem
+    ):
+        @flow(
+            result_storage=result_storage,
+        )
+        def hello_world():
+            return "Hello, world!"
+
+        infrastructure_bound_flow = bind_flow_to_infrastructure(
+            flow=hello_world, work_pool=work_pool.name, worker_cls=ProcessWorker
+        )
+
+        result = infrastructure_bound_flow(return_state=True)
+        assert result.is_completed()
+        assert result.result() == "Hello, world!"

--- a/tests/test_infrastructure_bound_flow.py
+++ b/tests/test_infrastructure_bound_flow.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -58,23 +59,23 @@ class TestInfrastructureBoundFlow:
             return "The works"
 
         @dragged_through_the_garden.on_completion
-        def on_completion(flow: Flow[[], str], flow_run: FlowRun, state: State):  # pyright: ignore[reportUnusedFunction]
+        def on_completion(flow: Flow[Any, str], flow_run: FlowRun, state: State):  # pyright: ignore[reportUnusedFunction]
             print(f"Flow run {flow_run.id} completed with state {state}")
 
         @dragged_through_the_garden.on_failure
-        def on_failure(flow: Flow[[], str], flow_run: FlowRun, state: State):  # pyright: ignore[reportUnusedFunction]
+        def on_failure(flow: Flow[Any, str], flow_run: FlowRun, state: State):  # pyright: ignore[reportUnusedFunction]
             print(f"Flow run {flow_run.id} failed with state {state}")
 
         @dragged_through_the_garden.on_cancellation
-        def on_cancellation(flow: Flow[[], str], flow_run: FlowRun, state: State):  # pyright: ignore[reportUnusedFunction]
+        def on_cancellation(flow: Flow[Any, str], flow_run: FlowRun, state: State):  # pyright: ignore[reportUnusedFunction]
             print(f"Flow run {flow_run.id} cancelled with state {state}")
 
         @dragged_through_the_garden.on_crashed
-        def on_crashed(flow: Flow[[], str], flow_run: FlowRun, state: State):  # pyright: ignore[reportUnusedFunction]
+        def on_crashed(flow: Flow[Any, str], flow_run: FlowRun, state: State):  # pyright: ignore[reportUnusedFunction]
             print(f"Flow run {flow_run.id} crashed with state {state}")
 
         @dragged_through_the_garden.on_running
-        def on_running(flow: Flow[[], str], flow_run: FlowRun, state: State):  # pyright: ignore[reportUnusedFunction]
+        def on_running(flow: Flow[Any, str], flow_run: FlowRun, state: State):  # pyright: ignore[reportUnusedFunction]
             print(f"Flow run {flow_run.id} is running with state {state}")
 
         infrastructure_bound_flow = bind_flow_to_infrastructure(


### PR DESCRIPTION
The PR adds the `InfrastructureBoundFlow` class, first explored in `prefect-kubernetes`, to `prefect` to support binding flows to infrastructure. Calls of `InfrastructureBoundFlow` will spin up infrastructure and submit the flow using the configured worker provided when the `InfrastructureBoundFlow` was created. The `bind_flow_to_infrastructure` can create an `InfrastructureBoundFlow` from a flow, work pool name, and worker class.

This PR also updates `ProcessWorker` to support testing `InfrastructureBoundFlow`. The `ProcessWorker` doesn't persist bundles for submitted flows because they can be passed to a subprocess.

Example usage:
```python
from prefect.filesystems import LocalFileSystem
from prefect.flows import bind_flow_to_infrastructure, flow
from prefect.workers.process import ProcessWorker

result_storage = LocalFileSystem(basepath="result_storage")
result_storage.save("my-result-storage")

@flow(
    result_storage=result_storage,
)
def hello_world():
    return "Hello, world!"

infrastructure_bound_flow = bind_flow_to_infrastructure(
    flow=hello_world, work_pool="my-work-pool", worker_cls=ProcessWorker
)

# Will run in a subprocess
assert infrastructure_bound_flow() == "Hello, world!"
```

Related to https://github.com/PrefectHQ/prefect/issues/17194