### PR TITLE
add `parameters` validator to `DeploymentCreateFlowRun`

### DIFF
--- a/src/prefect/client/orchestration/_deployments/client.py
+++ b/src/prefect/client/orchestration/_deployments/client.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Union
 from uuid import UUID
 
 from httpx import HTTPStatusError, RequestError
+from pydantic import BaseModel
 
 from prefect.client.orchestration.base import BaseAsyncClient, BaseClient
 from prefect.exceptions import ObjectNotFound
@@ -586,6 +587,13 @@ class DeploymentClient(BaseClient):
         from prefect.states import Scheduled, to_state_create
 
         parameters = parameters or {}
+        # Convert any pydantic models in parameters to plain data before they are
+        # placed in `DeploymentFlowRunCreate`; this avoids them being dropped by
+        # `model_dump(..., exclude_unset=True)` later on.
+        parameters = {
+            k: (v.model_dump(mode="json") if isinstance(v, BaseModel) else v)
+            for k, v in parameters.items()
+        }
         context = context or {}
         state = state or Scheduled()
         tags = tags or []
@@ -1182,6 +1190,14 @@ class DeploymentAsyncClient(BaseAsyncClient):
         from prefect.states import Scheduled, to_state_create
 
         parameters = parameters or {}
+        # Convert any pydantic models in parameters to plain data before they are
+        # placed in `DeploymentFlowRunCreate`; this avoids them being dropped by
+        # `model_dump(..., exclude_unset=True)` later on.
+        parameters = {
+            k: (v.model_dump(mode="json") if isinstance(v, BaseModel) else v)
+            for k, v in parameters.items()
+        }
+
         context = context or {}
         state = state or Scheduled()
         tags = tags or []

--- a/src/prefect/client/orchestration/_deployments/client.py
+++ b/src/prefect/client/orchestration/_deployments/client.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Union
 from uuid import UUID
 
 from httpx import HTTPStatusError, RequestError
-from pydantic import BaseModel
 
 from prefect.client.orchestration.base import BaseAsyncClient, BaseClient
 from prefect.exceptions import ObjectNotFound
@@ -587,13 +586,6 @@ class DeploymentClient(BaseClient):
         from prefect.states import Scheduled, to_state_create
 
         parameters = parameters or {}
-        # Convert any pydantic models in parameters to plain data before they are
-        # placed in `DeploymentFlowRunCreate`; this avoids them being dropped by
-        # `model_dump(..., exclude_unset=True)` later on.
-        parameters = {
-            k: (v.model_dump(mode="json") if isinstance(v, BaseModel) else v)
-            for k, v in parameters.items()
-        }
         context = context or {}
         state = state or Scheduled()
         tags = tags or []
@@ -1190,14 +1182,6 @@ class DeploymentAsyncClient(BaseAsyncClient):
         from prefect.states import Scheduled, to_state_create
 
         parameters = parameters or {}
-        # Convert any pydantic models in parameters to plain data before they are
-        # placed in `DeploymentFlowRunCreate`; this avoids them being dropped by
-        # `model_dump(..., exclude_unset=True)` later on.
-        parameters = {
-            k: (v.model_dump(mode="json") if isinstance(v, BaseModel) else v)
-            for k, v in parameters.items()
-        }
-
         context = context or {}
         state = state or Scheduled()
         tags = tags or []

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -1175,10 +1175,13 @@ async def test_create_flow_run_from_deployment_with_base_model_parameters(
         name="my-deployment",
     )
 
+    param_model_instance = MyBaseModel(x=1, y="hello")
+    param_model_instance.x = 42
+
     flow_run = await prefect_client.create_flow_run_from_deployment(
-        deployment_id, parameters={"param": MyBaseModel(x=1, y="hello")}
+        deployment_id, parameters={"param": param_model_instance}
     )
-    assert flow_run.parameters == {"param": {"x": 1, "y": "hello"}}
+    assert flow_run.parameters == {"param": {"x": 42, "y": "hello"}}
 
 
 async def test_create_flow_run_from_deployment_idempotency(


### PR DESCRIPTION
closes https://github.com/PrefectHQ/prefect/issues/17887

the sync and async versions of the client method are the only place this schema is used, and this should not impact any other cases (besides the problematic one currently giving unexpected results)

### ai summary

This pull request introduces enhancements to parameter handling in the `DeploymentFlowRunCreate` model and adds a corresponding test to ensure proper functionality. The most notable changes include adding a `model_validator` to convert Pydantic `BaseModel` parameters into plain JSON data and a new test case to validate this behavior.

### Enhancements to parameter handling:

* Added a `model_validator` method `convert_parameters_to_plain_data` in the `DeploymentFlowRunCreate` class to ensure that any `BaseModel` instances in the `parameters` field are converted to plain JSON data using the `model_dump` method. This conversion leverages the `visit_collection` utility for recursive processing. (`src/prefect/client/schemas/actions.py`, [src/prefect/client/schemas/actions.pyR521-R534](diffhunk://#diff-a91c42027554e27d0bd3239f5e9a05f49b24c7f23da10743b06b25a2bd9cf4d8R521-R534))

* Imported `BaseModel` from Pydantic and the `visit_collection` utility to support the new parameter conversion logic. (`src/prefect/client/schemas/actions.py`, [[1]](diffhunk://#diff-a91c42027554e27d0bd3239f5e9a05f49b24c7f23da10743b06b25a2bd9cf4d8L8-R8) [[2]](diffhunk://#diff-a91c42027554e27d0bd3239f5e9a05f49b24c7f23da10743b06b25a2bd9cf4d8L49-R49)

### Testing improvements:

* Added a new test case `test_create_flow_run_from_deployment_with_base_model_parameters` to validate that `BaseModel` instances passed as parameters are correctly converted to plain JSON data when creating a flow run from a deployment. (`tests/client/test_prefect_client.py`, [tests/client/test_prefect_client.pyR1160-R1186](diffhunk://#diff-78da5d958809b7f163aa49ffcff0ee9a7d854fada6be1e0286e039dfa51d78b4R1160-R1186))