### PR TITLE
Add default result storage for work pools

### DIFF
--- a/docs/v3/api-ref/rest-api/server/schema.json
+++ b/docs/v3/api-ref/rest-api/server/schema.json
@@ -24409,6 +24409,19 @@
                         ],
                         "title": "Bundle Execution Step",
                         "description": "The step to use for executing bundles."
+                    },
+                    "default_result_storage_block_id": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Default Result Storage Block Id",
+                        "description": "The block document ID of the default result storage block."
                     }
                 },
                 "additionalProperties": false,

--- a/docs/v3/deploy/submit-flows-directly-to-dynamic-infrastructure.mdx
+++ b/docs/v3/deploy/submit-flows-directly-to-dynamic-infrastructure.mdx
@@ -48,7 +48,6 @@ Before submitting workflows to specific infrastructure, you'll need:
 
 1. A work pool for each infrastructure type you want to use
 2. Object storage to associate with your work pool(s)
-3. A storage block to use for result storage
 
 ## Setting up work pools and storage
 
@@ -64,7 +63,7 @@ For detailed information on creating and configuring work pools, refer to the [w
 
 ### Configuring work pool storage
 
-To enable Prefect to run workflows in remote infrastructure, work pools need an associated storage location to store serialized versions of submitted workflows.
+To enable Prefect to run workflows in remote infrastructure, work pools need an associated storage location to store serialized versions of submitted workflows and results from workflow runs.
 
 Configure storage for your work pools using one of the supported storage types:
 
@@ -97,14 +96,6 @@ You can inspect your storage configuration using:
 ```bash
 prefect work-pool storage inspect WORK_POOL_NAME
 ```
-
-### Configuring result storage
-
-To retrieve the return value from an infrastructure-bound workflow, you'll need to [configure result storage](/v3/develop/results) for your workflow.
-
-The result storage location must be accessible by the workflow submitter and the remote infrastructure, so most of the time you'll want to use an object storage location like S3, GCS, or Azure Blob storage.
-
-Return values for submitted workflows must be serializable for storage and retrieval.
 
 <Note>
 **Local storage for `@docker`**

--- a/src/prefect/blocks/core.py
+++ b/src/prefect/blocks/core.py
@@ -95,6 +95,12 @@ class InvalidBlockRegistration(Exception):
     """
 
 
+class UnknownBlockType(Exception):
+    """
+    Raised when a block type is not found in the registry.
+    """
+
+
 def _collect_nested_reference_strings(
     obj: dict[str, Any] | list[Any],
 ) -> list[dict[str, Any]]:
@@ -786,7 +792,20 @@ class Block(BaseModel, ABC):
         # before looking up the block class, but only do this once
         load_prefect_collections()
 
-        return lookup_type(cls, key)
+        try:
+            return lookup_type(cls, key)
+        except KeyError:
+            message = f"No block class found for slug {key!r}."
+            # Handle common blocks types used for storage, which is the primary use case for looking up blocks by key
+            if key == "s3-bucket":
+                message += " Please ensure that `prefect-aws` is installed."
+            elif key == "gcs-bucket":
+                message += " Please ensure that `prefect-gcp` is installed."
+            elif key == "azure-blob-storage-container":
+                message += " Please ensure that `prefect-azure` is installed."
+            else:
+                message += " Please ensure that the block class is available in the current environment."
+            raise UnknownBlockType(message)
 
     def _define_metadata_on_nested_blocks(
         self, block_document_references: dict[str, dict[str, Any]]

--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -823,6 +823,13 @@ async def s3(
             )
 
         result_storage_block_document_name = f"default-{work_pool_name}-result-storage"
+        block_data = {
+            "bucket_name": bucket,
+            "bucket_folder": "results",
+            "credentials": {
+                "$ref": {"block_document_id": credentials_block_document.id}
+            },
+        }
 
         try:
             existing_block_document = await client.read_block_document_by_name(
@@ -835,12 +842,7 @@ async def s3(
             await client.update_block_document(
                 block_document_id=existing_block_document.id,
                 block_document=BlockDocumentUpdate(
-                    data={
-                        "bucket": bucket,
-                        "credentials": {
-                            "$ref": {"block_document_id": credentials_block_document.id}
-                        },
-                    },
+                    data=block_data,
                 ),
             )
             block_document = existing_block_document
@@ -866,12 +868,7 @@ async def s3(
                     name=result_storage_block_document_name,
                     block_type_id=block_type.id,
                     block_schema_id=block_schema.id,
-                    data={
-                        "bucket": bucket,
-                        "credentials": {
-                            "$ref": {"block_document_id": credentials_block_document.id}
-                        },
-                    },
+                    data=block_data,
                 )
             )
 

--- a/src/prefect/cli/work_pool.py
+++ b/src/prefect/cli/work_pool.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import datetime
 import json
 import textwrap
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 from rich.pretty import Pretty
@@ -21,7 +21,7 @@ from prefect.cli._utilities import (
 )
 from prefect.cli.root import app, is_interactive
 from prefect.client.collections import get_collections_metadata_client
-from prefect.client.orchestration import get_client
+from prefect.client.orchestration import PrefectClient, get_client
 from prefect.client.schemas.actions import (
     BlockDocumentCreate,
     BlockDocumentUpdate,
@@ -29,6 +29,7 @@ from prefect.client.schemas.actions import (
     WorkPoolUpdate,
 )
 from prefect.client.schemas.objects import (
+    BlockDocument,
     FlowRun,
     WorkPool,
     WorkPoolStorageConfiguration,
@@ -776,6 +777,52 @@ async def storage_inspect(
             exit_with_error(f"Work pool {work_pool_name!r} does not exist.")
 
 
+async def _create_or_update_result_storage_block(
+    client: PrefectClient,
+    block_document_name: str,
+    block_document_data: dict[str, Any],
+    block_type_slug: str,
+    missing_block_definition_error: str,
+) -> BlockDocument:
+    try:
+        existing_block_document = await client.read_block_document_by_name(
+            name=block_document_name, block_type_slug=block_type_slug
+        )
+    except ObjectNotFound:
+        existing_block_document = None
+
+    if existing_block_document is not None:
+        await client.update_block_document(
+            block_document_id=existing_block_document.id,
+            block_document=BlockDocumentUpdate(
+                data=block_document_data,
+            ),
+        )
+        block_document = existing_block_document
+    else:
+        try:
+            block_type = await client.read_block_type_by_slug(slug=block_type_slug)
+            block_schema = await client.get_most_recent_block_schema_for_block_type(
+                block_type_id=block_type.id
+            )
+        except ObjectNotFound:
+            exit_with_error(missing_block_definition_error)
+        else:
+            if block_schema is None:
+                exit_with_error(missing_block_definition_error)
+
+        block_document = await client.create_block_document(
+            block_document=BlockDocumentCreate(
+                name=block_document_name,
+                block_type_id=block_type.id,
+                block_schema_id=block_schema.id,
+                data=block_document_data,
+            )
+        )
+
+    return block_document
+
+
 work_pool_storage_configure_app: PrefectTyper = PrefectTyper(
     name="configure", help="EXPERIMENTAL: Configure work pool storage."
 )
@@ -831,46 +878,13 @@ async def s3(
             },
         }
 
-        try:
-            existing_block_document = await client.read_block_document_by_name(
-                name=result_storage_block_document_name, block_type_slug="s3-bucket"
-            )
-        except ObjectNotFound:
-            existing_block_document = None
-
-        if existing_block_document is not None:
-            await client.update_block_document(
-                block_document_id=existing_block_document.id,
-                block_document=BlockDocumentUpdate(
-                    data=block_data,
-                ),
-            )
-            block_document = existing_block_document
-        else:
-            MISSING_BLOCK_DEFINITION_ERROR = "S3 bucket block definition does not exist server-side. Please install `prefect-aws` and run `prefect blocks register -m prefect_aws`."
-            try:
-                block_type = await client.read_block_type_by_slug(slug="s3-bucket")
-                block_schema = await client.get_most_recent_block_schema_for_block_type(
-                    block_type_id=block_type.id
-                )
-            except ObjectNotFound:
-                exit_with_error(MISSING_BLOCK_DEFINITION_ERROR)
-            else:
-                if block_schema is None:
-                    exit_with_error(MISSING_BLOCK_DEFINITION_ERROR)
-
-            credentials_block_document = await client.read_block_document_by_name(
-                name=credentials_block_name, block_type_slug="aws-credentials"
-            )
-
-            block_document = await client.create_block_document(
-                block_document=BlockDocumentCreate(
-                    name=result_storage_block_document_name,
-                    block_type_id=block_type.id,
-                    block_schema_id=block_schema.id,
-                    data=block_data,
-                )
-            )
+        block_document = await _create_or_update_result_storage_block(
+            client=client,
+            block_document_name=result_storage_block_document_name,
+            block_document_data=block_data,
+            block_type_slug="s3-bucket",
+            missing_block_definition_error="S3 bucket block definition does not exist server-side. Please install `prefect-aws` and run `prefect blocks register -m prefect_aws`.",
+        )
 
         try:
             await client.update_work_pool(
@@ -932,13 +946,30 @@ async def gcs(
     """
     async with get_client() as client:
         try:
-            await client.read_block_document_by_name(
+            credentials_block_document = await client.read_block_document_by_name(
                 name=credentials_block_name, block_type_slug="gcp-credentials"
             )
         except ObjectNotFound:
             exit_with_error(
                 f"GCS credentials block {credentials_block_name!r} does not exist. Please create one using `prefect block create gcp-credentials`."
             )
+
+        result_storage_block_document_name = f"default-{work_pool_name}-result-storage"
+        block_data = {
+            "bucket_name": bucket,
+            "bucket_folder": "results",
+            "credentials": {
+                "$ref": {"block_document_id": credentials_block_document.id}
+            },
+        }
+
+        block_document = await _create_or_update_result_storage_block(
+            client=client,
+            block_document_name=result_storage_block_document_name,
+            block_document_data=block_data,
+            block_type_slug="gcs-bucket",
+            missing_block_definition_error="GCS bucket block definition does not exist server-side. Please install `prefect-gcp` and run `prefect blocks register -m prefect_gcp`.",
+        )
 
         try:
             await client.update_work_pool(
@@ -959,6 +990,7 @@ async def gcs(
                                 "credentials_block_name": credentials_block_name,
                             }
                         },
+                        default_result_storage_block_id=block_document.id,
                     ),
                 ),
             )
