### PR TITLE
Fixes `Runner` command handling for Windows

### DIFF
--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -780,10 +780,8 @@ class Runner:
         """
         if command is None:
             runner_command = [get_sys_executable(), "-m", "prefect.engine"]
-        elif os.name == "nt":
-            runner_command = command.split(" ")
         else:
-            runner_command = shlex.split(command)
+            runner_command = shlex.split(command, posix=(os.name != "nt"))
 
         flow_run_logger = self._get_flow_run_logger(flow_run)
 

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -780,6 +780,8 @@ class Runner:
         """
         if command is None:
             runner_command = [get_sys_executable(), "-m", "prefect.engine"]
+        elif os.name == "nt":
+            runner_command = command.split(" ")
         else:
             runner_command = shlex.split(command)
 


### PR DESCRIPTION
`shlex.split` removes the double-quotes we need to ensure that Python paths with spaces work on Windows. This carves out a case for Windows that I've tested on a Windows VM.

Closes https://github.com/PrefectHQ/prefect/issues/17820