### PR TITLE
Add `@docker` decorator

### DIFF
--- a/src/integrations/prefect-docker/prefect_docker/experimental/__init__.py
+++ b/src/integrations/prefect-docker/prefect_docker/experimental/__init__.py
@@ -1,0 +1,3 @@
+from .decorators import docker
+
+__all__ = ["docker"]

--- a/src/integrations/prefect-docker/prefect_docker/experimental/decorators.py
+++ b/src/integrations/prefect-docker/prefect_docker/experimental/decorators.py
@@ -1,0 +1,44 @@
+from typing import Any, Callable, TypeVar
+
+from typing_extensions import ParamSpec
+
+from prefect import Flow
+from prefect.flows import InfrastructureBoundFlow, bind_flow_to_infrastructure
+from prefect_docker.worker import DockerWorker
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def docker(work_pool: str, **job_variables: Any) -> Callable[[Flow[P, R]], Flow[P, R]]:
+    """
+    Decorator that binds execution of a flow to a Kubernetes work pool
+
+    Args:
+        work_pool: The name of the Kubernetes work pool to use
+        **job_variables: Additional job variables to use for infrastructure configuration
+
+    Example:
+        ```python
+        from prefect import flow
+        from prefect_kubernetes import kubernetes
+
+        @kubernetes(work_pool="my-pool")
+        @flow
+        def my_flow():
+            ...
+
+        # This will run the flow in a Kubernetes job
+        my_flow()
+        ```
+    """
+
+    def decorator(flow: Flow[P, R]) -> InfrastructureBoundFlow[P, R]:
+        return bind_flow_to_infrastructure(
+            flow,
+            work_pool=work_pool,
+            job_variables=job_variables,
+            worker_cls=DockerWorker,
+        )
+
+    return decorator

--- a/src/integrations/prefect-docker/prefect_docker/experimental/decorators.py
+++ b/src/integrations/prefect-docker/prefect_docker/experimental/decorators.py
@@ -12,23 +12,23 @@ R = TypeVar("R")
 
 def docker(work_pool: str, **job_variables: Any) -> Callable[[Flow[P, R]], Flow[P, R]]:
     """
-    Decorator that binds execution of a flow to a Kubernetes work pool
+    Decorator that binds execution of a flow to a Docker work pool
 
     Args:
-        work_pool: The name of the Kubernetes work pool to use
+        work_pool: The name of the Docker work pool to use
         **job_variables: Additional job variables to use for infrastructure configuration
 
     Example:
         ```python
         from prefect import flow
-        from prefect_kubernetes import kubernetes
+        from prefect_docker import docker
 
-        @kubernetes(work_pool="my-pool")
+        @docker(work_pool="my-pool")
         @flow
         def my_flow():
             ...
 
-        # This will run the flow in a Kubernetes job
+        # This will run the flow in a Docker container
         my_flow()
         ```
     """

