### PR TITLE
Add vcs version types for Gitlab, Bitbucket, and Azure Devops

### DIFF
--- a/docs/v3/deploy/index.mdx
+++ b/docs/v3/deploy/index.mdx
@@ -6,7 +6,7 @@ description: Learn how to use deployments to trigger flow runs remotely.
 
 Deployments allow you to run flows on a [schedule](/v3/automate/add-schedules/) and trigger runs based on [events](/v3/automate/events/automations-triggers/).
 
-Deployments are server-side representations of flows.
+Deployments are versioned server-side representations of flows.
 They store the crucial metadata for remote orchestration including when, where, and how a workflow should run.
 
 In addition to manually triggering and managing flow runs, deploying a flow exposes an API and UI that allow you to:

--- a/docs/v3/deploy/index.mdx
+++ b/docs/v3/deploy/index.mdx
@@ -6,7 +6,7 @@ description: Learn how to use deployments to trigger flow runs remotely.
 
 Deployments allow you to run flows on a [schedule](/v3/automate/add-schedules/) and trigger runs based on [events](/v3/automate/events/automations-triggers/).
 
-Deployments are versioned server-side representations of flows.
+Deployments are server-side representations of flows.
 They store the crucial metadata for remote orchestration including when, where, and how a workflow should run.
 
 In addition to manually triggering and managing flow runs, deploying a flow exposes an API and UI that allow you to:

--- a/src/prefect/_versioning.py
+++ b/src/prefect/_versioning.py
@@ -11,6 +11,11 @@ from pydantic import Field, model_validator
 from prefect.client.schemas.objects import VersionInfo
 
 
+async def get_commit_message_first_line() -> str:
+    result = await run_process(["git", "log", "-1", "--pretty=%B"])
+    return result.stdout.decode().strip().splitlines()[0]
+
+
 class SimpleVersionInfo(VersionInfo):
     type: Literal["prefect:simple"] = "prefect:simple"
     version: str = Field(default="")
