### PR TITLE
Fix warning on reconnect

### DIFF
--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -400,7 +400,7 @@ class PrefectEventsClient(EventsClient):
                 "Set PREFECT_DEBUG_MODE=1 to see the full error.",
                 self._events_socket_url,
                 str(e),
-                exc_info=PREFECT_DEBUG_MODE,
+                exc_info=PREFECT_DEBUG_MODE.value(),
             )
             raise
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

* Prefect Worker logs a warning on reconnection to server and `PREFECT_DEBUG_MODE` is passed as `exc_info`.
* However, it is not boolean, by prefect setting, hence `.value()` should be called on this object, so I assume it is a typo/bug indeed.
* Currently when using JSON logs formatter, the warning is failed to render with an exception
```
pydantic_core._pydantic_core.PydanticSerializationError: Unable to serialize unknown type: <class 'prefect.settings.legacy.Setting'>
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
