### PR TITLE
Add done callback prior to submitting

### DIFF
--- a/src/prefect/_internal/concurrency/threads.py
+++ b/src/prefect/_internal/concurrency/threads.py
@@ -174,13 +174,13 @@ class EventLoopThread(Portal):
             # Track the portal running the call
             call.set_runner(self)
 
+            if self._run_once:
+                call.future.add_done_callback(lambda _: self.shutdown())
+
             # Submit the call to the event loop
             assert self._loop is not None
             asyncio.run_coroutine_threadsafe(self._run_call(call), self._loop)
-
             self._submitted_count += 1
-            if self._run_once:
-                call.future.add_done_callback(lambda _: self.shutdown())
 
         return call
 


### PR DESCRIPTION
I've seen this test flake a lot, e.g., https://github.com/PrefectHQ/prefect/actions/runs/14669582788/job/41172805597

It crossed my mind that it _might_ be because the future finishes before the done callback is added to it that ensures proper shutdown. This PR changes the order of the logic to account for this race condition.