### PR TITLE
Polishes the experience with inferring versioning

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -16805,6 +16805,17 @@
                         ],
                         "title": "Enforce Parameter Schema",
                         "description": "Whether or not the deployment should enforce the parameter schema."
+                    },
+                    "version_info": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/VersionInfo"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "A description of this version of the deployment."
                     }
                 },
                 "additionalProperties": false,

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -769,7 +769,6 @@ async def _run_single_deploy(
 
     version_info = await _version_info_from_options(options, deploy_config)
 
-    app.console.print(f"Version info: {version_info}")
     apply_coro = deployment.apply(version_info=version_info)
     if TYPE_CHECKING:
         assert inspect.isawaitable(apply_coro)
@@ -866,14 +865,12 @@ async def _run_single_deploy(
 async def _version_info_from_options(
     options: dict[str, Any], deploy_config: dict[str, Any]
 ) -> VersionInfo | None:
-    if version_type := (
-        options.get("version_type") or deploy_config.get("version_type")
-    ):
-        app.console.print(f"Inferring version info for {version_type}...")
-        return await get_inferred_version_info(version_type)
-
     if version := options.get("version"):
         return VersionInfo(type="prefect:simple", version=version)
+
+    version_type = options.get("version_type") or deploy_config.get("version_type")
+    if version_info := await get_inferred_version_info(version_type):
+        return version_info
 
     return None
 

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -767,7 +767,7 @@ async def _run_single_deploy(
             "enforce_parameter_schema"
         )
 
-    version_info = await _version_info_from_options(options, deploy_config)
+    version_info = await _version_info_from_options(client, options, deploy_config)
 
     apply_coro = deployment.apply(version_info=version_info)
     if TYPE_CHECKING:
@@ -863,8 +863,13 @@ async def _run_single_deploy(
 
 
 async def _version_info_from_options(
-    options: dict[str, Any], deploy_config: dict[str, Any]
+    client: "PrefectClient",
+    options: dict[str, Any],
+    deploy_config: dict[str, Any],
 ) -> VersionInfo | None:
+    if client.server_type != ServerType.CLOUD:
+        return None
+
     if version := options.get("version"):
         return VersionInfo(type="prefect:simple", version=version)
 

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -767,7 +767,7 @@ async def _run_single_deploy(
             "enforce_parameter_schema"
         )
 
-    version_info = await _version_info_from_options(client, options, deploy_config)
+    version_info = await _version_info_from_options(options, deploy_config)
 
     apply_coro = deployment.apply(version_info=version_info)
     if TYPE_CHECKING:
@@ -863,9 +863,7 @@ async def _run_single_deploy(
 
 
 async def _version_info_from_options(
-    client: "PrefectClient",
-    options: dict[str, Any],
-    deploy_config: dict[str, Any],
+    options: dict[str, Any], deploy_config: dict[str, Any]
 ) -> VersionInfo | None:
     if version := options.get("version"):
         return VersionInfo(type="prefect:simple", version=version)

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -867,9 +867,6 @@ async def _version_info_from_options(
     options: dict[str, Any],
     deploy_config: dict[str, Any],
 ) -> VersionInfo | None:
-    if client.server_type != ServerType.CLOUD:
-        return None
-
     if version := options.get("version"):
         return VersionInfo(type="prefect:simple", version=version)
 

--- a/src/prefect/server/models/deployments.py
+++ b/src/prefect/server/models/deployments.py
@@ -80,7 +80,7 @@ async def _delete_scheduled_runs(
 async def create_deployment(
     db: PrefectDBInterface,
     session: AsyncSession,
-    deployment: schemas.core.Deployment,
+    deployment: schemas.core.Deployment | schemas.actions.DeploymentCreate,
 ) -> Optional[orm_models.Deployment]:
     """Upserts a deployment.
 
@@ -102,7 +102,7 @@ async def create_deployment(
 
     schedules = deployment.schedules
     insert_values = deployment.model_dump_for_orm(
-        exclude_unset=True, exclude={"schedules"}
+        exclude_unset=True, exclude={"schedules", "version_info"}
     )
 
     requested_concurrency_limit = insert_values.pop("concurrency_limit", "unset")
@@ -122,6 +122,7 @@ async def create_deployment(
             "schedules",
             "job_variables",
             "concurrency_limit",
+            "version_info",
         },
     )
     if job_variables:
@@ -225,7 +226,7 @@ async def update_deployment(
     # the user, ignoring any defaults on the model
     update_data = deployment.model_dump_for_orm(
         exclude_unset=True,
-        exclude={"work_pool_name"},
+        exclude={"work_pool_name", "version_info"},
     )
 
     requested_global_concurrency_limit_update = update_data.pop(

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -353,6 +353,10 @@ class DeploymentUpdate(ActionBaseModel):
     )
     model_config: ClassVar[ConfigDict] = ConfigDict(populate_by_name=True)
 
+    version_info: Optional[schemas.core.VersionInfo] = Field(
+        default=None, description="A description of this version of the deployment."
+    )
+
     def check_valid_configuration(self, base_job_template: dict[str, Any]) -> None:
         """
         Check that the combination of base_job_template defaults and job_variables

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -23,7 +23,7 @@ def project_dir(tmp_path: Path):
 @pytest.fixture(autouse=True)
 def clean_environment(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("GITHUB_SHA", raising=False)
-    monkeypatch.delenv("GITHUB_REF", raising=False)
+    monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
     monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
     monkeypatch.delenv("GITHUB_SERVER_URL", raising=False)
 
@@ -75,7 +75,7 @@ async def github_repo(
     project_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> GithubVersionInfo:
     monkeypatch.setenv("GITHUB_SHA", "abcdef1234567890")
-    monkeypatch.setenv("GITHUB_REF", "my-current-branch")
+    monkeypatch.setenv("GITHUB_REF_NAME", "my-current-branch")
     monkeypatch.setenv("GITHUB_REPOSITORY", "org/test-repo")
     monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
     return GithubVersionInfo(

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -5996,6 +5996,8 @@ export interface components {
              * @description Whether or not the deployment should enforce the parameter schema.
              */
             enforce_parameter_schema?: boolean | null;
+            /** @description A description of this version of the deployment. */
+            version_info?: components["schemas"]["VersionInfo"] | null;
         };
         /**
          * DoNothing


### PR DESCRIPTION
* We were making the classic `.rstrip` mistake of thinking it took a
  string to replace, when it really takes string full of characters to
  replace.  Here we parse it with `urlparse` and are more deliberate
  about removing the trailing `.git`
* We were using the `GITHUB_REF` (like `refs/heads/main`) instead of the
  friendlier `GITHUB_REF_NAME` (like `main`)
* We were printing the `repr` of the `VersionInfo` out during deploy,
  but that's extra noise we don't need
* We're now inferring the version even if a `version_type` isn't
  provided, which should make this more seamless for users.  If
  `version` is explicitly passed, we'll use that directly

<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [ ] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [ ] If this pull request adds functions or classes, it includes helpful docstrings.
