### PR TITLE
Propagates the currently triggering event (if any) for composite triggers

### DIFF
--- a/src/prefect/server/events/triggers.py
+++ b/src/prefect/server/events/triggers.py
@@ -307,6 +307,7 @@ async def evaluate_composite_trigger(session: AsyncSession, firing: Firing) -> N
                 trigger_states={TriggerState.Triggered},
                 triggered=prefect.types._datetime.now("UTC"),
                 triggering_firings=[firing],
+                triggering_event=firing.triggering_event,
             ),
         )
         return
@@ -357,6 +358,7 @@ async def evaluate_composite_trigger(session: AsyncSession, firing: Firing) -> N
                 trigger_states={TriggerState.Triggered},
                 triggered=prefect.types._datetime.now("UTC"),
                 triggering_firings=firings,
+                triggering_event=firing.triggering_event,
             ),
         )
 

--- a/tests/events/server/triggers/test_composite_triggers.py
+++ b/tests/events/server/triggers/test_composite_triggers.py
@@ -312,6 +312,7 @@ class TestCompoundTriggerAny:
         firing: Firing = act.call_args.args[0]
 
         assert firing.trigger.id == compound_automation_any_nested.trigger.id
+        assert firing.triggering_event == flow_run_events[-1]
 
     async def test_compound_automation_any_double_nested_trigger(
         self,
@@ -328,6 +329,7 @@ class TestCompoundTriggerAny:
         firing: Firing = act.call_args.args[0]
 
         assert firing.trigger.id == compound_automation_any_double_nested.trigger.id
+        assert firing.triggering_event == flow_run_events[-1]
 
 
 class TestCompoundTriggerAll:


### PR DESCRIPTION
Just like an event trigger, a composite trigger _may_ have a triggering
event that caused it to fire (like when all of its component triggers
are Reactive event triggers, a pretty common case).  Here, we propagate
that triggering event up through the firings so that folks can access
it from templates.  More importantly, this allows actions to make
inferences from the triggering event (like being able to infer a
deployment from it for the `PauseDeployment` action, for example).

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

closes https://github.com/PrefectHQ/prefect/issues/16399