@@ -145,8 +150,7 @@ async def get_github_version_info(
         url = url or f"{os.getenv('GITHUB_SERVER_URL')}/{repository}/tree/{commit_sha}"
 
         if not message:
-            result = await run_process(["git", "log", "-1", "--pretty=%B"])
-            message = result.stdout.decode().strip().splitlines()[0]
+            message = await get_commit_message_first_line()
 
         if not commit_sha:
             raise ValueError(
@@ -206,8 +210,7 @@ async def get_gitlab_version_info(
         url = url or f"{os.getenv('CI_PROJECT_URL')}/-/tree/{commit_sha}"
 
         if not message:
-            result = await run_process(["git", "log", "-1", "--pretty=%B"])
-            message = result.stdout.decode().strip().splitlines()[0]
+            message = await get_commit_message_first_line()
 
         if not commit_sha:
             raise ValueError(
@@ -271,8 +274,7 @@ async def get_bitbucket_version_info(
         url = url or f"{os.getenv('BITBUCKET_GIT_HTTP_ORIGIN')}/src/{commit_sha}"
 
         if not message:
-            result = await run_process(["git", "log", "-1", "--pretty=%B"])
-            message = result.stdout.decode().strip().splitlines()[0]
+            message = await get_commit_message_first_line()
 
         if not commit_sha:
             raise ValueError(
@@ -336,8 +338,7 @@ async def get_azuredevops_version_info(
         url = url or f"{os.getenv('BUILD_REPOSITORY_URI')}?version=GC{commit_sha}"
 
         if not message:
-            result = await run_process(["git", "log", "-1", "--pretty=%B"])
-            message = result.stdout.decode().strip().splitlines()[0]
+            message = await get_commit_message_first_line()
 
         if not commit_sha:
             raise ValueError(
@@ -401,8 +402,7 @@ async def get_git_version_info(
                 repository = repository[:-4]
 
         if not message:
-            result = await run_process(["git", "log", "-1", "--pretty=%B"])
-            message = result.stdout.decode().strip().splitlines()[0]
+            message = await get_commit_message_first_line()
 
         if not url and repository:
             # Use the full remote URL as the URL

--- a/src/prefect/_versioning.py
+++ b/src/prefect/_versioning.py
@@ -144,7 +144,9 @@ async def get_github_version_info(
     url = url or f"{os.getenv('GITHUB_SERVER_URL')}/{repository}"
 
     if not message:
-        result = await run_process(["git", "log", "-1", "--pretty=%B"])
+        result = await run_process(
+            ["git", "log", "-1", "--pretty=%B", "|", "head", "-n", "1"]
+        )
         message = result.stdout.decode().strip()
 
     if not commit_sha:
@@ -199,7 +201,9 @@ async def get_gitlab_version_info(
     url = url or os.getenv("CI_PROJECT_URL")
 
     if not message:
-        result = await run_process(["git", "log", "-1", "--pretty=%B"])
+        result = await run_process(
+            ["git", "log", "-1", "--pretty=%B", "|", "head", "-n", "1"]
+        )
         message = result.stdout.decode().strip()
 
     if not commit_sha:
@@ -256,7 +260,9 @@ async def get_bitbucket_version_info(
     url = url or os.getenv("BITBUCKET_GIT_HTTP_ORIGIN")
 
     if not message:
-        result = await run_process(["git", "log", "-1", "--pretty=%B"])
+        result = await run_process(
+            ["git", "log", "-1", "--pretty=%B", "|", "head", "-n", "1"]
+        )
         message = result.stdout.decode().strip()
 
     if not commit_sha:

--- a/src/prefect/_versioning.py
+++ b/src/prefect/_versioning.py
@@ -168,7 +168,7 @@ async def get_github_version_info(
 
     return GithubVersionInfo(
         type="vcs:github",
-        version=message,
+        version=commit_sha[:8],
         commit_sha=commit_sha,
         message=message,
         branch=branch,
@@ -233,7 +233,7 @@ async def get_gitlab_version_info(
 
     return GitlabVersionInfo(
         type="vcs:gitlab",
-        version=message,
+        version=commit_sha[:8],
         commit_sha=commit_sha,
         message=message,
         branch=branch,
@@ -298,7 +298,7 @@ async def get_bitbucket_version_info(
 
     return BitbucketVersionInfo(
         type="vcs:bitbucket",
-        version=message,
+        version=commit_sha[:8],
         commit_sha=commit_sha,
         message=message,
         branch=branch,
@@ -363,7 +363,7 @@ async def get_azuredevops_version_info(
 
     return AzureDevopsVersionInfo(
         type="vcs:azuredevops",
-        version=message,
+        version=commit_sha[:8],
         commit_sha=commit_sha,
         message=message,
         branch=branch,
@@ -418,7 +418,7 @@ async def get_git_version_info(
 
     return GitVersionInfo(
         type="vcs:git",
-        version=message,
+        version=commit_sha[:8],
         branch=branch,
         url=url,
         repository=repository,

--- a/src/prefect/_versioning.py
+++ b/src/prefect/_versioning.py
@@ -144,10 +144,8 @@ async def get_github_version_info(
     url = url or f"{os.getenv('GITHUB_SERVER_URL')}/{repository}"
 
     if not message:
-        result = await run_process(
-            ["git", "log", "-1", "--pretty=%B", "|", "head", "-n", "1"]
-        )
-        message = result.stdout.decode().strip()
+        result = await run_process(["git", "log", "-1", "--pretty=%B"])
+        message = result.stdout.decode().strip().splitlines()[0]
 
     if not commit_sha:
         raise ValueError(
@@ -201,10 +199,8 @@ async def get_gitlab_version_info(
     url = url or os.getenv("CI_PROJECT_URL")
 
     if not message:
-        result = await run_process(
-            ["git", "log", "-1", "--pretty=%B", "|", "head", "-n", "1"]
-        )
-        message = result.stdout.decode().strip()
+        result = await run_process(["git", "log", "-1", "--pretty=%B"])
+        message = result.stdout.decode().strip().splitlines()[0]
 
     if not commit_sha:
         raise ValueError(
@@ -260,10 +256,8 @@ async def get_bitbucket_version_info(
     url = url or os.getenv("BITBUCKET_GIT_HTTP_ORIGIN")
 
     if not message:
-        result = await run_process(
-            ["git", "log", "-1", "--pretty=%B", "|", "head", "-n", "1"]
-        )
-        message = result.stdout.decode().strip()
+        result = await run_process(["git", "log", "-1", "--pretty=%B"])
+        message = result.stdout.decode().strip().splitlines()[0]
 
     if not commit_sha:
         raise ValueError(
@@ -319,7 +313,10 @@ async def get_azuredevops_version_info(
     branch = branch or os.getenv("BUILD_SOURCEBRANCHNAME")
     repository = repository or os.getenv("BUILD_REPOSITORY_NAME")
     url = url or os.getenv("BUILD_REPOSITORY_URI")
-    message = message or os.getenv("BUILD_SOURCEVERSIONMESSAGE")
+
+    if not message:
+        result = await run_process(["git", "log", "-1", "--pretty=%B"])
+        message = result.stdout.decode().strip().splitlines()[0]
 
     if not commit_sha:
         raise ValueError(

--- a/src/prefect/_versioning.py
+++ b/src/prefect/_versioning.py
@@ -130,7 +130,7 @@ async def get_github_version_info(
         message: The commit message, falls back to git log -1 --pretty=%B
         branch: The git branch, falls back to GITHUB_REF_NAME env var
         repository: The repository name, falls back to GITHUB_REPOSITORY env var
-        url: The repository URL, constructed from GITHUB_SERVER_URL/GITHUB_REPOSITORY if not provided
+        url: The repository URL, constructed from GITHUB_SERVER_URL/GITHUB_REPOSITORY/tree/GITHUB_SHA if not provided
 
     Returns:
         A GithubVersionInfo
@@ -142,7 +142,7 @@ async def get_github_version_info(
         commit_sha = commit_sha or os.getenv("GITHUB_SHA")
         branch = branch or os.getenv("GITHUB_REF_NAME")
         repository = repository or os.getenv("GITHUB_REPOSITORY")
-        url = url or f"{os.getenv('GITHUB_SERVER_URL')}/{repository}"
+        url = url or f"{os.getenv('GITHUB_SERVER_URL')}/{repository}/tree/{commit_sha}"
 
         if not message:
             result = await run_process(["git", "log", "-1", "--pretty=%B"])
@@ -191,7 +191,7 @@ async def get_gitlab_version_info(
         message: The commit message, falls back to git log -1 --pretty=%B
         branch: The git branch, falls back to CI_COMMIT_REF_NAME env var
         repository: The repository name, falls back to CI_PROJECT_NAME env var
-        url: The repository URL, constructed from CI_PROJECT_URL if not provided
+        url: The repository URL, constructed from CI_PROJECT_URL/-/tree/CI_COMMIT_SHA if not provided
 
     Returns:
         A GitlabVersionInfo
@@ -203,7 +203,7 @@ async def get_gitlab_version_info(
         commit_sha = commit_sha or os.getenv("CI_COMMIT_SHA")
         branch = branch or os.getenv("CI_COMMIT_REF_NAME")
         repository = repository or os.getenv("CI_PROJECT_NAME")
-        url = url or os.getenv("CI_PROJECT_URL")
+        url = url or f"{os.getenv('CI_PROJECT_URL')}/-/tree/{commit_sha}"
 
         if not message:
             result = await run_process(["git", "log", "-1", "--pretty=%B"])
@@ -256,7 +256,7 @@ async def get_bitbucket_version_info(
         message: The commit message, falls back to git log -1 --pretty=%B
         branch: The git branch, falls back to BITBUCKET_BRANCH env var
         repository: The repository name, falls back to BITBUCKET_REPO_SLUG env var
-        url: The repository URL, constructed from BITBUCKET_GIT_HTTP_ORIGIN if not provided
+        url: The repository URL, constructed from BITBUCKET_GIT_HTTP_ORIGIN/BITBUCKET_REPO_SLUG/src/BITBUCKET_COMMIT if not provided
 
     Returns:
         A BitbucketVersionInfo
@@ -268,7 +268,7 @@ async def get_bitbucket_version_info(
         commit_sha = commit_sha or os.getenv("BITBUCKET_COMMIT")
         branch = branch or os.getenv("BITBUCKET_BRANCH")
         repository = repository or os.getenv("BITBUCKET_REPO_SLUG")
-        url = url or os.getenv("BITBUCKET_GIT_HTTP_ORIGIN")
+        url = url or f"{os.getenv('BITBUCKET_GIT_HTTP_ORIGIN')}/src/{commit_sha}"
 
         if not message:
             result = await run_process(["git", "log", "-1", "--pretty=%B"])
@@ -321,7 +321,7 @@ async def get_azuredevops_version_info(
         message: The commit message, falls back to git log -1 --pretty=%B
         branch: The git branch, falls back to BUILD_SOURCEBRANCHNAME env var
         repository: The repository name, falls back to BUILD_REPOSITORY_NAME env var
-        url: The repository URL, constructed from BUILD_REPOSITORY_URI if not provided
+        url: The repository URL, constructed from BUILD_REPOSITORY_URI?version=GCBUILD_SOURCEVERSION if not provided
 
     Returns:
         An AzureDevopsVersionInfo
@@ -333,7 +333,7 @@ async def get_azuredevops_version_info(
         commit_sha = commit_sha or os.getenv("BUILD_SOURCEVERSION")
         branch = branch or os.getenv("BUILD_SOURCEBRANCHNAME")
         repository = repository or os.getenv("BUILD_REPOSITORY_NAME")
-        url = url or os.getenv("BUILD_REPOSITORY_URI")
+        url = url or f"{os.getenv('BUILD_REPOSITORY_URI')}?version=GC{commit_sha}"
 
         if not message:
             result = await run_process(["git", "log", "-1", "--pretty=%B"])

--- a/src/prefect/_versioning.py
+++ b/src/prefect/_versioning.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Coroutine, Dict, Literal, Optional
 from urllib.parse import urlparse
 
 from anyio import run_process
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from prefect.client.schemas.objects import VersionInfo
 
@@ -32,18 +32,6 @@ class GithubVersionInfo(VersionInfo):
     repository: str
     url: str
 
-    @model_validator(mode="after")
-    def validate_branch(self):
-        if not self.branch:
-            raise ValueError("branch is required when type is 'vcs:github'")
-        return self
-
-    @model_validator(mode="after")
-    def validate_commit_sha(self):
-        if not self.commit_sha:
-            raise ValueError("commit_sha is required when type is 'vcs:github'")
-        return self
-
 
 class GitlabVersionInfo(VersionInfo):
     type: Literal["vcs:gitlab"] = "vcs:gitlab"
@@ -53,18 +41,6 @@ class GitlabVersionInfo(VersionInfo):
     branch: str
     repository: str
     url: str
-
-    @model_validator(mode="after")
-    def validate_branch(self):
-        if not self.branch:
-            raise ValueError("branch is required when type is 'vcs:gitlab'")
-        return self
-
-    @model_validator(mode="after")
-    def validate_commit_sha(self):
-        if not self.commit_sha:
-            raise ValueError("commit_sha is required when type is 'vcs:gitlab'")
-        return self
 
 
 class BitbucketVersionInfo(VersionInfo):
@@ -76,18 +52,6 @@ class BitbucketVersionInfo(VersionInfo):
     repository: str
     url: str
 
-    @model_validator(mode="after")
-    def validate_branch(self):
-        if not self.branch:
-            raise ValueError("branch is required when type is 'vcs:bitbucket'")
-        return self
-
-    @model_validator(mode="after")
-    def validate_commit_sha(self):
-        if not self.commit_sha:
-            raise ValueError("commit_sha is required when type is 'vcs:bitbucket'")
-        return self
-
 
 class AzureDevopsVersionInfo(VersionInfo):
     type: Literal["vcs:azuredevops"] = "vcs:azuredevops"
@@ -97,18 +61,6 @@ class AzureDevopsVersionInfo(VersionInfo):
     branch: str
     repository: str
     url: str
-
-    @model_validator(mode="after")
-    def validate_branch(self):
-        if not self.branch:
-            raise ValueError("branch is required when type is 'vcs:azuredevops'")
-        return self
-
-    @model_validator(mode="after")
-    def validate_commit_sha(self):
-        if not self.commit_sha:
-            raise ValueError("commit_sha is required when type is 'vcs:azuredevops'")
-        return self
 
 
 class GitVersionInfo(VersionInfo):

--- a/src/prefect/_versioning.py
+++ b/src/prefect/_versioning.py
@@ -138,26 +138,32 @@ async def get_github_version_info(
     Raises:
         ValueError: If any required fields cannot be determined
     """
-    commit_sha = commit_sha or os.getenv("GITHUB_SHA")
-    branch = branch or os.getenv("GITHUB_REF_NAME")
-    repository = repository or os.getenv("GITHUB_REPOSITORY")
-    url = url or f"{os.getenv('GITHUB_SERVER_URL')}/{repository}"
+    try:
+        commit_sha = commit_sha or os.getenv("GITHUB_SHA")
+        branch = branch or os.getenv("GITHUB_REF_NAME")
+        repository = repository or os.getenv("GITHUB_REPOSITORY")
+        url = url or f"{os.getenv('GITHUB_SERVER_URL')}/{repository}"
 
-    if not message:
-        result = await run_process(["git", "log", "-1", "--pretty=%B"])
-        message = result.stdout.decode().strip().splitlines()[0]
+        if not message:
+            result = await run_process(["git", "log", "-1", "--pretty=%B"])
+            message = result.stdout.decode().strip().splitlines()[0]
 
-    if not commit_sha:
+        if not commit_sha:
+            raise ValueError(
+                "commit_sha is required - must be provided or set in GITHUB_SHA"
+            )
+        if not branch:
+            raise ValueError(
+                "branch is required - must be provided or set in GITHUB_REF_NAME"
+            )
+        if not repository:
+            raise ValueError(
+                "repository is required - must be provided or set in GITHUB_REPOSITORY"
+            )
+
+    except Exception as e:
         raise ValueError(
-            "commit_sha is required - must be provided or set in GITHUB_SHA"
-        )
-    if not branch:
-        raise ValueError(
-            "branch is required - must be provided or set in GITHUB_REF_NAME"
-        )
-    if not repository:
-        raise ValueError(
-            "repository is required - must be provided or set in GITHUB_REPOSITORY"
+            f"Error getting git version info: {e}. You may not be in a Github repository."
         )
 
     return GithubVersionInfo(
@@ -193,29 +199,37 @@ async def get_gitlab_version_info(
     Raises:
         ValueError: If any required fields cannot be determined
     """
-    commit_sha = commit_sha or os.getenv("CI_COMMIT_SHA")
-    branch = branch or os.getenv("CI_COMMIT_REF_NAME")
-    repository = repository or os.getenv("CI_PROJECT_NAME")
-    url = url or os.getenv("CI_PROJECT_URL")
+    try:
+        commit_sha = commit_sha or os.getenv("CI_COMMIT_SHA")
+        branch = branch or os.getenv("CI_COMMIT_REF_NAME")
+        repository = repository or os.getenv("CI_PROJECT_NAME")
+        url = url or os.getenv("CI_PROJECT_URL")
 
-    if not message:
-        result = await run_process(["git", "log", "-1", "--pretty=%B"])
-        message = result.stdout.decode().strip().splitlines()[0]
+        if not message:
+            result = await run_process(["git", "log", "-1", "--pretty=%B"])
+            message = result.stdout.decode().strip().splitlines()[0]
 
-    if not commit_sha:
+        if not commit_sha:
+            raise ValueError(
+                "commit_sha is required - must be provided or set in CI_COMMIT_SHA"
+            )
+        if not branch:
+            raise ValueError(
+                "branch is required - must be provided or set in CI_COMMIT_REF_NAME"
+            )
+        if not repository:
+            raise ValueError(
+                "repository is required - must be provided or set in CI_PROJECT_NAME"
+            )
+        if not url:
+            raise ValueError(
+                "url is required - must be provided or set in CI_PROJECT_URL"
+            )
+
+    except Exception as e:
         raise ValueError(
-            "commit_sha is required - must be provided or set in CI_COMMIT_SHA"
+            f"Error getting git version info: {e}. You may not be in a Gitlab repository."
         )
-    if not branch:
-        raise ValueError(
-            "branch is required - must be provided or set in CI_COMMIT_REF_NAME"
-        )
-    if not repository:
-        raise ValueError(
-            "repository is required - must be provided or set in CI_PROJECT_NAME"
-        )
-    if not url:
-        raise ValueError("url is required - must be provided or set in CI_PROJECT_URL")
 
     return GitlabVersionInfo(
         type="vcs:gitlab",
@@ -250,30 +264,36 @@ async def get_bitbucket_version_info(
     Raises:
         ValueError: If any required fields cannot be determined
     """
-    commit_sha = commit_sha or os.getenv("BITBUCKET_COMMIT")
-    branch = branch or os.getenv("BITBUCKET_BRANCH")
-    repository = repository or os.getenv("BITBUCKET_REPO_SLUG")
-    url = url or os.getenv("BITBUCKET_GIT_HTTP_ORIGIN")
+    try:
+        commit_sha = commit_sha or os.getenv("BITBUCKET_COMMIT")
+        branch = branch or os.getenv("BITBUCKET_BRANCH")
+        repository = repository or os.getenv("BITBUCKET_REPO_SLUG")
+        url = url or os.getenv("BITBUCKET_GIT_HTTP_ORIGIN")
 
-    if not message:
-        result = await run_process(["git", "log", "-1", "--pretty=%B"])
-        message = result.stdout.decode().strip().splitlines()[0]
+        if not message:
+            result = await run_process(["git", "log", "-1", "--pretty=%B"])
+            message = result.stdout.decode().strip().splitlines()[0]
 
-    if not commit_sha:
+        if not commit_sha:
+            raise ValueError(
+                "commit_sha is required - must be provided or set in BITBUCKET_COMMIT"
+            )
+        if not branch:
+            raise ValueError(
+                "branch is required - must be provided or set in BITBUCKET_BRANCH"
+            )
+        if not repository:
+            raise ValueError(
+                "repository is required - must be provided or set in BITBUCKET_REPO_SLUG"
+            )
+        if not url:
+            raise ValueError(
+                "url is required - must be provided or set in BITBUCKET_GIT_HTTP_ORIGIN"
+            )
+
+    except Exception as e:
         raise ValueError(
-            "commit_sha is required - must be provided or set in BITBUCKET_COMMIT"
-        )
-    if not branch:
-        raise ValueError(
-            "branch is required - must be provided or set in BITBUCKET_BRANCH"
-        )
-    if not repository:
-        raise ValueError(
-            "repository is required - must be provided or set in BITBUCKET_REPO_SLUG"
-        )
-    if not url:
-        raise ValueError(
-            "url is required - must be provided or set in BITBUCKET_GIT_HTTP_ORIGIN"
+            f"Error getting git version info: {e}. You may not be in a Bitbucket repository."
         )
 
     return BitbucketVersionInfo(
@@ -309,30 +329,36 @@ async def get_azuredevops_version_info(
     Raises:
         ValueError: If any required fields cannot be determined
     """
-    commit_sha = commit_sha or os.getenv("BUILD_SOURCEVERSION")
-    branch = branch or os.getenv("BUILD_SOURCEBRANCHNAME")
-    repository = repository or os.getenv("BUILD_REPOSITORY_NAME")
-    url = url or os.getenv("BUILD_REPOSITORY_URI")
+    try:
+        commit_sha = commit_sha or os.getenv("BUILD_SOURCEVERSION")
+        branch = branch or os.getenv("BUILD_SOURCEBRANCHNAME")
+        repository = repository or os.getenv("BUILD_REPOSITORY_NAME")
+        url = url or os.getenv("BUILD_REPOSITORY_URI")
 
-    if not message:
-        result = await run_process(["git", "log", "-1", "--pretty=%B"])
-        message = result.stdout.decode().strip().splitlines()[0]
+        if not message:
+            result = await run_process(["git", "log", "-1", "--pretty=%B"])
+            message = result.stdout.decode().strip().splitlines()[0]
 
-    if not commit_sha:
+        if not commit_sha:
+            raise ValueError(
+                "commit_sha is required - must be provided or set in BUILD_SOURCEVERSION"
+            )
+        if not branch:
+            raise ValueError(
+                "branch is required - must be provided or set in BUILD_SOURCEBRANCHNAME"
+            )
+        if not repository:
+            raise ValueError(
+                "repository is required - must be provided or set in BUILD_REPOSITORY_NAME"
+            )
+        if not url:
+            raise ValueError(
+                "url is required - must be provided or set in BUILD_REPOSITORY_URI"
+            )
+
+    except Exception as e:
         raise ValueError(
-            "commit_sha is required - must be provided or set in BUILD_SOURCEVERSION"
-        )
-    if not branch:
-        raise ValueError(
-            "branch is required - must be provided or set in BUILD_SOURCEBRANCHNAME"
-        )
-    if not repository:
-        raise ValueError(
-            "repository is required - must be provided or set in BUILD_REPOSITORY_NAME"
-        )
-    if not url:
-        raise ValueError(
-            "url is required - must be provided or set in BUILD_REPOSITORY_URI"
+            f"Error getting git version info: {e}. You may not be in an Azure DevOps repository."
         )
 
     return AzureDevopsVersionInfo(
@@ -376,7 +402,7 @@ async def get_git_version_info(
 
         if not message:
             result = await run_process(["git", "log", "-1", "--pretty=%B"])
-            message = result.stdout.decode().strip()
+            message = result.stdout.decode().strip().splitlines()[0]
 
         if not url and repository:
             # Use the full remote URL as the URL

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -865,12 +865,16 @@ async def _run_single_deploy(
 async def _version_info_from_options(
     options: dict[str, Any], deploy_config: dict[str, Any]
 ) -> VersionInfo | None:
-    if version := options.get("version"):
-        return VersionInfo(type="prefect:simple", version=version)
-
     version_type = options.get("version_type") or deploy_config.get("version_type")
     if version_info := await get_inferred_version_info(version_type):
-        return version_info
+        if version := options.get("version"):
+            version_info.version = (
+                version  # use the supplied version as the version name
+            )
+        return version_info  # otherwise the version name is the first line of the commit message
+
+    if version := options.get("version"):
+        return VersionInfo(type="prefect:simple", version=version)
 
     return None
 

--- a/src/prefect/cli/deploy.py
+++ b/src/prefect/cli/deploy.py
@@ -867,13 +867,13 @@ async def _version_info_from_options(
 ) -> VersionInfo | None:
     version_type = options.get("version_type") or deploy_config.get("version_type")
     if version_info := await get_inferred_version_info(version_type):
-        if version := options.get("version"):
+        if version := options.get("version") or deploy_config.get("version"):
             version_info.version = (
                 version  # use the supplied version as the version name
             )
         return version_info  # otherwise the version name is the first line of the commit message
 
-    if version := options.get("version"):
+    if version := options.get("version") or deploy_config.get("version"):
         return VersionInfo(type="prefect:simple", version=version)
 
     return None

--- a/tests/cli/deploy/test_deploy_versioning.py
+++ b/tests/cli/deploy/test_deploy_versioning.py
@@ -78,6 +78,8 @@ async def mock_get_inferred_version_info():
         mock_get_inferred.return_value = GitVersionInfo(
             type="vcs:git",
             version="abcdef12",
+            commit_sha="abcdef12",
+            message="Initial commit",
             branch="main",
             url="https://github.com/org/repo",
             repository="org/repo",
@@ -110,6 +112,8 @@ async def test_deploy_with_inferred_version(
     assert passed_version_info == VersionInfo(
         type="vcs:git",
         version="abcdef12",
+        commit_sha="abcdef12",
+        message="Initial commit",
         branch="main",
         url="https://github.com/org/repo",
         repository="org/repo",

--- a/tests/cli/deploy/test_deploy_versioning.py
+++ b/tests/cli/deploy/test_deploy_versioning.py
@@ -77,7 +77,7 @@ async def mock_get_inferred_version_info():
     ) as mock_get_inferred:
         mock_get_inferred.return_value = GitVersionInfo(
             type="vcs:git",
-            version="abcdef12",
+            version="Initial commit",
             commit_sha="abcdef12",
             message="Initial commit",
             branch="main",
@@ -111,7 +111,7 @@ async def test_deploy_with_inferred_version(
 
     assert passed_version_info == VersionInfo(
         type="vcs:git",
-        version="abcdef12",
+        version="Initial commit",
         commit_sha="abcdef12",
         message="Initial commit",
         branch="main",

--- a/tests/cli/deploy/test_deploy_versioning.py
+++ b/tests/cli/deploy/test_deploy_versioning.py
@@ -77,7 +77,7 @@ async def mock_get_inferred_version_info():
     ) as mock_get_inferred:
         mock_get_inferred.return_value = GitVersionInfo(
             type="vcs:git",
-            version="Initial commit",
+            version="abcdef12",
             commit_sha="abcdef12",
             message="Initial commit",
             branch="main",
@@ -111,7 +111,7 @@ async def test_deploy_with_inferred_version(
 
     assert passed_version_info == VersionInfo(
         type="vcs:git",
-        version="Initial commit",
+        version="abcdef12",
         commit_sha="abcdef12",
         message="Initial commit",
         branch="main",

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -169,7 +169,7 @@ async def github_repo(
         version="Initial commit",
         branch="my-current-branch",
         repository="org/test-repo",
-        url="https://github.com/org/test-repo",
+        url="https://github.com/org/test-repo/tree/abcdef1234567890",
         commit_sha="abcdef1234567890",
         message="Initial commit",
     )
@@ -211,7 +211,7 @@ async def gitlab_repo(
         version="Initial commit",
         branch="my-current-branch",
         repository="org/test-repo",
-        url="https://gitlab.com/org/test-repo",
+        url="https://gitlab.com/org/test-repo/-/tree/abcdef1234567890",
         commit_sha="abcdef1234567890",
         message="Initial commit",
     )
@@ -255,7 +255,7 @@ async def bitbucket_repo(
         version="Initial commit",
         branch="my-current-branch",
         repository="org/test-repo",
-        url="https://bitbucket.org/org/test-repo",
+        url="https://bitbucket.org/org/test-repo/src/abcdef1234567890",
         commit_sha="abcdef1234567890",
         message="Initial commit",
     )
@@ -297,7 +297,7 @@ async def azure_devops_repo(
         version="Initial commit",
         branch="my-current-branch",
         repository="org/test-repo",
-        url="https://dev.azure.com/org/test-repo",
+        url="https://dev.azure.com/org/test-repo?version=GCabcdef1234567890",
         commit_sha="abcdef1234567890",
         message="Initial commit",
     )
@@ -324,7 +324,7 @@ async def test_github_takes_precedence_over_git(
         version="Initial commit",
         branch="my-current-branch",
         repository="org/test-repo",
-        url="https://github.com/org/test-repo",
+        url="https://github.com/org/test-repo/tree/abcdef1234567890",
         commit_sha="abcdef1234567890",
         message="Initial commit",
     )
@@ -344,7 +344,7 @@ async def test_gitlab_takes_precedence_over_git(
         version="Initial commit",
         branch="my-current-branch",
         repository="org/test-repo",
-        url="https://gitlab.com/org/test-repo",
+        url="https://gitlab.com/org/test-repo/-/tree/abcdef1234567890",
         commit_sha="abcdef1234567890",
         message="Initial commit",
     )
@@ -366,7 +366,7 @@ async def test_bitbucket_takes_precedence_over_git(
         version="Initial commit",
         branch="my-current-branch",
         repository="org/test-repo",
-        url="https://bitbucket.org/org/test-repo",
+        url="https://bitbucket.org/org/test-repo/src/abcdef1234567890",
         commit_sha="abcdef1234567890",
         message="Initial commit",
     )
@@ -386,7 +386,7 @@ async def test_azure_devops_takes_precedence_over_git(
         version="Initial commit",
         branch="my-current-branch",
         repository="org/test-repo",
-        url="https://dev.azure.com/org/test-repo",
+        url="https://dev.azure.com/org/test-repo?version=GCabcdef1234567890",
         commit_sha="abcdef1234567890",
         message="Initial commit",
     )

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -84,7 +84,7 @@ async def git_repo(project_dir: Path) -> GitVersionInfo:
 
     return GitVersionInfo(
         type="vcs:git",
-        version="Initial commit",
+        version=commit_sha[:8],
         branch="my-default-branch",
         url="https://example.com/my-repo",
         repository="my-repo",
@@ -123,7 +123,7 @@ async def git_repo_many_lines_message(project_dir: Path) -> GitVersionInfo:
 
     return GitVersionInfo(
         type="vcs:git",
-        version="Initial commit",
+        version=commit_sha[:8],
         branch="my-default-branch",
         url="https://example.com/my-repo",
         repository="my-repo",
@@ -166,7 +166,7 @@ async def github_repo(
     monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
     return GithubVersionInfo(
         type="vcs:github",
-        version="Initial commit",
+        version="abcdef12",
         branch="my-current-branch",
         repository="org/test-repo",
         url="https://github.com/org/test-repo/tree/abcdef1234567890",
@@ -208,7 +208,7 @@ async def gitlab_repo(
     monkeypatch.setenv("CI_PROJECT_URL", "https://gitlab.com/org/test-repo")
     return GitlabVersionInfo(
         type="vcs:gitlab",
-        version="Initial commit",
+        version="abcdef12",
         branch="my-current-branch",
         repository="org/test-repo",
         url="https://gitlab.com/org/test-repo/-/tree/abcdef1234567890",
@@ -252,7 +252,7 @@ async def bitbucket_repo(
     )
     return BitbucketVersionInfo(
         type="vcs:bitbucket",
-        version="Initial commit",
+        version="abcdef12",
         branch="my-current-branch",
         repository="org/test-repo",
         url="https://bitbucket.org/org/test-repo/src/abcdef1234567890",
@@ -294,7 +294,7 @@ async def azure_devops_repo(
     monkeypatch.setenv("BUILD_REPOSITORY_URI", "https://dev.azure.com/org/test-repo")
     return AzureDevopsVersionInfo(
         type="vcs:azuredevops",
-        version="Initial commit",
+        version="abcdef12",
         branch="my-current-branch",
         repository="org/test-repo",
         url="https://dev.azure.com/org/test-repo?version=GCabcdef1234567890",
@@ -321,7 +321,7 @@ async def test_github_takes_precedence_over_git(
     version_info = await get_inferred_version_info()
     assert version_info == GithubVersionInfo(
         type="vcs:github",
-        version="Initial commit",
+        version="abcdef12",
         branch="my-current-branch",
         repository="org/test-repo",
         url="https://github.com/org/test-repo/tree/abcdef1234567890",
@@ -341,7 +341,7 @@ async def test_gitlab_takes_precedence_over_git(
     version_info = await get_inferred_version_info()
     assert version_info == GitlabVersionInfo(
         type="vcs:gitlab",
-        version="Initial commit",
+        version="abcdef12",
         branch="my-current-branch",
         repository="org/test-repo",
         url="https://gitlab.com/org/test-repo/-/tree/abcdef1234567890",
@@ -363,7 +363,7 @@ async def test_bitbucket_takes_precedence_over_git(
     version_info = await get_inferred_version_info()
     assert version_info == BitbucketVersionInfo(
         type="vcs:bitbucket",
-        version="Initial commit",
+        version="abcdef12",
         branch="my-current-branch",
         repository="org/test-repo",
         url="https://bitbucket.org/org/test-repo/src/abcdef1234567890",
@@ -383,7 +383,7 @@ async def test_azure_devops_takes_precedence_over_git(
     version_info = await get_inferred_version_info()
     assert version_info == AzureDevopsVersionInfo(
         type="vcs:azuredevops",
-        version="Initial commit",
+        version="abcdef12",
         branch="my-current-branch",
         repository="org/test-repo",
         url="https://dev.azure.com/org/test-repo?version=GCabcdef1234567890",

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -7,7 +7,10 @@ import pytest
 from anyio import run_process
 
 from prefect._versioning import (
+    AzureDevopsVersionInfo,
+    BitbucketVersionInfo,
     GithubVersionInfo,
+    GitlabVersionInfo,
     GitVersionInfo,
     get_inferred_version_info,
 )
@@ -21,11 +24,36 @@ def project_dir(tmp_path: Path):
 
 
 @pytest.fixture(autouse=True)
-def clean_environment(monkeypatch: pytest.MonkeyPatch):
+def clean_github_environment(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("GITHUB_SHA", raising=False)
     monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
     monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
     monkeypatch.delenv("GITHUB_SERVER_URL", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def clean_gitlab_environment(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("CI_COMMIT_SHA", raising=False)
+    monkeypatch.delenv("CI_COMMIT_REF_NAME", raising=False)
+    monkeypatch.delenv("CI_PROJECT_NAME", raising=False)
+    monkeypatch.delenv("CI_PROJECT_URL", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def clean_bitbucket_environment(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("BITBUCKET_COMMIT", raising=False)
+    monkeypatch.delenv("BITBUCKET_BRANCH", raising=False)
+    monkeypatch.delenv("BITBUCKET_REPO_SLUG", raising=False)
+    monkeypatch.delenv("BITBUCKET_GIT_HTTP_ORIGIN", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def clean_azure_devops_environment(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("BUILD_SOURCEVERSION", raising=False)
+    monkeypatch.delenv("BUILD_SOURCEBRANCHNAME", raising=False)
+    monkeypatch.delenv("BUILD_REPOSITORY_NAME", raising=False)
+    monkeypatch.delenv("BUILD_REPOSITORY_URI", raising=False)
+    monkeypatch.delenv("BUILD_SOURCEVERSIONMESSAGE", raising=False)
 
 
 async def test_get_inferred_version_info_with_no_other_information():
@@ -56,10 +84,12 @@ async def git_repo(project_dir: Path) -> GitVersionInfo:
 
     return GitVersionInfo(
         type="vcs:git",
-        version=commit_sha,
+        version="Initial commit",
         branch="my-default-branch",
         url="https://example.com/my-repo",
         repository="my-repo",
+        commit_sha=commit_sha,
+        message="Initial commit",
     )
 
 
@@ -74,16 +104,34 @@ async def test_get_inferred_version_info_with_git_version_info(
 async def github_repo(
     project_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> GithubVersionInfo:
+    async def git(*args: str) -> CompletedProcess[bytes]:
+        result = await run_process(["git", *args], check=False)
+        assert result.returncode == 0, result.stdout + b"\n" + result.stderr
+        return result
+
+    await git("init", "--initial-branch", "my-default-branch")
+    await git("config", "user.email", "me@example.com")
+    await git("config", "user.name", "Me")
+    await git("remote", "add", "origin", "https://github.com/org/test-repo")
+
+    test_file = project_dir / "test_file.txt"
+    test_file.write_text("This is a test file for the git repository")
+
+    await git("add", ".")
+    await git("commit", "-m", "Initial commit")
+
     monkeypatch.setenv("GITHUB_SHA", "abcdef1234567890")
     monkeypatch.setenv("GITHUB_REF_NAME", "my-current-branch")
     monkeypatch.setenv("GITHUB_REPOSITORY", "org/test-repo")
     monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
     return GithubVersionInfo(
         type="vcs:github",
-        version="abcdef1234567890",
+        version="Initial commit",
         branch="my-current-branch",
         repository="org/test-repo",
         url="https://github.com/org/test-repo",
+        commit_sha="abcdef1234567890",
+        message="Initial commit",
     )
 
 
@@ -94,8 +142,142 @@ async def test_get_inferred_version_info_with_github_version_info(
     assert version_info == github_repo
 
 
+@pytest.fixture
+async def gitlab_repo(
+    project_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> GitlabVersionInfo:
+    async def git(*args: str) -> CompletedProcess[bytes]:
+        result = await run_process(["git", *args], check=False)
+        assert result.returncode == 0, result.stdout + b"\n" + result.stderr
+        return result
+
+    await git("init", "--initial-branch", "my-default-branch")
+    await git("config", "user.email", "me@example.com")
+    await git("config", "user.name", "Me")
+    await git("remote", "add", "origin", "https://gitlab.com/org/test-repo")
+
+    test_file = project_dir / "test_file.txt"
+    test_file.write_text("This is a test file for the git repository")
+
+    await git("add", ".")
+    await git("commit", "-m", "Initial commit")
+
+    monkeypatch.setenv("CI_COMMIT_SHA", "abcdef1234567890")
+    monkeypatch.setenv("CI_COMMIT_REF_NAME", "my-current-branch")
+    monkeypatch.setenv("CI_PROJECT_NAME", "org/test-repo")
+    monkeypatch.setenv("CI_PROJECT_URL", "https://gitlab.com/org/test-repo")
+    return GitlabVersionInfo(
+        type="vcs:gitlab",
+        version="Initial commit",
+        branch="my-current-branch",
+        repository="org/test-repo",
+        url="https://gitlab.com/org/test-repo",
+        commit_sha="abcdef1234567890",
+        message="Initial commit",
+    )
+
+
+async def test_get_inferred_version_info_with_gitlab_version_info(
+    gitlab_repo: GitlabVersionInfo,
+):
+    version_info = await get_inferred_version_info()
+    assert version_info == gitlab_repo
+
+
+@pytest.fixture
+async def bitbucket_repo(
+    project_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> BitbucketVersionInfo:
+    async def git(*args: str) -> CompletedProcess[bytes]:
+        result = await run_process(["git", *args], check=False)
+        assert result.returncode == 0, result.stdout + b"\n" + result.stderr
+        return result
+
+    await git("init", "--initial-branch", "my-default-branch")
+    await git("config", "user.email", "me@example.com")
+    await git("config", "user.name", "Me")
+    await git("remote", "add", "origin", "https://bitbucket.org/org/test-repo")
+
+    test_file = project_dir / "test_file.txt"
+    test_file.write_text("This is a test file for the git repository")
+
+    await git("add", ".")
+    await git("commit", "-m", "Initial commit")
+
+    monkeypatch.setenv("BITBUCKET_COMMIT", "abcdef1234567890")
+    monkeypatch.setenv("BITBUCKET_BRANCH", "my-current-branch")
+    monkeypatch.setenv("BITBUCKET_REPO_SLUG", "org/test-repo")
+    monkeypatch.setenv(
+        "BITBUCKET_GIT_HTTP_ORIGIN", "https://bitbucket.org/org/test-repo"
+    )
+    return BitbucketVersionInfo(
+        type="vcs:bitbucket",
+        version="Initial commit",
+        branch="my-current-branch",
+        repository="org/test-repo",
+        url="https://bitbucket.org/org/test-repo",
+        commit_sha="abcdef1234567890",
+        message="Initial commit",
+    )
+
+
+async def test_get_inferred_version_info_with_bitbucket_version_info(
+    bitbucket_repo: BitbucketVersionInfo,
+):
+    version_info = await get_inferred_version_info()
+    assert version_info == bitbucket_repo
+
+
+@pytest.fixture
+async def azure_devops_repo(
+    project_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> AzureDevopsVersionInfo:
+    monkeypatch.setenv("BUILD_SOURCEVERSION", "abcdef1234567890")
+    monkeypatch.setenv("BUILD_SOURCEBRANCHNAME", "my-current-branch")
+    monkeypatch.setenv("BUILD_REPOSITORY_NAME", "org/test-repo")
+    monkeypatch.setenv("BUILD_REPOSITORY_URI", "https://dev.azure.com/org/test-repo")
+    monkeypatch.setenv("BUILD_SOURCEVERSIONMESSAGE", "Initial commit")
+    return AzureDevopsVersionInfo(
+        type="vcs:azuredevops",
+        version="Initial commit",
+        branch="my-current-branch",
+        repository="org/test-repo",
+        url="https://dev.azure.com/org/test-repo",
+        commit_sha="abcdef1234567890",
+        message="Initial commit",
+    )
+
+
+async def test_get_inferred_version_info_with_azure_devops_version_info(
+    azure_devops_repo: AzureDevopsVersionInfo,
+):
+    version_info = await get_inferred_version_info()
+    assert version_info == azure_devops_repo
+
+
 async def test_github_takes_precedence_over_git(
     git_repo: GitVersionInfo, github_repo: GithubVersionInfo
 ):
     version_info = await get_inferred_version_info()
     assert version_info == github_repo
+
+
+async def test_gitlab_takes_precedence_over_git(
+    git_repo: GitVersionInfo, gitlab_repo: GitlabVersionInfo
+):
+    version_info = await get_inferred_version_info()
+    assert version_info == gitlab_repo
+
+
+async def test_bitbucket_takes_precedence_over_git(
+    git_repo: GitVersionInfo, bitbucket_repo: BitbucketVersionInfo
+):
+    version_info = await get_inferred_version_info()
+    assert version_info == bitbucket_repo
+
+
+async def test_azure_devops_takes_precedence_over_git(
+    git_repo: GitVersionInfo, azure_devops_repo: AzureDevopsVersionInfo
+):
+    version_info = await get_inferred_version_info()
+    assert version_info == azure_devops_repo


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! 
If this is your first contribution, please make sure to review our contribution guidelines: https://docs.prefect.io/contribute/index
-->

<!-- Include an overview of the proposed changes here -->
Adds vcs version types for Gitlab, Bitbucket, and Azure Devops.

Also adds the `commit_sha` and `message` fields to all `vcs` version types. The `message` field is the first line of the commit message.

Uses the `--version` from the CLI deploy or the `version` in a YAML deployment definition as the `version` field on `VersionInfo` if it's supplied, and uses the `message` as the `version` field otherwise.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "closes `<link to issue>`"
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] If this pull request adds new functionality, it includes unit tests that cover the changes
- [ ] If this pull request removes docs files, it includes redirect settings in `mint.json`.
- [x] If this pull request adds functions or classes, it includes helpful docstrings.
