### PR TITLE
Add CLI to configure GCS storage for a work pool

### DIFF
--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -706,6 +706,10 @@ def _determine_storage_type(storage_config: WorkPoolStorageConfiguration) -> str
         "prefect_aws" in step for step in storage_config.bundle_upload_step.keys()
     ):
         return "S3"
+    if storage_config.bundle_upload_step and any(
+        "prefect_gcp" in step for step in storage_config.bundle_upload_step.keys()
+    ):
+        return "GCS"
     return "Unknown"
 
 
@@ -771,14 +775,11 @@ work_pool_storage_app.add_typer(work_pool_storage_configure_app)
 
 @work_pool_storage_configure_app.command()
 async def s3(
-    work_pool_name: Annotated[
-        str,
-        typer.Argument(
-            ...,
-            help="The name of the work pool to configure storage for.",
-            show_default=False,
-        ),
-    ],
+    work_pool_name: str = typer.Argument(
+        ...,
+        help="The name of the work pool to configure storage for.",
+        show_default=False,
+    ),
     bucket: str = typer.Option(
         ...,
         "--bucket",
@@ -789,7 +790,7 @@ async def s3(
     credentials_block_name: str = typer.Option(
         ...,
         "--aws-credentials-block-name",
-        help="The name of the credentials block to use.",
+        help="The name of the AWS credentials block to use.",
         show_default=False,
         prompt="Enter the name of the AWS credentials block to use",
     ),
@@ -799,7 +800,7 @@ async def s3(
 
     \b
     Examples:
-        $ prefect work-pool storage configure s3 "my-pool" --bucket my-bucket --credentials-block-name my-credentials
+        $ prefect work-pool storage configure s3 "my-pool" --bucket my-bucket --aws-credentials-block-name my-credentials
     """
     # TODO: Allow passing in AWS keys and creating a block for the user.
     async with get_client() as client:
@@ -838,3 +839,70 @@ async def s3(
             exit_with_error(f"Work pool {work_pool_name!r} does not exist.")
 
         exit_with_success(f"Configured S3 storage for work pool {work_pool_name!r}")
+
+
+@work_pool_storage_configure_app.command()
+async def gcs(
+    work_pool_name: str = typer.Argument(
+        ...,
+        help="The name of the work pool to configure storage for.",
+        show_default=False,
+    ),
+    bucket: str = typer.Option(
+        ...,
+        "--bucket",
+        help="The name of the GCS bucket to use.",
+        show_default=False,
+        prompt="Enter the name of the GCS bucket to use",
+    ),
+    credentials_block_name: str = typer.Option(
+        ...,
+        "--gcp-credentials-block-name",
+        help="The name of the GCP credentials block to use.",
+        show_default=False,
+        prompt="Enter the name of the GCP credentials block to use",
+    ),
+):
+    """
+    EXPERIMENTAL: Configure GCS storage for a work pool.
+
+    \b
+    Examples:
+        $ prefect work-pool storage configure gcs "my-pool" --bucket my-bucket --gcp-credentials-block-name my-credentials
+    """
+    async with get_client() as client:
+        try:
+            await client.read_block_document_by_name(
+                name=credentials_block_name, block_type_slug="gcp-credentials"
+            )
+        except ObjectNotFound:
+            exit_with_error(
+                f"GCS credentials block {credentials_block_name!r} does not exist. Please create one using `prefect block create gcp-credentials`."
+            )
+
+        try:
+            await client.update_work_pool(
+                work_pool_name=work_pool_name,
+                work_pool=WorkPoolUpdate(
+                    storage_configuration=WorkPoolStorageConfiguration(
+                        bundle_upload_step={
+                            "prefect_gcp.experimental.bundles.upload": {
+                                "requires": "prefect-gcp",
+                                "bucket": bucket,
+                                "credentials_block_name": credentials_block_name,
+                            }
+                        },
+                        bundle_execution_step={
+                            "prefect_gcp.experimental.bundles.execute": {
+                                "requires": "prefect-gcp",
+                                "bucket": bucket,
+                                "credentials_block_name": credentials_block_name,
+                            }
+                        },
+                    ),
+                ),
+            )
+        except ObjectNotFound:
+            exit_with_error(f"Work pool {work_pool_name!r} does not exist.")
+
+        exit_with_success(f"Configured GCS storage for work pool {work_pool_name!r}")

--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -851,20 +851,20 @@ async def gcs(
     bucket: str = typer.Option(
         ...,
         "--bucket",
-        help="The name of the GCS bucket to use.",
+        help="The name of the Google Cloud Storage bucket to use.",
         show_default=False,
-        prompt="Enter the name of the GCS bucket to use",
+        prompt="Enter the name of the Google Cloud Storage bucket to use",
     ),
     credentials_block_name: str = typer.Option(
         ...,
         "--gcp-credentials-block-name",
-        help="The name of the GCP credentials block to use.",
+        help="The name of the Google Cloud credentials block to use.",
         show_default=False,
-        prompt="Enter the name of the GCP credentials block to use",
+        prompt="Enter the name of the Google Cloud credentials block to use",
     ),
 ):
     """
-    EXPERIMENTAL: Configure GCS storage for a work pool.
+    EXPERIMENTAL: Configure Google Cloud storage for a work pool.
 
     \b
     Examples:

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -923,90 +923,219 @@ async def aws_credentials(prefect_client: PrefectClient) -> BlockDocument:
     )
 
 
+@pytest.fixture
+async def gcs_credentials(prefect_client: PrefectClient) -> BlockDocument:
+    gcs_credentials_type = await prefect_client.create_block_type(
+        block_type=BlockTypeCreate(
+            name="GCP Credentials",
+            slug="gcp-credentials",
+        )
+    )
+
+    gcs_credentials_schema = await prefect_client.create_block_schema(
+        block_schema=BlockSchemaCreate(
+            block_type_id=gcs_credentials_type.id,
+            fields={"properties": {"service_account_info": {"type": "object"}}},
+        )
+    )
+
+    return await prefect_client.create_block_document(
+        block_document=BlockDocumentCreate(
+            name="my-gcs-creds",
+            block_type_id=gcs_credentials_type.id,
+            block_schema_id=gcs_credentials_schema.id,
+            data={
+                "service_account_info": {
+                    "type": "service_account",
+                    "project_id": "test-project",
+                    "private_key": "test-private-key",
+                    "client_email": "test-client-email",
+                    "private_key_id": "test-private-key-id",
+                    "client_id": "test-client-id",
+                }
+            },
+        )
+    )
+
+
 class TestStorageConfigure:
-    async def test_storage_configure_s3(
-        self,
-        prefect_client: PrefectClient,
-        work_pool: WorkPool,
-        aws_credentials: BlockDocument,
-    ):
-        """Test configuring S3 storage for a work pool."""
-        await run_sync_in_worker_thread(
-            invoke_and_assert,
-            command=[
-                "work-pool",
-                "storage",
-                "configure",
-                "s3",
-                work_pool.name,
-                "--bucket",
-                "test-bucket",
-                "--aws-credentials-block-name",
-                aws_credentials.name,
-            ],
-            expected_code=0,
-            expected_output_contains=[
-                f"Configured S3 storage for work pool {work_pool.name!r}"
-            ],
-        )
+    class TestS3:
+        async def test_storage_configure(
+            self,
+            prefect_client: PrefectClient,
+            work_pool: WorkPool,
+            aws_credentials: BlockDocument,
+        ):
+            """Test configuring S3 storage for a work pool."""
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "s3",
+                    work_pool.name,
+                    "--bucket",
+                    "test-bucket",
+                    "--aws-credentials-block-name",
+                    aws_credentials.name,
+                ],
+                expected_code=0,
+                expected_output_contains=[
+                    f"Configured S3 storage for work pool {work_pool.name!r}"
+                ],
+            )
 
-        # Verify the configuration was saved
-        client_res = await prefect_client.read_work_pool(work_pool.name)
-        assert client_res.storage_configuration.bundle_upload_step is not None
-        assert (
-            client_res.storage_configuration.bundle_upload_step[
-                "prefect_aws.experimental.bundles.upload"
-            ]["bucket"]
-            == "test-bucket"
-        )
-        assert (
-            client_res.storage_configuration.bundle_upload_step[
-                "prefect_aws.experimental.bundles.upload"
-            ]["aws_credentials_block_name"]
-            == aws_credentials.name
-        )
+            # Verify the configuration was saved
+            client_res = await prefect_client.read_work_pool(work_pool.name)
+            assert client_res.storage_configuration.bundle_upload_step == {
+                "prefect_aws.experimental.bundles.upload": {
+                    "requires": "prefect-aws",
+                    "bucket": "test-bucket",
+                    "aws_credentials_block_name": aws_credentials.name,
+                }
+            }
+            assert client_res.storage_configuration.bundle_execution_step == {
+                "prefect_aws.experimental.bundles.execute": {
+                    "requires": "prefect-aws",
+                    "bucket": "test-bucket",
+                    "aws_credentials_block_name": aws_credentials.name,
+                }
+            }
 
-    async def test_storage_configure_s3_nonexistent_pool(
-        self, aws_credentials: BlockDocument
-    ):
-        """Test configuring S3 storage for a nonexistent work pool."""
-        await run_sync_in_worker_thread(
-            invoke_and_assert,
-            command=[
-                "work-pool",
-                "storage",
-                "configure",
-                "s3",
-                "nonexistent-pool",
-                "--bucket",
-                "test-bucket",
-                "--aws-credentials-block-name",
-                aws_credentials.name,
-            ],
-            expected_code=1,
-            expected_output_contains=["Work pool 'nonexistent-pool' does not exist"],
-        )
+        async def test_storage_configure_nonexistent_pool(
+            self, aws_credentials: BlockDocument
+        ):
+            """Test configuring S3 storage for a nonexistent work pool."""
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "s3",
+                    "nonexistent-pool",
+                    "--bucket",
+                    "test-bucket",
+                    "--aws-credentials-block-name",
+                    aws_credentials.name,
+                ],
+                expected_code=1,
+                expected_output_contains=[
+                    "Work pool 'nonexistent-pool' does not exist"
+                ],
+            )
 
