### PR TITLE
Add `with_options` implementation to `InfrastructureBoundFlow`

### DIFF
--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -2147,6 +2147,63 @@ class InfrastructureBoundFlow(Flow[P, R]):
 
         return run_coro_as_sync(submit_func())
 
+    def with_options(
+        self,
+        *,
+        name: Optional[str] = None,
+        version: Optional[str] = None,
+        retries: Optional[int] = None,
+        retry_delay_seconds: Optional[Union[int, float]] = None,
+        description: Optional[str] = None,
+        flow_run_name: Optional[Union[Callable[[], str], str]] = None,
+        task_runner: Union[
+            Type[TaskRunner[PrefectFuture[Any]]], TaskRunner[PrefectFuture[Any]], None
+        ] = None,
+        timeout_seconds: Union[int, float, None] = None,
+        validate_parameters: Optional[bool] = None,
+        persist_result: Optional[bool] = NotSet,  # type: ignore
+        result_storage: Optional[ResultStorage] = NotSet,  # type: ignore
+        result_serializer: Optional[ResultSerializer] = NotSet,  # type: ignore
+        cache_result_in_memory: Optional[bool] = None,
+        log_prints: Optional[bool] = NotSet,  # type: ignore
+        on_completion: Optional[list[FlowStateHook[P, R]]] = None,
+        on_failure: Optional[list[FlowStateHook[P, R]]] = None,
+        on_cancellation: Optional[list[FlowStateHook[P, R]]] = None,
+        on_crashed: Optional[list[FlowStateHook[P, R]]] = None,
+        on_running: Optional[list[FlowStateHook[P, R]]] = None,
+        job_variables: Optional[dict[str, Any]] = None,
+    ) -> "InfrastructureBoundFlow[P, R]":
+        new_flow = super().with_options(
+            name=name,
+            version=version,
+            retries=retries,
+            retry_delay_seconds=retry_delay_seconds,
+            description=description,
+            flow_run_name=flow_run_name,
+            task_runner=task_runner,
+            timeout_seconds=timeout_seconds,
+            validate_parameters=validate_parameters,
+            persist_result=persist_result,
+            result_storage=result_storage,
+            result_serializer=result_serializer,
+            cache_result_in_memory=cache_result_in_memory,
+            log_prints=log_prints,
+            on_completion=on_completion,
+            on_failure=on_failure,
+            on_cancellation=on_cancellation,
+            on_crashed=on_crashed,
+            on_running=on_running,
+        )
+        new_infrastructure_bound_flow = bind_flow_to_infrastructure(
+            new_flow,
+            self.work_pool,
+            self.worker_cls,
+            job_variables=job_variables
+            if job_variables is not None
+            else self.job_variables,
+        )
+        return new_infrastructure_bound_flow
+
 
 def bind_flow_to_infrastructure(
     flow: Flow[P, R],

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -289,7 +289,7 @@ class TestDecorator:
 
 class TestResultPersistence:
     @pytest.mark.parametrize("persist_result", [True, False])
-    def test_persist_result_set_to_bool(self, persist_result):
+    def test_persist_result_set_to_bool(self, persist_result: bool):
         @flow(persist_result=persist_result)
         def my_flow():
             pass

--- a/tests/test_infrastructure_bound_flow.py
+++ b/tests/test_infrastructure_bound_flow.py
@@ -2,6 +2,7 @@ import os
 import uuid
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -113,6 +114,59 @@ class TestInfrastructureBoundFlow:
             infrastructure_bound_flow.task_runner
             == ThreadPoolTaskRunner()  # this one is implicit
         )
+
+    def test_with_options(self, work_pool: WorkPool, result_storage: LocalFileSystem):
+        on_mock = MagicMock()
+
+        @flow(
+            result_storage=result_storage,
+        )
+        def hello_world():
+            return "Hello, world!"
+
+        infrastructure_bound_flow = bind_flow_to_infrastructure(
+            flow=hello_world, work_pool=work_pool.name, worker_cls=ProcessWorker
+        )
+
+        infrastructure_bound_flow = infrastructure_bound_flow.with_options(
+            name="new-name",
+            description="new-description",
+            flow_run_name="new-flow-run-name",
+            retries=10,
+            retry_delay_seconds=1,
+            timeout_seconds=100,
+            validate_parameters=True,
+            persist_result=False,
+            result_storage=result_storage,
+            result_serializer=JSONSerializer(),
+            cache_result_in_memory=True,
+            log_prints=False,
+            on_completion=[on_mock],
+            on_failure=[on_mock],
+            on_cancellation=[on_mock],
+            on_crashed=[on_mock],
+            on_running=[on_mock],
+            job_variables={"key": "value"},
+        )
+
+        assert infrastructure_bound_flow.name == "new-name"
+        assert infrastructure_bound_flow.description == "new-description"
+        assert infrastructure_bound_flow.flow_run_name == "new-flow-run-name"
+        assert infrastructure_bound_flow.retries == 10
+        assert infrastructure_bound_flow.retry_delay_seconds == 1
+        assert infrastructure_bound_flow.timeout_seconds == 100
+        assert infrastructure_bound_flow.should_validate_parameters is True
+        assert infrastructure_bound_flow.persist_result is False
+        assert infrastructure_bound_flow.result_storage == result_storage
+        assert infrastructure_bound_flow.result_serializer == JSONSerializer()
+        assert infrastructure_bound_flow.cache_result_in_memory is True
+        assert infrastructure_bound_flow.log_prints is False
+        assert infrastructure_bound_flow.on_completion_hooks == [on_mock]
+        assert infrastructure_bound_flow.on_failure_hooks == [on_mock]
+        assert infrastructure_bound_flow.on_cancellation_hooks == [on_mock]
+        assert infrastructure_bound_flow.on_crashed_hooks == [on_mock]
+        assert infrastructure_bound_flow.on_running_hooks == [on_mock]
+        assert infrastructure_bound_flow.job_variables == {"key": "value"}
 
     @pytest.mark.filterwarnings("ignore::FutureWarning")
     def test_basic_call(self, work_pool: WorkPool, result_storage: LocalFileSystem):


### PR DESCRIPTION
Because `InfrastructureBoundFlow` subclasses `Flow` and `with_options` explicitly returns a `Flow` instance, we need a `with_options` implementation that handles the additional fields that `InfrastructureBoundFlow` exposes. This PR adds `with_options` to `InfrastructureBoundFlow` and allows users to update the `job_variables` associated with an `InfrastructureBoundFlow`.

Related to https://github.com/PrefectHQ/prefect/issues/17194