### PR TITLE
Fix null `Scheduling` case in Vertex worker

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/workers/vertex.py
@@ -513,12 +513,11 @@ class VertexAIWorker(BaseWorker):
         if "scheduling" in configuration.job_spec:
             scheduling_params = configuration.job_spec.pop("scheduling")
             # allow users to pass 'scheduling.strategy' as str
-            if type(scheduling_params.get("strategy")) is str:
+            if scheduling_params and type(scheduling_params.get("strategy")) is str:
                 scheduling_params["strategy"] = Scheduling.Strategy[
                     scheduling_params["strategy"]
                 ]
-
-            scheduling = Scheduling(**scheduling_params)
+                scheduling = Scheduling(**scheduling_params)
 
         # set 'scheduling.timeout' using "maximum_run_time_hours" for backward compatibility
         if "maximum_run_time_hours" in configuration.job_spec:

--- a/src/integrations/prefect-gcp/tests/test_vertex_worker.py
+++ b/src/integrations/prefect-gcp/tests/test_vertex_worker.py
@@ -163,6 +163,13 @@ class TestVertexAIWorker:
                 status_code=0, identifier="mock_display_name"
             )
 
+    async def test_missing_scheduling(self, flow_run, job_config):
+        job_config.job_spec["scheduling"] = None
+
+        async with VertexAIWorker("test-pool") as worker:
+            job_config.prepare_for_flow_run(flow_run, None, None)
+            await worker.run(flow_run=flow_run, configuration=job_config)
+
     async def test_params_worker_run(self, flow_run, job_config):
         async with VertexAIWorker("test-pool") as worker:
             # Initialize scheduling parameters


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
Handles cases where `Scheduling` job variable is `None`.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