@@ -999,7 +1031,7 @@ async def azure_blob_storage(
     """
     async with get_client() as client:
         try:
-            await client.read_block_document_by_name(
+            credentials_block_document = await client.read_block_document_by_name(
                 name=credentials_block_name,
                 block_type_slug="azure-blob-storage-credentials",
             )
@@ -1007,6 +1039,22 @@ async def azure_blob_storage(
             exit_with_error(
                 f"Azure Blob Storage credentials block {credentials_block_name!r} does not exist. Please create one using `prefect block create azure-blob-storage-credentials`."
             )
+
+        result_storage_block_document_name = f"default-{work_pool_name}-result-storage"
+        block_data = {
+            "container_name": container,
+            "credentials": {
+                "$ref": {"block_document_id": credentials_block_document.id}
+            },
+        }
+
+        block_document = await _create_or_update_result_storage_block(
+            client=client,
+            block_document_name=result_storage_block_document_name,
+            block_document_data=block_data,
+            block_type_slug="azure-blob-storage-container",
+            missing_block_definition_error="Azure Blob Storage container block definition does not exist server-side. Please install `prefect-azure[storage]` and run `prefect blocks register -m prefect_azure`.",
+        )
 
         try:
             await client.update_work_pool(
@@ -1027,6 +1075,7 @@ async def azure_blob_storage(
                                 "azure_blob_storage_credentials_block_name": credentials_block_name,
                             }
                         },
+                        default_result_storage_block_id=block_document.id,
                     ),
                 ),
             )

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -1461,7 +1461,7 @@ class WorkPoolStorageConfiguration(PrefectBaseModel):
     bundle_execution_step: Optional[dict[str, Any]] = Field(
         default=None, description="The bundle execution step for the work pool."
     )
-    default_result_storage_block_id: UUID | None = Field(
+    default_result_storage_block_id: Optional[UUID] = Field(
         default=None,
         description="The block document ID of the default result storage block.",
     )

--- a/src/prefect/client/schemas/objects.py
+++ b/src/prefect/client/schemas/objects.py
@@ -1461,6 +1461,10 @@ class WorkPoolStorageConfiguration(PrefectBaseModel):
     bundle_execution_step: Optional[dict[str, Any]] = Field(
         default=None, description="The bundle execution step for the work pool."
     )
+    default_result_storage_block_id: UUID | None = Field(
+        default=None,
+        description="The block document ID of the default result storage block.",
+    )
 
 
 class WorkPool(ObjectBaseModel):

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -1071,7 +1071,7 @@ class WorkPoolStorageConfiguration(PrefectBaseModel):
         default=None,
         description="The step to use for executing bundles.",
     )
-    default_result_storage_block_id: UUID | None = Field(
+    default_result_storage_block_id: Optional[UUID] = Field(
         default=None,
         description="The block document ID of the default result storage block.",
     )

--- a/src/prefect/server/schemas/core.py
+++ b/src/prefect/server/schemas/core.py
@@ -1071,6 +1071,10 @@ class WorkPoolStorageConfiguration(PrefectBaseModel):
         default=None,
         description="The step to use for executing bundles.",
     )
+    default_result_storage_block_id: UUID | None = Field(
+        default=None,
+        description="The block document ID of the default result storage block.",
+    )
 
 
 class WorkPool(ORMBaseModel):

--- a/tests/cli/test_work_pool.py
+++ b/tests/cli/test_work_pool.py
@@ -1053,7 +1053,8 @@ class TestStorageConfigure:
                 block_type_slug="s3-bucket",
             )
             assert block_document.data == {
-                "bucket": "test-bucket",
+                "bucket_name": "test-bucket",
+                "bucket_folder": "results",
                 "credentials": aws_credentials.data,
             }
 

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -2045,6 +2045,7 @@ class TestWorkPools:
         sample_bundle_upload_step: dict[str, Any],
         sample_bundle_execution_step: dict[str, Any],
     ):
+        default_result_storage_block_id = uuid4()
         work_pool = await prefect_client.create_work_pool(
             work_pool=WorkPoolCreate.model_validate(
                 {
@@ -2052,6 +2053,7 @@ class TestWorkPools:
                     "storage_configuration": {
                         "bundle_upload_step": sample_bundle_upload_step,
                         "bundle_execution_step": sample_bundle_execution_step,
+                        "default_result_storage_block_id": default_result_storage_block_id,
                     },
                 }
             ),
@@ -2059,6 +2061,7 @@ class TestWorkPools:
         assert work_pool.storage_configuration == WorkPoolStorageConfiguration(
             bundle_upload_step=sample_bundle_upload_step,
             bundle_execution_step=sample_bundle_execution_step,
+            default_result_storage_block_id=default_result_storage_block_id,
         )
 
     async def test_update_work_pool_with_storage_configuration(

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import sys
 import uuid
 from datetime import timedelta
@@ -8,6 +9,7 @@ from unittest import mock
 from unittest.mock import ANY, MagicMock, Mock
 
 import anyio.abc
+import cloudpickle
 import httpx
 import pytest
 import respx
@@ -19,6 +21,7 @@ from starlette import status
 import prefect
 import prefect.client.schemas as schemas
 from prefect._internal.compatibility.deprecated import PrefectDeprecationWarning
+from prefect._result_records import ResultRecord, ResultRecordMetadata
 from prefect.blocks.core import Block
 from prefect.client.base import ServerType
 from prefect.client.orchestration import PrefectClient, get_client
@@ -38,14 +41,17 @@ from prefect.exceptions import (
     CrashedRun,
     ObjectNotFound,
 )
+from prefect.filesystems import WritableFileSystem
 from prefect.flows import flow
 from prefect.futures import PrefectFlowRunFuture
+from prefect.serializers import PickleSerializer
 from prefect.server import models
 from prefect.server.schemas.actions import WorkPoolUpdate as ServerWorkPoolUpdate
 from prefect.server.schemas.core import Deployment
 from prefect.server.schemas.responses import DeploymentResponse
 from prefect.settings import (
     PREFECT_API_URL,
+    PREFECT_RESULTS_PERSIST_BY_DEFAULT,
     PREFECT_TEST_MODE,
     PREFECT_WORKER_PREFETCH_SECONDS,
     Setting,
@@ -78,6 +84,16 @@ class WorkerTestImpl(BaseWorker[BaseJobConfiguration, Any, BaseWorkerResult]):
 
     async def run(self):
         pass
+
+
+class FakeResultStorageBlock(WritableFileSystem):
+    place: str = Field(default="test-place")
+
+    async def read_path(self, path: str) -> bytes:
+        return base64.b64encode(cloudpickle.dumps("Here you go chief!"))
+
+    async def write_path(self, path: str, content: bytes) -> None:
+        print("What do you expect me to do with this?")
 
 
 @pytest.fixture(autouse=True)
@@ -2120,6 +2136,11 @@ class TestSubmit:
             }
         }
 
+        result_storage_block = FakeResultStorageBlock(place="test-place")
+        block_document_id = await result_storage_block.save(
+            name="my-result-storage-block"
+        )
+
         schema = BaseJobConfiguration.model_json_schema()
         for key, value in schema["properties"].items():
             if isinstance(value, dict):
@@ -2138,6 +2159,7 @@ class TestSubmit:
                 storage_configuration=WorkPoolStorageConfiguration(
                     bundle_upload_step=UPLOAD_STEP,
                     bundle_execution_step=EXECUTE_STEP,
+                    default_result_storage_block_id=block_document_id,
                 ),
                 base_job_template=base_job_template,
             )
@@ -2436,6 +2458,55 @@ class TestSubmit:
 
         flow_run = await prefect_client.read_flow_run(future.flow_run_id)
         assert set(flow_run.tags) == {"foo", "bar"}
+
+    @pytest.mark.usefixtures("mock_run_process")
+    async def test_submit_uses_work_pool_result_storage_block(
+        self,
+        work_pool: WorkPool,
+    ):
+        class SubmitterOfUnpreparedFlows(
+            BaseWorker[BaseJobConfiguration, Any, BaseWorkerResult]
+        ):
+            type = "submitter-of-unprepared-flows"
+            job_configuration = BaseJobConfiguration
+
+            async def run(
+                self,
+                flow_run: FlowRun,
+                configuration: BaseJobConfiguration,
+                task_status: anyio.abc.TaskStatus[int] | None = None,
+            ):
+                # Need to trick the client into saving the result record
+                with temporary_settings({PREFECT_RESULTS_PERSIST_BY_DEFAULT: True}):
+                    fake_state = Completed(
+                        data=ResultRecord(
+                            result="Totally legit result",
+                            metadata=ResultRecordMetadata(
+                                serializer=PickleSerializer(),
+                                expiration=None,
+                                storage_key="totally-legit-result",
+                                storage_block_id=work_pool.storage_configuration.default_result_storage_block_id,
+                            ),
+                        )
+                    )
+                    await self.client.set_flow_run_state(
+                        flow_run.id,
+                        state=fake_state,
+                        force=True,
+                    )
+                return BaseWorkerResult(identifier="test", status_code=0)
+
+        @flow
+        def unprepared_flow():
+            print("Dang it, I forgot my result storage. Can I borrow yours?")
+
+        async with SubmitterOfUnpreparedFlows(work_pool_name=work_pool.name) as worker:
+            with pytest.warns(FutureWarning):
+                future = await worker.submit(unprepared_flow)
+                assert isinstance(future, PrefectFlowRunFuture)
+
+        # Return value is hardcoded in the FakeResultStorage to ensure it is used as expected
+        assert future.result() == "Here you go chief!"
 
 
 class TestBackwardsCompatibility:

--- a/ui-v2/src/api/prefect.ts
+++ b/ui-v2/src/api/prefect.ts
@@ -9508,6 +9508,11 @@ export interface components {
             bundle_execution_step?: {
                 [key: string]: unknown;
             } | null;
+            /**
+             * Default Result Storage Block Id
+             * @description The block document ID of the default result storage block.
+             */
+            default_result_storage_block_id?: string | null;
         };
         /**
          * WorkPoolUpdate


### PR DESCRIPTION
This PR updates a work pool's storage configuration to include a default storage block to use for result storage. This improves the ergonomics when submitting flow runs directly to dynamic infrastructure because users won't need to provide their own result storage if they don't want to. Results are stored in the same storage location as bundles for execution, but under a `results` folder.

This PR also updates error handling for missing Block class definitions to direct users to install the necessary Prefect integration when possible. This is often a tripping point for users when using result storage.