### PR TITLE
serve all tasks in a module

### DIFF
--- a/src/prefect/cli/task.py
+++ b/src/prefect/cli/task.py
@@ -1,25 +1,47 @@
-from typing import TYPE_CHECKING, Any
+import inspect
+from typing import Any
 
 import typer
 
 from prefect.cli._types import PrefectTyper
 from prefect.cli._utilities import exit_with_error
 from prefect.cli.root import app
+from prefect.logging import get_logger
 from prefect.task_worker import serve as task_serve
-from prefect.utilities.importtools import import_object
-
-if TYPE_CHECKING:
-    from prefect.tasks import Task
+from prefect.tasks import Task
+from prefect.utilities.importtools import import_object, load_module
 
 task_app: PrefectTyper = PrefectTyper(name="task", help="Work with task scheduling.")
 app.add_typer(task_app, aliases=["task"])
 
+logger = get_logger("prefect.cli.task")
+
+
+def _import_tasks_from_module(module: str) -> list[Task[..., Any]]:
+    try:
+        mod = load_module(module)
+    except ModuleNotFoundError:
+        exit_with_error(
+            f"Module '{module}' could not be imported. Please check the module name and try again."
+        )
+    return [
+        obj
+        for _, obj in inspect.getmembers(mod)
+        if isinstance(obj, Task) and not inspect.ismodule(obj)
+    ]
+
 
 @task_app.command()
 async def serve(
-    entrypoints: list[str] = typer.Argument(
-        ...,
+    entrypoints: list[str] | None = typer.Argument(
+        None,
         help="The paths to one or more tasks, in the form of `./path/to/file.py:task_func_name`.",
+    ),
+    module: str | None = typer.Option(
+        None,
+        "--module",
+        "-m",
+        help="The module to import the tasks from. Defaults to the current directory.",
     ),
     limit: int = typer.Option(
         10,
@@ -38,7 +60,7 @@ async def serve(
     """
     tasks: list["Task[..., Any]"] = []
 
-    for entrypoint in entrypoints:
+    for entrypoint in entrypoints or []:
         if ".py:" not in entrypoint:
             exit_with_error(
                 (
@@ -54,5 +76,19 @@ async def serve(
             exit_with_error(
                 f"Error: {module!r} has no function {task_name!r}.", style="red"
             )
+
+    if module:
+        module_tasks = _import_tasks_from_module(module)
+        logger.debug(f"Found {len(module_tasks)} tasks in {module!r}.")
+        tasks.extend(module_tasks)
+
+    if not tasks:
+        sources: dict[str, list[str]] = {}
+        if entrypoints:
+            sources["entrypoints"] = entrypoints
+        if module:
+            sources["module"] = [module]
+
+        exit_with_error(f"No tasks found to serve in {sources!r}.")
 
     await task_serve(*tasks, limit=limit)

--- a/src/prefect/cli/task.py
+++ b/src/prefect/cli/task.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import inspect
-from typing import Any
+from typing import Any, Optional
 
 import typer
 
@@ -33,11 +35,11 @@ def _import_tasks_from_module(module: str) -> list[Task[Any, Any]]:
 
 @task_app.command()
 async def serve(
-    entrypoints: list[str] | None = typer.Argument(
+    entrypoints: Optional[list[str]] = typer.Argument(
         None,
         help="The paths to one or more tasks, in the form of `./path/to/file.py:task_func_name`.",
     ),
-    module: list[str] | None = typer.Option(
+    module: Optional[list[str]] = typer.Option(
         None,
         "--module",
         "-m",

--- a/src/prefect/cli/task.py
+++ b/src/prefect/cli/task.py
@@ -21,12 +21,7 @@ logger: logging.Logger = get_logger("prefect.cli.task")
 
 
 def _import_tasks_from_module(module: str) -> list[Task[Any, Any]]:
-    try:
-        mod = load_module(module)
-    except ModuleNotFoundError:
-        exit_with_error(
-            f"Module '{module}' could not be imported. Please check the module name and try again."
-        )
+    mod = load_module(module)
     return [
         obj
         for _, obj in inspect.getmembers(mod)
@@ -89,7 +84,12 @@ async def serve(
 
     elif module:
         for mod in module:
-            module_tasks = _import_tasks_from_module(mod)
+            try:
+                module_tasks = _import_tasks_from_module(mod)
+            except Exception as e:
+                exit_with_error(
+                    f"Module '{mod}' could not be imported. Please check the module name and try again.\n\n{e.__class__.__name__}: {e}"
+                )
             plural = "s" if len(module_tasks) > 1 else ""
             logger.debug(f"Found {len(module_tasks)} task{plural} in {mod!r}.")
             tasks.extend(module_tasks)

--- a/src/prefect/cli/task.py
+++ b/src/prefect/cli/task.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import logging
 from typing import Any, Optional
 
 import typer
@@ -16,7 +17,7 @@ from prefect.utilities.importtools import import_object, load_module
 task_app: PrefectTyper = PrefectTyper(name="task", help="Work with task scheduling.")
 app.add_typer(task_app, aliases=["task"])
 
-logger = get_logger("prefect.cli.task")
+logger: logging.Logger = get_logger("prefect.cli.task")
 
 
 def _import_tasks_from_module(module: str) -> list[Task[Any, Any]]:

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -80,3 +80,77 @@ async def test_multiple_entrypoints():
         assert len(served_tasks) == 2
         assert served_tasks[0].name == "do_the_dishes"
         assert served_tasks[1].name == "spacewalk"
+
+
+async def test_mutual_exclusivity():
+    await run_sync_in_worker_thread(
+        invoke_and_assert,
+        [
+            "task",
+            "serve",
+            f"{TEST_PROJECTS_DIR}/tasks/household.py:do_the_dishes",
+            "--module",
+            "tests.test-projects.tasks.household",
+        ],
+        expected_code=1,
+        expected_output_contains=[
+            "You may provide entrypoints or modules, but not both at the same time."
+        ],
+    )
+
+
+async def test_module_import_error():
+    await run_sync_in_worker_thread(
+        invoke_and_assert,
+        [
+            "task",
+            "serve",
+            "--module",
+            "tests.test-projects.tasks.doesnotexist",
+        ],
+        expected_code=1,
+        expected_output_contains=[
+            "Module 'tests.test-projects.tasks.doesnotexist' could not be imported. Please check the module name and try again."
+        ],
+    )
+
+
+async def test_single_module():
+    with mock.patch(
+        "prefect.cli.task.task_serve", new_callable=mock.AsyncMock
+    ) as task_serve:
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            [
+                "task",
+                "serve",
+                "--module",
+                "tests.test-projects.tasks.household",
+            ],
+            expected_code=0,
+        )
+        task_serve.assert_awaited_once_with(mock.ANY, limit=10)
+        served_tasks = task_serve.call_args_list[0][0]
+        assert any(getattr(t, "name", None) == "do_the_dishes" for t in served_tasks)
+
+
+async def test_multiple_modules():
+    with mock.patch(
+        "prefect.cli.task.task_serve", new_callable=mock.AsyncMock
+    ) as task_serve:
+        await run_sync_in_worker_thread(
+            invoke_and_assert,
+            [
+                "task",
+                "serve",
+                "--module",
+                "tests.test-projects.tasks.household",
+                "--module",
+                "tests.test-projects.tasks.space",
+            ],
+            expected_code=0,
+        )
+        task_serve.assert_awaited_once_with(mock.ANY, mock.ANY, limit=10)
+        served_tasks = task_serve.call_args_list[0][0]
+        assert any(getattr(t, "name", None) == "do_the_dishes" for t in served_tasks)
+        assert any(getattr(t, "name", None) == "spacewalk" for t in served_tasks)


### PR DESCRIPTION
This pull request enhances the `task serve` command in the Prefect CLI by introducing support for importing tasks from Python modules in addition to entrypoints.


* Added support for specifying tasks via the `--module` option, allowing users to import tasks directly from Python modules. A new helper function `_import_tasks_from_module` was introduced to handle module imports. [[1]](diffhunk://#diff-f3f9a30115e3340d1216e6704ad41d055c231121f8634b2ac3ed791a994c9423L1-R48) [[2]](diffhunk://#diff-f3f9a30115e3340d1216e6704ad41d055c231121f8634b2ac3ed791a994c9423L53-R107)
* Updated the `serve` command to enforce mutual exclusivity between `entrypoints` and `--module` options, with appropriate error messages when both are provided.

* Added tests to validate mutual exclusivity between `entrypoints` and `--module` options, module import errors, and successful task serving from single or multiple modules.


### example use
```bash
» prefect task serve -m sandbox.tasks
11:27:22.352 | DEBUG   | prefect.profiles - Using profile 'bleeding'
11:27:22.834 | DEBUG   | prefect.cli.task - Found 3 tasks in 'sandbox.tasks'.
11:27:22.850 | DEBUG   | prefect.task_worker - Starting task worker...
11:27:22.850 | DEBUG   | prefect.client - Connecting to API at http://127.0.0.1:4200/api/
11:27:22.850 | INFO    | prefect.task_worker - Starting task worker...
11:27:22.850 | INFO    | prefect.task_worker - Subscribing to runs of task(s): hello_world | hello_world_2 | hello_world_3
```

Note that since you're not allowed currently to provide both entrypoints and modules at the same time, it should be impossible to have duplicates.  Because even if you define the same task twice in the same module, only the latter would be in the namespace for the module.