--- a/src/integrations/prefect-docker/prefect_docker/worker.py
+++ b/src/integrations/prefect-docker/prefect_docker/worker.py
@@ -509,7 +509,7 @@ class DockerWorker(BaseWorker[DockerWorkerJobConfiguration, Any, DockerWorkerRes
                     "volumes": [
                         *existing_volumes,
                         *job_variable_volumes,
-                        # This is a temporary volume for the bundle and result
+                        # This is a temporary volume for the bundle
                         f"{temp_dir}:/tmp/",
                     ],
                 }
@@ -561,9 +561,6 @@ class DockerWorker(BaseWorker[DockerWorkerJobConfiguration, Any, DockerWorkerRes
                 work_pool=self._work_pool,
                 worker_name=self.name,
             )
-
-            if not flow.result_storage:
-                flow.result_storage = Path(temp_dir) / "results"
 
             bundle = create_bundle_for_flow_run(flow=flow, flow_run=flow_run)
 

--- a/src/integrations/prefect-docker/prefect_docker/worker.py
+++ b/src/integrations/prefect-docker/prefect_docker/worker.py
@@ -26,7 +26,6 @@ import tempfile
 import urllib.parse
 import uuid
 import warnings
-from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -487,13 +486,10 @@ class DockerWorker(BaseWorker[DockerWorkerJobConfiguration, Any, DockerWorkerRes
         ) as temp_dir:
             upload_command = None
             if not storage_configured_on_work_pool:
-                execute_command = [
-                    "python",
-                    "-m",
-                    "prefect._experimental.bundles.execute",
-                    "--key",
-                    (Path("/tmp") / bundle_key).as_posix(),
-                ]
+                execute_command = convert_step_to_command(
+                    {"prefect._experimental.bundles.execute": {"requires": "prefect"}},
+                    f"/tmp/{bundle_key}",
+                )
                 existing_volumes: list[str] = (
                     get_from_dict(
                         self._work_pool.base_job_template,

--- a/src/integrations/prefect-docker/pyproject.toml
+++ b/src/integrations/prefect-docker/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["prefect>=3.1.1", "docker>=6.1.1", "exceptiongroup"]
+dependencies = ["prefect>=3.3.5", "docker>=6.1.1", "exceptiongroup"]
 dynamic = ["version"]
 
 [dependency-groups]

--- a/src/integrations/prefect-docker/pyproject.toml
+++ b/src/integrations/prefect-docker/pyproject.toml
@@ -71,7 +71,7 @@ fail_under = 80
 show_missing = true
 
 [tool.uv.sources]
-prefect = { path = "../../../" }
+prefect = { path = "../../../", editable = true }
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "session"

--- a/src/integrations/prefect-docker/tests/experimental/test_decorators.py
+++ b/src/integrations/prefect-docker/tests/experimental/test_decorators.py
@@ -1,0 +1,193 @@
+import uuid
+from typing import Generator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from prefect_docker.experimental.decorators import docker
+from prefect_docker.worker import DockerWorker
+
+import prefect
+from prefect.client.schemas.actions import WorkPoolCreate
+from prefect.client.schemas.objects import WorkPool, WorkPoolStorageConfiguration
+from prefect.futures import PrefectFuture
+
+
+@pytest.fixture
+def mock_submit(monkeypatch: pytest.MonkeyPatch) -> Generator[AsyncMock, None, None]:
+    """Create a mock for the DockerWorker.submit method"""
+    # Create a mock state
+    mock_state = MagicMock(spec=prefect.State)
+    mock_state.is_completed.return_value = True
+    mock_state.message = "Success"
+
+    # Create a mock future
+    mock_future = MagicMock(spec=PrefectFuture)
+    mock_future.aresult = AsyncMock(return_value="test_result")
+    mock_future.wait_async = AsyncMock()
+    mock_future.state = mock_state
+
+    mock = AsyncMock(return_value=mock_future)
+
+    monkeypatch.setattr(DockerWorker, "submit", mock)
+    yield mock
+
+
+@pytest.fixture
+async def work_pool_without_storage_configuration():
+    async with prefect.get_client() as client:
+        work_pool = await client.create_work_pool(
+            WorkPoolCreate(
+                name=f"test-{uuid.uuid4()}",
+                base_job_template=DockerWorker.get_default_base_job_template(),
+            )
+        )
+        try:
+            yield work_pool
+        finally:
+            await client.delete_work_pool(work_pool.name)
+
+
+@pytest.fixture
+async def work_pool_with_storage_configuration():
+    UPLOAD_STEP = {
+        "prefect_mock.experimental.bundles.upload": {
+            "requires": "prefect-mock==0.5.5",
+            "bucket": "test-bucket",
+            "credentials_block_name": "my-creds",
+        }
+    }
+
+    EXECUTE_STEP = {
+        "prefect_mock.experimental.bundles.execute": {
+            "requires": "prefect-mock==0.5.5",
+            "bucket": "test-bucket",
+            "credentials_block_name": "my-creds",
+        }
+    }
+
+    async with prefect.get_client() as client:
+        work_pool = await client.create_work_pool(
+            WorkPoolCreate(
+                name=f"test-{uuid.uuid4()}",
+                base_job_template=DockerWorker.get_default_base_job_template(),
+                storage_configuration=WorkPoolStorageConfiguration(
+                    bundle_execution_step=EXECUTE_STEP,
+                    bundle_upload_step=UPLOAD_STEP,
+                ),
+            )
+        )
+        try:
+            yield work_pool
+        finally:
+            await client.delete_work_pool(work_pool.name)
+
+
+def test_docker_decorator_sync_flow(mock_submit: AsyncMock) -> None:
+    """Test that a synchronous flow is correctly decorated and executed"""
+
+    @docker(work_pool="test-pool", volumes=["/tmp/test:/tmp/test"])
+    @prefect.flow
+    def sync_test_flow(param1: str, param2: str = "default") -> str:
+        return f"{param1}-{param2}"
+
+    result = sync_test_flow("test")
+
+    mock_submit.assert_called_once()
+    args, kwargs = mock_submit.call_args
+    assert kwargs["parameters"] == {"param1": "test", "param2": "default"}
+    assert kwargs["job_variables"] == {"volumes": ["/tmp/test:/tmp/test"]}
+    assert result == "test_result"
+
+
+async def test_docker_decorator_async_flow(mock_submit: AsyncMock) -> None:
+    """Test that an asynchronous flow is correctly decorated and executed"""
+
+    @docker(work_pool="test-pool", volumes=["/tmp/test:/tmp/test"])
+    @prefect.flow
+    async def async_test_flow(param1: str) -> str:
+        return f"async-{param1}"
+
+    result = await async_test_flow("test")
+
+    mock_submit.assert_called_once()
+    args, kwargs = mock_submit.call_args
+    assert kwargs["parameters"] == {"param1": "test"}
+    assert kwargs["job_variables"] == {"volumes": ["/tmp/test:/tmp/test"]}
+    assert result == "test_result"
+
+
+@pytest.mark.usefixtures("mock_submit")
+def test_docker_decorator_return_state() -> None:
+    """Test that return_state=True returns the state instead of the result"""
+
+    @docker(work_pool="test-pool")
+    @prefect.flow
+    def test_flow():
+        return "completed"
+
+    state = test_flow(return_state=True)
+
+    assert state.is_completed()
+    assert state.message == "Success"
+
+
+@pytest.mark.usefixtures("mock_submit")
+def test_docker_decorator_preserves_flow_attributes() -> None:
+    """Test that the decorator preserves the original flow's attributes"""
+
+    @prefect.flow(name="custom-flow-name", description="Custom description")
+    def original_flow():
+        return "test"
+
+    original_name = original_flow.name
+    original_description = original_flow.description
+
+    decorated_flow = docker(work_pool="test-pool")(original_flow)
+
+    assert decorated_flow.name == original_name
+    assert decorated_flow.description == original_description
+
+    result = decorated_flow()
+    assert result == "test_result"
+
+
+def test_submit_method_receives_work_pool_name(mock_submit: AsyncMock) -> None:
+    """Test that the correct work pool name is passed to submit"""
+
+    @docker(work_pool="specific-pool")
+    @prefect.flow
+    def test_flow():
+        return "test"
+
+    test_flow()
+
+    mock_submit.assert_called_once()
+    kwargs = mock_submit.call_args.kwargs
+    assert "flow" in kwargs
+    assert "parameters" in kwargs
+    assert "job_variables" in kwargs
+
+
+def test_uses_volume_mount_when_work_pool_has_storage_configuration(
+    work_pool_without_storage_configuration: WorkPool, mock_submit: AsyncMock
+) -> None:
+    """Test that a volume mount is used when the work pool has a storage configuration"""
+
+    @docker(
+        work_pool=work_pool_without_storage_configuration.name,
+        volumes=["/tmp/test:/tmp/test"],
+    )
+    @prefect.flow
+    def test_flow():
+        return "test"
+
+    test_flow()
+
+    mock_submit.assert_called_once()
+    kwargs = mock_submit.call_args.kwargs
+    assert "job_variables" in kwargs
+    job_variables = kwargs["job_variables"]
+    assert "volumes" in job_variables
+    assert len(job_variables["volumes"]) == 2
+    assert job_variables["volumes"][0] == "/tmp/test:/tmp/test"
+    assert job_variables["volumes"][1].endswith("/tmp/")

--- a/src/prefect/_experimental/bundles/execute.py
+++ b/src/prefect/_experimental/bundles/execute.py
@@ -1,0 +1,34 @@
+import json
+
+import typer
+
+from prefect.utilities.asyncutils import run_coro_as_sync
+
+
+def execute_bundle_from_file(key: str):
+    """
+    Loads a bundle from a file and executes it.
+
+    Args:
+        key: The key of the bundle to execute.
+    """
+    with open(key, "r") as f:
+        bundle = json.load(f)
+
+    from prefect.runner.runner import Runner
+
+    run_coro_as_sync(Runner().execute_bundle(bundle))
+
+
+def _execute_bundle_from_file(key: str = typer.Option(...)):
+    """
+    Loads a bundle from a file and executes it.
+
+    Args:
+        key: The key of the bundle to execute.
+    """
+    execute_bundle_from_file(key)
+
+
+if __name__ == "__main__":
+    typer.run(_execute_bundle_from_file)

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -237,7 +237,7 @@ class Runner:
         self._deployment_ids: set[UUID] = set()
         self._flow_run_process_map: dict[UUID, ProcessMapEntry] = dict()
         self.__flow_run_process_map_lock: asyncio.Lock | None = None
-        self._flow_run_bundle_map: dict[UUID, SerializedBundle] = dict()
+        self._flow_run_bundle_map: dict[UUID, "SerializedBundle"] = dict()
         # Flip to True when we are rescheduling flow runs to avoid marking flow runs as crashed
         self._rescheduling: bool = False
 

--- a/src/prefect/runner/runner.py
+++ b/src/prefect/runner/runner.py
@@ -237,7 +237,7 @@ class Runner:
         self._deployment_ids: set[UUID] = set()
         self._flow_run_process_map: dict[UUID, ProcessMapEntry] = dict()
         self.__flow_run_process_map_lock: asyncio.Lock | None = None
-        self._flow_run_bundle_map: dict[UUID, "SerializedBundle"] = dict()
+        self._flow_run_bundle_map: dict[UUID, SerializedBundle] = dict()
         # Flip to True when we are rescheduling flow runs to avoid marking flow runs as crashed
         self._rescheduling: bool = False
 

--- a/uv.lock
+++ b/uv.lock
@@ -4074,7 +4074,7 @@ dependencies = [
 requires-dist = [
     { name = "docker", specifier = ">=6.1.1" },
     { name = "exceptiongroup" },
-    { name = "prefect", directory = "." },
+    { name = "prefect", editable = "." },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
This PR adds a `@docker` decorator to bind a flow to run in a Docker container. This decorator is slightly different from the others introduced because it can operate without storage configured on the work pool. If the work pool doesn't have storage configured, then the flow bundle will be persisted to a temporary directory and a volume mount will be added to the created container so the bundle will be available for execution.

Here's what the usage looks like:
```python
from prefect_docker.experimental import docker

from prefect import flow
from prefect.filesystems import LocalFileSystem

result_storage = LocalFileSystem(basepath="/tmp/results")
result_storage.save("result-storage", overwrite=True)


@docker(
    work_pool="in-ground",
    image="prefecthq/prefect:local",
    volumes=["/tmp/results:/tmp/results"],
)
@flow(result_storage=result_storage)
def run_in_docker():
    print("Hello, world!")


run_in_docker()
```

The local usage isn't quite as nice as I'd like because the user has to create a separate mount to get the results back from the container. If we can find a reliable way to know when to set up that result persistence on the user's behalf, then the DX can be improved.

Related to https://github.com/PrefectHQ/prefect/issues/17194