### PR TITLE
handle heartbeat event in `wait_for_flow_run`

### DIFF
--- a/src/prefect/flow_runs.py
+++ b/src/prefect/flow_runs.py
@@ -141,6 +141,9 @@ async def wait_for_flow_run(
                 return flow_run
 
             async for event in subscriber:
+                if event.event == "prefect.flow-run.heartbeat":
+                    logger.debug("Heartbeat received")
+                    continue
                 state_type = StateType(event.resource["prefect.state-type"])
                 state = State(type=state_type)
 

--- a/src/prefect/flow_runs.py
+++ b/src/prefect/flow_runs.py
@@ -141,10 +141,10 @@ async def wait_for_flow_run(
                 return flow_run
 
             async for event in subscriber:
-                if event.event == "prefect.flow-run.heartbeat":
-                    logger.debug("Heartbeat received")
+                if not (state_type := event.resource.get("prefect.state-type")):
+                    logger.debug(f"Received {event.event!r} event")
                     continue
-                state_type = StateType(event.resource["prefect.state-type"])
+                state_type = StateType(state_type)
                 state = State(type=state_type)
 
                 if log_states:

--- a/tests/test_flow_runs.py
+++ b/tests/test_flow_runs.py
@@ -1,13 +1,18 @@
+import asyncio
 import time
+import uuid
 
 import pytest
 
 import prefect.client.schemas as client_schemas
 from prefect import flow
 from prefect.client.orchestration import PrefectClient
+from prefect.events.utilities import emit_event
 from prefect.exceptions import FlowRunWaitTimeout
+from prefect.flow_engine import run_flow_async
 from prefect.flow_runs import wait_for_flow_run
-from prefect.states import Completed
+from prefect.server.events.pipeline import EventsPipeline
+from prefect.states import Completed, Pending
 
 
 async def test_create_then_wait_for_flow_run(prefect_client: PrefectClient):
@@ -37,3 +42,45 @@ async def test_create_then_wait_timeout(prefect_client: PrefectClient):
 
     with pytest.raises(FlowRunWaitTimeout):
         await wait_for_flow_run(flow_run.id, timeout=0)
+
+
+async def test_wait_for_flow_run_handles_heartbeats(
+    prefect_client: PrefectClient, emitting_events_pipeline: EventsPipeline
+):
+    """Tests that flow_runs.wait_for_flow_run correctly handles heartbeats.
+
+    Regression test for https://github.com/PrefectHQ/prefect/issues/17930
+    """
+
+    @flow
+    async def my_short_flow():
+        await asyncio.sleep(1)
+
+    flow_run = await prefect_client.create_flow_run(my_short_flow, state=Pending())
+    flow_run_id = flow_run.id
+
+    run_task = asyncio.create_task(
+        run_flow_async(flow=my_short_flow, flow_run=flow_run)
+    )
+
+    async def _emit_heartbeat():
+        await asyncio.sleep(0.1)
+        emit_event(
+            event="prefect.flow-run.heartbeat",
+            resource={"prefect.resource.id": f"prefect.flow-run.{flow_run_id}"},
+            id=uuid.uuid4(),
+        )
+        await emitting_events_pipeline.process_events()
+
+    heartbeat_task = asyncio.create_task(_emit_heartbeat())
+
+    finished_flow_run = await wait_for_flow_run(flow_run_id, log_states=True)
+
+    await run_task
+    await heartbeat_task
+
+    await emitting_events_pipeline.process_events()
+
+    assert finished_flow_run.id == flow_run_id
+    assert finished_flow_run.state is not None
+    assert finished_flow_run.state.is_completed()


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/17929

we are subscribing to all flow run events, which makes sense
```
    event_filter = EventFilter(
        event=EventNameFilter(prefix=["prefect.flow-run"]),
        resource=EventResourceFilter(id=[f"prefect.flow-run.{flow_run_id}"]),
    )
```

but we were assuming that the only type of flow run events would be state changes, which is not true at this point
```
                state_type = StateType(event.resource["prefect.state-type"])
```