-    async def test_storage_configure_s3_nonexistent_credentials(
-        self, work_pool: WorkPool
-    ):
-        """Test configuring S3 storage with nonexistent credentials block."""
-        res = await run_sync_in_worker_thread(
-            invoke_and_assert,
-            command=[
-                "work-pool",
-                "storage",
-                "configure",
-                "s3",
-                work_pool.name,
-                "--bucket",
-                "test-bucket",
-                "--aws-credentials-block-name",
-                "nonexistent-credentials",
-            ],
-            expected_code=1,
-            expected_output_contains=[
-                "AWS credentials block 'nonexistent-credentials' does not exist"
-            ],
-        )
-        assert res.exit_code == 1
+        async def test_storage_configure_s3_nonexistent_credentials(
+            self, work_pool: WorkPool
+        ):
+            """Test configuring S3 storage with nonexistent credentials block."""
+            res = await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "s3",
+                    work_pool.name,
+                    "--bucket",
+                    "test-bucket",
+                    "--aws-credentials-block-name",
+                    "nonexistent-credentials",
+                ],
+                expected_code=1,
+                expected_output_contains=[
+                    "AWS credentials block 'nonexistent-credentials' does not exist"
+                ],
+            )
+            assert res.exit_code == 1
+
+    class TestGCS:
+        async def test_storage_configure(
+            self,
+            work_pool: WorkPool,
+            gcs_credentials: BlockDocument,
+            prefect_client: PrefectClient,
+        ):
+            """Test configuring GCS storage for a work pool."""
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "gcs",
+                    work_pool.name,
+                    "--bucket",
+                    "test-bucket",
+                    "--gcp-credentials-block-name",
+                    gcs_credentials.name,
+                ],
+                expected_code=0,
+                expected_output_contains=[
+                    f"Configured GCS storage for work pool {work_pool.name!r}"
+                ],
+            )
+
+            # Verify the configuration was saved
+            client_res = await prefect_client.read_work_pool(work_pool.name)
+            assert client_res.storage_configuration.bundle_upload_step == {
+                "prefect_gcp.experimental.bundles.upload": {
+                    "requires": "prefect-gcp",
+                    "bucket": "test-bucket",
+                    "credentials_block_name": gcs_credentials.name,
+                }
+            }
+            assert client_res.storage_configuration.bundle_execution_step == {
+                "prefect_gcp.experimental.bundles.execute": {
+                    "requires": "prefect-gcp",
+                    "bucket": "test-bucket",
+                    "credentials_block_name": gcs_credentials.name,
+                }
+            }
+
+        async def test_storage_configure_nonexistent_pool(
+            self, gcs_credentials: BlockDocument
+        ):
+            """Test configuring GCS storage for a nonexistent work pool."""
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "gcs",
+                    "nonexistent-pool",
+                    "--bucket",
+                    "test-bucket",
+                    "--gcp-credentials-block-name",
+                    gcs_credentials.name,
+                ],
+                expected_code=1,
+                expected_output_contains=[
+                    "Work pool 'nonexistent-pool' does not exist"
+                ],
+            )
+
+        async def test_storage_configure_gcs_nonexistent_credentials(
+            self, work_pool: WorkPool
+        ):
+            """Test configuring GCS storage with nonexistent credentials block."""
+            await run_sync_in_worker_thread(
+                invoke_and_assert,
+                command=[
+                    "work-pool",
+                    "storage",
+                    "configure",
+                    "gcs",
+                    work_pool.name,
+                    "--bucket",
+                    "test-bucket",
+                    "--gcp-credentials-block-name",
+                    "nonexistent-credentials",
+                ],
+                expected_code=1,
+                expected_output_contains=[
+                    "GCS credentials block 'nonexistent-credentials' does not exist"
+                ],
+            )


### PR DESCRIPTION
This PR expands the work pool storage configuration CLI to include GCS.

Example:
```
~/d/P/prefect ❯❯❯ uv run prefect work-pool storage configure gcs olympic \
    --bucket storage-blocks-test-bucket \
    --gcp-credentials-block-name my-gcp-creds
Configured GCS storage for work pool 'olympic'

~/d/P/prefect ❯❯❯ uv run prefect work-pool storage inspect olympic
╭─────────── Storage Configuration for olympic ───────────╮
│ ┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
│ ┃ Setting                ┃ Value                      ┃ │
│ ┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩ │
│ │ type                   │ GCS                        │ │
│ │ bucket                 │ storage-blocks-test-bucket │ │
│ │ requires               │ prefect-gcs                │ │
│ │ credentials_block_name │ my-gcp-creds               │ │
│ └────────────────────────┴────────────────────────────┘ │
╰─────────────────────────────────────────────────────────╯
```